### PR TITLE
AI local API: batch 8 — search paging + books opt-in (retire the term-truncation trap)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/SearchTermBudgetTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SearchTermBudgetTests.cs
@@ -34,36 +34,66 @@ public class SearchTermBudgetTests
         // first pageSize (2) terms and THEN filtered -> only t2; t4 and t6 were lost. Now t4 is included.
         var terms = new[] { "t1", "t2", "t3", "t4", "t5", "t6" };
 
-        var (selected, total, truncated) = await SearchService.SelectTermsWithinBudgetAsync(
-            terms, pageSize: 2, Occurrences(("t2", 1), ("t4", 1), ("t6", 1)), s => s, CancellationToken.None);
+        var (selected, total, hasMore) = await SearchService.SelectTermsWithinBudgetAsync(
+            terms, skip: 0, pageSize: 2, Occurrences(("t2", 1), ("t4", 1), ("t6", 1)), s => s, CancellationToken.None);
 
         Assert.Equal(new[] { "t2", "t4" }, selected.Select(x => x.Term));
-        Assert.True(truncated); // t6 survives the filter beyond the page
+        Assert.True(hasMore); // t6 survives the filter beyond the page
         Assert.Equal(2, total);
     }
 
     [Fact]
-    public async Task Budget_NoTruncation_WhenSurvivorsFitWithinPage_AndDisplayApplied()
+    public async Task Budget_NoMore_WhenSurvivorsFitWithinPage_AndDisplayApplied()
     {
         var terms = new[] { "a", "b", "c" };
 
-        var (selected, total, truncated) = await SearchService.SelectTermsWithinBudgetAsync(
-            terms, pageSize: 10, Occurrences(("a", 3), ("c", 4)), s => s.ToUpperInvariant(), CancellationToken.None);
+        var (selected, total, hasMore) = await SearchService.SelectTermsWithinBudgetAsync(
+            terms, skip: 0, pageSize: 10, Occurrences(("a", 3), ("c", 4)), s => s.ToUpperInvariant(), CancellationToken.None);
 
         Assert.Equal(new[] { "a", "c" }, selected.Select(x => x.Term));           // "b" missing -> skipped
         Assert.Equal(new[] { "A", "C" }, selected.Select(x => x.DisplayTerm));    // toDisplay applied
-        Assert.False(truncated);
+        Assert.False(hasMore);
         Assert.Equal(7, total);
     }
 
     [Fact]
     public async Task Budget_ReturnsEmpty_WhenNoTermSurvives()
     {
-        var (selected, total, truncated) = await SearchService.SelectTermsWithinBudgetAsync(
-            new[] { "x", "y" }, pageSize: 5, Occurrences(), s => s, CancellationToken.None);
+        var (selected, total, hasMore) = await SearchService.SelectTermsWithinBudgetAsync(
+            new[] { "x", "y" }, skip: 0, pageSize: 5, Occurrences(), s => s, CancellationToken.None);
 
         Assert.Empty(selected);
         Assert.Equal(0, total);
-        Assert.False(truncated);
+        Assert.False(hasMore);
+    }
+
+    [Fact]
+    public async Task Budget_Skip_pages_over_survivors_without_overlap()
+    {
+        // survivors in order: t2, t4, t6; page size 2.
+        var terms = new[] { "t1", "t2", "t3", "t4", "t5", "t6" };
+        var occ = Occurrences(("t2", 1), ("t4", 1), ("t6", 1));
+
+        var (page1, _, more1) = await SearchService.SelectTermsWithinBudgetAsync(
+            terms, skip: 0, pageSize: 2, occ, s => s, CancellationToken.None);
+        Assert.Equal(new[] { "t2", "t4" }, page1.Select(x => x.Term));
+        Assert.True(more1);
+
+        var (page2, _, more2) = await SearchService.SelectTermsWithinBudgetAsync(
+            terms, skip: 2, pageSize: 2, occ, s => s, CancellationToken.None);
+        Assert.Equal(new[] { "t6" }, page2.Select(x => x.Term));   // the remainder, no overlap with page 1
+        Assert.False(more2);
+    }
+
+    [Fact]
+    public async Task Budget_HasMore_isFalse_when_page_exactly_exhausts_survivors()
+    {
+        // Exactly 2 survivors, page size 2 -> a FULL page but nothing after it. The N+1 probe (not the page
+        // length) is what makes hasMore false here; a short page would be trivially unambiguous.
+        var (selected, _, hasMore) = await SearchService.SelectTermsWithinBudgetAsync(
+            new[] { "a", "b" }, skip: 0, pageSize: 2, Occurrences(("a", 1), ("b", 1)), s => s, CancellationToken.None);
+
+        Assert.Equal(2, selected.Count);
+        Assert.False(hasMore);
     }
 }

