### PR TITLE
AI local API: batch 10 — counts-only fast path + fix paging cache-key bug

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -24,6 +24,13 @@ namespace CST.Avalonia.Tests.Integration
 
         private static StringContent Json(string body) => new(body, Encoding.UTF8, "application/json");
 
+        private static async Task<JsonDocument> PostDoc(HttpClient http, string path, string body)
+        {
+            var resp = await http.PostAsync(path, Json(body));
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            return JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        }
+
         [Fact]
         public async Task All_core_endpoints_respond()
         {
@@ -67,25 +74,43 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
-        public async Task Search_returns_the_indexed_term_with_bookCount_and_books_opt_in()
+        public async Task Search_countsOnly_matches_the_postings_path_and_books_are_opt_in()
         {
             using var http = _api.Http();
-            var resp = await http.PostAsync("/v1/search", Json("{\"query\":\"dhamma\",\"mode\":\"Exact\"}"));
-            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
 
-            var terms = doc.RootElement.GetProperty("terms");
-            Assert.True(terms.GetArrayLength() >= 1, "the indexed term should be found");
-            var t = terms[0];
-            Assert.True(t.GetProperty("totalCount").GetInt32() >= 2);     // dhamma occurs in both fixture books
-            Assert.Equal(2, t.GetProperty("bookCount").GetInt32());       // ...across 2 books
-            Assert.Equal(0, t.GetProperty("books").GetArrayLength());     // per-book breakdown is opt-in
+            // Default request => the COUNTS-ONLY fast path (index stats, no postings, no per-book breakdown).
+            using var lean = await PostDoc(http, "/v1/search", "{\"query\":\"dhamma\",\"mode\":\"Exact\"}");
+            var leanTerm = lean.RootElement.GetProperty("terms")[0];
+            int leanTotal = leanTerm.GetProperty("totalCount").GetInt32();
+            int leanBooks = leanTerm.GetProperty("bookCount").GetInt32();
+            Assert.Equal(2, leanBooks);                                       // dhamma occurs in both fixture books
+            Assert.True(leanTotal >= 2);
+            Assert.Equal(0, leanTerm.GetProperty("books").GetArrayLength());  // per-book breakdown omitted
 
-            // Opt in -> the breakdown appears.
-            var withBooks = await http.PostAsync("/v1/search",
-                Json("{\"query\":\"dhamma\",\"mode\":\"Exact\",\"includeBooks\":true}"));
-            using var doc2 = JsonDocument.Parse(await withBooks.Content.ReadAsStringAsync());
-            Assert.Equal(2, doc2.RootElement.GetProperty("terms")[0].GetProperty("books").GetArrayLength());
+            // includeBooks => the POSTINGS path, with the per-book breakdown. Counts must AGREE across paths.
+            using var full = await PostDoc(http, "/v1/search",
+                "{\"query\":\"dhamma\",\"mode\":\"Exact\",\"includeBooks\":true}");
+            var fullTerm = full.RootElement.GetProperty("terms")[0];
+            Assert.Equal(2, fullTerm.GetProperty("books").GetArrayLength());
+            Assert.Equal(leanTotal, fullTerm.GetProperty("totalCount").GetInt32());
+            Assert.Equal(leanBooks, fullTerm.GetProperty("bookCount").GetInt32());
+        }
+
+        [Fact]
+        public async Task Search_pages_over_terms_without_a_cache_collision()
+        {
+            using var http = _api.Http();
+            // maxTerms:1 => one term per page. Page 2 must be a DIFFERENT term - the regression is that the
+            // cache key now includes skip/pageSize, so page 2 no longer returns the cached page 1.
+            using var p1 = await PostDoc(http, "/v1/search",
+                "{\"query\":\"*\",\"mode\":\"Wildcard\",\"maxTerms\":1,\"skip\":0}");
+            using var p2 = await PostDoc(http, "/v1/search",
+                "{\"query\":\"*\",\"mode\":\"Wildcard\",\"maxTerms\":1,\"skip\":1}");
+
+            Assert.True(p1.RootElement.GetProperty("hasMore").GetBoolean());
+            var term1 = p1.RootElement.GetProperty("terms")[0].GetProperty("term").GetString();
+            var term2 = p2.RootElement.GetProperty("terms")[0].GetProperty("term").GetString();
+            Assert.NotEqual(term1, term2);
         }
 
         [Fact]

--- a/src/CST.Avalonia/Models/SearchModels.cs
+++ b/src/CST.Avalonia/Models/SearchModels.cs
@@ -32,6 +32,10 @@ public class SearchQuery
     /// <summary>How many filter-surviving terms to skip before the page (0 = first page). Paging over the
     /// single-term enumeration; the UI leaves it 0.</summary>
     public int Skip { get; set; } = 0;
+    /// <summary>Counts-only fast path: when true AND no book filter is applied, the single-term enumeration
+    /// takes each term's total-count and book-count straight from the index (no per-term postings reads) and
+    /// leaves per-book Occurrences empty. The UI leaves this false (it renders the per-book breakdown).</summary>
+    public bool CountsOnly { get; set; } = false;
     public bool IsPhrase { get; set; }
     public bool IsMultiWord { get; set; }
     public int ProximityDistance { get; set; } = 10;
@@ -81,6 +85,10 @@ public class MatchingTerm
     public string DisplayTerm { get; set; } = string.Empty;  // Current script
     public List<BookOccurrence> Occurrences { get; set; } = new();
     public int TotalCount { get; set; }
+
+    // Number of books the term occurs in. Set from the index (DocFreq) on the counts-only path where
+    // Occurrences is left empty; the postings path leaves it 0 and callers fall back to Occurrences.Count.
+    public int BookCount { get; set; }
 }
 
 public class BookOccurrence

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -93,7 +93,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   many books the term is in) is ALWAYS present. Returns
   `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, hasMore, truncated, note }`. NOTE: the
   `total*` fields are per-PAGE sums, not whole-result-set totals - for a stem's true footprint, page through
