### PR TITLE
AI local API: batch 7b — proximity in context (multi-word occurrences + multi-highlight)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
+++ b/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using CST.Conversion;
 using CST.Navigation;
 using CST.Search;
@@ -68,6 +69,30 @@ namespace CST.Avalonia.Tests.Search
             var r = TeiSnippetExtractor.Extract(Prose, hs, 6, markers, Deva(min: 1));
 
             Assert.Equal("TARGET", r.Snippet.Substring(r.HitStart, r.HitLength));
+        }
+
+        [Fact]
+        public void Multi_mark_reports_each_span_with_a_single_anchor()
+        {
+            var markers = BookMarkers.Build(Prose);
+            int ddd = HitStart(Prose, "ddd");
+            int tgt = HitStart(Prose, "TARGET");
+            var marks = new[]
+            {
+                new SnippetMark(ddd, ddd + 3, true),    // anchor
+                new SnippetMark(tgt, tgt + 6, false),   // context (same sentence)
+            };
+            var r = TeiSnippetExtractor.Extract(Prose, marks, markers, Deva(min: 1));
+
+            Assert.Equal(2, r.Highlights.Count);
+            Assert.Equal(1, r.Highlights.Count(h => h.IsAnchor));
+            // each highlight's local range points at its own word
+            Assert.Equal("ddd", r.Snippet.Substring(r.Highlights[0].Start, r.Highlights[0].Length));
+            Assert.Equal("TARGET", r.Snippet.Substring(r.Highlights[1].Start, r.Highlights[1].Length));
+            // HitStart/HitLength mirror the anchor for continuity
+            var anchor = r.Highlights.Single(h => h.IsAnchor);
+            Assert.Equal(anchor.Start, r.HitStart);
+            Assert.Equal("ddd", r.Snippet.Substring(r.HitStart, r.HitLength));
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -176,6 +177,54 @@ namespace CST.Avalonia.Tests.Tools
                 Assert.Equal(book, o.BookId);
                 Assert.False(string.IsNullOrEmpty(o.BookName));
                 Assert.Equal(hit, o.Cursor);   // unique locator = the hit's char offset (for /v1/passage)
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task GetOccurrencesAsync_multiword_marks_each_cooccurring_word()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cst-occ-mw-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                const string book = "s0101m.mul.xml";
+                string xml =
+                    "<body><div id=\"dn1\" type=\"book\">" +
+                    "<pb ed=\"V\" n=\"1.0003\"/>" +
+                    "<p rend=\"bodytext\" n=\"12\">aaa AVIJJA bbb ccc SANKHARA ddd\u0964</p>" +
+                    "</div></body>";
+                await File.WriteAllTextAsync(Path.Combine(dir, book), xml, Encoding.Unicode);
+
+                int a = xml.IndexOf("AVIJJA", StringComparison.Ordinal);
+                int sk = xml.IndexOf("SANKHARA", StringComparison.Ordinal);
+                // A proximity hit: two co-occurring words, the first flagged as the navigable anchor.
+                var hit = new List<TermPosition>
+                {
+                    new TermPosition { StartOffset = a, EndOffset = a + 6, IsFirstTerm = true, Word = "avijja" },
+                    new TermPosition { StartOffset = sk, EndOffset = sk + 8, IsFirstTerm = false, Word = "sankhara" },
+                };
+                var search = new Mock<ISearchService>();
+                search.Setup(s => s.GetMultiWordPositionsAsync(book, "avijja sankhara",
+                        It.IsAny<SearchMode>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new List<List<TermPosition>> { hit });
+
+                var tool = new SearchTool(search.Object, Settings(dir));
+                var occ = await tool.GetOccurrencesAsync(new OccurrenceRequest(
+                    book, "avijja sankhara", OutputScript: Script.Devanagari, MinChars: 1, ProximityDistance: 5));
+
+                var o = Assert.Single(occ);
+                Assert.Equal(2, o.Highlights.Count);
+                Assert.Equal(1, o.Highlights.Count(h => h.IsAnchor));   // exactly one navigable anchor
+                Assert.True(o.Highlights[0].IsAnchor);                  // AVIJJA (first by offset) is the anchor
+                // each highlight's snippet-local range points at its own word
+                Assert.Equal("AVIJJA", o.Snippet.Substring(o.Highlights[0].Start, o.Highlights[0].Length));
+                Assert.Equal("SANKHARA", o.Snippet.Substring(o.Highlights[1].Start, o.Highlights[1].Length));
+                // cursor is the anchor's SOURCE offset (for /v1/passage)
+                Assert.Equal(a, o.Cursor);
             }
             finally
             {

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -79,11 +79,18 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, proximityDistance?, outputScript? }`.
   Returns `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, truncated, note }`; when `truncated`
   is true (e.g. `maxTerms` was reached), `note` explains and more forms exist beyond the cap.
-- `POST /v1/occurrences` - "search results in context": KWIC snippets plus citation refs for one term in one
-  book. Body: `{ bookId, term, includeVariantReadings?, outputScript?, skip?, take?, minChars?, maxChars? }`
-  where `term` is a `term` value from a prior `/v1/search`.
-  Each occurrence is `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedVariants, cursor }`.
-  `snippet` is hit-centered with the term at `[hitStart, hitStart+hitLength)`. Citation data is NESTED
+- `POST /v1/occurrences` - "search results in context": KWIC snippets plus citation refs for one query in one
+  book. Body: `{ bookId, term, mode?, proximityDistance?, includeVariantReadings?, outputScript?, skip?, take?,
+  minChars?, maxChars? }`. `term` is EITHER a single `term` from a prior `/v1/search`, OR a MULTI-WORD /
+  PROXIMITY query - space-separated words that co-occur within `proximityDistance`, or a quoted run for an
+  adjacent phrase (`mode` expands wildcard/regex per word, same as `/v1/search`). This is how you read a
+  PROXIMITY search in context: its `~`-joined search `term` does NOT round-trip here, so pass the ORIGINAL
+  multi-word query instead.
+  Each occurrence is `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedVariants, cursor,
+  highlights }`. `snippet` is hit-centered; `highlights` is the ordered set of marked spans in SNIPPET-LOCAL
+  offsets - `[{ start, length, isAnchor }]`: a single-term hit has one, a proximity/phrase hit has one PER
+  co-occurring word with exactly one `isAnchor:true` (the navigable word; the rest are the co-occurring
+  context). `hitStart`/`hitLength` mirror the anchor. Citation data is NESTED
   under `refs` (NOT top-level as on `/v1/passage`): `refs.paragraphNumber`, `refs.paragraphBookCode`
   (the Multi sub-book code, e.g. "kn17"), and `refs.pages[]` where each page is `{ edition, volume, number }`
   - e.g. `{ "edition": "Vri", "volume": 3, "number": 196 }`, conventionally cited "VRI 3:196" (edition

--- a/src/CST.Avalonia/Services/ISearchService.cs
+++ b/src/CST.Avalonia/Services/ISearchService.cs
@@ -13,4 +13,13 @@ public interface ISearchService
     // term is a display-script term (e.g. the romanized Latin term from a prior search); it is converted to
     // IPE internally for the index lookup.
     Task<List<TermPosition>> GetTermPositionsAsync(string bookFileName, string term, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Book-scoped multi-word / proximity hits: parse <paramref name="query"/> into units (spaces = separate
+    /// proximity units, quotes = an adjacent phrase), expand wildcard/regex slots per <paramref name="mode"/>,
+    /// and return the co-occurrence hits within one book. Each hit is the matched word positions, exactly one
+    /// flagged <see cref="TermPosition.IsFirstTerm"/> (the navigable anchor).
+    /// </summary>
+    Task<List<List<TermPosition>>> GetMultiWordPositionsAsync(
+        string bookFileName, string query, SearchMode mode, int proximityDistance, CancellationToken cancellationToken = default);
 }

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -867,6 +867,81 @@ public class SearchService : ISearchService
         }
     }
 
+    /// <summary>
+    /// Book-scoped multi-word / proximity hits — the book-scoped sibling of <see cref="GetTermPositionsAsync"/>
+    /// for reading a multi-word search in context (AI_INTEGRATION.md §6.1). Reuses the pure matcher
+    /// (<see cref="MultiWordSearch"/>) over positions gathered for one book only.
+    /// </summary>
+    public Task<List<List<TermPosition>>> GetMultiWordPositionsAsync(
+        string bookFileName, string query, SearchMode mode, int proximityDistance, CancellationToken cancellationToken = default)
+    {
+        var empty = new List<List<TermPosition>>();
+        DirectoryReader? reader = null;
+        try
+        {
+            reader = AcquireReader();
+            var book = Books.Inst.FirstOrDefault(b =>
+                string.Equals(b.FileName, bookFileName, StringComparison.OrdinalIgnoreCase));
+            if (book == null || book.DocId < 0) return Task.FromResult(empty);
+            int docId = book.DocId;
+            var liveDocs = MultiFields.GetLiveDocs(reader);
+
+            // Same query normalization as SearchAsync: strip pasted joiners, collapse spaces, normalize quotes.
+            var ipe = Any2Ipe.Convert(MultiWordSearch.StripJoiners(query ?? string.Empty));
+            ipe = ipe.Replace("  ", " ").Trim().Replace("\u201C", "\"").Replace("\u201D", "\"");
+            var units = MultiWordSearch.ParseUnits(ipe);
+            if (units.Count == 0) return Task.FromResult(empty);
+
+            var unitOccurrences = new List<List<UnitOccurrence>>(units.Count);
+            foreach (var unit in units)
+            {
+                var wordSlots = new List<TermPosition>[unit.Words.Count];
+                for (int s = 0; s < unit.Words.Count; s++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var w = unit.Words[s];
+                    List<string> expansions =
+                        mode == SearchMode.Wildcard && (w.Contains('*') || w.Contains('?')) ? ExpandWildcard(w, reader, out _)
+                        : mode == SearchMode.Regex ? ExpandRegex(w, reader, out _)
+                        : new List<string> { w };
+
+                    var positions = new List<TermPosition>();
+                    foreach (var term in expansions)
+                    {
+                        var dape = MultiFields.GetTermPositionsEnum(reader, liveDocs, "text",
+                            new BytesRef(Encoding.UTF8.GetBytes(term)));
+                        if (dape == null || dape.Advance(docId) != docId) continue;
+                        int freq = dape.Freq;
+                        for (int i = 0; i < freq; i++)
+                        {
+                            int pos = dape.NextPosition();
+                            int so = dape.StartOffset, eo = dape.EndOffset;
+                            if (so < 0 || eo <= so) continue;
+                            positions.Add(new TermPosition { Position = pos, StartOffset = so, EndOffset = eo, Word = term });
+                        }
+                    }
+                    if (positions.Count == 0) return Task.FromResult(empty); // a slot unmatched in this book -> no hits
+                    positions.Sort();
+                    wordSlots[s] = positions;
+                }
+                var occs = MultiWordSearch.FindUnitOccurrences(wordSlots);
+                if (occs.Count == 0) return Task.FromResult(empty);
+                unitOccurrences.Add(occs);
+            }
+
+            return Task.FromResult(MultiWordSearch.FindHits(unitOccurrences, proximityDistance));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get multi-word positions for book: {Book}, query: {Query}", bookFileName, query);
+            throw;
+        }
+        finally
+        {
+            reader?.DecRef();
+        }
+    }
+
     private BitArray CalculateBookBits(BookFilter filter, Books books)
     {
         int bookCount = books.Count;

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models;
+using CST.Avalonia.Search;
 using CST.Conversion;
 using CST.Search;
 using CST.Tools;
@@ -82,14 +83,36 @@ namespace CST.Avalonia.Services.Tools
         public async Task<IReadOnlyList<Occurrence>> GetOccurrencesAsync(
             OccurrenceRequest request, CancellationToken ct = default)
         {
-            var positions = await _search.GetTermPositionsAsync(request.BookId, request.Term, ct)
-                .ConfigureAwait(false);
-            if (positions.Count == 0) return Array.Empty<Occurrence>();
-
             var dir = _settings.Settings?.XmlBooksDirectory;
             if (string.IsNullOrEmpty(dir)) return Array.Empty<Occurrence>();
             var path = Path.Combine(dir, request.BookId);
             if (!File.Exists(path)) return Array.Empty<Occurrence>();
+
+            // Route: a quoted phrase or 2+ space-separated units => proximity/phrase (each occurrence is a set of
+            // co-occurring words); else a single term (each occurrence is one word). This is the bridge a
+            // proximity search needs — its ~-joined term does not round-trip. (AI_INTEGRATION.md §6.1)
+            var units = MultiWordSearch.ParseUnits(request.Term ?? string.Empty);
+            bool multiWord = units.Count > 1 || (units.Count == 1 && units[0].IsPhrase);
+
+            List<List<SnippetMark>> perOccurrence;
+            if (multiWord)
+            {
+                var hits = await _search.GetMultiWordPositionsAsync(
+                    request.BookId, request.Term ?? string.Empty, MapMode(request.Mode), request.ProximityDistance, ct).ConfigureAwait(false);
+                perOccurrence = hits
+                    .Select(h => h.Select(tp => new SnippetMark(tp.StartOffset, tp.EndOffset, tp.IsFirstTerm)).ToList())
+                    .OrderBy(AnchorStart)
+                    .ToList();
+            }
+            else
+            {
+                var positions = await _search.GetTermPositionsAsync(request.BookId, request.Term ?? string.Empty, ct).ConfigureAwait(false);
+                perOccurrence = positions
+                    .OrderBy(p => p.StartOffset)
+                    .Select(p => new List<SnippetMark> { new SnippetMark(p.StartOffset, p.EndOffset, true) })
+                    .ToList();
+            }
+            if (perOccurrence.Count == 0) return Array.Empty<Occurrence>();
 
             // Char offsets index the decoded (BOM-stripped) UTF-16 text — read it the same way.
             string xml = await File.ReadAllTextAsync(path, Encoding.Unicode, ct).ConfigureAwait(false);
@@ -107,10 +130,10 @@ namespace CST.Avalonia.Services.Tools
             string bookName = ScriptConverter.Convert(rawBookName, Script.Devanagari, request.OutputScript);
 
             var occurrences = new List<Occurrence>();
-            foreach (var p in positions.OrderBy(p => p.StartOffset).Skip(request.Skip).Take(request.Take))
+            foreach (var marks in perOccurrence.Skip(request.Skip).Take(request.Take))
             {
                 ct.ThrowIfCancellationRequested();
-                var s = TeiSnippetExtractor.Extract(xml, p.StartOffset, p.EndOffset - p.StartOffset, markers, opts);
+                var s = TeiSnippetExtractor.Extract(xml, marks, markers, opts);
                 occurrences.Add(new Occurrence(
                     BookId: request.BookId,
                     BookName: bookName,
@@ -119,11 +142,19 @@ namespace CST.Avalonia.Services.Tools
                     HitLength: s.HitLength,
                     Refs: new OccurrenceRefs(s.ParagraphNumber, s.ParagraphBookCode, s.Pages),
                     IncludedVariants: s.IncludedVariants,
-                    // The hit's char offset — a unique locator to read the exact passage via /v1/passage
+                    // The anchor's char offset — a unique locator to read the exact passage via /v1/passage
                     // (paragraph numbers repeat within a book). (#186 cold test)
-                    Cursor: p.StartOffset));
+                    Cursor: AnchorStart(marks),
+                    Highlights: s.Highlights
+                        .Select(h => new OccurrenceHighlight(h.Start, h.Length, h.IsAnchor)).ToList()));
             }
             return occurrences;
+
+            static int AnchorStart(List<SnippetMark> m)
+            {
+                var a = m.FirstOrDefault(x => x.IsAnchor);
+                return a?.Start ?? (m.Count > 0 ? m[0].Start : 0);
+            }
         }
 
         private static SearchMode MapMode(SearchToolMode mode) => mode switch

--- a/src/CST.Core/Search/SnippetModels.cs
+++ b/src/CST.Core/Search/SnippetModels.cs
@@ -23,8 +23,23 @@ namespace CST.Search
     public sealed record SnippetPageRef(PageEdition Edition, int Volume, int Number);
 
     /// <summary>
+    /// One matched span to mark in a snippet, as source-XML char offsets. <see cref="IsAnchor"/> flags the
+    /// single navigable span (the first unit of a proximity/phrase hit, or the lone term of a single-word hit);
+    /// the rest are context. Input to <see cref="TeiSnippetExtractor.Extract(string, IReadOnlyList{SnippetMark}, BookMarkers, SnippetOptions)"/>.
+    /// </summary>
+    public sealed record SnippetMark(int Start, int End, bool IsAnchor);
+
+    /// <summary>
+    /// One highlight within a rendered snippet, in SNIPPET-LOCAL char offsets (into <see cref="SnippetResult.Snippet"/>):
+    /// the span occupies <c>[Start, Start+Length)</c>. A single-term hit yields one; a proximity/phrase hit yields
+    /// one per matched word, exactly one of which has <see cref="IsAnchor"/> true.
+    /// </summary>
+    public sealed record SnippetHighlight(int Start, int Length, bool IsAnchor);
+
+    /// <summary>
     /// A rendered snippet plus the citation refs at the hit. <see cref="Snippet"/> is the concordance line
-    /// (term-centered, romanized); the matched term occupies <c>[HitStart, HitStart+HitLength)</c> within it.
+    /// (term-centered, romanized). <see cref="Highlights"/> is the ordered set of marked spans; for a single-term
+    /// hit it has one entry and <see cref="HitStart"/>/<see cref="HitLength"/> mirror the anchor for continuity.
     /// </summary>
     public sealed record SnippetResult(
         string Snippet,
@@ -33,5 +48,6 @@ namespace CST.Search
         int? ParagraphNumber,
         string? ParagraphBookCode,
         IReadOnlyList<SnippetPageRef> Pages,
-        bool IncludedVariants);
+        bool IncludedVariants,
+        IReadOnlyList<SnippetHighlight> Highlights);
 }

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace CST.Search
 {
@@ -14,12 +16,34 @@ namespace CST.Search
     /// </summary>
     public static class TeiSnippetExtractor
     {
+        /// <summary>Single-term convenience overload — the degenerate one-mark case.</summary>
         public static SnippetResult Extract(string xml, int hitStart, int hitLength, BookMarkers markers, SnippetOptions opts)
-        {
-            hitStart = Math.Clamp(hitStart, 0, xml.Length);
-            int hitEnd = Math.Clamp(hitStart + hitLength, hitStart, xml.Length);
+            => Extract(xml, new[] { new SnippetMark(hitStart, hitStart + hitLength, true) }, markers, opts);
 
-            var (openIdx, pStart, pEnd, rend) = FindEnclosingP(xml, hitStart);
+        /// <summary>
+        /// Extract a snippet marking one or more spans (a single term, or the several co-occurring words of a
+        /// proximity/phrase hit). The window spans all marks; each mark's rendered range is reported in
+        /// snippet-local coordinates via <see cref="SnippetResult.Highlights"/>, exactly one flagged as the anchor.
+        /// </summary>
+        public static SnippetResult Extract(string xml, IReadOnlyList<SnippetMark> marks, BookMarkers markers, SnippetOptions opts)
+        {
+            // Clamp + sort marks; drop any that clamp to empty. Fall back to a zero-width mark at 0 if none remain.
+            var ms = marks
+                .Select(m =>
+                {
+                    int s = Math.Clamp(m.Start, 0, xml.Length);
+                    int e = Math.Clamp(m.End, s, xml.Length);
+                    return new SnippetMark(s, e, m.IsAnchor);
+                })
+                .OrderBy(m => m.Start).ThenBy(m => m.End)
+                .ToList();
+            if (ms.Count == 0) ms.Add(new SnippetMark(0, 0, true));
+
+            int spanStart = ms[0].Start;
+            int spanEnd = ms[ms.Count - 1].End;
+            var anchor = ms.FirstOrDefault(m => m.IsAnchor) ?? ms[0];
+
+            var (openIdx, pStart, pEnd, rend) = FindEnclosingP(xml, spanStart);
             if (pStart < 0) { openIdx = -1; pStart = 0; pEnd = xml.Length; rend = ""; }
 
             int winStart, winEnd;
@@ -29,22 +53,41 @@ namespace CST.Search
                 (winStart, winEnd) = VerseWindow(xml, openIdx, pStart, pEnd);
             else
                 (winStart, winEnd, ellipsisStart, ellipsisEnd) =
-                    ProseWindow(xml, pStart, pEnd, hitStart, hitEnd, opts);
+                    ProseWindow(xml, pStart, pEnd, spanStart, spanEnd, opts);
 
-            string before = TeiText.Collapse(TeiText.Convert(TeiText.Clean(xml, winStart, hitStart, opts.IncludeVariantReadings), opts.OutputScript));
-            string hit = TeiText.Convert(TeiText.Clean(xml, hitStart, hitEnd, opts.IncludeVariantReadings), opts.OutputScript).Trim();
-            string after = TeiText.Collapse(TeiText.Convert(TeiText.Clean(xml, hitEnd, winEnd, opts.IncludeVariantReadings), opts.OutputScript));
+            // Render as segments: prefix . before . [mark . gap]* . mark . after . suffix, tracking each mark's
+            // snippet-local start as the cumulative rendered length before it. Same length rule as the single-mark
+            // markStart, accumulated over the marks.
+            var sb = new StringBuilder();
+            var highlights = new List<SnippetHighlight>(ms.Count);
 
-            before = before.TrimStart();
-            after = after.TrimEnd();
-            string prefix = ellipsisStart ? "... " : "";
-            string suffix = ellipsisEnd ? " ..." : "";
+            sb.Append(ellipsisStart ? "... " : "");
+            sb.Append(TeiText.Collapse(TeiText.Convert(
+                TeiText.Clean(xml, winStart, ms[0].Start, opts.IncludeVariantReadings), opts.OutputScript)).TrimStart());
 
-            string snippet = prefix + before + hit + after + suffix;
-            int markStart = prefix.Length + before.Length;
+            for (int i = 0; i < ms.Count; i++)
+            {
+                string markText = TeiText.Convert(
+                    TeiText.Clean(xml, ms[i].Start, ms[i].End, opts.IncludeVariantReadings), opts.OutputScript).Trim();
+                highlights.Add(new SnippetHighlight(sb.Length, markText.Length, ms[i].IsAnchor));
+                sb.Append(markText);
 
-            var (num, code, pages) = markers.RefsAt(hitStart);
-            return new SnippetResult(snippet, markStart, hit.Length, num, code, pages, opts.IncludeVariantReadings);
+                if (i < ms.Count - 1)
+                {
+                    string gap = TeiText.Collapse(TeiText.Convert(
+                        TeiText.Clean(xml, ms[i].End, ms[i + 1].Start, opts.IncludeVariantReadings), opts.OutputScript));
+                    sb.Append(gap.Length == 0 ? " " : gap); // never fuse two distinct marked words
+                }
+            }
+
+            sb.Append(TeiText.Collapse(TeiText.Convert(
+                TeiText.Clean(xml, ms[ms.Count - 1].End, winEnd, opts.IncludeVariantReadings), opts.OutputScript)).TrimEnd());
+            sb.Append(ellipsisEnd ? " ..." : "");
+
+            var (num, code, pages) = markers.RefsAt(anchor.Start);
+            var anchorHl = highlights.FirstOrDefault(h => h.IsAnchor) ?? highlights[0];
+            return new SnippetResult(
+                sb.ToString(), anchorHl.Start, anchorHl.Length, num, code, pages, opts.IncludeVariantReadings, highlights);
         }
 
         private static (int start, int end, bool ellStart, bool ellEnd) ProseWindow(

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -94,9 +94,13 @@ namespace CST.Tools
         string BookName,
         int Count);
 
-    /// <summary>A request for a term's in-context occurrences within one book, paged.</summary>
-    /// <param name="Term">The term to locate, in any script (e.g. the romanized <c>Term</c> from a prior
-    /// search). Converted to the internal encoding for lookup — the caller never handles it.</param>
+    /// <summary>A request for a term's (or a multi-word/proximity query's) in-context occurrences within one book, paged.</summary>
+    /// <param name="Term">The query to locate, in any script. A single word (e.g. the romanized <c>Term</c> from a
+    /// prior search), OR a multi-word/proximity query — space-separated words co-occur within
+    /// <see cref="ProximityDistance"/>, a quoted run is an adjacent phrase. This is how a proximity hit is read in
+    /// context (its <c>~</c>-joined search term does not round-trip). Converted to the internal encoding for lookup.</param>
+    /// <param name="Mode">How to interpret <see cref="Term"/> — Exact / Wildcard / Regex (wildcard and regex expand per word).</param>
+    /// <param name="ProximityDistance">For a multi-word <see cref="Term"/>, the co-occurrence window in words.</param>
     /// <param name="MinChars">Prose snippet floor (rendered chars); null uses the engine default.</param>
     /// <param name="MaxChars">Prose snippet ceiling (rendered chars); null uses the engine default.</param>
     public sealed record OccurrenceRequest(
@@ -107,7 +111,9 @@ namespace CST.Tools
         int Skip = 0,
         int Take = 50,
         int? MinChars = null,
-        int? MaxChars = null);
+        int? MaxChars = null,
+        SearchToolMode Mode = SearchToolMode.Exact,
+        int ProximityDistance = 10);
 
     /// <summary>Citation refs at a hit: the paragraph (with Multi sub-book code) and the page in each edition.</summary>
     public sealed record OccurrenceRefs(
@@ -115,11 +121,18 @@ namespace CST.Tools
         string? ParagraphBookCode,
         IReadOnlyList<SnippetPageRef> Pages);
 
+    /// <summary>One marked span within a snippet, in snippet-local char offsets: <c>[Start, Start+Length)</c>.
+    /// A single-word hit has one; a proximity/phrase hit has one per matched word, exactly one with
+    /// <see cref="IsAnchor"/> (the navigable word — the others are the co-occurring context).</summary>
+    public sealed record OccurrenceHighlight(int Start, int Length, bool IsAnchor);
+
     /// <summary>
-    /// One occurrence of a term, shown in context: a hit-centered snippet (term at
-    /// <c>[HitStart, HitStart+HitLength)</c>, romanized) plus its citation refs.
+    /// One occurrence shown in context: a hit-centered snippet plus its citation refs. For a single term the
+    /// snippet marks one span; for a proximity/phrase hit it marks every co-occurring word, and
+    /// <see cref="Highlights"/> gives all of them (with the one anchor flagged). <see cref="HitStart"/>/
+    /// <see cref="HitLength"/> mirror the anchor for continuity.
     /// </summary>
-    /// <param name="Cursor">The hit's unique locator — pass it to <c>/v1/passage</c> as <c>cursor</c> to read
+    /// <param name="Cursor">The anchor's unique locator — pass it to <c>/v1/passage</c> as <c>cursor</c> to read
     /// the exact passage around <em>this</em> occurrence. (Paragraph numbers repeat within a book, so they are
     /// not a unique locator.)</param>
     public sealed record Occurrence(
@@ -130,5 +143,6 @@ namespace CST.Tools
         int HitLength,
         OccurrenceRefs Refs,
         bool IncludedVariants,
-        int Cursor);
+        int Cursor,
+        IReadOnlyList<OccurrenceHighlight> Highlights);
 }


### PR DESCRIPTION
Closes the one real engineering item from report #8: a **proximity search's `~`-joined term wouldn't round-trip into `/v1/occurrences`**, so co-occurrence hits couldn't be read in context. Implements AI_INTEGRATION.md §6.1 (the design merged in #250).

### What changed
- **Multi-mark snippet extractor** — `TeiSnippetExtractor.Extract` now takes an ordered set of marks and renders them as segments (`before · mark · gap · mark · … · after`), returning `SnippetResult.Highlights` = `[{ start, length, isAnchor }]` in snippet-local coords. The single-term call is the degenerate one-mark case, so there's **one implementation, not two** (the old `markStart = prefix + before.Length` rule, just accumulated across marks).
- **Book-scoped multi-word positions** — `SearchService.GetMultiWordPositionsAsync` reuses the existing pure matcher (`MultiWordSearch.ParseUnits`/`FindUnitOccurrences`/`FindHits`) over postings gathered for **one book only**, returning the co-occurrence hits (each a set of `TermPosition`s with exactly one `IsFirstTerm` anchor). No new matching logic — just scoped position gathering.
- **Occurrences accepts the multi-word/proximity query** — `OccurrenceRequest` gains `mode` + `proximityDistance`; `Occurrence` gains `highlights[]`. `GetOccurrencesAsync` routes a quoted-phrase / 2+-unit query to the multi-word path (one occurrence per co-occurrence window, full highlight set, anchor `cursor`), and a single word to the existing single-term path (now emitting a one-element `highlights`). The agent passes the **original** query, not the `~`-composite.
- **`llms.txt`** documents the multi-word/proximity input and the `highlights[]` array.

### Deferred (surface-E groundwork, not needed for this fix)
`includeTokenOffsets`, the tier-2/3 source spans, and the color/reveal command — those land when surface E is actually built.

### Tests
Multi-mark snippet rendering (each span marked, one anchor, snippet-local offsets); multi-word occurrences round-trip (each co-occurring word marked, one anchor, `cursor` = anchor source offset). Single-term path unchanged. **Full suite green (564).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)