### PR TITLE
#194: re-validate cached PDFs so pre-fix truncated files heal

### DIFF
--- a/src/CST.Avalonia.Tests/Services/SharePointDownloadTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SharePointDownloadTests.cs
@@ -91,6 +91,63 @@ public class SharePointDownloadTests : IDisposable
         Assert.False(File.Exists(PartPath));
     }
 
+    // ---- #194: IsIntactPdf gates the cache hit so a pre-fix truncated PDF is re-fetched, not trusted. ----
+
+    private string WritePdf(string content)
+    {
+        var path = Path.Combine(_dir, "chk-" + Guid.NewGuid().ToString("N") + ".pdf");
+        File.WriteAllBytes(path, Encoding.ASCII.GetBytes(content));
+        return path;
+    }
+
+    private const string ValidPdf = "%PDF-1.4\n1 0 obj\n<< >>\nendobj\ntrailer\n<< >>\nstartxref\n0\n%%EOF";
+
+    [Fact]
+    public void IsIntactPdf_TrueForCompletePdf()
+    {
+        Assert.True(SharePointService.IsIntactPdf(WritePdf(ValidPdf)));
+    }
+
+    [Fact]
+    public void IsIntactPdf_TrueWhenEofFollowedByTrailingWhitespace()
+    {
+        // A real PDF often ends with a newline after %%EOF; the tail scan must still find the marker.
+        Assert.True(SharePointService.IsIntactPdf(WritePdf(ValidPdf + "\r\n")));
+    }
+
+    [Fact]
+    public void IsIntactPdf_TrueForLargePdf_EofBeyondFirstKilobyte()
+    {
+        // The %%EOF lives only in the final chunk; a large file must still validate (proves the tail scan).
+        Assert.True(SharePointService.IsIntactPdf(WritePdf("%PDF-1.5\n" + new string('a', 5000) + "\n%%EOF")));
+    }
+
+    [Fact]
+    public void IsIntactPdf_FalseForTruncatedPdf_NoEofMarker()
+    {
+        // Header present, but the transfer was cut before the trailer/%%EOF - the #194 scenario.
+        Assert.False(SharePointService.IsIntactPdf(WritePdf("%PDF-1.4\n" + new string('a', 4000))));
+    }
+
+    [Fact]
+    public void IsIntactPdf_FalseForWrongHeader_EvenWithEofPresent()
+    {
+        Assert.False(SharePointService.IsIntactPdf(WritePdf("not a pdf at all\n%%EOF")));
+    }
+
+    [Fact]
+    public void IsIntactPdf_FalseForEmptyOrTinyFile()
+    {
+        Assert.False(SharePointService.IsIntactPdf(WritePdf("")));
+        Assert.False(SharePointService.IsIntactPdf(WritePdf("%PDF")));
+    }
+
+    [Fact]
+    public void IsIntactPdf_FalseForMissingFile()
+    {
+        Assert.False(SharePointService.IsIntactPdf(Path.Combine(_dir, "does-not-exist.pdf")));
+    }
+
     // A read-stream that always throws, to simulate a dropped connection mid-download.
     private sealed class ThrowingStream : Stream
     {

--- a/src/CST.Avalonia/Services/SharePointService.cs
+++ b/src/CST.Avalonia/Services/SharePointService.cs
@@ -192,11 +192,19 @@ namespace CST.Avalonia.Services
 
             var localPath = GetLocalPdfPath(sharePointPath);
 
-            // Check if file already exists
+            // Use the cached copy only if it's an intact PDF. A pre-NET-1 truncated download left at localPath
+            // would otherwise be trusted forever (these files are the permanent preservation store, never
+            // evicted, so it never heals). A corrupt cached file falls through to a fresh, size-verified
+            // re-download below, which atomically REPLACES the bad file - re-downloading a corrupt file does not
+            // conflict with the preservation rule. (#194, follow-up to NET-1)
             if (File.Exists(localPath))
             {
-                _logger.LogInformation("PDF already cached locally: {Path}", localPath);
-                return localPath;
+                if (IsIntactPdf(localPath))
+                {
+                    _logger.LogInformation("PDF already cached locally: {Path}", localPath);
+                    return localPath;
+                }
+                _logger.LogWarning("Cached PDF failed integrity check (truncated/corrupt); re-downloading: {Path}", localPath);
             }
 
             try
@@ -292,6 +300,42 @@ namespace CST.Avalonia.Services
         {
             try { if (File.Exists(path)) File.Delete(path); }
             catch { /* best-effort cleanup of the partial file */ }
+        }
+
+        /// <summary>
+        /// A cheap, offline structural check that a file is a complete PDF: it must begin with the
+        /// <c>%PDF-</c> header and carry the <c>%%EOF</c> end-of-file marker near its tail. A download
+        /// truncated mid-transfer keeps a valid header but loses the trailing <c>%%EOF</c>, so this catches the
+        /// #194 pre-fix truncation without a network round-trip (the authoritative byte-size check happens on
+        /// (re)download via <see cref="SaveStreamVerifiedAsync"/>). Anything unreadable is treated as not intact
+        /// so it gets re-fetched. (#194)
+        /// </summary>
+        internal static bool IsIntactPdf(string path)
+        {
+            ReadOnlySpan<byte> header = "%PDF-"u8;
+            ReadOnlySpan<byte> eof = "%%EOF"u8;
+            try
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                long length = fs.Length;
+                if (length < header.Length + eof.Length) return false;
+
+                Span<byte> headBuf = stackalloc byte[5];
+                fs.ReadExactly(headBuf);
+                if (!headBuf.SequenceEqual(header)) return false;
+
+                // Scan the final chunk for %%EOF (the spec allows trailing whitespace/newlines after it).
+                int tailLength = (int)Math.Min(1024, length);
+                Span<byte> tailBuf = stackalloc byte[1024];
+                tailBuf = tailBuf.Slice(0, tailLength);
+                fs.Seek(-tailLength, SeekOrigin.End);
+                fs.ReadExactly(tailBuf);
+                return tailBuf.IndexOf(eof) >= 0;
+            }
+            catch
+            {
+                return false; // unreadable/locked => treat as not intact and re-fetch rather than trust it
+            }
         }
 
         public string GetLocalPdfPath(string sharePointPath)


### PR DESCRIPTION
Follow-up to #129 (NET-1). Closes #194.

## Problem
`SharePointService.DownloadPdfAsync` accepted any file already at `localPath` (`if (File.Exists(localPath)) return localPath;`). The NET-1 atomic-download fix stops NEW truncated PDFs, but a PDF left truncated by a *pre-fix* download is still trusted forever — the downloaded source PDFs are the permanent preservation store (never evicted), so such a file never heals.

## Fix
Gate the cache hit on a new cheap, **offline** integrity predicate, `IsIntactPdf`:
- must begin with the `%PDF-` header, and
- must carry the `%%EOF` end-of-file marker within its final chunk (the spec allows trailing whitespace after it).

A download truncated mid-transfer keeps a valid header but loses the trailing `%%EOF`, so this catches the #194 scenario with no network round-trip. A cached file that fails the check falls through to the existing atomic, size-verified re-download (`SaveStreamVerifiedAsync`), which **replaces** the corrupt file — re-downloading a corrupt file does not conflict with the preservation rule, and the authoritative byte-size check still happens there.

## Tests
7 new unit tests for `IsIntactPdf` (complete / `%%EOF`-with-trailing-whitespace / large file with EOF beyond the first KB / truncated-no-EOF / wrong-header / empty-or-tiny / missing-file), alongside the existing NET-1 `SaveStreamVerifiedAsync` tests. Full suite: 584 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)