### PR TITLE
#78: ApplicationState/Settings validation + version-migration + Script-enum font keys

### DIFF
--- a/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
+++ b/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
@@ -1,0 +1,349 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using CST.Avalonia.Models;
+using CST.Conversion;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Models;
+
+/// <summary>
+/// Unit tests for the pure ApplicationState/Settings validators, migration, and the ScriptKeys enum guard (#78).
+/// No I/O or DI - these exercise the load-time self-healing logic directly.
+/// </summary>
+public class StateValidationTests
+{
+    // ---------- ScriptKeys ----------
+
+    [Theory]
+    [InlineData(Script.Devanagari, "Devanagari")]
+    [InlineData(Script.Latin, "Latin")]
+    [InlineData(Script.Myanmar, "Myanmar")]
+    public void ScriptKeys_Of_IsEnumName(Script script, string expected)
+        => Assert.Equal(expected, ScriptKeys.Of(script));
+
+    [Theory]
+    [InlineData("Devanagari", true)]
+    [InlineData("Thai", true)]
+    [InlineData("NotAScript", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("7", false)]    // numeric form Enum.TryParse would otherwise accept
+    [InlineData("-1", false)]
+    [InlineData("devanagari", false)] // case-sensitive: keys are produced by ToString()
+    public void ScriptKeys_IsValidKey(string? key, bool expected)
+        => Assert.Equal(expected, ScriptKeys.IsValidKey(key));
+
+    [Fact]
+    public void ScriptKeys_TryParse_RoundTrips()
+    {
+        foreach (Script s in System.Enum.GetValues<Script>())
+        {
+            Assert.True(ScriptKeys.TryParse(ScriptKeys.Of(s), out var parsed));
+            Assert.Equal(s, parsed);
+        }
+    }
+
+    // ---------- ApplicationStateValidator.Migrate ----------
+
+    [Fact]
+    public void Migrate_EmptyVersion_StampsCurrent()
+    {
+        var state = new ApplicationState { Version = "" };
+        var notes = ApplicationStateValidator.Migrate(state);
+        Assert.Equal(ApplicationStateValidator.CurrentVersion, state.Version);
+        Assert.NotEmpty(notes);
+    }
+
+    [Fact]
+    public void Migrate_CurrentVersion_NoChange()
+    {
+        var state = new ApplicationState { Version = ApplicationStateValidator.CurrentVersion };
+        var notes = ApplicationStateValidator.Migrate(state);
+        Assert.Empty(notes);
+        Assert.Equal(ApplicationStateValidator.CurrentVersion, state.Version);
+    }
+
+    [Fact]
+    public void Migrate_OlderVersion_UpgradesToCurrent()
+    {
+        var state = new ApplicationState { Version = "0.9" };
+        ApplicationStateValidator.Migrate(state);
+        Assert.Equal(ApplicationStateValidator.CurrentVersion, state.Version);
+    }
+
+    [Fact]
+    public void Migrate_NewerVersion_LeftAsIs()
+    {
+        var state = new ApplicationState { Version = "99.0" };
+        var notes = ApplicationStateValidator.Migrate(state);
+        Assert.Equal("99.0", state.Version); // forward-compatible read, not clobbered
+        Assert.Contains(notes, n => n.Contains("newer"));
+    }
+
+    [Theory]
+    [InlineData("1.0", "1.0", 0)]
+    [InlineData("1.0", "1.1", -1)]
+    [InlineData("2.0", "1.9", 1)]
+    [InlineData("1", "1.0", 0)]
+    [InlineData("1.2.3", "1.2", 1)]
+    public void CompareVersions_Works(string a, string b, int sign)
+        => Assert.Equal(sign, System.Math.Sign(ApplicationStateValidator.CompareVersions(a, b)));
+
+    // ---------- ApplicationStateValidator.Sanitize ----------
+
+    [Fact]
+    public void Sanitize_FixesNonPositiveAndNanWindowSizes()
+    {
+        var state = new ApplicationState();
+        state.MainWindow.Width = -5;
+        state.MainWindow.Height = double.NaN;
+        state.OpenBookDialog.Width = 0;
+        state.DictionaryDialog.Height = double.PositiveInfinity;
+
+        var fixes = ApplicationStateValidator.Sanitize(state);
+
+        Assert.True(state.MainWindow.Width > 0);
+        Assert.True(state.MainWindow.Height > 0);
+        Assert.True(state.OpenBookDialog.Width > 0);
+        Assert.True(state.DictionaryDialog.Height > 0);
+        Assert.NotEmpty(fixes);
+    }
+
+    [Fact]
+    public void Sanitize_ClearsNaNInfinityCoordinates()
+    {
+        var state = new ApplicationState();
+        state.MainWindow.X = double.NaN;
+        state.MainWindow.Y = double.NegativeInfinity;
+
+        ApplicationStateValidator.Sanitize(state);
+
+        Assert.Null(state.MainWindow.X);
+        Assert.Null(state.MainWindow.Y);
+    }
+
+    [Fact]
+    public void Sanitize_PreservesValidValues()
+    {
+        var state = new ApplicationState();
+        state.MainWindow.Width = 1234;
+        state.MainWindow.Height = 567;
+        state.MainWindow.X = 100;
+        state.MainWindow.Y = 50;
+
+        var fixes = ApplicationStateValidator.Sanitize(state);
+
+        Assert.Empty(fixes);
+        Assert.Equal(1234, state.MainWindow.Width);
+        Assert.Equal(567, state.MainWindow.Height);
+        Assert.Equal(100, state.MainWindow.X);
+        Assert.Equal(50, state.MainWindow.Y);
+    }
+
+    [Fact]
+    public void Sanitize_RemovesBookWindowsWithNegativeIndex()
+    {
+        var state = new ApplicationState();
+        state.BookWindows.Add(new BookWindowState { BookIndex = 5 });
+        state.BookWindows.Add(new BookWindowState { BookIndex = -1 });
+        state.BookWindows.Add(new BookWindowState { BookIndex = -99 });
+
+        ApplicationStateValidator.Sanitize(state);
+
+        Assert.Single(state.BookWindows);
+        Assert.Equal(5, state.BookWindows[0].BookIndex);
+    }
+
+    [Fact]
+    public void Sanitize_ClampsBookWindowHitAndTabIndices()
+    {
+        var state = new ApplicationState();
+        state.BookWindows.Add(new BookWindowState { BookIndex = 0, CurrentHitIndex = 0, TotalHits = -3, TabIndex = -1, Width = -1 });
+
+        ApplicationStateValidator.Sanitize(state);
+
+        var w = state.BookWindows[0];
+        Assert.Equal(1, w.CurrentHitIndex);
+        Assert.Equal(0, w.TotalHits);
+        Assert.Equal(0, w.TabIndex);
+        Assert.True(w.Width > 0);
+    }
+
+    [Fact]
+    public void Sanitize_FixesProximityAndMaxRecent()
+    {
+        var state = new ApplicationState();
+        state.SearchDialog.ProximityDistance = -1;
+        state.Preferences.MaxRecentBooks = -5;
+
+        ApplicationStateValidator.Sanitize(state);
+
+        Assert.True(state.SearchDialog.ProximityDistance >= 0);
+        Assert.True(state.Preferences.MaxRecentBooks >= 0);
+    }
+
+    [Fact]
+    public void Sanitize_TrimsRecentBooksToMax_AndDropsNegativeIndex()
+    {
+        var state = new ApplicationState();
+        state.Preferences.MaxRecentBooks = 2;
+        state.Preferences.RecentBooks.Add(new RecentBookItem { BookIndex = 1 });
+        state.Preferences.RecentBooks.Add(new RecentBookItem { BookIndex = -1 }); // dropped
+        state.Preferences.RecentBooks.Add(new RecentBookItem { BookIndex = 2 });
+        state.Preferences.RecentBooks.Add(new RecentBookItem { BookIndex = 3 });
+        state.Preferences.RecentBooks.Add(new RecentBookItem { BookIndex = 4 }); // over max -> trimmed
+
+        ApplicationStateValidator.Sanitize(state);
+
+        Assert.Equal(2, state.Preferences.RecentBooks.Count);
+        Assert.DoesNotContain(state.Preferences.RecentBooks, r => r.BookIndex < 0);
+    }
+
+    [Fact]
+    public void Sanitize_IsIdempotent()
+    {
+        var state = new ApplicationState();
+        state.MainWindow.Width = -1;
+        ApplicationStateValidator.Sanitize(state);
+        var second = ApplicationStateValidator.Sanitize(state);
+        Assert.Empty(second); // already clean
+    }
+
+    [Fact]
+    public void Validate_ReportsRecoverableIssues()
+    {
+        var state = new ApplicationState { Version = "" };
+        state.MainWindow.Width = -1;
+
+        var result = ApplicationStateValidator.Validate(state);
+
+        Assert.False(result.IsValid);
+        Assert.True(result.CanRecover);
+        Assert.NotEmpty(result.Warnings);
+    }
+
+    [Fact]
+    public void Validate_CleanStateIsValid()
+        => Assert.True(ApplicationStateValidator.Validate(new ApplicationState()).IsValid);
+
+    // ---------- Round-trip: an old JSON state file upgrades cleanly ----------
+
+    [Fact]
+    public void OldStateJson_DeserializesMigratesAndSanitizes()
+    {
+        // A minimal, older-style file: no version, a bad window size, a stray negative-index book window.
+        const string json = """
+        {
+          "mainWindow": { "width": -1, "height": 0 },
+          "bookWindows": [ { "bookIndex": -1 }, { "bookIndex": 3, "bookFileName": "s0101m.mul.xml" } ]
+        }
+        """;
+        var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var state = JsonSerializer.Deserialize<ApplicationState>(json, opts)!;
+
+        ApplicationStateValidator.Migrate(state);
+        ApplicationStateValidator.Sanitize(state);
+
+        Assert.Equal(ApplicationStateValidator.CurrentVersion, state.Version);
+        Assert.True(state.MainWindow.Width > 0 && state.MainWindow.Height > 0);
+        Assert.Single(state.BookWindows);
+        Assert.Equal(3, state.BookWindows[0].BookIndex);
+        Assert.True(ApplicationStateValidator.Validate(state).IsValid);
+    }
+
+    // ---------- SettingsValidator ----------
+
+    [Fact]
+    public void Settings_Migrate_EmptyVersion_StampsCurrent()
+    {
+        var s = new Settings { Version = "" };
+        SettingsValidator.Migrate(s);
+        Assert.Equal(SettingsValidator.CurrentVersion, s.Version);
+    }
+
+    [Fact]
+    public void Settings_Sanitize_FixesInvalidLogLevel()
+    {
+        var s = new Settings();
+        s.DeveloperSettings.LogLevel = "Verbose"; // not a Microsoft log level
+        SettingsValidator.Sanitize(s);
+        Assert.Equal("Information", s.DeveloperSettings.LogLevel);
+    }
+
+    [Theory]
+    [InlineData("Debug")]
+    [InlineData("Warning")]
+    [InlineData("information")] // case-insensitive accept
+    public void Settings_Sanitize_KeepsValidLogLevel(string level)
+    {
+        var s = new Settings();
+        s.DeveloperSettings.LogLevel = level;
+        SettingsValidator.Sanitize(s);
+        Assert.Equal(level, s.DeveloperSettings.LogLevel);
+    }
+
+    [Fact]
+    public void Settings_Sanitize_ResetsEmptyRepoFields()
+    {
+        var s = new Settings();
+        s.XmlUpdateSettings.XmlRepositoryOwner = "";
+        s.XmlUpdateSettings.XmlRepositoryName = "   ";
+        s.XmlUpdateSettings.XmlRepositoryBranch = "";
+        SettingsValidator.Sanitize(s);
+        Assert.False(string.IsNullOrWhiteSpace(s.XmlUpdateSettings.XmlRepositoryOwner));
+        Assert.False(string.IsNullOrWhiteSpace(s.XmlUpdateSettings.XmlRepositoryName));
+        Assert.False(string.IsNullOrWhiteSpace(s.XmlUpdateSettings.XmlRepositoryBranch));
+    }
+
+    [Fact]
+    public void Settings_Sanitize_ClampsNonPositiveFontSizes()
+    {
+        var s = new Settings();
+        s.FontSettings.LocalizationFontSize = 0;
+        s.FontSettings.ScriptFonts["Devanagari"].FontSize = -3;
+        SettingsValidator.Sanitize(s);
+        Assert.True(s.FontSettings.LocalizationFontSize > 0);
+        Assert.True(s.FontSettings.ScriptFonts["Devanagari"].FontSize > 0);
+    }
+
+    [Fact]
+    public void Settings_Sanitize_DropsUnknownScriptFontKeys()
+    {
+        var s = new Settings();
+        s.FontSettings.ScriptFonts["Klingon"] = new ScriptFontSetting { FontSize = 12 };
+        s.FontSettings.ScriptFonts["7"] = new ScriptFontSetting { FontSize = 12 };
+
+        SettingsValidator.Sanitize(s);
+
+        Assert.False(s.FontSettings.ScriptFonts.ContainsKey("Klingon"));
+        Assert.False(s.FontSettings.ScriptFonts.ContainsKey("7"));
+        Assert.True(s.FontSettings.ScriptFonts.ContainsKey("Devanagari")); // real keys kept
+        Assert.All(s.FontSettings.ScriptFonts.Keys, k => Assert.True(ScriptKeys.IsValidKey(k)));
+    }
+
+    [Fact]
+    public void Settings_Sanitize_ClearsPathWithInvalidChars()
+    {
+        var s = new Settings();
+        s.XmlBooksDirectory = "/valid/path";          // kept (non-existence is fine)
+        s.IndexDirectory = "bad\0path";               // NUL is an invalid path char
+        SettingsValidator.Sanitize(s);
+        Assert.Equal("/valid/path", s.XmlBooksDirectory);
+        Assert.Equal("", s.IndexDirectory);
+    }
+
+    [Fact]
+    public void Settings_DefaultIsClean()
+        => Assert.Empty(SettingsValidator.Sanitize(new Settings()));
+
+    [Fact]
+    public void FontSettings_TryGetFont_TypedLookup()
+    {
+        var fs = new FontSettings();
+        Assert.True(fs.TryGetFont(Script.Devanagari, out var deva));
+        Assert.NotNull(deva);
+        // A script with no entry (Ipe is not a display script) returns false.
+        Assert.False(fs.TryGetFont(Script.Ipe, out _));
+    }
+}

--- a/src/CST.Avalonia/Models/ApplicationStateValidator.cs
+++ b/src/CST.Avalonia/Models/ApplicationStateValidator.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Services;
+
+namespace CST.Avalonia.Models;
+
+/// <summary>
+/// Pure (no I/O, no DI) validation, sanitization, and version-migration for <see cref="ApplicationState"/>,
+/// so older/corrupt state files upgrade and self-heal cleanly on load. Directly unit-testable. (#78)
+/// </summary>
+public static class ApplicationStateValidator
+{
+    /// <summary>
+    /// Current on-disk state schema version. Bump this and add an ordered step in <see cref="Migrate"/> when a
+    /// breaking schema change needs older files transformed.
+    /// </summary>
+    public const string CurrentVersion = "1.0";
+
+    // Model defaults, kept here so sanitization restores the same values the constructors use.
+    private const double MainW = 1400, MainH = 900;
+    private const double OpenBookW = 900, OpenBookH = 700;
+    private const double DictW = 500, DictH = 400;
+    private const double BookW = 800, BookH = 600;
+
+    /// <summary>
+    /// Upgrade an older / missing-version state to <see cref="CurrentVersion"/>. Returns human-readable notes
+    /// (for logging). A version newer than we understand is left untouched (forward-compatible read).
+    /// </summary>
+    public static IReadOnlyList<string> Migrate(ApplicationState state)
+    {
+        var notes = new List<string>();
+        if (state == null) return notes;
+
+        var v = (state.Version ?? string.Empty).Trim();
+        if (v.Length == 0)
+        {
+            state.Version = CurrentVersion;
+            notes.Add($"state had no version; stamped {CurrentVersion}");
+            return notes;
+        }
+
+        // --- ordered migration steps go here as the schema evolves, e.g.:
+        //   if (v == "1.0") { /* transform */ v = "1.1"; notes.Add("migrated 1.0 -> 1.1"); }
+
+        if (CompareVersions(v, CurrentVersion) > 0)
+        {
+            notes.Add($"state version {v} is newer than supported {CurrentVersion}; reading as-is");
+            return notes;
+        }
+
+        if (v != CurrentVersion)
+        {
+            state.Version = CurrentVersion;
+            notes.Add($"migrated state {v} -> {CurrentVersion}");
+        }
+        return notes;
+    }
+
+    /// <summary>
+    /// Repair invalid values in place (NaN/Infinity/non-positive sizes, out-of-range indices, stray entries).
+    /// Idempotent and safe to run on every load. Returns the list of fixes applied (for logging).
+    /// </summary>
+    public static IReadOnlyList<string> Sanitize(ApplicationState state)
+    {
+        var fixes = new List<string>();
+        if (state == null) return fixes;
+
+        // Main window
+        var mw = state.MainWindow ??= new MainWindowState();
+        if (IsBadSize(mw.Width)) { mw.Width = MainW; fixes.Add($"main window width -> {MainW}"); }
+        if (IsBadSize(mw.Height)) { mw.Height = MainH; fixes.Add($"main window height -> {MainH}"); }
+        if (IsBadCoord(mw.X)) { mw.X = null; fixes.Add("main window X cleared (NaN/Infinity)"); }
+        if (IsBadCoord(mw.Y)) { mw.Y = null; fixes.Add("main window Y cleared (NaN/Infinity)"); }
+
+        // Open Book dialog
+        var ob = state.OpenBookDialog ??= new OpenBookDialogState();
+        if (IsBadSize(ob.Width)) { ob.Width = OpenBookW; fixes.Add($"open-book dialog width -> {OpenBookW}"); }
+        if (IsBadSize(ob.Height)) { ob.Height = OpenBookH; fixes.Add($"open-book dialog height -> {OpenBookH}"); }
+        if (IsBadCoord(ob.X)) { ob.X = null; fixes.Add("open-book dialog X cleared"); }
+        if (IsBadCoord(ob.Y)) { ob.Y = null; fixes.Add("open-book dialog Y cleared"); }
+
+        // Dictionary dialog
+        var dd = state.DictionaryDialog ??= new DictionaryDialogState();
+        if (IsBadSize(dd.Width)) { dd.Width = DictW; fixes.Add($"dictionary dialog width -> {DictW}"); }
+        if (IsBadSize(dd.Height)) { dd.Height = DictH; fixes.Add($"dictionary dialog height -> {DictH}"); }
+        if (IsBadCoord(dd.X)) { dd.X = null; fixes.Add("dictionary dialog X cleared"); }
+        if (IsBadCoord(dd.Y)) { dd.Y = null; fixes.Add("dictionary dialog Y cleared"); }
+
+        // Search dialog
+        var sd = state.SearchDialog ??= new SearchDialogState();
+        if (sd.ProximityDistance < 0) { sd.ProximityDistance = 10; fixes.Add("search proximity distance -> 10"); }
+
+        // Book windows
+        state.BookWindows ??= new List<BookWindowState>();
+        int removed = state.BookWindows.RemoveAll(w => w == null || w.BookIndex < 0);
+        if (removed > 0) fixes.Add($"removed {removed} book window(s) with a negative book index");
+        foreach (var w in state.BookWindows)
+        {
+            if (IsBadSize(w.Width)) { w.Width = BookW; fixes.Add($"book window '{w.BookFileName}' width -> {BookW}"); }
+            if (IsBadSize(w.Height)) { w.Height = BookH; fixes.Add($"book window '{w.BookFileName}' height -> {BookH}"); }
+            if (IsBadCoord(w.X)) w.X = null;
+            if (IsBadCoord(w.Y)) w.Y = null;
+            if (string.IsNullOrEmpty(w.WindowId)) { w.WindowId = Guid.NewGuid().ToString(); fixes.Add("book window assigned a new id"); }
+            if (w.CurrentHitIndex < 1) { w.CurrentHitIndex = 1; fixes.Add("book window hit index -> 1"); }
+            if (w.TotalHits < 0) { w.TotalHits = 0; fixes.Add("book window total hits -> 0"); }
+            if (w.TabIndex < 0) { w.TabIndex = 0; fixes.Add("book window tab index -> 0"); }
+        }
+
+        // Preferences
+        var pref = state.Preferences ??= new ApplicationPreferences();
+        if (pref.MaxRecentBooks < 0) { pref.MaxRecentBooks = 10; fixes.Add("max recent books -> 10"); }
+        if (string.IsNullOrWhiteSpace(pref.InterfaceLanguage)) { pref.InterfaceLanguage = "en"; fixes.Add("interface language -> en"); }
+        pref.RecentBooks ??= new List<RecentBookItem>();
+        int recRemoved = pref.RecentBooks.RemoveAll(r => r == null || r.BookIndex < 0);
+        if (recRemoved > 0) fixes.Add($"removed {recRemoved} recent book(s) with a negative index");
+        if (pref.RecentBooks.Count > pref.MaxRecentBooks)
+        {
+            int trim = pref.RecentBooks.Count - pref.MaxRecentBooks;
+            pref.RecentBooks.RemoveRange(pref.MaxRecentBooks, trim);
+            fixes.Add($"trimmed {trim} recent book(s) over the {pref.MaxRecentBooks} max");
+        }
+
+        return fixes;
+    }
+
+    /// <summary>
+    /// Non-mutating report used by <c>IApplicationStateService.ValidateStateAsync</c>. Every issue we detect is
+    /// repairable by <see cref="Sanitize"/>, so <see cref="StateValidationResult.CanRecover"/> is always true
+    /// (true corruption surfaces earlier, as a deserialization failure).
+    /// </summary>
+    public static StateValidationResult Validate(ApplicationState state)
+    {
+        if (state == null)
+            return new StateValidationResult { IsValid = false, CanRecover = false, Errors = new[] { "state is null" } };
+
+        var warnings = new List<string>();
+        if (string.IsNullOrEmpty(state.Version)) warnings.Add("missing version information");
+        if (state.MainWindow != null && (IsBadSize(state.MainWindow.Width) || IsBadSize(state.MainWindow.Height)))
+            warnings.Add("invalid main window dimensions");
+        if (state.BookWindows != null && state.BookWindows.Any(w => w == null || w.BookIndex < 0))
+            warnings.Add("one or more book windows have an invalid book index");
+        if (state.Preferences != null && state.Preferences.MaxRecentBooks < 0)
+            warnings.Add("invalid max recent books");
+
+        var result = new StateValidationResult
+        {
+            IsValid = warnings.Count == 0,
+            CanRecover = true,
+            Warnings = warnings.ToArray()
+        };
+        if (!result.IsValid)
+            result.SuggestedAction = "State has recoverable issues; sanitization will repair them on load.";
+        return result;
+    }
+
+    private static bool IsBadSize(double v) => double.IsNaN(v) || double.IsInfinity(v) || v <= 0;
+    private static bool IsBadCoord(double? v) => v.HasValue && (double.IsNaN(v.Value) || double.IsInfinity(v.Value));
+
+    /// <summary>Compare dotted numeric versions ("1", "1.0", "1.2.3"). Non-numeric parts sort as 0.</summary>
+    internal static int CompareVersions(string a, string b)
+    {
+        int[] pa = ParseVersion(a), pb = ParseVersion(b);
+        int n = Math.Max(pa.Length, pb.Length);
+        for (int i = 0; i < n; i++)
+        {
+            int x = i < pa.Length ? pa[i] : 0;
+            int y = i < pb.Length ? pb[i] : 0;
+            if (x != y) return x.CompareTo(y);
+        }
+        return 0;
+    }
+
+    private static int[] ParseVersion(string v) =>
+        (v ?? string.Empty).Split('.').Select(p => int.TryParse(p, out var n) ? n : 0).ToArray();
+}

--- a/src/CST.Avalonia/Models/ScriptKeys.cs
+++ b/src/CST.Avalonia/Models/ScriptKeys.cs
@@ -1,0 +1,31 @@
+using System;
+using CST.Conversion;
+
+namespace CST.Avalonia.Models;
+
+/// <summary>
+/// Single source of truth for the string keys used to index per-script settings (e.g.
+/// <see cref="FontSettings.ScriptFonts"/>). The on-disk format keeps string keys for backward
+/// compatibility, but every key must correspond to a <see cref="Script"/> enum member, so callers
+/// go through here instead of sprinkling magic strings / raw <c>script.ToString()</c> calls. (#78)
+/// </summary>
+public static class ScriptKeys
+{
+    /// <summary>The canonical key for a script (its enum name, matching the persisted dictionary keys).</summary>
+    public static string Of(Script script) => script.ToString();
+
+    /// <summary>True if <paramref name="key"/> is exactly the name of a defined <see cref="Script"/> member.</summary>
+    public static bool IsValidKey(string? key) => TryParse(key, out _);
+
+    /// <summary>
+    /// Parse a persisted key back to its <see cref="Script"/>. Case-sensitive and numeric-rejecting so that
+    /// only real enum names (the values <see cref="Of"/> produces) round-trip.
+    /// </summary>
+    public static bool TryParse(string? key, out Script script)
+    {
+        script = default;
+        if (string.IsNullOrEmpty(key) || char.IsDigit(key[0]) || key[0] == '-')
+            return false; // reject the numeric forms Enum.TryParse would otherwise accept
+        return Enum.TryParse(key, ignoreCase: false, out script) && Enum.IsDefined(typeof(Script), script);
+    }
+}

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -1,9 +1,15 @@
 using System.Collections.Generic;
+using CST.Conversion;
 
 namespace CST.Avalonia.Models
 {
     public class Settings
     {
+        /// <summary>
+        /// Settings-file schema version, for backward-compatible migration. (#78)
+        /// </summary>
+        public string Version { get; set; } = "1.0";
+
         public string XmlBooksDirectory { get; set; } = "";
         public string IndexDirectory { get; set; } = "";  // Empty means use default
         public FontSettings FontSettings { get; set; } = new();
@@ -53,6 +59,13 @@ namespace CST.Avalonia.Models
                 ["Tibetan"] = new ScriptFontSetting { FontFamily = "", FontSize = 14 }
             };
         }
+
+        /// <summary>
+        /// Typed lookup of a script's font setting. Centralizes the <see cref="ScriptKeys"/> mapping so callers
+        /// use the <see cref="Script"/> enum instead of raw string keys. (#78)
+        /// </summary>
+        public bool TryGetFont(Script script, out ScriptFontSetting? setting) =>
+            ScriptFonts.TryGetValue(ScriptKeys.Of(script), out setting);
     }
     
     public class ScriptFontSetting

