### PR TITLE
AI local API: secure loopback server skeleton + /v1/status (#186)

### DIFF
--- a/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
+++ b/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
@@ -29,6 +29,11 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
+  <!-- Needed to run LocalApiServer (hosts ASP.NET Core) in tests. -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\CST.Avalonia\CST.Avalonia.csproj" />
     <ProjectReference Include="..\CST.Lucene\CST.Lucene.csproj" />

--- a/src/CST.Avalonia.Tests/Services/LocalApiTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApiTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using CST.Avalonia.Services.LocalApi;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services
+{
+    public class LocalApiInfoTests
+    {
+        [Fact]
+        public void Write_read_delete_roundtrip()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cst-info-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                new LocalApiInfo(52344, "tok-abc", 4242).Write(dir);
+
+                var read = LocalApiInfo.Read(dir);
+                Assert.NotNull(read);
+                Assert.Equal(52344, read!.Port);
+                Assert.Equal("tok-abc", read.Token);
+                Assert.Equal(4242, read.Pid);
+
+                if (!OperatingSystem.IsWindows())
+                    Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                        File.GetUnixFileMode(LocalApiInfo.PathIn(dir)));
+
+                LocalApiInfo.Delete(dir);
+                Assert.Null(LocalApiInfo.Read(dir));
+            }
+            finally { Directory.Delete(dir, recursive: true); }
+        }
+    }
+
+    /// <summary>
+    /// Integration tests: start the real loopback server on an ephemeral port and exercise the security gate.
+    /// A fresh server (own port + token) per test via <see cref="IAsyncLifetime"/>.
+    /// </summary>
+    public class LocalApiServerTests : IAsyncLifetime
+    {
+        private string _dir = null!;
+        private LocalApiServer _server = null!;
+
+        public async Task InitializeAsync()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "cst-api-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            _server = new LocalApiServer("5.0.0-test", _dir, Serilog.Log.Logger);
+            await _server.StartAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _server.StopAsync();
+            try { Directory.Delete(_dir, recursive: true); } catch { }
+        }
+
+        private HttpClient Client(bool withToken = true, string? origin = null)
+        {
+            var http = new HttpClient { BaseAddress = new Uri(_server.BaseUrl!) };
+            if (withToken) http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _server.Token);
+            if (origin != null) http.DefaultRequestHeaders.Add("Origin", origin);
+            return http;
+        }
+
+        [Fact]
+        public async Task Status_requires_the_token()
+        {
+            using var http = Client(withToken: false);
+            var resp = await http.GetAsync("/v1/status");
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Status_ok_with_the_token()
+        {
+            using var http = Client();
+            var resp = await http.GetAsync("/v1/status");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Contains("5.0.0-test", await resp.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task Wrong_token_is_rejected()
+        {
+            var http = new HttpClient { BaseAddress = new Uri(_server.BaseUrl!) };
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "not-the-token");
+            var resp = await http.GetAsync("/v1/status");
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Origin_header_is_rejected_even_with_token()
+        {
+            using var http = Client(origin: "http://evil.example");
+            var resp = await http.GetAsync("/v1/status");
+            Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        }
+
+        [Fact]
+        public void Handshake_file_advertises_port_and_token()
+        {
+            var info = LocalApiInfo.Read(_dir);
+            Assert.NotNull(info);
+            Assert.Equal(_server.Token, info!.Token);
+            Assert.True(info.Port > 0);
+            Assert.Equal(Environment.ProcessId, info.Pid);
+        }
+
+        [Fact]
+        public async Task Stop_removes_the_handshake_file()
+        {
+            Assert.NotNull(LocalApiInfo.Read(_dir));
+            await _server.StopAsync();
+            Assert.Null(LocalApiInfo.Read(_dir));
+            // Re-start so DisposeAsync's StopAsync is a no-op-safe call.
+            await _server.StartAsync();
+        }
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -42,6 +42,9 @@ public partial class App : Application
 {
     public static ServiceProvider? ServiceProvider { get; private set; }
     public static Window? MainWindow { get; private set; }
+
+    // Opt-in loopback API server for AI tools; gated on settings at launch (restart to apply). (#186)
+    private CST.Avalonia.Services.LocalApi.LocalApiServer? _localApiServer;
     /// <summary>
     /// True once application shutdown has begun. Floating windows close as part of shutdown too;
     /// consumers (e.g. CstDockFactory.CloseHostWindow's book rescue) use this to distinguish
@@ -300,11 +303,37 @@ public partial class App : Application
             if (settingsService != null)
             {
                 await settingsService.LoadSettingsAsync();
+                await StartLocalApiIfEnabledAsync(settingsService);
             }
         }
         catch (Exception ex)
         {
             Log.Warning(ex, "Failed to load settings");
+        }
+    }
+
+    /// <summary>
+    /// Start the opt-in loopback API server if AI features + the local API are enabled. Gated at launch:
+    /// changes to the setting take effect on restart (live toggle is a later iteration). (#186)
+    /// </summary>
+    private async Task StartLocalApiIfEnabledAsync(ISettingsService settingsService)
+    {
+        try
+        {
+            if (!settingsService.Settings.Ai.LocalApiEnabled) return;
+
+            var dir = System.IO.Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                CST.Avalonia.Constants.AppConstants.AppDataDirectoryName);
+            System.IO.Directory.CreateDirectory(dir);
+
+            var version = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown";
+            _localApiServer = new CST.Avalonia.Services.LocalApi.LocalApiServer(version, dir, Log.Logger);
+            await _localApiServer.StartAsync();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to start local API server");
         }
     }
 
@@ -835,6 +864,12 @@ public partial class App : Application
             {
                 await settingsService.FlushPendingSaveAsync();
                 Log.Information("SHUTDOWN: Pending settings save flushed");
+            }
+
+            if (_localApiServer != null)
+            {
+                await _localApiServer.StopAsync();
+                Log.Information("SHUTDOWN: Local API server stopped");
             }
         }
         catch (Exception ex)

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -48,6 +48,11 @@
     <ProjectReference Include="..\CST.Lucene\CST.Lucene.csproj" />
   </ItemGroup>
 
