### PR TITLE
AI local API: cold-test batch 3 — occurrence cursor, unknown-book 404, search docs

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
@@ -110,6 +110,16 @@ namespace CST.Avalonia.Tests.Services
         }
 
         [Fact]
+        public async Task Occurrences_with_unknown_book_returns_404_not_500()
+        {
+            using var http = Authed();
+            var resp = await http.PostAsync("/v1/occurrences",
+                Json("{\"bookId\":\"no-such-book.xml\",\"term\":\"x\"}"));
+
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+
+        [Fact]
         public async Task Unprovided_tool_endpoint_is_not_mapped()
         {
             // No dictionary tool was supplied, so its endpoint doesn't exist.

--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -157,6 +157,7 @@ namespace CST.Avalonia.Tests.Tools
                 Assert.Contains(o.Refs.Pages, p => p.Edition == PageEdition.Vri && p.Volume == 1 && p.Number == 3);
                 Assert.Equal(book, o.BookId);
                 Assert.False(string.IsNullOrEmpty(o.BookName));
+                Assert.Equal(hit, o.Cursor);   // unique locator = the hit's char offset (for /v1/passage)
             }
             finally
             {

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -38,16 +38,27 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - `GET  /v1/status` - app version, API version, readiness.
 - `GET  /v1/books` - the catalog. Each: `{ bookId, name, shortName, pitaka, commentaryLevel, bookType, indexed }`.
   `name`/`shortName` are romanized by default; add `?script=Devanagari` (etc.) to change.
-- `POST /v1/search` - matching terms. Wildcard/regex match LITERAL character patterns, not grammatical
-  inflections: a trailing `*` is a prefix match, so it will not catch inflected endings unless the stem
-  before the `*` already covers them - broaden the stem or use a regex for full inflectional coverage.
+- `POST /v1/search` - matching terms. Search is over WHOLE-WORD tokens matched as LITERAL character
+  patterns, not grammatical inflections. To cover a stem's inflected endings, reach FIRST for a trailing
+  `*` WILDCARD (`dhamm*`): the `*` absorbs the case/number endings, so you do NOT need to hand-write a
+  regex enumerating declension suffixes. Use `mode: "Regex"` only for patterns a wildcard can't express.
+  Sandhi caveat: the VRI edition faithfully preserves Pali sandhi (with few exceptions), so a "word" is
+  often a long euphonic compound and your target stem can sit in the MIDDLE of a token, not at its start -
+  a prefix `stem*` will miss those. Regex is .NET syntax (System.Text.RegularExpressions) and matches
+  ANYWHERE in a token (substring), so it catches those interior occurrences; anchor with `^...$` for
+  whole-word forms (else e.g. `mett` also matches inside `alamettavata`). Handy middle ground: a
+  length-bounded anchored regex like `^dhamm.{1,6}$` catches a stem's inflectional endings while
+  EXCLUDING longer sandhi compounds - `.{1,6}` allows 1-6 trailing chars, `$` stops it running into the
+  next word.
   Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, proximityDistance?, outputScript? }`.
   Returns `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, truncated, note }`; when `truncated`
   is true (e.g. `maxTerms` was reached), `note` explains and more forms exist beyond the cap.
 - `POST /v1/occurrences` - "search results in context": KWIC snippets plus citation refs for one term in one
   book. Body: `{ bookId, term, includeVariantReadings?, outputScript?, skip?, take?, minChars?, maxChars? }`
   where `term` is a `term` value from a prior `/v1/search`.
-  Each occurrence: a hit-centered snippet, the paragraph number, and the per-edition page numbers.
+  Each occurrence: a hit-centered snippet, the paragraph number, the per-edition page numbers, and a
+  `cursor` - pass that cursor to `/v1/passage` to read the exact passage around THIS hit (paragraph numbers
+  repeat within a book, so the paragraph number alone is not a unique locator).
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
   Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeVariantReadings? }`.
   Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, ... }`. Page by passing back the
@@ -64,5 +75,6 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 1. `POST /v1/search` for a word -> pick the inflected form(s) you want (keep each `term`).
 2. `POST /v1/occurrences` for that `term` in a book -> scan the concordance snippets; cite by paragraph
    and per-edition page.
-3. `POST /v1/passage` at a paragraph -> read the surrounding text, paging with the cursor if you need more.
+3. `POST /v1/passage` with an occurrence's `cursor` -> read the exact passage around that hit; page with
+   `prevCursor` / `nextCursor` for more. (Open by paragraph only when you don't have a cursor.)
 4. `POST /v1/dictionary/lookup` -> gloss unfamiliar words.

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -160,6 +160,10 @@ namespace CST.Avalonia.Services.LocalApi
         private static Script ParseScript(string? name) =>
             Enum.TryParse<Script>(name, ignoreCase: true, out var script) ? script : Script.Latin;
 
+        private static bool BookExists(string? bookId) =>
+            !string.IsNullOrEmpty(bookId) &&
+            Books.Inst.Any(b => string.Equals(b.FileName, bookId, StringComparison.OrdinalIgnoreCase));
+
         private static bool IsDiscoveryPath(PathString path) =>
             !path.HasValue || path == "/"
             || path.Equals("/llms.txt", StringComparison.OrdinalIgnoreCase)
@@ -211,8 +215,10 @@ namespace CST.Avalonia.Services.LocalApi
             {
                 app.MapPost(v + "/search",
                     async (SearchToolRequest req, CancellationToken ct) => Results.Json(await search.SearchAsync(req, ct)));
-                app.MapPost(v + "/occurrences",
-                    async (OccurrenceRequest req, CancellationToken ct) => Results.Json(await search.GetOccurrencesAsync(req, ct)));
+                app.MapPost(v + "/occurrences", async (OccurrenceRequest req, CancellationToken ct) =>
+                    BookExists(req.BookId)
+                        ? Results.Json(await search.GetOccurrencesAsync(req, ct))
+                        : Results.NotFound(new { error = $"Unknown book '{req.BookId}'." }));
             }
 
             if (_dictionary is { } dictionary)
@@ -226,6 +232,8 @@ namespace CST.Avalonia.Services.LocalApi
             {
                 app.MapPost(v + "/passage", async (PassageHttpRequest req, CancellationToken ct) =>
                 {
+                    if (!BookExists(req.BookId))
+                        return Results.NotFound(new { error = $"Unknown book '{req.BookId}'." });
                     NavigationReference reference = req.Paragraph is int n
                         ? new NavigationReference.Paragraph(n, req.BookCode)
                         : new NavigationReference.WholeBook();

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -810,9 +810,11 @@ public class SearchService : ISearchService
         try
         {
             reader = AcquireReader();
-            var books = Books.Inst;
-            var book = books[bookFileName];
-            
+            // Books' string indexer throws on an unknown file name; use a safe lookup so a bad bookId can't
+            // become an unhandled 500 in the occurrences endpoint. (#186 cold test)
+            var book = Books.Inst.FirstOrDefault(b =>
+                string.Equals(b.FileName, bookFileName, StringComparison.OrdinalIgnoreCase));
+
             if (book == null || book.DocId < 0)
             {
                 return new List<TermPosition>();

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -110,7 +110,10 @@ namespace CST.Avalonia.Services.Tools
                     HitStart: s.HitStart,
                     HitLength: s.HitLength,
                     Refs: new OccurrenceRefs(s.ParagraphNumber, s.ParagraphBookCode, s.Pages),
-                    IncludedVariants: s.IncludedVariants));
+                    IncludedVariants: s.IncludedVariants,
+                    // The hit's char offset — a unique locator to read the exact passage via /v1/passage
+                    // (paragraph numbers repeat within a book). (#186 cold test)
+                    Cursor: p.StartOffset));
             }
             return occurrences;
         }

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -110,6 +110,9 @@ namespace CST.Tools
     /// One occurrence of a term, shown in context: a hit-centered snippet (term at
     /// <c>[HitStart, HitStart+HitLength)</c>, romanized) plus its citation refs.
     /// </summary>
+    /// <param name="Cursor">The hit's unique locator — pass it to <c>/v1/passage</c> as <c>cursor</c> to read
+    /// the exact passage around <em>this</em> occurrence. (Paragraph numbers repeat within a book, so they are
+    /// not a unique locator.)</param>
     public sealed record Occurrence(
         string BookId,
         string BookName,
@@ -117,5 +120,6 @@ namespace CST.Tools
         int HitStart,
         int HitLength,
         OccurrenceRefs Refs,
-        bool IncludedVariants);
+        bool IncludedVariants,
+        int Cursor);
 }


### PR DESCRIPTION
Third cold-agent friction log against surface C (the local corpus API). Findings fixed:

**1. Occurrences had no unique locator back to a passage.** Paragraph numbers repeat within a book, so an occurrence's paragraph number alone couldn't address "read the passage around *this* hit." `Occurrence` now carries a `Cursor` (the hit's character offset); pass it to `/v1/passage` as `cursor`. Documented in `llms.txt` and the typical-flow steps.

**2. Unknown `bookId` → 500.** `Books`' string indexer throws on an unknown file name, surfacing as an unhandled 500 on `/v1/occurrences`. `SearchService.GetTermPositionsAsync` now uses a safe `FirstOrDefault` lookup, and `LocalApiServer` validates `bookId` up front on both `/v1/occurrences` and `/v1/passage`, returning **404** with a clear message.

**3. Search guidance.** The cold agent reached for a regex enumerating declension suffixes rather than a wildcard. `llms.txt` now:
- steers to a trailing `*` wildcard first for inflectional coverage (the `*` absorbs case/number endings — no need to hand-write suffixes);
- documents that Regex mode is **.NET** syntax (`System.Text.RegularExpressions`), matches **anywhere in a token** (substring), and the `^stem.{1,6}$` bounded idiom (catches inflectional tails, excludes long compounds);
- notes that the VRI edition faithfully preserves Pāli **sandhi**, so a "word" is often a long euphonic compound and the target stem may sit mid-token (which is why an interior-matching regex is sometimes needed).

Tests: `Cursor` assertion in the occurrences test; a `404-not-500` endpoint test. `llms.txt` verified all-ASCII. Full suite green (557 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)