### PR TITLE
#187: navigation/present-in-context core (pure-logic resolver + contract)

### DIFF
--- a/src/CST.Avalonia.Tests/Navigation/NavigationResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Navigation/NavigationResolverTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST;
+using CST.Navigation;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Navigation
+{
+    /// <summary>
+    /// Unit tests for the pure-logic navigation core (#187 / AI_INTEGRATION.md §4.1). Uses the real book
+    /// catalog (Books.Inst is an in-memory, hardcoded catalog — no XML/IO) for book resolution + BookType,
+    /// and a hand-built fake anchor catalog to exercise range-validation and disambiguation.
+    /// </summary>
+    public class NavigationResolverTests
+    {
+        private static readonly Books Catalog = Books.Inst;
+
+        private static Book NonMultiBook() =>
+            Catalog.First(b => b.BookType != BookType.Multi && !string.IsNullOrEmpty(b.FileName));
+
+        private static Book MultiBook() =>
+            Catalog.First(b => b.BookType == BookType.Multi);
+
+        private static NavigationResolver Resolver(IAnchorCatalog? catalog = null) =>
+            new NavigationResolver(Catalog, catalog);
+
+        // --- book resolution -------------------------------------------------
+
+        [Fact]
+        public void UnknownBook_returns_UnknownBook()
+        {
+            var r = Resolver().Resolve(new NavigationRequest("no-such-book.xml", new NavigationReference.WholeBook()));
+            Assert.Equal(NavigationStatus.UnknownBook, r.Status);
+        }
+
+        [Fact]
+        public void FileName_match_is_case_insensitive()
+        {
+            var b = NonMultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName.ToUpperInvariant(), new NavigationReference.WholeBook()));
+            Assert.Equal(NavigationStatus.Resolved, r.Status);
+            Assert.Equal(b.FileName, r.Target!.BookFileName);
+        }
+
+        [Fact]
+        public void WholeBook_resolves_to_empty_anchor()
+        {
+            var b = NonMultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.WholeBook()));
+            Assert.Equal(NavigationStatus.Resolved, r.Status);
+            Assert.Equal("", r.Target!.Anchor);
+        }
+
+        // --- paragraphs ------------------------------------------------------
+
+        [Fact]
+        public void Paragraph_nonMulti_builds_para_anchor()
+        {
+            var b = NonMultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.Paragraph(123)));
+            Assert.Equal(NavigationStatus.Resolved, r.Status);
+            Assert.Equal("para123", r.Target!.Anchor);
+        }
+
+        [Fact]
+        public void Paragraph_zero_or_negative_is_InvalidReference()
+        {
+            var b = NonMultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.Paragraph(0)));
+            Assert.Equal(NavigationStatus.InvalidReference, r.Status);
+        }
+
+        [Fact]
+        public void Paragraph_multi_without_code_and_no_catalog_is_InvalidReference()
+        {
+            var b = MultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.Paragraph(5)));
+            Assert.Equal(NavigationStatus.InvalidReference, r.Status);
+        }
+
+        [Fact]
+        public void Paragraph_multi_with_explicit_code_builds_suffixed_anchor()
+        {
+            var b = MultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.Paragraph(5, "an5")));
+            Assert.Equal(NavigationStatus.Resolved, r.Status);
+            Assert.Equal("para5_an5", r.Target!.Anchor);
+            Assert.Contains("an5", r.Target!.NormalizedReference);
+        }
+
+        [Fact]
+        public void Paragraph_multi_single_catalog_code_is_auto_suffixed()
+        {
+            var b = MultiBook();
+            var cat = new FakeCatalog(b.FileName, paragraphs: new[] { new ParagraphAnchor(5, "an5") });
+            var r = Resolver(cat).Resolve(new NavigationRequest(b.FileName, new NavigationReference.Paragraph(5)));
+            Assert.Equal(NavigationStatus.Resolved, r.Status);
+            Assert.Equal("para5_an5", r.Target!.Anchor);
+        }
+
+        [Fact]
+        public void Paragraph_multi_multiple_catalog_codes_is_Ambiguous_with_candidates()
+        {
+            var b = MultiBook();
+            var cat = new FakeCatalog(b.FileName,
+                paragraphs: new[] { new ParagraphAnchor(5, "an5"), new ParagraphAnchor(5, "an6") });
+            var r = Resolver(cat).Resolve(new NavigationRequest(b.FileName, new NavigationReference.Paragraph(5)));
+            Assert.Equal(NavigationStatus.AmbiguousReference, r.Status);
+            Assert.Equal(2, r.Candidates!.Count);
+            Assert.Contains(r.Candidates!, c => c.Anchor == "para5_an5");
+            Assert.Contains(r.Candidates!, c => c.Anchor == "para5_an6");
+        }
+
+        [Fact]
+        public void Paragraph_nonMulti_missing_in_catalog_is_OutOfRange()
+        {
+            var b = NonMultiBook();
+            var cat = new FakeCatalog(b.FileName, paragraphs: new[] { new ParagraphAnchor(1, null) });
+            var r = Resolver(cat).Resolve(new NavigationRequest(b.FileName, new NavigationReference.Paragraph(999)));
+            Assert.Equal(NavigationStatus.ReferenceOutOfRange, r.Status);
+        }
+
+        // --- pages -----------------------------------------------------------
+
+        [Fact]
+        public void Page_with_volume_builds_padded_anchor()
+        {
+            var b = NonMultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.Page(PageEdition.Vri, 50, 2)));
+            Assert.Equal("V2.0050", r.Target!.Anchor);
+        }
+
+        [Fact]
+        public void Page_without_volume_defaults_to_zero_without_catalog()
+        {
+            var b = NonMultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.Page(PageEdition.Myanmar, 7)));
+            Assert.Equal("M0.0007", r.Target!.Anchor);
+        }
+
+        [Fact]
+        public void Page_without_volume_resolves_single_volume_from_catalog()
+        {
+            var b = NonMultiBook();
+            var cat = new FakeCatalog(b.FileName, pages: new[] { new PageAnchor(PageEdition.Pts, 3, 42) });
+            var r = Resolver(cat).Resolve(new NavigationRequest(b.FileName, new NavigationReference.Page(PageEdition.Pts, 42)));
+            Assert.Equal(NavigationStatus.Resolved, r.Status);
+            Assert.Equal("P3.0042", r.Target!.Anchor);
+        }
+
+        [Fact]
+        public void Page_without_volume_multiple_volumes_is_Ambiguous()
+        {
+            var b = NonMultiBook();
+            var cat = new FakeCatalog(b.FileName,
+                pages: new[] { new PageAnchor(PageEdition.Vri, 1, 10), new PageAnchor(PageEdition.Vri, 2, 10) });
+            var r = Resolver(cat).Resolve(new NavigationRequest(b.FileName, new NavigationReference.Page(PageEdition.Vri, 10)));
+            Assert.Equal(NavigationStatus.AmbiguousReference, r.Status);
+            Assert.Equal(2, r.Candidates!.Count);
+        }
+
+        [Fact]
+        public void Page_out_of_range_with_catalog_is_OutOfRange()
+        {
+            var b = NonMultiBook();
+            var cat = new FakeCatalog(b.FileName, pages: new[] { new PageAnchor(PageEdition.Vri, 1, 10) });
+            var r = Resolver(cat).Resolve(new NavigationRequest(b.FileName, new NavigationReference.Page(PageEdition.Vri, 999, 1)));
+            Assert.Equal(NavigationStatus.ReferenceOutOfRange, r.Status);
+        }
+
+        // --- chapters / raw / passthrough -----------------------------------
+
+        [Fact]
+        public void Chapter_passes_through_id_as_anchor()
+        {
+            var b = NonMultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.Chapter("dn1")));
+            Assert.Equal(NavigationStatus.Resolved, r.Status);
+            Assert.Equal("dn1", r.Target!.Anchor);
+        }
+
+        [Fact]
+        public void Chapter_missing_in_catalog_is_OutOfRange()
+        {
+            var b = NonMultiBook();
+            var cat = new FakeCatalog(b.FileName, chapterIds: new[] { "dn1" });
+            var r = Resolver(cat).Resolve(new NavigationRequest(b.FileName, new NavigationReference.Chapter("zz9")));
+            Assert.Equal(NavigationStatus.ReferenceOutOfRange, r.Status);
+        }
+
+        [Fact]
+        public void RawAnchor_passes_through()
+        {
+            var b = NonMultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.RawAnchor("para42_sn1")));
+            Assert.Equal(NavigationStatus.Resolved, r.Status);
+            Assert.Equal("para42_sn1", r.Target!.Anchor);
+        }
+
+        [Fact]
+        public void SearchTerms_are_carried_through()
+        {
+            var b = NonMultiBook();
+            var terms = new[] { "metta", "karuna" };
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.Paragraph(1), terms));
+            Assert.Equal(terms, r.Target!.SearchTerms);
+        }
+
+        [Fact]
+        public void SearchTerms_default_to_empty_not_null()
+        {
+            var b = NonMultiBook();
+            var r = Resolver().Resolve(new NavigationRequest(b.FileName, new NavigationReference.WholeBook()));
+            Assert.NotNull(r.Target!.SearchTerms);
+            Assert.Empty(r.Target!.SearchTerms);
+        }
+
+        // --- fake catalog ----------------------------------------------------
+
+        private sealed class FakeCatalog : IAnchorCatalog
+        {
+            private readonly string _file;
+            private readonly BookAnchors _anchors;
+
+            public FakeCatalog(
+                string file,
+                IReadOnlyList<ParagraphAnchor>? paragraphs = null,
+                IReadOnlyList<PageAnchor>? pages = null,
+                IReadOnlyList<string>? chapterIds = null)
+            {
+                _file = file;
+                _anchors = new BookAnchors(
+                    paragraphs ?? Array.Empty<ParagraphAnchor>(),
+                    pages ?? Array.Empty<PageAnchor>(),
+                    chapterIds ?? Array.Empty<string>());
+            }
+
+            public BookAnchors? GetBookAnchors(string bookFileName) =>
+                string.Equals(bookFileName, _file, StringComparison.OrdinalIgnoreCase) ? _anchors : null;
+        }
+    }
+}

