### PR TITLE
#46: resolve the 7 skipped tests (clean 0-skipped run)

### DIFF
--- a/src/CST.Avalonia.Tests/BugFix/DefaultIndexDirectorySettingTest.cs
+++ b/src/CST.Avalonia.Tests/BugFix/DefaultIndexDirectorySettingTest.cs
@@ -58,7 +58,7 @@ namespace CST.Avalonia.Tests.BugFix
                 Directory.Delete(_testAppDataDir, true);
         }
 
-        [Fact(Skip = "Mock settings service validation issue - revisit post Beta 3")]
+        [Fact]
         public async Task DefaultIndexDirectory_GetsSavedToSettings_OnFirstRun()
         {
             // Arrange
@@ -73,9 +73,10 @@ namespace CST.Avalonia.Tests.BugFix
 
             // Assert
             // After initialization, the IndexDirectory should be populated with the default path
+            // (.../<AppDataDirectoryName>/index, e.g. ".../CSTReader/index").
             Assert.NotEmpty(_testSettings.IndexDirectory);
-            Assert.Contains("CST.Avalonia", _testSettings.IndexDirectory);
-            Assert.Contains("Index", _testSettings.IndexDirectory);
+            Assert.Contains("CSTReader", _testSettings.IndexDirectory);
+            Assert.EndsWith("index", _testSettings.IndexDirectory);
             
             _output.WriteLine($"Final IndexDirectory setting: '{_testSettings.IndexDirectory}'");
 

--- a/src/CST.Avalonia.Tests/BugFix/IncrementalIndexingOnlyChangedBooksTest.cs
+++ b/src/CST.Avalonia.Tests/BugFix/IncrementalIndexingOnlyChangedBooksTest.cs
@@ -117,43 +117,11 @@ namespace CST.Avalonia.Tests.BugFix
             _output.WriteLine("✅ Incremental indexing only processed the 1 changed book, not all books");
         }
 
-        [Fact(Skip = "Test incomplete - needs all 217 XML files or mocked Books catalog")]
-        public async Task InitialIndexing_ProcessesAllBooks_WhenNoChangedFiles()
-        {
-            // Arrange
-            var progressMessages = new List<string>();
-            var progress = new Progress<IndexingProgress>(p => 
-            {
-                progressMessages.Add(p.StatusMessage);
-                _output.WriteLine($"Progress: {p.StatusMessage}");
-            });
-
-            // Mock XmlFileDatesService to return empty changed books list (initial indexing)
-            var changedBooks = new List<int>(); // Empty list = initial indexing
-            _mockXmlFileDatesService.Setup(x => x.GetChangedBooksAsync()).ReturnsAsync(changedBooks);
-            
-            // Mock IsIndexValidAsync to return false so indexing proceeds
-            var indexingService = new IndexingService(
-                _mockLogger.Object, 
-                _mockSettingsService.Object, 
-                _mockXmlFileDatesService.Object);
-
-            await indexingService.InitializeAsync();
-
-            // Act
-            await indexingService.BuildIndexAsync(progress);
-
-            // Assert
-            // For initial indexing with empty changed files, it should process all books that need indexing
-            // This validates that the fix doesn't break initial indexing behavior
-            var indexingMessages = progressMessages.FindAll(m => m.Contains("Building search index."));
-            
-            _output.WriteLine($"\nFound {indexingMessages.Count} indexing progress messages for initial indexing");
-            
-            // Should have processed some books (exact count depends on Books.Inst implementation)
-            Assert.True(indexingMessages.Count >= 0, "Initial indexing should process books as needed");
-            
-            _output.WriteLine("✅ Initial indexing behavior preserved when no changed files specified");
-        }
+        // (Removed InitialIndexing_ProcessesAllBooks_WhenNoChangedFiles: it could not verify its premise at the
+        // unit level. It mocked GetChangedBooksAsync() to return an EMPTY list, but in BuildIndexAsync an empty
+        // changed-set means PerformIndexingAsync processes nothing - the "all books on first run" set comes from
+        // the real GetChangedBooksAsync, which the mock replaced. Its only assertion (Count >= 0) was trivially
+        // true. Full/initial indexing over the real catalog is exercised by the Integration tests
+        // (IndexingIntegrationTests / IncrementalIndexingTests). (#46)
     }
 }

--- a/src/CST.Avalonia.Tests/Services/IndexingServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/IndexingServiceTests.cs
@@ -113,7 +113,7 @@ namespace CST.Avalonia.Tests.Services
             Assert.Null(ex);
         }
 
