### PR TITLE
AI local API: cold-test fixes — work in Latin, fix occurrences, romanize books (#186)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
@@ -31,7 +31,7 @@ namespace CST.Avalonia.Tests.Services
             var search = new Mock<ISearchTool>();
             search.Setup(t => t.SearchAsync(It.IsAny<SearchToolRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new SearchToolResult(
-                    new List<SearchTermResult> { new("dhamma", "dhamma-ipe", 5, new List<BookHitSummary>()) },
+                    new List<SearchTermResult> { new("dhamma", 5, new List<BookHitSummary>()) },
                     TotalTermCount: 1, TotalOccurrenceCount: 5, TotalBookCount: 1, Truncated: false, Note: null));
 
             _server = new LocalApiServer("5.0.0-test", _dir, Serilog.Log.Logger, search.Object);
@@ -73,13 +73,15 @@ namespace CST.Avalonia.Tests.Services
         }
 
         [Fact]
-        public async Task Books_endpoint_lists_the_catalog()
+        public async Task Books_endpoint_lists_the_catalog_romanized()
         {
             using var http = Authed();
             var resp = await http.GetAsync("/v1/books");
 
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-            Assert.Contains(".xml", await resp.Content.ReadAsStringAsync()); // real book file names
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.Contains(".xml", body);                                    // real book file names
+            Assert.DoesNotContain(body, c => c >= '\u0900' && c <= '\u097F'); // names romanized, no Devanagari leaked
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Tools/DictionaryToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/DictionaryToolTests.cs
@@ -42,7 +42,6 @@ namespace CST.Avalonia.Tests.Tools
             var entries = await tool.LookupAsync(new DictionaryRequest("en", "metta")); // OutputScript = Latin
 
             var e = Assert.Single(entries);
-            Assert.Equal("abc", e.HeadwordIpe);                                          // stable IPE preserved
             Assert.Equal(ScriptConverter.Convert("abc", Script.Ipe, Script.Latin), e.Headword);
             Assert.Equal("<b>loving-kindness</b>", e.MeaningHtml);                       // HTML pass-through
         }

--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -92,7 +92,6 @@ namespace CST.Avalonia.Tests.Tools
             Assert.Equal("capped", result.Note);
 
             var term = Assert.Single(result.Terms);
-            Assert.Equal("abc", term.TermIpe);
             Assert.Equal(ScriptConverter.Convert("abc", Script.Ipe, Script.Latin), term.Term);
 
             var hit = Assert.Single(term.Books);

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -18,8 +18,11 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 
 - Pali output is ROMANIZED (Latin / IAST, with diacritics) by DEFAULT. Pass `outputScript` to override,
   e.g. "Devanagari", "Thai", "Myanmar", "Sinhala" (14 scripts are supported).
-- Every Pali term and headword also carries a stable internal encoding (`termIpe`, `headwordIpe`). Use it as
-  an unambiguous cross-script key when calling follow-up endpoints - it does not change with `outputScript`.
+- You work entirely in readable Pali (romanized by default). To read a search hit in context, pass the
+  term's `term` value (exactly as `/v1/search` returned it, in whatever script you requested) back to
+  `/v1/occurrences` as `term`. There is no opaque id to round-trip - the server handles the internal encoding.
+- An empty result array means NO MATCHES, not an error. Errors use HTTP status codes (400 bad request,
+  401 missing/invalid token, 404 unknown path); a 2xx with `[]` or empty fields is simply "nothing found".
 - Books are identified by file name (e.g. `s0101m.mul.xml`). Get the list from `GET /v1/books`.
 - References: the paragraph number is the primary citation unit; page numbers exist per edition
   (VRI / Myanmar / PTS / Thai). Search occurrences report both.
@@ -29,23 +32,25 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 
 - `GET  /v1/status` - app version, API version, readiness.
 - `GET  /v1/books` - the catalog. Each: `{ bookId, name, shortName, pitaka, commentaryLevel, bookType, indexed }`.
+  `name`/`shortName` are romanized by default; add `?script=Devanagari` (etc.) to change.
 - `POST /v1/search` - matching terms (a wildcard/regex expands to many inflected forms).
   Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, proximityDistance?, outputScript? }`.
   Returns terms, each with the books it occurs in and counts.
 - `POST /v1/occurrences` - "search results in context": KWIC snippets plus citation refs for one term in one
-  book. Body: `{ bookId, termIpe, includeVariantReadings?, outputScript?, skip?, take?, minChars?, maxChars? }`.
+  book. Body: `{ bookId, term, includeVariantReadings?, outputScript?, skip?, take?, minChars?, maxChars? }`
+  where `term` is a `term` value from a prior `/v1/search`.
   Each occurrence: a hit-centered snippet, the paragraph number, and the per-edition page numbers.
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
   Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeVariantReadings? }`.
   Page forward/backward by passing back `prevCursor` / `nextCursor`.
 - `GET  /v1/dictionary/languages` - available dictionary language codes (e.g. "en", "hi").
 - `POST /v1/dictionary/lookup` - `{ language, query, outputScript?, maxEntries? }`
