### PR TITLE
AI local API: cold-test batch 2 — romanize bookName, doc polish (#186)

### DIFF
--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -33,7 +33,8 @@ namespace CST.Avalonia.Tests.Tools
 
         private static SearchResult OneTermResult(out Book book)
         {
-            book = new Book { FileName = "s0101m.mul.xml", LongNavPath = "Sutta > Digha > Silakkhandhavagga" };
+            // Nav path stored in Devanagari (as the real catalog is), to verify bookName is romanized on output.
+            book = new Book { FileName = "s0101m.mul.xml", LongNavPath = "\u0938\u0941\u0924\u094d\u0924" };
             return new SearchResult
             {
                 Terms = new List<MatchingTerm>
@@ -96,7 +97,8 @@ namespace CST.Avalonia.Tests.Tools
 
             var hit = Assert.Single(term.Books);
             Assert.Equal(book.FileName, hit.BookId);
-            Assert.Equal(book.LongNavPath, hit.BookName);
+            Assert.False(string.IsNullOrEmpty(hit.BookName));
+            Assert.DoesNotContain(hit.BookName, c => c >= '\u0900' && c <= '\u097F'); // bookName romanized, not Devanagari
             Assert.Equal(7, hit.Count);
         }
 

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -16,8 +16,13 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 
 ## Conventions
 
-- Pali output is ROMANIZED (Latin / IAST, with diacritics) by DEFAULT. Pass `outputScript` to override,
-  e.g. "Devanagari", "Thai", "Myanmar", "Sinhala" (14 scripts are supported).
+- Pali output is ROMANIZED by DEFAULT. The romanized script token is `"Latin"` (IAST, with diacritics). Pass
+  `outputScript` to override (e.g. "Devanagari", "Thai", "Myanmar", "Sinhala"); `GET /v1/scripts` lists every
+  valid value.
+- Cursors (`prevCursor` / `nextCursor` from `/v1/passage`) are INTEGERS, and opaque - pass one back verbatim
+  as `cursor` to page; do not interpret them or do arithmetic on them. `null` means the start/end of the book.
+- Response shape is per endpoint: `/v1/search`, `/v1/passage`, `/v1/convert`, `/v1/status` return a JSON
+  object; `/v1/occurrences`, `/v1/dictionary/lookup`, `/v1/books`, `/v1/scripts` return a bare JSON array.
 - You work entirely in readable Pali (romanized by default). To read a search hit in context, pass the
   term's `term` value (exactly as `/v1/search` returned it, in whatever script you requested) back to
   `/v1/occurrences` as `term`. There is no opaque id to round-trip - the server handles the internal encoding.
@@ -33,16 +38,20 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - `GET  /v1/status` - app version, API version, readiness.
 - `GET  /v1/books` - the catalog. Each: `{ bookId, name, shortName, pitaka, commentaryLevel, bookType, indexed }`.
   `name`/`shortName` are romanized by default; add `?script=Devanagari` (etc.) to change.
-- `POST /v1/search` - matching terms (a wildcard/regex expands to many inflected forms).
+- `POST /v1/search` - matching terms. Wildcard/regex match LITERAL character patterns, not grammatical
+  inflections: a trailing `*` is a prefix match, so it will not catch inflected endings unless the stem
+  before the `*` already covers them - broaden the stem or use a regex for full inflectional coverage.
   Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, proximityDistance?, outputScript? }`.
-  Returns terms, each with the books it occurs in and counts.
+  Returns `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, truncated, note }`; when `truncated`
+  is true (e.g. `maxTerms` was reached), `note` explains and more forms exist beyond the cap.
 - `POST /v1/occurrences` - "search results in context": KWIC snippets plus citation refs for one term in one
   book. Body: `{ bookId, term, includeVariantReadings?, outputScript?, skip?, take?, minChars?, maxChars? }`
   where `term` is a `term` value from a prior `/v1/search`.
   Each occurrence: a hit-centered snippet, the paragraph number, and the per-edition page numbers.
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
   Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeVariantReadings? }`.
-  Page forward/backward by passing back `prevCursor` / `nextCursor`.
+  Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, ... }`. Page by passing back the
+  integer `prevCursor` / `nextCursor` as `cursor` (see the cursor note above).
 - `GET  /v1/dictionary/languages` - available dictionary language codes (e.g. "en", "hi").
 - `POST /v1/dictionary/lookup` - `{ language, query, outputScript?, maxEntries? }`
   -> entries `{ headword, meaningHtml }`.

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -49,7 +49,8 @@ namespace CST.Avalonia.Services.Tools
                 TotalCount: t.TotalCount,
                 Books: t.Occurrences.Select(o => new BookHitSummary(
                     BookId: o.Book?.FileName ?? string.Empty,
-                    BookName: o.Book?.LongNavPath ?? string.Empty,
+                    // Nav paths are stored Devanagari; romanize to the requested script like everything else. (#186 cold test)
+                    BookName: ScriptConverter.Convert(o.Book?.LongNavPath ?? string.Empty, Script.Devanagari, request.OutputScript),
                     Count: o.Count)).ToList())).ToList();
 
             return new SearchToolResult(
@@ -91,9 +92,11 @@ namespace CST.Avalonia.Services.Tools
                 MinChars: request.MinChars ?? 60,
                 MaxChars: request.MaxChars ?? 320);
 
-            string bookName = Books.Inst
+            string rawBookName = Books.Inst
                 .FirstOrDefault(b => string.Equals(b.FileName, request.BookId, StringComparison.OrdinalIgnoreCase))
                 ?.LongNavPath ?? request.BookId;
+            // Nav paths are stored Devanagari; romanize to the requested script. (#186 cold test)
+            string bookName = ScriptConverter.Convert(rawBookName, Script.Devanagari, request.OutputScript);
 
             var occurrences = new List<Occurrence>();
             foreach (var p in positions.OrderBy(p => p.StartOffset).Skip(request.Skip).Take(request.Take))


### PR DESCRIPTION
Second **fresh-eyes** cold run passed all 5 tasks cleanly (occurrences, passage paging, dictionary all work now). This addresses its friction log. Part of epic #186.

## Bug
- **`bookName` in `/v1/search` & `/v1/occurrences` results stayed Devanagari**, ignoring `outputScript`. #239 fixed `/v1/books`, but the search tool's own DTO mapping passed `Book.LongNavPath` (Devanagari) through unconverted. Now romanized via `ScriptConverter`, like terms/snippets.

## `llms.txt` polish (the rest of the log)
- **Name the romanized token** explicitly (`"Latin"`); point at `GET /v1/scripts` for the full list.
- **Cursors are integers, opaque** — pass back verbatim as `cursor`, don't interpret/do arithmetic; `null` = start/end.
- **Wildcard/regex match literal patterns** (a trailing `*` is a prefix), *not* grammatical inflections — broaden the stem or use regex for full coverage.
- **Per-endpoint response shape** documented (object vs. bare array), and the `truncated`/`note` fields on `/v1/search` (they already exist — `SearchService` sets them on the `maxTerms` cap).

## Notes
- The report's `/v1/scripts` empty-body + "which token is romanized?" findings were from a **build predating #241** (which adds `/v1/scripts` and lists `"Latin"`) — resolved once that build runs.
- Tests: search fixture's nav path → Devanagari, asserts `bookName` comes back romanized. **29 tool/API tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)