### PR TITLE
#126 (SRCH-1): commit file-dates only after a book is indexed, not at detection

### DIFF
--- a/src/CST.Avalonia.Tests/Services/XmlFileDatesServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/XmlFileDatesServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using CST;
 using CST.Avalonia.Services;
 using CST.Avalonia.Models;
 using Microsoft.Extensions.Logging;
@@ -202,6 +203,54 @@ namespace CST.Avalonia.Tests.Services
             Assert.True(data!.Files.TryGetValue("e0801n.nrf.xml", out var info));
             Assert.Equal(indexedTime, info!.LastIndexedTimestamp);
             Assert.Equal("def456", info.CommitHash);
+        }
+
+        [Fact]
+        public async Task GetChangedBooksAsync_DoesNotCommitDates_UntilMarkedIndexed()
+        {
+            // SRCH-1: detection must be read-only. A changed book stays "changed" across repeated
+            // detection passes until it is explicitly marked indexed.
+            var (service, bookIndex) = await SeedChangedBookAsync();
+
+            var first = await service.GetChangedBooksAsync();
+            var second = await service.GetChangedBooksAsync();
+
+            Assert.Contains(bookIndex, first);
+            Assert.Contains(bookIndex, second); // still changed - detection did not commit the new timestamp
+        }
+
+        [Fact]
+        public async Task MarkBooksIndexed_CommitsPendingDate_SoBookNoLongerDetectedChanged()
+        {
+            // SRCH-1: after a successful index, MarkBooksIndexed promotes the detection-time timestamp so
+            // the book is no longer reported as changed.
+            var (service, bookIndex) = await SeedChangedBookAsync();
+
+            Assert.Contains(bookIndex, await service.GetChangedBooksAsync());
+
+            service.MarkBooksIndexed(new[] { bookIndex });
+
+            Assert.DoesNotContain(bookIndex, await service.GetChangedBooksAsync());
+        }
+
+        // Seed a persisted cache with an old timestamp for the first book, then drop an XML file with a
+        // newer write time so the book is detected as changed. Returns an initialized service + the index.
+        private async Task<(TestableXmlFileDatesService service, int bookIndex)> SeedChangedBookAsync()
+        {
+            var fileName = Books.Inst[0].FileName;
+            var oldTime = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            await File.WriteAllTextAsync(
+                Path.Combine(_testAppDataDir, "file-dates.json"),
+                JsonSerializer.Serialize(new Dictionary<string, DateTime> { [fileName] = oldTime }));
+
+            var xmlPath = Path.Combine(_testXmlDir, fileName);
+            await File.WriteAllTextAsync(xmlPath, "<x/>");
+            File.SetLastWriteTimeUtc(xmlPath, oldTime.AddDays(10));
+
+            var service = new TestableXmlFileDatesService(_mockLogger.Object, _mockSettingsService.Object, _testAppDataDir);
+            await service.InitializeAsync();
+            return (service, 0);
         }
 
         // Testable version that allows us to override the app data directory

--- a/src/CST.Avalonia/Services/IXmlFileDatesService.cs
+++ b/src/CST.Avalonia/Services/IXmlFileDatesService.cs
@@ -9,6 +9,13 @@ namespace CST.Avalonia.Services
         Task<List<int>> GetChangedBooksAsync();
         Task SaveFileDatesAsync();
         void UpdateFileDate(int bookIndex, DateTime lastWriteTime);
+
+        /// <summary>
+        /// Commit the timestamps detected by the most recent <see cref="GetChangedBooksAsync"/> for the
+        /// given books into the persisted cache, marking them as successfully indexed. Called only after
+        /// indexing succeeds so a failed index never marks a book up-to-date (SRCH-1).
+        /// </summary>
+        void MarkBooksIndexed(IEnumerable<int> bookIndexes);
         Task InitializeAsync();
         
         // Enhanced format methods for XmlUpdateService

--- a/src/CST.Avalonia/Services/IndexingService.cs
+++ b/src/CST.Avalonia/Services/IndexingService.cs
@@ -188,6 +188,11 @@ namespace CST.Avalonia.Services
 
             await _bookIndexer.IndexAllAsync(progress, changedBooks);
 