--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -68,15 +68,55 @@ namespace CST.Avalonia.Tests.Tools
             await tool.SearchAsync(new SearchToolRequest(
                 "dhamma", SearchToolMode.Wildcard,
                 new ToolBookFilter(Sutta: true, Abhidhamma: false),
-                MaxTerms: 42, ProximityDistance: 3));
+                MaxTerms: 42, ProximityDistance: 3, Skip: 7));
 
             Assert.NotNull(captured);
             Assert.Equal("dhamma", captured!.QueryText);
             Assert.Equal(SearchMode.Wildcard, captured.Mode);
             Assert.Equal(42, captured.PageSize);
+            Assert.Equal(7, captured.Skip);
             Assert.Equal(3, captured.ProximityDistance);
             Assert.True(captured.Filter.IncludeSutta);
             Assert.False(captured.Filter.IncludeAbhidhamma);
+        }
+
+        [Fact]
+        public async Task SearchAsync_books_opt_in_bookCount_and_hasMore_always_present()
+        {
+            var book1 = new Book { FileName = "s0101m.mul.xml", LongNavPath = "\u0938" };
+            var book2 = new Book { FileName = "s0102m.mul.xml", LongNavPath = "\u0938" };
+            var searchResult = new SearchResult
+            {
+                Terms = new List<MatchingTerm>
+                {
+                    new MatchingTerm
+                    {
+                        Term = "abc", TotalCount = 10,
+                        Occurrences = new List<BookOccurrence>
+                        {
+                            new BookOccurrence { Book = book1, Count = 6 },
+                            new BookOccurrence { Book = book2, Count = 4 },
+                        }
+                    }
+                },
+                TotalTermCount = 1, TotalOccurrenceCount = 10, TotalBookCount = 2,
+                HasMore = true
+            };
+            var mock = new Mock<ISearchService>();
+            mock.Setup(s => s.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(searchResult);
+            var tool = new SearchTool(mock.Object, Settings());
+
+            // Default: the per-book breakdown is omitted, but bookCount and hasMore are always present.
+            var lean = await tool.SearchAsync(new SearchToolRequest("q"));
+            var t = Assert.Single(lean.Terms);
+            Assert.Empty(t.Books);
+            Assert.Equal(2, t.BookCount);
+            Assert.True(lean.HasMore);
+
+            // Opt in: the full per-book breakdown comes back.
+            var full = await tool.SearchAsync(new SearchToolRequest("q", IncludeBooks: true));
+            Assert.Equal(2, Assert.Single(full.Terms).Books.Count);
         }
 
         [Fact]
@@ -87,7 +127,8 @@ namespace CST.Avalonia.Tests.Tools
                 .ReturnsAsync(OneTermResult(out var book));
 
             var tool = new SearchTool(mock.Object, Settings());
-            var result = await tool.SearchAsync(new SearchToolRequest("q")); // OutputScript defaults to Latin
+            // OutputScript defaults to Latin; opt into the per-book breakdown to verify bookName romanization.
+            var result = await tool.SearchAsync(new SearchToolRequest("q", IncludeBooks: true));
 
             Assert.Equal(1, result.TotalTermCount);
             Assert.True(result.Truncated);

--- a/src/CST.Avalonia/Models/SearchModels.cs
+++ b/src/CST.Avalonia/Models/SearchModels.cs
@@ -29,6 +29,9 @@ public class SearchQuery
     public SearchMode Mode { get; set; } = SearchMode.Exact;
     public BookFilter Filter { get; set; } = new BookFilter();
     public int PageSize { get; set; } = 100;
+    /// <summary>How many filter-surviving terms to skip before the page (0 = first page). Paging over the
+    /// single-term enumeration; the UI leaves it 0.</summary>
+    public int Skip { get; set; } = 0;
     public bool IsPhrase { get; set; }
     public bool IsMultiWord { get; set; }
     public int ProximityDistance { get; set; } = 10;
@@ -61,6 +64,10 @@ public class SearchResult
     // Surfaced in the UI so users know the result set may be incomplete.
     public bool ResultsTruncated { get; set; }
     public string? TruncationMessage { get; set; }
+
+    // True when at least one more filter-surviving term exists after this page (Skip + PageSize).
+    // The precise paging signal (fetch-N+1); an agent pages while this is true.
+    public bool HasMore { get; set; }
 }
 
 public class MatchingTerm

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -79,9 +79,18 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   canonical result you must set `other:false`. Strictly-canonical commentaries-only is therefore
   `{ "mula": false, "atthakatha": true, "tika": true, "other": false }`. Unknown filter keys are REJECTED
   with 400 (so a misnamed key can't silently return the unfiltered corpus).
-  Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, proximityDistance?, outputScript? }`.
-  Returns `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, truncated, note }`; when `truncated`
-  is true (e.g. `maxTerms` was reached), `note` explains and more forms exist beyond the cap.
+  Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, skip?, includeBooks?,
+  proximityDistance?, outputScript? }`.
+  PAGING: `maxTerms` is the PAGE SIZE, `skip` (default 0) the offset. Page by re-requesting with
+  `skip += maxTerms` WHILE the response's `hasMore` is true - never infer end-of-results from a short page (a
+  full page can also be the last one; `hasMore` is the signal). No fixed upper bound on how far you can page.
+  Each term is `{ term, totalCount, bookCount, books }`. `books` (the per-book `{ bookId, bookName, count }`
+  breakdown) is OMITTED unless you pass `includeBooks: true` - it is the bulk of the payload; `bookCount` (how
+  many books the term is in) is ALWAYS present. Returns
+  `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, hasMore, truncated, note }`. NOTE: the
+  `total*` fields are per-PAGE sums, not whole-result-set totals - for a stem's true footprint, page through
+  and add, or run an Exact query per form. `truncated` is SEPARATE from `hasMore`: it flags that a very broad
+  wildcard/regex overflowed the engine's expansion limit.
 - `POST /v1/occurrences` - "search results in context": KWIC snippets plus citation refs for one query in one
   book. Body: `{ bookId, term, mode?, proximityDistance?, includeVariantReadings?, outputScript?, skip?, take?,
   minChars?, maxChars? }`. `term` is EITHER a single `term` from a prior `/v1/search`, OR a MULTI-WORD /

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -182,15 +182,16 @@ public class SearchService : ISearchService
         
         _logger.LogInformation("Using {Mode} matcher for IPE term: '{IpeTerm}'", query.Mode, ipeTerm);
 