-        [Fact(Skip = "Mock settings service not triggering SaveSettingsAsync - revisit post Beta 3")]
+        [Fact]
         public async Task InitializeAsync_WithConfiguredIndexDirectory_UsesConfiguredDirectory()
         {
             // Act
@@ -122,19 +122,21 @@ namespace CST.Avalonia.Tests.Services
             // Assert
             Assert.Equal(_testIndexDir, _service.IndexDirectory);
             Assert.True(Directory.Exists(_testIndexDir));
-            _mockXmlFileDatesService.Verify(x => x.InitializeAsync(), Times.Once);
+            // (XmlFileDatesService.InitializeAsync is no longer called from IndexingService.InitializeAsync -
+            //  it was moved to CheckForXmlUpdatesAsync - so that verification was removed. (#46))
         }
 
-        [Fact(Skip = "Mock settings service not triggering SaveSettingsAsync - revisit post Beta 3")]
+        [Fact]
         public async Task InitializeAsync_WithEmptyIndexDirectory_UsesDefaultDirectory()
         {
             // Arrange
             _mockSettingsService.Setup(s => s.Settings)
-                .Returns(new Settings 
-                { 
+                .Returns(new Settings
+                {
                     IndexDirectory = "",
                     XmlBooksDirectory = _testXmlDir
                 });
+            _mockSettingsService.Setup(s => s.SaveSettingsAsync()).Returns(Task.CompletedTask);
 
             var service = new IndexingService(_mockLogger.Object, _mockSettingsService.Object, _mockXmlFileDatesService.Object);
 
@@ -144,7 +146,8 @@ namespace CST.Avalonia.Tests.Services
             // Assert
             Assert.NotEmpty(service.IndexDirectory);
             Assert.NotEqual(_testIndexDir, service.IndexDirectory); // Should use default, not configured
-            _mockXmlFileDatesService.Verify(x => x.InitializeAsync(), Times.Once);
+            // Defaulting persists the chosen directory back to settings.
+            _mockSettingsService.Verify(s => s.SaveSettingsAsync(), Times.Once);
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Services/MacFontServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/MacFontServiceTests.cs
@@ -27,26 +27,9 @@ namespace CST.Avalonia.Tests.Services
             _mockSettingsService = new Mock<ISettingsService>();
         }
 
-        [Fact(Skip = "Test outdated - GetLanguageCodeForScript method no longer exists")]
-        public void MacFontService_LanguageCodeMapping_ReturnsCorrectCodes()
-        {
-            // Arrange
-            var macFontService = new MacFontService(_mockLogger.Object);
-
-            // Act & Assert - Test language code mapping using reflection since the method is private
-            var getLanguageCodeMethod = typeof(MacFontService).GetMethod("GetLanguageCodeForScript", 
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            
-            Assert.NotNull(getLanguageCodeMethod);
-
-            // Test various scripts
-            Assert.Equal("hi", getLanguageCodeMethod.Invoke(null, new object[] { Script.Devanagari }));
-            Assert.Equal("bn", getLanguageCodeMethod.Invoke(null, new object[] { Script.Bengali }));
-            Assert.Equal("en", getLanguageCodeMethod.Invoke(null, new object[] { Script.Latin }));
-            Assert.Equal("my", getLanguageCodeMethod.Invoke(null, new object[] { Script.Myanmar }));
-            Assert.Equal("th", getLanguageCodeMethod.Invoke(null, new object[] { Script.Thai }));
-            Assert.Null(getLanguageCodeMethod.Invoke(null, new object[] { (Script)999 })); // Invalid script
-        }
+        // (Removed MacFontService_LanguageCodeMapping_ReturnsCorrectCodes: it reflected on the private static
+        // GetLanguageCodeForScript, which no longer exists - the implementation switched to a character-set
+        // based approach (GetSampleCharactersForScript). The current behaviour is covered below. (#46))
 
         [Fact]
         public void MacFontService_CoreFoundation_DiagnosticTest()
@@ -118,26 +101,29 @@ namespace CST.Avalonia.Tests.Services
         private IntPtr MacFontService_TestDlopen(string path) => dlopen(path, 0);
         private IntPtr MacFontService_TestDlsym(IntPtr handle, string symbol) => dlsym(handle, symbol);
 
-        [Fact(Skip = "Test outdated - implementation now returns fallback fonts for unsupported scripts")]
-        public async Task MacFontService_GetAvailableFontsForScriptAsync_HandlesUnsupportedScript()
+        [Fact]
+        public async Task MacFontService_GetAvailableFontsForScriptAsync_UnsupportedScript_ReturnsFallbackFonts()
         {
-            // This test can run on any platform since it tests the early return path
+            // An unrecognized script has no sample characters, so the service returns its generic fallback
+            // font list (no Core Text query needed) and logs a warning. Runs on any platform - this path does
+            // not touch the macOS font APIs.
             // Arrange
             var macFontService = new MacFontService(_mockLogger.Object);
 
             // Act
             var result = await macFontService.GetAvailableFontsForScriptAsync((Script)999);
 
-            // Assert
+            // Assert - generic fallback set, not empty
             Assert.NotNull(result);
-            Assert.Empty(result);
+            Assert.NotEmpty(result);
+            Assert.Contains("Arial", result);
 
-            // Verify warning was logged
+            // Verify the "no sample characters" warning was logged
             _mockLogger.Verify(
                 x => x.Log(
                     LogLevel.Warning,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("No language code mapping")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("No sample characters available")),
                     It.IsAny<Exception>(),
                     It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
@@ -332,36 +318,9 @@ namespace CST.Avalonia.Tests.Services
             }
         }
 
-        [Fact(Skip = "Test requires Avalonia font manager infrastructure not available in test environment")]
-        public async Task FontService_GetAvailableFontsForScriptAsync_UsesFallbackOnNonMacOS()
-        {
-            // This test simulates non-macOS behavior by not providing MacFontService
-            // Arrange
-            var mockSettings = new CST.Avalonia.Models.Settings();
-            _mockSettingsService.Setup(x => x.Settings).Returns(mockSettings);
-            
-            // Create FontService without MacFontService (simulates non-macOS)
-            var fontService = new FontService(_mockSettingsService.Object, _mockFontServiceLogger.Object);
-
-            // Act
-            var result = await fontService.GetAvailableFontsForScriptAsync(Script.Devanagari);
-
-            // Assert
-            Assert.NotNull(result);
-            _output.WriteLine($"FontService fallback returned {result.Count} fonts");
-            
-            // The fallback should return all system fonts
-            Assert.True(result.Count > 0, "Fallback should return at least some system fonts");
-
-            // Verify that the FontService logged that it's using fallback
-            _mockFontServiceLogger.Verify(
-                x => x.Log(
-                    LogLevel.Debug,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Using fallback method")),
-                    It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-                Times.Once);
-        }
+        // (Removed FontService_GetAvailableFontsForScriptAsync_UsesFallbackOnNonMacOS: the non-macOS fallback
+        // path calls Avalonia's FontManager.Current.SystemFonts, which requires an initialized Avalonia
+        // application that the headless unit-test host doesn't provide - it exercised the framework's font
+        // enumeration rather than our logic. (#46))
     }
 }


### PR DESCRIPTION
Closes #46.

## Summary

Took the suite from **225 passing / 7 skipped** to **363 passing / 0 skipped**. Each skip was a stale test or assertion (test-infrastructure debt, not a production bug); diagnosed and either fixed or removed it.

## Fixed (now run + pass)

- **`DefaultIndexDirectory_GetsSavedToSettings_OnFirstRun`** — asserted the default path contained `"CST.Avalonia"` and `"Index"`, but it's `.../CSTReader/index`. Corrected to `"CSTReader"` + ends-with `"index"`. (The skip note blamed a mock issue; the real cause was wrong assertions — its sibling tests already exercise the same `InitializeAsync`.)
- **`IndexingService.InitializeAsync_WithConfiguredIndexDirectory` / `_WithEmptyIndexDirectory`** — removed the obsolete `_mockXmlFileDatesService.Verify(InitializeAsync, Once)`; that call was moved out of `IndexingService.InitializeAsync` (into `CheckForXmlUpdatesAsync`). For the empty-dir case, assert the real behavior instead — `SaveSettingsAsync` called once — and set up that mock.
- **`MacFontService` unsupported-script test** — rewritten to the current contract: an unknown script returns the generic fallback font list and logs `"No sample characters available"` (it used to expect an empty list + `"No language code mapping"`).

## Removed (obsolete / not unit-testable)

- **`MacFontService_LanguageCodeMapping_ReturnsCorrectCodes`** — reflected on a private static `GetLanguageCodeForScript` that no longer exists (the implementation switched to a character-set approach).
- **`FontService_..._UsesFallbackOnNonMacOS`** — the fallback path calls Avalonia `FontManager.Current.SystemFonts`, which requires an initialized Avalonia application the headless unit-test host doesn't provide; it exercised framework behavior, not our logic.
- **`InitialIndexing_ProcessesAllBooks_WhenNoChangedFiles`** — mocked `GetChangedBooksAsync()` to return an **empty** list, so `PerformIndexingAsync` processes nothing; it couldn't verify "all books" (that set comes from the real service the mock replaced), and its only assertion was `Count >= 0`. Full/initial indexing over the real catalog is covered by the Integration tests.

Each change is annotated in-place with the reason. Full suite: **363 passed, 0 failed, 0 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)