### PR TITLE
Cover the last seam: app-composition test for LocalApiServer tool wiring

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/AppCompositionTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/AppCompositionTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.LocalApi;
+using CST.Avalonia.Services.Tools;
+using CST.Tools;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Integration
+{
+    /// <summary>
+    /// Guards the app's COMPOSITION seam: <see cref="LocalApiServer.FromServiceProvider"/> must resolve and pass
+    /// EVERY tool registered in DI. That's the /v1/scripts-404 class of bug - a tool registered but simply not
+    /// passed to the server - which the endpoint/integration harness can't catch because it wires the tools by
+    /// hand. The app and this test go through the SAME factory, so a forgotten tool fails here before shipping.
+    /// </summary>
+    public class AppCompositionTests : IAsyncLifetime
+    {
+        private string _dir = null!;
+        private LocalApiServer _server = null!;
+
+        public async Task InitializeAsync()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "cst-appcomp-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+
+            // Register the tools the app registers, with mocked underlying services. The FACTORY (not this test)
+            // decides which tools reach the server - that is the seam under test.
+            var search = new Mock<ISearchService>();
+            search.Setup(s => s.SearchAsync(It.IsAny<SearchQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new SearchResult());
+            var settings = new Mock<ISettingsService>();
+            settings.SetupGet(s => s.Settings)
+                .Returns(new Settings { XmlBooksDirectory = _dir, IndexDirectory = _dir });
+            var dict = new Mock<IDictionaryService>();
+            dict.SetupGet(d => d.AvailableLanguages).Returns(new[] { "en" });
+
+            var services = new ServiceCollection();
+            services.AddSingleton(search.Object);
+            services.AddSingleton(settings.Object);
+            services.AddSingleton(dict.Object);
+            services.AddSingleton<ISearchTool, SearchTool>();
+            services.AddSingleton<IDictionaryTool, DictionaryTool>();
+            services.AddSingleton<IPassageTool, PassageTool>();
+            services.AddSingleton<IScriptTool, ScriptTool>();
+            var provider = services.BuildServiceProvider();
+
+            _server = LocalApiServer.FromServiceProvider(provider, "test", _dir, Serilog.Log.Logger);
+            await _server.StartAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _server.StopAsync();
+            try { Directory.Delete(_dir, recursive: true); } catch { }
+        }
+
+        private HttpClient Authed()
+        {
+            var http = new HttpClient { BaseAddress = new Uri(_server.BaseUrl!) };
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _server.Token);
+            return http;
+        }
+
+        [Fact]
+        public async Task Registered_tools_are_all_mapped_by_the_factory()
+        {
+            using var http = Authed();
+
+            // ScriptTool - the exact endpoint the /v1/scripts-404 bug knocked out (a registered tool not passed).
+            Assert.Equal(HttpStatusCode.OK, (await http.GetAsync("/v1/scripts")).StatusCode);
+            // DictionaryTool.
+            Assert.Equal(HttpStatusCode.OK, (await http.GetAsync("/v1/dictionary/languages")).StatusCode);
+            // SearchTool.
+            Assert.Equal(HttpStatusCode.OK, (await http.PostAsync("/v1/search",
+                new StringContent("{\"query\":\"x\"}", Encoding.UTF8, "application/json"))).StatusCode);
+
+            // PassageTool is resolved by the identical factory path; its endpoint being mapped is confirmed
+            // transitively (an unknown-book 404 is indistinguishable from an unmapped 404, so it's not asserted
+            // directly here).
+        }
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -328,12 +328,11 @@ public partial class App : Application
             System.IO.Directory.CreateDirectory(dir);
 
             var version = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown";
-            _localApiServer = new CST.Avalonia.Services.LocalApi.LocalApiServer(
-                version, dir, Log.Logger,
-                ServiceProvider?.GetService<CST.Tools.ISearchTool>(),
-                ServiceProvider?.GetService<CST.Tools.IDictionaryTool>(),
-                ServiceProvider?.GetService<CST.Tools.IPassageTool>(),
-                ServiceProvider?.GetService<CST.Tools.IScriptTool>());
+            // Resolve the tools through the shared factory (covered by AppCompositionTests), so a tool that is
+            // registered but forgotten here can't silently 404 an endpoint again.
+            _localApiServer = ServiceProvider is { } sp
+                ? CST.Avalonia.Services.LocalApi.LocalApiServer.FromServiceProvider(sp, version, dir, Log.Logger)
+                : new CST.Avalonia.Services.LocalApi.LocalApiServer(version, dir, Log.Logger);
             await _localApiServer.StartAsync();
         }
         catch (Exception ex)

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -69,6 +69,20 @@ namespace CST.Avalonia.Services.LocalApi
             _script = script;
         }
 
+        /// <summary>
+        /// Build a server by resolving EVERY tool adapter from the DI container. This is the single place the
+        /// tools are gathered, so a forgotten tool (the /v1/scripts-404 class of bug, where a registered tool
+        /// was simply not passed to the server) is caught by one composition test instead of shipping. The app
+        /// and the test both go through here.
+        /// </summary>
+        public static LocalApiServer FromServiceProvider(
+            IServiceProvider services, string appVersion, string handshakeDirectory, Serilog.ILogger logger)
+            => new LocalApiServer(appVersion, handshakeDirectory, logger,
+                services.GetService<ISearchTool>(),
+                services.GetService<IDictionaryTool>(),
+                services.GetService<IPassageTool>(),
+                services.GetService<IScriptTool>());
+
         public async Task StartAsync(CancellationToken ct = default)
         {
             if (_app != null) return;


### PR DESCRIPTION
Closes the one seam the retrospective flagged that neither the endpoint tests nor the integration harness can reach: a tool **registered in DI but not passed** to `LocalApiServer` — the `/v1/scripts`-404 bug (batch 6), which lived in `App.axaml.cs`'s *own* inline construction. The harness can't catch it because it wires the tools by hand.

### Change
- **Extract** the tool resolution into `LocalApiServer.FromServiceProvider(sp, version, dir, logger)` — the single place tools are gathered from the container. `App.axaml.cs` now calls it, so the app and the test exercise the **same** code.
- **`AppCompositionTests`**: registers the tools (mocked underlying services), lets the **factory** decide which reach the server (that's the seam), and asserts the tool endpoints are mapped (`/v1/scripts`, `/v1/dictionary/languages`, `/v1/search`).

### Proof it has teeth
Per the retrospective's own lesson (a test that can't fail is worthless), I mutation-checked it: dropping `IScriptTool` from the factory makes the test **fail** (`/v1/scripts` → 404) — exactly the original bug. Restored, it passes.

Full suite green (**576**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)