--- a/src/CST.Avalonia/Models/SettingsValidator.cs
+++ b/src/CST.Avalonia/Models/SettingsValidator.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CST.Avalonia.Models;
+
+/// <summary>
+/// Pure (no I/O, no DI) validation, sanitization, and version-migration for <see cref="Settings"/>. Runs on
+/// load so malformed/older settings files self-heal cleanly. Directly unit-testable. (#78)
+/// </summary>
+public static class SettingsValidator
+{
+    /// <summary>Current settings-file schema version. Bump + add a step in <see cref="Migrate"/> on a breaking change.</summary>
+    public const string CurrentVersion = "1.0";
+
+    private static readonly HashSet<string> ValidLogLevels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Trace", "Debug", "Information", "Warning", "Error", "Critical", "None"
+    };
+
+    /// <summary>Upgrade an older / missing-version settings object to <see cref="CurrentVersion"/>. Returns notes.</summary>
+    public static IReadOnlyList<string> Migrate(Settings settings)
+    {
+        var notes = new List<string>();
+        if (settings == null) return notes;
+
+        var v = (settings.Version ?? string.Empty).Trim();
+        if (v.Length == 0)
+        {
+            settings.Version = CurrentVersion;
+            notes.Add($"settings had no version; stamped {CurrentVersion}");
+            return notes;
+        }
+
+        // --- ordered migration steps go here as the schema evolves ---
+
+        if (ApplicationStateValidator.CompareVersions(v, CurrentVersion) > 0)
+        {
+            notes.Add($"settings version {v} is newer than supported {CurrentVersion}; reading as-is");
+            return notes;
+        }
+        if (v != CurrentVersion)
+        {
+            settings.Version = CurrentVersion;
+            notes.Add($"migrated settings {v} -> {CurrentVersion}");
+        }
+        return notes;
+    }
+
+    /// <summary>
+    /// Repair invalid settings in place (bad paths, unknown log level, non-positive font sizes, stray repo
+    /// fields, script-font keys that are not real scripts). Idempotent. Returns the fixes applied.
+    /// </summary>
+    public static IReadOnlyList<string> Sanitize(Settings settings)
+    {
+        var fixes = new List<string>();
+        if (settings == null) return fixes;
+
+        // Directory paths: a non-existent path is fine (created on demand), but one with illegal characters is
+        // not - clear it so the app falls back to its default rather than throwing later.
+        if (HasInvalidPathChars(settings.XmlBooksDirectory))
+        {
+            settings.XmlBooksDirectory = "";
+            fixes.Add("cleared XmlBooksDirectory (contained invalid path characters)");
+        }
+        if (HasInvalidPathChars(settings.IndexDirectory))
+        {
+            settings.IndexDirectory = "";
+            fixes.Add("cleared IndexDirectory (contained invalid path characters)");
+        }
+
+        // Developer log level
+        var dev = settings.DeveloperSettings ??= new DeveloperSettings();
+        if (string.IsNullOrWhiteSpace(dev.LogLevel) || !ValidLogLevels.Contains(dev.LogLevel))
+        {
+            var bad = dev.LogLevel;
+            dev.LogLevel = "Information";
+            fixes.Add($"log level '{bad}' -> Information");
+        }
+
+        // XML update repository fields
+        var xml = settings.XmlUpdateSettings ??= new XmlUpdateSettings();
+        if (string.IsNullOrWhiteSpace(xml.XmlRepositoryOwner)) { xml.XmlRepositoryOwner = "VipassanaTech"; fixes.Add("xml repo owner -> VipassanaTech"); }
+        if (string.IsNullOrWhiteSpace(xml.XmlRepositoryName)) { xml.XmlRepositoryName = "tipitaka-xml"; fixes.Add("xml repo name -> tipitaka-xml"); }
+        if (string.IsNullOrWhiteSpace(xml.XmlRepositoryBranch)) { xml.XmlRepositoryBranch = "main"; fixes.Add("xml repo branch -> main"); }
+
+        // Fonts
+        var fonts = settings.FontSettings ??= new FontSettings();
+        if (fonts.LocalizationFontSize <= 0) { fonts.LocalizationFontSize = 12; fixes.Add("localization font size -> 12"); }
+        fonts.ScriptFonts ??= new Dictionary<string, ScriptFontSetting>();
+
+        // Drop any script-font key that is not a real Script enum name (magic-string guard, #78)
+        foreach (var key in fonts.ScriptFonts.Keys.Where(k => !ScriptKeys.IsValidKey(k)).ToList())
+        {
+            fonts.ScriptFonts.Remove(key);
+            fixes.Add($"removed unknown script-font key '{key}'");
+        }
+        // Replace any null setting (keys materialized first so we don't mutate the dict mid-enumeration).
+        foreach (var key in fonts.ScriptFonts.Where(kv => kv.Value == null).Select(kv => kv.Key).ToList())
+        {
+            fonts.ScriptFonts[key] = new ScriptFontSetting();
+            fixes.Add($"script-font '{key}' was null; reset to default");
+        }
+        // Clamp non-positive sizes (mutates the value object only, never the dictionary itself).
+        foreach (var kvp in fonts.ScriptFonts)
+        {
+            if (kvp.Value.FontSize <= 0)
+            {
+                kvp.Value.FontSize = 12;
+                fixes.Add($"script-font '{kvp.Key}' size -> 12");
+            }
+        }
+
+        return fixes;
+    }
+
+    private static bool HasInvalidPathChars(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return false; // empty = "use default", not invalid
+        return path.IndexOfAny(Path.GetInvalidPathChars()) >= 0;
+    }
+}