-  and add, or run an Exact query per form. `hasMore` and `truncated` are DIFFERENT signals: a normal large
+  and add, or run an Exact query per form. (`totalBookCount` is populated only with `includeBooks:true`; the
+  default fast path leaves it 0 - use the per-term `bookCount` instead.) `hasMore` and `truncated` are DIFFERENT signals: a normal large
   result set is `hasMore:true, truncated:false` (just page it) - `truncated:true` means a very broad
   wildcard/regex overflowed the engine's expansion limit so some forms are UNREACHABLE (NARROW the pattern;
   paging will not recover them).

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -182,20 +182,28 @@ public class SearchService : ISearchService
         
         _logger.LogInformation("Using {Mode} matcher for IPE term: '{IpeTerm}'", query.Mode, ipeTerm);
 
-        // Lazily enumerate matching terms (IPE-ordinal order); the budget below stops the enumeration early.
-        var matchingTerms = GetMatchingTerms(reader, termMatcher, cancellationToken);
-
-        // Apply the page budget (Skip + PageSize) to terms that SURVIVE the book filter. Truncating up
-        // front (before checking occurrences) spent the budget on terms not in the selected books, dropping
-        // legitimate results past the page size when the filter was narrow. (SRCH-12)
+        // Apply the page budget (Skip + PageSize). FAST PATH: when no book filter is applied and the caller
+        // wants counts only (no per-book breakdown), take each term's total-count and book-count straight from
+        // the index (TotalTermFreq/DocFreq) and NEVER read postings. Otherwise walk the filter survivors,
+        // computing per-book occurrences. (SRCH-12: apply the budget to filter survivors, not raw matches.)
         var conversionStopwatch = Stopwatch.StartNew();
