### PR TITLE
AI local API: cold-test batch 5 — worked inflection recipe + rendered page example

### DIFF
--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -60,7 +60,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   `snippet` is hit-centered with the term at `[hitStart, hitStart+hitLength)`. Citation data is NESTED
   under `refs` (NOT top-level as on `/v1/passage`): `refs.paragraphNumber`, `refs.paragraphBookCode`
   (the Multi sub-book code, e.g. "kn17"), and `refs.pages[]` where each page is `{ edition, volume, number }`
-  (editions: VRI / Myanmar / PTS / Thai). `cursor` is the hit's unique locator - pass it to `/v1/passage`
+  - e.g. `{ "edition": "Vri", "volume": 3, "number": 196 }`, conventionally cited "VRI 3:196" (edition
+  values: `Vri`, `Myanmar`, `Pts`, `Thai`). `cursor` is the hit's unique locator - pass it to `/v1/passage`
   as `cursor` to read the exact passage around THIS hit (paragraph numbers repeat within a book, so the
   paragraph number alone is not a unique locator).
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
@@ -76,7 +77,12 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 
 ## A typical research flow
 
-1. `POST /v1/search` for a word -> pick the inflected form(s) you want (keep each `term`).
+1. `POST /v1/search` for a word -> keep each `term` you want. NOTE: `mode: "Exact"` matches ONE literal
+   whole-word form, so its `totalOccurrenceCount` is that single form's count, NOT the stem's whole
+   footprint. To gather a stem's inflectional family (nominative, accusative, instrumental... together),
+   follow up with a length-bounded anchored regex - `{ "query": "^metta.{1,4}$", "mode": "Regex" }`
+   returns each case-form (`metta`, `mettam`, `mettaya`, `mettena`, ...) as its own `term` with its own
+   count. Use `stem*` (Wildcard) instead when you also WANT the compounds. (See the /v1/search note above.)
 2. `POST /v1/occurrences` for that `term` in a book -> scan the concordance snippets; cite by paragraph
    and per-edition page.
 3. `POST /v1/passage` with an occurrence's `cursor` -> read the exact passage around that hit; page with


### PR DESCRIPTION
Fifth cold-agent friction log against surface C. The agent again completed **all five** research tasks unaided from `/llms.txt`, and confirmed batch-4 landed: it called the nested-`refs` pre-warning *"a genuine gotcha that the docs defuse before you hit it."* No endpoint errored.

Two small doc additions, from the report's only concrete suggestions:

**1. A worked "get all inflections of a stem" recipe.** The report flagged the most likely early stumble: a newcomer runs only `mode: "Exact"`, sees "mettā → 393", and concludes that's the stem's footprint — when Exact matches *one literal form* and the real footprint (incl. `mettaṃ`, `mettāya`, `mettena`) is ~1600. Typical-flow step 1 now spells out the recipe inline: Exact = one form → follow up with `^metta.{1,4}$` Regex to gather the case-forms as separate terms, or `stem*` when you also want the compounds.

**2. A rendered `refs.pages` example.** The doc named the fields but showed no rendered citation. Now: `{ "edition": "Vri", "volume": 3, "number": 196 }` → conventionally "VRI 3:196", with the exact edition enum values (`Vri`, `Myanmar`, `Pts`, `Thai`).

The remaining friction-log items are not API defects: the Metteyya/mettā homograph mixing is a semantic judgment left to the caller, and the dictionary being en+hi with raw `meaningHtml` is expected.

Docs-only change to the embedded `llms.txt`; verified all-ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)