--- a/src/CST.Avalonia/Services/ApplicationStateService.cs
+++ b/src/CST.Avalonia/Services/ApplicationStateService.cs
@@ -148,24 +148,19 @@ public class ApplicationStateService : IApplicationStateService, IDisposable
                 return false;
             }
 
-            // Validate loaded state
-            var validation = await ValidateLoadedState(state);
-            if (!validation.IsValid)
-            {
-                _logger.LogWarning("Loaded state validation failed: {Errors}", 
-                    string.Join(", ", validation.Errors));
-                
-                if (!validation.CanRecover)
-                {
-                    _logger.LogError("State is corrupted and cannot be recovered, using default state");
-                    return false;
-                }
-                
-                // Apply fixes for recoverable issues
-                ApplyStateFixes(state, validation);
-            }
+            // Migrate older/missing-version files, then repair any invalid values in place (#78).
+            var migrationNotes = ApplicationStateValidator.Migrate(state);
+            foreach (var note in migrationNotes)
+                _logger.LogInformation("State migration: {Note}", note);
+            var stateFixes = ApplicationStateValidator.Sanitize(state);
+            foreach (var fix in stateFixes)
+                _logger.LogWarning("State sanitized: {Fix}", fix);
 
             Current = state;
+
+            // If we upgraded or repaired anything, persist it so the on-disk file is brought up to date.
+            if (migrationNotes.Count > 0 || stateFixes.Count > 0)
+                MarkDirty();
             // Don't fire StateChanged on load to prevent infinite loops
             // Initial state will be handled separately
             