-        var (selectedTerms, totalOccurrences, hasMore) = await SelectTermsWithinBudgetAsync(
-            matchingTerms,
-            query.Skip,
-            query.PageSize,
-            term => GetTermOccurrencesAsync(reader, term, bookBits, books, cancellationToken),
-            ConvertToDisplayScript,
-            cancellationToken);
+        List<MatchingTerm> selectedTerms;
+        int totalOccurrences;
+        bool hasMore;
+        if (query.CountsOnly && IsUnfiltered(query.Filter))
+        {
+            (selectedTerms, totalOccurrences, hasMore) = SelectTermsCountsOnly(
+                GetMatchingTermStats(reader, termMatcher, cancellationToken),
+                query.Skip, query.PageSize, ConvertToDisplayScript, cancellationToken);
+        }
+        else
+        {
+            (selectedTerms, totalOccurrences, hasMore) = await SelectTermsWithinBudgetAsync(
+                GetMatchingTerms(reader, termMatcher, cancellationToken),
+                query.Skip, query.PageSize,
+                term => GetTermOccurrencesAsync(reader, term, bookBits, books, cancellationToken),
+                ConvertToDisplayScript, cancellationToken);
+        }
         conversionStopwatch.Stop();
 
         result.Terms.AddRange(selectedTerms);
@@ -607,6 +615,72 @@ public class SearchService : ISearchService
             if (matcher.Matches(term))
                 yield return term;
         }
+    }
+
+    // Term identity plus its cheap index statistics (no postings read): DocFreq = number of books the term
+    // occurs in, TotalTermFreq = its total occurrences across the corpus.
+    private readonly record struct TermStat(string Term, int DocFreq, long TotalTermFreq);
+
+    // Like GetMatchingTerms, but also yields each term's DocFreq/TotalTermFreq - both available straight off the
+    // terms enumerator, without touching postings. Backs the counts-only fast path.
+    private static IEnumerable<TermStat> GetMatchingTermStats(
+        DirectoryReader reader,
+        ITermMatcher matcher,
+        CancellationToken cancellationToken)
+    {
+        var terms = MultiFields.GetFields(reader)?.GetTerms("text");
+        if (terms == null) yield break;
+
+        var termsEnum = terms.GetEnumerator();
+        while (termsEnum.MoveNext())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var term = termsEnum.Term.Utf8ToString();
+            if (matcher.Matches(term))
+                yield return new TermStat(term, termsEnum.DocFreq, termsEnum.TotalTermFreq);
+        }
+    }
+
+    // All books included => no restriction => the counts-only fast path is safe (every matching term survives).
+    private static bool IsUnfiltered(BookFilter f) =>
+        f.IncludeVinaya && f.IncludeSutta && f.IncludeAbhidhamma &&
+        f.IncludeMula && f.IncludeAttha && f.IncludeTika && f.IncludeOther;
+
+    // Counts-only page budget: page over matching terms using ONLY their index stats (no postings, no per-book
+    // Occurrences). Mirrors SelectTermsWithinBudgetAsync's skip/hasMore (fetch-N+1) semantics; there is no
+    // filter, so every matching term is a survivor.
+    private static (List<MatchingTerm> terms, int totalOccurrences, bool hasMore) SelectTermsCountsOnly(
+        IEnumerable<TermStat> stats,
+        int skip,
+        int pageSize,
+        Func<string, string> toDisplay,
+        CancellationToken cancellationToken)
+    {
+        var terms = new List<MatchingTerm>();
+        long totalOccurrences = 0;
+        int seen = 0;
+
+        foreach (var s in stats)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            seen++;
+            if (seen <= skip)
+                continue;
+            if (terms.Count >= pageSize)
+                return (terms, (int)totalOccurrences, true);   // one more term exists after the page -> hasMore
+
+            terms.Add(new MatchingTerm
+            {
+                Term = s.Term,
+                DisplayTerm = toDisplay(s.Term),
+                TotalCount = (int)s.TotalTermFreq,
+                BookCount = s.DocFreq
+                // Occurrences intentionally empty on the counts-only path.
+            });
+            totalOccurrences += s.TotalTermFreq;
+        }
+
+        return (terms, (int)totalOccurrences, false);
     }
 
     /// <summary>
