### PR TITLE
AI local API: script-conversion endpoint (#240)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Services.LocalApi;
+using CST.Avalonia.Services.Tools;
 using CST.Tools;
 using Moq;
 using Xunit;
@@ -34,7 +35,8 @@ namespace CST.Avalonia.Tests.Services
                     new List<SearchTermResult> { new("dhamma", 5, new List<BookHitSummary>()) },
                     TotalTermCount: 1, TotalOccurrenceCount: 5, TotalBookCount: 1, Truncated: false, Note: null));
 
-            _server = new LocalApiServer("5.0.0-test", _dir, Serilog.Log.Logger, search.Object);
+            _server = new LocalApiServer("5.0.0-test", _dir, Serilog.Log.Logger,
+                search.Object, dictionary: null, passage: null, script: new ScriptTool());
             await _server.StartAsync();
         }
 
@@ -82,6 +84,29 @@ namespace CST.Avalonia.Tests.Services
             var body = await resp.Content.ReadAsStringAsync();
             Assert.Contains(".xml", body);                                    // real book file names
             Assert.DoesNotContain(body, c => c >= '\u0900' && c <= '\u097F'); // names romanized, no Devanagari leaked
+        }
+
+        [Fact]
+        public async Task Scripts_endpoint_lists_script_names()
+        {
+            using var http = Authed();
+            var resp = await http.GetAsync("/v1/scripts");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Contains("Latin", await resp.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task Convert_endpoint_converts_to_the_requested_script()
+        {
+            using var http = Authed();
+            // Devanagari "dhamma" -> Latin: response must carry no Devanagari.
+            var resp = await http.PostAsync("/v1/convert",
+                Json("{\"text\":\"\\u0927\\u092e\\u094d\\u092e\",\"outputScript\":\"Latin\"}"));
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.DoesNotContain(body, c => c >= '\u0900' && c <= '\u097F');
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Tools/ScriptToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/ScriptToolTests.cs
@@ -1,0 +1,44 @@
+using CST.Avalonia.Services.Tools;
+using CST.Conversion;
+using CST.Tools;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Tools
+{
+    /// <summary>
+    /// The stateless script-conversion tool (#240): auto-detects input (mixed-script safe) and converts to the
+    /// requested script. Devanagari fixtures use \uXXXX escapes.
+    /// </summary>
+    public class ScriptToolTests
+    {
+        [Fact]
+        public void Scripts_lists_output_scripts_without_the_autodetect_sentinel()
+        {
+            var scripts = new ScriptTool().Scripts;
+
+            Assert.Contains("Latin", scripts);
+            Assert.Contains("Devanagari", scripts);
+            Assert.Contains("Ipe", scripts);
+            Assert.DoesNotContain("Unknown", scripts);   // Unknown is the auto-detect input sentinel, not an output
+        }
+
+        [Fact]
+        public void Convert_devanagari_to_latin_produces_romanized_text()
+        {
+            // Devanagari "dhamma": dha + ma + virama + ma
+            var result = new ScriptTool().Convert(new ConvertRequest("\u0927\u092e\u094d\u092e", Script.Latin));
+
+            Assert.Equal(Script.Latin, result.OutputScript);
+            Assert.NotEqual("", result.Text);
+            Assert.DoesNotContain(result.Text, c => c >= '\u0900' && c <= '\u097F'); // no Devanagari left
+        }
+
+        [Fact]
+        public void Convert_defaults_to_latin_and_auto_detects_input()
+        {
+            var result = new ScriptTool().Convert(new ConvertRequest("\u0927\u092e\u094d\u092e"));   // no OutputScript -> Latin
+            Assert.Equal(Script.Latin, result.OutputScript);
+            Assert.DoesNotContain(result.Text, c => c >= '\u0900' && c <= '\u097F');
+        }
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -975,6 +975,7 @@ public partial class App : Application
         services.AddSingleton<CST.Tools.ISearchTool, Services.Tools.SearchTool>();
         services.AddSingleton<CST.Tools.IDictionaryTool, Services.Tools.DictionaryTool>();
         services.AddSingleton<CST.Tools.IPassageTool, Services.Tools.PassageTool>();
+        services.AddSingleton<CST.Tools.IScriptTool, Services.Tools.ScriptTool>();
         services.AddTransient<TreeStateService>();
         
         // Indexing services

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -46,6 +46,9 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - `GET  /v1/dictionary/languages` - available dictionary language codes (e.g. "en", "hi").
 - `POST /v1/dictionary/lookup` - `{ language, query, outputScript?, maxEntries? }`
   -> entries `{ headword, meaningHtml }`.
+- `POST /v1/convert` - convert Pali text to another script. Body `{ text, outputScript }` -> `{ text, outputScript }`.
+  Input script is auto-detected and mixed-script input is handled in one pass.
+- `GET  /v1/scripts` - the valid script names for `outputScript` and the `?script=` params.
 
 ## A typical research flow
 

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -43,6 +43,7 @@ namespace CST.Avalonia.Services.LocalApi
         private readonly ISearchTool? _search;
         private readonly IDictionaryTool? _dictionary;
         private readonly IPassageTool? _passage;
+        private readonly IScriptTool? _script;
 
         private WebApplication? _app;
 
@@ -56,7 +57,8 @@ namespace CST.Avalonia.Services.LocalApi
 
         public LocalApiServer(
             string appVersion, string handshakeDirectory, Serilog.ILogger logger,
-            ISearchTool? search = null, IDictionaryTool? dictionary = null, IPassageTool? passage = null)
+            ISearchTool? search = null, IDictionaryTool? dictionary = null, IPassageTool? passage = null,
+            IScriptTool? script = null)
         {
             _appVersion = appVersion;
             _handshakeDirectory = handshakeDirectory;
@@ -64,6 +66,7 @@ namespace CST.Avalonia.Services.LocalApi
             _search = search;
             _dictionary = dictionary;
             _passage = passage;
+            _script = script;
         }
 
         public async Task StartAsync(CancellationToken ct = default)
@@ -230,6 +233,13 @@ namespace CST.Avalonia.Services.LocalApi
                         req.OutputScript, req.IncludeVariantReadings);
                     return Results.Json(await passage.FetchPassageAsync(pr, ct));
                 });
+            }
+
+            if (_script is { } scriptTool)
+            {
+                app.MapGet(v + "/scripts", () => Results.Json(scriptTool.Scripts));
+                app.MapPost(v + "/convert",
+                    (ConvertRequest req) => Results.Json(scriptTool.Convert(req)));
             }
 
             // Book catalog — agents need book ids to call the other tools. Always available (no service