-        // Get all matching terms
-        var matchingTerms = await GetMatchingTermsAsync(reader, termMatcher, cancellationToken);
+        // Lazily enumerate matching terms (IPE-ordinal order); the budget below stops the enumeration early.
+        var matchingTerms = GetMatchingTerms(reader, termMatcher, cancellationToken);
 
-        // Apply the page budget to terms that SURVIVE the book filter. Truncating matchingTerms up
+        // Apply the page budget (Skip + PageSize) to terms that SURVIVE the book filter. Truncating up
         // front (before checking occurrences) spent the budget on terms not in the selected books, dropping
         // legitimate results past the page size when the filter was narrow. (SRCH-12)
         var conversionStopwatch = Stopwatch.StartNew();
-        var (selectedTerms, totalOccurrences, truncated) = await SelectTermsWithinBudgetAsync(
+        var (selectedTerms, totalOccurrences, hasMore) = await SelectTermsWithinBudgetAsync(
             matchingTerms,
+            query.Skip,
             query.PageSize,
             term => GetTermOccurrencesAsync(reader, term, bookBits, books, cancellationToken),
             ConvertToDisplayScript,
@@ -199,7 +200,9 @@ public class SearchService : ISearchService
 
         result.Terms.AddRange(selectedTerms);
         result.TotalOccurrenceCount += totalOccurrences;
-        if (truncated)
+        result.HasMore = hasMore;
+        // Keep the UI's "showing the first N" message for the first page (Skip == 0); the API pages via HasMore.
+        if (hasMore && query.Skip == 0)
         {
             result.ResultsTruncated = true;
             result.TruncationMessage = $"Showing the first {query.PageSize:N0} matching words \u2014 refine your search to narrow the results.";
@@ -220,8 +223,9 @@ public class SearchService : ISearchService
     /// drop legitimate terms past the page size (SRCH-12). Returns the built terms, their total occurrence
     /// count, and whether a filter-surviving term was left off the page.
     /// </summary>
-    internal static async Task<(List<MatchingTerm> terms, int totalOccurrences, bool truncated)> SelectTermsWithinBudgetAsync(
-        IReadOnlyList<string> matchingTerms,
+    internal static async Task<(List<MatchingTerm> terms, int totalOccurrences, bool hasMore)> SelectTermsWithinBudgetAsync(
+        IEnumerable<string> matchingTerms,
+        int skip,
         int pageSize,
         Func<string, Task<List<BookOccurrence>>> getOccurrences,
         Func<string, string> toDisplay,
@@ -229,6 +233,7 @@ public class SearchService : ISearchService
     {
         var terms = new List<MatchingTerm>();
         int totalOccurrences = 0;
+        int survivorsSeen = 0;   // filter-surviving terms seen so far - drives both skip and the hasMore (N+1) test
 
         foreach (var term in matchingTerms)
         {
@@ -236,10 +241,14 @@ public class SearchService : ISearchService
 
             var occurrences = await getOccurrences(term).ConfigureAwait(false);
             if (occurrences.Count == 0)
-                continue; // not in the selected books - doesn't count toward the page budget
+                continue; // not in the selected books - doesn't survive the filter, doesn't count toward the page
+
+            survivorsSeen++;
+            if (survivorsSeen <= skip)
+                continue; // before the requested page
 
             if (terms.Count >= pageSize)
-                return (terms, totalOccurrences, true); // a filter-surviving term exists beyond the page
+                return (terms, totalOccurrences, true); // a filter-surviving term exists AFTER the page -> hasMore
 
             var totalCount = occurrences.Sum(o => o.Count);
             terms.Add(new MatchingTerm
@@ -576,31 +585,27 @@ public class SearchService : ISearchService
         return occurrences;
     }
 
-    private async Task<List<string>> GetMatchingTermsAsync(
+    // Lazily yield every index term matching the pattern, in index (IPE-ordinal) order. LAZY so that paging
+    // over a very broad pattern (e.g. a `.*` regex matching ~500k terms) stops enumerating as soon as the page
+    // is filled, instead of materializing the whole match set. There is NO term cap here — the page budget
+    // (Skip + PageSize) bounds the result and the agent pages via HasMore. (The 5,000-form
+    // WildcardExpansionLimit is a separate UI-latency bound on multi-word slot expansion, not on this path.)
+    private static IEnumerable<string> GetMatchingTerms(
         DirectoryReader reader,
         ITermMatcher matcher,
         CancellationToken cancellationToken)
     {
-        var matchingTerms = new List<string>();
-        var fields = MultiFields.GetFields(reader);
-        var terms = fields.GetTerms("text");
-        
-        if (terms == null) return matchingTerms;
-        
-        var termsEnum = terms.GetEnumerator();
+        var terms = MultiFields.GetFields(reader)?.GetTerms("text");
+        if (terms == null) yield break;
 
+        var termsEnum = terms.GetEnumerator();
         while (termsEnum.MoveNext())
         {
             cancellationToken.ThrowIfCancellationRequested();
-            
             var term = termsEnum.Term.Utf8ToString();
             if (matcher.Matches(term))
-            {
-                matchingTerms.Add(term);
-            }
+                yield return term;
         }
-
-        return matchingTerms;
     }
 
     /// <summary>

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -38,6 +38,7 @@ namespace CST.Avalonia.Services.Tools
                 QueryText = request.Query ?? string.Empty,
                 Mode = MapMode(request.Mode),
                 PageSize = request.MaxTerms,
+                Skip = request.Skip,
                 ProximityDistance = request.ProximityDistance,
                 Filter = MapFilter(request.Filter)
                 // IsPhrase / IsMultiWord are derived by SearchService from the query text.
@@ -48,11 +49,15 @@ namespace CST.Avalonia.Services.Tools
             var terms = result.Terms.Select(t => new SearchTermResult(
                 Term: ScriptConverter.Convert(t.Term, Script.Ipe, request.OutputScript),
                 TotalCount: t.TotalCount,
-                Books: t.Occurrences.Select(o => new BookHitSummary(
-                    BookId: o.Book?.FileName ?? string.Empty,
-                    // Nav paths are stored Devanagari; romanize to the requested script like everything else. (#186 cold test)
-                    BookName: ScriptConverter.Convert(o.Book?.LongNavPath ?? string.Empty, Script.Devanagari, request.OutputScript),
-                    Count: o.Count)).ToList())).ToList();
+                // Per-book breakdown is opt-in (it's the payload weight); bookCount is always cheap to include.
+                Books: request.IncludeBooks
+                    ? t.Occurrences.Select(o => new BookHitSummary(
+                        BookId: o.Book?.FileName ?? string.Empty,
+                        // Nav paths are stored Devanagari; romanize to the requested script like everything else. (#186 cold test)
+                        BookName: ScriptConverter.Convert(o.Book?.LongNavPath ?? string.Empty, Script.Devanagari, request.OutputScript),
+                        Count: o.Count)).ToList()
+                    : (IReadOnlyList<BookHitSummary>)Array.Empty<BookHitSummary>(),
+                BookCount: t.Occurrences.Count)).ToList();
 
             // Guard the silent-empty footgun: '*'/'?' are literal outside Wildcard mode, so an Exact query
             // containing them matches no term and returns [] with no hint. Surface it in the note. (#186 cold test)
@@ -68,6 +73,7 @@ namespace CST.Avalonia.Services.Tools
                 TotalOccurrenceCount: result.TotalOccurrenceCount,
                 TotalBookCount: result.TotalBookCount,
                 Truncated: result.ResultsTruncated,
+                HasMore: result.HasMore,
                 Note: modeNote ?? result.TruncationMessage);
         }
 

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -63,30 +63,47 @@ namespace CST.Tools
         bool Other = true);
 
     /// <summary>A search request. The query may be in any script; it is normalized to IPE internally.</summary>
+    /// <param name="MaxTerms">Page size: how many matching term-forms to return.</param>
+    /// <param name="Skip">How many matching term-forms to skip before this page (0 = first page). Page by
+    /// re-requesting with <c>Skip += MaxTerms</c> while the result's <c>HasMore</c> is true.</param>
+    /// <param name="IncludeBooks">When true, each term carries its full per-book <c>books[]</c> breakdown;
+    /// when false (default) it carries only <c>bookCount</c> — much lighter. Ask for books only when you need them.</param>
     public sealed record SearchToolRequest(
         string Query,
         SearchToolMode Mode = SearchToolMode.Exact,
         ToolBookFilter? Filter = null,
         int MaxTerms = 100,
         int ProximityDistance = 10,
-        Script OutputScript = Script.Latin);
+        Script OutputScript = Script.Latin,
+        int Skip = 0,
+        bool IncludeBooks = false);
 
-    /// <summary>Search results: matching terms with per-book counts (token-frugal — positions are opt-in).</summary>
+    /// <summary>Search results: matching terms (token-frugal — per-book breakdown and positions are opt-in).</summary>
+    /// <param name="TotalOccurrenceCount">Sum over the terms IN THIS PAGE (not the whole result set).</param>
+    /// <param name="TotalBookCount">Distinct books over the terms IN THIS PAGE (not the whole result set).</param>
+    /// <param name="HasMore">True if at least one more matching term exists after this page — request the next
+    /// page with <c>Skip += MaxTerms</c>. This, not the page length, is the paging signal.</param>
+    /// <param name="Truncated">The pattern overflowed the engine's expansion limit (very broad wildcard/regex);
+    /// distinct from <see cref="HasMore"/>.</param>
     public sealed record SearchToolResult(
         IReadOnlyList<SearchTermResult> Terms,
         int TotalTermCount,
         int TotalOccurrenceCount,
         int TotalBookCount,
         bool Truncated,
+        bool HasMore = false,
         string? Note = null);
 
     /// <summary>One matching term and the books it occurs in.</summary>
     /// <param name="Term">The term in the requested output script — pass it back verbatim as
     /// <c>OccurrenceRequest.Term</c> to read it in context.</param>
+    /// <param name="BookCount">How many books this term occurs in (always present — the spread, without the list).</param>
+    /// <param name="Books">Per-book breakdown; empty unless <c>SearchToolRequest.IncludeBooks</c> was true.</param>
     public sealed record SearchTermResult(
         string Term,
         int TotalCount,
-        IReadOnlyList<BookHitSummary> Books);
+        IReadOnlyList<BookHitSummary> Books,
+        int BookCount = 0);
 
     /// <summary>A term's occurrence count within one book (call <c>GetOccurrencesAsync</c> for the snippets).</summary>
     public sealed record BookHitSummary(


### PR DESCRIPTION
Replaces the silent term-truncation from report #9 — where a capped result dropped the highest-frequency form (`paññāya`, 2535 occ) out of "the first 200," a ~40% undercount — with **lossless paging**, and makes the heavy per-book breakdown **opt-in**. Design agreed in-thread (no frequency reordering; `hasMore`; `skip`/`includeBooks`; per-page totals).

### What changed
- **Paging** — `SearchToolRequest` gains `skip` (offset) alongside `maxTerms` (page size); `SearchToolResult` gains **`hasMore`**. Page with `skip += maxTerms` *while* `hasMore` is true — nothing dropped, order preserved. `hasMore` is the **fetch-N+1 survivor probe**, so a *full* page is unambiguous (exact-fill → `hasMore:false`); page length is never the signal.
- **Books opt-in** — `books[]` (the per-book `{bookId,bookName,count}` breakdown, the payload weight) is omitted unless `includeBooks:true`. `bookCount` (the spread) is **always** present. Positions stay opt-in via `/v1/occurrences` — the agent gets detail only for the exact terms it picks.
- **Lazy enumeration** — `GetMatchingTerms` now yields matches lazily (**no term cap**), so paging over a very broad pattern (a `.*` regex ≈500k terms) stops as soon as the page fills instead of materializing the whole match set. The 5,000-form `WildcardExpansionLimit` stays purely a **UI-latency** bound on multi-word slot expansion.
- **UI byte-identical** — `Skip` defaults 0; the "showing the first N" message and the first-page term set are unchanged. `total*` documented as **per-page** sums.

Multi-word/proximity returns its complete combo set (`hasMore:false`).

### Tests
skip paging (no overlap across pages), `hasMore` exact-fill (full page → false), books opt-in + `bookCount` + `hasMore` mapping, `Skip` mapping. Single-term/UI budget behavior preserved. **Full suite green (567).**

### Deferred → batch 9
Server-side **cheap-count**: on the unfiltered path, take `totalCount`/`bookCount` from the index (`TotalTermFreq`/`DocFreq`) so enumeration never reads postings — a latency win behind the same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)