### PR TITLE
AI local API: cold-test batch 7a — fail-loud fixes, apparatus braces, no IPE

### DIFF
--- a/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
+++ b/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
@@ -56,6 +56,7 @@ namespace CST.Avalonia.Tests.Search
             Assert.DoesNotContain("aaa", r.Snippet);   // neighbor sentence, floor off
             Assert.DoesNotContain("ggg", r.Snippet);   // neighbor sentence
             Assert.DoesNotContain("VAR", r.Snippet);   // footnote excluded by default
+            Assert.DoesNotContain("{", r.Snippet);     // ...and no apparatus braces when notes are off
             Assert.DoesNotContain("Q", r.Snippet);     // paranum marker not in window
         }
 
@@ -77,6 +78,12 @@ namespace CST.Avalonia.Tests.Search
             var with = TeiSnippetExtractor.Extract(Prose, hs, 6, markers, Deva(min: 1, notes: true));
 
             Assert.Contains("VAR", with.Snippet);
+            // Included apparatus is delimited by curly braces (absent from the corpus) so a consumer can tell
+            // it from base text; the note content sits inside a `{...}`.
+            int open = with.Snippet.IndexOf('{');
+            int close = with.Snippet.IndexOf('}');
+            Assert.True(open >= 0 && close > open, "note should be wrapped in { }");
+            Assert.Contains("VAR", with.Snippet.Substring(open, close - open));
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -41,6 +41,30 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void ReadWindow_wraps_included_notes_in_braces()
+        {
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<pb ed=\"V\" n=\"1.0001\"/>" +
+                "<p rend=\"bodytext\" n=\"5\">alpha bravo <note>VAR (si)</note> charlie</p>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(xml);
+            int start = markers.PositionOfParagraph(5);
+
+            var off = TeiPassageReader.ReadWindow(xml, start, maxChars: 10000, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+            Assert.DoesNotContain("VAR", off.Text);   // note stripped by default
+            Assert.DoesNotContain("{", off.Text);
+
+            var on = TeiPassageReader.ReadWindow(xml, start, maxChars: 10000, includeVariants: true,
+                outputScript: Script.Devanagari, markers);
+            int open = on.Text.IndexOf('{');
+            int close = on.Text.IndexOf('}');
+            Assert.True(open >= 0 && close > open, "note should be wrapped in { }");
+            Assert.Contains("VAR", on.Text.Substring(open, close - open));
+        }
+
+        [Fact]
         public void ReadWindow_large_budget_reaches_end()
         {
             var markers = BookMarkers.Build(Xml);

--- a/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
@@ -110,6 +110,40 @@ namespace CST.Avalonia.Tests.Services
         }
 
         [Fact]
+        public async Task Search_with_unknown_filter_key_returns_400_not_silent_unfiltered()
+        {
+            // A misnamed filter key (the agent's guessed shape) must fail loud, not bind to all-defaults and
+            // silently return the unfiltered corpus. JsonUnmappedMemberHandling.Disallow -> 400.
+            using var http = Authed();
+            var resp = await http.PostAsync("/v1/search",
+                Json("{\"query\":\"x\",\"filter\":{\"commentaryLevel\":\"Mula\"}}"));
+
+            Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Search_with_valid_filter_keys_still_works()
+        {
+            using var http = Authed();
+            var resp = await http.PostAsync("/v1/search",
+                Json("{\"query\":\"x\",\"filter\":{\"mula\":false,\"atthakatha\":true,\"tika\":true}}"));
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Convert_to_Ipe_outputScript_is_rejected_400()
+        {
+            // IPE is a legacy internal font encoding and must never be exposed to clients: requesting it as an
+            // outputScript is a 400, not glyph bytes.
+            using var http = Authed();
+            var resp = await http.PostAsync("/v1/convert",
+                Json("{\"text\":\"dhamma\",\"outputScript\":\"Ipe\"}"));
+
+            Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        }
+
+        [Fact]
         public async Task Occurrences_with_unknown_book_returns_404_not_500()
         {
             using var http = Authed();

--- a/src/CST.Avalonia.Tests/Tools/ScriptToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/ScriptToolTests.cs
@@ -18,8 +18,8 @@ namespace CST.Avalonia.Tests.Tools
 
             Assert.Contains("Latin", scripts);
             Assert.Contains("Devanagari", scripts);
-            Assert.Contains("Ipe", scripts);
             Assert.DoesNotContain("Unknown", scripts);   // Unknown is the auto-detect input sentinel, not an output
+            Assert.DoesNotContain("Ipe", scripts);       // Ipe is a legacy non-Unicode font encoding, useless to an agent
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -103,6 +103,24 @@ namespace CST.Avalonia.Tests.Tools
         }
 
         [Fact]
+        public async Task SearchAsync_flags_wildcard_chars_used_in_Exact_mode()
+        {
+            var mock = new Mock<ISearchService>();
+            mock.Setup(s => s.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new SearchResult());
+            var tool = new SearchTool(mock.Object, Settings());
+
+            // Exact mode + '*' -> literal, matches nothing: the note must warn instead of silently returning [].
+            var flagged = await tool.SearchAsync(new SearchToolRequest("dhamm*", SearchToolMode.Exact));
+            Assert.NotNull(flagged.Note);
+            Assert.Contains("Wildcard", flagged.Note);
+
+            // Wildcard mode: no footgun note.
+            var clean = await tool.SearchAsync(new SearchToolRequest("dhamm*", SearchToolMode.Wildcard));
+            Assert.Null(clean.Note);
+        }
+
+        [Fact]
         public async Task SearchAsync_null_filter_defaults_to_include_all()
         {
             SearchQuery? captured = null;

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -31,13 +31,25 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - Books are identified by file name (e.g. `s0101m.mul.xml`). Get the list from `GET /v1/books`.
 - References: the paragraph number is the primary citation unit; page numbers exist per edition
   (VRI / Myanmar / PTS / Thai). Search occurrences report both.
+- Variant readings / apparatus (`includeVariantReadings: true` on `/v1/occurrences` and `/v1/passage`): the
+  texts carry the print editions' FOOTNOTES (Myanmar 1955-57 / VRI 1995-96), rendered INLINE and wrapped in
+  curly braces `{...}`. Curly braces occur nowhere else in the corpus, so they reliably delimit apparatus from
+  base text - split on `{...}` to extract each note. Inside a note, position disambiguates: a `(...)` group
+  names the WITNESS edition(s) attesting the reading; a short token FOLLOWED BY A NUMBER is a CROSS-REFERENCE
+  to another text. (Same token can differ by position: `(ka)` = the Cambodian edition, but `ka 2` = a
+  cross-reference, the Kaccayana grammar.) Witness sigla, romanized (diacritics dropped here; they arrive
+  script-converted to your `outputScript`): `sya`=Thai (Syama), `si`=Sinhala, `kam`/`ka`=Cambodian, `pi`=PTS.
+  These are digitized print footnotes - mostly variant readings, but also editorial notes and cross-refs, with
+  NO structural type marker, so any "variant vs footnote" split is your interpretation, not the data's.
 - Terminology: when writing about the texts, call them "Pali", "the Tipitaka", or "VRI texts".
 
 ## Endpoints
 
 - `GET  /v1/status` - app version, API version, readiness.
 - `GET  /v1/books` - the catalog. Each: `{ bookId, name, shortName, pitaka, commentaryLevel, bookType, indexed }`.
-  `name`/`shortName` are romanized by default; add `?script=Devanagari` (etc.) to change.
+  `name`/`shortName` are romanized by default; add `?script=Devanagari` (etc.) to change. Classify with
+  `commentaryLevel` (`Mula`/`Atthakatha`/`Tika`) and `pitaka`; `bookType` is a legacy field, often
+  `Unknown` - do not rely on it.
 - `POST /v1/search` - matching terms. Search is over WHOLE-WORD tokens matched as LITERAL character
   patterns, not grammatical inflections. To cover a stem's inflected endings, reach FIRST for a trailing
   `*` WILDCARD (`dhamm*`): the `*` absorbs the case/number endings, so you do NOT need to hand-write a
@@ -50,6 +62,16 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   length-bounded anchored regex like `^dhamm.{1,6}$` catches a stem's inflectional endings while
   EXCLUDING longer sandhi compounds - `.{1,6}` allows 1-6 trailing chars, `$` stops it running into the
   next word.
+  MODE MATTERS: `*`/`?` expand ONLY with `mode:"Wildcard"`, and regex patterns ONLY with `mode:"Regex"`; in
+  the default `Exact` mode those characters are LITERAL and match nothing (the response `note` flags this).
+  PROXIMITY: a multi-word `query` (space-separated) plus `proximityDistance` finds those words co-occurring
+  within N words; quote a run - `"a b"` - for an exact adjacent phrase; combine with `mode:"Wildcard"`/`"Regex"`
+  to expand each word before matching.
+  FILTER: `filter` is an object of booleans, all default true -
+  `{ vinaya, sutta, abhidhamma, mula, atthakatha, tika, other }`. The pitaka flags OR within their group, the
+  text-class flags OR within theirs, and the two groups AND together - so commentaries-only is
+  `{ "mula": false, "atthakatha": true, "tika": true }`. Unknown filter keys are REJECTED with 400 (so a
+  misnamed key can't silently return the unfiltered corpus).
   Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, proximityDistance?, outputScript? }`.
   Returns `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, truncated, note }`; when `truncated`
   is true (e.g. `maxTerms` was reached), `note` explains and more forms exist beyond the cap.
@@ -63,7 +85,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   - e.g. `{ "edition": "Vri", "volume": 3, "number": 196 }`, conventionally cited "VRI 3:196" (edition
   values: `Vri`, `Myanmar`, `Pts`, `Thai`). `cursor` is the hit's unique locator - pass it to `/v1/passage`
   as `cursor` to read the exact passage around THIS hit (paragraph numbers repeat within a book, so the
-  paragraph number alone is not a unique locator).
+  paragraph number alone is not a unique locator). `includedVariants` echoes your request flag (whether
+  variant readings were rendered), NOT whether this particular hit has any; see the apparatus note above.
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
   Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeVariantReadings? }`.
   Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, ... }`. Page by passing back the

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -81,7 +81,8 @@ namespace CST.Avalonia.Services.LocalApi
             builder.Services.ConfigureHttpJsonOptions(o =>
             {
                 o.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-                o.SerializerOptions.Converters.Add(new JsonStringEnumConverter()); // "Latin" not 3
+                o.SerializerOptions.Converters.Add(new ScriptJsonConverter()); // reject Ipe/Unknown outputScript (before the enum factory)
+                o.SerializerOptions.Converters.Add(new JsonStringEnumConverter()); // "Latin" not 3, for other enums
             });
 
             var app = builder.Build();
@@ -158,7 +159,9 @@ namespace CST.Avalonia.Services.LocalApi
             host is "127.0.0.1" or "localhost" or "[::1]" or "::1";
 
         private static Script ParseScript(string? name) =>
-            Enum.TryParse<Script>(name, ignoreCase: true, out var script) ? script : Script.Latin;
+            Enum.TryParse<Script>(name, ignoreCase: true, out var script)
+                && script is not (Script.Ipe or Script.Unknown)   // never expose the internal IPE font encoding
+                ? script : Script.Latin;
 
         private static bool BookExists(string? bookId) =>
             !string.IsNullOrEmpty(bookId) &&

--- a/src/CST.Avalonia/Services/LocalApi/ScriptJsonConverter.cs
+++ b/src/CST.Avalonia/Services/LocalApi/ScriptJsonConverter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CST.Conversion;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>
+    /// Boundary policy for the <see cref="Script"/> enum on the agent-facing API: accept the public output
+    /// scripts by name (case-insensitive), but REJECT <see cref="Script.Ipe"/> (a legacy CSCD *font* encoding
+    /// that emits non-Unicode glyph bytes) and <see cref="Script.Unknown"/> (the auto-detect *input* sentinel,
+    /// never a valid output). IPE is purely internal and must never be exposed to clients. Rejecting on read
+    /// turns a bad <c>outputScript</c> into a clean 400 instead of glyph soup — for every body endpoint at once,
+    /// since they all deserialize <c>outputScript</c> through this. (#186 cold test)
+    /// </summary>
+    internal sealed class ScriptJsonConverter : JsonConverter<Script>
+    {
+        public override Script Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string? name = reader.GetString();
+            if (!Enum.TryParse<Script>(name, ignoreCase: true, out var script)
+                || script is Script.Ipe or Script.Unknown)
+                throw new JsonException($"Unknown or unsupported script '{name}'. See GET /v1/scripts for valid values.");
+            return script;
+        }
+
+        public override void Write(Utf8JsonWriter writer, Script value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value.ToString());
+    }
+}

--- a/src/CST.Avalonia/Services/Tools/ScriptTool.cs
+++ b/src/CST.Avalonia/Services/Tools/ScriptTool.cs
@@ -13,8 +13,12 @@ namespace CST.Avalonia.Services.Tools
     /// </summary>
     public sealed class ScriptTool : IScriptTool
     {
+        // Exclude Unknown (the auto-detect sentinel) and Ipe (a legacy CSCD *font* encoding that emits
+        // non-Unicode glyph bytes, useless to an agent) from the advertised output scripts. (#186 cold test)
         private static readonly IReadOnlyList<string> AllScripts =
-            Enum.GetNames<Script>().Where(n => n != nameof(Script.Unknown)).ToList();
+            Enum.GetNames<Script>()
+                .Where(n => n != nameof(Script.Unknown) && n != nameof(Script.Ipe))
+                .ToList();
 
         public IReadOnlyList<string> Scripts => AllScripts;
 

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -53,13 +53,21 @@ namespace CST.Avalonia.Services.Tools
                     BookName: ScriptConverter.Convert(o.Book?.LongNavPath ?? string.Empty, Script.Devanagari, request.OutputScript),
                     Count: o.Count)).ToList())).ToList();
 
+            // Guard the silent-empty footgun: '*'/'?' are literal outside Wildcard mode, so an Exact query
+            // containing them matches no term and returns [] with no hint. Surface it in the note. (#186 cold test)
+            var q = request.Query ?? string.Empty;
+            string? modeNote = request.Mode == SearchToolMode.Exact && (q.Contains('*') || q.Contains('?'))
+                ? "Query contains wildcard characters ('*'/'?') but mode is Exact, so they were matched literally "
+                  + "(and match no term). Set mode:\"Wildcard\" to expand them."
+                : null;
+
             return new SearchToolResult(
                 Terms: terms,
                 TotalTermCount: result.TotalTermCount,
                 TotalOccurrenceCount: result.TotalOccurrenceCount,
                 TotalBookCount: result.TotalBookCount,
                 Truncated: result.ResultsTruncated,
-                Note: result.TruncationMessage);
+                Note: modeNote ?? result.TruncationMessage);
         }
 
         public async Task<IReadOnlyList<string>> CompleteTermsAsync(

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -41,8 +41,22 @@ namespace CST.Search
                     if (gt < 0 || gt >= end) break;
                     string tag = xml.Substring(i, gt - i + 1);
                     string name = TagName(tag);
-                    if (name == "note" && !includeNotes && !tag.EndsWith("/>", System.StringComparison.Ordinal))
-                        i = SkipSubtree(xml, gt + 1, "note", end);
+                    if (name == "note" && !tag.EndsWith("/>", System.StringComparison.Ordinal))
+                    {
+                        if (!includeNotes)
+                            i = SkipSubtree(xml, gt + 1, "note", end);
+                        else
+                        {
+                            // Delimit an included note with curly braces (which never occur in the corpus - 0
+                            // across all 217 files) so a consumer can tell injected footnote/variant apparatus
+                            // from the base text; the parentheses the notes carry are otherwise indistinguishable
+                            // from the text's own. Open tag => '{', close tag => '}'; inside stays `reading (sigla)`.
+                            bool isClose = tag.StartsWith("</", System.StringComparison.Ordinal);
+                            if (!isClose && sb.Length > 0 && sb[sb.Length - 1] != ' ') sb.Append(' ');
+                            sb.Append(isClose ? '}' : '{');
+                            i = gt + 1;
+                        }
+                    }
                     else if (name == "hi" && IsStructuralHi(tag) && !tag.EndsWith("/>", System.StringComparison.Ordinal))
                         i = SkipSubtree(xml, gt + 1, "hi", end);
                     else

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Conversion;
@@ -43,7 +44,15 @@ namespace CST.Tools
         Regex
     }
 
-    /// <summary>Which parts of the corpus to search. Defaults include everything.</summary>
+    /// <summary>
+    /// Which parts of the corpus to search. Defaults include everything. The pitaka flags
+    /// (<see cref="Vinaya"/>/<see cref="Sutta"/>/<see cref="Abhidhamma"/>) OR within their group, the text-class
+    /// flags (<see cref="Mula"/>/<see cref="Atthakatha"/>/<see cref="Tika"/>) OR within theirs, and the two groups
+    /// AND together — so e.g. commentaries-only is <c>{ mula:false, atthakatha:true, tika:true }</c>.
+    /// <c>Disallow</c> unmapped members so a misnamed key (e.g. a guessed <c>commentaryLevel</c>) fails with a
+    /// 400 rather than binding to all-defaults and silently returning the unfiltered corpus. (#186 cold test)
+    /// </summary>
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     public sealed record ToolBookFilter(
         bool Vinaya = true,
         bool Sutta = true,


### PR DESCRIPTION
Seventh cold-agent run (the Devanagari / Abhidhamma endpoint-coverage prompt). All five tasks completed unaided in Devanagari, exercising the previously-dark surface (convert, scripts, filter, proximity, variant readings, open-by-paragraph). Two themes across the fixes: **stop silently ignoring malformed-but-accepted requests**, and **stop handing the agent structure it has to reverse-engineer**.

### Fixes

- **`filter` (biggest friction)** — a misnamed filter key (the agent's guessed `{commentaryLevel: …}`) bound to all-defaults and **silently returned the unfiltered corpus with 200**. `ToolBookFilter` now uses `JsonUnmappedMemberHandling.Disallow` → unknown keys **400**. `llms.txt` documents the 7-bool schema (pitaka OR-group AND text-class OR-group) with the "commentaries only" example.
- **Wildcard-in-Exact footgun** — `*`/`?` are literal outside `mode:"Wildcard"`, so an Exact query containing them matched nothing and returned `[]` with no hint (this is what made proximity-with-wildcards look broken). `SearchTool` now sets a `note` explaining it. Docs add **MODE MATTERS**, **PROXIMITY** (multi-word query + `proximityDistance`, quotes = phrase), and **FILTER**.
- **Apparatus / variant readings** — the print-edition footnotes render inline and were indistinguishable from the base text's own parentheses (the agent had to infer the convention across many passages). Each included `<note>` is now wrapped in **curly braces `{…}`** — verified as a 0-occurrence sentinel across all 217 corpus files — in the shared `TeiText` path, so it lands on **both** `/v1/occurrences` and `/v1/passage`. Docs teach the braces convention, the **positional rule** (`(…)` = witness edition, token+number = cross-reference; `(ka)` = Cambodian but `ka 2` = Kaccāyana), the witness glossary (`sya`/`si`/`kam`,`ka`/`pi`), and that these are digitized print footnotes with **no** structural variant-vs-footnote type.
- **`includedVariants`** — documented as a request-flag echo, not "this hit has variants".
- **No IPE exposed** — `Ipe` (a legacy CSCD *font* encoding that emits non-Unicode glyph bytes) is removed from `/v1/scripts`, and a new `ScriptJsonConverter` **rejects `outputScript` `Ipe`/`Unknown` with 400** across every body endpoint (`ParseScript` guards the `/v1/books?script=` path too). No "IPE" string is served anywhere.
- **`bookType`** — documented as an unreliable legacy (CST4-era) field; steer to `commentaryLevel`/`pitaka`. The **13→7 Abhidhamma book-grouping** case it surfaced (Yamaka ×3, Paṭṭhāna ×5) is added to #174 (relationship modeling), not a new issue.

### Tests
filter 400 (unknown key) + 200 (valid keys), convert→Ipe 400, wildcard-in-Exact note, snippet + passage braces, scripts-list excludes Ipe. Full suite green (**562**).

### Deferred to 7b (gated on the `ai-doc-highlight-coordinate-model` design review)
The proximity→`/v1/occurrences` bridge (the `~`-composite term can't round-trip) + the multi-highlight snippet model + token offsets — see AI_INTEGRATION.md §6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)