+  <!-- Local AI-tool API server (loopback, opt-in). Hosts a minimal ASP.NET Core API in-process. -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="CST.Avalonia.Tests" />
   </ItemGroup>

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>
+    /// The discovery/handshake file for the local API (AI_INTEGRATION.md §6). Written to
+    /// <c>…/CSTReader/local-api.json</c> when the server starts so a client (the MCP adapter, a coding agent)
+    /// can find the ephemeral <see cref="Port"/> and present the per-session bearer <see cref="Token"/>. The
+    /// <see cref="Pid"/> lets a client detect a stale file after a crash. Written owner-only where the OS
+    /// supports it; never contains anything but this handshake (the token is a session secret, not persisted
+    /// to settings).
+    /// </summary>
+    public sealed record LocalApiInfo(
+        [property: JsonPropertyName("port")] int Port,
+        [property: JsonPropertyName("token")] string Token,
+        [property: JsonPropertyName("pid")] int Pid)
+    {
+        public const string FileName = "local-api.json";
+
+        private static readonly JsonSerializerOptions Options = new() { WriteIndented = true };
+
+        public static string PathIn(string directory) => Path.Combine(directory, FileName);
+
+        public void Write(string directory)
+        {
+            var path = PathIn(directory);
+            File.WriteAllText(path, JsonSerializer.Serialize(this, Options));
+            TrySetOwnerOnly(path);
+        }
+
+        public static LocalApiInfo? Read(string directory)
+        {
+            try
+            {
+                var path = PathIn(directory);
+                if (!File.Exists(path)) return null;
+                return JsonSerializer.Deserialize<LocalApiInfo>(File.ReadAllText(path), Options);
+            }
+            catch { return null; }
+        }
+
+        public static void Delete(string directory)
+        {
+            try { File.Delete(PathIn(directory)); } catch { /* best effort */ }
+        }
+
+        private static void TrySetOwnerOnly(string path)
+        {
+            // Owner read/write only, where the OS models Unix permissions (macOS/Linux). No-op on Windows.
+            try
+            {
+                if (!OperatingSystem.IsWindows())
+                    File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+            catch { /* best effort */ }
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>
+    /// The opt-in loopback API server that exposes the corpus tools to agents (AI_INTEGRATION.md surface C).
+    /// Binds <c>127.0.0.1</c> on an ephemeral port, mints a per-session bearer token, and advertises both via
+    /// <see cref="LocalApiInfo"/> (<c>local-api.json</c>). Every request must carry the token and must not
+    /// carry an <c>Origin</c> header (no browsers) — the honest threat model is that this stops browser-origin
+    /// attacks (rebinding/CSRF), not a malicious same-user local process, which is the OS's boundary.
+    /// This PR is the secure skeleton: only <c>/v1/status</c>. Tool endpoints follow.
+    /// A startable/stoppable host so live enable/disable can be wired later; for now it's gated at launch.
+    /// </summary>
+    public sealed class LocalApiServer : IAsyncDisposable
+    {
+        private const string ApiVersion = "v1";
+
+        private readonly string _appVersion;
+        private readonly string _handshakeDirectory;
+        private readonly Serilog.ILogger _logger;
+
+        private WebApplication? _app;
+
+        /// <summary>The base URL once started (e.g. <c>http://127.0.0.1:52344</c>), or null if not running.</summary>
+        public string? BaseUrl { get; private set; }
+
+        /// <summary>The per-session bearer token once started, or null if not running.</summary>
+        public string? Token { get; private set; }
+
+        public bool IsRunning => _app != null;
+
+        public LocalApiServer(string appVersion, string handshakeDirectory, Serilog.ILogger logger)
+        {
+            _appVersion = appVersion;
+            _handshakeDirectory = handshakeDirectory;
+            _logger = logger.ForContext<LocalApiServer>();
+        }
+
+        public async Task StartAsync(CancellationToken ct = default)
+        {
+            if (_app != null) return;
+
+            string token = GenerateToken();
+
+            var builder = WebApplication.CreateSlimBuilder();
+            builder.Logging.ClearProviders(); // don't spam stdout; the app logs via Serilog
+            builder.WebHost.ConfigureKestrel(k => k.Listen(IPAddress.Loopback, 0)); // 127.0.0.1:ephemeral
+
+            var app = builder.Build();
+
+            // Security gate: no browsers, loopback host only, valid bearer token.
+            app.Use(async (context, next) =>
+            {
+                if (context.Request.Headers.ContainsKey("Origin"))
+                {
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden; // reject browser-origin requests
+                    return;
+                }
+                if (!IsLoopbackHost(context.Request.Host.Host))
+                {
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    return;
+                }
+                if (!IsAuthorized(context, token))
+                {
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    return;
+                }
+                await next();
+            });
+
+            app.MapGet("/" + ApiVersion + "/status",
+                () => Results.Json(new StatusResponse(_appVersion, ApiVersion, "ok")));
+
+            await app.StartAsync(ct);
+
+            int port = ResolvePort(app);
+            _app = app;
+            Token = token;
+            BaseUrl = $"http://127.0.0.1:{port}";
+
+            new LocalApiInfo(port, token, Environment.ProcessId).Write(_handshakeDirectory);
+            _logger.Information("Local API listening on {BaseUrl}", BaseUrl);
+        }
+
+        public async Task StopAsync()
+        {
+            if (_app == null) return;
+            try { await _app.StopAsync(); } catch (Exception ex) { _logger.Warning(ex, "Local API stop error"); }
+            await _app.DisposeAsync();
+            _app = null;
+            BaseUrl = null;
+            Token = null;
+            LocalApiInfo.Delete(_handshakeDirectory);
+            _logger.Information("Local API stopped");
+        }
+
+        public ValueTask DisposeAsync() => new(StopAsync());
+
+        private static bool IsLoopbackHost(string host) =>
+            host is "127.0.0.1" or "localhost" or "[::1]" or "::1";
+
+        private static bool IsAuthorized(HttpContext context, string token)
+        {
+            string header = context.Request.Headers.Authorization.ToString();
+            if (!header.StartsWith("Bearer ", StringComparison.Ordinal)) return false;
+            // Constant-time compare so a wrong token can't be timed out char by char.
+            return CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(header.Substring("Bearer ".Length)),
+                Encoding.UTF8.GetBytes(token));
+        }
+
+        private static string GenerateToken()
+        {
+            Span<byte> bytes = stackalloc byte[32];
+            RandomNumberGenerator.Fill(bytes);
+            return Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+        }
+
+        private static int ResolvePort(WebApplication app)
+        {
+            var addresses = app.Services.GetRequiredService<IServer>()
+                .Features.Get<IServerAddressesFeature>()!.Addresses;
+            return new Uri(addresses.First()).Port;
+        }
+
+        private sealed record StatusResponse(string App, string Api, string Status);
+    }
+}


### PR DESCRIPTION
**Make surface C real (part 1):** an opt-in local HTTP server to expose the corpus tools to agents (Claude Code / MCP). This PR is the **secure skeleton** — transport + security + `/v1/status`, no tool endpoints yet. Part of epic #186. Server tech = ASP.NET Core minimal API (decided with @fsnow).

## What
- **`LocalApiServer`** — `WebApplication.CreateSlimBuilder`, bound to **`127.0.0.1` on an ephemeral port**, per-session bearer token. Security gate on every request:
  - reject requests carrying an **`Origin`** header (no browsers — defeats DNS-rebinding/CSRF),
  - **loopback host only**,
  - **constant-time bearer-token** check (`CryptographicOperations.FixedTimeEquals`).
  - Honest threat model documented: this stops browser-origin attacks, not a malicious same-user local process (the OS's boundary).
  - `/v1/status` → `{ app, api, status }`. Startable/stoppable host.
- **`LocalApiInfo`** — writes `{port, token, pid}` to `…/CSTReader/local-api.json`, **owner-only (0600)** where the OS supports it. The token is a session secret — never in `settings.json`.
- **Launch-time gating** — `App.axaml.cs` starts it after settings load **iff `Settings.Ai.LocalApiEnabled`**, stops on shutdown. Restart-to-apply (live toggle is a fast-follow once `SettingsService` gains a change signal).
- `FrameworkReference Microsoft.AspNetCore.App` added to the app + test projects.

## Tests
**7 tests**, all green: real server start, `401` (no/wrong token), `403` (`Origin`), `200` (valid token), handshake file written + deleted on stop.

## CI note
Full suite **543/544**. The one failure is the **pre-existing flaky** `IndexingPerformanceTests.MultipleIndexValidations_Performance_AreConsistent` (timing-consistency) — it **passes in isolation** (133 ms); it tripped under full-suite CPU load (the new Kestrel integration tests add pressure). Unrelated to this change.

## Next
Tool endpoints (`/v1/search`, `/occurrences`, `/dictionary`, `/passage`, `/books`) + `llms.txt` in later PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)