### PR TITLE
#133 (CORE-3): detect Cyrillic (+ combining marks); dedupe GetScript

### DIFF
--- a/src/CST.Avalonia.Tests/Conversion/ScriptDetectorCyrillicTests.cs
+++ b/src/CST.Avalonia.Tests/Conversion/ScriptDetectorCyrillicTests.cs
@@ -1,0 +1,52 @@
+using CST.Conversion;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Conversion;
+
+/// <summary>
+/// CORE-3: Cyrillic input must be script-detected (U+0400–04FF) and its combining diacritical marks
+/// (U+0300–036F, used by the Cyrillic Pāli scheme) must join the surrounding run rather than split it —
+/// otherwise Cyrillic search/dictionary input misroutes to Latin and yields zero results. Includes a Thai
+/// regression confirming the rewrite's four new input parsers (Thai/Telugu/Tibetan/Khmer) already work.
+/// Non-Latin characters are written as \uXXXX escapes per repo convention.
+/// </summary>
+public class ScriptDetectorCyrillicTests
+{
+    [Theory]
+    [InlineData(0x0400)] // start of the Cyrillic block
+    [InlineData(0x0434)] // Cyrillic 'de'
+    [InlineData(0x04FF)] // end of the Cyrillic block
+    public void GetScript_ClassifiesCyrillic(int codepoint)
+        => Assert.Equal(Script.Cyrillic, ScriptDetector.GetScript((char)codepoint));
+
+    [Theory]
+    [InlineData(0x0300)] // start of Combining Diacritical Marks
+    [InlineData(0x0307)] // combining dot above (used by the Cyrillic scheme)
+    [InlineData(0x0303)] // combining tilde
+    [InlineData(0x036F)] // end of the block
+    public void GetScript_CombiningMarksAreUnknown_SoTheyJoinTheRun(int codepoint)
+        => Assert.Equal(Script.Unknown, ScriptDetector.GetScript((char)codepoint));
+
+    [Fact]
+    public void Any2Deva_ConvertsCyrillicSyllable()
+    {
+        // Cyrl2Deva maps U+0434 (Cyrillic de) + U+0307 (combining dot-above) to Devanagari 'ta' (U+0924).
+        Assert.Equal("\u0924", Any2Deva.Convert("\u0434\u0307"));
+    }
+
+    [Fact]
+    public void Any2Ipe_CyrillicMatchesDevanagari()
+    {
+        // The Cyrillic 'ta' syllable and the Devanagari 'ta' must produce the same IPE term (so a Cyrillic
+        // query would hit the same index entries). Before the fix the Cyrillic form misrouted to Latin.
+        Assert.Equal(Any2Ipe.Convert("\u0924"), Any2Ipe.Convert("\u0434\u0307"));
+    }
+
+    [Fact]
+    public void Any2Ipe_ThaiMatchesDevanagari_Regression()
+    {
+        // Thai 'a' (U+0E2D) maps to Devanagari 'a' (U+0905); both must yield the same IPE. Confirms the
+        // Thai input parser (added in the rewrite, not in CST4) is wired — the SRCH-9 concern was stale.
+        Assert.Equal(Any2Ipe.Convert("\u0905"), Any2Ipe.Convert("\u0E2D"));
+    }
+}

--- a/src/CST.Core/Conversion/Any2Deva.cs
+++ b/src/CST.Core/Conversion/Any2Deva.cs
@@ -65,40 +65,7 @@ namespace CST.Conversion
                 return str;
         }
 
