### PR TITLE
AI local API: cold-test batch 4 — document the occurrences `refs` shape

### DIFF
--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -56,9 +56,13 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - `POST /v1/occurrences` - "search results in context": KWIC snippets plus citation refs for one term in one
   book. Body: `{ bookId, term, includeVariantReadings?, outputScript?, skip?, take?, minChars?, maxChars? }`
   where `term` is a `term` value from a prior `/v1/search`.
-  Each occurrence: a hit-centered snippet, the paragraph number, the per-edition page numbers, and a
-  `cursor` - pass that cursor to `/v1/passage` to read the exact passage around THIS hit (paragraph numbers
-  repeat within a book, so the paragraph number alone is not a unique locator).
+  Each occurrence is `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedVariants, cursor }`.
+  `snippet` is hit-centered with the term at `[hitStart, hitStart+hitLength)`. Citation data is NESTED
+  under `refs` (NOT top-level as on `/v1/passage`): `refs.paragraphNumber`, `refs.paragraphBookCode`
+  (the Multi sub-book code, e.g. "kn17"), and `refs.pages[]` where each page is `{ edition, volume, number }`
+  (editions: VRI / Myanmar / PTS / Thai). `cursor` is the hit's unique locator - pass it to `/v1/passage`
+  as `cursor` to read the exact passage around THIS hit (paragraph numbers repeat within a book, so the
+  paragraph number alone is not a unique locator).
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
   Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeVariantReadings? }`.
   Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, ... }`. Page by passing back the


### PR DESCRIPTION
Fourth cold-agent friction log against surface C (the local corpus API). The agent completed **all five** research tasks — books/DN-mūla, search, occurrences-in-context, passage paging, dictionary — **unaided, from `/llms.txt` alone**, and the batch-3 guidance visibly paid off (it recognized `mettā*` was dominated by sandhi compounds and switched to the `^mett.{1,4}$` bounded regex on its own).

**One real finding — doc/response mismatch on `/v1/occurrences`:**
The docs described each hit as reporting "the paragraph number, the per-edition page numbers" as if those were top-level fields. They actually live nested under `refs` — and `/v1/passage` exposes *its* reference data top-level, so the two endpoints disagree in shape.

**Fix (docs, not contract):** `llms.txt` now documents the actual occurrence object —
`{ bookId, bookName, snippet, hitStart, hitLength, refs, includedVariants, cursor }` — and names the nested citation fields: `refs.paragraphNumber`, `refs.paragraphBookCode` (Multi sub-book code, e.g. `kn17`), `refs.pages[] = { edition, volume, number }` (VRI / Myanmar / PTS / Thai), explicitly calling out that this is nested, unlike passage. Field names verified against `SnippetPageRef`.

I chose to document rather than reshape the contract: the data was all present, the agent still cited correctly, and nesting refs per-occurrence is reasonable (occurrences is an array of hits; passage is a single window). Happy to align the shapes instead if you'd prefer consistency over stability.

Other friction-log items needed no code change — the metteyya proper-name mixing is a semantic judgment left to the caller, and the "kinduess" gloss is an OCR artifact in the underlying dictionary data surfaced faithfully.

Docs-only change to the embedded `llms.txt`; verified all-ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)