### PR TITLE
AI surface C: wire search-results-in-context into the search tool (#186/#190)

### DIFF
--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CST;
@@ -6,6 +9,7 @@ using CST.Avalonia.Models;
 using CST.Avalonia.Services;
 using CST.Avalonia.Services.Tools;
 using CST.Conversion;
+using CST.Navigation;
 using CST.Tools;
 using Moq;
 using Xunit;
@@ -13,13 +17,20 @@ using Xunit;
 namespace CST.Avalonia.Tests.Tools
 {
     /// <summary>
-    /// Unit tests for the surface-C search tool wrapper. The underlying ISearchService is mocked, so these
-    /// assert the request/response mapping and script projection — not search behavior itself. Term text uses
-    /// ASCII placeholders and expected script output is computed inline via ScriptConverter (no hardcoded
-    /// non-Latin in source).
+    /// Unit tests for the surface-C search tool wrapper. ISearchService is mocked, so these assert the
+    /// request/response mapping and script projection -- not search behavior. Term text uses ASCII placeholders
+    /// with expected output computed inline (no hardcoded non-Latin). GetOccurrencesAsync is exercised
+    /// end-to-end against a temp UTF-16 book file with Script.Devanagari output (identity conversion).
     /// </summary>
     public class SearchToolTests
     {
+        private static ISettingsService Settings(string dir = "")
+        {
+            var m = new Mock<ISettingsService>();
+            m.SetupGet(s => s.Settings).Returns(new Settings { XmlBooksDirectory = dir });
+            return m.Object;
+        }
+
         private static SearchResult OneTermResult(out Book book)
         {
             book = new Book { FileName = "s0101m.mul.xml", LongNavPath = "Sutta > Digha > Silakkhandhavagga" };
@@ -31,10 +42,7 @@ namespace CST.Avalonia.Tests.Tools
                     {
                         Term = "abc",          // stand-in IPE term (ASCII placeholder)
                         TotalCount = 7,
-                        Occurrences = new List<BookOccurrence>
-                        {
-                            new BookOccurrence { Book = book, Count = 7 }
-                        }
+                        Occurrences = new List<BookOccurrence> { new BookOccurrence { Book = book, Count = 7 } }
                     }
                 },
                 TotalTermCount = 1,
@@ -54,7 +62,7 @@ namespace CST.Avalonia.Tests.Tools
                 .Callback<SearchQuery, CancellationToken>((q, _) => captured = q)
                 .ReturnsAsync(OneTermResult(out _));
 
-            var tool = new SearchTool(mock.Object);
+            var tool = new SearchTool(mock.Object, Settings());
             await tool.SearchAsync(new SearchToolRequest(
                 "dhamma", SearchToolMode.Wildcard,
                 new ToolBookFilter(Sutta: true, Abhidhamma: false),
@@ -76,44 +84,21 @@ namespace CST.Avalonia.Tests.Tools
             mock.Setup(s => s.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(OneTermResult(out var book));
 
-            var tool = new SearchTool(mock.Object);
+            var tool = new SearchTool(mock.Object, Settings());
             var result = await tool.SearchAsync(new SearchToolRequest("q")); // OutputScript defaults to Latin
 
             Assert.Equal(1, result.TotalTermCount);
-            Assert.Equal(7, result.TotalOccurrenceCount);
             Assert.True(result.Truncated);
             Assert.Equal("capped", result.Note);
 
             var term = Assert.Single(result.Terms);
-            Assert.Equal("abc", term.TermIpe);                                   // stable IPE preserved
-            Assert.Equal(ScriptConverter.Convert("abc", Script.Ipe, Script.Latin), term.Term); // projected
-            Assert.Equal(7, term.TotalCount);
+            Assert.Equal("abc", term.TermIpe);
+            Assert.Equal(ScriptConverter.Convert("abc", Script.Ipe, Script.Latin), term.Term);
 
             var hit = Assert.Single(term.Books);
             Assert.Equal(book.FileName, hit.BookId);
             Assert.Equal(book.LongNavPath, hit.BookName);
             Assert.Equal(7, hit.Count);
-        }
-
-        [Fact]
-        public async Task GetTermHitsAsync_maps_positions()
-        {
-            var mock = new Mock<ISearchService>();
-            mock.Setup(s => s.GetTermPositionsAsync("b.xml", "abc", It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new List<TermPosition>
-                {
-                    new TermPosition { WordIndex = 2, StartOffset = 10, EndOffset = 15, IsFirstTerm = true, Word = "abc" }
-                });
-
-            var tool = new SearchTool(mock.Object);
-            var hits = await tool.GetTermHitsAsync("b.xml", "abc");
-
-            var h = Assert.Single(hits);
-            Assert.Equal(2, h.WordIndex);
-            Assert.Equal(10, h.StartOffset);
-            Assert.Equal(15, h.EndOffset);
-            Assert.True(h.IsPrimaryTerm);
-            Assert.Equal("abc", h.WordIpe);
         }
 
         [Fact]
@@ -125,12 +110,70 @@ namespace CST.Avalonia.Tests.Tools
                 .Callback<SearchQuery, CancellationToken>((q, _) => captured = q)
                 .ReturnsAsync(new SearchResult());
 
-            var tool = new SearchTool(mock.Object);
+            var tool = new SearchTool(mock.Object, Settings());
             await tool.SearchAsync(new SearchToolRequest("q"));
 
             Assert.NotNull(captured);
             Assert.True(captured!.Filter.IncludeSutta && captured.Filter.IncludeVinaya
                         && captured.Filter.IncludeAbhidhamma && captured.Filter.IncludeMula);
+        }
+
+        [Fact]
+        public async Task GetOccurrencesAsync_returns_snippet_with_citation_refs()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cst-occ-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                const string book = "s0101m.mul.xml"; // a real catalog book, so BookName resolves
+                string xml =
+                    "<body><div id=\"dn1\" type=\"book\">" +
+                    "<pb ed=\"V\" n=\"1.0003\"/>" +
+                    "<p rend=\"bodytext\" n=\"12\">aaa bbb\u0964 ccc TARGET ddd\u0964 eee fff\u0964</p>" +
+                    "</div></body>";
+                await File.WriteAllTextAsync(Path.Combine(dir, book), xml, Encoding.Unicode);
+
+                int hit = xml.IndexOf("TARGET", StringComparison.Ordinal);
+                var search = new Mock<ISearchService>();
+                search.Setup(s => s.GetTermPositionsAsync(book, "tgt", It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new List<TermPosition>
+                    {
+                        new TermPosition { StartOffset = hit, EndOffset = hit + 6, IsFirstTerm = true, Word = "tgt" }
+                    });
+
+                var tool = new SearchTool(search.Object, Settings(dir));
+                var occ = await tool.GetOccurrencesAsync(
+                    new OccurrenceRequest(book, "tgt", OutputScript: Script.Devanagari, MinChars: 1));
+
+                var o = Assert.Single(occ);
+                Assert.Contains("TARGET", o.Snippet);
+                Assert.Contains("ccc", o.Snippet);
+                Assert.Contains("ddd", o.Snippet);
+                Assert.DoesNotContain("aaa", o.Snippet);   // neighbor sentence, floor off
+                Assert.Equal("TARGET", o.Snippet.Substring(o.HitStart, o.HitLength));
+                Assert.Equal(12, o.Refs.ParagraphNumber);
+                Assert.Equal("dn1", o.Refs.ParagraphBookCode);
+                Assert.Contains(o.Refs.Pages, p => p.Edition == PageEdition.Vri && p.Volume == 1 && p.Number == 3);
+                Assert.Equal(book, o.BookId);
+                Assert.False(string.IsNullOrEmpty(o.BookName));
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task GetOccurrencesAsync_empty_when_no_positions()
+        {
+            var search = new Mock<ISearchService>();
+            search.Setup(s => s.GetTermPositionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<TermPosition>());
+
+            var tool = new SearchTool(search.Object, Settings("/nonexistent"));
+            var occ = await tool.GetOccurrencesAsync(new OccurrenceRequest("x.xml", "t"));
+
+            Assert.Empty(occ);
         }
     }
 }

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -1,9 +1,13 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models;
 using CST.Conversion;
+using CST.Search;
 using CST.Tools;
 
 namespace CST.Avalonia.Services.Tools
@@ -11,14 +15,20 @@ namespace CST.Avalonia.Services.Tools
     /// <summary>
     /// <see cref="ISearchTool"/> over the app's <see cref="ISearchService"/> (AI_INTEGRATION.md surface C).
     /// Maps the transport-agnostic tool request/response to/from the internal search models and projects IPE
-    /// terms to the requested output script. Headless — <see cref="ISearchService"/> is reference-counted and
-    /// thread-safe (SRCH-6/11), so this is safe to call from a local HTTP handler.
+    /// terms to the requested output script. <see cref="GetOccurrencesAsync"/> adds "search results in
+    /// context" — snippets + citation refs — by reading the book XML and running the snippet engine. Headless —
+    /// <see cref="ISearchService"/> is reference-counted and thread-safe (SRCH-6/11), safe from an HTTP handler.
     /// </summary>
     public sealed class SearchTool : ISearchTool
     {
         private readonly ISearchService _search;
+        private readonly ISettingsService _settings;
 
-        public SearchTool(ISearchService search) => _search = search;
+        public SearchTool(ISearchService search, ISettingsService settings)
+        {
+            _search = search;
+            _settings = settings;
+        }
 
         public async Task<SearchToolResult> SearchAsync(SearchToolRequest request, CancellationToken ct = default)
         {
@@ -61,16 +71,46 @@ namespace CST.Avalonia.Services.Tools
             return terms.Select(t => ScriptConverter.Convert(t, Script.Unknown, outputScript)).ToList();
         }
 
-        public async Task<IReadOnlyList<TermHit>> GetTermHitsAsync(
-            string bookId, string termIpe, CancellationToken ct = default)
+        public async Task<IReadOnlyList<Occurrence>> GetOccurrencesAsync(
+            OccurrenceRequest request, CancellationToken ct = default)
         {
-            var positions = await _search.GetTermPositionsAsync(bookId, termIpe, ct).ConfigureAwait(false);
-            return positions.Select(p => new TermHit(
-                WordIndex: p.WordIndex,
-                StartOffset: p.StartOffset,
-                EndOffset: p.EndOffset,
-                IsPrimaryTerm: p.IsFirstTerm,
-                WordIpe: p.Word)).ToList();
+            var positions = await _search.GetTermPositionsAsync(request.BookId, request.TermIpe, ct)
+                .ConfigureAwait(false);
+            if (positions.Count == 0) return Array.Empty<Occurrence>();
+
+            var dir = _settings.Settings?.XmlBooksDirectory;
+            if (string.IsNullOrEmpty(dir)) return Array.Empty<Occurrence>();
+            var path = Path.Combine(dir, request.BookId);
+            if (!File.Exists(path)) return Array.Empty<Occurrence>();
+
+            // Char offsets index the decoded (BOM-stripped) UTF-16 text — read it the same way.
+            string xml = await File.ReadAllTextAsync(path, Encoding.Unicode, ct).ConfigureAwait(false);
+            var markers = BookMarkers.Build(xml);
+            var opts = new SnippetOptions(
+                OutputScript: request.OutputScript,
+                IncludeVariantReadings: request.IncludeVariantReadings,
+                MinChars: request.MinChars ?? 60,
+                MaxChars: request.MaxChars ?? 320);
+
+            string bookName = Books.Inst
+                .FirstOrDefault(b => string.Equals(b.FileName, request.BookId, StringComparison.OrdinalIgnoreCase))
+                ?.LongNavPath ?? request.BookId;
+
+            var occurrences = new List<Occurrence>();
+            foreach (var p in positions.OrderBy(p => p.StartOffset).Skip(request.Skip).Take(request.Take))
+            {
+                ct.ThrowIfCancellationRequested();
+                var s = TeiSnippetExtractor.Extract(xml, p.StartOffset, p.EndOffset - p.StartOffset, markers, opts);
+                occurrences.Add(new Occurrence(
+                    BookId: request.BookId,
+                    BookName: bookName,
+                    Snippet: s.Snippet,
+                    HitStart: s.HitStart,
+                    HitLength: s.HitLength,
+                    Refs: new OccurrenceRefs(s.ParagraphNumber, s.ParagraphBookCode, s.Pages),
+                    IncludedVariants: s.IncludedVariants));
+            }
+            return occurrences;
         }
 
         private static SearchMode MapMode(SearchToolMode mode) => mode switch

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Conversion;
+using CST.Search;
 
 namespace CST.Tools
 {
@@ -22,11 +23,12 @@ namespace CST.Tools
             string prefix, int limit = 50, Script outputScript = Script.Latin, CancellationToken ct = default);
 
         /// <summary>
-        /// Opt-in, heavier: the individual hit positions of a term within one book (for highlighting or
-        /// offset-level work). Keyed by the stable <paramref name="termIpe"/> from a prior search.
+        /// "Search results in context" (the concordance/KWIC bridge): each occurrence of a term in one book
+        /// as a hit-centered <b>snippet</b> plus citation refs (paragraph number + per-edition pages), paged.
+        /// Keyed by the stable <paramref name="OccurrenceRequest.TermIpe"/> from a prior search. This is the
+        /// data behind both the agent loop (scan → cite/fetch) and the human concordance panel.
         /// </summary>
-        Task<IReadOnlyList<TermHit>> GetTermHitsAsync(
-            string bookId, string termIpe, CancellationToken ct = default);
+        Task<IReadOnlyList<Occurrence>> GetOccurrencesAsync(OccurrenceRequest request, CancellationToken ct = default);
     }
 
     /// <summary>How the query text is interpreted.</summary>
@@ -70,25 +72,48 @@ namespace CST.Tools
 
     /// <summary>One matching term and the books it occurs in.</summary>
     /// <param name="Term">The term in the requested output script.</param>
-    /// <param name="TermIpe">The stable IPE form — use this as the key for <c>GetTermHitsAsync</c>.</param>
+    /// <param name="TermIpe">The stable IPE form — use this as the key for <c>GetOccurrencesAsync</c>.</param>
     public sealed record SearchTermResult(
         string Term,
         string TermIpe,
         int TotalCount,
         IReadOnlyList<BookHitSummary> Books);
 
-    /// <summary>A term's occurrence count within one book (no positions — call <c>GetTermHitsAsync</c> for those).</summary>
+    /// <summary>A term's occurrence count within one book (call <c>GetOccurrencesAsync</c> for the snippets).</summary>
     public sealed record BookHitSummary(
         string BookId,
         string BookName,
         int Count);
 
-    /// <summary>A single hit position of a term within a book.</summary>
-    /// <param name="IsPrimaryTerm">True for the main term; false for context words (two-color highlighting).</param>
-    public sealed record TermHit(
-        int WordIndex,
-        int StartOffset,
-        int EndOffset,
-        bool IsPrimaryTerm,
-        string? WordIpe);
+    /// <summary>A request for a term's in-context occurrences within one book, paged.</summary>
+    /// <param name="MinChars">Prose snippet floor (rendered chars); null uses the engine default.</param>
+    /// <param name="MaxChars">Prose snippet ceiling (rendered chars); null uses the engine default.</param>
+    public sealed record OccurrenceRequest(
+        string BookId,
+        string TermIpe,
+        bool IncludeVariantReadings = false,
+        Script OutputScript = Script.Latin,
+        int Skip = 0,
+        int Take = 50,
+        int? MinChars = null,
+        int? MaxChars = null);
+
+    /// <summary>Citation refs at a hit: the paragraph (with Multi sub-book code) and the page in each edition.</summary>
+    public sealed record OccurrenceRefs(
+        int? ParagraphNumber,
+        string? ParagraphBookCode,
+        IReadOnlyList<SnippetPageRef> Pages);
+
+    /// <summary>
+    /// One occurrence of a term, shown in context: a hit-centered snippet (term at
+    /// <c>[HitStart, HitStart+HitLength)</c>, romanized) plus its citation refs.
+    /// </summary>
+    public sealed record Occurrence(
+        string BookId,
+        string BookName,
+        string Snippet,
+        int HitStart,
+        int HitLength,
+        OccurrenceRefs Refs,
+        bool IncludedVariants);
 }


### PR DESCRIPTION
Wires the [snippet engine (#231)](../commits) into the search tool — reshaping the search-hit method from raw offsets into **in-context occurrences**. This is the search → cite/jump bridge that was missing, and the data behind both the agent loop and the eventual human concordance panel. Part of epic #186 / read tool set #190.

## Contract change (`ISearchTool`)
- **Removed** `GetTermHitsAsync` / `TermHit` (raw word-index + char offsets — an agent couldn't do anything useful with them).
- **Added** `GetOccurrencesAsync(OccurrenceRequest) → IReadOnlyList<Occurrence>`:
  - `OccurrenceRequest(BookId, TermIpe, IncludeVariantReadings=false, OutputScript=Latin, Skip=0, Take=50, MinChars?, MaxChars?)`
  - `Occurrence(BookId, BookName, Snippet, HitStart, HitLength, Refs, IncludedVariants)`
  - `OccurrenceRefs(ParagraphNumber, ParagraphBookCode, Pages[])` — full citation across paragraph + every edition.

## Implementation (`SearchTool`)
Get term positions → read the book XML (`Encoding.Unicode`; the offsets index the decoded text) → build `BookMarkers` once → run `TeiSnippetExtractor` per position → page → resolve `BookName` from the catalog. Now takes `ISettingsService` for the XML dir.

## Tests
Updated for the new constructor/method; adds an **end-to-end** `GetOccurrencesAsync` test over a temp UTF-16 book (asserts snippet content, paragraph 12 / sub-book `dn1` / VRI 1.3 refs, and the hit range) plus an empty-result case. **14 tool/engine tests pass**, app builds clean.

Still not DI-registered — that lands with the HTTP-API consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)