--- a/src/CST.Core/Navigation/IAnchorCatalog.cs
+++ b/src/CST.Core/Navigation/IAnchorCatalog.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CST.Navigation
+{
+    /// <summary>
+    /// Pure-logic enumeration of the <em>valid navigation targets</em> in a book — the counterpart to the
+    /// reader's runtime (WebView) anchor cache. This is the precomputed "anchor catalog"
+    /// (AI_INTEGRATION.md §4.2) that lets <see cref="NavigationResolver"/> validate references and produce
+    /// disambiguation candidates without rendering the book. Implementations precompute/parse from the TEI
+    /// XML. A resolver given no catalog degrades to building anchors <em>without</em> range validation.
+    /// </summary>
+    public interface IAnchorCatalog
+    {
+        /// <summary>
+        /// The anchors for a book by file name, or <c>null</c> if the book is unknown or not yet catalogued.
+        /// </summary>
+        BookAnchors? GetBookAnchors(string bookFileName);
+    }
+
+    /// <summary>The valid anchors in a single book.</summary>
+    public sealed record BookAnchors(
+        IReadOnlyList<ParagraphAnchor> Paragraphs,
+        IReadOnlyList<PageAnchor> Pages,
+        IReadOnlyList<string> ChapterIds)
+    {
+        /// <summary>True if any paragraph with this number exists (in any sub-book).</summary>
+        public bool HasParagraph(int number) => Paragraphs.Any(p => p.Number == number);
+
+        /// <summary>The distinct sub-book codes that contain the given paragraph number.</summary>
+        public IReadOnlyList<string> BookCodesFor(int number) =>
+            Paragraphs.Where(p => p.Number == number && p.BookCode != null)
+                      .Select(p => p.BookCode!)
+                      .Distinct()
+                      .ToList();
+
+        /// <summary>True if the exact edition+volume+page exists.</summary>
+        public bool HasPage(PageEdition edition, int volume, int number) =>
+            Pages.Any(p => p.Edition == edition && p.Volume == volume && p.Number == number);
+
+        /// <summary>The distinct volumes in which the given edition+page number appears.</summary>
+        public IReadOnlyList<int> VolumesFor(PageEdition edition, int number) =>
+            Pages.Where(p => p.Edition == edition && p.Number == number)
+                 .Select(p => p.Volume)
+                 .Distinct()
+                 .ToList();
+
+        /// <summary>True if a chapter/division with this id exists.</summary>
+        public bool HasChapter(string chapterId) => ChapterIds.Contains(chapterId);
+    }
+
+    /// <summary>A paragraph anchor: its number and, in a Multi book, the sub-book code (else null).</summary>
+    public sealed record ParagraphAnchor(int Number, string? BookCode);
+
+    /// <summary>A page-break anchor: edition, volume, and page number.</summary>
+    public sealed record PageAnchor(PageEdition Edition, int Volume, int Number);
+}

