### PR TITLE
AI surface C: fetch_passage as a bounded, paged reading window (#186/#190)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -1,0 +1,56 @@
+using CST.Conversion;
+using CST.Navigation;
+using CST.Search;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Search
+{
+    /// <summary>
+    /// Tests for the bounded paged reading window. ASCII placeholder words + danda escapes; Script.Devanagari
+    /// output (identity) so the window/paging can be asserted exactly.
+    /// </summary>
+    public class TeiPassageReaderTests
+    {
+        private const string Xml =
+            "<body><div id=\"dn1\" type=\"book\">" +
+            "<pb ed=\"V\" n=\"1.0001\"/>" +
+            "<p rend=\"bodytext\" n=\"5\">alpha bravo\u0964 charlie delta\u0964 echo foxtrot\u0964 golf hotel\u0964</p>" +
+            "</div></body>";
+
+        [Fact]
+        public void ReadWindow_is_bounded_and_pages_forward()
+        {
+            var markers = BookMarkers.Build(Xml);
+            int start = markers.PositionOfParagraph(5);
+            Assert.True(start >= 0);
+
+            var w1 = TeiPassageReader.ReadWindow(Xml, start, maxChars: 15, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("alpha", w1.Text);
+            Assert.DoesNotContain("echo", w1.Text);        // beyond the budgeted window
+            Assert.NotNull(w1.NextCursor);                 // more to read
+            Assert.Equal(5, w1.ParagraphNumber);
+            Assert.Contains(w1.Pages, p => p.Edition == PageEdition.Vri && p.Volume == 1 && p.Number == 1);
+
+            // Page forward from the cursor.
+            var w2 = TeiPassageReader.ReadWindow(Xml, w1.NextCursor!.Value, maxChars: 15, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+            Assert.Contains("echo", w2.Text);
+            Assert.DoesNotContain("alpha", w2.Text);
+        }
+
+        [Fact]
+        public void ReadWindow_large_budget_reaches_end()
+        {
+            var markers = BookMarkers.Build(Xml);
+            int start = markers.PositionOfParagraph(5);
+
+            var w = TeiPassageReader.ReadWindow(Xml, start, maxChars: 10000, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("hotel", w.Text);
+            Assert.Null(w.NextCursor);                     // reached the end of the book
+        }
+    }
+}

--- a/src/CST.Avalonia.Tests/Tools/PassageToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/PassageToolTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Tools;
+using CST.Conversion;
+using CST.Navigation;
+using CST.Tools;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Tools
+{
+    /// <summary>
+    /// End-to-end tests for the passage tool: resolve a paragraph reference to a start position in a temp
+    /// UTF-16 book, read a bounded window, report citation refs + cursors. Script.Devanagari (identity).
+    /// </summary>
+    public class PassageToolTests
+    {
+        private static ISettingsService Settings(string dir)
+        {
+            var m = new Mock<ISettingsService>();
+            m.SetupGet(s => s.Settings).Returns(new Settings { XmlBooksDirectory = dir });
+            return m.Object;
+        }
+
+        private const string Xml =
+            "<body><div id=\"dn1\" type=\"book\">" +
+            "<pb ed=\"V\" n=\"1.0001\"/>" +
+            "<p rend=\"bodytext\" n=\"5\">alpha bravo\u0964 charlie delta\u0964 echo foxtrot\u0964</p>" +
+            "</div></body>";
+
+        [Fact]
+        public async Task FetchPassage_by_paragraph_returns_window_with_refs()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cst-pass-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                const string book = "s0101m.mul.xml";
+                await File.WriteAllTextAsync(Path.Combine(dir, book), Xml, Encoding.Unicode);
+
+                var tool = new PassageTool(Settings(dir));
+                var r = await tool.FetchPassageAsync(new PassageRequest(
+                    book, new NavigationReference.Paragraph(5), MaxChars: 15, OutputScript: Script.Devanagari));
+
+                Assert.Contains("alpha", r.Text);
+                Assert.Equal(5, r.ParagraphNumber);
+                Assert.Equal("dn1", r.ParagraphBookCode);
+                Assert.Equal("paragraph 5 (dn1)", r.NormalizedReference);
+                Assert.Contains(r.Pages, p => p.Edition == PageEdition.Vri && p.Volume == 1 && p.Number == 1);
+                Assert.NotNull(r.NextCursor);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task FetchPassage_missing_book_returns_empty()
+        {
+            var tool = new PassageTool(Settings("/nonexistent"));
+            var r = await tool.FetchPassageAsync(new PassageRequest("x.xml", new NavigationReference.WholeBook()));
+
+            Assert.Equal("", r.Text);
+            Assert.Null(r.NextCursor);
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Navigation;
+using CST.Search;
+using CST.Tools;
+
+namespace CST.Avalonia.Services.Tools
+{
+    /// <summary>
+    /// <see cref="IPassageTool"/> — reads a bounded, paged reading window of a book's text (AI_INTEGRATION.md
+    /// surface C). Resolves a paragraph reference (the ref an occurrence reports) or a page cursor to a start
+    /// position, reads the book XML, and runs <see cref="TeiPassageReader"/>. Headless; needs the XML dir.
+    /// First cut: supports paragraph / whole-book references and cursor paging; page/chapter/anchor references
+    /// are not yet resolved (they return an empty window).
+    /// </summary>
+    public sealed class PassageTool : IPassageTool
+    {
+        private readonly ISettingsService _settings;
+
+        public PassageTool(ISettingsService settings) => _settings = settings;
+
+        public async Task<PassageResult> FetchPassageAsync(PassageRequest request, CancellationToken ct = default)
+        {
+            var dir = _settings.Settings?.XmlBooksDirectory;
+            var path = string.IsNullOrEmpty(dir) ? null : Path.Combine(dir, request.BookId);
+            if (path == null || !File.Exists(path))
+                return Empty(request, "book not available");
+
+            // Char offsets index the decoded (BOM-stripped) UTF-16 text — read it the same way.
+            string xml = await File.ReadAllTextAsync(path, Encoding.Unicode, ct).ConfigureAwait(false);
+            var markers = BookMarkers.Build(xml);
+
+            int startPos = request.Cursor ?? ResolveStart(request.Reference, markers);
+            if (startPos < 0) return Empty(request, "reference not found");
+            startPos = Math.Clamp(startPos, 0, xml.Length);
+
+            var w = TeiPassageReader.ReadWindow(
+                xml, startPos, Math.Max(1, request.MaxChars),
+                request.IncludeVariantReadings, request.OutputScript, markers);
+
+            return new PassageResult(
+                BookId: request.BookId,
+                NormalizedReference: Describe(w.ParagraphNumber, w.ParagraphBookCode),
+                Text: w.Text,
+                Pages: w.Pages,
+                ParagraphNumber: w.ParagraphNumber,
+                ParagraphBookCode: w.ParagraphBookCode,
+                PrevCursor: w.PrevCursor,
+                NextCursor: w.NextCursor);
+        }
+
+        private static int ResolveStart(NavigationReference? reference, BookMarkers markers) => reference switch
+        {
+            null => 0,
+            NavigationReference.WholeBook => 0,
+            NavigationReference.Paragraph p => markers.PositionOfParagraph(p.Number, p.BookCode),
+            _ => -1   // Page / Chapter / RawAnchor: not resolved in the first cut
+        };
+
+        private static string Describe(int? number, string? bookCode) =>
+            number is null ? "start of book"
+            : bookCode is null ? $"paragraph {number}"
+            : $"paragraph {number} ({bookCode})";
+
+        private static PassageResult Empty(PassageRequest request, string note) =>
+            new(request.BookId, note, "", Array.Empty<SnippetPageRef>(), null, null, null, null);
+    }
+}

--- a/src/CST.Core/Search/BookMarkers.cs
+++ b/src/CST.Core/Search/BookMarkers.cs
@@ -58,6 +58,15 @@ namespace CST.Search
             return m;
         }
 
+        /// <summary>The character position of a numbered paragraph (optionally within a Multi sub-book), or -1.</summary>
+        public int PositionOfParagraph(int number, string? bookCode = null)
+        {
+            foreach (var p in _paras)
+                if (p.Number == number && (bookCode == null || p.BookCode == bookCode))
+                    return p.Pos;
+            return -1;
+        }
+
         /// <summary>The paragraph number (and Multi-book sub-code) and per-edition pages in effect at <paramref name="pos"/>.</summary>
         public (int? Number, string? BookCode, IReadOnlyList<SnippetPageRef> Pages) RefsAt(int pos)
         {

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using CST.Conversion;
+
+namespace CST.Search
+{
+    /// <summary>
+    /// Reads a bounded, paged "reading window" from a book — the level-2 zoom above a snippet. From a start
+    /// position it returns up to <c>maxChars</c> of rendered text (tags transparent; footnotes/paranum
+    /// stripped by default), extended to the next sentence boundary so it never cuts mid-sentence, romanized
+    /// to the requested script — plus prev/next cursors (character positions) to page through the surrounding
+    /// text, and the citation refs at the start. A wall-of-text paragraph just becomes page 1 of N.
+    /// </summary>
+    public static class TeiPassageReader
+    {
+        public static PassageWindow ReadWindow(
+            string xml, int startPos, int maxChars, bool includeVariants, Script outputScript, BookMarkers markers)
+        {
+            startPos = Math.Clamp(startPos, 0, xml.Length);
+            if (maxChars < 1) maxChars = 1;
+
+            int end = WalkForward(xml, startPos, maxChars, includeVariants, xml.Length);
+            string text = TeiText.Collapse(
+                TeiText.Convert(TeiText.Clean(xml, startPos, end, includeVariants), outputScript)).Trim();
+
+            int? next = end < xml.Length ? end : (int?)null;
+            int prevStart = WalkBackward(xml, startPos, maxChars, 0);
+            int? prev = prevStart < startPos ? prevStart : (int?)null;
+
+            var (num, code, pages) = markers.RefsAt(startPos);
+            return new PassageWindow(text, prev, next, num, code, pages);
+        }
+
+        // Raw end position after accumulating ~maxChars rendered chars, then extending to the next sentence
+        // boundary (capped) so we never cut mid-sentence. Tags and stripped subtrees cost zero budget.
+        private static int WalkForward(string xml, int start, int maxChars, bool includeNotes, int limit)
+        {
+            int i = start, rendered = 0, hardCap = maxChars + maxChars / 2;
+            bool budgetReached = false;
+            while (i < limit)
+            {
+                char c = xml[i];
+                if (c == '<')
+                {
+                    int gt = xml.IndexOf('>', i);
+                    if (gt < 0) break;
+                    string tag = xml.Substring(i, gt - i + 1);
+                    string name = TeiText.TagName(tag);
+                    if (name == "note" && !includeNotes && !tag.EndsWith("/>", StringComparison.Ordinal))
+                        i = TeiText.SkipSubtree(xml, gt + 1, "note", limit);
+                    else if (name == "hi" && TeiText.IsStructuralHi(tag) && !tag.EndsWith("/>", StringComparison.Ordinal))
+                        i = TeiText.SkipSubtree(xml, gt + 1, "hi", limit);
+                    else i = gt + 1;
+                }
+                else
+                {
+                    if (budgetReached && TeiText.IsBoundary(c)) return i + 1;   // stop just past a sentence end
+                    rendered++;
+                    i++;
+                    if (rendered >= maxChars) budgetReached = true;
+                    if (rendered >= hardCap) return i;                          // no boundary found: hard cap
+                }
+            }
+            return i;
+        }
+
+        // Start position ~maxChars rendered chars before <paramref name="start"/>, snapped forward to a
+        // sentence start. Approximate (tags treated as zero-width backward); good enough for a page cursor.
+        private static int WalkBackward(string xml, int start, int maxChars, int limit)
+        {
+            int i = start - 1, rendered = 0;
+            while (i >= limit && rendered < maxChars)
+            {
+                if (xml[i] == '>')
+                {
+                    int lt = xml.LastIndexOf('<', i);
+                    i = lt >= limit ? lt - 1 : limit - 1;
+                }
+                else { rendered++; i--; }
+            }
+            for (int j = Math.Max(i, limit); j < start; j++)
+                if (TeiText.IsBoundary(xml[j])) return j + 1;                   // begin at a sentence start
+            return Math.Max(i + 1, limit);
+        }
+    }
+
+    /// <summary>A reading window: the text plus page cursors and the citation refs at its start.</summary>
+    public sealed record PassageWindow(
+        string Text,
+        int? PrevCursor,
+        int? NextCursor,
+        int? ParagraphNumber,
+        string? ParagraphBookCode,
+        IReadOnlyList<SnippetPageRef> Pages);
+}

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Text.RegularExpressions;
-using CST.Conversion;
 
 namespace CST.Search
 {
@@ -13,13 +10,10 @@ namespace CST.Search
     /// verse (<c>rend="gatha..."</c>) includes the hit's line plus one line each side. Footnotes
     /// (<c>&lt;note&gt;</c>) and the paragraph-number marker are stripped by default; text is romanized to the
     /// requested script and the matched term's range within the snippet is recomputed after conversion.
+    /// Low-level rendering/cleaning lives in <see cref="TeiText"/>.
     /// </summary>
     public static class TeiSnippetExtractor
     {
-        private const char Danda = '\u0964';        // Devanagari danda - sentence end
-        private const char DoubleDanda = '\u0965';  // Devanagari double danda - verse/gatha end
-        private static readonly Regex Whitespace = new(@"\s+", RegexOptions.Compiled);
-
         public static SnippetResult Extract(string xml, int hitStart, int hitLength, BookMarkers markers, SnippetOptions opts)
         {
             hitStart = Math.Clamp(hitStart, 0, xml.Length);
@@ -37,11 +31,10 @@ namespace CST.Search
                 (winStart, winEnd, ellipsisStart, ellipsisEnd) =
                     ProseWindow(xml, pStart, pEnd, hitStart, hitEnd, opts);
 
-            string before = Collapse(Convert(Clean(xml, winStart, hitStart, opts.IncludeVariantReadings), opts.OutputScript));
-            string hit = Convert(Clean(xml, hitStart, hitEnd, opts.IncludeVariantReadings), opts.OutputScript).Trim();
-            string after = Collapse(Convert(Clean(xml, hitEnd, winEnd, opts.IncludeVariantReadings), opts.OutputScript));
+            string before = TeiText.Collapse(TeiText.Convert(TeiText.Clean(xml, winStart, hitStart, opts.IncludeVariantReadings), opts.OutputScript));
+            string hit = TeiText.Convert(TeiText.Clean(xml, hitStart, hitEnd, opts.IncludeVariantReadings), opts.OutputScript).Trim();
+            string after = TeiText.Collapse(TeiText.Convert(TeiText.Clean(xml, hitEnd, winEnd, opts.IncludeVariantReadings), opts.OutputScript));
 
-            // Keep exactly one space between context and the hit; drop stray edge whitespace.
             before = before.TrimStart();
             after = after.TrimEnd();
             string prefix = ellipsisStart ? "... " : "";
@@ -54,18 +47,15 @@ namespace CST.Search
             return new SnippetResult(snippet, markStart, hit.Length, num, code, pages, opts.IncludeVariantReadings);
         }
 
-        // --- window selection -----------------------------------------------
-
         private static (int start, int end, bool ellStart, bool ellEnd) ProseWindow(
             string xml, int pStart, int pEnd, int hitStart, int hitEnd, SnippetOptions opts)
         {
-            var notes = NoteRegions(xml, pStart, pEnd);
+            var notes = TeiText.NoteRegions(xml, pStart, pEnd);
 
             int start = SentenceStart(xml, pStart, hitStart, notes);
             int end = SentenceEnd(xml, hitEnd, pEnd, notes);
 
-            // Floor: widen to neighboring sentences until enough rendered text.
-            while (VisibleLen(xml, start, end) < opts.MinChars)
+            while (TeiText.VisibleLen(xml, start, end) < opts.MinChars)
             {
                 int ns = start > pStart ? SentenceStart(xml, pStart, start - 1, notes) : start;
                 int ne = end < pEnd ? SentenceEnd(xml, end, pEnd, notes) : end;
@@ -73,9 +63,8 @@ namespace CST.Search
                 start = ns; end = ne;
             }
 
-            // Ceiling: a single long sentence gets trimmed toward the hit, with ellipses.
             bool ellStart = false, ellEnd = false;
-            if (VisibleLen(xml, start, end) > opts.MaxChars)
+            if (TeiText.VisibleLen(xml, start, end) > opts.MaxChars)
             {
                 int half = opts.MaxChars / 2;
                 int ns = SnapToSpace(xml, Math.Max(pStart, hitStart - half), +1, hitStart);
@@ -103,63 +92,19 @@ namespace CST.Search
             return (start, end);
         }
 
-        // --- sentence boundaries (raw, note-aware) --------------------------
-
         private static int SentenceStart(string xml, int lo, int from, List<(int s, int e)> notes)
         {
             for (int i = Math.Min(from, xml.Length) - 1; i >= lo; i--)
-                if (IsBoundary(xml[i]) && !InNote(i, notes)) return i + 1;
+                if (TeiText.IsBoundary(xml[i]) && !TeiText.InNote(i, notes)) return i + 1;
             return lo;
         }
 
         private static int SentenceEnd(string xml, int from, int hi, List<(int s, int e)> notes)
         {
             for (int i = from; i < hi; i++)
-                if (IsBoundary(xml[i]) && !InNote(i, notes)) return i + 1;
+                if (TeiText.IsBoundary(xml[i]) && !TeiText.InNote(i, notes)) return i + 1;
             return hi;
         }
-
-        private static bool IsBoundary(char c) => c == Danda || c == DoubleDanda;
-
-        // --- cleaning: raw range -> rendered text ---------------------------
-
-        private static string Clean(string xml, int start, int end, bool includeNotes)
-        {
-            if (start >= end) return "";
-            var sb = new StringBuilder(end - start);
-            int i = start;
-            while (i < end)
-            {
-                char c = xml[i];
-                if (c == '<')
-                {
-                    int gt = xml.IndexOf('>', i);
-                    if (gt < 0 || gt >= end) break;
-                    string tag = xml.Substring(i, gt - i + 1);
-                    string name = TagName(tag);
-                    if (name == "note" && !includeNotes && !tag.EndsWith("/>", StringComparison.Ordinal))
-                        i = SkipSubtree(xml, gt + 1, "note", end);
-                    else if (name == "hi" && IsStructuralHi(tag) && !tag.EndsWith("/>", StringComparison.Ordinal))
-                        i = SkipSubtree(xml, gt + 1, "hi", end);
-                    else
-                    {
-                        if (sb.Length > 0 && sb[sb.Length - 1] != ' ') sb.Append(' ');
-                        i = gt + 1;
-                    }
-                }
-                else { sb.Append(c); i++; }
-            }
-            return sb.ToString();
-        }
-
-        private static int VisibleLen(string xml, int start, int end) => Clean(xml, start, end, false).Length;
-
-        // --- helpers --------------------------------------------------------
-
-        private static string Convert(string deva, Script output) =>
-            deva.Length == 0 ? "" : ScriptConverter.Convert(deva, Script.Devanagari, output);
-
-        private static string Collapse(string s) => Whitespace.Replace(s, " ");
 
         private static (int openIdx, int contentStart, int pEnd, string rend) FindEnclosingP(string xml, int hitStart)
         {
@@ -170,7 +115,7 @@ namespace CST.Search
             if (gt < 0) return (-1, -1, -1, "");
             int pEnd = xml.IndexOf("</p>", gt + 1, StringComparison.Ordinal);
             if (pEnd < 0) pEnd = xml.Length;
-            return (open, gt + 1, pEnd, Attr(xml.Substring(open, gt - open + 1), "rend"));
+            return (open, gt + 1, pEnd, TeiText.Attr(xml.Substring(open, gt - open + 1), "rend"));
         }
 
         private static int FindLastPOpen(string xml, int before)
@@ -196,72 +141,11 @@ namespace CST.Search
             return -1;
         }
 
-        private static List<(int s, int e)> NoteRegions(string xml, int lo, int hi)
-        {
-            var list = new List<(int, int)>();
-            int i = lo;
-            while ((i = xml.IndexOf("<note", i, StringComparison.Ordinal)) >= 0 && i < hi)
-            {
-                int gt = xml.IndexOf('>', i);
-                if (gt < 0) break;
-                if (xml[gt - 1] == '/') { i = gt + 1; continue; }        // self-closing
-                int e = SkipSubtree(xml, gt + 1, "note", xml.Length);
-                list.Add((i, e));
-                i = e;
-            }
-            return list;
-        }
-
-        private static bool InNote(int pos, List<(int s, int e)> notes)
-        {
-            foreach (var (s, e) in notes) if (pos >= s && pos < e) return true;
-            return false;
-        }
-
-        // Position just past the matching close tag for an already-open element.
-        private static int SkipSubtree(string xml, int from, string name, int limit)
-        {
-            int depth = 1, i = from;
-            string open = "<" + name, close = "</" + name;
-            while (i < limit && depth > 0)
-            {
-                int lt = xml.IndexOf('<', i);
-                if (lt < 0 || lt >= limit) return limit;
-                if (xml.AsSpan(lt).StartsWith(close)) { depth--; i = xml.IndexOf('>', lt); i = i < 0 ? limit : i + 1; }
-                else if (xml.AsSpan(lt).StartsWith(open) && (lt + open.Length >= xml.Length ||
-                         xml[lt + open.Length] is ' ' or '>' or '\t' or '\n' or '\r'))
-                { int gt = xml.IndexOf('>', lt); if (gt >= 0 && xml[gt - 1] != '/') depth++; i = gt < 0 ? limit : gt + 1; }
-                else i = lt + 1;
-            }
-            return i;
-        }
-
         private static int SnapToSpace(string xml, int pos, int dir, int stopAt)
         {
             for (int i = pos; dir > 0 ? i < stopAt : i > stopAt; i += dir)
                 if (xml[i] == ' ' || xml[i] == '\n') return i + (dir > 0 ? 1 : 0);
             return pos;
-        }
-
-        private static string TagName(string tag)
-        {
-            int i = 1;
-            if (i < tag.Length && tag[i] == '/') i++;
-            int start = i;
-            while (i < tag.Length && (char.IsLetterOrDigit(tag[i]) || tag[i] == ':')) i++;
-            return tag.Substring(start, i - start);
-        }
-
-        private static bool IsStructuralHi(string tag)
-        {
-            string rend = Attr(tag, "rend");
-            return rend == "paranum" || rend == "dot";
-        }
-
-        private static string Attr(string tag, string name)
-        {
-            var m = Regex.Match(tag, name + "\\s*=\\s*\"([^\"]*)\"");
-            return m.Success ? m.Groups[1].Value : "";
         }
     }
 }

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using CST.Conversion;
+
+namespace CST.Search
+{
+    /// <summary>
+    /// Shared low-level TEI text helpers used by the snippet extractor and the passage reader: turning a raw
+    /// XML range into rendered Pali text (tags transparent, footnotes and the paragraph-number marker
+    /// stripped), sentence-boundary detection, and Devanagari-to-script conversion.
+    /// </summary>
+    internal static class TeiText
+    {
+        internal const char Danda = '\u0964';        // Devanagari danda - sentence end
+        internal const char DoubleDanda = '\u0965';  // Devanagari double danda - verse/gatha end
+        private static readonly Regex Whitespace = new(@"\s+", RegexOptions.Compiled);
+
+        internal static bool IsBoundary(char c) => c == Danda || c == DoubleDanda;
+
+        internal static string Convert(string deva, Script output) =>
+            deva.Length == 0 ? "" : ScriptConverter.Convert(deva, Script.Devanagari, output);
+
+        internal static string Collapse(string s) => Whitespace.Replace(s, " ");
+
+        internal static int VisibleLen(string xml, int start, int end) => Clean(xml, start, end, false).Length;
+
+        /// <summary>Render a raw XML range to text: drop tags (paranum/dot hi and, unless requested, notes are stripped whole).</summary>
+        internal static string Clean(string xml, int start, int end, bool includeNotes)
+        {
+            if (start >= end) return "";
+            var sb = new StringBuilder(end - start);
+            int i = start;
+            while (i < end)
+            {
+                char c = xml[i];
+                if (c == '<')
+                {
+                    int gt = xml.IndexOf('>', i);
+                    if (gt < 0 || gt >= end) break;
+                    string tag = xml.Substring(i, gt - i + 1);
+                    string name = TagName(tag);
+                    if (name == "note" && !includeNotes && !tag.EndsWith("/>", System.StringComparison.Ordinal))
+                        i = SkipSubtree(xml, gt + 1, "note", end);
+                    else if (name == "hi" && IsStructuralHi(tag) && !tag.EndsWith("/>", System.StringComparison.Ordinal))
+                        i = SkipSubtree(xml, gt + 1, "hi", end);
+                    else
+                    {
+                        if (sb.Length > 0 && sb[sb.Length - 1] != ' ') sb.Append(' ');
+                        i = gt + 1;
+                    }
+                }
+                else { sb.Append(c); i++; }
+            }
+            return sb.ToString();
+        }
+
+        internal static List<(int s, int e)> NoteRegions(string xml, int lo, int hi)
+        {
+            var list = new List<(int, int)>();
+            int i = lo;
+            while ((i = xml.IndexOf("<note", i, System.StringComparison.Ordinal)) >= 0 && i < hi)
+            {
+                int gt = xml.IndexOf('>', i);
+                if (gt < 0) break;
+                if (xml[gt - 1] == '/') { i = gt + 1; continue; }        // self-closing
+                int e = SkipSubtree(xml, gt + 1, "note", xml.Length);
+                list.Add((i, e));
+                i = e;
+            }
+            return list;
+        }
+
+        internal static bool InNote(int pos, List<(int s, int e)> notes)
+        {
+            foreach (var (s, e) in notes) if (pos >= s && pos < e) return true;
+            return false;
+        }
+
+        // Position just past the matching close tag for an already-open element.
+        internal static int SkipSubtree(string xml, int from, string name, int limit)
+        {
+            int depth = 1, i = from;
+            string open = "<" + name, close = "</" + name;
+            while (i < limit && depth > 0)
+            {
+                int lt = xml.IndexOf('<', i);
+                if (lt < 0 || lt >= limit) return limit;
+                if (xml.AsSpan(lt).StartsWith(close)) { depth--; i = xml.IndexOf('>', lt); i = i < 0 ? limit : i + 1; }
+                else if (xml.AsSpan(lt).StartsWith(open) && (lt + open.Length >= xml.Length ||
+                         xml[lt + open.Length] is ' ' or '>' or '\t' or '\n' or '\r'))
+                { int gt = xml.IndexOf('>', lt); if (gt >= 0 && xml[gt - 1] != '/') depth++; i = gt < 0 ? limit : gt + 1; }
+                else i = lt + 1;
+            }
+            return i;
+        }
+
+        internal static string TagName(string tag)
+        {
+            int i = 1;
+            if (i < tag.Length && tag[i] == '/') i++;
+            int start = i;
+            while (i < tag.Length && (char.IsLetterOrDigit(tag[i]) || tag[i] == ':')) i++;
+            return tag.Substring(start, i - start);
+        }
+
+        internal static bool IsStructuralHi(string tag)
+        {
+            string rend = Attr(tag, "rend");
+            return rend == "paranum" || rend == "dot";
+        }
+
+        internal static string Attr(string tag, string name)
+        {
+            var m = Regex.Match(tag, name + "\\s*=\\s*\"([^\"]*)\"");
+            return m.Success ? m.Groups[1].Value : "";
+        }
+    }
+}

--- a/src/CST.Core/Tools/PassageToolContracts.cs
+++ b/src/CST.Core/Tools/PassageToolContracts.cs
@@ -3,50 +3,52 @@ using System.Threading;
 using System.Threading.Tasks;
 using CST.Conversion;
 using CST.Navigation;
+using CST.Search;
 
 namespace CST.Tools
 {
     /// <summary>
     /// The passage-fetch tool exposed to agents (AI_INTEGRATION.md surface C). Returns the *text* of a
-    /// passage — not rendered HTML — so an agent gets grounded source it can quote/cite. Text is in the
-    /// requested script (default romanized Latin). Unlike search/dictionary, this has no existing service to
-    /// wrap: the implementation needs a pure-logic TEI reader (shared with the anchor catalog).
+    /// passage — not rendered HTML — as a bounded, paged reading window (the level-2 zoom above a search
+    /// snippet), so an agent gets grounded source it can quote/cite without a wall of text. Text is in the
+    /// requested script (default romanized Latin).
     /// </summary>
     public interface IPassageTool
     {
-        /// <summary>Fetch the text at a reference, optionally with neighboring paragraphs for context.</summary>
+        /// <summary>Read a bounded window of text at a reference (or continue from a cursor), with page cursors.</summary>
         Task<PassageResult> FetchPassageAsync(PassageRequest request, CancellationToken ct = default);
     }
 
     /// <summary>
-    /// A passage request. <see cref="Reference"/> reuses the navigation core's reference model (paragraph /
-    /// page / chapter / raw anchor), so resolving and fetching speak the same language.
+    /// A passage request. Provide either a <see cref="Reference"/> (paragraph — the ref an occurrence reports)
+    /// to start reading there, or a <see cref="Cursor"/> from a previous result to page forward/backward. The
+    /// window is bounded by <see cref="MaxChars"/> of rendered text and ends at a sentence boundary, so a
+    /// long paragraph becomes page 1 of N rather than a wall.
     /// </summary>
-    /// <param name="ContextParagraphs">Neighbors to include on each side (0 = just the target).</param>
-    /// <param name="IncludeMarkup">Return light structural markup instead of plain text.</param>
+    /// <param name="Cursor">A page cursor from a prior <see cref="PassageResult"/>; overrides <see cref="Reference"/> when set.</param>
+    /// <param name="MaxChars">Rendered-character budget for the window.</param>
     public sealed record PassageRequest(
         string BookId,
-        NavigationReference Reference,
-        int ContextParagraphs = 0,
+        NavigationReference? Reference = null,
+        int? Cursor = null,
+        int MaxChars = 1200,
         Script OutputScript = Script.Latin,
-        bool IncludeMarkup = false);
+        bool IncludeVariantReadings = false);
 
-    /// <summary>The fetched passage plus the anchors needed to page forward/backward and cite pages.</summary>
-    /// <param name="Anchor">The normalized anchor the text starts at.</param>
-    /// <param name="NormalizedReference">Short human-readable reference (e.g. "paragraph 123 (an5)").</param>
+    /// <summary>
+    /// A reading window: the text, the citation refs at its start, and cursors to page through. Pass a cursor
+    /// back as <see cref="PassageRequest.Cursor"/> to continue; a null cursor means the book start/end.
+    /// </summary>
+    /// <param name="NormalizedReference">Short human-readable reference at the window start (e.g. "paragraph 123 (an5)").</param>
     /// <param name="Text">The passage text in the requested script.</param>
-    /// <param name="Pages">The per-edition page(s) this passage spans, for citation.</param>
-    /// <param name="PreviousAnchor">Anchor of the preceding paragraph, or null at the start.</param>
-    /// <param name="NextAnchor">Anchor of the following paragraph, or null at the end.</param>
+    /// <param name="Pages">The per-edition page(s) at the window start, for citation.</param>
     public sealed record PassageResult(
         string BookId,
-        string Anchor,
         string NormalizedReference,
         string Text,
-        IReadOnlyList<PassagePageRef> Pages,
-        string? PreviousAnchor,
-        string? NextAnchor);
-
-    /// <summary>A page reference a passage spans (edition + volume + page).</summary>
-    public sealed record PassagePageRef(PageEdition Edition, int Volume, int Number);
+        IReadOnlyList<SnippetPageRef> Pages,
+        int? ParagraphNumber,
+        string? ParagraphBookCode,
+        int? PrevCursor,
+        int? NextCursor);
 }


### PR DESCRIPTION
`fetch_passage` — the level-2 zoom above a search snippet: read a book's text in **bounded chunks with paging**, never a wall. First cut (we can iterate). Part of epic #186 / read tool set #190.

## What
- **`TeiText`** — refactor the shared low-level TEI layer (tag/note cleaning, rendered length, Devanagari→script conversion, sentence boundaries) out of `TeiSnippetExtractor`, so the snippet extractor and the new passage reader share one implementation. Snippet engine tests unchanged and green.
- **`TeiPassageReader.ReadWindow`** — from a start position, returns up to `MaxChars` of **rendered** text, extended to the next sentence boundary so it never cuts mid-sentence (tags/notes/paranum are transparent to the budget), romanized to the requested script — plus **prev/next char cursors** for paging and the citation refs (paragraph + per-edition pages) at the start.
- **`BookMarkers.PositionOfParagraph`** — resolve a paragraph reference (the ref an occurrence reports) to a start position.
- **Reshaped `IPassageTool` contract** — `PassageRequest(Reference? | Cursor, MaxChars=1200, OutputScript, IncludeVariantReadings)` → `PassageResult(Text, Pages, ParagraphNumber/BookCode, PrevCursor, NextCursor)`. Drops `ContextParagraphs`/anchors in favor of the char-budget window + cursors.
- **`PassageTool`** — resolves paragraph / whole-book / cursor, reads the book XML (char offsets into the decoded UTF-16), runs the reader.

## Notes / first-cut scope
- **Page/chapter/anchor references aren't resolved yet** — they return an empty window. Paragraph + whole-book + cursor cover the occurrence→passage loop; the rest is a natural iteration.
- Prev cursor is an approximate rendered-length backward walk (good enough to page; can tighten later).
- **Full suite: 537 pass.** Not DI-registered yet — lands with the HTTP API consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)