@@ -395,9 +390,9 @@ public class ApplicationStateService : IApplicationStateService, IDisposable
         }
     }
 
-    public async Task<StateValidationResult> ValidateStateAsync()
+    public Task<StateValidationResult> ValidateStateAsync()
     {
-        return await ValidateLoadedState(Current);
+        return Task.FromResult(ApplicationStateValidator.Validate(Current));
     }
 
     public string[] GetBackupFilePaths()
@@ -461,18 +456,15 @@ public class ApplicationStateService : IApplicationStateService, IDisposable
                     
                     if (state != null)
                     {
-                        var validation = await ValidateLoadedState(state);
-                        if (validation.IsValid || validation.CanRecover)
-                        {
-                            if (!validation.IsValid)
-                                ApplyStateFixes(state, validation);
-                                
-                            Current = state;
-                            FireStateChangedEvent();
-                            
-                            _logger.LogInformation("Loaded application state from backup: {BackupPath}", backupPath);
-                            return true;
-                        }
+                        // Migrate + sanitize the backup the same way as the primary file (#78).
+                        ApplicationStateValidator.Migrate(state);
+                        ApplicationStateValidator.Sanitize(state);
+
+                        Current = state;
+                        FireStateChangedEvent();
+
+                        _logger.LogInformation("Loaded application state from backup: {BackupPath}", backupPath);
+                        return true;
                     }
                 }
                 catch (Exception ex)
