### PR TITLE
#123 (CORE-4): culture-invariant case folding on the Pāli conversion paths

### DIFF
--- a/src/CST.Avalonia.Tests/Conversion/CultureInvariantCasingTests.cs
+++ b/src/CST.Avalonia.Tests/Conversion/CultureInvariantCasingTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Globalization;
+using CST.Conversion;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Conversion;
+
+/// <summary>
+/// CORE-4: Pāli case folding on the conversion hot paths must be culture-invariant. Under the Turkish
+/// (tr) / Azeri (az) locales the default ToLower/ToUpper map I and i through the dotted/dotless-i letters
+/// (dotless small i U+0131 / dotted capital I U+0130), which would corrupt Latin to IPE conversion
+/// (search silently fails) and Latin capitalization (wrong glyph). These tests force tr-TR and assert the
+/// ASCII mapping still holds. Non-Latin characters are written as \uXXXX escapes per repo convention.
+/// </summary>
+public class CultureInvariantCasingTests
+{
+    private const char DotlessSmallI = '\u0131';
+    private const char DottedCapitalI = '\u0130';
+
+    private static void InTurkishCulture(Action body)
+    {
+        var prev = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+        try { body(); }
+        finally { CultureInfo.CurrentCulture = prev; }
+    }
+
+    [Fact]
+    public void Latn2Ipe_Convert_CapitalI_FoldsToAscii_UnderTurkishCulture()
+    {
+        InTurkishCulture(() =>
+        {
+            // "Iti" must lower-case to ASCII "iti", not the dotless-i form (starts U+0131, no IPE mapping).
+            Assert.Equal(Latn2Ipe.Convert("iti"), Latn2Ipe.Convert("Iti"));
+            Assert.DoesNotContain(DotlessSmallI, Latn2Ipe.Convert("Iti"));
+        });
+    }
+
+    [Fact]
+    public void Latn2Ipe_Convert_MatchesFrozenReference_UnderTurkishCulture()
+    {
+        // The #86 oracle equivalence (Convert == ConvertReference) must hold even in a hostile locale.
+        InTurkishCulture(() =>
+        {
+            foreach (var s in new[] { "Iti", "BUDDHA", "Dhammo", "Idani", "III" })
+                Assert.Equal(Latn2Ipe.ConvertReference(s), Latn2Ipe.Convert(s));
+        });
+    }
+
+    [Fact]
+    public void ScriptConverter_ToTitleCase_UsesAsciiI_UnderTurkishCulture()
+    {
+        InTurkishCulture(() =>
+        {
+            Assert.Equal("Iti", ScriptConverter.ToTitleCase("iti"));
+            Assert.DoesNotContain(DottedCapitalI, ScriptConverter.ToTitleCase("iti"));
+        });
+    }
+
+    [Fact]
+    public void Deva2Latn_ConvertBook_CapitalizesWithAsciiI_UnderTurkishCulture()
+    {
+        // Devanagari "iti" (independent-i U+0907 + ta U+0924 + i-sign U+093F) at paragraph start. The
+        // capitalized first letter must be ASCII 'I', never the dotted '\u0130' the Turkish ToUpper produces.
+        var devaIti = "\u0907\u0924\u093F";
+        InTurkishCulture(() =>
+        {
+            var html = Deva2Latn.ConvertBook($"<p rend=\"bodytext\">{devaIti}</p>");
+            Assert.Contains("Iti", html);
+            Assert.DoesNotContain(DottedCapitalI.ToString(), html);
+        });
+    }
+}

--- a/src/CST.Core/Conversion/LatinCapitalizer.cs
+++ b/src/CST.Core/Conversion/LatinCapitalizer.cs
@@ -143,7 +143,8 @@ namespace CST.Conversion
 
         public string CapitalReplacer(Match m)
         {
-            return m.Value.Substring(1).ToUpper();
+            // Invariant upper-casing: on tr/az the default ToUpper maps 'i' to the dotted 'İ' (U+0130). (CORE-4)
+            return m.Value.Substring(1).ToUpperInvariant();
         }
 
         public string DebugRegex(Match m)