--- a/src/CST.Core/Navigation/NavigationReference.cs
+++ b/src/CST.Core/Navigation/NavigationReference.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+
+namespace CST.Navigation
+{
+    /// <summary>
+    /// A location within a book to navigate to. The kinds mirror the reader's existing anchor scheme
+    /// (paragraph / per-edition page / chapter div / raw anchor), so <see cref="NavigationResolver"/> can
+    /// normalize any of them to the same anchor string the reader already understands
+    /// (e.g. "para123", "para123_an5", "V2.0050", "dn1").
+    /// This is a closed hierarchy — the nested sealed records are the only kinds.
+    /// </summary>
+    public abstract record NavigationReference
+    {
+        protected NavigationReference() { }
+
+        /// <summary>Open the book at its start (no specific anchor).</summary>
+        public sealed record WholeBook() : NavigationReference;
+
+        /// <summary>
+        /// A paragraph by number. <paramref name="BookCode"/> selects the sub-book inside a
+        /// <see cref="BookType.Multi"/> volume (e.g. "an5"); leave it null to let the resolver disambiguate
+        /// from the anchor catalog.
+        /// </summary>
+        public sealed record Paragraph(int Number, string? BookCode = null) : NavigationReference;
+
+        /// <summary>
+        /// A page in a specific edition. <paramref name="Volume"/> may be null; the resolver then resolves
+        /// it from the catalog when available, otherwise defaults to volume 0.
+        /// </summary>
+        public sealed record Page(PageEdition Edition, int Number, int? Volume = null) : NavigationReference;
+
+        /// <summary>A chapter/division by its id (the div @id, e.g. "dn1", "dn1_1").</summary>
+        public sealed record Chapter(string ChapterId) : NavigationReference;
+
+        /// <summary>A pre-formed anchor string, passed through after optional catalog validation.</summary>
+        public sealed record RawAnchor(string Anchor) : NavigationReference;
+    }
+
+    /// <summary>The page-numbering editions the corpus carries, matching the TEI <c>pb/@ed</c> prefixes.</summary>
+    public enum PageEdition
+    {
+        /// <summary>VRI edition — anchor prefix "V".</summary>
+        Vri,
+        /// <summary>Myanmar edition — anchor prefix "M".</summary>
+        Myanmar,
+        /// <summary>PTS edition — anchor prefix "P".</summary>
+        Pts,
+        /// <summary>Thai edition — anchor prefix "T".</summary>
+        Thai,
+        /// <summary>Other edition — anchor prefix "O".</summary>
+        Other
+    }
+
+    /// <summary>
+    /// A request to resolve a navigation target: which book, where in it, and any search terms to carry
+    /// through for highlighting. <see cref="BookId"/> is the exact book file name (as listed by the anchor
+    /// catalog); fuzzy name/abbreviation resolution is a later enhancement.
+    /// </summary>
+    public sealed record NavigationRequest(
+        string BookId,
+        NavigationReference Reference,
+        IReadOnlyList<string>? SearchTerms = null);
+}

