### PR TITLE
AI local API: wire IScriptTool into the server (fix /v1/scripts + /v1/convert 404)

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -332,7 +332,8 @@ public partial class App : Application
                 version, dir, Log.Logger,
                 ServiceProvider?.GetService<CST.Tools.ISearchTool>(),
                 ServiceProvider?.GetService<CST.Tools.IDictionaryTool>(),
-                ServiceProvider?.GetService<CST.Tools.IPassageTool>());
+                ServiceProvider?.GetService<CST.Tools.IPassageTool>(),
+                ServiceProvider?.GetService<CST.Tools.IScriptTool>());
             await _localApiServer.StartAsync();
         }
         catch (Exception ex)

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -262,6 +262,12 @@ namespace CST.Avalonia.Services.LocalApi
                     ScriptConverter.Convert(b.ShortNavPath, Script.Devanagari, outputScript),
                     b.Pitaka, b.Matn, b.BookType, b.DocId >= 0)).ToList());
             });
+
+            // Surface which tool groups got wired, so a missing DI hand-off (e.g. a null IScriptTool leaving
+            // /v1/scripts + /v1/convert unmapped -> 404) is visible in the log instead of only at call time.
+            _logger.Information(
+                "Local API tools wired: search={Search} dictionary={Dictionary} passage={Passage} script={Script}",
+                _search != null, _dictionary != null, _passage != null, _script != null);
         }
 
         private sealed record RootResponse(string Name, string App, string Api, string Docs, string Status);


### PR DESCRIPTION
The sixth cold-agent run (the new Devanagari/Abhidhamma endpoint-coverage prompt) caught a **real bug** on its first unused-endpoint task: `GET /v1/scripts` returned **404** despite being documented, and `/v1/convert` would have too.

**Root cause:** `IScriptTool` is registered in DI (`App.axaml.cs:978`), but the `LocalApiServer` construction (`App.axaml.cs:331`) passed only `ISearchTool`/`IDictionaryTool`/`IPassageTool` and **omitted the script tool**. With `_script` null, `MapToolEndpoints` never maps `/v1/scripts` or `/v1/convert` — hence 404, not 500.

**Why it slipped through:** the endpoint tests construct `LocalApiServer` with a `ScriptTool` passed in directly, so they verified the endpoints *work when the tool is present* — but nothing exercised the app's positional hand-wiring, where the argument was simply missing.

**Fix:**
- Pass `ServiceProvider`'s `IScriptTool` as the fourth tool argument.
- Log which tool groups are wired at startup (`search=… dictionary=… passage=… script=…`), so a future missing hand-off shows up in the log rather than only as a call-time 404.

Build clean; tool + local-api endpoint tests green (30).

Note: this is exactly the kind of gap the "force the unused endpoints" prompt variant was designed to expose — the earlier mettā/DN task set never called `/v1/scripts` or `/v1/convert`, so the omission stayed invisible across five green runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)