-  -> entries `{ headword, headwordIpe, meaningHtml }`.
+  -> entries `{ headword, meaningHtml }`.
 
 ## A typical research flow
 
-1. `POST /v1/search` for a word -> pick the inflected form(s) you want (keep each `termIpe`).
-2. `POST /v1/occurrences` for that `termIpe` in a book -> scan the concordance snippets; cite by paragraph
+1. `POST /v1/search` for a word -> pick the inflected form(s) you want (keep each `term`).
+2. `POST /v1/occurrences` for that `term` in a book -> scan the concordance snippets; cite by paragraph
    and per-edition page.
 3. `POST /v1/passage` at a paragraph -> read the surrounding text, paging with the cursor if you need more.
 4. `POST /v1/dictionary/lookup` -> gloss unfamiliar words.

--- a/src/CST.Avalonia/Services/ISearchService.cs
+++ b/src/CST.Avalonia/Services/ISearchService.cs
@@ -10,5 +10,7 @@ public interface ISearchService
     Task<SearchResult> SearchAsync(SearchQuery query, CancellationToken cancellationToken = default);
     Task<List<string>> GetAllTermsAsync(string prefix = "", int limit = 100, CancellationToken cancellationToken = default);
     Task<SearchResult> GetNextPageAsync(string continuationToken, CancellationToken cancellationToken = default);
+    // term is a display-script term (e.g. the romanized Latin term from a prior search); it is converted to
+    // IPE internally for the index lookup.
     Task<List<TermPosition>> GetTermPositionsAsync(string bookFileName, string term, CancellationToken cancellationToken = default);
 }

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -154,6 +154,9 @@ namespace CST.Avalonia.Services.LocalApi
         private static bool IsLoopbackHost(string host) =>
             host is "127.0.0.1" or "localhost" or "[::1]" or "::1";
 
+        private static Script ParseScript(string? name) =>
+            Enum.TryParse<Script>(name, ignoreCase: true, out var script) ? script : Script.Latin;
+
         private static bool IsDiscoveryPath(PathString path) =>
             !path.HasValue || path == "/"
             || path.Equals("/llms.txt", StringComparison.OrdinalIgnoreCase)
@@ -229,10 +232,18 @@ namespace CST.Avalonia.Services.LocalApi
                 });
             }
 
-            // Book catalog — agents need book ids to call the other tools. Always available (no service needed).
-            app.MapGet(v + "/books", () => Results.Json(
-                Books.Inst.Select(b => new BookSummary(
-                    b.FileName, b.LongNavPath, b.ShortNavPath, b.Pitaka, b.Matn, b.BookType, b.DocId >= 0)).ToList()));
+            // Book catalog — agents need book ids to call the other tools. Always available (no service
+            // needed). Nav-path names are stored Devanagari; romanize to the requested script (Latin default,
+            // like every other endpoint) via ?script=. (#186 cold-agent test: names came back Devanagari.)
+            app.MapGet(v + "/books", (string? script) =>
+            {
+                var outputScript = ParseScript(script);
+                return Results.Json(Books.Inst.Select(b => new BookSummary(
+                    b.FileName,
+                    ScriptConverter.Convert(b.LongNavPath, Script.Devanagari, outputScript),
+                    ScriptConverter.Convert(b.ShortNavPath, Script.Devanagari, outputScript),
+                    b.Pitaka, b.Matn, b.BookType, b.DocId >= 0)).ToList());
+            });
         }
 
         private sealed record RootResponse(string Name, string App, string Api, string Docs, string Status);

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -818,6 +818,8 @@ public class SearchService : ISearchService
                 return new List<TermPosition>();
             }
 
