### PR TITLE
#144 (SRCH-11): validate the index for real and recover from a corrupt one

### DIFF
--- a/src/CST.Avalonia.Tests/BugFix/IncrementalIndexingBugFixTest.cs
+++ b/src/CST.Avalonia.Tests/BugFix/IncrementalIndexingBugFixTest.cs
@@ -8,6 +8,7 @@ using CST.Lucene;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit.Abstractions;
 
 namespace CST.Avalonia.Tests.BugFix
@@ -69,8 +70,7 @@ namespace CST.Avalonia.Tests.BugFix
             await indexingService.InitializeAsync();
 
             // Create a fake valid index (this is what was causing the bug)
-            var fakeIndexFile = Path.Combine(_testIndexDir, "test.cfs");
-            await File.WriteAllTextAsync(fakeIndexFile, "fake index content");
+            TestIndex.CreateMinimal(_testIndexDir);
 
             // Verify the index appears valid (this was the condition that triggered the bug)
             var isIndexValid = await indexingService.IsIndexValidAsync();
@@ -112,8 +112,7 @@ namespace CST.Avalonia.Tests.BugFix
             await indexingService.InitializeAsync();
 
             // Create a fake valid index
-            var fakeIndexFile = Path.Combine(_testIndexDir, "test.cfs");
-            await File.WriteAllTextAsync(fakeIndexFile, "fake index content");
+            TestIndex.CreateMinimal(_testIndexDir);
 
             // Set up NO changed books
             var changedBooks = new List<int>(); // No changes

--- a/src/CST.Avalonia.Tests/Integration/IncrementalIndexingTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/IncrementalIndexingTests.cs
@@ -8,6 +8,7 @@ using CST.Lucene;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit.Abstractions;
 
 namespace CST.Avalonia.Tests.Integration
@@ -63,9 +64,8 @@ namespace CST.Avalonia.Tests.Integration
             await xmlFileDatesService.InitializeAsync();
             await indexingService.InitializeAsync();
 
-            // Create a fake index file to make the index appear valid
-            var fakeIndexFile = Path.Combine(_testIndexDir, "test.cfs");
-            await File.WriteAllTextAsync(fakeIndexFile, "fake index content");
+            // A real (minimal) index so the validity check passes. (SRCH-11)
+            TestIndex.CreateMinimal(_testIndexDir);
 
             // Set up initial state - no changed books
             var initialChangedBooks = new List<int>();
@@ -111,9 +111,8 @@ namespace CST.Avalonia.Tests.Integration
             await xmlFileDatesService.InitializeAsync();
             await indexingService.InitializeAsync();
 
-            // Create a fake index file to make the index appear valid
-            var fakeIndexFile = Path.Combine(_testIndexDir, "test.cfs");
-            await File.WriteAllTextAsync(fakeIndexFile, "fake index content");
+            // A real (minimal) index so the validity check passes. (SRCH-11)
+            TestIndex.CreateMinimal(_testIndexDir);
 
             // Verify index appears valid
             var indexValid = await indexingService.IsIndexValidAsync();
@@ -128,10 +127,11 @@ namespace CST.Avalonia.Tests.Integration
             var exception = await Assert.ThrowsAnyAsync<Exception>(
                 async () => await indexingService.BuildIndexAsync(null!));
 
-            // Assert
+            // Assert - changed books were checked even though the index was valid, and indexing was
+            // attempted (it throws only because there's no real XML corpus in this test).
             Assert.True(xmlFileDatesService.GetChangedBooksWasCalled);
-            Assert.True(exception is FileNotFoundException || exception.GetType().Name.Contains("IndexNotFoundException"));
-            _output.WriteLine("✅ BuildIndexAsync called GetChangedBooksAsync even with valid index");
+            Assert.NotNull(exception);
+            _output.WriteLine($"✅ BuildIndexAsync checked for changes with a valid index; rebuild threw {exception.GetType().Name} (no corpus)");
         }
 
         [Fact]
@@ -144,9 +144,8 @@ namespace CST.Avalonia.Tests.Integration
             await xmlFileDatesService.InitializeAsync();
             await indexingService.InitializeAsync();
 
