### PR TITLE
AI local API: batch 9 — truncated means overflow (not paging) + occurrences wildcard fix

### DIFF
--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -51,6 +51,7 @@ namespace CST.Avalonia.Tests.Tools
                 TotalOccurrenceCount = 7,
                 TotalBookCount = 1,
                 ResultsTruncated = true,
+                ExpansionCapped = true,   // agent-facing `truncated` maps from ExpansionCapped, not the page cap
                 TruncationMessage = "capped"
             };
         }
@@ -271,6 +272,77 @@ namespace CST.Avalonia.Tests.Tools
             {
                 Directory.Delete(dir, recursive: true);
             }
+        }
+
+        [Fact]
+        public async Task GetOccurrencesAsync_single_word_wildcard_uses_the_expanding_path()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cst-occ-wc-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                const string book = "s0101m.mul.xml";
+                string xml =
+                    "<body><div id=\"dn1\" type=\"book\">" +
+                    "<pb ed=\"V\" n=\"1.0003\"/>" +
+                    "<p rend=\"bodytext\" n=\"12\">aaa AVIJJA bbb</p>" +
+                    "</div></body>";
+                await File.WriteAllTextAsync(Path.Combine(dir, book), xml, Encoding.Unicode);
+                int a = xml.IndexOf("AVIJJA", StringComparison.Ordinal);
+
+                var search = new Mock<ISearchService>();
+                // A single-word WILDCARD must route to the expanding path (it has to expand `avij*`), NOT the
+                // literal single-term lookup which would match no index term and silently return [].
+                search.Setup(s => s.GetMultiWordPositionsAsync(book, "avij*", SearchMode.Wildcard,
+                        It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new List<List<TermPosition>>
+                    {
+                        new List<TermPosition> { new TermPosition { StartOffset = a, EndOffset = a + 6, IsFirstTerm = true, Word = "avijja" } }
+                    });
+
+                var tool = new SearchTool(search.Object, Settings(dir));
+                var occ = await tool.GetOccurrencesAsync(new OccurrenceRequest(
+                    book, "avij*", OutputScript: Script.Devanagari, MinChars: 1, Mode: SearchToolMode.Wildcard));
+
+                var o = Assert.Single(occ);
+                Assert.Equal("AVIJJA", o.Snippet.Substring(o.HitStart, o.HitLength));
+                search.Verify(s => s.GetTermPositionsAsync(It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()), Times.Never);   // NOT the literal path
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task SearchAsync_pageable_result_is_hasMore_not_truncated()
+        {
+            var mock = new Mock<ISearchService>();
+            var tool = new SearchTool(mock.Object, Settings());
+
+            // A normal "more than one page" result: the UI page-cap is set, but it is NOT an expansion overflow.
+            mock.Setup(s => s.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new SearchResult
+                {
+                    HasMore = true, ResultsTruncated = true,
+                    TruncationMessage = "Showing the first 100 matching words - refine your search."
+                });
+            var paged = await tool.SearchAsync(new SearchToolRequest("dhamm*", SearchToolMode.Wildcard));
+            Assert.True(paged.HasMore);
+            Assert.False(paged.Truncated);   // paging, not overflow
+            Assert.Null(paged.Note);         // the UI "refine" message is not leaked to the API
+
+            // A genuine expansion overflow: truncated true, with the cap message as the note.
+            mock.Setup(s => s.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new SearchResult
+                {
+                    ExpansionCapped = true, ResultsTruncated = true,
+                    TruncationMessage = "matched more than 5,000 forms"
+                });
+            var capped = await tool.SearchAsync(new SearchToolRequest("dhamm*", SearchToolMode.Wildcard));
+            Assert.True(capped.Truncated);
+            Assert.Contains("5,000", capped.Note);
         }
 
         [Fact]

--- a/src/CST.Avalonia/Models/SearchModels.cs
+++ b/src/CST.Avalonia/Models/SearchModels.cs
@@ -68,6 +68,11 @@ public class SearchResult
     // True when at least one more filter-surviving term exists after this page (Skip + PageSize).
     // The precise paging signal (fetch-N+1); an agent pages while this is true.
     public bool HasMore { get; set; }
+
+    // True ONLY when a wildcard/regex overflowed the engine's expansion limit (WildcardExpansionLimit),
+    // so some matches were never enumerated. Distinct from ResultsTruncated (which also covers the ordinary
+    // "more than one page" case): this means "narrow the pattern", not "page for more". Agent-facing `truncated`.
+    public bool ExpansionCapped { get; set; }
 }
 
 public class MatchingTerm

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -84,13 +84,17 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   PAGING: `maxTerms` is the PAGE SIZE, `skip` (default 0) the offset. Page by re-requesting with
   `skip += maxTerms` WHILE the response's `hasMore` is true - never infer end-of-results from a short page (a
   full page can also be the last one; `hasMore` is the signal). No fixed upper bound on how far you can page.
