### PR TITLE
AI local API: llms.txt discovery front door (#186)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LocalApiTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApiTests.cs
@@ -103,6 +103,27 @@ namespace CST.Avalonia.Tests.Services
         }
 
         [Fact]
+        public async Task Llms_txt_is_served_without_a_token_and_is_version_stamped()
+        {
+            using var http = Client(withToken: false);
+            var resp = await http.GetAsync("/llms.txt");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.Contains("/v1/search", body);       // endpoint orientation
+            Assert.Contains("Bearer", body);           // auth handshake
+            Assert.Contains("5.0.0-test", body);       // version stamp
+        }
+
+        [Fact]
+        public async Task Llms_txt_still_rejects_an_origin_header()
+        {
+            using var http = Client(withToken: false, origin: "http://evil.example");
+            var resp = await http.GetAsync("/llms.txt");
+            Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        }
+
+        [Fact]
         public void Handshake_file_advertises_port_and_token()
         {
             var info = LocalApiInfo.Read(_dir);

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -41,6 +41,7 @@
     </None>
     <EmbeddedResource Include="Resources\welcome-content.html" />
     <EmbeddedResource Include="Resources\buddha-transparent.png" />
+    <EmbeddedResource Include="Resources\LocalApi\llms.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -1,0 +1,51 @@
+# CST Reader - Local Corpus API
+
+CST Reader (CST = Chattha Sangayana Tipitaka) exposes its Pali corpus, full-text search, and dictionaries
+as read-only tools over this loopback HTTP API, for AI agents such as Claude Code. The app owns all storage
+formats; you get clean JSON and never touch the underlying files.
+
+## Connecting
+
+This document is served WITHOUT authentication. Every other endpoint requires a token.
+
+1. Read the handshake file `local-api.json` in the app-support directory
+   (macOS: `~/Library/Application Support/CSTReader/local-api.json`). It is `{ "port", "token", "pid" }`.
+2. Base URL is `http://127.0.0.1:<port>` (loopback only).
+3. Send `Authorization: Bearer <token>` on every request.
+4. Do NOT send an `Origin` header - browser-origin requests are rejected by design.
+
+## Conventions
+
+- Pali output is ROMANIZED (Latin / IAST, with diacritics) by DEFAULT. Pass `outputScript` to override,
+  e.g. "Devanagari", "Thai", "Myanmar", "Sinhala" (14 scripts are supported).
+- Every Pali term and headword also carries a stable internal encoding (`termIpe`, `headwordIpe`). Use it as
+  an unambiguous cross-script key when calling follow-up endpoints - it does not change with `outputScript`.
+- Books are identified by file name (e.g. `s0101m.mul.xml`). Get the list from `GET /v1/books`.
+- References: the paragraph number is the primary citation unit; page numbers exist per edition
+  (VRI / Myanmar / PTS / Thai). Search occurrences report both.
+- Terminology: when writing about the texts, call them "Pali", "the Tipitaka", or "VRI texts".
+
+## Endpoints
+
+- `GET  /v1/status` - app version, API version, readiness.
+- `GET  /v1/books` - the catalog. Each: `{ bookId, name, shortName, pitaka, commentaryLevel, bookType, indexed }`.
+- `POST /v1/search` - matching terms (a wildcard/regex expands to many inflected forms).
+  Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, proximityDistance?, outputScript? }`.
+  Returns terms, each with the books it occurs in and counts.
+- `POST /v1/occurrences` - "search results in context": KWIC snippets plus citation refs for one term in one
+  book. Body: `{ bookId, termIpe, includeVariantReadings?, outputScript?, skip?, take?, minChars?, maxChars? }`.
+  Each occurrence: a hit-centered snippet, the paragraph number, and the per-edition page numbers.
+- `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
+  Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeVariantReadings? }`.
+  Page forward/backward by passing back `prevCursor` / `nextCursor`.
+- `GET  /v1/dictionary/languages` - available dictionary language codes (e.g. "en", "hi").
+- `POST /v1/dictionary/lookup` - `{ language, query, outputScript?, maxEntries? }`
+  -> entries `{ headword, headwordIpe, meaningHtml }`.
+
+## A typical research flow
+
+1. `POST /v1/search` for a word -> pick the inflected form(s) you want (keep each `termIpe`).
+2. `POST /v1/occurrences` for that `termIpe` in a book -> scan the concordance snippets; cite by paragraph
+   and per-edition page.
+3. `POST /v1/passage` at a paragraph -> read the surrounding text, paging with the cursor if you need more.
+4. `POST /v1/dictionary/lookup` -> gloss unfamiliar words.

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -1,6 +1,8 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -94,7 +96,9 @@ namespace CST.Avalonia.Services.LocalApi
                     context.Response.StatusCode = StatusCodes.Status403Forbidden;
                     return;
                 }
-                if (!IsAuthorized(context, token))
+                // Discovery (llms.txt / docs) is unauthenticated so an agent can bootstrap: read the docs,
+                // learn the handshake, then authenticate. It carries no secrets. Everything else needs the token.
+                if (!IsDiscoveryPath(context.Request.Path) && !IsAuthorized(context, token))
                 {
                     context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                     return;
@@ -104,6 +108,16 @@ namespace CST.Avalonia.Services.LocalApi
 
             app.MapGet("/" + ApiVersion + "/status",
                 () => Results.Json(new StatusResponse(_appVersion, ApiVersion, "ok")));
+
+            // Unauthenticated front door: the agent's orientation (endpoints, conventions, auth handshake).
+            // Version-stamped so it can't be mistaken for a different build's surface.
+            app.MapGet("/llms.txt", () =>
+            {
+                var body = ReadResource("LocalApi.llms.txt")
+                    ?? "# CST Reader Local API\n\n(llms.txt resource missing)\n";
+                var stamped = $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + body;
+                return Results.Text(stamped, "text/markdown; charset=utf-8");
+            });
 
             MapToolEndpoints(app);
 
@@ -134,6 +148,22 @@ namespace CST.Avalonia.Services.LocalApi
 
         private static bool IsLoopbackHost(string host) =>
             host is "127.0.0.1" or "localhost" or "[::1]" or "::1";
+
+        private static bool IsDiscoveryPath(PathString path) =>
+            path.Equals("/llms.txt", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWithSegments("/docs", StringComparison.OrdinalIgnoreCase);
+
+        private static string? ReadResource(string endsWith)
+        {
+            var assembly = typeof(LocalApiServer).Assembly;
+            var name = assembly.GetManifestResourceNames()
+                .FirstOrDefault(n => n.EndsWith(endsWith, StringComparison.OrdinalIgnoreCase));
+            if (name is null) return null;
+            using var stream = assembly.GetManifestResourceStream(name);
+            if (stream is null) return null;
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
 
         private static bool IsAuthorized(HttpContext context, string token)
         {


### PR DESCRIPTION
The agent's **unauthenticated front door** (AI_INTEGRATION.md §8): `GET /llms.txt` orients an agent so it can bootstrap and use the corpus tools correctly. Part of epic #186.

## What
- **`GET /llms.txt`** returns markdown covering: what the API is, the **auth handshake** (read `local-api.json` → send `Authorization: Bearer` → no `Origin` header), the **conventions** (romanized-Latin default + stable `…Ipe` keys, book ids from `/v1/books`, paragraph + per-edition page citation, terminology rule), the **endpoint list**, and a **typical research flow** (search → occurrences → passage → dictionary).
- Content is an **embedded markdown resource** — authored once, served verbatim.
- **Discovery is unauthenticated** so an agent can bootstrap (read the docs → learn the handshake → authenticate); it carries no secrets. The **`Origin` + loopback checks still apply**, and every non-discovery endpoint still requires the token.
- **Version-stamped** at serve time (an HTML comment with app + API version) so it can't be mistaken for a different build's surface. The discovery exemption also reserves `/docs/*` for later deep docs.

## Tests
**13 local-API tests** (+2): `/llms.txt` served without a token, contains the endpoint + handshake orientation + version stamp, and still rejects an `Origin` header.

## Notes
- Isolated to the local-API subsystem (+ one embedded resource); no `App.axaml.cs` change this time.
- (The pre-existing flaky `IndexingPerformanceTests` timing test is untouched by this PR.)

## Next
The thin stdio **MCP adapter** so BYO-MCP-chat clients (claude.ai / Desktop) can reach the same API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)