--- a/src/CST.Core/Navigation/NavigationResolver.cs
+++ b/src/CST.Core/Navigation/NavigationResolver.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CST.Navigation
+{
+    /// <summary>
+    /// Resolves a <see cref="NavigationRequest"/> to a normalized, validated <see cref="NavigationResult"/>
+    /// — the pure-logic half of the "navigation / present-in-context core" (AI_INTEGRATION.md §4.1). It owns
+    /// the reference→anchor rules (mirroring the reader's Go-To scheme) and, when an <see cref="IAnchorCatalog"/>
+    /// is supplied, range-validation and disambiguation. It does NOT drive the UI: the caller feeds the
+    /// resulting <see cref="ResolvedTarget.Anchor"/> to the reader's existing anchor navigation.
+    /// </summary>
+    public sealed class NavigationResolver
+    {
+        private readonly Books _books;
+        private readonly IAnchorCatalog? _catalog;
+
+        /// <param name="books">The book catalog (e.g. <see cref="Books.Inst"/>).</param>
+        /// <param name="catalog">
+        /// Optional anchor catalog. When null, the resolver still normalizes references to anchors but cannot
+        /// detect <see cref="NavigationStatus.ReferenceOutOfRange"/> or disambiguate Multi-book paragraphs.
+        /// </param>
+        public NavigationResolver(Books books, IAnchorCatalog? catalog = null)
+        {
+            _books = books ?? throw new ArgumentNullException(nameof(books));
+            _catalog = catalog;
+        }
+
+        public NavigationResult Resolve(NavigationRequest request)
+        {
+            if (request is null) throw new ArgumentNullException(nameof(request));
+
+            var book = FindBook(request.BookId);
+            if (book is null) return NavigationResult.UnknownBook(request.BookId);
+
+            var anchors = _catalog?.GetBookAnchors(book.FileName);
+
+            return request.Reference switch
+            {
+                NavigationReference.WholeBook => Resolved(book, anchor: "", normalized: "start of book", request),
+                NavigationReference.Paragraph p => ResolveParagraph(book, p, anchors, request),
+                NavigationReference.Page pg => ResolvePage(book, pg, anchors, request),
+                NavigationReference.Chapter c => ResolveChapter(book, c, anchors, request),
+                NavigationReference.RawAnchor r => ResolveRawAnchor(book, r, anchors, request),
+                _ => NavigationResult.InvalidReference("Unsupported reference kind.")
+            };
+        }
+
+        private Book? FindBook(string? bookId)
+        {
+            if (string.IsNullOrWhiteSpace(bookId)) return null;
+            // Books.this[string] throws on a miss; scan the (small, in-memory) catalog for a safe lookup and
+            // to avoid mutating Books. Case-insensitive so "S0101M.MUL.XML" resolves like the lower-case name.
+            foreach (var b in _books)
+                if (string.Equals(b.FileName, bookId, StringComparison.OrdinalIgnoreCase))
+                    return b;
+            return null;
+        }
+
+        private NavigationResult ResolveParagraph(
+            Book book, NavigationReference.Paragraph p, BookAnchors? anchors, NavigationRequest req)
+        {
+            if (p.Number < 1)
+                return NavigationResult.InvalidReference($"Paragraph number must be positive (got {p.Number}).");
+
+            bool isMulti = book.BookType == BookType.Multi;
+            string? bookCode = p.BookCode;
+
+            if (isMulti)
+            {
+                if (bookCode is null)
+                {
+                    if (anchors is null)
+                        return NavigationResult.InvalidReference(
+                            $"'{book.FileName}' is a multi-book volume; a book code is required to place " +
+                            $"paragraph {p.Number} (anchor catalog unavailable to disambiguate).");
+
+                    var codes = anchors.BookCodesFor(p.Number);
+                    if (codes.Count == 0)
+                        return NavigationResult.OutOfRange($"No paragraph {p.Number} in '{book.FileName}'.");
+                    if (codes.Count > 1)
+                        return NavigationResult.Ambiguous(
+                            codes.Select(c => new NavigationCandidate(
+                                $"para{p.Number}_{c}", $"paragraph {p.Number} in sub-book '{c}'")).ToList(),
+                            $"Paragraph {p.Number} appears in {codes.Count} sub-books of '{book.FileName}'; " +
+                            "specify a book code.");
+                    bookCode = codes[0];
+                }
+                else if (anchors is not null && !anchors.BookCodesFor(p.Number).Contains(bookCode))
+                {
+                    return NavigationResult.OutOfRange(
+                        $"No paragraph {p.Number} in sub-book '{bookCode}' of '{book.FileName}'.");
+                }
+            }
+            else if (anchors is not null && !anchors.HasParagraph(p.Number))
+            {
+                return NavigationResult.OutOfRange($"No paragraph {p.Number} in '{book.FileName}'.");
+            }
+
+            string anchor = $"para{p.Number}";
+            string normalized = $"paragraph {p.Number}";
+            if (isMulti && bookCode is not null)
+            {
+                anchor += $"_{bookCode}";
+                normalized += $" ({bookCode})";
+            }
+            return Resolved(book, anchor, normalized, req);
+        }
+
+        private NavigationResult ResolvePage(
+            Book book, NavigationReference.Page pg, BookAnchors? anchors, NavigationRequest req)
+        {
+            if (pg.Number < 1)
+                return NavigationResult.InvalidReference($"Page number must be positive (got {pg.Number}).");
+
+            string prefix = EditionPrefix(pg.Edition);
+            string editionName = EditionName(pg.Edition);
+            int volume;
+
+            if (pg.Volume.HasValue)
+            {
+                volume = pg.Volume.Value;
+                if (anchors is not null && !anchors.HasPage(pg.Edition, volume, pg.Number))
+                    return NavigationResult.OutOfRange(
+                        $"No {editionName} page {volume}.{pg.Number} in '{book.FileName}'.");
+            }
+            else if (anchors is not null)
+            {
+                var volumes = anchors.VolumesFor(pg.Edition, pg.Number);
+                if (volumes.Count == 0)
+                    return NavigationResult.OutOfRange(
+                        $"No {editionName} page {pg.Number} in '{book.FileName}'.");
+                if (volumes.Count > 1)
+                    return NavigationResult.Ambiguous(
+                        volumes.Select(v => new NavigationCandidate(
+                            $"{prefix}{v}.{pg.Number:D4}", $"{editionName} page {v}.{pg.Number}")).ToList(),
+                        $"{editionName} page {pg.Number} exists in volumes " +
+                        $"{string.Join(", ", volumes)}; specify a volume.");
+                volume = volumes[0];
+            }
+            else
+            {
+                // No current-position context and no catalog: mirror Go-To's volume-0 default.
+                volume = 0;
+            }
+
+            string anchor = $"{prefix}{volume}.{pg.Number:D4}";
+            string normalized = $"{editionName} page {volume}.{pg.Number}";
+            return Resolved(book, anchor, normalized, req);
+        }
+
+        private NavigationResult ResolveChapter(
+            Book book, NavigationReference.Chapter c, BookAnchors? anchors, NavigationRequest req)
+        {
+            if (string.IsNullOrWhiteSpace(c.ChapterId))
+                return NavigationResult.InvalidReference("Chapter id is empty.");
+            if (anchors is not null && !anchors.HasChapter(c.ChapterId))
+                return NavigationResult.OutOfRange($"No chapter '{c.ChapterId}' in '{book.FileName}'.");
+            return Resolved(book, c.ChapterId, $"chapter {c.ChapterId}", req);
+        }
+
+        private NavigationResult ResolveRawAnchor(
+            Book book, NavigationReference.RawAnchor r, BookAnchors? anchors, NavigationRequest req)
+        {
+            if (string.IsNullOrWhiteSpace(r.Anchor))
+                return NavigationResult.InvalidReference("Anchor is empty.");
+            // A raw anchor is trusted through as-is; the catalog cannot cheaply validate arbitrary strings
+            // yet (it exposes typed anchors, not a flat set). Validation can tighten once that lands.
+            return Resolved(book, r.Anchor, r.Anchor, req);
+        }
+
+        private static NavigationResult Resolved(Book book, string anchor, string normalized, NavigationRequest req) =>
+            NavigationResult.Resolved(new ResolvedTarget(
+                book.FileName,
+                book.Index,
+                book.DocId,
+                anchor,
+                normalized,
+                req.SearchTerms ?? Array.Empty<string>()));
+
+        private static string EditionPrefix(PageEdition e) => e switch
+        {
+            PageEdition.Vri => "V",
+            PageEdition.Myanmar => "M",
+            PageEdition.Pts => "P",
+            PageEdition.Thai => "T",
+            PageEdition.Other => "O",
+            _ => "V"
+        };
+
+        private static string EditionName(PageEdition e) => e switch
+        {
+            PageEdition.Vri => "VRI",
+            PageEdition.Myanmar => "Myanmar",
+            PageEdition.Pts => "PTS",
+            PageEdition.Thai => "Thai",
+            PageEdition.Other => "other",
+            _ => e.ToString()
+        };
+    }
+}

