### PR TITLE
AI settings: first cut of the "AI" settings area (#186)

### DIFF
--- a/src/CST.Avalonia.Tests/Models/AiSettingsTests.cs
+++ b/src/CST.Avalonia.Tests/Models/AiSettingsTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using CST.Avalonia.Models;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Models
+{
+    /// <summary>
+    /// The "AI" settings area (surface C gate): master "Enable AI Features" defaults OFF; sub-permissions
+    /// default ON, so enabling the master turns everything on and the user pares back. Effective state is
+    /// always master AND the specific permission. Adding the block is non-breaking — an old settings file
+    /// with no "ai" object deserializes to AI-off.
+    /// </summary>
+    public class AiSettingsTests
+    {
+        [Fact]
+        public void Defaults_master_off_subpermissions_on()
+        {
+            var ai = new Settings().Ai;
+
+            Assert.False(ai.Enabled);                 // master OFF
+            Assert.True(ai.LocalApi.Enabled);         // sub-permissions ON...
+            Assert.True(ai.LocalApi.AllowRemoteControl);
+            Assert.Equal(0, ai.LocalApi.Port);        // ephemeral
+        }
+
+        [Fact]
+        public void Master_off_disables_everything_regardless_of_subpermissions()
+        {
+            var ai = new AiSettings
+            {
+                Enabled = false,
+                LocalApi = new LocalApiSettings { Enabled = true, AllowRemoteControl = true }
+            };
+
+            Assert.False(ai.LocalApiEnabled);
+            Assert.False(ai.RemoteControlAllowed);
+        }
+
+        [Fact]
+        public void Master_on_with_default_subpermissions_enables_everything()
+        {
+            var ai = new AiSettings { Enabled = true }; // LocalApi defaults on
+
+            Assert.True(ai.LocalApiEnabled);
+            Assert.True(ai.RemoteControlAllowed);
+        }
+
+        [Fact]
+        public void Master_on_but_local_api_off_disables_server_and_remote_control()
+        {
+            var ai = new AiSettings
+            {
+                Enabled = true,
+                LocalApi = new LocalApiSettings { Enabled = false, AllowRemoteControl = true }
+            };
+
+            Assert.False(ai.LocalApiEnabled);
+            Assert.False(ai.RemoteControlAllowed);
+        }
+
+        [Fact]
+        public void Master_on_local_api_on_but_remote_control_off()
+        {
+            var ai = new AiSettings
+            {
+                Enabled = true,
+                LocalApi = new LocalApiSettings { Enabled = true, AllowRemoteControl = false }
+            };
+
+            Assert.True(ai.LocalApiEnabled);          // read-only data access still on
+            Assert.False(ai.RemoteControlAllowed);    // ...but no driving the reader
+        }
+
+        [Fact]
+        public void Missing_ai_block_deserializes_to_defaults_off()
+        {
+            // An old settings file, before the "ai" area existed.
+            const string json = "{ \"version\": \"1.0\", \"xmlBooksDirectory\": \"/x\" }";
+            var settings = JsonSerializer.Deserialize<Settings>(json,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            Assert.NotNull(settings);
+            Assert.NotNull(settings!.Ai);
+            Assert.False(settings.Ai.Enabled);        // AI off for upgraded files
+            Assert.False(settings.Ai.LocalApiEnabled);
+        }
+
+        [Fact]
+        public void Computed_helpers_are_not_persisted()
+        {
+            var json = JsonSerializer.Serialize(new Settings());
+
+            Assert.DoesNotContain("localApiEnabled", json, System.StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("remoteControlAllowed", json, System.StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using CST.Conversion;
 
 namespace CST.Avalonia.Models
@@ -15,6 +16,43 @@ namespace CST.Avalonia.Models
         public FontSettings FontSettings { get; set; } = new();
         public DeveloperSettings DeveloperSettings { get; set; } = new();
         public XmlUpdateSettings XmlUpdateSettings { get; set; } = new();
+        public AiSettings Ai { get; set; } = new();
+    }
+
+    /// <summary>
+    /// The "AI" settings area. <see cref="Enabled"/> is the master "Enable AI Features" switch (default OFF);
+    /// the sub-permissions default ON, so enabling the master turns everything on and the user can then pare
+    /// back. Effective state is always master AND the specific permission, so unchecking the master disables
+    /// everything at once. Secrets (the local-API port + bearer token) are never stored here — they are
+    /// written to <c>local-api.json</c> at runtime.
+    /// </summary>
+    public class AiSettings
+    {
+        /// <summary>Master switch — "Enable AI Features". Default OFF (opt-in); nothing AI-related runs while false.</summary>
+        public bool Enabled { get; set; } = false;
+
+        public LocalApiSettings LocalApi { get; set; } = new();
+
+        /// <summary>The local API server should run only when the master and the local-API permission are both on.</summary>
+        [JsonIgnore]
+        public bool LocalApiEnabled => Enabled && LocalApi.Enabled;
+
+        /// <summary>Agents may drive the reader only when the local API is enabled and remote control is permitted.</summary>
+        [JsonIgnore]
+        public bool RemoteControlAllowed => LocalApiEnabled && LocalApi.AllowRemoteControl;
+    }
+
+    /// <summary>Permissions for the loopback API server that exposes the corpus tools to agents (surface C).</summary>
+    public class LocalApiSettings
+    {
+        /// <summary>Run the local API (corpus data access). On by default under the master switch.</summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>Let agents drive the reader (navigate/highlight) vs. read-only. On by default under the master.</summary>
+        public bool AllowRemoteControl { get; set; } = true;
+
+        /// <summary>Loopback port; 0 = ephemeral (recommended, advertised via local-api.json). Fixed only for debugging.</summary>
+        public int Port { get; set; } = 0;
     }
     
     public class DeveloperSettings


### PR DESCRIPTION
The first cut of the **"AI" settings area** — the gate for surface C (and later surface B). Model + gating only; the "AI" tab UI is a separate Kestrel change. Part of epic #186.

## Model
- **`AiSettings.Enabled`** — the master **"Enable AI Features"** switch, **DEFAULT OFF** (opt-in; nothing AI-related runs while false).
- **`LocalApiSettings`** (`Enabled`, `AllowRemoteControl`, `Port`) — sub-permissions that **DEFAULT ON**, so enabling the master turns everything on and the user pares back; unchecking the master disables everything.
- **Effective-state helpers** the server will gate on (`[JsonIgnore]`, not persisted):
  - `LocalApiEnabled` = `Enabled && LocalApi.Enabled`
  - `RemoteControlAllowed` = `LocalApiEnabled && LocalApi.AllowRemoteControl`

## Behavior (agreed with @fsnow)
Opt in once → everything on → pare back. Fresh install = master off = nothing binds a socket.

## Notes
- **Secrets stay out of settings** — the port + per-session bearer token are written to `local-api.json` at runtime, never `settings.json`.
- **No `Version` bump** — additive/non-breaking; an old file with no `ai` object deserializes to AI-off. Per `SettingsValidator`'s stated convention (bump only on a breaking change). Flagging since I'd mentioned a bump earlier — it isn't warranted here.
- **7 tests**: defaults (master off / sub-permissions on), the master-AND-permission truth table, missing-block migration, and that computed helpers aren't persisted.
- This refines doc §6 (remote-control is *on* once AI is enabled, revocable) — I'll fold that into `AI_INTEGRATION.md` when I next touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)