--- a/src/CST.Avalonia/Services/Tools/ScriptTool.cs
+++ b/src/CST.Avalonia/Services/Tools/ScriptTool.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST.Conversion;
+using CST.Tools;
+
+namespace CST.Avalonia.Services.Tools
+{
+    /// <summary>
+    /// <see cref="IScriptTool"/> over <see cref="ScriptConverter"/> (surface C, #240). Stateless: converts
+    /// text to the requested script, always auto-detecting the input via <see cref="Script.Unknown"/> — so
+    /// <see cref="ScriptConverter"/> splits mixed input into per-script runs and converts each correctly.
+    /// </summary>
+    public sealed class ScriptTool : IScriptTool
+    {
+        private static readonly IReadOnlyList<string> AllScripts =
+            Enum.GetNames<Script>().Where(n => n != nameof(Script.Unknown)).ToList();
+
+        public IReadOnlyList<string> Scripts => AllScripts;
+
+        public ConvertResult Convert(ConvertRequest request)
+        {
+            string converted = ScriptConverter.Convert(request.Text ?? string.Empty, Script.Unknown, request.OutputScript);
+            return new ConvertResult(converted, request.OutputScript);
+        }
+    }
+}

--- a/src/CST.Core/Tools/ScriptToolContracts.cs
+++ b/src/CST.Core/Tools/ScriptToolContracts.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using CST.Conversion;
+
+namespace CST.Tools
+{
+    /// <summary>
+    /// A stateless script-conversion tool (AI_INTEGRATION.md surface C, #240). Converts Pāli text to a target
+    /// script; the input is always auto-detected. The converters detect and convert per character-run, so
+    /// mixed-script input is handled correctly in a single pass — the caller only names the desired output.
+    /// No corpus/index — a thin wrapper over <see cref="ScriptConverter"/>.
+    /// </summary>
+    public interface IScriptTool
+    {
+        /// <summary>The script names that can be requested as output — excludes the auto-detect sentinel.</summary>
+        IReadOnlyList<string> Scripts { get; }
+
+        /// <summary>Convert <see cref="ConvertRequest.Text"/> to <see cref="ConvertRequest.OutputScript"/>.</summary>
+        ConvertResult Convert(ConvertRequest request);
+    }
+
+    /// <summary>A conversion request — text plus the desired output script. Input is auto-detected (mixed-script safe).</summary>
+    public sealed record ConvertRequest(
+        string Text,
+        Script OutputScript = Script.Latin);
+
+    /// <summary>The converted text.</summary>
+    public sealed record ConvertResult(
+        string Text,
+        Script OutputScript);
+}


### PR DESCRIPTION
Closes #240. A stateless **script-conversion** tool on the local API (surface C, epic #186) — a quick win over the existing `ScriptConverter`.

## What
- **`IScriptTool` / `ScriptTool`** — `Convert(text, outputScript)` → converted text. **Input is always auto-detected** (`Script.Unknown`), so the converters split mixed-script input into per-run pieces and convert each correctly in a single pass; the caller only names the desired output. `Scripts` lists the valid output names (all except the `Unknown` auto-detect sentinel).
- **Endpoints:** `POST /v1/convert` `{ text, outputScript }`; `GET /v1/scripts`. DI-registered and passed to `LocalApiServer`.
- **`llms.txt`** documents both, noting auto-detect + mixed-script handling.

## Design note (per @fsnow)
The converters handle **multiple scripts per run**, so forcing a single input script — or reporting one `detectedScript` — would be *wrong* for mixed text. So: auto-detect only, no `inputScript`/`detectedScript` fields. Text in, target script out.

## Tests
**29 tool/API tests** (5 new): `Scripts` excludes `Unknown`; Devanagari→Latin romanizes (no Devanagari remains); default output is Latin; `/v1/scripts` and `/v1/convert` endpoints. App builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)