+  Terms come back in INDEX (ordinal) order, NOT by frequency, so a COMMON form can sit on a LATER page - to
+  gather a stem's COMPLETE family you MUST page while `hasMore`; do not treat page 1 as the whole set.
   Each term is `{ term, totalCount, bookCount, books }`. `books` (the per-book `{ bookId, bookName, count }`
   breakdown) is OMITTED unless you pass `includeBooks: true` - it is the bulk of the payload; `bookCount` (how
   many books the term is in) is ALWAYS present. Returns
   `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, hasMore, truncated, note }`. NOTE: the
   `total*` fields are per-PAGE sums, not whole-result-set totals - for a stem's true footprint, page through
-  and add, or run an Exact query per form. `truncated` is SEPARATE from `hasMore`: it flags that a very broad
-  wildcard/regex overflowed the engine's expansion limit.
+  and add, or run an Exact query per form. `hasMore` and `truncated` are DIFFERENT signals: a normal large
+  result set is `hasMore:true, truncated:false` (just page it) - `truncated:true` means a very broad
+  wildcard/regex overflowed the engine's expansion limit so some forms are UNREACHABLE (NARROW the pattern;
+  paging will not recover them).
 - `POST /v1/occurrences` - "search results in context": KWIC snippets plus citation refs for one query in one
   book. Body: `{ bookId, term, mode?, proximityDistance?, includeVariantReadings?, outputScript?, skip?, take?,
   minChars?, maxChars? }`. `term` is EITHER a single `term` from a prior `/v1/search`, OR a MULTI-WORD /
@@ -133,7 +137,11 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
    footprint. To gather a stem's inflectional family (nominative, accusative, instrumental... together),
    follow up with a length-bounded anchored regex - `{ "query": "^metta.{1,4}$", "mode": "Regex" }`
    returns each case-form (`metta`, `mettam`, `mettaya`, `mettena`, ...) as its own `term` with its own
-   count. Use `stem*` (Wildcard) instead when you also WANT the compounds. (See the /v1/search note above.)
+   count. Use `stem*` (Wildcard) instead when you also WANT the compounds. Results are in ordinal order, so
+   PAGE while `hasMore` (with `skip`) to see EVERY form - a common one can be on a later page; a single page
+   is not the complete family. Or, once you know the exact forms you want, get them all in one call with an
+   anchored alternation - `{ "query": "^(metta|mettaya|mettam)$", "mode": "Regex", "includeBooks": true }`.
+   (See the /v1/search note above.)
 2. `POST /v1/occurrences` for that `term` in a book -> scan the concordance snippets; cite by paragraph
    and per-edition page.
 3. `POST /v1/passage` with an occurrence's `cursor` -> read the exact passage around that hit; page with

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -319,6 +319,7 @@ public class SearchService : ISearchService
         if (truncatedTermCount > 0)
         {
             result.ResultsTruncated = true;
+            result.ExpansionCapped = true;   // genuine overflow of the expansion limit: "narrow the pattern"
             result.TruncationMessage = $"{truncatedTermCount} wildcard word(s) matched more than {WildcardExpansionLimit:N0} forms and were truncated — some results may be missing. Use more specific wildcards for complete results.";
         }
 

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -72,9 +72,12 @@ namespace CST.Avalonia.Services.Tools
                 TotalTermCount: result.TotalTermCount,
                 TotalOccurrenceCount: result.TotalOccurrenceCount,
                 TotalBookCount: result.TotalBookCount,
-                Truncated: result.ResultsTruncated,
+                // `truncated` means ONLY that the pattern overflowed the expansion cap (narrow it) — a normal
+                // large result is `hasMore:true, truncated:false` (page it). Don't leak the UI's page-cap
+                // "refine your search" message as the note; only the genuine cap message.
+                Truncated: result.ExpansionCapped,
                 HasMore: result.HasMore,
