### PR TITLE
#171 (NET-8): share one HttpClient in WelcomeUpdateService instead of leaking one per instance

### DIFF
--- a/src/CST.Avalonia.Tests/Services/WelcomeUpdateHttpClientTests.cs
+++ b/src/CST.Avalonia.Tests/Services/WelcomeUpdateHttpClientTests.cs
@@ -1,0 +1,39 @@
+using System.Net.Http;
+using System.Reflection;
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// NET-8: a WelcomeUpdateService is created per welcome document (and each layout reset). It must not
+/// new up a fresh HttpClient each time (they were never disposed) — instances share one long-lived
+/// client. An explicitly injected client is still honored (for tests).
+/// </summary>
+public class WelcomeUpdateHttpClientTests
+{
+    private static HttpClient? ClientOf(WelcomeUpdateService svc) =>
+        (HttpClient?)typeof(WelcomeUpdateService)
+            .GetField("_httpClient", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(svc);
+
+    [Fact]
+    public void Instances_ShareOneHttpClient_WhenNoneInjected()
+    {
+        var a = new WelcomeUpdateService();
+        var b = new WelcomeUpdateService();
+
+        Assert.NotNull(ClientOf(a));
+        Assert.Same(ClientOf(a), ClientOf(b)); // shared, not a leaked new client per instance
+    }
+
+    [Fact]
+    public void InjectedHttpClient_IsUsed()
+    {
+        using var injected = new HttpClient();
+
+        var svc = new WelcomeUpdateService(injected);
+
+        Assert.Same(injected, ClientOf(svc));
+    }
+}

--- a/src/CST.Avalonia/Services/WelcomeUpdateService.cs
+++ b/src/CST.Avalonia/Services/WelcomeUpdateService.cs
@@ -29,12 +29,17 @@ namespace CST.Avalonia.Services
         private static readonly TimeSpan MaxCacheAge = TimeSpan.FromDays(30);
         private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(10);
 
+        // One shared client for the app lifetime. A WelcomeUpdateService is created per welcome document
+        // (and each layout reset), so newing an HttpClient per instance leaked an undisposed client every
+        // time. A single long-lived HttpClient is the recommended pattern and needs no disposal. (NET-8)
+        private static readonly HttpClient SharedHttpClient = new() { Timeout = HttpTimeout };
+
         // Current app version - will be injected from App.axaml.cs
         public string CurrentAppVersion { get; set; } = "5.0.0-beta.5";
 
         public WelcomeUpdateService(HttpClient? httpClient = null)
         {
-            _httpClient = httpClient ?? new HttpClient { Timeout = HttpTimeout };
+            _httpClient = httpClient ?? SharedHttpClient;
             _logger = Log.ForContext<WelcomeUpdateService>();
 
             // Determine cache directory based on platform


### PR DESCRIPTION
Fixes #171 (NET-8 from the 2026-07-01 code review).

## Problem

`WelcomeUpdateService` created `new HttpClient` when none was injected, and a `WelcomeUpdateService` is created **per welcome document** (`new WelcomeViewModel()` → `new WelcomeUpdateService()`, from `CstDockFactory`). So each layout reset **leaked another undisposed HttpClient**.

## Fix

Default to a **single static long-lived HttpClient** shared by all instances — the recommended HttpClient pattern, with nothing to leak. An explicitly injected client is still honored (tests).

I kept this to the one file rather than restructuring the `WelcomeViewModel`/dock construction into DI; a DI singleton (as the review suggests) would achieve the same one-client outcome, and can be layered on later if the whole service is moved into the container. Happy to switch to that if preferred.

## Tests

- Two default-constructed instances share the same `HttpClient` (no per-instance leak).
- An injected `HttpClient` is used as-is.

Build clean; 2/2 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)