### PR TITLE
Settings: remove up/down spinner arrows from the local-API Port field

### DIFF
--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -348,6 +348,7 @@
                                                           Value="{Binding Port}"
                                                           IsEnabled="{Binding SubPermissionsEnabled}"
                                                           Minimum="0" Maximum="65535" Increment="1"
+                                                          ShowButtonSpinner="False"
                                                           FormatString="0"
                                                           Width="160" HorizontalAlignment="Left"/>
                                         </Grid>


### PR DESCRIPTION
Small UI tweak per @fsnow: the local-API **Port** field is a `NumericUpDown`, so it showed up/down spinner arrows. A port is typed, not incremented (and it defaults to `0 = automatic`), so the arrows were noise.

`ShowButtonSpinner="False"` removes the arrows while keeping the numeric field and its range validation (`0..65535`, integer format). No behavior change beyond the visual.

(Confirmed while here: the Port field is **port-only** and doesn't touch the bind address, so the "loopback" description stays accurate — it's still `127.0.0.1`, same-host only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)