### PR TITLE
AI surface C: search + dictionary tool implementations (#186/#190)

### DIFF
--- a/src/CST.Avalonia.Tests/Tools/DictionaryToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/DictionaryToolTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Tools;
+using CST.Conversion;
+using CST.Tools;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Tools
+{
+    /// <summary>
+    /// Unit tests for the surface-C dictionary tool wrapper. IDictionaryService is mocked; these assert the
+    /// entry mapping, headword script projection, meaning pass-through, and MaxEntries limit. Headword text
+    /// uses ASCII placeholders with expected output computed inline (no hardcoded non-Latin).
+    /// </summary>
+    public class DictionaryToolTests
+    {
+        [Fact]
+        public void Languages_passes_through()
+        {
+            var mock = new Mock<IDictionaryService>();
+            mock.SetupGet(d => d.AvailableLanguages).Returns(new[] { "en", "hi" });
+
+            var tool = new DictionaryTool(mock.Object);
+
+            Assert.Equal(new[] { "en", "hi" }, tool.Languages);
+        }
+
+        [Fact]
+        public async Task LookupAsync_maps_entries_and_projects_headword()
+        {
+            var mock = new Mock<IDictionaryService>();
+            mock.Setup(d => d.LookupAsync("en", "metta"))
+                .ReturnsAsync(new List<DictionaryWord>
+                {
+                    new DictionaryWord("abc", "<b>loving-kindness</b>")
+                });
+
+            var tool = new DictionaryTool(mock.Object);
+            var entries = await tool.LookupAsync(new DictionaryRequest("en", "metta")); // OutputScript = Latin
+
+            var e = Assert.Single(entries);
+            Assert.Equal("abc", e.HeadwordIpe);                                          // stable IPE preserved
+            Assert.Equal(ScriptConverter.Convert("abc", Script.Ipe, Script.Latin), e.Headword);
+            Assert.Equal("<b>loving-kindness</b>", e.MeaningHtml);                       // HTML pass-through
+        }
+
+        [Fact]
+        public async Task LookupAsync_respects_MaxEntries()
+        {
+            var mock = new Mock<IDictionaryService>();
+            mock.Setup(d => d.LookupAsync("en", "d"))
+                .ReturnsAsync(new List<DictionaryWord>
+                {
+                    new DictionaryWord("a", "1"),
+                    new DictionaryWord("b", "2"),
+                    new DictionaryWord("c", "3")
+                });
+
+            var tool = new DictionaryTool(mock.Object);
+            var entries = await tool.LookupAsync(new DictionaryRequest("en", "d", MaxEntries: 2));
+
+            Assert.Equal(2, entries.Count);
+        }
+    }
+}

--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CST;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Tools;
+using CST.Conversion;
+using CST.Tools;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Tools
+{
+    /// <summary>
+    /// Unit tests for the surface-C search tool wrapper. The underlying ISearchService is mocked, so these
+    /// assert the request/response mapping and script projection — not search behavior itself. Term text uses
+    /// ASCII placeholders and expected script output is computed inline via ScriptConverter (no hardcoded
+    /// non-Latin in source).
+    /// </summary>
+    public class SearchToolTests
+    {
+        private static SearchResult OneTermResult(out Book book)
+        {
+            book = new Book { FileName = "s0101m.mul.xml", LongNavPath = "Sutta > Digha > Silakkhandhavagga" };
+            return new SearchResult
+            {
+                Terms = new List<MatchingTerm>
+                {
+                    new MatchingTerm
+                    {
+                        Term = "abc",          // stand-in IPE term (ASCII placeholder)
+                        TotalCount = 7,
+                        Occurrences = new List<BookOccurrence>
+                        {
+                            new BookOccurrence { Book = book, Count = 7 }
+                        }
+                    }
+                },
+                TotalTermCount = 1,
+                TotalOccurrenceCount = 7,
+                TotalBookCount = 1,
+                ResultsTruncated = true,
+                TruncationMessage = "capped"
+            };
+        }
+
+        [Fact]
+        public async Task SearchAsync_maps_request_to_query()
+        {
+            SearchQuery? captured = null;
+            var mock = new Mock<ISearchService>();
+            mock.Setup(s => s.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+                .Callback<SearchQuery, CancellationToken>((q, _) => captured = q)
+                .ReturnsAsync(OneTermResult(out _));
+
+            var tool = new SearchTool(mock.Object);
+            await tool.SearchAsync(new SearchToolRequest(
+                "dhamma", SearchToolMode.Wildcard,
+                new ToolBookFilter(Sutta: true, Abhidhamma: false),
+                MaxTerms: 42, ProximityDistance: 3));
+
+            Assert.NotNull(captured);
+            Assert.Equal("dhamma", captured!.QueryText);
+            Assert.Equal(SearchMode.Wildcard, captured.Mode);
+            Assert.Equal(42, captured.PageSize);
+            Assert.Equal(3, captured.ProximityDistance);
+            Assert.True(captured.Filter.IncludeSutta);
+            Assert.False(captured.Filter.IncludeAbhidhamma);
+        }
+
+        [Fact]
+        public async Task SearchAsync_maps_result_and_projects_term_script()
+        {
+            var mock = new Mock<ISearchService>();
+            mock.Setup(s => s.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OneTermResult(out var book));
+
+            var tool = new SearchTool(mock.Object);
+            var result = await tool.SearchAsync(new SearchToolRequest("q")); // OutputScript defaults to Latin
+
+            Assert.Equal(1, result.TotalTermCount);
+            Assert.Equal(7, result.TotalOccurrenceCount);
+            Assert.True(result.Truncated);
+            Assert.Equal("capped", result.Note);
+
+            var term = Assert.Single(result.Terms);
+            Assert.Equal("abc", term.TermIpe);                                   // stable IPE preserved
+            Assert.Equal(ScriptConverter.Convert("abc", Script.Ipe, Script.Latin), term.Term); // projected
+            Assert.Equal(7, term.TotalCount);
+
+            var hit = Assert.Single(term.Books);
+            Assert.Equal(book.FileName, hit.BookId);
+            Assert.Equal(book.LongNavPath, hit.BookName);
+            Assert.Equal(7, hit.Count);
+        }
+
+        [Fact]
+        public async Task GetTermHitsAsync_maps_positions()
+        {
+            var mock = new Mock<ISearchService>();
+            mock.Setup(s => s.GetTermPositionsAsync("b.xml", "abc", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<TermPosition>
+                {
+                    new TermPosition { WordIndex = 2, StartOffset = 10, EndOffset = 15, IsFirstTerm = true, Word = "abc" }
+                });
+
+            var tool = new SearchTool(mock.Object);
+            var hits = await tool.GetTermHitsAsync("b.xml", "abc");
+
+            var h = Assert.Single(hits);
+            Assert.Equal(2, h.WordIndex);
+            Assert.Equal(10, h.StartOffset);
+            Assert.Equal(15, h.EndOffset);
+            Assert.True(h.IsPrimaryTerm);
+            Assert.Equal("abc", h.WordIpe);
+        }
+
+        [Fact]
+        public async Task SearchAsync_null_filter_defaults_to_include_all()
+        {
+            SearchQuery? captured = null;
+            var mock = new Mock<ISearchService>();
+            mock.Setup(s => s.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+                .Callback<SearchQuery, CancellationToken>((q, _) => captured = q)
+                .ReturnsAsync(new SearchResult());
+
+            var tool = new SearchTool(mock.Object);
+            await tool.SearchAsync(new SearchToolRequest("q"));
+
+            Assert.NotNull(captured);
+            Assert.True(captured!.Filter.IncludeSutta && captured.Filter.IncludeVinaya
+                        && captured.Filter.IncludeAbhidhamma && captured.Filter.IncludeMula);
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/Tools/DictionaryTool.cs
+++ b/src/CST.Avalonia/Services/Tools/DictionaryTool.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Conversion;
+using CST.Tools;
+
+namespace CST.Avalonia.Services.Tools
+{
+    /// <summary>
+    /// <see cref="IDictionaryTool"/> over the app's <see cref="IDictionaryService"/> (AI_INTEGRATION.md
+    /// surface C / §9). The service owns the on-disk format; this maps entries to the tool DTO and projects
+    /// the IPE headword to the requested output script. The meaning is passed through as its source HTML.
+    /// </summary>
+    public sealed class DictionaryTool : IDictionaryTool
+    {
+        private readonly IDictionaryService _dictionary;
+
+        public DictionaryTool(IDictionaryService dictionary) => _dictionary = dictionary;
+
+        public IReadOnlyList<string> Languages => _dictionary.AvailableLanguages;
+
+        public async Task<IReadOnlyList<DictionaryEntry>> LookupAsync(
+            DictionaryRequest request, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var words = await _dictionary.LookupAsync(request.Language, request.Query ?? string.Empty)
+                .ConfigureAwait(false);
+
+            return words
+                .Take(request.MaxEntries)
+                .Select(w => new DictionaryEntry(
+                    Headword: ScriptConverter.Convert(w.Word, Script.Ipe, request.OutputScript),
+                    HeadwordIpe: w.Word,
+                    MeaningHtml: w.Meaning))
+                .ToList();
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Conversion;
+using CST.Tools;
+
+namespace CST.Avalonia.Services.Tools
+{
+    /// <summary>
+    /// <see cref="ISearchTool"/> over the app's <see cref="ISearchService"/> (AI_INTEGRATION.md surface C).
+    /// Maps the transport-agnostic tool request/response to/from the internal search models and projects IPE
+    /// terms to the requested output script. Headless — <see cref="ISearchService"/> is reference-counted and
+    /// thread-safe (SRCH-6/11), so this is safe to call from a local HTTP handler.
+    /// </summary>
+    public sealed class SearchTool : ISearchTool
+    {
+        private readonly ISearchService _search;
+
+        public SearchTool(ISearchService search) => _search = search;
+
+        public async Task<SearchToolResult> SearchAsync(SearchToolRequest request, CancellationToken ct = default)
+        {
+            var query = new SearchQuery
+            {
+                QueryText = request.Query ?? string.Empty,
+                Mode = MapMode(request.Mode),
+                PageSize = request.MaxTerms,
+                ProximityDistance = request.ProximityDistance,
+                Filter = MapFilter(request.Filter)
+                // IsPhrase / IsMultiWord are derived by SearchService from the query text.
+            };
+
+            var result = await _search.SearchAsync(query, ct).ConfigureAwait(false);
+
+            var terms = result.Terms.Select(t => new SearchTermResult(
+                Term: ScriptConverter.Convert(t.Term, Script.Ipe, request.OutputScript),
+                TermIpe: t.Term,
+                TotalCount: t.TotalCount,
+                Books: t.Occurrences.Select(o => new BookHitSummary(
+                    BookId: o.Book?.FileName ?? string.Empty,
+                    BookName: o.Book?.LongNavPath ?? string.Empty,
+                    Count: o.Count)).ToList())).ToList();
+
+            return new SearchToolResult(
+                Terms: terms,
+                TotalTermCount: result.TotalTermCount,
+                TotalOccurrenceCount: result.TotalOccurrenceCount,
+                TotalBookCount: result.TotalBookCount,
+                Truncated: result.ResultsTruncated,
+                Note: result.TruncationMessage);
+        }
+
+        public async Task<IReadOnlyList<string>> CompleteTermsAsync(
+            string prefix, int limit = 50, Script outputScript = Script.Latin, CancellationToken ct = default)
+        {
+            var terms = await _search.GetAllTermsAsync(prefix ?? string.Empty, limit, ct).ConfigureAwait(false);
+            // GetAllTermsAsync returns terms in the app's *current display* script; re-project to the
+            // requested output script (auto-detecting the input) so the tool is independent of app state.
+            return terms.Select(t => ScriptConverter.Convert(t, Script.Unknown, outputScript)).ToList();
+        }
+
+        public async Task<IReadOnlyList<TermHit>> GetTermHitsAsync(
+            string bookId, string termIpe, CancellationToken ct = default)
+        {
+            var positions = await _search.GetTermPositionsAsync(bookId, termIpe, ct).ConfigureAwait(false);
+            return positions.Select(p => new TermHit(
+                WordIndex: p.WordIndex,
+                StartOffset: p.StartOffset,
+                EndOffset: p.EndOffset,
+                IsPrimaryTerm: p.IsFirstTerm,
+                WordIpe: p.Word)).ToList();
+        }
+
+        private static SearchMode MapMode(SearchToolMode mode) => mode switch
+        {
+            SearchToolMode.Exact => SearchMode.Exact,
+            SearchToolMode.Wildcard => SearchMode.Wildcard,
+            SearchToolMode.Regex => SearchMode.Regex,
+            _ => SearchMode.Exact
+        };
+
+        private static BookFilter MapFilter(ToolBookFilter? f)
+        {
+            if (f == null) return new BookFilter();
+            return new BookFilter
+            {
+                IncludeVinaya = f.Vinaya,
+                IncludeSutta = f.Sutta,
+                IncludeAbhidhamma = f.Abhidhamma,
+                IncludeMula = f.Mula,
+                IncludeAttha = f.Atthakatha,
+                IncludeTika = f.Tika,
+                IncludeOther = f.Other
+            };
+        }
+    }
+}


### PR DESCRIPTION
Realizes two of the surface-C data tools (AI_INTEGRATION.md §4.2) as thin, headless wrappers over the existing services. Part of epic #186 / read tool set #190. Pure backend — no UI, no consumer wired yet.

## What
- **`SearchTool : ISearchTool`** (`CST.Avalonia/Services/Tools/`) — wraps `ISearchService`.
  - `SearchToolRequest` → `SearchQuery` (mode / piṭaka+commentary filter / `MaxTerms` / proximity). `IsPhrase`/`IsMultiWord` are derived by `SearchService` itself, so the wrapper doesn't set them.
  - `SearchResult` → `SearchToolResult` (terms + per-book counts; positions are opt-in via `GetTermHitsAsync`).
  - **Script projection:** IPE terms → requested `OutputScript` (default romanized Latin); each term also returns its stable IPE key. `CompleteTermsAsync` re-projects autocomplete output (which `GetAllTermsAsync` returns in the app's *current* display script) so the tool is independent of app state.
- **`DictionaryTool : IDictionaryTool`** — wraps `IDictionaryService`. `DictionaryWord` → `DictionaryEntry`, headword projected to the output script, meaning passed through as source HTML, `MaxEntries` honored.

## Notes
- No internal types (`SearchResult`/`MatchingTerm`/`DictionaryWord`) cross the boundary.
- **7 Moq-based unit tests** (request/response mapping + script projection); underlying services are mocked so tests don't need a live index or dictionary files. App builds clean (0 warnings).
- **Not DI-registered yet** — deliberately deferred to the HTTP-API PR that will consume these (keeps this change off `App.axaml.cs`).
- **`fetch_passage`** (needs a pure TEI *text* reader) is the next C increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)