### PR TITLE
#165 (NET-4): stage XML downloads on the destination volume; retry the move

### DIFF
--- a/src/CST.Avalonia.Tests/Services/XmlUpdateStagingTests.cs
+++ b/src/CST.Avalonia.Tests/Services/XmlUpdateStagingTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// NET-4: XML-update downloads must stage on the same volume as the destination so the final move is an
+/// atomic rename (Path.GetTempPath() is often a different filesystem, degrading Move to a non-atomic
+/// copy+delete), and the move must tolerate a briefly-open file rather than aborting the apply.
+/// </summary>
+public class XmlUpdateStagingTests : IDisposable
+{
+    private readonly string _root;
+
+    public XmlUpdateStagingTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cst-net4-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void CreateStagingDirectory_IsSiblingOfXmlDir_OnSameVolume()
+    {
+        var xmlDir = Path.Combine(_root, "xml");
+        Directory.CreateDirectory(xmlDir);
+
+        var staging = XmlUpdateService.CreateStagingDirectory(xmlDir);
+
+        Assert.True(Directory.Exists(staging));
+        Assert.NotEqual(xmlDir, staging);
+        // Same parent as the XML dir => same volume => the final File.Move is an atomic rename.
+        Assert.Equal(Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(xmlDir)),
+                     Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(staging)));
+        Assert.Equal(Path.GetPathRoot(xmlDir), Path.GetPathRoot(staging));
+    }
+
+    [Fact]
+    public async Task MoveIntoPlaceAsync_MovesFile_AndOverwritesDestination()
+    {
+        var src = Path.Combine(_root, "src.xml");
+        var dest = Path.Combine(_root, "dest.xml");
+        await File.WriteAllTextAsync(dest, "OLD");
+        await File.WriteAllTextAsync(src, "NEW");
+
+        await XmlUpdateService.MoveIntoPlaceAsync(src, dest);
+
+        Assert.False(File.Exists(src));
+        Assert.Equal("NEW", await File.ReadAllTextAsync(dest));
+    }
+}

--- a/src/CST.Avalonia/Services/XmlUpdateService.cs
+++ b/src/CST.Avalonia/Services/XmlUpdateService.cs
@@ -350,8 +350,7 @@ namespace CST.Avalonia.Services
                 
                 // STEP 3: Download each file via direct HTTPS (no API calls)
                 var downloadedFiles = new Dictionary<string, FileCommitInfo>();
-                var tempDir = Path.Combine(Path.GetTempPath(), $"cst-download-{Guid.NewGuid()}");
-                Directory.CreateDirectory(tempDir);
+                var tempDir = CreateStagingDirectory(xmlDir);
                 
                 try
                 {
@@ -397,7 +396,7 @@ namespace CST.Avalonia.Services
                     {
                         var fileName = Path.GetFileName(file);
                         var destPath = Path.Combine(xmlDir, fileName);
-                        File.Move(file, destPath, overwrite: true);
+                        await MoveIntoPlaceAsync(file, destPath);
                     }
                     
                     // Save file dates with commit hashes
@@ -664,8 +663,7 @@ namespace CST.Avalonia.Services
                 _logger.LogInformation("Downloading {Count} updated files via direct HTTPS", filesToUpdate.Count);
                 UpdateStatusChanged?.Invoke($"Downloading {filesToUpdate.Count} updated files...");
                 
-                var tempDir = Path.Combine(Path.GetTempPath(), $"cst-update-{Guid.NewGuid()}");
-                Directory.CreateDirectory(tempDir);
+                var tempDir = CreateStagingDirectory(xmlDir);
                 
                 try
                 {
@@ -716,7 +714,7 @@ namespace CST.Avalonia.Services
                     {
                         var fileName = Path.GetFileName(file);
                         var destPath = Path.Combine(xmlDir, fileName);
-                        File.Move(file, destPath, overwrite: true);
+                        await MoveIntoPlaceAsync(file, destPath);
                     }
                     
                     // Trigger incremental indexing BEFORE persisting file dates. The
@@ -754,6 +752,40 @@ namespace CST.Avalonia.Services
             }
         }
 
+
+        // Create a staging directory as a SIBLING of the XML directory, so it's on the same volume and the
+        // final File.Move into place is an atomic same-volume rename. Path.GetTempPath() is often a different
+        // filesystem, where Move degrades to a non-atomic copy+delete that can leave a truncated XML file on
+        // a crash. (NET-4)
+        internal static string CreateStagingDirectory(string xmlDir)
+        {
+            var parent = Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(xmlDir));
+            if (string.IsNullOrEmpty(parent))
+                parent = xmlDir; // fall back to inside the XML dir if it has no parent
+            var staging = Path.Combine(parent, $".cst-staging-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(staging);
+            return staging;
+        }
+
+        // Move a staged file into place, retrying briefly. On Windows File.Move over a file an open book tab
+        // is reading throws a sharing violation; the read is short, so a few retries let it finish rather than
+        // aborting the apply and leaving a mixed-commit corpus. (NET-4)
+        internal static async Task MoveIntoPlaceAsync(string source, string dest)
+        {
+            const int maxAttempts = 5;
+            for (int attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    File.Move(source, dest, overwrite: true);
+                    return;
+                }
+                catch (IOException) when (attempt < maxAttempts)
+                {
+                    await Task.Delay(100 * attempt);
+                }
+            }
+        }
 
         private string GetAppDataDirectory()
         {


### PR DESCRIPTION
Fixes #165 (NET-4 from the 2026-07-01 code review).

## Problem

`XmlUpdateService` staged downloads in `Path.GetTempPath()` and `File.Move`d each file into the XML directory (both the initial-download and update-download paths). The temp dir is often on a **different volume**, so `File.Move` degrades to a non-atomic copy+delete (a crash mid-copy can leave a **truncated XML file**); and on Windows `File.Move` over a file an open book tab is reading throws, **aborting the apply mid-corpus**.

## Fix

- **`CreateStagingDirectory`** — a `.cst-staging-<guid>` directory that is a **sibling of the XML dir** (same volume), so the final move is an atomic same-volume rename. Replaces the `GetTempPath()` staging in both paths.
- **`MoveIntoPlaceAsync`** — retries the move briefly so a transient sharing violation (open tab) doesn't abort the apply.

## Tests

- Staging dir is a same-volume sibling of the XML dir (same parent + same path root).
- Move overwrites the destination and removes the source.

Build clean; 2/2 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)