-        public static Script GetScript(char c)
-        {
-            int ccode = System.Convert.ToInt32(c);
-            Script script;
-            if (ccode == 0x200C || ccode == 0x200D) // ZWJ and ZWNJ
-                script = Script.Unknown;
-            else if (ccode >= 0x0900 && ccode <= 0x097F)
-                script = Script.Devanagari;
-            else if (ccode >= 0x0980 && ccode <= 0x09FF)
-                script = Script.Bengali;
-            else if (ccode >= 0x0A00 && ccode <= 0x0A7F)
-                script = Script.Gurmukhi;
-            else if (ccode >= 0x0A80 && ccode <= 0x0AFF)
-                script = Script.Gujarati;
-            else if (ccode >= 0x0C00 && ccode <= 0x0C7F)
-                script = Script.Telugu;
-            else if (ccode >= 0x0C80 && ccode <= 0x0CFF)
-                script = Script.Kannada;
-            else if (ccode >= 0x0D00 && ccode <= 0x0D7F)
-                script = Script.Malayalam;
-            else if (ccode >= 0x0D80 && ccode <= 0x0DFF)
-                script = Script.Sinhala;
-            else if (ccode >= 0x0E00 && ccode <= 0x0E7F)
-                script = Script.Thai;
-            else if (ccode >= 0x0F00 && ccode <= 0x0FFF)
-                script = Script.Tibetan;
-            else if (ccode >= 0x1000 && ccode <= 0x107F)
-                script = Script.Myanmar;
-            else if (ccode >= 0x1780 && ccode <= 0x17FF)
-                script = Script.Khmer;
-            else
-                script = Script.Latin;
-
-            return script;
-        }
+        // Delegates to the shared detector (kept as a public method for existing callers/tests). (CORE-3)
+        public static Script GetScript(char c) => ScriptDetector.GetScript(c);
     }
 }

--- a/src/CST.Core/Conversion/Any2Ipe.cs
+++ b/src/CST.Core/Conversion/Any2Ipe.cs
@@ -13,7 +13,7 @@ namespace CST.Conversion
             
             foreach (char c in str.ToCharArray())
             {
-                Script cScript = GetScript(c);
+                Script cScript = ScriptDetector.GetScript(c);
                 if (cScript == lastScript || cScript == Script.Unknown)
                     run += c;
                 else
@@ -65,40 +65,5 @@ namespace CST.Conversion
                 return str;
         }
 
-        private static Script GetScript(char c)
-        {
-            int ccode = System.Convert.ToInt32(c);
-            Script script;
-            if (ccode == 0x200C || ccode == 0x200D) // ZWJ and ZWNJ
-                script = Script.Unknown;
-            else if (ccode >= 0x0900 && ccode <= 0x097F)
-                script = Script.Devanagari;
-            else if (ccode >= 0x0980 && ccode <= 0x09FF)
-                script = Script.Bengali;
-            else if (ccode >= 0x0A00 && ccode <= 0x0A7F)
-                script = Script.Gurmukhi;
-            else if (ccode >= 0x0A80 && ccode <= 0x0AFF)
-                script = Script.Gujarati;
-            else if (ccode >= 0x0C00 && ccode <= 0x0C7F)
-                script = Script.Telugu;
-            else if (ccode >= 0x0C80 && ccode <= 0x0CFF)
-                script = Script.Kannada;
-            else if (ccode >= 0x0D00 && ccode <= 0x0D7F)
-                script = Script.Malayalam;
-            else if (ccode >= 0x0D80 && ccode <= 0x0DFF)
-                script = Script.Sinhala;
-            else if (ccode >= 0x0E00 && ccode <= 0x0E7F)
-                script = Script.Thai;
-            else if (ccode >= 0x0F00 && ccode <= 0x0FFF)
-                script = Script.Tibetan;
-            else if (ccode >= 0x1000 && ccode <= 0x107F)
-                script = Script.Myanmar;
-            else if (ccode >= 0x1780 && ccode <= 0x17FF)
-                script = Script.Khmer;
-            else
-                script = Script.Latin;
-
-            return script;
-        }
     }
 }