--- a/src/CST.Core/Conversion/Latn2Ipe.cs
+++ b/src/CST.Core/Conversion/Latn2Ipe.cs
@@ -106,7 +106,9 @@ namespace CST.Conversion
         public static string ConvertReference(string latn)
         {
             StringBuilder sb = new StringBuilder();
-            char[] arr = latn.ToLower().ToCharArray();
+            // Culture-invariant lower-casing: on tr/az locales the default ToLower maps 'I' to the dotless
+            // 'ı' (U+0131), which has no latn2Ipe entry and would corrupt the term. (CORE-4)
+            char[] arr = latn.ToLowerInvariant().ToCharArray();
             for (int i = 0; i < arr.Length; i++)
             {
                 char c = arr[i];
@@ -130,14 +132,14 @@ namespace CST.Conversion
         }
 
         // Optimized single pass (#86): byte-identical to ConvertReference (verified by tests). Replaces the
-        // per-char c.ToString() dictionary lookups and the aspiratable HashSet with char[] tables. Keeps the
-        // reference's ToLower() so casing behaviour is identical.
+        // per-char c.ToString() dictionary lookups and the aspiratable HashSet with char[] tables. Uses the
+        // same culture-invariant lower-casing as the reference so casing behaviour is identical. (CORE-4)
         public static string Convert(string latn)
         {
             if (string.IsNullOrEmpty(latn))
                 return latn;
 
-            string lower = latn.ToLower();
+            string lower = latn.ToLowerInvariant();
             int n = lower.Length;
             var buf = new char[n]; // each input char -> at most 1 IPE char; an aspirate consumes 2 -> 1
             int k = 0;

--- a/src/CST.Core/Conversion/ScriptConverter.cs
+++ b/src/CST.Core/Conversion/ScriptConverter.cs
@@ -147,7 +147,7 @@ namespace CST.Conversion
                 if (Char.IsLetter(c))
                 {
                     if (lastWasLetter == false)
-                        c = Char.ToUpper(c);
+                        c = Char.ToUpperInvariant(c); // invariant: 'i' -> 'I', not tr/az 'İ' (CORE-4)
 
                     lastWasLetter = true;
                 }


### PR DESCRIPTION
Fixes #123 (CORE-4 from the 2026-07-01 code review).

## Problem

`Latn2Ipe`, `ScriptConverter.ToTitleCase`, and `LatinCapitalizer` used culture-sensitive `ToLower()`/`ToUpper()`/`Char.ToUpper()`. On the Turkish/Azeri locales the dotted/dotless-i mapping differs from ASCII (`I → ı` U+0131, `i → İ` U+0130), so:

- a capital-`I` Latin **search** converts to an unmapped dotless `ı` → wrong IPE term → **silent zero results**;
- Latin **capitalization** emits the dotted `İ` instead of `I`.

Unlikely in practice (no known tr/az users) but a genuine "works on my machine" latent bug — fixing for completeness.

## Fix (culture-invariant variants)

- `Latn2Ipe.Convert` **and** `.ConvertReference`: `ToLower` → `ToLowerInvariant` — changed **together** so the #86 frozen-oracle equivalence (`Convert == ConvertReference` over the corpus) still holds.
- `ScriptConverter.ToTitleCase`: `Char.ToUpper` → `Char.ToUpperInvariant`.
- `LatinCapitalizer.CapitalReplacer`: `ToUpper` → `ToUpperInvariant`.

Byte-identical to prior behavior for all real Pāli Latin input outside tr/az.

## Tests

New `CultureInvariantCasingTests` force `tr-TR` and assert: `Latn2Ipe` folds capital `I` to ASCII (no dotless `ı` in the term); `Convert == ConvertReference` under Turkish; `ToTitleCase` and `Deva2Latn.ConvertBook` capitalize with ASCII `I`, never `İ`. Non-Latin literals use `\u` escapes per repo convention.

Full CST.Core conversion suite (incl. the #86 corpus oracle and #92 capitalizer): **105/105**, build clean.

## Out of scope

The 4th occurrence, `SettingsViewModel.cs:593` (font-preview `.ToUpper()`), is UI — left for that session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)