@@ -490,66 +482,6 @@ public class ApplicationStateService : IApplicationStateService, IDisposable
         }
     }
 
-    private async Task<StateValidationResult> ValidateLoadedState(ApplicationState state)
-    {
-        var result = new StateValidationResult { IsValid = true, CanRecover = true };
-        var errors = new List<string>();
-        var warnings = new List<string>();
-
-        // Validate version compatibility
-        if (string.IsNullOrEmpty(state.Version))
-        {
-            warnings.Add("Missing version information");
-            result.IsValid = false;
-        }
-
-        // Validate main window state
-        if (state.MainWindow.Width <= 0 || state.MainWindow.Height <= 0)
-        {
-            warnings.Add("Invalid main window dimensions");
-            result.IsValid = false;
-        }
-
-        // Validate book window states
-        foreach (var bookWindow in state.BookWindows)
-        {
-            if (bookWindow.BookIndex < 0)
-            {
-                warnings.Add($"Invalid book index: {bookWindow.BookIndex}");
-                result.IsValid = false;
-            }
-        }
-
-        // (Tree expansion is now identity-keyed (#64), so no positional count/version consistency check.)
-
-        result.Errors = errors.ToArray();
-        result.Warnings = warnings.ToArray();
-
-        if (!result.IsValid && warnings.Count > 0 && errors.Count == 0)
-        {
-            result.SuggestedAction = "State has warnings but can be recovered with fixes";
-        }
-        else if (errors.Count > 0)
-        {
-            result.CanRecover = false;
-            result.SuggestedAction = "State is corrupted - recommend clearing and starting fresh";
-        }
-
-        return result;
-    }
-
-    private void ApplyStateFixes(ApplicationState state, StateValidationResult validation)
-    {
-        // Fix invalid window dimensions
-        if (state.MainWindow.Width <= 0) state.MainWindow.Width = 1024;
-        if (state.MainWindow.Height <= 0) state.MainWindow.Height = 768;
-
-        // Remove invalid book windows
-        state.BookWindows.RemoveAll(w => w.BookIndex < 0);
-
-        _logger.LogInformation("Applied fixes to application state");
-    }
-    
     /// <summary>
     /// Force immediate save of state (for shutdown scenarios)
     /// </summary>

