### PR TITLE
#151 (SRCH-14): buffer per book in DevaXmlTokenizer.Reset(); drop analyzer's shared field

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DevaXmlAnalyzerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DevaXmlAnalyzerTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.IO;
+using CST;                       // DevaXmlAnalyzer
+using CST.Conversion;
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Util;
+using Xunit;
+
+namespace CST.Avalonia.Tests;
+
+/// <summary>
+/// SRCH-14: DevaXmlAnalyzer must not share tokenizer state across documents. Reusing one analyzer
+/// instance (Lucene's normal path, via GetTokenStream) must yield each document's own tokens — the
+/// per-document buffering now happens in DevaXmlTokenizer.Reset() from the tokenizer's own reader, not
+/// through a shared analyzer field. Diacritics are written directly (Latin-extended), matching
+/// OffsetConventionTests.
+/// </summary>
+public class DevaXmlAnalyzerTests
+{
+    private static List<string> Terms(Analyzer analyzer, string deva)
+    {
+        var terms = new List<string>();
+        using var ts = analyzer.GetTokenStream("text", new StringReader(deva));
+        var termAtt = ts.GetAttribute<ICharTermAttribute>();
+        ts.Reset();
+        while (ts.IncrementToken())
+            terms.Add(termAtt.ToString());
+        ts.End();
+        return terms;
+    }
+
+    [Fact]
+    public void ReusedAnalyzer_ProducesEachDocumentsOwnTokens()
+    {
+        using var analyzer = new DevaXmlAnalyzer(LuceneVersion.LUCENE_48);
+        var docA = ScriptConverter.Convert("buddho dhammo", Script.Latin, Script.Devanagari);
+        var docB = ScriptConverter.Convert("saṅgho", Script.Latin, Script.Devanagari);
+
+        var a1 = Terms(analyzer, docA);
+        var b = Terms(analyzer, docB);   // reuse: must re-buffer from B's reader, not carry A's text over
+        var a2 = Terms(analyzer, docA);  // reuse again
+
+        Assert.Equal(new[] { Any2Ipe.Convert("buddho"), Any2Ipe.Convert("dhammo") }, a1);
+        Assert.Equal(new[] { Any2Ipe.Convert("saṅgho") }, b);
+        Assert.Equal(a1, a2);
+    }
+}

--- a/src/CST.Lucene/DevaXmlAnalyzer.cs
+++ b/src/CST.Lucene/DevaXmlAnalyzer.cs
@@ -8,7 +8,6 @@ namespace CST
     public class DevaXmlAnalyzer : Analyzer
     {
         private readonly LuceneVersion matchVersion;
-        private DevaXmlTokenizer tokenizer = null!;
 
         public DevaXmlAnalyzer(LuceneVersion matchVersion)
         {
@@ -17,20 +16,9 @@ namespace CST
 
         protected override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
         {
-            tokenizer = new DevaXmlTokenizer(matchVersion, reader);
-            //WhitespaceTokenizer tokenizer = new WhitespaceTokenizer(matchVersion, reader);
-            //DummyTokenizer tokenizer = new DummyTokenizer(matchVersion, reader);
-            return new TokenStreamComponents(tokenizer);
-        }
-
-        protected override TextReader InitReader(string fieldName, TextReader reader)
-        {
-            TextReader reader2 = base.InitReader(fieldName, reader);
-            if (tokenizer != null)
-            {
-                tokenizer.InitPerBook(reader2);
-            }
-            return reader2;
+            // No shared state: each (per-thread) TokenStreamComponents gets its own tokenizer, and the
+            // tokenizer buffers the document in its Reset() from its own reader. (SRCH-14)
+            return new TokenStreamComponents(new DevaXmlTokenizer(matchVersion, reader));
         }
     }
 }

--- a/src/CST.Lucene/DevaXmlTokenizer.cs
+++ b/src/CST.Lucene/DevaXmlTokenizer.cs
@@ -37,7 +37,7 @@ namespace CST
             : base(input)
         {
             //Init(input);
-            InitInstance(input);
+            InitInstance();
         }
 
         /// <summary>
@@ -47,10 +47,10 @@ namespace CST
             : base(factory, input)
         {
             //Init(input);
-            InitInstance(input);
+            InitInstance();
         }
 
-        private void InitInstance(TextReader input)
+        private void InitInstance()
         {
             termAtt = AddAttribute<ICharTermAttribute>();
             posIncrAtt = AddAttribute<IPositionIncrementAttribute>();
@@ -133,16 +133,19 @@ namespace CST
                 '_' // placeholder for <hi rend="bold"> and </hi>, which can occur inside words
             };
             wordChars = tempHashSet.ToImmutableHashSet<char>();
-
-            InitPerBook(input);
         }
 
-        public void InitPerBook(TextReader input)
+        /// <summary>
+        /// Buffers the whole document from the current reader (<c>m_input</c>) and strips XML/non-token
+        /// characters. Lucene calls this at the start of every token stream — i.e. once per book — so the
+        /// per-document state lives entirely on the tokenizer instance, with nothing shared through the
+        /// analyzer. (SRCH-14)
+        /// </summary>
+        public override void Reset()
         {
-            text = new StringBuilder(input.ReadToEnd());
-
+            base.Reset(); // makes m_input the active reader (the one passed to the ctor or SetReader)
+            text = new StringBuilder(m_input.ReadToEnd());
             FirstPass();
-
             pos = 0;
         }
 


### PR DESCRIPTION
Fixes #151 (SRCH-14 from the 2026-07-01 code review).

## Problem

`DevaXmlAnalyzer` kept the last-created tokenizer in a shared instance field and re-buffered it via `InitReader`. Lucene caches `TokenStreamComponents` per thread, so under any concurrency one thread's `CreateComponents` overwrites the field another thread's `InitReader` reads → interleaved book text. Safe only because indexing is single-threaded today.

## Fix (standard Lucene buffering-tokenizer pattern)

- Move the per-document `ReadToEnd` + `FirstPass` into `DevaXmlTokenizer.Reset()`, reading the tokenizer's own `m_input`. The ctor no longer consumes the reader.
- Drop `DevaXmlAnalyzer`'s `tokenizer` field and `InitReader` override; `CreateComponents` returns a fresh tokenizer with no shared state.

## Tests

- Tokens/offsets **unchanged** — verified by the #53 `OffsetConventionTests`, `MultiScriptSupportTests`, and the real-index suites (which index via `DevaXmlAnalyzer`).
- New `DevaXmlAnalyzerTests`: one analyzer instance reused across documents yields each document's own tokens (re-buffered in `Reset()`), never stale/interleaved.

Build clean; tokenizer/analyzer/index tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)