--- a/src/CST.Core/Conversion/ScriptDetector.cs
+++ b/src/CST.Core/Conversion/ScriptDetector.cs
@@ -1,0 +1,52 @@
+namespace CST.Conversion
+{
+    /// <summary>
+    /// Classifies a single character to its <see cref="Script"/> for run-splitting during script
+    /// auto-detection. Shared by <see cref="Any2Ipe"/> and <see cref="Any2Deva"/> so the two detection
+    /// tables cannot drift (they previously had to be fixed in tandem — e.g. ZWJ/ZWNJ handling).
+    /// </summary>
+    public static class ScriptDetector
+    {
+        public static Script GetScript(char c)
+        {
+            int ccode = System.Convert.ToInt32(c);
+            Script script;
+            if (ccode == 0x200C || ccode == 0x200D) // ZWJ and ZWNJ
+                script = Script.Unknown;
+            else if (ccode >= 0x0300 && ccode <= 0x036F)
+                // Combining diacritical marks (used by the Cyrillic Pāli scheme, e.g. dot-above / tilde).
+                // Treat as Unknown so they stay with the surrounding run instead of splitting it. (CORE-3)
+                script = Script.Unknown;
+            else if (ccode >= 0x0400 && ccode <= 0x04FF)
+                script = Script.Cyrillic; // (CORE-3)
+            else if (ccode >= 0x0900 && ccode <= 0x097F)
+                script = Script.Devanagari;
+            else if (ccode >= 0x0980 && ccode <= 0x09FF)
+                script = Script.Bengali;
+            else if (ccode >= 0x0A00 && ccode <= 0x0A7F)
+                script = Script.Gurmukhi;
+            else if (ccode >= 0x0A80 && ccode <= 0x0AFF)
+                script = Script.Gujarati;
+            else if (ccode >= 0x0C00 && ccode <= 0x0C7F)
+                script = Script.Telugu;
+            else if (ccode >= 0x0C80 && ccode <= 0x0CFF)
+                script = Script.Kannada;
+            else if (ccode >= 0x0D00 && ccode <= 0x0D7F)
+                script = Script.Malayalam;
+            else if (ccode >= 0x0D80 && ccode <= 0x0DFF)
+                script = Script.Sinhala;
+            else if (ccode >= 0x0E00 && ccode <= 0x0E7F)
+                script = Script.Thai;
+            else if (ccode >= 0x0F00 && ccode <= 0x0FFF)
+                script = Script.Tibetan;
+            else if (ccode >= 0x1000 && ccode <= 0x107F)
+                script = Script.Myanmar;
+            else if (ccode >= 0x1780 && ccode <= 0x17FF)
+                script = Script.Khmer;
+            else
+                script = Script.Latin;
+
+            return script;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #133 (CORE-3 from the 2026-07-01 code review).

## Problem

`GetScript` (duplicated in `Any2Ipe.cs` and `Any2Deva.cs`) had no branch for the Cyrillic block (U+0400–04FF), so Cyrillic input fell through to `Latin` and was converted by `Latn2Ipe` — even though `Convert(str, Script.Cyrillic) → Cyrl2Deva` already existed (a dead branch, since detection never returned `Cyrillic`). A Cyrillic Pāli query produced a wrong IPE term → **zero results**. The Cyrillic Pāli scheme also uses **combining diacritical marks** (U+0300–036F, e.g. dot-above / tilde), which must join the surrounding run.

## Fix

- Add `U+0400–04FF → Cyrillic` and `U+0300–036F → Unknown` (join the run) to detection.
- **Dedupe** the two identical `GetScript` copies into a shared `ScriptDetector` so they can't drift (they already had to be fixed in tandem for ZWJ/ZWNJ in #115). `Any2Deva.GetScript` is kept as a public delegator so existing callers/tests are unaffected.

## SRCH-9 note

SRCH-9 (Telugu/Thai/Tibetan/Khmer "silently zero results") was assessed against the **old CST4** `src/CST/Conversion/Any2Ipe.cs`. In the current `CST.Core` those four input parsers (added in the rewrite, not in CST4) are fully wired and work — Cyrillic was the only genuine remaining gap, and it's this issue.

## Tests

- `GetScript` classifies Cyrillic; combining marks are `Unknown`.
- A Cyrillic syllable converts to the same IPE/Devanagari as its Devanagari equivalent (Any2Ipe + Any2Deva).
- Thai regression: Thai input yields the same IPE as the equivalent Devanagari (confirms the rewrite parser is wired).

Conversion suite incl. the #86 corpus oracle: **107/107**, build clean. Non-Latin test inputs use `\u` escapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)