--- a/src/CST.Avalonia/Services/FontService.cs
+++ b/src/CST.Avalonia/Services/FontService.cs
@@ -41,7 +41,7 @@ namespace CST.Avalonia.Services
         {
             var scriptName = script.ToString();
             _logger.LogDebug("[FONT SERVICE] GetScriptFontFamily called for script: {Script}", scriptName);
-            if (CurrentFontSettings.ScriptFonts.TryGetValue(scriptName, out var setting))
+            if (CurrentFontSettings.TryGetFont(script, out var setting) && setting != null)
             {
                 var fontFamily = setting.FontFamily;
                 _logger.LogDebug("[FONT SERVICE] Font family for {Script}: '{FontFamily}' (null/empty=system default)", scriptName, fontFamily ?? "null");
@@ -58,7 +58,7 @@ namespace CST.Avalonia.Services
         public int GetScriptFontSize(Script script)
         {
             var scriptName = script.ToString();
-            if (CurrentFontSettings.ScriptFonts.TryGetValue(scriptName, out var setting))
+            if (CurrentFontSettings.TryGetFont(script, out var setting) && setting != null)
             {
                 _logger.LogDebug("Font size for {Script}: {FontSize}", scriptName, setting.FontSize);
                 return setting.FontSize;

--- a/src/CST.Avalonia/Services/SettingsService.cs
+++ b/src/CST.Avalonia/Services/SettingsService.cs
@@ -51,8 +51,20 @@ namespace CST.Avalonia.Services
                     
                     if (loadedSettings != null)
                     {
+                        // Migrate older/missing-version files, then repair any invalid values in place (#78).
+                        var notes = SettingsValidator.Migrate(loadedSettings);
+                        foreach (var note in notes)
+                            _logger.Information("Settings migration: {Note}", note);
+                        var fixes = SettingsValidator.Sanitize(loadedSettings);
+                        foreach (var fix in fixes)
+                            _logger.Warning("Settings sanitized: {Fix}", fix);
+
                         _settings = loadedSettings;
                         _logger.Information("Settings loaded successfully from {Path}", _settingsFilePath);
+
+                        // Persist the upgraded/repaired settings so the on-disk file is brought up to date.
+                        if (notes.Count > 0 || fixes.Count > 0)
+                            RequestSave();
                     }
                     else
                     {


### PR DESCRIPTION
Closes #78.

## Summary

Adds **load-time self-healing** for the persisted `ApplicationState` and `Settings` files: a version-migration framework, value validation/sanitization, and enforcement of the `Script` enum for the font dictionary's keys (replacing magic strings). All logic is **pure (no I/O, no DI)** so it's directly unit-tested — no UI run required.

## What's added

- **`ApplicationStateValidator`** (pure)
  - `Migrate`: stamps a missing version, upgrades older versions via ordered steps (extension point in place), and reads a newer-than-supported version as-is (forward compatible).
  - `Sanitize`: repairs NaN/Infinity/non-positive window, dialog, and book sizes; clears NaN/Infinity X/Y; drops book-window and recent-book entries with negative indices; clamps proximity distance, hit index, total hits, tab index, and max-recent; trims the recent list to its max. Idempotent.
  - `Validate`: non-mutating report backing `IApplicationStateService.ValidateStateAsync`.
- **`SettingsValidator`** (pure): same migration shape + `Sanitize` for invalid path characters, unknown log levels, empty repo fields, non-positive font sizes, and **script-font keys that aren't real scripts**.
- **`ScriptKeys`**: single source of truth mapping the font dictionary's string keys ↔ the `Script` enum (case-sensitive, numeric-rejecting). `FontSettings.TryGetFont(Script)` is the new typed accessor; `FontService` now uses it instead of raw `script.ToString()` lookups.

## Wiring

- `ApplicationStateService.LoadStateAsync` / `TryLoadFromBackupAsync` and `SettingsService.LoadSettingsAsync` now migrate + sanitize on load, and **mark the file dirty / request a save when a load actually changed something**, so upgrades persist. Replaces the old minimal inline `ValidateLoadedState`/`ApplyStateFixes`.
- `Settings` gains a `Version` field for symmetric migration.

## Compatibility & verification

- **On-disk formats are unchanged** — script-font keys stay string enum-names, so existing settings/state files load as-is (and self-upgrade where needed).
- **43 new unit tests** in `StateValidationTests` (migration, sanitize edge cases incl. a round-trip "old JSON file upgrades cleanly", settings sanitize, ScriptKeys, typed font lookup). Full suite green: **350 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)