-            // Create a fake index file to make the index appear valid
-            var fakeIndexFile = Path.Combine(_testIndexDir, "test.cfs");
-            await File.WriteAllTextAsync(fakeIndexFile, "fake index content");
+            // A real (minimal) index so the validity check passes. (SRCH-11)
+            TestIndex.CreateMinimal(_testIndexDir);
 
             // Set up no changed books
             var changedBooks = new List<int>();

--- a/src/CST.Avalonia.Tests/Integration/IndexStructureTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/IndexStructureTests.cs
@@ -12,6 +12,7 @@ using Lucene.Net.Util;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using CST.Avalonia.Tests.TestSupport;
 
 namespace CST.Avalonia.Tests.Integration
 {
@@ -133,23 +134,20 @@ namespace CST.Avalonia.Tests.Integration
         {
             // Arrange
             await _service.InitializeAsync();
-            
-            // Create a corrupted index file
-            var corruptedFile = Path.Combine(_testIndexDir, "segments.gen");
-            await File.WriteAllTextAsync(corruptedFile, "corrupted content");
 
-            // Act & Assert
-            // The IsIndexValidAsync method only checks for file existence, not corruption
-            // For actual corruption detection, we'd need to try opening the index
-            var isValidByFileCheck = await _service.IsIndexValidAsync();
-            Assert.False(isValidByFileCheck); // No .cfs or .fdt files, so invalid
+            // Garbage that isn't a readable index -> invalid (SRCH-11: validity means openable, not
+            // merely that files exist).
+            await File.WriteAllTextAsync(Path.Combine(_testIndexDir, "segments.gen"), "corrupted content");
+            Assert.False(await _service.IsIndexValidAsync());
 
-            // Add a fake index file to make it appear valid
-            var fakeIndexFile = Path.Combine(_testIndexDir, "test.cfs");
-            await File.WriteAllTextAsync(fakeIndexFile, "fake content");
-            
-            var isValidWithFiles = await _service.IsIndexValidAsync();
-            Assert.True(isValidWithFiles); // Now has files, so appears valid
+            // A stray file with an index extension is still not a real index.
+            await File.WriteAllTextAsync(Path.Combine(_testIndexDir, "test.cfs"), "fake content");
+            Assert.False(await _service.IsIndexValidAsync());
+
+            // A real index is valid.
+            foreach (var f in System.IO.Directory.GetFiles(_testIndexDir)) File.Delete(f);
+            TestIndex.CreateMinimal(_testIndexDir);
+            Assert.True(await _service.IsIndexValidAsync());
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Integration/IndexingIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/IndexingIntegrationTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using CST.Avalonia.Tests.TestSupport;
 
 namespace CST.Avalonia.Tests.Integration
 {
@@ -116,9 +117,8 @@ namespace CST.Avalonia.Tests.Integration
             // Act
             var isValidEmpty = await indexingService.IsIndexValidAsync();
 
-            // Create a fake index file
-            var fakeIndexFile = Path.Combine(_testIndexDir, "test.cfs");
-            await File.WriteAllTextAsync(fakeIndexFile, "fake index content");
+            // A real (minimal) index so the validity check passes. (SRCH-11)
+            TestIndex.CreateMinimal(_testIndexDir);
 
             var isValidWithFiles = await indexingService.IsIndexValidAsync();
 

--- a/src/CST.Avalonia.Tests/Performance/IndexingPerformanceTests.cs
+++ b/src/CST.Avalonia.Tests/Performance/IndexingPerformanceTests.cs
@@ -7,6 +7,7 @@ using CST.Avalonia.Models;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit.Abstractions;
 
 namespace CST.Avalonia.Tests.Performance
@@ -78,20 +79,8 @@ namespace CST.Avalonia.Tests.Performance
             // Arrange
             await _service.InitializeAsync();
             
-            // Create some fake index files to test file system performance
-            var indexFiles = new[]
-            {
-                Path.Combine(_testIndexDir, "segments_1"),
-                Path.Combine(_testIndexDir, "test1.cfs"),
-                Path.Combine(_testIndexDir, "test1.fdt"),
-                Path.Combine(_testIndexDir, "test2.cfs"),
-                Path.Combine(_testIndexDir, "test2.fdt")
-            };
-            
-            foreach (var file in indexFiles)
-            {
-                await File.WriteAllTextAsync(file, "test content");
-            }
+            // A real index so validity (which now actually opens the index) passes. (SRCH-11)
+            TestIndex.CreateMinimal(_testIndexDir);
 
             var stopwatch = Stopwatch.StartNew();
 
@@ -113,8 +102,7 @@ namespace CST.Avalonia.Tests.Performance
         {
             // Arrange
             await _service.InitializeAsync();
-            var indexFile = Path.Combine(_testIndexDir, "test.cfs");
-            await File.WriteAllTextAsync(indexFile, "test content");
+            TestIndex.CreateMinimal(_testIndexDir);
 
             var times = new long[10];
 

--- a/src/CST.Avalonia.Tests/Services/IndexCorruptionTests.cs
+++ b/src/CST.Avalonia.Tests/Services/IndexCorruptionTests.cs
@@ -69,9 +69,8 @@ namespace CST.Avalonia.Tests.Services
             var result = await _service.IsIndexValidAsync();
 
             // Assert
-            // The current implementation only checks for file existence, not validity
-            // This test documents the current behavior - it returns true if files exist
-            Assert.True(result);
+            // Segment files exist but the index isn't readable -> invalid (SRCH-11).
+            Assert.False(result);
         }
 
         [Fact]
@@ -95,34 +94,25 @@ namespace CST.Avalonia.Tests.Services
         }
 
         [Fact]
-        public async Task BuildIndexAsync_WithCorruptedIndex_RebuildsIndex()
+        public async Task BuildIndexAsync_WithCorruptedIndex_DeletesIndexAndResetsFileDates()
         {
-            // Arrange
+            // Arrange - a present-but-unreadable index (garbage where segment files would be).
             await _service.InitializeAsync();
-            
-            // Create corrupted index files
-            var corruptedFile = Path.Combine(_testIndexDir, "segments.gen");
-            await File.WriteAllTextAsync(corruptedFile, "corrupted");
-            
-            var changedBooks = new List<int> { 0 };
+            var corruptSegments = Path.Combine(_testIndexDir, "segments_1");
+            await File.WriteAllTextAsync(corruptSegments, "corrupted");
+            await File.WriteAllTextAsync(Path.Combine(_testIndexDir, "_0.cfs"), "corrupted");
+
+            // Recovery runs before re-detecting changed books; stop there so the test doesn't need the real
+            // XML corpus to actually rebuild. The point is that corruption triggers recovery, not a skip. (SRCH-11)
             _mockXmlFileDatesService.Setup(x => x.GetChangedBooksAsync())
-                .ReturnsAsync(changedBooks);
+                .ThrowsAsync(new InvalidOperationException("stop after recovery"));
 
-            var progressReports = new List<IndexingProgress>();
-            var progress = new Progress<IndexingProgress>(p => progressReports.Add(p));
+            // Act
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _service.BuildIndexAsync(null!));
 
-            // Act & Assert
-            // This will fail with a Lucene exception because we have corrupted the index
-            var exception = await Assert.ThrowsAnyAsync<Exception>(
-                async () => await _service.BuildIndexAsync(progress));
-            
-            // Verify we get a Lucene-specific exception for corruption
-            Assert.True(exception.GetType().Name.Contains("IndexFormatTooNewException") ||
-                       exception.GetType().Name.Contains("CorruptIndexException") ||
-                       exception.Message.Contains("Format version"));
-
-            // Verify that the service attempted to get changed books (indicating a rebuild)
-            _mockXmlFileDatesService.Verify(x => x.GetChangedBooksAsync(), Times.Once);
+            // Assert - the corrupt index was deleted and the file-dates cache reset (forcing a full rebuild).
+            _mockXmlFileDatesService.Verify(x => x.ResetFileDates(), Times.Once);
+            Assert.False(File.Exists(corruptSegments));
         }
 
         [Fact]
@@ -163,42 +153,35 @@ namespace CST.Avalonia.Tests.Services
         }
 
         [Fact]
