### PR TITLE
#129 (NET-1): download source PDFs atomically with size verification

### DIFF
--- a/src/CST.Avalonia.Tests/Services/SharePointDownloadTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SharePointDownloadTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// NET-1: <see cref="SharePointService.SaveStreamVerifiedAsync"/> must never leave a partial or corrupt
+/// file at the destination — the downloaded source PDFs are the permanent preservation store and the
+/// cache check trusts any file already present. A partial/failed download must leave the destination
+/// absent (or unchanged) and clean up its ".part".
+/// </summary>
+public class SharePointDownloadTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _final;
+
+    public SharePointDownloadTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cst-net1-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _final = Path.Combine(_dir, "sub", "doc.pdf"); // includes a not-yet-created subdirectory
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private static Stream Bytes(int n) => new MemoryStream(Encoding.ASCII.GetBytes(new string('a', n)));
+    private string PartPath => _final + ".part";
+
+    [Fact]
+    public async Task CorrectSize_WritesFinalFile_AndLeavesNoPart()
+    {
+        var ok = await SharePointService.SaveStreamVerifiedAsync(Bytes(1000), _final, 1000, NullLogger.Instance);
+
+        Assert.True(ok);
+        Assert.True(File.Exists(_final));
+        Assert.Equal(1000, new FileInfo(_final).Length);
+        Assert.False(File.Exists(PartPath));
+    }
+
+    [Fact]
+    public async Task NullExpectedSize_SkipsVerification_AndWritesFile()
+    {
+        var ok = await SharePointService.SaveStreamVerifiedAsync(Bytes(500), _final, null, NullLogger.Instance);
+
+        Assert.True(ok);
+        Assert.True(File.Exists(_final));
+        Assert.Equal(500, new FileInfo(_final).Length);
+    }
+
+    [Fact]
+    public async Task SizeMismatch_ReturnsFalse_NoFinalFile_NoPart()
+    {
+        // Server said 2000 bytes but the stream only had 1000 (truncated download).
+        var ok = await SharePointService.SaveStreamVerifiedAsync(Bytes(1000), _final, 2000, NullLogger.Instance);
+
+        Assert.False(ok);
+        Assert.False(File.Exists(_final));
+        Assert.False(File.Exists(PartPath));
+    }
+
+    [Fact]
+    public async Task StreamThrowsMidCopy_Throws_NoFinalFile_NoPart()
+    {
+        await Assert.ThrowsAsync<IOException>(() =>
+            SharePointService.SaveStreamVerifiedAsync(new ThrowingStream(), _final, 1000, NullLogger.Instance));
+
+        Assert.False(File.Exists(_final));
+        Assert.False(File.Exists(PartPath));
+    }
+
+    [Fact]
+    public async Task DoesNotClobberExistingGoodFile_WhenNewDownloadFails()
+    {
+        // A previously-preserved good PDF must survive a later failed re-download.
+        Directory.CreateDirectory(Path.GetDirectoryName(_final)!);
+        await File.WriteAllTextAsync(_final, "GOOD-PRESERVED-PDF");
+
+        var ok = await SharePointService.SaveStreamVerifiedAsync(Bytes(10), _final, 999, NullLogger.Instance);
+
+        Assert.False(ok);
+        Assert.Equal("GOOD-PRESERVED-PDF", await File.ReadAllTextAsync(_final));
+        Assert.False(File.Exists(PartPath));
+    }
+
+    // A read-stream that always throws, to simulate a dropped connection mid-download.
+    private sealed class ThrowingStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set { } }
+        public override int Read(byte[] buffer, int offset, int count) => throw new IOException("connection dropped");
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => throw new IOException("connection dropped");
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/CST.Avalonia/Services/SharePointService.cs
+++ b/src/CST.Avalonia/Services/SharePointService.cs
@@ -232,22 +232,13 @@ namespace CST.Avalonia.Services
                     return null;
                 }
 
-                // Ensure directory exists
-                var localDir = Path.GetDirectoryName(localPath);
-                if (!string.IsNullOrEmpty(localDir))
-                {
-                    Directory.CreateDirectory(localDir);
-                }
+                // Save atomically with size verification. A partial download must never land at localPath:
+                // the cache check above trusts any file already there, and these PDFs are the permanent
+                // preservation store (not an evictable cache). (NET-1)
+                if (!await SaveStreamVerifiedAsync(contentStream, localPath, driveItem.Size, _logger))
+                    return null;
 