--- a/src/CST.Core/Navigation/NavigationResult.cs
+++ b/src/CST.Core/Navigation/NavigationResult.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+
+namespace CST.Navigation
+{
+    /// <summary>Outcome of resolving a <see cref="NavigationRequest"/>.</summary>
+    public enum NavigationStatus
+    {
+        /// <summary>Resolved to a concrete, in-range target (<see cref="NavigationResult.Target"/>).</summary>
+        Resolved,
+        /// <summary>No book matched <see cref="NavigationRequest.BookId"/>.</summary>
+        UnknownBook,
+        /// <summary>The reference was malformed for its kind (e.g. non-positive paragraph, empty chapter id).</summary>
+        InvalidReference,
+        /// <summary>The reference maps to more than one target; see <see cref="NavigationResult.Candidates"/>.</summary>
+        AmbiguousReference,
+        /// <summary>The reference is well-formed but no such anchor exists in the book (catalog-validated).</summary>
+        ReferenceOutOfRange,
+        /// <summary>The corpus/index isn't ready (e.g. still (re)indexing); retry later.</summary>
+        NotReady
+    }
+
+    /// <summary>A resolved, normalized navigation target ready to hand to the reader's anchor navigation.</summary>
+    /// <param name="BookFileName">The resolved book's file name.</param>
+    /// <param name="BookIndex">The resolved book's catalog index.</param>
+    /// <param name="BookDocId">The resolved book's Lucene doc id (-1 if not yet indexed).</param>
+    /// <param name="Anchor">The normalized anchor string (empty = start of book).</param>
+    /// <param name="NormalizedReference">A short human-readable description (e.g. "paragraph 123 (an5)").</param>
+    /// <param name="SearchTerms">Search terms to highlight, carried through from the request.</param>
+    public sealed record ResolvedTarget(
+        string BookFileName,
+        int BookIndex,
+        int BookDocId,
+        string Anchor,
+        string NormalizedReference,
+        IReadOnlyList<string> SearchTerms);
+
+    /// <summary>One option offered when a reference is ambiguous.</summary>
+    public sealed record NavigationCandidate(string Anchor, string Description);
+
+    /// <summary>
+    /// The structured outcome of navigation resolution. Exactly one of <see cref="Target"/> /
+    /// <see cref="Candidates"/> is populated depending on <see cref="Status"/>; <see cref="Message"/> is a
+    /// human- and machine-readable explanation. Callers (HTTP API, App Intents bridge, in-app) inspect
+    /// <see cref="Status"/> and never guess.
+    /// </summary>
+    public sealed record NavigationResult(
+        NavigationStatus Status,
+        ResolvedTarget? Target = null,
+        IReadOnlyList<NavigationCandidate>? Candidates = null,
+        string? Message = null)
+    {
+        public bool IsResolved => Status == NavigationStatus.Resolved;
+
+        public static NavigationResult Resolved(ResolvedTarget target) =>
+            new(NavigationStatus.Resolved, Target: target);
+
+        public static NavigationResult UnknownBook(string bookId) =>
+            new(NavigationStatus.UnknownBook, Message: $"No book with identifier '{bookId}'.");
+
+        public static NavigationResult InvalidReference(string message) =>
+            new(NavigationStatus.InvalidReference, Message: message);
+
+        public static NavigationResult Ambiguous(IReadOnlyList<NavigationCandidate> candidates, string message) =>
+            new(NavigationStatus.AmbiguousReference, Candidates: candidates, Message: message);
+
+        public static NavigationResult OutOfRange(string message) =>
+            new(NavigationStatus.ReferenceOutOfRange, Message: message);
+
+        public static NavigationResult NotReady(string message) =>
+            new(NavigationStatus.NotReady, Message: message);
+    }
+}


### PR DESCRIPTION
The non-UI half of the navigation core (AI_INTEGRATION.md §4.1), in `CST.Core/Navigation` — pure, reusable by the future HTTP API / App Intents bridge. Part of epic #186.

- **`NavigationReference`** — closed hierarchy (WholeBook / Paragraph(n,bookCode?) / Page(edition,n,vol?) / Chapter(id) / RawAnchor) + `PageEdition` + `NavigationRequest`.
- **`NavigationResult`** — structured outcome: Resolved / UnknownBook / InvalidReference / AmbiguousReference(candidates) / ReferenceOutOfRange / NotReady. Never fire-and-forget, never silent best-guess.
- **`IAnchorCatalog`** + `BookAnchors` — the §4.2 validation/disambiguation seam (impl to follow); absent → resolver degrades to building anchors without range validation.
- **`NavigationResolver`** — book resolution + reference→anchor rules mirroring Go-To (`para123` / `para123_an5` / `V2.0050` / chapter id), with catalog-driven validation + Multi-book / multi-volume disambiguation.

Does not touch the in-progress `GoToDialogViewModel`. **20 unit tests, all passing.** UI wiring and the anchor-catalog implementation are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)