+            // Indexing succeeded (IndexAllAsync did not throw) → commit the detected file timestamps for
+            // these books so SaveFileDatesAsync persists them. If it had thrown, nothing is committed and
+            // the books are re-detected as changed next run. (SRCH-1)
+            _xmlFileDatesService.MarkBooksIndexed(changedBooks);
+
             progress?.Report(new IndexingProgress
             {
                 StatusMessage = "Indexing complete",

--- a/src/CST.Avalonia/Services/XmlFileDatesService.cs
+++ b/src/CST.Avalonia/Services/XmlFileDatesService.cs
@@ -15,6 +15,9 @@ namespace CST.Avalonia.Services
         private readonly ILogger<XmlFileDatesService> _logger;
         private readonly ISettingsService _settingsService;
         private Dictionary<string, DateTime> _fileDates = new();
+        // Timestamps observed during the last GetChangedBooksAsync detection pass, held out of the
+        // persisted cache until the corresponding books are confirmed indexed via MarkBooksIndexed (SRCH-1).
+        private readonly Dictionary<string, DateTime> _pendingFileDates = new();
         private FileDatesWithCommits? _fileDatesData;
         private string _fileDatesPath = string.Empty;
 
@@ -146,8 +149,10 @@ namespace CST.Avalonia.Services
                         _logger.LogInformation("Book {BookIndex} ({FileName}) not in cache, needs indexing", i, book.FileName);
                     }
                     
-                    // Update the cache with current time
-                    _fileDates[book.FileName] = lastWriteTime;
+                    // Record the observed time as pending; it is only promoted into the persisted cache
+                    // once the book is confirmed indexed (MarkBooksIndexed), so a failed index can't mark
+                    // a book up-to-date. (SRCH-1)
+                    _pendingFileDates[book.FileName] = lastWriteTime;
                 }
                 else
                 {
@@ -224,6 +229,22 @@ namespace CST.Avalonia.Services
             {
                 var book = books[bookIndex];
                 _fileDates[book.FileName] = lastWriteTime;
+            }
+        }
+
+        public void MarkBooksIndexed(IEnumerable<int> bookIndexes)
+        {
+            var books = Books.Inst;
+            foreach (var bookIndex in bookIndexes)
+            {
+                if (bookIndex < 0 || bookIndex >= books.Count)
+                    continue;
+
+                var fileName = books[bookIndex].FileName;
+                // Promote the detection-time timestamp (not a re-read now) so we record exactly the version
+                // that was indexed, even if the file changed again since detection. (SRCH-1)
+                if (_pendingFileDates.TryGetValue(fileName, out var ts))
+                    _fileDates[fileName] = ts;
             }
         }
         


### PR DESCRIPTION
Fixes #126 (SRCH-1 from the 2026-07-01 code review).

## Problem

`XmlFileDatesService.GetChangedBooksAsync` wrote the current file timestamp into the persisted `_fileDates` cache **while detecting** changes. If indexing then failed partway, a later `SaveFileDatesAsync` persisted timestamps for books that were never indexed → they were considered up-to-date and **silently never re-indexed** (stale/missing search results) until the file changed again.

The live path is `App` / `XmlUpdateService` → `IndexingService.BuildIndexAsync` → `GetChangedBooksAsync` → `PerformIndexingAsync` → `SaveFileDatesAsync`. (`UpdateIndexAsync` is currently dead, so this is the only path.)

## Fix

Detection is now **read-only**, and a book's timestamp is committed only **after** it is indexed:

- `GetChangedBooksAsync` records observed timestamps into a private `_pendingFileDates` map instead of mutating `_fileDates`.
- New `IXmlFileDatesService.MarkBooksIndexed(indexes)` promotes the **detection-time** timestamps (not a re-read, so it records exactly the version that was indexed) into the persisted cache.
- `IndexingService` calls `MarkBooksIndexed(changedBooks)` only after `IndexAllAsync` succeeds, before `SaveFileDatesAsync`.

If indexing throws, nothing is committed → the books are re-detected as changed next run (conservative and correct, vs. today's silent-stale).

## Tests

- `GetChangedBooksAsync_DoesNotCommitDates_UntilMarkedIndexed` — two consecutive detection passes both report the changed book (detection no longer commits).
- `MarkBooksIndexed_CommitsPendingDate_SoBookNoLongerDetectedChanged` — after marking, the book is no longer reported changed.

New interface method is auto-stubbed by the existing loose Moq mocks (no hand-rolled fakes / strict mocks). Full suite: **435/435**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)