-        public async Task IsIndexValidAsync_WithMixedFileTypes_ReturnsTrue()
+        public async Task IsIndexValidAsync_WithNonIndexFilesPresent_ReturnsFalse()
         {
-            // Arrange
+            // Arrange - stray files that merely share index extensions are not a readable index. (SRCH-11)
             await _service.InitializeAsync();
-            
-            // Create both .cfs and .fdt files to test file type detection
-            var cfsFile = Path.Combine(_testIndexDir, "test.cfs");
-            var fdtFile = Path.Combine(_testIndexDir, "test.fdt");
-            var randomFile = Path.Combine(_testIndexDir, "test.txt");
-            
-            await File.WriteAllTextAsync(cfsFile, "content");
-            await File.WriteAllTextAsync(fdtFile, "content");
-            await File.WriteAllTextAsync(randomFile, "content");
+
+            await File.WriteAllTextAsync(Path.Combine(_testIndexDir, "test.cfs"), "content");
+            await File.WriteAllTextAsync(Path.Combine(_testIndexDir, "test.fdt"), "content");
+            await File.WriteAllTextAsync(Path.Combine(_testIndexDir, "test.txt"), "content");
 
             // Act
             var result = await _service.IsIndexValidAsync();
 
             // Assert
-            Assert.True(result); // Should find the .cfs file first
+            Assert.False(result);
         }
 
         [Fact]
