### PR TITLE
#157 (SRCH-6): refresh the highlighting index reader after re-indexing

### DIFF
--- a/src/CST.Avalonia.Tests/Services/IndexingServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/IndexingServiceTests.cs
@@ -84,9 +84,32 @@ namespace CST.Avalonia.Tests.Services
             var reader = _service.GetIndexReader();
             Assert.NotNull(reader);
             Assert.Equal(3, reader!.NumDocs);
+            reader.DecRef(); // GetIndexReader hands out a counted reference (SRCH-6)
 
-            // Dispose releases the reader/FSDirectory and must be safe to call more than once.
+            // Dispose releases the owner ref/FSDirectory and must be safe to call more than once.
             _service.Dispose();
+            _service.Dispose();
+        }
+
+        [Fact]
+        public async Task GetIndexReader_RefreshesAfterReindex()
+        {
+            // SRCH-6: after the index changes, the highlighting reader must reflect the new content, not a
+            // stale generation (which would give wrong term vectors / out-of-range docIds).
+            CreateMinimalIndex(2);
+            await _service.InitializeAsync();
+
+            var reader1 = _service.GetIndexReader();
+            Assert.Equal(2, reader1!.NumDocs);
+            reader1.DecRef();
+
+            // Simulate a mid-session re-index that adds documents (CreateMinimalIndex appends + commits).
+            CreateMinimalIndex(3);
+
+            var reader2 = _service.GetIndexReader();
+            Assert.True(reader2!.NumDocs > 2, $"reader was not refreshed after re-index (still {reader2.NumDocs} docs)");
+            reader2.DecRef();
+
             _service.Dispose();
         }
 

--- a/src/CST.Avalonia/Services/IIndexingService.cs
+++ b/src/CST.Avalonia/Services/IIndexingService.cs
@@ -14,6 +14,12 @@ namespace CST.Avalonia.Services
         Task OptimizeIndexAsync();
         string IndexDirectory { get; }
         Task InitializeAsync();
+
+        /// <summary>
+        /// Returns a reference-counted, up-to-date <see cref="DirectoryReader"/> for highlighting, or null
+        /// if none is available. The caller MUST release it with <c>DecRef()</c> in a finally. The reader is
+        /// refreshed when the index changes, so it never serves stale term vectors after a re-index (SRCH-6).
+        /// </summary>
         DirectoryReader? GetIndexReader();
     }
 }

--- a/src/CST.Avalonia/Services/IndexingService.cs
+++ b/src/CST.Avalonia/Services/IndexingService.cs
@@ -256,35 +256,40 @@ namespace CST.Avalonia.Services
             return indexPath;
         }
 
+        // Returns a reference-counted DirectoryReader for highlighting; the caller MUST release it with
+        // DecRef() in a finally. Refreshes when the index has changed (IsCurrent), so a mid-session
+        // re-index doesn't leave highlighting reading stale term vectors against new-generation docIds.
+        // Reference counting lets the refresh open a fresh reader without disposing one an in-flight
+        // caller is still enumerating. Mirrors SearchService's reader (SRCH-2). (SRCH-6)
         public DirectoryReader? GetIndexReader()
         {
             lock (_readerLock)
             {
                 try
                 {
-                    // If reader is null or closed, open a new one
-                    if (_indexReader == null || _indexReader.RefCount <= 0)
+                    if (_indexReader == null || !_indexReader.IsCurrent())
                     {
-                        if (System.IO.Directory.Exists(_indexDirectory))
-                        {
-                            // Reuse a single FSDirectory; only (re)open it when missing or the
-                            // index path changes. Opening a new directory each time without
-                            // disposing it leaked native handles.
-                            if (_directory == null || _directoryPath != _indexDirectory)
-                            {
-                                _directory?.Dispose();
-                                _directory = FSDirectory.Open(_indexDirectory);
-                                _directoryPath = _indexDirectory;
-                            }
-                            _indexReader = DirectoryReader.Open(_directory);
-                            _logger.LogDebug("Opened new index reader for highlighting");
-                        }
-                        else
+                        if (!System.IO.Directory.Exists(_indexDirectory))
                         {
                             _logger.LogWarning("Index directory does not exist: {IndexDirectory}", _indexDirectory);
                             return null;
                         }
+
+                        // Reuse a single FSDirectory; only (re)open it when missing or the index path
+                        // changes (a new directory per call without disposing leaked native handles).
+                        if (_directory == null || _directoryPath != _indexDirectory)
+                        {
+                            _directory?.Dispose();
+                            _directory = FSDirectory.Open(_indexDirectory);
+                            _directoryPath = _indexDirectory;
+                        }
+
+                        var newReader = DirectoryReader.Open(_directory);
+                        _indexReader?.DecRef();   // release the owner ref; closes once in-flight callers DecRef too
+                        _indexReader = newReader;
+                        _logger.LogDebug("Opened fresh index reader for highlighting ({DocCount} docs)", _indexReader.NumDocs);
                     }
+                    _indexReader.IncRef();   // hand out a counted reference; caller DecRefs in a finally
                     return _indexReader;
                 }
                 catch (Exception ex)
@@ -299,7 +304,7 @@ namespace CST.Avalonia.Services
         {
             lock (_readerLock)
             {
-                _indexReader?.Dispose();
+                _indexReader?.DecRef();   // release the owner ref (closes once any in-flight callers DecRef) - SRCH-6
                 _indexReader = null;
                 _directory?.Dispose();
                 _directory = null;

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -963,6 +963,7 @@ namespace CST.Avalonia.ViewModels
                 return xmlContent;
             }
 
+            DirectoryReader? indexReader = null;
             try
             {
                 // NEW: If we have pre-computed positions (from phrase/proximity search), use them directly
@@ -978,7 +979,7 @@ namespace CST.Avalonia.ViewModels
                     return xmlContent;
                 }
 
-                var indexReader = indexingService.GetIndexReader();
+                indexReader = indexingService.GetIndexReader();
                 if (indexReader == null)
                 {
                     _logger.Warning("Could not get index reader for highlighting");
@@ -1122,6 +1123,10 @@ namespace CST.Avalonia.ViewModels
                 _logger.Error(ex, "Failed to apply search highlighting");
                 Log.Error(ex, "[BookDisplay] Error applying highlights");
                 return xmlContent; // Return original content on error
+            }
+            finally
+            {
+                indexReader?.DecRef(); // release the counted reference (SRCH-6, mirrors SRCH-2)
             }
         }
 


### PR DESCRIPTION
Fixes #157 (SRCH-6 from the 2026-07-01 code review).

## Problem

`IndexingService.GetIndexReader` (consumed by `BookDisplayViewModel` highlighting) reopened the reader only when it was null or refcount-dead — no `IsCurrent()` check. After a mid-session re-index (XML update), the reader is a stale generation, so highlighting reads term vectors against new-generation docIds → wrong highlight offsets or out-of-range failures.

## Fix (mirror SearchService's refcounted reader, SRCH-2)

- `GetIndexReader` refreshes when `!IsCurrent()`, hands out a **reference-counted** reader (`IncRef`), and `DecRef`s the superseded owner ref so an in-flight highlight isn't disposed mid-use.
- The sole consumer (`BookDisplayViewModel`) releases the reader with `DecRef()` in a `finally`.
- `Dispose` releases the owner ref via `DecRef` (not `Dispose`, which would break in-flight callers under refcounting).

## Tests

- New: `GetIndexReader` returns a reader reflecting new content after a re-index (not the stale 2-doc generation).
- Existing `GetIndexReader` test updated to release its counted reference.

Full suite **463/463**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)