### PR TITLE
#162 (NET-5): build the PDF file:// URL with Uri.AbsoluteUri, not string concat

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/PdfUrlTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/PdfUrlTests.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using System.Linq;
+using CST.Avalonia.ViewModels;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// NET-5: the PDF browser URL must be a properly-escaped file:// URI plus a #page=N fragment. The old
+/// $"file://{path}#page=N" left spaces raw (real PDF paths live under ".../Application Support/...") and
+/// would let a '#' in the path truncate the URL.
+/// </summary>
+public class PdfUrlTests
+{
+    [Fact]
+    public void BuildPdfUrl_EscapesSpaces_AndAppendsPageFragment()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "sub dir", "my source.pdf");
+
+        var url = PdfDisplayViewModel.BuildPdfUrl(path, 5);
+
+        Assert.StartsWith("file:///", url);   // a real file URI, not "file://<raw path>"
+        Assert.EndsWith("#page=5", url);
+        Assert.Contains("%20", url);           // space escaped
+        Assert.DoesNotContain(" ", url);       // no raw spaces
+    }
+
+    [Fact]
+    public void BuildPdfUrl_EscapesHashInPath_SoTheOnlyFragmentIsThePage()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "a#b.pdf");
+
+        var url = PdfDisplayViewModel.BuildPdfUrl(path, 2);
+
+        Assert.Contains("a%23b.pdf", url);            // '#' inside the path is escaped, not a fragment
+        Assert.EndsWith("#page=2", url);
+        Assert.Equal(1, url.Count(c => c == '#'));    // exactly one '#': the page fragment
+    }
+}

--- a/src/CST.Avalonia/ViewModels/PdfDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/PdfDisplayViewModel.cs
@@ -203,9 +203,9 @@ namespace CST.Avalonia.ViewModels
                 int pdfPage = _targetPage;
                 if (pdfPage < 1) pdfPage = 1;
 
-                // Build the file:// URL with page fragment
-                // CEF's PDFium supports #page=N fragments
-                PdfUrl = $"file://{localPath}#page={pdfPage}";
+                // CEF/PDFium honors a #page=N fragment. Build the file:// URL via Uri.AbsoluteUri so the
+                // path is escaped correctly (spaces, '#', Windows drive letters) — string concat was not. (NET-5)
+                PdfUrl = BuildPdfUrl(localPath, pdfPage);
 
                 Title = $"{Path.GetFileNameWithoutExtension(localPath)} - Page {pdfPage}";
                 StatusText = $"{SourceTypeName} - Page {pdfPage}";
@@ -236,6 +236,12 @@ namespace CST.Avalonia.ViewModels
             // Float/unfloat for PDF not yet implemented
             _logger.Warning("Unfloat not yet implemented for PDF windows");
         }
+
+        // Build the browser URL for a local PDF at a given page: a properly-escaped file:// URI plus the
+        // PDFium #page=N fragment. Uri.AbsoluteUri escapes spaces / '#' and emits file:///C:/... on Windows;
+        // the old $"file://{path}#page=N" produced malformed, unescaped URLs. (NET-5)
+        internal static string BuildPdfUrl(string localPath, int page)
+            => new Uri(localPath).AbsoluteUri + $"#page={page}";
 
         private static string GetSourceTypeName(Sources.SourceType sourceType)
         {


### PR DESCRIPTION
Fixes #162 (NET-5 from the 2026-07-01 code review).

## Problem

`PdfDisplayViewModel` built the browser URL as `$"file://{localPath}#page={pdfPage}"`. Real PDF paths live under `.../Application Support/...`, so the space was left **raw** (malformed URL); on Windows `file://C:\...` is invalid; and a `#` anywhere in the path would truncate the URL.

## Fix

`new Uri(localPath).AbsoluteUri + $"#page={pdfPage}"`. Verified on macOS: `Application Support` -> `Application%20Support`, `a#b.pdf` -> `a%23b.pdf`, and `file:///C:/...` on Windows. Extracted as `internal BuildPdfUrl`.

## Tests

Spaces escaped (`%20`) with the page fragment appended; a `#` in the path is escaped (`%23`) so the only `#` is the `#page=N` fragment. Build clean; 2/2 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)