### PR TITLE
#117 (DICT-1): render merged-headword definition breaks instead of a literal <hr/>

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionaryOracleTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryOracleTests.cs
@@ -57,9 +57,10 @@ public class DictionaryOracleTests
         if (!DataPresent) return;
         var (words, meaning) = await LookupLatn("en", "abbhuto");
         Assert.Equal("abbhuto", words[0]);
-        // Both definitions of the repeated headword, joined by the separator.
+        // Both definitions of the repeated headword, joined by the separator sentinel (the renderer
+        // turns that sentinel into a visual break — see MeaningParserTests, DICT-1).
         Assert.Contains("Mysterious", meaning);
         Assert.Contains("Marvellous", meaning);
-        Assert.Contains("<hr/>", meaning);
+        Assert.Contains(DictionaryService.MeaningSeparator, meaning);
     }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/MeaningParserTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/MeaningParserTests.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+using CST.Avalonia.Services;
+using CST.Avalonia.ViewModels;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// Tests for <see cref="MeaningParser"/>, which splits a dictionary definition fragment into renderable
+/// segments. The key regression is DICT-1: the merge separator between duplicate-headword definitions
+/// must become a <see cref="MeaningSegment.Separator"/>, never a literal text run.
+/// </summary>
+public class MeaningParserTests
+{
+    // Identity link display so assertions don't depend on script conversion.
+    private static System.Collections.Generic.IReadOnlyList<MeaningSegment> Parse(string html)
+        => MeaningParser.Parse(html, s => s);
+
+    [Fact]
+    public void EmptyOrNull_YieldsNoSegments()
+    {
+        Assert.Empty(Parse(""));
+        Assert.Empty(MeaningParser.Parse(null, s => s));
+    }
+
+    [Fact]
+    public void PlainText_IsOneTextSegment()
+    {
+        var segs = Parse("Agreement, combination");
+        var seg = Assert.Single(segs);
+        Assert.False(seg.IsLink);
+        Assert.False(seg.IsSeparator);
+        Assert.Equal("Agreement, combination", seg.Text);
+    }
+
+    [Fact]
+    public void SeeTag_BecomesLinkSegmentWithTarget()
+    {
+        var segs = Parse("see <see>dhammo</see>");
+        Assert.Equal(2, segs.Count);
+        Assert.Equal("see ", segs[0].Text);
+        Assert.False(segs[0].IsLink);
+        Assert.True(segs[1].IsLink);
+        Assert.Equal("dhammo", segs[1].Text);
+        Assert.Equal("dhammo", segs[1].Target);
+    }
+
+    [Fact]
+    public void MergedDefinitions_ProduceSeparator_NotLiteralTag()
+    {
+        // DICT-1: two definitions joined by the sentinel must render as text + separator + text,
+        // and the raw sentinel must never appear in any segment's text.
+        var html = "Mysterious; wonderful, portentous"
+                   + DictionaryService.MeaningSeparator
+                   + "The Marvellous; a gambler's stake";
+
+        var segs = Parse(html);
+
+        Assert.Equal(3, segs.Count);
+        Assert.Equal("Mysterious; wonderful, portentous", segs[0].Text);
+        Assert.True(segs[1].IsSeparator);
+        Assert.False(segs[1].IsLink);
+        Assert.Equal("The Marvellous; a gambler's stake", segs[2].Text);
+        Assert.DoesNotContain(segs, s => s.Text.Contains(DictionaryService.MeaningSeparator));
+    }
+
+    [Fact]
+    public void ThreeMergedDefinitions_YieldTwoSeparators()
+    {
+        var sep = DictionaryService.MeaningSeparator;
+        var segs = Parse("a" + sep + "b" + sep + "c");
+        Assert.Equal(5, segs.Count);
+        Assert.Equal(new[] { false, true, false, true, false }, segs.Select(s => s.IsSeparator).ToArray());
+        Assert.Equal(new[] { "a", "b", "c" }, segs.Where(s => !s.IsSeparator).Select(s => s.Text).ToArray());
+    }
+
+    [Fact]
+    public void LeadingWhitespace_InEachDefinition_IsTrimmed()
+    {
+        var sep = DictionaryService.MeaningSeparator;
+        var segs = Parse(" first" + sep + " second");
+        Assert.Equal("first", segs[0].Text);
+        Assert.Equal("second", segs[2].Text);
+    }
+
+    [Fact]
+    public void HtmlEntities_AreDecoded()
+    {
+        var seg = Assert.Single(Parse("a &amp; b"));
+        Assert.Equal("a & b", seg.Text);
+    }
+}

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -21,9 +21,13 @@ namespace CST.Avalonia.Services;
 /// </summary>
 public sealed class DictionaryService : IDictionaryService
 {
-    // Separator inserted between the definitions of a repeated headword within a file. (CST4's English
-    // loader used a malformed "</p><hr/<p>"; this emits valid markup.)
-    private const string MeaningSeparator = "<hr/>";
+    /// <summary>
+    /// Sentinel inserted between the definitions of a repeated headword within a file (a merged entry).
+    /// The dictionary renderer splits on this and shows a visual break; it is not HTML that any WebView
+    /// renders. Shared here so the loader and the renderer (<c>MeaningParser</c>) cannot drift.
+    /// (CST4's English loader used a malformed <c>"&lt;/p&gt;&lt;hr/&lt;p&gt;"</c>.)
+    /// </summary>
+    public const string MeaningSeparator = "<hr/>";
 
     private readonly ILogger<DictionaryService> _logger;
     private readonly string _dictionariesDirectory;

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -2,12 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Net;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CST.Avalonia.Services;
@@ -26,8 +24,6 @@ namespace CST.Avalonia.ViewModels;
 /// </summary>
 public class DictionaryViewModel : ReactiveTool, IDisposable
 {
-    private static readonly Regex SeeTag = new(@"<see>(.*?)</see>", RegexOptions.Compiled | RegexOptions.Singleline);
-
     private readonly IDictionaryService _dictionaryService;
     private readonly IScriptService _scriptService;
     private readonly IFontService _fontService;
@@ -187,36 +183,8 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
 
     private void UpdateMeaning()
     {
-        var meaning = SelectedWord?.Source.Meaning;
-        MeaningSegments = string.IsNullOrEmpty(meaning)
-            ? Array.Empty<MeaningSegment>()
-            : ParseMeaning(meaning);
+        MeaningSegments = MeaningParser.Parse(SelectedWord?.Source.Meaning, PaliToDisplay);
     }
-
-    // Split an HTML definition fragment into plain-text runs and <see>word</see> link runs.
-    private IReadOnlyList<MeaningSegment> ParseMeaning(string html)
-    {
-        var segments = new List<MeaningSegment>();
-        int pos = 0;
-        foreach (Match m in SeeTag.Matches(html))
-        {
-            if (m.Index > pos)
-                segments.Add(new MeaningSegment(Decode(html.Substring(pos, m.Index - pos)), false, null));
-
-            var target = m.Groups[1].Value.Trim();
-            segments.Add(new MeaningSegment(PaliToDisplay(target), true, target));
-            pos = m.Index + m.Length;
-        }
-        if (pos < html.Length)
-            segments.Add(new MeaningSegment(Decode(html.Substring(pos)), false, null));
-
-        // Some source definitions carry a leading space (e.g. the "a" entry); don't render it as an indent.
-        if (segments.Count > 0 && !segments[0].IsLink)
-            segments[0] = segments[0] with { Text = segments[0].Text.TrimStart() };
-        return segments;
-    }
-
-    private static string Decode(string s) => WebUtility.HtmlDecode(s);
 
     // A stored IPE headword -> the user's current display script.
     private string IpeToDisplay(string ipe)
@@ -286,5 +254,13 @@ public sealed class DictionaryEntryViewModel
     public string DisplayWord { get; }
 }
 
-/// <summary>A piece of a rendered definition: literal text, or a clickable <c>&lt;see&gt;</c> cross-reference.</summary>
-public sealed record MeaningSegment(string Text, bool IsLink, string? Target);
+/// <summary>
+/// A piece of a rendered definition: literal text, a clickable <c>&lt;see&gt;</c> cross-reference
+/// (<see cref="IsLink"/>), or a break between the definitions of a merged headword
+/// (<see cref="IsSeparator"/>).
+/// </summary>
+public sealed record MeaningSegment(string Text, bool IsLink, string? Target, bool IsSeparator = false)
+{
+    /// <summary>A break rendered between the definitions of a merged (duplicate) headword.</summary>
+    public static readonly MeaningSegment Separator = new(string.Empty, false, null, true);
+}

--- a/src/CST.Avalonia/ViewModels/MeaningParser.cs
+++ b/src/CST.Avalonia/ViewModels/MeaningParser.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text.RegularExpressions;
+using CST.Avalonia.Services;
+
+namespace CST.Avalonia.ViewModels;
+
+/// <summary>
+/// Turns a dictionary definition fragment into renderable <see cref="MeaningSegment"/>s. The data is
+/// plain text plus two markers: <c>&lt;see&gt;word&lt;/see&gt;</c> cross-references, and the
+/// <see cref="DictionaryService.MeaningSeparator"/> that joins the definitions of a merged
+/// (duplicate) headword. Pure and UI-free so the parsing (including the separator handling — DICT-1) is
+/// directly unit-testable; the view renders the segments as native inlines.
+/// </summary>
+public static class MeaningParser
+{
+    private static readonly Regex SeeTag = new(@"<see>(.*?)</see>", RegexOptions.Compiled | RegexOptions.Singleline);
+
+    /// <summary>
+    /// Parse <paramref name="html"/> into segments. Each merged definition is emitted in order, with a
+    /// <see cref="MeaningSegment.Separator"/> between them; <c>&lt;see&gt;</c> targets are mapped to
+    /// display text via <paramref name="linkDisplay"/>.
+    /// </summary>
+    public static IReadOnlyList<MeaningSegment> Parse(string? html, Func<string, string> linkDisplay)
+    {
+        var segments = new List<MeaningSegment>();
+        if (string.IsNullOrEmpty(html))
+            return segments;
+
+        var definitions = html.Split(DictionaryService.MeaningSeparator, StringSplitOptions.None);
+        for (int d = 0; d < definitions.Length; d++)
+        {
+            if (d > 0)
+                segments.Add(MeaningSegment.Separator);
+            // Trim each definition's outer whitespace so a merged break (or a source's leading space,
+            // e.g. the "a" entry) doesn't render as a stray indent.
+            ParseDefinition(definitions[d].Trim(), linkDisplay, segments);
+        }
+        return segments;
+    }
+
+    private static void ParseDefinition(string html, Func<string, string> linkDisplay, List<MeaningSegment> segments)
+    {
+        int pos = 0;
+        foreach (Match m in SeeTag.Matches(html))
+        {
+            if (m.Index > pos)
+                segments.Add(new MeaningSegment(WebUtility.HtmlDecode(html.Substring(pos, m.Index - pos)), false, null));
+
+            var target = m.Groups[1].Value.Trim();
+            segments.Add(new MeaningSegment(linkDisplay(target), true, target));
+            pos = m.Index + m.Length;
+        }
+        if (pos < html.Length)
+            segments.Add(new MeaningSegment(WebUtility.HtmlDecode(html.Substring(pos)), false, null));
+    }
+}

--- a/src/CST.Avalonia/Views/DictionaryPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/DictionaryPanel.axaml.cs
@@ -43,7 +43,14 @@ public partial class DictionaryPanel : UserControl
         text.Inlines.Clear();
         foreach (var seg in segments)
         {
-            if (seg.IsLink)
+            if (seg.IsSeparator)
+            {
+                // Break between the definitions of a merged (duplicate) headword: a blank line, so the
+                // separator reads as a boundary instead of showing the raw sentinel (DICT-1).
+                text.Inlines.Add(new LineBreak());
+                text.Inlines.Add(new LineBreak());
+            }
+            else if (seg.IsLink)
             {
                 var link = new TextBlock { Text = seg.Text };
                 link.Classes.Add("dict-link");


### PR DESCRIPTION
Fixes #117 (DICT-1 from the 2026-07-01 code review).

## Problem

Duplicate headwords have their definitions joined by a `<hr/>` sentinel in `DictionaryService`, but the panel renderer (`DictionaryViewModel.ParseMeaning`) only understood `<see>` tags — so the ~337 duplicated English headwords (e.g. `abbhuto`, `aṃso`) showed a **literal `<hr/>`** in the middle of the definition.

## Fix

- Extract the definition parsing into a pure, UI-free **`MeaningParser`** that splits on the shared separator and emits a `MeaningSegment.Separator` between definitions.
- `MeaningSegment` gains an `IsSeparator` kind; `DictionaryPanel.BuildMeaning` renders it as a **blank line** (a visual break) instead of literal text.
- `DictionaryService.MeaningSeparator` is now a **public const** so the loader and renderer can't drift; the oracle test asserts against it rather than a hardcoded tag (addresses the review's "the oracle test pins the tag in" note).

## Tests

- New `MeaningParserTests` (7) — the DICT-1 regression (merge separator → `Separator` segment, never literal text), plus `<see>` links, HTML-entity decoding, multi-definition merges, and per-definition whitespace trimming.
- `DictionaryOracleTests.Abbhuto_*` updated to assert `DictionaryService.MeaningSeparator`.
- Full dictionary + parser suite: 28 passing; build clean (0 warnings).

## Notes

- The `<hr/>` sentinel is retained as the backend join marker (now documented as a non-HTML sentinel the renderer turns into a break) — no data change.
- A blank line is the pragmatic visual break for the single-`TextBlock` inline renderer; a full-width rule would need a different control and is out of scope here.
- Backend matching/loading logic is unchanged (the review's "verified-clean" items stand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)