### PR TITLE
#154 (SRCH-12): spend the page budget on filter-surviving terms

### DIFF
--- a/src/CST.Avalonia.Tests/Services/SearchTermBudgetTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SearchTermBudgetTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// SRCH-12: the page budget must be spent on terms that actually occur in the selected books. Truncating
+/// the matched-term list before the book filter dropped legitimate terms past the page size when the
+/// filter was narrow. These test <see cref="SearchService.SelectTermsWithinBudgetAsync"/> in isolation.
+/// </summary>
+public class SearchTermBudgetTests
+{
+    // Terms in the given "survivor" set return a single occurrence with that count; all others return an
+    // empty list, standing in for "not present in the selected books".
+    private static Func<string, Task<List<BookOccurrence>>> Occurrences(params (string term, int count)[] survivors)
+    {
+        var map = survivors.ToDictionary(s => s.term, s => s.count);
+        return term => Task.FromResult(
+            map.TryGetValue(term, out var c)
+                ? new List<BookOccurrence> { new BookOccurrence { Count = c } }
+                : new List<BookOccurrence>());
+    }
+
+    [Fact]
+    public async Task Budget_CountsOnlyFilterSurvivors_NotTermsMissingFromSelectedBooks()
+    {
+        // t1/t3/t5 aren't in the selected books; survivors in order are t2, t4, t6. The old code took the
+        // first pageSize (2) terms and THEN filtered -> only t2; t4 and t6 were lost. Now t4 is included.
+        var terms = new[] { "t1", "t2", "t3", "t4", "t5", "t6" };
+
+        var (selected, total, truncated) = await SearchService.SelectTermsWithinBudgetAsync(
+            terms, pageSize: 2, Occurrences(("t2", 1), ("t4", 1), ("t6", 1)), s => s, CancellationToken.None);
+
+        Assert.Equal(new[] { "t2", "t4" }, selected.Select(x => x.Term));
+        Assert.True(truncated); // t6 survives the filter beyond the page
+        Assert.Equal(2, total);
+    }
+
+    [Fact]
+    public async Task Budget_NoTruncation_WhenSurvivorsFitWithinPage_AndDisplayApplied()
+    {
+        var terms = new[] { "a", "b", "c" };
+
+        var (selected, total, truncated) = await SearchService.SelectTermsWithinBudgetAsync(
+            terms, pageSize: 10, Occurrences(("a", 3), ("c", 4)), s => s.ToUpperInvariant(), CancellationToken.None);
+
+        Assert.Equal(new[] { "a", "c" }, selected.Select(x => x.Term));           // "b" missing -> skipped
+        Assert.Equal(new[] { "A", "C" }, selected.Select(x => x.DisplayTerm));    // toDisplay applied
+        Assert.False(truncated);
+        Assert.Equal(7, total);
+    }
+
+    [Fact]
+    public async Task Budget_ReturnsEmpty_WhenNoTermSurvives()
+    {
+        var (selected, total, truncated) = await SearchService.SelectTermsWithinBudgetAsync(
+            new[] { "x", "y" }, pageSize: 5, Occurrences(), s => s, CancellationToken.None);
+
+        Assert.Empty(selected);
+        Assert.Equal(0, total);
+        Assert.False(truncated);
+    }
+}

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -185,60 +185,74 @@ public class SearchService : ISearchService
         // Get all matching terms
         var matchingTerms = await GetMatchingTermsAsync(reader, termMatcher, cancellationToken);
 
-        var termsToProcess = matchingTerms.Take(query.PageSize).ToList();
-        if (matchingTerms.Count > termsToProcess.Count)
+        // Apply the page budget to terms that SURVIVE the book filter. Truncating matchingTerms up
+        // front (before checking occurrences) spent the budget on terms not in the selected books, dropping
+        // legitimate results past the page size when the filter was narrow. (SRCH-12)
+        var conversionStopwatch = Stopwatch.StartNew();
+        var (selectedTerms, totalOccurrences, truncated) = await SelectTermsWithinBudgetAsync(
+            matchingTerms,
+            query.PageSize,
+            term => GetTermOccurrencesAsync(reader, term, bookBits, books, cancellationToken),
+            ConvertToDisplayScript,
+            cancellationToken);
+        conversionStopwatch.Stop();
+
+        result.Terms.AddRange(selectedTerms);
+        result.TotalOccurrenceCount += totalOccurrences;
+        if (truncated)
         {
             result.ResultsTruncated = true;
-            result.TruncationMessage = $"Showing the first {termsToProcess.Count:N0} of {matchingTerms.Count:N0} matching words — refine your search to narrow the results.";
+            result.TruncationMessage = $"Showing the first {query.PageSize:N0} matching words \u2014 refine your search to narrow the results.";
         }