-        public async Task IsIndexValidAsync_WithOnlyFdtFiles_ReturnsTrue()
+        public async Task IsIndexValidAsync_WithOnlyStrayFdtFile_ReturnsFalse()
         {
             // Arrange
             await _service.InitializeAsync();
-            
-            // Create only .fdt files (no .cfs files)
-            var fdtFile = Path.Combine(_testIndexDir, "test.fdt");
-            await File.WriteAllTextAsync(fdtFile, "content");
+
+            await File.WriteAllTextAsync(Path.Combine(_testIndexDir, "test.fdt"), "content");
 
             // Act
             var result = await _service.IsIndexValidAsync();
 
             // Assert
-            Assert.True(result); // Should fall back to checking .fdt files
+            Assert.False(result);
         }
     }
 }

--- a/src/CST.Avalonia.Tests/Services/IndexingServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/IndexingServiceTests.cs
@@ -164,9 +164,9 @@ namespace CST.Avalonia.Tests.Services
         }
 
         [Fact]
-        public async Task IsIndexValidAsync_WithCfsFiles_ReturnsTrue()
+        public async Task IsIndexValidAsync_WithStrayCfsFile_ReturnsFalse()
         {
-            // Arrange
+            // A file that merely has an index extension is not a readable Lucene index. (SRCH-11)
             await _service.InitializeAsync();
             var testFile = Path.Combine(_testIndexDir, "test.cfs");
             await File.WriteAllTextAsync(testFile, "test content");
@@ -175,13 +175,12 @@ namespace CST.Avalonia.Tests.Services
             var result = await _service.IsIndexValidAsync();
 
             // Assert
-            Assert.True(result);
+            Assert.False(result);
         }
 
         [Fact]
-        public async Task IsIndexValidAsync_WithFdtFiles_ReturnsTrue()
+        public async Task IsIndexValidAsync_WithStrayFdtFile_ReturnsFalse()
         {
-            // Arrange
             await _service.InitializeAsync();
             var testFile = Path.Combine(_testIndexDir, "test.fdt");
             await File.WriteAllTextAsync(testFile, "test content");
@@ -190,7 +189,7 @@ namespace CST.Avalonia.Tests.Services
             var result = await _service.IsIndexValidAsync();
 
             // Assert
-            Assert.True(result);
+            Assert.False(result);
         }
 
         [Fact]
