### PR TITLE
docs: fix stale DICTIONARIES.md link in AI_INTEGRATION §15

### DIFF
--- a/docs/features/planned/AI_INTEGRATION.md
+++ b/docs/features/planned/AI_INTEGRATION.md
@@ -287,7 +287,7 @@ Three markdown layers, one format, **distinct purposes** — single-source only 
 
 - **#41** — App Intents / Siri & Apple Intelligence (surface **A**).
 - **#27** — Vector / semantic search + RAG (surface **D**).
-- `docs/features/planned/DICTIONARIES.md` — dictionary feature (§9 prerequisite).
+- `docs/features/in-progress/DICTIONARIES.md` — dictionary feature (§9 prerequisite).
 - Auto-update work (#178/#181) — shares the offline/disconnected-user constraint (§11) and the
   user-control/Settings philosophy (§6 consent toggles).
 


### PR DESCRIPTION
Restores the `planned/` → `in-progress/` link fix from `caf9083` that the #226 conflict resolution (branch-supersedes-main took the doc wholesale) inadvertently reverted. One-line docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)