-        _logger.LogInformation("Processing {Count} terms for display conversion", termsToProcess.Count);
-        
-        // Debug: Log first and last few terms to understand the order
-        if (termsToProcess.Count > 0)
-        {
-            var firstTerms = string.Join(", ", termsToProcess.Take(5));
-            var lastTerms = string.Join(", ", termsToProcess.TakeLast(5));
-            _logger.LogInformation("First 5 terms: {FirstTerms}", firstTerms);
-            _logger.LogInformation("Last 5 terms: {LastTerms}", lastTerms);
-        }
-        
-        var conversionStopwatch = Stopwatch.StartNew();
-        foreach (var term in termsToProcess)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var convertedTerm = ConvertToDisplayScript(term);
-            var matchingTerm = new MatchingTerm
-            {
-                Term = term,
-                DisplayTerm = convertedTerm
-            };
-
-            // Get occurrences for this term
-            var occurrences = await GetTermOccurrencesAsync(reader, term, bookBits, books, cancellationToken);
-            
-            // Only add the term if it has occurrences in the selected books
-            if (occurrences.Any())
-            {
-                matchingTerm.Occurrences = occurrences;
-                matchingTerm.TotalCount = occurrences.Sum(o => o.Count);
-                result.Terms.Add(matchingTerm);
-            }
-            else
-            {
-                _logger.LogDebug("Skipping term '{Term}' - no occurrences in selected books", term);
-            }
-            result.TotalOccurrenceCount += matchingTerm.TotalCount;
-        }
-        
-        conversionStopwatch.Stop();
-        _logger.LogInformation("Script conversion completed in {Elapsed}ms for {Count} terms", 
-            conversionStopwatch.ElapsedMilliseconds, termsToProcess.Count);
+        _logger.LogInformation("Script conversion completed in {Elapsed}ms for {Count} terms",
+            conversionStopwatch.ElapsedMilliseconds, result.Terms.Count);
 
         result.TotalTermCount = result.Terms.Count;
         result.TotalBookCount = result.Terms.SelectMany(t => t.Occurrences).Select(o => o.Book).Distinct().Count();
 
         return result;
+    }
+
+    /// <summary>
+    /// From an ordered list of index terms that matched the query, build up to <paramref name="pageSize"/>
+    /// <see cref="MatchingTerm"/>s that actually occur in the selected books, preserving order. Terms with
+    /// no occurrences in the selected books do NOT consume the page budget, so a narrow book filter can't
+    /// drop legitimate terms past the page size (SRCH-12). Returns the built terms, their total occurrence
+    /// count, and whether a filter-surviving term was left off the page.
+    /// </summary>
+    internal static async Task<(List<MatchingTerm> terms, int totalOccurrences, bool truncated)> SelectTermsWithinBudgetAsync(
+        IReadOnlyList<string> matchingTerms,
+        int pageSize,
+        Func<string, Task<List<BookOccurrence>>> getOccurrences,
+        Func<string, string> toDisplay,
+        CancellationToken cancellationToken)
+    {
+        var terms = new List<MatchingTerm>();
+        int totalOccurrences = 0;
+
+        foreach (var term in matchingTerms)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var occurrences = await getOccurrences(term).ConfigureAwait(false);
+            if (occurrences.Count == 0)
+                continue; // not in the selected books - doesn't count toward the page budget
+
+            if (terms.Count >= pageSize)
+                return (terms, totalOccurrences, true); // a filter-surviving term exists beyond the page
+
+            var totalCount = occurrences.Sum(o => o.Count);
+            terms.Add(new MatchingTerm
+            {
+                Term = term,
+                DisplayTerm = toDisplay(term),
+                Occurrences = occurrences,
+                TotalCount = totalCount
+            });
+            totalOccurrences += totalCount;
+        }
+
+        return (terms, totalOccurrences, false);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #154 (SRCH-12 from the 2026-07-01 code review).

## Problem

`SearchService.SearchSingleTermAsync` did `matchingTerms.Take(query.PageSize)` **before** checking each term's occurrences in the selected books, then dropped terms not in those books. For a broad wildcard + a narrow book filter, the page budget was spent on terms that don't appear in the selected books, so legitimate terms past the 500th were dropped while the displayed list looked short.

## Fix

Count only filter-surviving terms toward the page budget. Extracted `SelectTermsWithinBudgetAsync`: iterate the matched terms in order, fetch each term's occurrences in the selected books, **skip terms with none** (they don't consume the budget), and stop once `PageSize` surviving terms are collected (truncated if another survivor exists beyond the page). The truncation message now reads "Showing the first N matching words".

## Tests

Unit tests on the extracted helper (isolated from Lucene): survivors past the old page window are now included; no truncation when survivors fit; `toDisplay` applied; empty when nothing survives. Full suite **464/464**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)