### PR TITLE
AI local API: cold-test batch 7d — apparatus is mula-only + occurrences proximity is literal

### DIFF
--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -41,6 +41,9 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   script-converted to your `outputScript`): `sya`=Thai (Syama), `si`=Sinhala, `kam`/`ka`=Cambodian, `pi`=PTS.
   These are digitized print footnotes - mostly variant readings, but also editorial notes and cross-refs, with
   NO structural type marker, so any "variant vs footnote" split is your interpretation, not the data's.
+  LAYER: apparatus lives almost entirely in MULA (root) texts; the ATTHAKATHA and TIKA (commentary /
+  sub-commentary) layers carry NONE. So `includeVariantReadings` on a commentary is always empty - expected,
+  not a bug (and a commentary-restricted search will never surface variants).
 - Terminology: when writing about the texts, call them "Pali", "the Tipitaka", or "VRI texts".
 
 ## Endpoints
@@ -85,7 +88,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   PROXIMITY query - space-separated words that co-occur within `proximityDistance`, or a quoted run for an
   adjacent phrase (`mode` expands wildcard/regex per word, same as `/v1/search`). This is how you read a
   PROXIMITY search in context: its `~`-joined search `term` does NOT round-trip here, so pass the ORIGINAL
-  multi-word query instead.
+  multi-word query instead. Words match LITERALLY (as in search), so reuse the SAME wildcards you searched
+  with - a bare `avijja` will miss the sandhi forms `avijjaya`/`avijjapaccaya`, whereas `avijj*` catches them.
   Each occurrence is `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedVariants, cursor,
   highlights }`. `snippet` is hit-centered; `highlights` is the ordered set of marked spans in SNIPPET-LOCAL
   offsets - `[{ start, length, isAnchor }]`: a single-term hit has one, a proximity/phrase hit has one PER


### PR DESCRIPTION
From the **7b verification run** (report #9). First, the good news: **7b/7c validated end-to-end** — the agent read proximity co-occurrences via `/v1/occurrences` *directly* (678 hits across 50 books, no `~`-decompose workaround), and the `other:false` commentaries-only filter worked as documented. Both report-#8 findings are gone from the "mismatches" list.

Two docs-only clarifications from the new findings (both verified against the corpus):

1. **Apparatus is mūla-only.** Counting `<note>` by layer across all 217 files: **mūla 18,111 notes** (59/61 books), **aṭṭhakathā 0** (0/49), **ṭīkā 0** (0/22), other 4,234. So `includeVariantReadings` on a commentary is *always* empty — documented as expected, not a bug (and a commentary-restricted search will never surface variants, which is why Tasks 3–4 showed none).
2. **`/v1/occurrences` proximity matches words literally**, like search — reuse the same wildcards; a bare `avijja` misses the sandhi forms `avijjāya`/`avijjāpaccayā` that `avijj*` catches.

### Deferred — needs a core-search decision (touches the UI)
The report's most serious finding: **regex/wildcard term enumeration truncates in *index* order, not by frequency.** `^paññ.{0,6}$` capped at 200 dropped `paññāya` (**2535 occ**, the 2nd-largest form) → a silent ~40% undercount for anyone trusting the enumeration. The fix is **frequency-ranked truncation** (keep top-N by `TotalTermFreq`), but it's in the shared `ExpandRegex`/`ExpandWildcard`, so it changes which terms the *app's* search shows when truncated — holding it for @fsnow's call on the UX/perf before implementing.

Docs-only; `llms.txt` verified all-ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)