### PR TITLE
#120 (DICT-4): normalize dictionary queries (strip joiners + NFC) before IPE conversion

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionaryServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryServiceTests.cs
@@ -95,6 +95,33 @@ public class DictionaryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Lookup_DecomposedDiacritics_MatchPrecomposedHeadword()
+    {
+        // DICT-4: headword stored precomposed (NFC) as "g\u0101th\u0101" (ā = U+0101); query pasted with the
+        // macron decomposed ("a" + U+0304). Without NFC normalization these produce different IPE keys
+        // and the exact match is silently lost.
+        WriteLang("en", "d.txt", "g\u0101th\u0101", "<p>a verse</p>");
+
+        var r = await Service().LookupAsync("en", "ga\u0304tha\u0304");
+
+        Assert.Single(r);
+        Assert.Contains("a verse", r[0].Meaning);
+    }
+
+    [Fact]
+    public async Task Lookup_PastedZeroWidthJoiners_StillMatches()
+    {
+        // DICT-4 (same class as SRCH-3): ZWNJ/ZWJ pasted into a Latin query would survive into the IPE
+        // key and match nothing unless stripped.
+        WriteLang("en", "d.txt", "dhamma", "<p>the teaching</p>");
+
+        var r = await Service().LookupAsync("en", "dha\u200Cm\u200Dma");
+
+        Assert.Single(r);
+        Assert.Contains("the teaching", r[0].Meaning);
+    }
+
+    [Fact]
     public async Task Lookup_RepeatedHeadword_MergesDefinitions()
     {
         WriteLang("en", "d.txt", "eva", "<p>indeed</p>", "eva", "<p>emphatic particle</p>");

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Constants;
 using CST.Avalonia.Models;
+using CST.Avalonia.Search;
 using CST.Conversion;
 using Microsoft.Extensions.Logging;
 
@@ -129,9 +131,12 @@ public sealed class DictionaryService : IDictionaryService
         if (index == null)
             return Array.Empty<DictionaryWord>();
 
-        // Normalize the query the same way headwords were normalized: lower-case (CST4 lower-cased the
-        // input box) then convert any script to IPE.
-        var ipeQuery = Any2Ipe.Convert(query.ToLowerInvariant());
+        // Normalize the pasted query so it matches the (NFC-clean) headwords: drop zero-width joiners
+        // (same class as SRCH-3 — reuse its stripper so the joiner set stays single-sourced), lower-case
+        // (CST4 lower-cased the input box), and compose to NFC so decomposed diacritics (e.g. a + U+0304
+        // instead of ā) don't produce a different IPE key. Then convert any script to IPE. (DICT-4)
+        var normalized = MultiWordSearch.StripJoiners(query).ToLowerInvariant().Normalize(NormalizationForm.FormC);
+        var ipeQuery = Any2Ipe.Convert(normalized);
         return index.Lookup(ipeQuery);
     }
 


### PR DESCRIPTION
Fixes #120 (DICT-4 from the 2026-07-01 code review). Same bug class as SRCH-3 (#115), in the dictionary path.

## Problem

`DictionaryService.LookupAsync` converted the query straight to IPE (`Any2Ipe.Convert(query.ToLowerInvariant())`) with no normalization, so two pasted-input cases silently lost an otherwise-exact match against the NFC-clean headwords:

1. **Decomposed diacritics** — a pasted `a` + U+0304 (combining macron) instead of precomposed `ā` (U+0101) produced a different IPE key than the headword.
2. **Zero-width joiners** — U+200C/U+200D in a Latin run were classified `Script.Unknown` and passed through into the IPE key, matching nothing (the SRCH-3 mechanism).

## Fix

In `LookupAsync`, before conversion:
- **Strip joiners**, reusing `MultiWordSearch.StripJoiners` so the joiner set stays single-sourced with SRCH-3.
- **`Normalize(NormalizationForm.FormC)`** so decomposed diacritics compose to the same form as the headwords.

Only the query side is touched (the data files are verified clean NFC), matching the SRCH-3 approach.

## Tests

- `Lookup_DecomposedDiacritics_MatchPrecomposedHeadword` — decomposed-macron query matches the precomposed headword.
- `Lookup_PastedZeroWidthJoiners_StillMatches` — query with pasted ZWNJ/ZWJ still matches.
- Non-Latin test inputs use `\u` escapes (repo convention). Build clean (0 warnings); dictionary suite 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)