### PR TITLE
AI local API: wire the surface-C tool endpoints (#186)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Services.LocalApi;
+using CST.Tools;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services
+{
+    /// <summary>
+    /// Integration tests for the tool endpoints: a real loopback server with a mocked search tool (asserts
+    /// routing + auth + JSON round-trip, not search behavior) and the real book catalog for /v1/books.
+    /// </summary>
+    public class LocalApiEndpointTests : IAsyncLifetime
+    {
+        private string _dir = null!;
+        private LocalApiServer _server = null!;
+
+        public async Task InitializeAsync()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "cst-ep-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+
+            var search = new Mock<ISearchTool>();
+            search.Setup(t => t.SearchAsync(It.IsAny<SearchToolRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new SearchToolResult(
+                    new List<SearchTermResult> { new("dhamma", "dhamma-ipe", 5, new List<BookHitSummary>()) },
+                    TotalTermCount: 1, TotalOccurrenceCount: 5, TotalBookCount: 1, Truncated: false, Note: null));
+
+            _server = new LocalApiServer("5.0.0-test", _dir, Serilog.Log.Logger, search.Object);
+            await _server.StartAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _server.StopAsync();
+            try { Directory.Delete(_dir, recursive: true); } catch { }
+        }
+
+        private HttpClient Authed()
+        {
+            var http = new HttpClient { BaseAddress = new Uri(_server.BaseUrl!) };
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _server.Token);
+            return http;
+        }
+
+        private static StringContent Json(string body) => new(body, Encoding.UTF8, "application/json");
+
+        [Fact]
+        public async Task Search_endpoint_returns_the_mapped_result()
+        {
+            using var http = Authed();
+            var resp = await http.PostAsync("/v1/search", Json("{\"query\":\"x\"}"));
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Contains("dhamma", await resp.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task Tool_endpoint_still_requires_the_token()
+        {
+            using var http = new HttpClient { BaseAddress = new Uri(_server.BaseUrl!) };
+            var resp = await http.PostAsync("/v1/search", Json("{\"query\":\"x\"}"));
+
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Books_endpoint_lists_the_catalog()
+        {
+            using var http = Authed();
+            var resp = await http.GetAsync("/v1/books");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Contains(".xml", await resp.Content.ReadAsStringAsync()); // real book file names
+        }
+
+        [Fact]
+        public async Task Unprovided_tool_endpoint_is_not_mapped()
+        {
+            // No dictionary tool was supplied, so its endpoint doesn't exist.
+            using var http = Authed();
+            var resp = await http.GetAsync("/v1/dictionary/languages");
+
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -328,7 +328,11 @@ public partial class App : Application
             System.IO.Directory.CreateDirectory(dir);
 
             var version = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown";
-            _localApiServer = new CST.Avalonia.Services.LocalApi.LocalApiServer(version, dir, Log.Logger);
+            _localApiServer = new CST.Avalonia.Services.LocalApi.LocalApiServer(
+                version, dir, Log.Logger,
+                ServiceProvider?.GetService<CST.Tools.ISearchTool>(),
+                ServiceProvider?.GetService<CST.Tools.IDictionaryTool>(),
+                ServiceProvider?.GetService<CST.Tools.IPassageTool>());
             await _localApiServer.StartAsync();
         }
         catch (Exception ex)
@@ -966,6 +970,11 @@ public partial class App : Application
         // services.AddSingleton<IBookService, BookService>();
         services.AddSingleton<ISearchService, SearchService>();
         services.AddSingleton<IDictionaryService, DictionaryService>();
+
+        // Surface-C tool wrappers (exposed over the local API). (#186)
+        services.AddSingleton<CST.Tools.ISearchTool, Services.Tools.SearchTool>();
+        services.AddSingleton<CST.Tools.IDictionaryTool, Services.Tools.DictionaryTool>();
+        services.AddSingleton<CST.Tools.IPassageTool, Services.Tools.PassageTool>();
         services.AddTransient<TreeStateService>();
         
         // Indexing services

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -12,6 +12,12 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CST;
+using CST.Conversion;
+using CST.Navigation;
+using CST.Tools;
 using Serilog;
 
 namespace CST.Avalonia.Services.LocalApi
@@ -32,6 +38,9 @@ namespace CST.Avalonia.Services.LocalApi
         private readonly string _appVersion;
         private readonly string _handshakeDirectory;
         private readonly Serilog.ILogger _logger;
+        private readonly ISearchTool? _search;
+        private readonly IDictionaryTool? _dictionary;
+        private readonly IPassageTool? _passage;
 
         private WebApplication? _app;
 
@@ -43,11 +52,16 @@ namespace CST.Avalonia.Services.LocalApi
 
         public bool IsRunning => _app != null;
 
-        public LocalApiServer(string appVersion, string handshakeDirectory, Serilog.ILogger logger)
+        public LocalApiServer(
+            string appVersion, string handshakeDirectory, Serilog.ILogger logger,
+            ISearchTool? search = null, IDictionaryTool? dictionary = null, IPassageTool? passage = null)
         {
             _appVersion = appVersion;
             _handshakeDirectory = handshakeDirectory;
             _logger = logger.ForContext<LocalApiServer>();
+            _search = search;
+            _dictionary = dictionary;
+            _passage = passage;
         }
 
         public async Task StartAsync(CancellationToken ct = default)
@@ -59,6 +73,11 @@ namespace CST.Avalonia.Services.LocalApi
             var builder = WebApplication.CreateSlimBuilder();
             builder.Logging.ClearProviders(); // don't spam stdout; the app logs via Serilog
             builder.WebHost.ConfigureKestrel(k => k.Listen(IPAddress.Loopback, 0)); // 127.0.0.1:ephemeral
+            builder.Services.ConfigureHttpJsonOptions(o =>
+            {
+                o.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+                o.SerializerOptions.Converters.Add(new JsonStringEnumConverter()); // "Latin" not 3
+            });
 
             var app = builder.Build();
 
@@ -85,6 +104,8 @@ namespace CST.Avalonia.Services.LocalApi
 
             app.MapGet("/" + ApiVersion + "/status",
                 () => Results.Json(new StatusResponse(_appVersion, ApiVersion, "ok")));
+
+            MapToolEndpoints(app);
 
             await app.StartAsync(ct);
 
@@ -138,6 +159,57 @@ namespace CST.Avalonia.Services.LocalApi
             return new Uri(addresses.First()).Port;
         }
 
+        // Map the surface-C tool endpoints for whichever tools were provided. Each is a thin adapter over an
+        // already-tested tool; the tools themselves keep the corpus formats behind the boundary.
+        private void MapToolEndpoints(WebApplication app)
+        {
+            string v = "/" + ApiVersion;
+
+            if (_search is { } search)
+            {
+                app.MapPost(v + "/search",
+                    async (SearchToolRequest req, CancellationToken ct) => Results.Json(await search.SearchAsync(req, ct)));
+                app.MapPost(v + "/occurrences",
+                    async (OccurrenceRequest req, CancellationToken ct) => Results.Json(await search.GetOccurrencesAsync(req, ct)));
+            }
+
+            if (_dictionary is { } dictionary)
+            {
+                app.MapGet(v + "/dictionary/languages", () => Results.Json(dictionary.Languages));
+                app.MapPost(v + "/dictionary/lookup",
+                    async (DictionaryRequest req, CancellationToken ct) => Results.Json(await dictionary.LookupAsync(req, ct)));
+            }
+
+            if (_passage is { } passage)
+            {
+                app.MapPost(v + "/passage", async (PassageHttpRequest req, CancellationToken ct) =>
+                {
+                    NavigationReference reference = req.Paragraph is int n
+                        ? new NavigationReference.Paragraph(n, req.BookCode)
+                        : new NavigationReference.WholeBook();
+                    var pr = new PassageRequest(req.BookId, reference, req.Cursor, req.MaxChars,
+                        req.OutputScript, req.IncludeVariantReadings);
+                    return Results.Json(await passage.FetchPassageAsync(pr, ct));
+                });
+            }
+
+            // Book catalog — agents need book ids to call the other tools. Always available (no service needed).
+            app.MapGet(v + "/books", () => Results.Json(
+                Books.Inst.Select(b => new BookSummary(
+                    b.FileName, b.LongNavPath, b.ShortNavPath, b.Pitaka, b.Matn, b.BookType, b.DocId >= 0)).ToList()));
+        }
+
         private sealed record StatusResponse(string App, string Api, string Status);
+
+        // Flat request for /v1/passage — avoids polymorphic JSON for NavigationReference. Paragraph (or none =
+        // whole book) unless a Cursor from a prior response is supplied to page forward/backward.
+        private sealed record PassageHttpRequest(
+            string BookId,
+            int? Paragraph = null,
+            string? BookCode = null,
+            int? Cursor = null,
+            int MaxChars = 1200,
+            Script OutputScript = Script.Latin,
+            bool IncludeVariantReadings = false);
     }
 }


### PR DESCRIPTION
**Make surface C real (part 2):** expose the corpus tools over the loopback server. Behind the same bearer-token/`Origin` gate from #235; JSON is camelCase with string enums (`"Latin"`, `"Wildcard"`). Part of epic #186.

## Endpoints (mapped only for tools that were provided)
- `POST /v1/search` · `POST /v1/occurrences`
- `GET /v1/dictionary/languages` · `POST /v1/dictionary/lookup`
- `POST /v1/passage` — **flat body** (`bookId`, `paragraph?`, `bookCode?`, `cursor?`, `maxChars`, `outputScript`, `includeVariantReadings`) to avoid polymorphic JSON for `NavigationReference`
- `GET /v1/books` — the catalog, so an agent has book ids to call the others
- (`GET /v1/status` from #235)

## Wiring
- DI-registered `ISearchTool`/`IDictionaryTool`/`IPassageTool`; `App.axaml.cs` passes the DI-resolved tools to `LocalApiServer`.
- Each endpoint is a thin adapter over an already-unit-tested tool — corpus formats stay behind the boundary.

## Tests
**11 local-API tests** (4 new): endpoint routing, auth still enforced on tool endpoints, JSON round-trip (mocked search tool), real `/v1/books`, and unprovided-tool → 404.

## CI note
Full suite **547/548**. The one failure is the **same pre-existing flaky** `IndexingPerformanceTests.MultipleIndexValidations_Performance_AreConsistent` — passes in isolation, trips under full-suite CPU load. It's now a **reliable flake** under the heavier suite (the Kestrel integration tests add pressure); might be worth relaxing its threshold or excluding it from the full run in a separate change. Unrelated to this PR.

## Next
`llms.txt` + `/docs` discovery (unauthenticated), then the thin MCP adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)