### PR TITLE
Integration harness for the local API (covers the seam bugs) + ZWNJ doc note

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CST.Avalonia.Tests.TestSupport;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Integration
+{
+    /// <summary>
+    /// End-to-end integration tests over the REAL surface-C stack (real <c>LocalApiServer</c> + real
+    /// <c>SearchService</c> + real tools + a tiny real Lucene index). These cover the DI/JSON/routing SEAMS the
+    /// mocked endpoint tests bypass - the class of bug several cold-agent findings turned out to be. All tests
+    /// share one server (built once) and run serially, because building the fixture index mutates global
+    /// <c>Books</c> DocId state.
+    /// </summary>
+    public class LocalApiIntegrationTests : IAsyncLifetime
+    {
+        private LocalApiTestServer _api = null!;
+
+        public async Task InitializeAsync() => _api = await LocalApiTestServer.StartAsync();
+        public async Task DisposeAsync() => await _api.DisposeAsync();
+
+        private static StringContent Json(string body) => new(body, Encoding.UTF8, "application/json");
+
+        [Fact]
+        public async Task All_core_endpoints_respond()
+        {
+            using var http = _api.Http();
+            foreach (var path in new[] { "/v1/status", "/v1/books", "/v1/scripts" })
+            {
+                var resp = await http.GetAsync(path);
+                Assert.True(resp.IsSuccessStatusCode, $"GET {path} -> {(int)resp.StatusCode}");
+            }
+            // convert + search over real JSON binding.
+            Assert.Equal(HttpStatusCode.OK,
+                (await http.PostAsync("/v1/convert", Json("{\"text\":\"dhamma\",\"outputScript\":\"Devanagari\"}"))).StatusCode);
+            Assert.Equal(HttpStatusCode.OK,
+                (await http.PostAsync("/v1/search", Json("{\"query\":\"dhamma\"}"))).StatusCode);
+        }
+
+        [Fact]
+        public async Task Requires_the_bearer_token()
+        {
+            using var http = new HttpClient { BaseAddress = new System.Uri(_api.BaseUrl) };
+            var resp = await http.GetAsync("/v1/scripts");
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Unknown_filter_key_is_400_through_real_json()
+        {
+            // The mock-bypassed seam bug: unknown JSON filter keys must fail loud, not bind to defaults.
+            using var http = _api.Http();
+            var resp = await http.PostAsync("/v1/search",
+                Json("{\"query\":\"dhamma\",\"filter\":{\"commentaryLevel\":\"Mula\"}}"));
+            Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Convert_to_Ipe_is_rejected_400_through_real_json()
+        {
+            using var http = _api.Http();
+            var resp = await http.PostAsync("/v1/convert", Json("{\"text\":\"dhamma\",\"outputScript\":\"Ipe\"}"));
+            Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Search_returns_the_indexed_term_with_bookCount_and_books_opt_in()
+        {
+            using var http = _api.Http();
+            var resp = await http.PostAsync("/v1/search", Json("{\"query\":\"dhamma\",\"mode\":\"Exact\"}"));
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+
+            var terms = doc.RootElement.GetProperty("terms");
+            Assert.True(terms.GetArrayLength() >= 1, "the indexed term should be found");
+            var t = terms[0];
+            Assert.True(t.GetProperty("totalCount").GetInt32() >= 2);     // dhamma occurs in both fixture books
+            Assert.Equal(2, t.GetProperty("bookCount").GetInt32());       // ...across 2 books
+            Assert.Equal(0, t.GetProperty("books").GetArrayLength());     // per-book breakdown is opt-in
+
+            // Opt in -> the breakdown appears.
+            var withBooks = await http.PostAsync("/v1/search",
+                Json("{\"query\":\"dhamma\",\"mode\":\"Exact\",\"includeBooks\":true}"));
+            using var doc2 = JsonDocument.Parse(await withBooks.Content.ReadAsStringAsync());
+            Assert.Equal(2, doc2.RootElement.GetProperty("terms")[0].GetProperty("books").GetArrayLength());
+        }
+
+        [Fact]
+        public async Task Occurrences_single_word_wildcard_expands_not_empty()
+        {
+            // batch-9 regression: a single-word wildcard on /v1/occurrences must EXPAND (dhamm* -> dhamma),
+            // not do a literal term lookup that silently returns []. Exercised over the real search engine.
+            using var http = _api.Http();
+            var resp = await http.PostAsync("/v1/occurrences",
+                Json($"{{\"bookId\":\"{_api.MulaBook}\",\"term\":\"dhamm*\",\"mode\":\"Wildcard\"}}"));
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.True(doc.RootElement.GetArrayLength() >= 1, "single-word wildcard should return occurrences");
+        }
+    }
+}

--- a/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
+++ b/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using CST;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.LocalApi;
+using CST.Avalonia.Services.Tools;
+using CST.Conversion;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CST.Avalonia.Tests.TestSupport
+{
+    /// <summary>
+    /// Stands up the REAL surface-C stack for integration tests: a tiny self-contained Lucene index (built by the
+    /// real <see cref="BookIndexer"/> over a few synthetic books that carry REAL catalog filenames), a real
+    /// <see cref="SearchService"/>, the real tool adapters, and a real <see cref="LocalApiServer"/> over loopback
+    /// HTTP. Unlike the mocked endpoint tests, this exercises the ASSEMBLED path - the DI/JSON/routing seams the
+    /// mocks hide. Devanagari fixture content is generated at runtime from ASCII-Latin words via
+    /// <see cref="ScriptConverter"/>, so there are no non-Latin literals in source.
+    ///
+    /// NOTE: building the index writes DocIds into the global <see cref="Books"/> singleton, so integration tests
+    /// that use this MUST run serially (keep them in one test class / collection).
+    /// </summary>
+    public sealed class LocalApiTestServer : IAsyncDisposable
+    {
+        private readonly string _root;
+        private readonly LocalApiServer _server;
+
+        public string BaseUrl { get; }
+        public string Token { get; }
+
+        /// <summary>The indexed books, by role (real catalog filenames), for tests to reference.</summary>
+        public string MulaBook { get; }
+        public string AtthaBook { get; }
+
+        private LocalApiTestServer(string root, LocalApiServer server, string mula, string attha)
+        {
+            _root = root;
+            _server = server;
+            BaseUrl = server.BaseUrl!;
+            Token = server.Token!;
+            MulaBook = mula;
+            AtthaBook = attha;
+        }
+
+        /// <summary>An HttpClient pointed at the server with the bearer token attached.</summary>
+        public HttpClient Http()
+        {
+            var http = new HttpClient { BaseAddress = new Uri(BaseUrl) };
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            return http;
+        }
+
+        public static async Task<LocalApiTestServer> StartAsync()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "cst-int-" + Guid.NewGuid().ToString("N"));
+            var xmlDir = Path.Combine(root, "xml");
+            var indexDir = Path.Combine(root, "index");
+            var handshakeDir = Path.Combine(root, "app");
+            Directory.CreateDirectory(xmlDir);
+            Directory.CreateDirectory(indexDir);
+            Directory.CreateDirectory(handshakeDir);
+
+            // Two REAL catalog books so Books.Inst resolves them (name/pitaka/commentaryLevel come from the catalog).
+            var mula = Books.Inst.First(b => b.FileName.EndsWith(".mul.xml", StringComparison.Ordinal));
+            var attha = Books.Inst.First(b => b.FileName.EndsWith(".att.xml", StringComparison.Ordinal));
+
+            // Synthetic Devanagari content generated from ASCII-Latin words (no non-Latin literals here). The
+            // tokenizer converts Devanagari -> IPE; a Latin query converts to the SAME IPE, so it matches.
+            static string Deva(params string[] latin) =>
+                string.Join(" ", latin.Select(w => ScriptConverter.Convert(w, Script.Latin, Script.Devanagari)));
+
+            // Mula: several words + an apparatus <note>; "dhamma" also appears in the Atthakatha (bookCount test).
+            string mulaXml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<pb ed=\"V\" n=\"1.0001\"/>" +
+                "<p rend=\"bodytext\" n=\"1\">" + Deva("dhamma", "citta", "kamma", "dukkha") +
+                " <note>" + Deva("dhamma") + " (si)</note></p>" +
+                "</div></body>";
+            string atthaXml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<pb ed=\"V\" n=\"1.0001\"/>" +
+                "<p rend=\"bodytext\" n=\"1\">" + Deva("dhamma", "magga") + "</p>" +
+                "</div></body>";
+
+            await File.WriteAllTextAsync(Path.Combine(xmlDir, mula.FileName), mulaXml, Encoding.Unicode);
+            await File.WriteAllTextAsync(Path.Combine(xmlDir, attha.FileName), atthaXml, Encoding.Unicode);
+
+            // Build the index directly via the real BookIndexer (bypassing the IndexingService pipeline).
+            var indexer = new BookIndexer { XmlDirectory = xmlDir, IndexDirectory = indexDir };
+            indexer.IndexAll(_ => { }, new List<int> { mula.Index, attha.Index });
+
+            // Wire the REAL SearchService + tool adapters.
+            var settings = new Mock<ISettingsService>();
+            settings.SetupGet(s => s.Settings)
+                .Returns(new Settings { IndexDirectory = indexDir, XmlBooksDirectory = xmlDir });
+            var scriptSvc = new Mock<IScriptService>();
+            scriptSvc.SetupGet(s => s.CurrentScript).Returns(Script.Latin);
+            var indexingSvc = new Mock<IIndexingService>();   // stored but unused by SearchService's read path
+
+            var searchService = new SearchService(
+                NullLogger<SearchService>.Instance, indexingSvc.Object, scriptSvc.Object, settings.Object);
+
+            var searchTool = new SearchTool(searchService, settings.Object);
+            var passageTool = new PassageTool(settings.Object);
+            var scriptTool = new ScriptTool();
+
+            var server = new LocalApiServer("test", handshakeDir, Serilog.Log.Logger,
+                searchTool, dictionary: null, passage: passageTool, script: scriptTool);
+            await server.StartAsync();
+
+            return new LocalApiTestServer(root, server, mula.FileName, attha.FileName);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try { await _server.StopAsync(); } catch { /* best-effort */ }
+            try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -19,6 +19,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - Pali output is ROMANIZED by DEFAULT. The romanized script token is `"Latin"` (IAST, with diacritics). Pass
   `outputScript` to override (e.g. "Devanagari", "Thai", "Myanmar", "Sinhala"); `GET /v1/scripts` lists every
   valid value.
+- Devanagari output embeds a zero-width non-joiner (U+200C) inside SOME consonant conjuncts (a ligature
+  convention) - normalize/strip U+200C before comparing or matching strings.
 - Cursors (`prevCursor` / `nextCursor` from `/v1/passage`) are INTEGERS, and opaque - pass one back verbatim
   as `cursor` to page; do not interpret them or do arithmetic on them. `null` means the start/end of the book.
 - Response shape is per endpoint: `/v1/search`, `/v1/passage`, `/v1/convert`, `/v1/status` return a JSON


### PR DESCRIPTION
Follow-through on the retrospective: the last several cold-agent bugs were **assembly/seam bugs** — DI wiring (`/v1/scripts` 404), JSON binding (filter silent no-op), routing (occurrences single-word wildcard `[]`) — that unit tests **structurally couldn't catch**, because the tests mock the very seams the bugs live in. This stands up a real end-to-end harness that exercises the *assembled* path, and it's fast, deterministic, and CI-able.

### What it is
- **`LocalApiTestServer`** (TestSupport): builds a **tiny self-contained Lucene index** via the real `BookIndexer` over a couple of synthetic books that carry **real catalog filenames** — Devanagari content generated at runtime from ASCII-Latin words via `ScriptConverter`, so **no non-Latin literals in source** — then wires a **real `SearchService` + real tool adapters + a real `LocalApiServer`** over loopback HTTP.
- **`LocalApiIntegrationTests`**: hits the real endpoints over HTTP. Retroactively covers the exact seam bugs:
  - unknown filter key → **400 through real JSON deserialization**,
  - `outputScript: "Ipe"` → **400**,
  - `/v1/occurrences` single-word wildcard **expands** (`dhamm*` → hits) instead of a literal lookup returning `[]`,
  - search returns the indexed term with `bookCount` and `books` **opt-in**,
  - bearer token required; all core endpoints respond.
  - The `dhamma` round-trip (Latin query → IPE **==** indexed Devanagari → IPE) is verified through the real engine.

### Known limitation (honest scope)
The harness wires the tools itself, so it does **not** catch a wiring omission in `App.axaml.cs`'s own construction (the `/v1/scripts`-404 class specifically). Catching that needs a test of the app's *real* composition — a good follow-up.

### Also
- `llms.txt`: note that Devanagari output embeds a **U+200C** inside some consonant conjuncts (a ligature convention) — consumers should normalize before comparing strings. (Recurring cold-test observation; generalized per @fsnow since it's a set of conjuncts, not just ञ्ञ.)

Full suite green (**575**, incl. the 6 new integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)