+            // term is a display-script term (e.g. the romanized Latin term from a prior search); convert it
+            // to IPE for the index lookup. Any2Ipe auto-detects the input script.
             var ipeTerm = Any2Ipe.Convert(term);
             var termBytes = new BytesRef(Encoding.UTF8.GetBytes(ipeTerm));
             var liveDocs = MultiFields.GetLiveDocs(reader);

--- a/src/CST.Avalonia/Services/Tools/DictionaryTool.cs
+++ b/src/CST.Avalonia/Services/Tools/DictionaryTool.cs
@@ -31,7 +31,6 @@ namespace CST.Avalonia.Services.Tools
                 .Take(request.MaxEntries)
                 .Select(w => new DictionaryEntry(
                     Headword: ScriptConverter.Convert(w.Word, Script.Ipe, request.OutputScript),
-                    HeadwordIpe: w.Word,
                     MeaningHtml: w.Meaning))
                 .ToList();
         }

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -46,7 +46,6 @@ namespace CST.Avalonia.Services.Tools
 
             var terms = result.Terms.Select(t => new SearchTermResult(
                 Term: ScriptConverter.Convert(t.Term, Script.Ipe, request.OutputScript),
-                TermIpe: t.Term,
                 TotalCount: t.TotalCount,
                 Books: t.Occurrences.Select(o => new BookHitSummary(
                     BookId: o.Book?.FileName ?? string.Empty,
@@ -74,7 +73,7 @@ namespace CST.Avalonia.Services.Tools
         public async Task<IReadOnlyList<Occurrence>> GetOccurrencesAsync(
             OccurrenceRequest request, CancellationToken ct = default)
         {
-            var positions = await _search.GetTermPositionsAsync(request.BookId, request.TermIpe, ct)
+            var positions = await _search.GetTermPositionsAsync(request.BookId, request.Term, ct)
                 .ConfigureAwait(false);
             if (positions.Count == 0) return Array.Empty<Occurrence>();
 

--- a/src/CST.Core/Tools/DictionaryToolContracts.cs
+++ b/src/CST.Core/Tools/DictionaryToolContracts.cs
@@ -31,10 +31,8 @@ namespace CST.Tools
 
     /// <summary>One dictionary entry.</summary>
     /// <param name="Headword">The headword in the requested output script.</param>
-    /// <param name="HeadwordIpe">The stable IPE form of the headword.</param>
     /// <param name="MeaningHtml">The definition as an HTML fragment (the source format).</param>
     public sealed record DictionaryEntry(
         string Headword,
-        string HeadwordIpe,
         string MeaningHtml);
 }

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -10,8 +10,9 @@ namespace CST.Tools
     /// The search tool exposed to agents (AI_INTEGRATION.md surface C). A transport-agnostic, headless
     /// wrapper over the app's search service: an agent gets clean terms → book hits, never Lucene segments.
     /// Implementations live in the app layer and map internal results to these DTOs. All Pāli text is
-    /// returned in <see cref="SearchToolRequest.OutputScript"/> (default romanized Latin); every term also
-    /// carries its stable IPE form as an unambiguous cross-script key.
+    /// returned in <see cref="SearchToolRequest.OutputScript"/> (default romanized Latin); a term returned by
+    /// search is passed back verbatim (in that same script) to read it in context — the caller never handles
+    /// the internal encoding.
     /// </summary>
     public interface ISearchTool
     {
@@ -25,8 +26,8 @@ namespace CST.Tools
         /// <summary>
         /// "Search results in context" (the concordance/KWIC bridge): each occurrence of a term in one book
         /// as a hit-centered <b>snippet</b> plus citation refs (paragraph number + per-edition pages), paged.
-        /// Keyed by the stable <paramref name="OccurrenceRequest.TermIpe"/> from a prior search. This is the
-        /// data behind both the agent loop (scan → cite/fetch) and the human concordance panel.
+        /// Pass the <c>Term</c> from a prior search (in whatever script it came back). This is the data behind
+        /// both the agent loop (scan → cite/fetch) and the human concordance panel.
         /// </summary>
         Task<IReadOnlyList<Occurrence>> GetOccurrencesAsync(OccurrenceRequest request, CancellationToken ct = default);
     }
@@ -71,11 +72,10 @@ namespace CST.Tools
         string? Note = null);
 
     /// <summary>One matching term and the books it occurs in.</summary>
-    /// <param name="Term">The term in the requested output script.</param>
-    /// <param name="TermIpe">The stable IPE form — use this as the key for <c>GetOccurrencesAsync</c>.</param>
+    /// <param name="Term">The term in the requested output script — pass it back verbatim as
+    /// <c>OccurrenceRequest.Term</c> to read it in context.</param>
     public sealed record SearchTermResult(
         string Term,
-        string TermIpe,
         int TotalCount,
         IReadOnlyList<BookHitSummary> Books);
 
@@ -86,11 +86,13 @@ namespace CST.Tools
         int Count);
 
     /// <summary>A request for a term's in-context occurrences within one book, paged.</summary>
+    /// <param name="Term">The term to locate, in any script (e.g. the romanized <c>Term</c> from a prior
+    /// search). Converted to the internal encoding for lookup — the caller never handles it.</param>
     /// <param name="MinChars">Prose snippet floor (rendered chars); null uses the engine default.</param>
     /// <param name="MaxChars">Prose snippet ceiling (rendered chars); null uses the engine default.</param>
     public sealed record OccurrenceRequest(
         string BookId,
-        string TermIpe,
+        string Term,
         bool IncludeVariantReadings = false,
         Script OutputScript = Script.Latin,
         int Skip = 0,


### PR DESCRIPTION
Batch of fixes from the **cold-agent test** (a fresh Claude Code session given only `local-api.json` + `llms.txt`). It surfaced exactly what we wanted: the agent **burned effort** round-tripping an opaque `termIpe` key (even resorting to Python to preserve the bytes) and **debugging a real bug** — `/v1/occurrences` returning `[]` for terms `search` confirms exist. Everything here is toward @fsnow's directive: **make it easy.** Part of epic #186.

## Bug: `/v1/occurrences` returned `[]` for known-nonzero terms
The tool passed the **already-IPE** key into `GetTermPositionsAsync`, which runs `Any2Ipe` **again** → mangled term → no index match → empty (no error, so the agent couldn't tell bug from no-match). Root cause: making the agent handle IPE at all.

## Redesign (the real fix): work only in readable Pāli
Dropped the opaque `termIpe` / `headwordIpe` fields. `search` returns `term` (romanized by default); you pass that **same `term`** back to `/v1/occurrences`. The server converts Latin→IPE **once, internally**. No opaque round-trip, no byte-preservation gymnastics.
- **Contract change** (from #232/#236): `SearchTermResult` drops `TermIpe`; `OccurrenceRequest.TermIpe` → `Term`; `DictionaryEntry` drops `HeadwordIpe`.

## Bug: `/v1/books` returned Devanagari names
Despite the romanized-default promise. Now romanized via `ScriptConverter`, with `?script=` to override.

## `llms.txt` for "easy"
- Replaced the IPE/opacity paragraph with the plain **search → `term` → occurrences** flow.
- Stated **empty array = no matches, not an error** (so an agent doesn't debug a non-bug).
- Noted `/v1/books` romanization + `?script=`.

## Tests
Contracts/tools/endpoints updated; added a `/v1/books` "no Devanagari leaked" assertion. **Full suite 551/551.**

Re-run the same cold prompt after merge — it should sail search → occurrences → passage → dictionary with no debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)