@@ -219,10 +218,9 @@ namespace CST.Avalonia.Tests.Services
         {
             // Arrange
             await _service.InitializeAsync();
-            
-            // Create a fake index file to make the index appear valid
-            var testFile = Path.Combine(_testIndexDir, "test.cfs");
-            await File.WriteAllTextAsync(testFile, "test content");
+
+            // A real Lucene index so the validity check actually passes. (SRCH-11)
+            CreateMinimalIndex(1);
 
             _mockXmlFileDatesService.Setup(x => x.GetChangedBooksAsync())
                 .ReturnsAsync(new List<int>());

--- a/src/CST.Avalonia.Tests/TestSupport/TestIndex.cs
+++ b/src/CST.Avalonia.Tests/TestSupport/TestIndex.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using CST.Lucene;
+using Lucene.Net.Documents;
+using Lucene.Net.Index;
+using Lucene.Net.Store;
+using Lucene.Net.Util;
+
+namespace CST.Avalonia.Tests.TestSupport
+{
+    /// <summary>
+    /// Test helper that writes a real, openable Lucene index. Since IsIndexValidAsync now actually opens
+    /// the index (SRCH-11), tests can no longer fake validity by dropping a stray <c>.cfs</c> file.
+    /// </summary>
+    public static class TestIndex
+    {
+        public static void CreateMinimal(string indexDir, int docCount = 1)
+        {
+            System.IO.Directory.CreateDirectory(indexDir);
+            using var directory = FSDirectory.Open(indexDir);
+            using var analyzer = new DevaXmlAnalyzer(LuceneVersion.LUCENE_48);
+            using var writer = new IndexWriter(directory, new IndexWriterConfig(LuceneVersion.LUCENE_48, analyzer));
+            for (int i = 0; i < docCount; i++)
+            {
+                var doc = new Document();
+                doc.Add(new TextField("text", "\u0927\u092E\u094D\u092E", Field.Store.NO)); // "dhamma" (Devanagari)
+                writer.AddDocument(doc);
+            }
+            writer.Commit();
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/IXmlFileDatesService.cs
+++ b/src/CST.Avalonia/Services/IXmlFileDatesService.cs
@@ -16,6 +16,14 @@ namespace CST.Avalonia.Services
         /// indexing succeeds so a failed index never marks a book up-to-date (SRCH-1).
         /// </summary>
         void MarkBooksIndexed(IEnumerable<int> bookIndexes);
+
+        /// <summary>
+        /// Clear the in-memory file-date cache so every book is reported changed on the next
+        /// <see cref="GetChangedBooksAsync"/> — used to force a full re-index after the search index is
+        /// found corrupt and deleted (SRCH-11). The persisted file is overwritten on the next save.
+        /// </summary>
+        void ResetFileDates();
+
         Task InitializeAsync();
         
         // Enhanced format methods for XmlUpdateService

--- a/src/CST.Avalonia/Services/IndexingService.cs
+++ b/src/CST.Avalonia/Services/IndexingService.cs
@@ -65,35 +65,52 @@ namespace CST.Avalonia.Services
             _logger.LogInformation("IndexingService.InitializeAsync() completed successfully");
         }
 
-        public async Task<bool> IsIndexValidAsync()
+        public Task<bool> IsIndexValidAsync()
         {
+            // Validity means the index is actually readable, not merely that segment files exist. A torn or
+            // half-written index has files but throws on open; the old file-existence check reported it valid,
+            // so indexing was skipped and every search then failed with no recovery. (SRCH-11)
             try
             {
-                _logger.LogInformation("Checking index validity in directory: {IndexDirectory}", _indexDirectory);
-                
                 if (!System.IO.Directory.Exists(_indexDirectory))
+                    return Task.FromResult(false);
+
+                using var dir = FSDirectory.Open(_indexDirectory);
+                if (!DirectoryReader.IndexExists(dir))
                 {
-                    _logger.LogInformation("Index directory does not exist, index is invalid");
-                    return false;
+                    _logger.LogInformation("No readable index in {IndexDirectory}", _indexDirectory);
+                    return Task.FromResult(false);
                 }
 
-                var indexFiles = System.IO.Directory.GetFiles(_indexDirectory, "*.cfs");
-                _logger.LogInformation("Found {Count} .cfs files", indexFiles.Length);
-                
-                if (indexFiles.Length == 0)
-                {
-                    indexFiles = System.IO.Directory.GetFiles(_indexDirectory, "*.fdt");
-                    _logger.LogInformation("Found {Count} .fdt files", indexFiles.Length);
-                }
-
-                bool isValid = indexFiles.Length > 0;
-                _logger.LogInformation("Index validity check result: {IsValid}", isValid);
-                return isValid;
+                // A cheap open confirms readability; a corrupt index throws here.
+                using var reader = DirectoryReader.Open(dir);
+                _logger.LogInformation("Index is present and readable ({Count} docs)", reader.NumDocs);
+                return Task.FromResult(true);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error checking index validity");
-                return false;
+                _logger.LogWarning(ex, "Index in {IndexDirectory} is missing or corrupt", _indexDirectory);
+                return Task.FromResult(false);
+            }
+        }
+
+        // True if the index directory contains any files (so an invalid index here means corrupt, not absent).
+        private bool IndexDirectoryHasFiles()
+            => System.IO.Directory.Exists(_indexDirectory)
+               && System.IO.Directory.GetFiles(_indexDirectory).Length > 0;
+
+        // Delete the contents of a corrupt index so it can be rebuilt from scratch. Closes any open reader
+        // first so the files aren't held. (SRCH-11)
+        private void DeleteCorruptIndex()
+        {
+            Dispose(); // release _indexReader / _directory handles
+            if (!System.IO.Directory.Exists(_indexDirectory))
+                return;
+
+            foreach (var file in System.IO.Directory.GetFiles(_indexDirectory))
+            {
+                try { System.IO.File.Delete(file); }
+                catch (Exception ex) { _logger.LogWarning(ex, "Could not delete corrupt index file {File}", file); }
             }
         }
 
@@ -103,12 +120,23 @@ namespace CST.Avalonia.Services
             {
                 _logger.LogInformation("BuildIndexAsync() started");
 
-                // Get changed books (all books on first run)
+                // Recover from a corrupt/torn index: if index files are present but not readable, delete the
+                // index and reset the file-dates cache so every book is re-indexed from scratch — rather than
+                // skipping indexing (because "files exist") and leaving every search to throw. (SRCH-11)
+                var indexValid = await IsIndexValidAsync();
+                if (!indexValid && IndexDirectoryHasFiles())
+                {
+                    _logger.LogWarning("Search index is present but not readable (corrupt) - deleting and rebuilding from scratch");
+                    DeleteCorruptIndex();
+                    _xmlFileDatesService.ResetFileDates();
+                }
+
+                // Get changed books (all books on first run, or after a corrupt-index reset)
                 _logger.LogInformation("Getting changed books from XmlFileDatesService...");
                 var changedBooks = await _xmlFileDatesService.GetChangedBooksAsync();
                 _logger.LogInformation("Found {Count} changed books to index", changedBooks.Count);
 
-                if (changedBooks.Count == 0 && await IsIndexValidAsync())
+                if (changedBooks.Count == 0 && indexValid)
                 {
                     _logger.LogInformation("No changed books and index is valid - index is up to date");
                     progress?.Report(new IndexingProgress

--- a/src/CST.Avalonia/Services/XmlFileDatesService.cs
+++ b/src/CST.Avalonia/Services/XmlFileDatesService.cs
@@ -247,7 +247,17 @@ namespace CST.Avalonia.Services
                     _fileDates[fileName] = ts;
             }
         }
-        
+
+        public void ResetFileDates()
+        {
+            // Drop all cached dates so GetChangedBooksAsync reports every book as changed; the persisted
+            // enhanced-format timestamps are cleared too and overwritten on the next SaveFileDatesAsync. (SRCH-11)
+            _fileDates.Clear();
+            _pendingFileDates.Clear();
+            _fileDatesData?.Files.Clear();
+            _logger.LogInformation("File-date cache reset; all books will be re-indexed");
+        }
+
         // Enhanced format methods for XmlUpdateService
         public async Task<FileDatesWithCommits?> GetFileDatesDataAsync()
         {


### PR DESCRIPTION
Fixes #144 (SRCH-11 from the 2026-07-01 code review).

## Problem

`IndexingService.IsIndexValidAsync` treated the index as valid if **any `*.cfs`/`*.fdt` file existed**. A torn/corrupt index (segment files present but unreadable) passed the check, so `BuildIndexAsync` skipped indexing (`changedBooks == 0 && IsIndexValidAsync()`) and then **every search threw** against the corrupt reader — with no recovery.

## Fix

- **Real validity:** `IsIndexValidAsync` now opens the index (`DirectoryReader.IndexExists` + a cheap `DirectoryReader.Open`); a present-but-unreadable index reports invalid.
- **Recovery:** `BuildIndexAsync` — when the index directory has files but isn't readable — deletes the index and resets the file-dates cache (new `IXmlFileDatesService.ResetFileDates`), forcing a full rebuild instead of skipping and leaving search broken.

## Tests

Since validity now actually opens the index, tests can no longer fake it with a stray `.cfs`. Added a shared `TestIndex.CreateMinimal` (writes a real minimal index) and updated the index suites accordingly:
- `IndexCorruptionTests` / `IndexingServiceTests`: corrupt or stray-extension files → invalid; the recovery test asserts the corrupt index is deleted + `ResetFileDates` is called.
- `Integration` / `BugFix` / `Performance`: use a real index where "valid" is required (relaxed one over-specific exception-type assertion).

Full suite: **461/461**, build clean. (This finding's blast radius was larger than most — the old file-existence semantics were baked into 5 test files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)