### PR TITLE
AI local API: cold-test batch 7c — doc fixes from the first post-7a run

### DIFF
--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -48,8 +48,9 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - `GET  /v1/status` - app version, API version, readiness.
 - `GET  /v1/books` - the catalog. Each: `{ bookId, name, shortName, pitaka, commentaryLevel, bookType, indexed }`.
   `name`/`shortName` are romanized by default; add `?script=Devanagari` (etc.) to change. Classify with
-  `commentaryLevel` (`Mula`/`Atthakatha`/`Tika`) and `pitaka`; `bookType` is a legacy field, often
-  `Unknown` - do not rely on it.
+  `commentaryLevel` (`Mula`/`Atthakatha`/`Tika`/`Other`) and `pitaka`; `bookType` is a legacy field, often
+  `Unknown` - do not rely on it. The `.mul`/`.att`/`.tik` FILENAME suffix is only a hint and can DISAGREE with
+  `commentaryLevel` (e.g. `e0102n.mul.xml` is `commentaryLevel:"Other"`) - trust the field, not the name.
 - `POST /v1/search` - matching terms. Search is over WHOLE-WORD tokens matched as LITERAL character
   patterns, not grammatical inflections. To cover a stem's inflected endings, reach FIRST for a trailing
   `*` WILDCARD (`dhamm*`): the `*` absorbs the case/number endings, so you do NOT need to hand-write a
@@ -68,10 +69,13 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   within N words; quote a run - `"a b"` - for an exact adjacent phrase; combine with `mode:"Wildcard"`/`"Regex"`
   to expand each word before matching.
   FILTER: `filter` is an object of booleans, all default true -
-  `{ vinaya, sutta, abhidhamma, mula, atthakatha, tika, other }`. The pitaka flags OR within their group, the
-  text-class flags OR within theirs, and the two groups AND together - so commentaries-only is
-  `{ "mula": false, "atthakatha": true, "tika": true }`. Unknown filter keys are REJECTED with 400 (so a
-  misnamed key can't silently return the unfiltered corpus).
+  `{ vinaya, sutta, abhidhamma, mula, atthakatha, tika, other }`. The pitaka flags (vinaya/sutta/abhidhamma)
+  OR within their group, the text-class flags (mula/atthakatha/tika) OR within theirs, and those two groups
+  AND together. `other` is SEPARATE and ADDITIVE: it UNIONs the non-canonical "Other" books (anthologies etc.,
+  with `pitaka`/`commentaryLevel` = "Other") on top of that result, and it defaults TRUE - so for a STRICTLY
+  canonical result you must set `other:false`. Strictly-canonical commentaries-only is therefore
+  `{ "mula": false, "atthakatha": true, "tika": true, "other": false }`. Unknown filter keys are REJECTED
+  with 400 (so a misnamed key can't silently return the unfiltered corpus).
   Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, proximityDistance?, outputScript? }`.
   Returns `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, truncated, note }`; when `truncated`
   is true (e.g. `maxTerms` was reached), `note` explains and more forms exist beyond the cap.
@@ -83,14 +87,18 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   under `refs` (NOT top-level as on `/v1/passage`): `refs.paragraphNumber`, `refs.paragraphBookCode`
   (the Multi sub-book code, e.g. "kn17"), and `refs.pages[]` where each page is `{ edition, volume, number }`
   - e.g. `{ "edition": "Vri", "volume": 3, "number": 196 }`, conventionally cited "VRI 3:196" (edition
-  values: `Vri`, `Myanmar`, `Pts`, `Thai`). `cursor` is the hit's unique locator - pass it to `/v1/passage`
+  values: `Vri`, `Myanmar`, `Pts`, `Thai`; `volume` is `0` for a single-volume edition). `cursor` is the
+  hit's unique locator - pass it to `/v1/passage`
   as `cursor` to read the exact passage around THIS hit (paragraph numbers repeat within a book, so the
   paragraph number alone is not a unique locator). `includedVariants` echoes your request flag (whether
   variant readings were rendered), NOT whether this particular hit has any; see the apparatus note above.
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
   Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeVariantReadings? }`.
   Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, ... }`. Page by passing back the
-  integer `prevCursor` / `nextCursor` as `cursor` (see the cursor note above).
+  integer `prevCursor` / `nextCursor` as `cursor` (see the cursor note above). NOTE: `paragraph:N` opens at the
+  START of paragraph N but the window is bounded by `maxChars`, so a long paragraph spans several windows and
+  `nextCursor` may still be INSIDE the same paragraph - keep paging until `normalizedReference` changes, or
+  raise `maxChars`.
 - `GET  /v1/dictionary/languages` - available dictionary language codes (e.g. "en", "hi").
 - `POST /v1/dictionary/lookup` - `{ language, query, outputScript?, maxEntries? }`
   -> entries `{ headword, meaningHtml }`.


### PR DESCRIPTION
Eighth cold-agent run — the **first against the batch-7a build**, so it's both validation and a small friction log.

### 7a validated
- **Apparatus braces work** — the agent found `{…}` notes, cited `{नहारु (सी॰ पी॰), नहारू (स्या॰ कं॰)}`, and used the **sigla glossary + positional rule** correctly (`(ka)` = witness vs `ka 2` = cross-ref). The exact reverse-engineering friction we removed.
- **Wildcard + proximity works with `mode:"Wildcard"`** (70 pairs / 125 occ) — confirms the earlier `[]` was purely the missing mode, not a second bug.
- **14 scripts (no Ipe)**, and **Devanagari clean end-to-end** including in-text cross-refs (`म॰ नि॰ १.४०२`) and apparatus sigla — all script-converted as promised.

### Fixes (all docs-only, embedded `llms.txt`)
1. **Filter `other` — a doc bug I introduced in 7a.** My "commentaries only" example `{mula:false, atthakatha:true, tika:true}` was wrong: `other` isn't part of the pitaka∧class AND — it's a **separate additive** flag (`if (IncludeOther) bookBits.Or(OtherBits)`) that defaults **true**, so 7 non-canonical "Other" books leaked in. Corrected the example to include `other:false` and documented the additive semantics.
2. **Filename suffix ≠ `commentaryLevel`** — `e0102n.mul.xml` is `commentaryLevel:"Other"`; trust the field, not the `.mul`/`.att`/`.tik` name. (Added `Other` to the value list.)
3. **`pages[].volume` is `0`** for single-volume editions — documented.
4. **`/v1/passage` `paragraph:N` is a bounded window** — a long paragraph (one here was ~32k chars) spans several `maxChars` windows, so `nextCursor` may stay in the same paragraph; page until `normalizedReference` changes.

### Still 7b (deferred)
The proximity `term` (`~`-joined pair) not round-tripping into `/v1/occurrences` — the composite-bridge work, gated on the `ai-doc-highlight-coordinate-model` design review.

Docs-only; `llms.txt` verified all-ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)