@@ -1045,6 +1119,14 @@ public class SearchService : ISearchService
         // Proximity distance affects multi-word results, so it must be part of the key —
         // otherwise changing the Word Distance and re-running returns the stale cached result.
         sb.Append(query.ProximityDistance);
+        sb.Append('|');
+        // The page window and the counts-only projection change the result, so they are part of its identity -
+        // otherwise paging (Skip += PageSize) would keep returning the cached FIRST page under the same key.
+        sb.Append(query.Skip);
+        sb.Append('/');
+        sb.Append(query.PageSize);
+        sb.Append('/');
+        sb.Append(query.CountsOnly);
         sb.Append('|');
         sb.Append(query.Filter.IncludeVinaya);
         sb.Append(query.Filter.IncludeSutta);

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -39,6 +39,9 @@ namespace CST.Avalonia.Services.Tools
                 Mode = MapMode(request.Mode),
                 PageSize = request.MaxTerms,
                 Skip = request.Skip,
+                // No per-book breakdown requested => let the engine take counts straight from the index (no
+                // postings) when the search is also unfiltered.
+                CountsOnly = !request.IncludeBooks,
                 ProximityDistance = request.ProximityDistance,
                 Filter = MapFilter(request.Filter)
                 // IsPhrase / IsMultiWord are derived by SearchService from the query text.
@@ -57,7 +60,9 @@ namespace CST.Avalonia.Services.Tools
                         BookName: ScriptConverter.Convert(o.Book?.LongNavPath ?? string.Empty, Script.Devanagari, request.OutputScript),
                         Count: o.Count)).ToList()
                     : (IReadOnlyList<BookHitSummary>)Array.Empty<BookHitSummary>(),
-                BookCount: t.Occurrences.Count)).ToList();
+                // Counts-only path sets BookCount from the index (Occurrences empty); the postings path leaves
+                // BookCount 0, so fall back to the per-book count it computed.
+                BookCount: t.BookCount > 0 ? t.BookCount : t.Occurrences.Count)).ToList();
 
             // Guard the silent-empty footgun: '*'/'?' are literal outside Wildcard mode, so an Exact query
             // containing them matches no term and returns [] with no hint. Surface it in the note. (#186 cold test)


### PR DESCRIPTION
The cheap-count perf work uncovered a real correctness bug along the way, so this PR is both.

### 🔴 Cache-key bug (correctness — introduced in batch 8)
`GenerateCacheKey` included neither `Skip` nor `PageSize`. So paging the API (`Skip += MaxTerms`) kept returning the **cached first page** under the same key — page 2 *was* page 1. It slipped through because the **UI never pages** (always `Skip:0`) and the cold agent used a large `maxTerms` instead of paging. The key now includes `Skip`, `PageSize`, and `CountsOnly`. New integration test asserts page 1 and page 2 return **different terms** (would have failed before).

### ⚡ Counts-only fast path (perf)
When a search is **unfiltered** *and* the caller wants no per-book breakdown (`includeBooks:false`), take each term's `totalCount` (`TotalTermFreq`) and `bookCount` (`DocFreq`) **straight from the term dictionary — never reading postings**. This is exactly the enumeration/`.*`-paging case you flagged.
- `SearchQuery.CountsOnly` (SearchTool sets it `= !IncludeBooks`); `MatchingTerm.BookCount` carries `DocFreq` on this path (Occurrences left empty).
- A filter *or* `includeBooks:true` → the postings path, unchanged. The **UI** (`CountsOnly:false`) is unaffected.
- `totalBookCount` is left `0` on the fast path (distinct-books-across-page needs postings) and documented; the per-term `bookCount` is always present.

### Verified over the real index
The integration harness proves the counts-only path returns the **same** `totalCount` and `bookCount` as the postings path — against real Lucene stats, not a mock. Full suite green (the lone failure was the known-flaky `IndexingPerformanceTests` timing test; passes on retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)