-                // Save to local file
-                using (var fileStream = File.Create(localPath))
-                {
-                    await contentStream.CopyToAsync(fileStream);
-                }
-
-                var fileInfo = new FileInfo(localPath);
-                _logger.LogInformation("Downloaded PDF to: {Path} ({Size:N0} bytes)", localPath, fileInfo.Length);
-
+                _logger.LogInformation("Downloaded PDF to: {Path} ({Size:N0} bytes)", localPath, new FileInfo(localPath).Length);
                 return localPath;
             }
             catch (Exception ex)
@@ -255,6 +246,52 @@ namespace CST.Avalonia.Services
                 _logger.LogError(ex, "Failed to download PDF: {Path}", sharePointPath);
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Write a download stream to <paramref name="finalPath"/> without ever leaving a partial file
+        /// there: stream into a sibling ".part", verify the byte count against the server-reported size
+        /// (when known), then atomically move it into place. On a size mismatch or any exception the
+        /// ".part" is removed and <paramref name="finalPath"/> is left untouched. (NET-1)
+        /// </summary>
+        internal static async Task<bool> SaveStreamVerifiedAsync(Stream content, string finalPath, long? expectedSize, ILogger logger)
+        {
+            var localDir = Path.GetDirectoryName(finalPath);
+            if (!string.IsNullOrEmpty(localDir))
+                Directory.CreateDirectory(localDir);
+
+            var tempPath = finalPath + ".part";
+            try
+            {
+                using (var fileStream = File.Create(tempPath))
+                {
+                    await content.CopyToAsync(fileStream);
+                }
+
+                var downloadedLength = new FileInfo(tempPath).Length;
+                if (expectedSize.HasValue && downloadedLength != expectedSize.Value)
+                {
+                    logger.LogError("Downloaded size mismatch for {Path}: got {Actual:N0} bytes, expected {Expected:N0}; discarding partial download",
+                        finalPath, downloadedLength, expectedSize.Value);
+                    TryDelete(tempPath);
+                    return false;
+                }
+
+                // Same-volume rename -> atomic promote into place.
+                File.Move(tempPath, finalPath, overwrite: true);
+                return true;
+            }
+            catch
+            {
+                TryDelete(tempPath);
+                throw;
+            }
+        }
+
+        private static void TryDelete(string path)
+        {
+            try { if (File.Exists(path)) File.Delete(path); }
+            catch { /* best-effort cleanup of the partial file */ }
         }
 
         public string GetLocalPdfPath(string sharePointPath)


### PR DESCRIPTION
Fixes #129 (NET-1 from the 2026-07-01 code review).

## Problem

`SharePointService.DownloadPdfAsync` streamed the Graph content **straight into the final path** (`File.Create(localPath)` + `CopyToAsync`) — no temp file, no atomic rename, no size verification (`driveItem.Size` was fetched but unused). A dropped connection left a **truncated PDF at `localPath`**, which the cache check (`if (File.Exists(localPath)) return localPath;`) then trusted **forever**, including through the user's Refresh. Because these PDFs are the permanent preservation store (not an evictable cache), the corruption persisted. The XML path got this hardening in #65; the PDF path never did.

## Fix (mirror the XML path)

- New internal `SaveStreamVerifiedAsync`: stream into a sibling `.part`, verify the byte count against the server-reported size (when known), then atomically `File.Move` into place. On a size mismatch or any exception, the `.part` is deleted and the destination is left untouched.
- `DownloadPdfAsync` uses it, passing `driveItem.Size`.

## Tests (5)

- correct size → file written, no leftover `.part`;
- null expected size → verification skipped, file written;
- truncated download (size mismatch) → discarded, no final file, no `.part`;
- stream throws mid-copy → exception surfaces, no final file, no `.part`;
- a previously-preserved good file **survives** a failed re-download.

Build clean (0 warnings); download suite 5/5. The Graph call itself isn't mockable, so the extracted file-integrity logic (the actual bug) is what's covered.

## Note

Size verification is the practical integrity check here. Graph also exposes `File.Hashes` (SharePoint's quickXorHash), but validating it would require implementing that non-standard hash client-side — a possible future enhancement, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)