### PR TITLE
#140 (NET-3): offer pre-release updates that CompareTo ranks newer; parse dotless build

### DIFF
--- a/src/CST.Avalonia.Tests/Services/VersionComparerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/VersionComparerTests.cs
@@ -15,6 +15,10 @@ namespace CST.Avalonia.Tests.Services
         [InlineData("5.0.0-beta.1", "5.0.0-beta.2", VersionComparison.PatchOutdated)]
         [InlineData("5.0.0-beta.1", "5.0.0", VersionComparison.PreReleaseToStable)]
         [InlineData("v5.0.0", "5.0.0", VersionComparison.Current)] // Handle 'v' prefix
+        [InlineData("5.0.0-alpha", "5.0.0-alpha.1", VersionComparison.PatchOutdated)]   // NET-3: build added
+        [InlineData("5.0.0-beta", "5.0.0-beta.2", VersionComparison.PatchOutdated)]     // NET-3: no build vs build
+        [InlineData("5.0.0-alpha.2", "5.0.0-beta.1", VersionComparison.PatchOutdated)]  // alpha < beta
+        [InlineData("5.0.0-alpha.1", "5.0.0-alpha", VersionComparison.NewerThanLatest)] // current is newer
         public void Compare_VariousVersions_ReturnsCorrectComparison(string current, string latest, VersionComparison expected)
         {
             var result = VersionComparer.Compare(current, latest);
@@ -36,6 +40,7 @@ namespace CST.Avalonia.Tests.Services
         [Theory]
         [InlineData("5.0.0", 5, 0, 0, null, null)]
         [InlineData("5.0.0-beta.1", 5, 0, 0, "beta", 1)]
+        [InlineData("5.0.0-beta1", 5, 0, 0, "beta", 1)] // NET-3: dot before build is optional
         [InlineData("5.0.0-alpha", 5, 0, 0, "alpha", null)]
         [InlineData("v5.0.0", 5, 0, 0, null, null)]
         public void ParseVersion_ValidVersions_ParsesCorrectly(string version, int major, int minor, int patch, string? preRelease, int? preReleaseBuild)

--- a/src/CST.Avalonia/Services/VersionComparer.cs
+++ b/src/CST.Avalonia/Services/VersionComparer.cs
@@ -77,10 +77,10 @@ namespace CST.Avalonia.Services
     /// </summary>
     public static class VersionComparer
     {
-        // Regex pattern for semantic versioning with optional pre-release
-        // Matches: 1.0.0, 5.0.0-beta.1, 4.5.0-alpha, etc.
+        // Regex pattern for semantic versioning with optional pre-release.
+        // Matches: 1.0.0, 5.0.0-beta.1, 5.0.0-beta1 (dot before the build is optional), 4.5.0-alpha, etc.
         private static readonly Regex VersionPattern = new Regex(
-            @"^v?(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z]+)(?:\.(\d+))?)?",
+            @"^v?(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z]+)(?:\.?(\d+))?)?",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
@@ -160,28 +160,14 @@ namespace CST.Avalonia.Services
                 return VersionComparison.PreReleaseToStable;
             }
 
-            // Same major.minor.patch, both are pre-release, different pre-release versions
-            // e.g., 5.0.0-beta.1 vs 5.0.0-beta.2
-            if (current.IsPreRelease && latest.IsPreRelease &&
-                current.Major == latest.Major &&
-                current.Minor == latest.Minor &&
-                current.Patch == latest.Patch)
-            {
-                // If pre-release identifiers are the same, check build numbers
-                if (string.Equals(current.PreRelease, latest.PreRelease, StringComparison.OrdinalIgnoreCase))
-                {
-                    if (current.PreReleaseBuild.HasValue && latest.PreReleaseBuild.HasValue &&
-                        current.PreReleaseBuild.Value < latest.PreReleaseBuild.Value)
-                    {
-                        return VersionComparison.PatchOutdated; // Pre-release build update
-                    }
-                }
-                // Different pre-release identifiers (e.g., alpha vs beta)
-                else if (string.Compare(current.PreRelease, latest.PreRelease, StringComparison.OrdinalIgnoreCase) < 0)
-                {
-                    return VersionComparison.PatchOutdated;
-                }
-            }
+            // At this point comparison < 0 (current is older per SemanticVersion.CompareTo) and
+            // major.minor.patch are equal (the outdated-major/minor/patch and pre-release→stable cases
+            // returned above), so both are pre-release and current is the older pre-release — e.g.
+            // 5.0.0-alpha vs 5.0.0-alpha.1, 5.0.0-beta vs 5.0.0-beta.2, or alpha vs beta. Surface a
+            // pre-release/patch update rather than falling through to "Current", which contradicted
+            // CompareTo and offered no update. (NET-3)
+            if (current.IsPreRelease && latest.IsPreRelease)
+                return VersionComparison.PatchOutdated;
 
             return VersionComparison.Current;
         }


### PR DESCRIPTION
Fixes #140 (NET-3 from the 2026-07-01 code review).

## Problem

`Compare`'s pre-release block is reached only when `current.CompareTo(latest) < 0` **and** major.minor.patch are equal, but it only returned `PatchOutdated` for narrow shapes — so genuinely-older pre-releases fell through to `Current` (no update offered), contradicting `SemanticVersion.CompareTo`:

- `5.0.0-alpha` vs `5.0.0-alpha.1` (current has no build → the build check was skipped)
- `5.0.0-beta` vs `5.0.0-beta.2`

Separately, the parse regex required a **dot** before the pre-release build, so `5.0.0-beta1` lost its `1`.

## Fix

- Once past the major/minor/patch and pre-release→stable checks with `comparison < 0`, both are pre-release and current is older → return `PatchOutdated` (matching `CompareTo`) instead of falling through to `Current`.
- Make the dot before the build optional (`(?:\.?(\d+))?`) so `beta1` parses build `1` (`beta.1` still works).

Numeric-only pre-release (`5.0.0-1`) remains unsupported — not used by this project.

## Tests

- `alpha` vs `alpha.1` and `beta` vs `beta.2` → `PatchOutdated`; `alpha.1` vs `alpha` → `NewerThanLatest`; `alpha.2` vs `beta.1` → `PatchOutdated`.
- `ParseVersion("5.0.0-beta1")` → `beta` / build `1`.
- Existing comparisons unchanged. VersionComparer suite **55/55**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)