### PR TITLE
AI surface C: transport-agnostic tool contracts (#186/#190)

### DIFF
--- a/src/CST.Core/Tools/DictionaryToolContracts.cs
+++ b/src/CST.Core/Tools/DictionaryToolContracts.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Conversion;
+
+namespace CST.Tools
+{
+    /// <summary>
+    /// The dictionary tool exposed to agents (AI_INTEGRATION.md surface C + §9). A thin wrapper over the
+    /// app's dictionary service, which owns the on-disk format — an agent calls <c>lookup</c> and never
+    /// parses dictionary files. The contract is format-agnostic, so added dictionaries don't change it.
+    /// </summary>
+    public interface IDictionaryTool
+    {
+        /// <summary>Available dictionary language codes (e.g. "en", "hi").</summary>
+        IReadOnlyList<string> Languages { get; }
+
+        /// <summary>
+        /// Look up a headword (exact match plus the prefix run, or the nearest-neighbor run on a miss).
+        /// The query may be in any script; headwords are returned in the requested output script.
+        /// </summary>
+        Task<IReadOnlyList<DictionaryEntry>> LookupAsync(DictionaryRequest request, CancellationToken ct = default);
+    }
+
+    /// <summary>A dictionary lookup request.</summary>
+    public sealed record DictionaryRequest(
+        string Language,
+        string Query,
+        Script OutputScript = Script.Latin,
+        int MaxEntries = 25);
+
+    /// <summary>One dictionary entry.</summary>
+    /// <param name="Headword">The headword in the requested output script.</param>
+    /// <param name="HeadwordIpe">The stable IPE form of the headword.</param>
+    /// <param name="MeaningHtml">The definition as an HTML fragment (the source format).</param>
+    public sealed record DictionaryEntry(
+        string Headword,
+        string HeadwordIpe,
+        string MeaningHtml);
+}

--- a/src/CST.Core/Tools/ICorpusTools.cs
+++ b/src/CST.Core/Tools/ICorpusTools.cs
@@ -1,0 +1,12 @@
+namespace CST.Tools
+{
+    /// <summary>
+    /// The complete surface-C tool set as a single facade (AI_INTEGRATION.md §4.2) — search, navigation +
+    /// catalog, passage fetch, and dictionary. The local HTTP API and the in-app AI surface (B) both call
+    /// this; the out-of-process MCP adapter proxies to the HTTP endpoints that expose it. Composed from the
+    /// focused interfaces so each tool stays independently implementable and testable.
+    /// </summary>
+    public interface ICorpusTools : ISearchTool, INavigationTool, IPassageTool, IDictionaryTool
+    {
+    }
+}

--- a/src/CST.Core/Tools/NavigationToolContracts.cs
+++ b/src/CST.Core/Tools/NavigationToolContracts.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using CST.Navigation;
+
+namespace CST.Tools
+{
+    /// <summary>
+    /// The navigation/catalog tool exposed to agents (AI_INTEGRATION.md surface C + §4.1/§4.2). Resolves a
+    /// reference to a validated target and enumerates what's addressable — so an agent knows the valid
+    /// navigation targets before it asks. Reuses the <see cref="CST.Navigation"/> core: resolution and the
+    /// anchor catalog are the same spine as the #187 navigation core.
+    /// </summary>
+    public interface INavigationTool
+    {
+        /// <summary>
+        /// Resolve a reference to a normalized, validated target — or a structured failure
+        /// (unknown book / invalid / ambiguous + candidates / out-of-range). Never a silent best-guess.
+        /// </summary>
+        NavigationResult Resolve(NavigationRequest request);
+
+        /// <summary>List the books that are addressable, optionally filtered by piṭaka / commentary level.</summary>
+        IReadOnlyList<BookSummary> ListBooks(BookListFilter? filter = null);
+
+        /// <summary>
+        /// The valid anchors in a book — paragraphs (with sub-book codes), per-edition pages, chapters —
+        /// or <c>null</c> if the book is unknown / not yet catalogued.
+        /// </summary>
+        BookAnchors? ListAnchors(string bookId);
+    }
+
+    /// <summary>A book as seen by an agent: its id (file name), names, classification, and index state.</summary>
+    public sealed record BookSummary(
+        string BookId,
+        string Name,
+        string ShortName,
+        Pitaka Pitaka,
+        CommentaryLevel CommentaryLevel,
+        BookType BookType,
+        bool Indexed);
+
+    /// <summary>Which books to list. Defaults include everything.</summary>
+    public sealed record BookListFilter(
+        bool Vinaya = true,
+        bool Sutta = true,
+        bool Abhidhamma = true,
+        bool Mula = true,
+        bool Atthakatha = true,
+        bool Tika = true,
+        bool Other = true);
+}

--- a/src/CST.Core/Tools/PassageToolContracts.cs
+++ b/src/CST.Core/Tools/PassageToolContracts.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Conversion;
+using CST.Navigation;
+
+namespace CST.Tools
+{
+    /// <summary>
+    /// The passage-fetch tool exposed to agents (AI_INTEGRATION.md surface C). Returns the *text* of a
+    /// passage — not rendered HTML — so an agent gets grounded source it can quote/cite. Text is in the
+    /// requested script (default romanized Latin). Unlike search/dictionary, this has no existing service to
+    /// wrap: the implementation needs a pure-logic TEI reader (shared with the anchor catalog).
+    /// </summary>
+    public interface IPassageTool
+    {
+        /// <summary>Fetch the text at a reference, optionally with neighboring paragraphs for context.</summary>
+        Task<PassageResult> FetchPassageAsync(PassageRequest request, CancellationToken ct = default);
+    }
+
+    /// <summary>
+    /// A passage request. <see cref="Reference"/> reuses the navigation core's reference model (paragraph /
+    /// page / chapter / raw anchor), so resolving and fetching speak the same language.
+    /// </summary>
+    /// <param name="ContextParagraphs">Neighbors to include on each side (0 = just the target).</param>
+    /// <param name="IncludeMarkup">Return light structural markup instead of plain text.</param>
+    public sealed record PassageRequest(
+        string BookId,
+        NavigationReference Reference,
+        int ContextParagraphs = 0,
+        Script OutputScript = Script.Latin,
+        bool IncludeMarkup = false);
+
+    /// <summary>The fetched passage plus the anchors needed to page forward/backward and cite pages.</summary>
+    /// <param name="Anchor">The normalized anchor the text starts at.</param>
+    /// <param name="NormalizedReference">Short human-readable reference (e.g. "paragraph 123 (an5)").</param>
+    /// <param name="Text">The passage text in the requested script.</param>
+    /// <param name="Pages">The per-edition page(s) this passage spans, for citation.</param>
+    /// <param name="PreviousAnchor">Anchor of the preceding paragraph, or null at the start.</param>
+    /// <param name="NextAnchor">Anchor of the following paragraph, or null at the end.</param>
+    public sealed record PassageResult(
+        string BookId,
+        string Anchor,
+        string NormalizedReference,
+        string Text,
+        IReadOnlyList<PassagePageRef> Pages,
+        string? PreviousAnchor,
+        string? NextAnchor);
+
+    /// <summary>A page reference a passage spans (edition + volume + page).</summary>
+    public sealed record PassagePageRef(PageEdition Edition, int Volume, int Number);
+}

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Conversion;
+
+namespace CST.Tools
+{
+    /// <summary>
+    /// The search tool exposed to agents (AI_INTEGRATION.md surface C). A transport-agnostic, headless
+    /// wrapper over the app's search service: an agent gets clean terms → book hits, never Lucene segments.
+    /// Implementations live in the app layer and map internal results to these DTOs. All Pāli text is
+    /// returned in <see cref="SearchToolRequest.OutputScript"/> (default romanized Latin); every term also
+    /// carries its stable IPE form as an unambiguous cross-script key.
+    /// </summary>
+    public interface ISearchTool
+    {
+        /// <summary>Run a search and return matching terms with per-book occurrence counts.</summary>
+        Task<SearchToolResult> SearchAsync(SearchToolRequest request, CancellationToken ct = default);
+
+        /// <summary>Autocomplete: terms in the index beginning with <paramref name="prefix"/>.</summary>
+        Task<IReadOnlyList<string>> CompleteTermsAsync(
+            string prefix, int limit = 50, Script outputScript = Script.Latin, CancellationToken ct = default);
+
+        /// <summary>
+        /// Opt-in, heavier: the individual hit positions of a term within one book (for highlighting or
+        /// offset-level work). Keyed by the stable <paramref name="termIpe"/> from a prior search.
+        /// </summary>
+        Task<IReadOnlyList<TermHit>> GetTermHitsAsync(
+            string bookId, string termIpe, CancellationToken ct = default);
+    }
+
+    /// <summary>How the query text is interpreted.</summary>
+    public enum SearchToolMode
+    {
+        /// <summary>Whole-word exact match.</summary>
+        Exact,
+        /// <summary>Wildcards: <c>*</c> (any run) and <c>?</c> (one char).</summary>
+        Wildcard,
+        /// <summary>Regular expression.</summary>
+        Regex
+    }
+
+    /// <summary>Which parts of the corpus to search. Defaults include everything.</summary>
+    public sealed record ToolBookFilter(
+        bool Vinaya = true,
+        bool Sutta = true,
+        bool Abhidhamma = true,
+        bool Mula = true,
+        bool Atthakatha = true,
+        bool Tika = true,
+        bool Other = true);
+
+    /// <summary>A search request. The query may be in any script; it is normalized to IPE internally.</summary>
+    public sealed record SearchToolRequest(
+        string Query,
+        SearchToolMode Mode = SearchToolMode.Exact,
+        ToolBookFilter? Filter = null,
+        int MaxTerms = 100,
+        int ProximityDistance = 10,
+        Script OutputScript = Script.Latin);
+
+    /// <summary>Search results: matching terms with per-book counts (token-frugal — positions are opt-in).</summary>
+    public sealed record SearchToolResult(
+        IReadOnlyList<SearchTermResult> Terms,
+        int TotalTermCount,
+        int TotalOccurrenceCount,
+        int TotalBookCount,
+        bool Truncated,
+        string? Note = null);
+
+    /// <summary>One matching term and the books it occurs in.</summary>
+    /// <param name="Term">The term in the requested output script.</param>
+    /// <param name="TermIpe">The stable IPE form — use this as the key for <c>GetTermHitsAsync</c>.</param>
+    public sealed record SearchTermResult(
+        string Term,
+        string TermIpe,
+        int TotalCount,
+        IReadOnlyList<BookHitSummary> Books);
+
+    /// <summary>A term's occurrence count within one book (no positions — call <c>GetTermHitsAsync</c> for those).</summary>
+    public sealed record BookHitSummary(
+        string BookId,
+        string BookName,
+        int Count);
+
+    /// <summary>A single hit position of a term within a book.</summary>
+    /// <param name="IsPrimaryTerm">True for the main term; false for context words (two-color highlighting).</param>
+    public sealed record TermHit(
+        int WordIndex,
+        int StartOffset,
+        int EndOffset,
+        bool IsPrimaryTerm,
+        string? WordIpe);
+}


### PR DESCRIPTION
The "read services exposed as tools" core (AI_INTEGRATION.md §4.2), as pure `CST.Core` contracts + DTOs. Part of epic #186; the read tool set of #190. Depends on #187's `CST.Navigation` types (now on main).

Transport-agnostic — the local HTTP API and the in-app AI surface (B) call these; the out-of-process MCP adapter proxies to the HTTP endpoints that expose them. No internal types (`SearchResult`/`MatchingTerm`/`DictionaryWord`) leak across the boundary.

- **`ISearchTool`** — `SearchAsync` → terms + per-book counts (token-frugal; positions opt-in via `GetTermHitsAsync`), `CompleteTermsAsync`. Exact/Wildcard/Regex, piṭaka/commentary filter.
- **`INavigationTool`** — `Resolve` (reuses the #187 resolver), `ListBooks`, `ListAnchors` (reuses `BookAnchors`).
- **`IPassageTool`** — `FetchPassageAsync` → passage *text* (not HTML) + page refs + prev/next anchors. Needs a new pure TEI reader (no service to wrap).
- **`IDictionaryTool`** — `Languages`, `LookupAsync`.
- **`ICorpusTools`** — facade composing all four.

Script-aware throughout: every request carries an output `Script` (default romanized Latin, §11); every term/headword also returns its stable IPE form as a cross-script key. Builds clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)