### PR TITLE
AI local API: root pointer to the docs (cold-agent test finding) (#186)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LocalApiTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApiTests.cs
@@ -26,6 +26,9 @@ namespace CST.Avalonia.Tests.Services
                 Assert.Equal("tok-abc", read.Token);
                 Assert.Equal(4242, read.Pid);
 
+                Assert.Contains("\"docs\"", File.ReadAllText(LocalApiInfo.PathIn(dir)));   // points to the orientation doc
+                Assert.Equal("/llms.txt", read.Docs);
+
                 if (!OperatingSystem.IsWindows())
                     Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite,
                         File.GetUnixFileMode(LocalApiInfo.PathIn(dir)));
@@ -100,6 +103,18 @@ namespace CST.Avalonia.Tests.Services
             using var http = Client(origin: "http://evil.example");
             var resp = await http.GetAsync("/v1/status");
             Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Root_points_to_the_docs_without_a_token()
+        {
+            using var http = Client(withToken: false);
+            var resp = await http.GetAsync("/");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.Contains("/llms.txt", body);       // names where the orientation doc lives
+            Assert.Contains("/v1/status", body);
         }
 
         [Fact]

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
@@ -20,6 +20,10 @@ namespace CST.Avalonia.Services.LocalApi
     {
         public const string FileName = "local-api.json";
 
+        /// <summary>Where the (unauthenticated) orientation doc lives, so a client needn't guess. Relative to the base URL.</summary>
+        [JsonPropertyName("docs")]
+        public string Docs => "/llms.txt";
+
         private static readonly JsonSerializerOptions Options = new() { WriteIndented = true };
 
         public static string PathIn(string directory) => Path.Combine(directory, FileName);

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -106,6 +106,11 @@ namespace CST.Avalonia.Services.LocalApi
                 await next();
             });
 
+            // Unauthenticated root pointer, so an agent that connects via local-api.json isn't left staring at
+            // an empty "/" — it names where the docs and status live. (Cold-agent test finding.)
+            app.MapGet("/", () => Results.Json(
+                new RootResponse("CST Reader local API", _appVersion, ApiVersion, "/llms.txt", "/" + ApiVersion + "/status")));
+
             app.MapGet("/" + ApiVersion + "/status",
                 () => Results.Json(new StatusResponse(_appVersion, ApiVersion, "ok")));
 
@@ -150,7 +155,8 @@ namespace CST.Avalonia.Services.LocalApi
             host is "127.0.0.1" or "localhost" or "[::1]" or "::1";
 
         private static bool IsDiscoveryPath(PathString path) =>
-            path.Equals("/llms.txt", StringComparison.OrdinalIgnoreCase)
+            !path.HasValue || path == "/"
+            || path.Equals("/llms.txt", StringComparison.OrdinalIgnoreCase)
             || path.StartsWithSegments("/docs", StringComparison.OrdinalIgnoreCase);
 
         private static string? ReadResource(string endsWith)
@@ -228,6 +234,8 @@ namespace CST.Avalonia.Services.LocalApi
                 Books.Inst.Select(b => new BookSummary(
                     b.FileName, b.LongNavPath, b.ShortNavPath, b.Pitaka, b.Matn, b.BookType, b.DocId >= 0)).ToList()));
         }
+
+        private sealed record RootResponse(string Name, string App, string Api, string Docs, string Status);
 
         private sealed record StatusResponse(string App, string Api, string Status);
 


### PR DESCRIPTION
**First fix from the cold-agent test.** A fresh Claude Code session on Kestrel connected fine via `local-api.json` (found the port + token), but hitting `/` returned **empty** — so it had to *guess* the API shape instead of being pointed at the docs. This closes that discovery gap. Part of epic #186.

## Fix
- **`GET /`** (unauthenticated) now returns `{ name, app, api, docs: "/llms.txt", status: "/v1/status" }` — the root self-advertises where to go next.
- **`local-api.json`** now includes `"docs": "/llms.txt"`, so the handshake file names the orientation doc without even a round-trip.
- Root is a discovery path (unauthenticated, like `/llms.txt`); `Origin` + loopback checks still apply; every other endpoint still requires the token.

## Tests
**14 local-API tests** (+1, plus `docs` assertions): `GET /` returns the pointer without a token; `local-api.json` carries the `docs` field.

Isolated to the local-API subsystem. Fetch + re-run the cold test — the agent should now go `local-api.json` → `/` (or the file's `docs`) → `/llms.txt` → work, with no guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)