### PR TITLE
AI surface C: search-results-in-context snippet engine (#186/#190)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
+++ b/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
@@ -1,0 +1,117 @@
+using CST.Conversion;
+using CST.Navigation;
+using CST.Search;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Search
+{
+    /// <summary>
+    /// Unit tests for the pure snippet engine (BookMarkers + TeiSnippetExtractor). Fixtures use ASCII
+    /// placeholder "words" plus \u0964 (danda) / \u0965 (double danda) boundary escapes -- no literal
+    /// Devanagari in source -- and request Script.Devanagari output so conversion is identity and the
+    /// windowing/cleaning structure can be asserted exactly.
+    /// </summary>
+    public class SnippetEngineTests
+    {
+        // paranum "Q" + dot ".", three prose sentences, a footnote inside the hit sentence, two page editions.
+        private const string Prose =
+            "<TEI.2><text><body>" +
+            "<div id=\"an1\" n=\"an1\" type=\"book\">" +
+            "<pb ed=\"V\" n=\"1.0001\"/>" +
+            "<pb ed=\"M\" n=\"2.0005\"/>" +
+            "<p rend=\"bodytext\" n=\"7\">" +
+            "<hi rend=\"paranum\">Q</hi><hi rend=\"dot\">.</hi> " +
+            "aaa bbb ccc\u0964 " +
+            "ddd eee TARGET <note>VAR\u0964z</note> fff\u0964 " +
+            "ggg hhh iii\u0964" +
+            "</p></div></body></text></TEI.2>";
+
+        private static int HitStart(string xml, string term) => xml.IndexOf(term, System.StringComparison.Ordinal);
+
+        private static SnippetOptions Deva(int min = 1, int max = 4000, bool notes = false) =>
+            new(OutputScript: Script.Devanagari, IncludeVariantReadings: notes, MinChars: min, MaxChars: max);
+
+        [Fact]
+        public void Markers_report_paragraph_and_all_editions_at_hit()
+        {
+            var markers = BookMarkers.Build(Prose);
+            var (num, code, pages) = markers.RefsAt(HitStart(Prose, "TARGET"));
+
+            Assert.Equal(7, num);
+            Assert.Equal("an1", code);
+            Assert.Contains(pages, p => p.Edition == PageEdition.Vri && p.Volume == 1 && p.Number == 1);
+            Assert.Contains(pages, p => p.Edition == PageEdition.Myanmar && p.Volume == 2 && p.Number == 5);
+        }
+
+        [Fact]
+        public void Prose_snippet_is_the_hit_sentence_only()
+        {
+            var markers = BookMarkers.Build(Prose);
+            int hs = HitStart(Prose, "TARGET");
+            var r = TeiSnippetExtractor.Extract(Prose, hs, 6, markers, Deva(min: 1));
+
+            Assert.Contains("TARGET", r.Snippet);
+            Assert.Contains("ddd", r.Snippet);
+            Assert.Contains("fff", r.Snippet);
+            Assert.DoesNotContain("aaa", r.Snippet);   // neighbor sentence, floor off
+            Assert.DoesNotContain("ggg", r.Snippet);   // neighbor sentence
+            Assert.DoesNotContain("VAR", r.Snippet);   // footnote excluded by default
+            Assert.DoesNotContain("Q", r.Snippet);     // paranum marker not in window
+        }
+
+        [Fact]
+        public void Hit_range_points_at_the_term_in_the_snippet()
+        {
+            var markers = BookMarkers.Build(Prose);
+            int hs = HitStart(Prose, "TARGET");
+            var r = TeiSnippetExtractor.Extract(Prose, hs, 6, markers, Deva(min: 1));
+
+            Assert.Equal("TARGET", r.Snippet.Substring(r.HitStart, r.HitLength));
+        }
+
+        [Fact]
+        public void Variant_readings_included_on_request()
+        {
+            var markers = BookMarkers.Build(Prose);
+            int hs = HitStart(Prose, "TARGET");
+            var with = TeiSnippetExtractor.Extract(Prose, hs, 6, markers, Deva(min: 1, notes: true));
+
+            Assert.Contains("VAR", with.Snippet);
+        }
+
+        [Fact]
+        public void Floor_widens_to_neighbor_sentences_and_still_strips_paranum()
+        {
+            var markers = BookMarkers.Build(Prose);
+            int hs = HitStart(Prose, "TARGET");
+            var r = TeiSnippetExtractor.Extract(Prose, hs, 6, markers, Deva(min: 200));
+
+            Assert.Contains("aaa", r.Snippet);   // previous sentence pulled in
+            Assert.Contains("ggg", r.Snippet);   // next sentence pulled in
+            Assert.DoesNotContain("Q", r.Snippet); // paranum still stripped
+            Assert.Equal("TARGET", r.Snippet.Substring(r.HitStart, r.HitLength));
+        }
+
+        // --- verse ----------------------------------------------------------
+
+        private const string Verse =
+            "<body><div id=\"x\" type=\"book\">" +
+            "<p rend=\"gatha1\" n=\"10\">line one alpha\u0965</p>" +
+            "<p rend=\"gatha2\">line two TARGET beta\u0965</p>" +
+            "<p rend=\"gathalast\">line three gamma\u0965</p>" +
+            "</div></body>";
+
+        [Fact]
+        public void Verse_hit_includes_one_line_each_side()
+        {
+            var markers = BookMarkers.Build(Verse);
+            int hs = HitStart(Verse, "TARGET");
+            var r = TeiSnippetExtractor.Extract(Verse, hs, 6, markers, Deva());
+
+            Assert.Contains("one", r.Snippet);    // line before
+            Assert.Contains("TARGET", r.Snippet); // hit line
+            Assert.Contains("three", r.Snippet);  // line after
+            Assert.Equal("TARGET", r.Snippet.Substring(r.HitStart, r.HitLength));
+        }
+    }
+}

--- a/src/CST.Core/Search/BookMarkers.cs
+++ b/src/CST.Core/Search/BookMarkers.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using CST.Navigation;
+
+namespace CST.Search
+{
+    /// <summary>
+    /// A position index of a book's citation markers — page breaks (per edition) and numbered paragraphs —
+    /// keyed by character position in the decoded XML (the same coordinate the search offsets use). Built
+    /// once per book; answers "what page/paragraph is in effect at this hit position?" in a few binary
+    /// searches. Reports current position only; it is not the navigation anchor catalog.
+    /// </summary>
+    public sealed class BookMarkers
+    {
+        private static readonly Regex TagRx = new(@"<[^>]*>", RegexOptions.Compiled);
+        private static readonly Regex AttrRx = new("(\\w+)\\s*=\\s*\"([^\"]*)\"", RegexOptions.Compiled);
+
+        // Ascending-by-position lists.
+        private readonly List<(int Pos, int Number, string? BookCode)> _paras = new();
+        private readonly Dictionary<PageEdition, List<(int Pos, int Volume, int Number)>> _pages = new();
+
+        private BookMarkers() { }
+
+        /// <summary>Scan a decoded book XML string and index its page/paragraph markers.</summary>
+        public static BookMarkers Build(string xml)
+        {
+            var m = new BookMarkers();
+            var divStack = new List<(bool IsBook, string? Id)>();
+
+            foreach (Match tag in TagRx.Matches(xml))
+            {
+                var (closing, name, attrs) = Parse(tag.Value);
+                switch (name)
+                {
+                    case "div":
+                        if (closing) { if (divStack.Count > 0) divStack.RemoveAt(divStack.Count - 1); }
+                        else if (!tag.Value.EndsWith("/>"))
+                            divStack.Add((attrs.TryGetValue("type", out var t) && t == "book",
+                                          attrs.TryGetValue("id", out var id) ? id : null));
+                        break;
+
+                    case "pb":
+                        if (!closing && attrs.TryGetValue("ed", out var ed) && attrs.TryGetValue("n", out var pn)
+                            && Edition(ed) is PageEdition edition && SplitVolPage(pn, out int vol, out int num))
+                        {
+                            if (!m._pages.TryGetValue(edition, out var list))
+                                m._pages[edition] = list = new();
+                            list.Add((tag.Index, vol, num));
+                        }
+                        break;
+
+                    case "p":
+                        if (!closing && attrs.TryGetValue("n", out var nStr) && int.TryParse(nStr, out int pnum))
+                            m._paras.Add((tag.Index, pnum, CurrentBook(divStack)));
+                        break;
+                }
+            }
+            return m;
+        }
+
+        /// <summary>The paragraph number (and Multi-book sub-code) and per-edition pages in effect at <paramref name="pos"/>.</summary>
+        public (int? Number, string? BookCode, IReadOnlyList<SnippetPageRef> Pages) RefsAt(int pos)
+        {
+            int? number = null; string? code = null;
+            var pi = UpperBound(_paras.Count, i => _paras[i].Pos <= pos) - 1;
+            if (pi >= 0) { number = _paras[pi].Number; code = _paras[pi].BookCode; }
+
+            var pages = new List<SnippetPageRef>();
+            foreach (var (edition, list) in _pages)
+            {
+                var idx = UpperBound(list.Count, i => list[i].Pos <= pos) - 1;
+                if (idx >= 0) pages.Add(new SnippetPageRef(edition, list[idx].Volume, list[idx].Number));
+            }
+            pages.Sort((a, b) => a.Edition.CompareTo(b.Edition));
+            return (number, code, pages);
+        }
+
+        // Largest index+1 whose predicate holds over an ascending-sorted list (i.e. count of leading trues).
+        private static int UpperBound(int count, System.Func<int, bool> leadingTrue)
+        {
+            int lo = 0, hi = count;
+            while (lo < hi) { int mid = (lo + hi) / 2; if (leadingTrue(mid)) lo = mid + 1; else hi = mid; }
+            return lo;
+        }
+
+        private static string? CurrentBook(List<(bool IsBook, string? Id)> stack)
+        {
+            foreach (var d in stack) if (d.IsBook && d.Id != null) return d.Id;  // outermost book div
+            return null;
+        }
+
+        private static (bool Closing, string Name, Dictionary<string, string> Attrs) Parse(string tag)
+        {
+            int i = 1;
+            bool closing = i < tag.Length && tag[i] == '/';
+            if (closing) i++;
+            int start = i;
+            while (i < tag.Length && (char.IsLetterOrDigit(tag[i]) || tag[i] == ':')) i++;
+            string name = tag.Substring(start, i - start);
+            var attrs = new Dictionary<string, string>();
+            if (!closing)
+                foreach (Match a in AttrRx.Matches(tag)) attrs[a.Groups[1].Value] = a.Groups[2].Value;
+            return (closing, name, attrs);
+        }
+
+        private static PageEdition? Edition(string ed) => ed switch
+        {
+            "V" => PageEdition.Vri,
+            "M" => PageEdition.Myanmar,
+            "P" => PageEdition.Pts,
+            "T" => PageEdition.Thai,
+            "O" => PageEdition.Other,
+            _ => null
+        };
+
+        private static bool SplitVolPage(string n, out int volume, out int number)
+        {
+            volume = 0; number = 0;
+            int dot = n.IndexOf('.');
+            if (dot >= 0)
+                return int.TryParse(n.Substring(0, dot), out volume) && int.TryParse(n.Substring(dot + 1), out number);
+            return int.TryParse(n, out number);
+        }
+    }
+}

--- a/src/CST.Core/Search/SnippetModels.cs
+++ b/src/CST.Core/Search/SnippetModels.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using CST.Conversion;
+using CST.Navigation;
+
+namespace CST.Search
+{
+    /// <summary>
+    /// Options for extracting a search-hit snippet ("search results in context" — the CSCD concordance
+    /// feature). Context length is measured in <em>rendered</em> Pāli characters (XML tags and, when
+    /// excluded, footnotes are transparent and don't count).
+    /// </summary>
+    /// <param name="OutputScript">Script for the snippet text (default romanized Latin).</param>
+    /// <param name="IncludeVariantReadings">Include <c>&lt;note&gt;</c> (variant-reading) text (default off).</param>
+    /// <param name="MinChars">Prose floor: extend to neighboring sentences until at least this many rendered chars.</param>
+    /// <param name="MaxChars">Prose ceiling: a longer single sentence is trimmed+ellipsized around the hit.</param>
+    public sealed record SnippetOptions(
+        Script OutputScript = Script.Latin,
+        bool IncludeVariantReadings = false,
+        int MinChars = 60,
+        int MaxChars = 320);
+
+    /// <summary>A page reference at a hit, in one edition's numbering.</summary>
+    public sealed record SnippetPageRef(PageEdition Edition, int Volume, int Number);
+
+    /// <summary>
+    /// A rendered snippet plus the citation refs at the hit. <see cref="Snippet"/> is the concordance line
+    /// (term-centered, romanized); the matched term occupies <c>[HitStart, HitStart+HitLength)</c> within it.
+    /// </summary>
+    public sealed record SnippetResult(
+        string Snippet,
+        int HitStart,
+        int HitLength,
+        int? ParagraphNumber,
+        string? ParagraphBookCode,
+        IReadOnlyList<SnippetPageRef> Pages,
+        bool IncludedVariants);
+}

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using CST.Conversion;
+
+namespace CST.Search
+{
+    /// <summary>
+    /// Extracts a "search result in context" snippet around a hit, given the decoded book XML and the hit's
+    /// character offsets (the same coordinate the search offsets use). Prose is bounded to the sentence(s)
+    /// around the hit (danda / double-danda), measured in rendered text length so XML tags don't count;
+    /// verse (<c>rend="gatha..."</c>) includes the hit's line plus one line each side. Footnotes
+    /// (<c>&lt;note&gt;</c>) and the paragraph-number marker are stripped by default; text is romanized to the
+    /// requested script and the matched term's range within the snippet is recomputed after conversion.
+    /// </summary>
+    public static class TeiSnippetExtractor
+    {
+        private const char Danda = '\u0964';        // Devanagari danda - sentence end
+        private const char DoubleDanda = '\u0965';  // Devanagari double danda - verse/gatha end
+        private static readonly Regex Whitespace = new(@"\s+", RegexOptions.Compiled);
+
+        public static SnippetResult Extract(string xml, int hitStart, int hitLength, BookMarkers markers, SnippetOptions opts)
+        {
+            hitStart = Math.Clamp(hitStart, 0, xml.Length);
+            int hitEnd = Math.Clamp(hitStart + hitLength, hitStart, xml.Length);
+
+            var (openIdx, pStart, pEnd, rend) = FindEnclosingP(xml, hitStart);
+            if (pStart < 0) { openIdx = -1; pStart = 0; pEnd = xml.Length; rend = ""; }
+
+            int winStart, winEnd;
+            bool ellipsisStart = false, ellipsisEnd = false;
+
+            if (rend.StartsWith("gatha", StringComparison.Ordinal))
+                (winStart, winEnd) = VerseWindow(xml, openIdx, pStart, pEnd);
+            else
+                (winStart, winEnd, ellipsisStart, ellipsisEnd) =
+                    ProseWindow(xml, pStart, pEnd, hitStart, hitEnd, opts);
+
+            string before = Collapse(Convert(Clean(xml, winStart, hitStart, opts.IncludeVariantReadings), opts.OutputScript));
+            string hit = Convert(Clean(xml, hitStart, hitEnd, opts.IncludeVariantReadings), opts.OutputScript).Trim();
+            string after = Collapse(Convert(Clean(xml, hitEnd, winEnd, opts.IncludeVariantReadings), opts.OutputScript));
+
+            // Keep exactly one space between context and the hit; drop stray edge whitespace.
+            before = before.TrimStart();
+            after = after.TrimEnd();
+            string prefix = ellipsisStart ? "... " : "";
+            string suffix = ellipsisEnd ? " ..." : "";
+
+            string snippet = prefix + before + hit + after + suffix;
+            int markStart = prefix.Length + before.Length;
+
+            var (num, code, pages) = markers.RefsAt(hitStart);
+            return new SnippetResult(snippet, markStart, hit.Length, num, code, pages, opts.IncludeVariantReadings);
+        }
+
+        // --- window selection -----------------------------------------------
+
+        private static (int start, int end, bool ellStart, bool ellEnd) ProseWindow(
+            string xml, int pStart, int pEnd, int hitStart, int hitEnd, SnippetOptions opts)
+        {
+            var notes = NoteRegions(xml, pStart, pEnd);
+
+            int start = SentenceStart(xml, pStart, hitStart, notes);
+            int end = SentenceEnd(xml, hitEnd, pEnd, notes);
+
+            // Floor: widen to neighboring sentences until enough rendered text.
+            while (VisibleLen(xml, start, end) < opts.MinChars)
+            {
+                int ns = start > pStart ? SentenceStart(xml, pStart, start - 1, notes) : start;
+                int ne = end < pEnd ? SentenceEnd(xml, end, pEnd, notes) : end;
+                if (ns == start && ne == end) break;
+                start = ns; end = ne;
+            }
+
+            // Ceiling: a single long sentence gets trimmed toward the hit, with ellipses.
+            bool ellStart = false, ellEnd = false;
+            if (VisibleLen(xml, start, end) > opts.MaxChars)
+            {
+                int half = opts.MaxChars / 2;
+                int ns = SnapToSpace(xml, Math.Max(pStart, hitStart - half), +1, hitStart);
+                int ne = SnapToSpace(xml, Math.Min(pEnd, hitEnd + half), -1, hitEnd);
+                if (ns > start) { start = ns; ellStart = true; }
+                if (ne < end) { end = ne; ellEnd = true; }
+            }
+            return (start, end, ellStart, ellEnd);
+        }
+
+        private static (int start, int end) VerseWindow(string xml, int openIdx, int pStart, int pEnd)
+        {
+            int start = pStart, end = pEnd;
+            if (openIdx >= 0)
+            {
+                int prevOpen = FindLastPOpen(xml, openIdx);
+                if (prevOpen >= 0) { int gt = xml.IndexOf('>', prevOpen); if (gt >= 0) start = gt + 1; }
+            }
+            int nextOpen = FindNextPOpen(xml, pEnd);
+            if (nextOpen >= 0)
+            {
+                int nextEnd = xml.IndexOf("</p>", nextOpen, StringComparison.Ordinal);
+                if (nextEnd >= 0) end = nextEnd;
+            }
+            return (start, end);
+        }
+
+        // --- sentence boundaries (raw, note-aware) --------------------------
+
+        private static int SentenceStart(string xml, int lo, int from, List<(int s, int e)> notes)
+        {
+            for (int i = Math.Min(from, xml.Length) - 1; i >= lo; i--)
+                if (IsBoundary(xml[i]) && !InNote(i, notes)) return i + 1;
+            return lo;
+        }
+
+        private static int SentenceEnd(string xml, int from, int hi, List<(int s, int e)> notes)
+        {
+            for (int i = from; i < hi; i++)
+                if (IsBoundary(xml[i]) && !InNote(i, notes)) return i + 1;
+            return hi;
+        }
+
+        private static bool IsBoundary(char c) => c == Danda || c == DoubleDanda;
+
+        // --- cleaning: raw range -> rendered text ---------------------------
+
+        private static string Clean(string xml, int start, int end, bool includeNotes)
+        {
+            if (start >= end) return "";
+            var sb = new StringBuilder(end - start);
+            int i = start;
+            while (i < end)
+            {
+                char c = xml[i];
+                if (c == '<')
+                {
+                    int gt = xml.IndexOf('>', i);
+                    if (gt < 0 || gt >= end) break;
+                    string tag = xml.Substring(i, gt - i + 1);
+                    string name = TagName(tag);
+                    if (name == "note" && !includeNotes && !tag.EndsWith("/>", StringComparison.Ordinal))
+                        i = SkipSubtree(xml, gt + 1, "note", end);
+                    else if (name == "hi" && IsStructuralHi(tag) && !tag.EndsWith("/>", StringComparison.Ordinal))
+                        i = SkipSubtree(xml, gt + 1, "hi", end);
+                    else
+                    {
+                        if (sb.Length > 0 && sb[sb.Length - 1] != ' ') sb.Append(' ');
+                        i = gt + 1;
+                    }
+                }
+                else { sb.Append(c); i++; }
+            }
+            return sb.ToString();
+        }
+
+        private static int VisibleLen(string xml, int start, int end) => Clean(xml, start, end, false).Length;
+
+        // --- helpers --------------------------------------------------------
+
+        private static string Convert(string deva, Script output) =>
+            deva.Length == 0 ? "" : ScriptConverter.Convert(deva, Script.Devanagari, output);
+
+        private static string Collapse(string s) => Whitespace.Replace(s, " ");
+
+        private static (int openIdx, int contentStart, int pEnd, string rend) FindEnclosingP(string xml, int hitStart)
+        {
+            int lastClose = xml.LastIndexOf("</p>", Math.Min(hitStart, xml.Length), StringComparison.Ordinal);
+            int open = FindLastPOpen(xml, hitStart);
+            if (open < 0 || open < lastClose) return (-1, -1, -1, "");
+            int gt = xml.IndexOf('>', open);
+            if (gt < 0) return (-1, -1, -1, "");
+            int pEnd = xml.IndexOf("</p>", gt + 1, StringComparison.Ordinal);
+            if (pEnd < 0) pEnd = xml.Length;
+            return (open, gt + 1, pEnd, Attr(xml.Substring(open, gt - open + 1), "rend"));
+        }
+
+        private static int FindLastPOpen(string xml, int before)
+        {
+            int idx = Math.Min(before, xml.Length);
+            while ((idx = xml.LastIndexOf("<p", idx - 1, StringComparison.Ordinal)) >= 0)
+            {
+                char c = idx + 2 < xml.Length ? xml[idx + 2] : '\0';
+                if (c == ' ' || c == '>' || c == '\t' || c == '\n' || c == '\r') return idx;
+            }
+            return -1;
+        }
+
+        private static int FindNextPOpen(string xml, int from)
+        {
+            int idx = Math.Max(from, 0);
+            while ((idx = xml.IndexOf("<p", idx, StringComparison.Ordinal)) >= 0)
+            {
+                char c = idx + 2 < xml.Length ? xml[idx + 2] : '\0';
+                if (c == ' ' || c == '>' || c == '\t' || c == '\n' || c == '\r') return idx;
+                idx += 2;
+            }
+            return -1;
+        }
+
+        private static List<(int s, int e)> NoteRegions(string xml, int lo, int hi)
+        {
+            var list = new List<(int, int)>();
+            int i = lo;
+            while ((i = xml.IndexOf("<note", i, StringComparison.Ordinal)) >= 0 && i < hi)
+            {
+                int gt = xml.IndexOf('>', i);
+                if (gt < 0) break;
+                if (xml[gt - 1] == '/') { i = gt + 1; continue; }        // self-closing
+                int e = SkipSubtree(xml, gt + 1, "note", xml.Length);
+                list.Add((i, e));
+                i = e;
+            }
+            return list;
+        }
+
+        private static bool InNote(int pos, List<(int s, int e)> notes)
+        {
+            foreach (var (s, e) in notes) if (pos >= s && pos < e) return true;
+            return false;
+        }
+
+        // Position just past the matching close tag for an already-open element.
+        private static int SkipSubtree(string xml, int from, string name, int limit)
+        {
+            int depth = 1, i = from;
+            string open = "<" + name, close = "</" + name;
+            while (i < limit && depth > 0)
+            {
+                int lt = xml.IndexOf('<', i);
+                if (lt < 0 || lt >= limit) return limit;
+                if (xml.AsSpan(lt).StartsWith(close)) { depth--; i = xml.IndexOf('>', lt); i = i < 0 ? limit : i + 1; }
+                else if (xml.AsSpan(lt).StartsWith(open) && (lt + open.Length >= xml.Length ||
+                         xml[lt + open.Length] is ' ' or '>' or '\t' or '\n' or '\r'))
+                { int gt = xml.IndexOf('>', lt); if (gt >= 0 && xml[gt - 1] != '/') depth++; i = gt < 0 ? limit : gt + 1; }
+                else i = lt + 1;
+            }
+            return i;
+        }
+
+        private static int SnapToSpace(string xml, int pos, int dir, int stopAt)
+        {
+            for (int i = pos; dir > 0 ? i < stopAt : i > stopAt; i += dir)
+                if (xml[i] == ' ' || xml[i] == '\n') return i + (dir > 0 ? 1 : 0);
+            return pos;
+        }
+
+        private static string TagName(string tag)
+        {
+            int i = 1;
+            if (i < tag.Length && tag[i] == '/') i++;
+            int start = i;
+            while (i < tag.Length && (char.IsLetterOrDigit(tag[i]) || tag[i] == ':')) i++;
+            return tag.Substring(start, i - start);
+        }
+
+        private static bool IsStructuralHi(string tag)
+        {
+            string rend = Attr(tag, "rend");
+            return rend == "paranum" || rend == "dot";
+        }
+
+        private static string Attr(string tag, string name)
+        {
+            var m = Regex.Match(tag, name + "\\s*=\\s*\"([^\"]*)\"");
+            return m.Success ? m.Groups[1].Value : "";
+        }
+    }
+}


### PR DESCRIPTION
The pure engine for **"search results in context"** — the CSCD concordance/KWIC feature (present in VRI's CSCD, absent from CST4/CST5, requested by monks). Part of epic #186 / read tool set #190. Pure `CST.Core`, no UI, fully fixture-tested.

## Design (settled with @fsnow)
A search hit is shown as a **snippet** — sentence/verse-bounded, hit-anchored — not a whole paragraph/page. The unit is the occurrence, with citation refs across every numbering system.

- **`BookMarkers`** — position index of page breaks (per edition) + numbered paragraphs, keyed by **character offset** (confirmed char-into-decoded-XML, not byte, by reading the highlighting consumer: `File.ReadAllText(Encoding.Unicode)` then `Substring(startOffset, …)`). `RefsAt(pos)` → paragraph number (+ Multi sub-book code) and per-edition pages (V/M/P/T/O) in effect at the hit — the full citation set.
- **`TeiSnippetExtractor`** —
  - **Prose:** bounded to the sentence(s) around the hit (danda `।` / double-danda `॥`), measured in **rendered text length** so XML tags don't count; a **floor** widens short sentences, a **ceiling** ellipsizes long ones.
  - **Verse** (`rend="gatha…"`): the hit line **±1 line**.
  - **Variant readings** (`<note>`) stripped by default, opt-in; **paragraph-number marker** stripped; text **romanized** to the requested script (default Latin) with the hit's range recomputed after conversion.

## Notes
- All Devanagari boundary chars are `\uXXXX` escapes; fixtures use ASCII placeholder words (hard rule: no literal non-Latin in source). **6 fixture tests** pass; CST.Core builds clean.
- **Engine only.** Next PR wires it into the tool: reshape `ISearchTool` (replace the raw-offset `GetTermHitsAsync` with an in-context `GetOccurrences…` that runs over search positions, reads the book file, pages results) — the search→cite/jump bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)