-                Note: modeNote ?? result.TruncationMessage);
+                Note: modeNote ?? (result.ExpansionCapped ? result.TruncationMessage : null));
         }
 
         public async Task<IReadOnlyList<string>> CompleteTermsAsync(
@@ -94,17 +97,19 @@ namespace CST.Avalonia.Services.Tools
             var path = Path.Combine(dir, request.BookId);
             if (!File.Exists(path)) return Array.Empty<Occurrence>();
 
-            // Route: a quoted phrase or 2+ space-separated units => proximity/phrase (each occurrence is a set of
-            // co-occurring words); else a single term (each occurrence is one word). This is the bridge a
-            // proximity search needs — its ~-joined term does not round-trip. (AI_INTEGRATION.md §6.1)
+            // Route to the EXPANDING path (GetMultiWordPositionsAsync) for anything that needs term expansion or
+            // co-occurrence: a phrase, 2+ units, OR a single Wildcard/Regex word — which must be EXPANDED, not
+            // looked up literally (a literal `avijj*` lookup matches no index term and silently returns []). Only
+            // a single EXACT word takes the fast literal single-term path. (AI_INTEGRATION.md §6.1)
+            var mode = MapMode(request.Mode);
             var units = MultiWordSearch.ParseUnits(request.Term ?? string.Empty);
-            bool multiWord = units.Count > 1 || (units.Count == 1 && units[0].IsPhrase);
+            bool multiUnit = units.Count > 1 || (units.Count == 1 && units[0].IsPhrase);
 
             List<List<SnippetMark>> perOccurrence;
-            if (multiWord)
+            if (multiUnit || mode != SearchMode.Exact)
             {
                 var hits = await _search.GetMultiWordPositionsAsync(
-                    request.BookId, request.Term ?? string.Empty, MapMode(request.Mode), request.ProximityDistance, ct).ConfigureAwait(false);
+                    request.BookId, request.Term ?? string.Empty, mode, request.ProximityDistance, ct).ConfigureAwait(false);
                 perOccurrence = hits
                     .Select(h => h.Select(tp => new SnippetMark(tp.StartOffset, tp.EndOffset, tp.IsFirstTerm)).ToList())
                     .OrderBy(AnchorStart)


### PR DESCRIPTION
Two findings from the **batch-8 verification run** (tested against merged #253).

### 1. The agent didn't page — a misleading `truncated` flag defeated batch 8's paging
It ran `^paññ.{1,6}$`, saw **`truncated:true`**, concluded *"overflows the expansion limit… unusable for a complete family,"* and fell back to Exact-per-form — so the paging batch 8 added got bypassed. But that pattern matches only a few hundred forms, **nowhere near** the 5,000 cap; `truncated:true` was purely my batch-8 **page-cap** signal leaking through.

**Fix:** the agent-facing `truncated` now maps from a new `SearchResult.ExpansionCapped`, set **only** at the genuine 5,000-form expansion cap — not the ordinary page cap. So:
- a normal large result → **`hasMore:true, truncated:false`** ("page it"),
- a real overflow → `truncated:true` ("narrow the pattern; paging won't recover the rest").

The UI's `ResultsTruncated` / "showing the first N" message is unchanged; that message is no longer leaked into the API `note`.

### 2. `/v1/occurrences` single-word wildcard silently returned `[]`
The docs (which I wrote) tell agents to reuse wildcards there, but `GetOccurrencesAsync` routed a *single* word to the **literal** term lookup, which never expands `*`. `avijj*` → `[]`; Exact `avijjā` and multi-word `avijjā saṅkhār*` worked.

**Fix:** route any **non-Exact** query (single or multi word) to the expanding path; only a single **Exact** word takes the fast literal lookup.

### Docs
Enumeration is **index order**, so a common form can be on a later page — **page while `hasMore`** for the complete family (page 1 ≠ the whole set); `truncated` vs `hasMore` clarified; added the **anchored-alternation** recipe (`^(a|b|c)$` + `includeBooks`) to fetch a known set of forms in one call.

### Tests
single-word wildcard uses the expanding path (verifies the literal lookup is *not* called); pageable result is `hasMore`-not-`truncated`, genuine overflow is `truncated` with the cap note. Full suite green — the lone failure was the **known-flaky** `IndexingPerformanceTests` timing test (passes on retry, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)