### PR TITLE
#137 (NET-2): return Unknown for unparseable versions; beta→stable fallback

### DIFF
--- a/src/CST.Avalonia.Tests/Services/VersionComparerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/VersionComparerTests.cs
@@ -22,6 +22,18 @@ namespace CST.Avalonia.Tests.Services
         }
 
         [Theory]
+        [InlineData("5.0.0-beta.1", null)]         // NET-2: beta channel removed post-GA -> null latest
+        [InlineData(null, "5.0.0")]
+        [InlineData("5.0.0", "")]
+        [InlineData("5.0.0", "not-a-version")]
+        [InlineData("garbage", "5.0.0")]
+        public void Compare_MissingOrUnparseable_ReturnsUnknown(string? current, string? latest)
+        {
+            // Must NOT be Current: that would render as a false "you're on the latest version". (NET-2)
+            Assert.Equal(VersionComparison.Unknown, VersionComparer.Compare(current, latest));
+        }
+
+        [Theory]
         [InlineData("5.0.0", 5, 0, 0, null, null)]
         [InlineData("5.0.0-beta.1", 5, 0, 0, "beta", 1)]
         [InlineData("5.0.0-alpha", 5, 0, 0, "alpha", null)]
@@ -73,6 +85,7 @@ namespace CST.Avalonia.Tests.Services
         [InlineData(VersionComparison.MajorOutdated, "6.0.0", "A major update is available (6.0.0)")]
         [InlineData(VersionComparison.PreReleaseToStable, "5.0.0", "The stable version is now available (5.0.0)")]
         [InlineData(VersionComparison.NewerThanLatest, "5.0.0", "You're running a development version")]
+        [InlineData(VersionComparison.Unknown, "5.0.0", "Version status unknown")]
         public void GetComparisonDescription_VariousComparisons_ReturnsCorrectDescription(VersionComparison comparison, string latestVersion, string expectedStart)
         {
             var description = VersionComparer.GetComparisonDescription(comparison, latestVersion);

--- a/src/CST.Avalonia/Services/VersionComparer.cs
+++ b/src/CST.Avalonia/Services/VersionComparer.cs
@@ -13,7 +13,9 @@ namespace CST.Avalonia.Services
         MinorOutdated,
         MajorOutdated,
         PreReleaseToStable,
-        NewerThanLatest
+        NewerThanLatest,
+        /// <summary>Either version was missing or unparseable — status can't be determined. (NET-2)</summary>
+        Unknown
     }
 
     /// <summary>
@@ -124,8 +126,10 @@ namespace CST.Avalonia.Services
             var current = ParseVersion(currentVersion);
             var latest = ParseVersion(latestVersion);
 
+            // A missing/unparseable version is not a match — surface "unknown" rather than a false
+            // "you're on the latest version". (NET-2)
             if (current == null || latest == null)
-                return VersionComparison.Current;
+                return VersionComparison.Unknown;
 
             var comparison = current.CompareTo(latest);
 
@@ -228,6 +232,7 @@ namespace CST.Avalonia.Services
                 VersionComparison.MajorOutdated => $"A major update is available ({latestVersion})",
                 VersionComparison.PreReleaseToStable => $"The stable version is now available ({latestVersion})",
                 VersionComparison.NewerThanLatest => "You're running a development version",
+                VersionComparison.Unknown => "Version status unknown",
                 _ => "Version status unknown"
             };
         }

--- a/src/CST.Avalonia/Services/WelcomeUpdateService.cs
+++ b/src/CST.Avalonia/Services/WelcomeUpdateService.cs
@@ -255,8 +255,12 @@ namespace CST.Avalonia.Services
 
             // Determine which channel to check based on current version
             var currentVersion = VersionComparer.ParseVersion(CurrentAppVersion);
+            // A pre-release user checks the beta channel, but if it's been removed (e.g. post-GA) fall back
+            // to Stable so they still see the stable upgrade rather than a false "up to date". (NET-2)
             var latestVersion = currentVersion?.IsPreRelease == true
-                ? updates.CurrentVersion.Beta
+                ? (string.IsNullOrWhiteSpace(updates.CurrentVersion.Beta)
+                    ? updates.CurrentVersion.Stable
+                    : updates.CurrentVersion.Beta)
                 : updates.CurrentVersion.Stable;
 
             _logger.Information("Version check - Latest version for channel: '{LatestVersion}' (using {Channel} channel)",
@@ -285,13 +289,17 @@ namespace CST.Avalonia.Services
                     _logger.Information("Version check - Found version-specific message for '{Version}' (stripped build metadata from '{OriginalVersion}')", versionWithoutBuildMetadata, CurrentAppVersion);
                 }
             }
-            if (message == null && comparison != VersionComparison.Current && updates.Messages.ContainsKey("default"))
+            if (message == null && comparison != VersionComparison.Current
+                && comparison != VersionComparison.Unknown && updates.Messages.ContainsKey("default"))
             {
                 message = updates.Messages["default"];
                 _logger.Information("Version check - Using default message");
             }
 
-            var isUpdateAvailable = comparison != VersionComparison.Current && comparison != VersionComparison.NewerThanLatest;
+            // Unknown (missing/unparseable latest) is not an update — don't prompt, and don't claim latest. (NET-2)
+            var isUpdateAvailable = comparison != VersionComparison.Current
+                && comparison != VersionComparison.NewerThanLatest
+                && comparison != VersionComparison.Unknown;
 
             _logger.Information("Version check - Update available: {IsUpdateAvailable} (comparison: {Comparison})",
                 isUpdateAvailable, comparison);


### PR DESCRIPTION
Fixes #137 (NET-2 from the 2026-07-01 code review).

## Problem

`VersionComparer.Compare` returned `Current` when either version was null or unparseable — and `Current` renders as *"You're running the latest version."* So a missing/garbled latest produced a **false green** even when an upgrade existed. This is reachable: `WelcomeUpdateService` compares a **beta** user against `updates.CurrentVersion.Beta`; if that channel is removed post-GA (null), `Compare(current, null)` → `Current` → the beta user is told they're up to date though a stable release exists.

## Fix

- **`VersionComparer`**: add `VersionComparison.Unknown`; `Compare` returns it (not `Current`) when either side is null/unparseable; `GetComparisonDescription` maps it to *"Version status unknown."*
- **`WelcomeUpdateService`**: a pre-release user whose beta channel is null/empty now **falls back to `Stable`**; `Unknown` is treated as *not* an update in both the default-message and `isUpdateAvailable` checks (no false green, no bogus prompt).

## Tests

- `Compare(null / "" / "not-a-version")` → `Unknown` (including the beta-removed-post-GA case).
- `Unknown` → "Version status unknown".
- Existing comparisons unchanged. VersionComparer suite **50/50**, build clean.

## Out of scope

NET-3 (pre-release comparison edges — `5.0.0-alpha` vs `5.0.0-alpha.1`, numeric-only pre-release regex) is a separate finding in the same file, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)