### PR TITLE
docs: research spikes for #55 (index shrink) and #109 (DPD dictionary)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -90,10 +90,12 @@ Exploratory research and investigations:
 - [Alternative Rendering Engines](research/ALTERNATIVE_RENDERING_ENGINES.md) - Comparison of rendering approaches
 - [Browser Embedding Options](research/BROWSER_EMBEDDING_OPTIONS.md) - WebView alternatives
 - [Button-Based Float Approach](research/BUTTON_BASED_FLOAT_APPROACH.md) - Manual float/unfloat to prevent CEF crashes
+- [DPD Dictionary Integration Spike](research/DPD_DICTIONARY_INTEGRATION_SPIKE.md) - #109 third-party dictionary support: DPD + external-dictionary import format
 - [Git Integration](research/GIT_INTEGRATION.md) - Git-based features
 - [MAUI Blazor POC Plan](research/MAUI_BLAZOR_POC_PLAN.md) - Cross-platform proof of concept planning
 - [MAUI Blazor POC Results](research/MAUI_BLAZOR_POC_RESULTS.md) - POC findings and conclusions
 - [Rendering Requirements](research/RENDERING_REQUIREMENTS.md) - Content rendering needs analysis
+- [Search Index Shrink Spike](research/SEARCH_INDEX_SHRINK_SPIKE.md) - #55 dropping redundant term vectors / norms / payloads (~135 MB → ~75 MB)
 - [Strategic Technology Options](research/STRATEGIC_TECHNOLOGY_OPTIONS.md) - Technology direction evaluation
 
 ### 📚 **reference/** - Reference Materials

--- a/docs/research/DPD_DICTIONARY_INTEGRATION_SPIKE.md
+++ b/docs/research/DPD_DICTIONARY_INTEGRATION_SPIKE.md
@@ -1,0 +1,230 @@
+# Third-Party Dictionary Support (DPD + Import Format) — Research Spike (#109)
+
+*Read-only spike. Backend-only; UI/layout explicitly out of scope. This is analysis for planning, not an implementation.*
+
+## Executive summary
+
+- The Digital Pāḷi Dictionary (DPD) is a large, actively maintained (roughly monthly) Pāli→English dictionary. Latest release at time of writing: **`v0.4.20260531`** with **~89,050 headwords** (~47k fully complete).
+- **The data is licensed CC BY-NC-SA 4.0** — Attribution + **NonCommercial** + **ShareAlike**. This is the single most decision-critical fact in this report. Both the **NC** and **SA** clauses have real implications for a distributed reader and argue for **on-demand download with clear attribution rather than bundling**.
+- DPD ships many consumer formats plus **machine-readable sources**: the full SQLite `dpd.db` (177 MB compressed), a mobile SQLite db (141 MB), a **plain-text export (`dpd-txt.zip`, ~4.2 MB)**, and — inside the git repo — a canonical **50-column TSV backup** of the headwords table. The TSV/SQLite are the right programmatic import sources.
+- DPD entries are **richly structured** (lemma, POS, grammar, meaning, root, construction, examples, inflection data, etc.), far beyond the current `headword \n definition` shape. Recommendation: import DPD as a **flattened HTML fragment per headword** into a slightly generalized version of the existing model, not DPD's full relational schema.
+- Proposed: a **simple, documented external-dictionary import format** (a `manifest.json` + a 2-column TSV payload) that both a DPD converter and hand-made user dictionaries can target, with IPE normalization of headwords at import time.
+- Recommended backend evolution: move from per-**language** selection to per-**source** selection, keep the existing EN/HI built-ins working unchanged, and keep `IDictionaryService` / `IDictionaryTool` format-agnostic.
+
+## 1. Current backend (verified against the code)
+
+The dictionary backend today is a faithful, UI-free port of CST4's `FormDictionary`:
+
+- **Model** (`Models/DictionaryWord.cs`): `{ string Word /* IPE-normalized headword, the sort/search key */, string Meaning /* HTML fragment */ }`.
+- **Index** (`Services/DictionaryIndex.cs`): an immutable list sorted by **ordinal** comparison of IPE headwords (the IPE collation invariant: codepoint order == Pāli alphabetical order). `Lookup` does binary search → exact hit + `StartsWith` prefix run, or on a miss the tied-longest-common-prefix nearest-neighbor run. Pure and unit-testable.
+- **Service** (`Services/DictionaryService.cs` + `IDictionaryService.cs`): reads **every file** in `dictionaries/<lang>/`, parses **alternating lines** (headword, definition), IPE-normalizes each headword via `Any2Ipe.Convert`, and **merges duplicate headwords** by joining definitions with a `MeaningSeparator` (`<hr/>`). Data is loaded lazily per language and cached. First run seeds app-support from a bundled `dictionaries/` copy (`EnsureBundledDictionaries`).
+- **On disk**: `~/Library/Application Support/CSTReader/dictionaries/en/…` and `…/hi/…`; repo source-of-truth mirror at `src/CST.Avalonia/dictionaries/`. Files are UTF-8/LF.
+- **Selection unit is a *language***: `AvailableLanguages` returns two-letter codes; `LookupAsync(language, query)`. Multiple source files *within* a language dir merge transparently.
+- **Agent contract** (`CST.Core/Tools/DictionaryToolContracts.cs`): `IDictionaryTool` with `Languages` and `LookupAsync(DictionaryRequest{ Language, Query, OutputScript, MaxEntries })` → `DictionaryEntry{ Headword, MeaningHtml }`. Explicitly documented as format-agnostic.
+
+Design doc of record: `docs/features/in-progress/DICTIONARIES.md`.
+
+**Key takeaway:** the backend already supports *multiple merged files per language* and a *format-agnostic* tool contract. What it does **not** have is the concept of a *named source* with its own metadata/attribution, or per-source selection — which is exactly what #109 needs.
+
+## 2. DPD data landscape
+
+### 2.1 What DPD is
+DPD is a feature-rich Pāḷi-English dictionary by **Bhikkhu Bodhirāsa**, running on the web (dpdict.net) and in GoldenDict/MDict/DictTango/Kindle/Kobo/etc. Data + build code live in [`digitalpalidictionary/dpd-db`](https://github.com/digitalpalidictionary/dpd-db).
+
+### 2.2 Distribution formats (release `v0.4.20260531`, verified via GitHub API)
+
+| Asset | Size | Notes |
+|---|---|---|
+| `dpd.db.tar.bz2` | **177 MB** | **Full SQLite database** (all tables) — the canonical machine-readable source |
+| `dpd-mobile-db.zip` | **141 MB** | Trimmed **SQLite** db for mobile apps |
+| `dpd-txt.zip` | **4.2 MB** | **Plain-text** rendered export |
+| `dpd-mdict.zip` | 318 MB | MDict |
+| `dpd-goldendict.zip` | 273 MB | GoldenDict |
+| `dpd-slob.zip` | 302 MB | Aard2 Slob |
+| `dpd-kindle.mobi` / `.epub` | 74 MB / 19 MB | Kindle |
+| `dpd-kobo.zip` | 14 MB | Kobo |
+| `dpd-apple.dictionary.zip` | 34 MB | Apple Dictionary.app |
+| `dpd-anki.apkg` | 13 MB | Anki deck |
+| `dpd-pdf.zip` | 36 MB | PDF |
+
+Additionally, **inside the git repo** (not a release asset) there is a canonical **TSV backup** of the source data: `db/backup_tsv/dpd_headwords_part_001..003.tsv` (+ `dpd_roots_part_001.tsv`, `sutta_info.tsv`). The headwords TSV has **50 quoted, tab-separated columns**, header row first.
+
+**Best programmatic import source:** the **full SQLite `dpd.db`** (query exactly the fields you want) or the **repo TSV backup** (no DB engine needed, versioned in git). `dpd-txt.zip` is pre-rendered prose — convenient but lossy. GoldenDict/MDict/Slob are consumer bundles, awkward to parse. **Recommendation: convert from SQLite (preferred) or TSV.**
+
+### 2.3 Entry structure (the `DpdHeadword` table)
+Verified from `db/models.py` and the TSV header. Core fields relevant to import:
+
+- **Identity / headword**: `id`, `lemma_1` (headword *with* homonym disambiguation, e.g. `dhamma 1`), `lemma_2`.
+- **Grammar**: `pos`, `grammar`, `neg`, `verb`, `trans`, `plus_case`, `derived_from`.
+- **Meaning**: `meaning_1` (primary), `meaning_lit` (literal), `meaning_2` (secondary/legacy); computed `meaning_combo`, `degree_of_completion`.
+- **Etymology / morphology**: `root_key`, `root_sign`, `root_base`, `family_root`, `family_word`, `family_compound`, `construction`, `derivative`, `suffix`, `phonetic`, `compound_type`, `sanskrit`, `non_ia`.
+- **Attestation**: `source_1/sutta_1/example_1`, `source_2/sutta_2/example_2`.
+- **Relations / notes**: `antonym`, `synonym`, `variant`, `commentary`, `notes`, `cognate`, `link`, `origin`.
+- **Inflection**: `stem`, `pattern`, `inflections*` (incl. Sinhala/Devanagari/Thai variants), `inflections_html`, plus frequency data.
+
+**Two "layers".** DPD is effectively two related datasets: (a) the **headword/word layer** (`DpdHeadword`) and (b) a **root layer** (`DpdRoot`: `root`, `root_meaning`, dhātupāṭha references, etc.). There is also a critical (c) **`Lookup` table** mapping any **inflected/looked-up form → headword id(s)** — this is how DPD resolves an inflected form the user typed to the right lemma. See §9 (a functional gap for our IPE-prefix approach).
+
+Reported statistics (release `v0.3.20260202`): 88,350 headwords (47,535 complete / 11,472 partial / 29,343 incomplete), 754 roots, 3,350 root families, **1,477,220** inflected forms, **858,681** compound deconstructions. Latest release: **89,050 headwords**.
+
+### 2.4 Update cadence & versioning
+- **Cadence:** roughly **monthly** releases.
+- **Version tags:** `v[MAJOR].[MINOR].[YYYYMMDD]` (e.g. `v0.4.20260531`). The embedded date makes "is my copy stale?" a trivial comparison; `DbInfo` inside the db carries version metadata.
+
+## 3. Licensing & attribution (decision-critical)
+
+**The DPD data is licensed [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)** (the repo build code carries its own separate open-source terms; the *content* is CC BY-NC-SA 4.0). From `docs/license.md`:
+
+> Digital Pāḷi Dictionary is made available under a **CC BY-NC-SA 4.0** license.
+> — **CC**: free to share and adapt … **BY**: attribute the source, **NC**: don't use it commercially, **SA**: share under the same conditions.
+
+Implications for CST Reader (a free reader for VRI texts):
+
+1. **BY (Attribution) — required.** Any shipped/derived DPD data must display attribution: creator **Bhikkhu Bodhirāsa**, title **Digital Pāḷi Dictionary**, the **CC BY-NC-SA 4.0** license (with link), the **version** used, and the homepage **https://dpdict.net**. This belongs in the import manifest and somewhere user-visible (credits — a UI concern, flagged for the maintainer).
+
+2. **NC (NonCommercial) — the main constraint.** DPD may not be used "primarily intended for or directed toward commercial advantage." A genuinely free reader distributing DPD at no charge is squarely in the intended use. Grey areas to decide: paid app-store listings, bundling inside a paid/pro tier, or any future monetization would be **incompatible**. Distributing via free channels is generally fine (CC's NC FAQ treats no-charge distribution as non-commercial), but this is a judgment call — **flag for maintainer**.
+
+3. **SA (ShareAlike) — applies to *adaptations*.** A converted/flattened DPD file **is an adaptation** and must be offered under CC BY-NC-SA 4.0 (or compatible). SA attaches to the **adapted DPD data**, *not* to CST Reader's own source code: bundling a separately-licensed data file alongside independently-licensed application code is a **"mere aggregation / collection,"** which SA does not reach. So the app's own license is unaffected, **but** the shipped DPD-derived file must itself be marked CC BY-NC-SA 4.0.
+
+4. **Bundle vs. download.** Because both NC and SA "travel with" the DPD data, the cleanest posture is to **keep the DPD data physically and licensally separate from the app**: download it **on demand** into the user's asset store, tagged with its own manifest carrying the license, rather than embedding it in the signed app bundle. This keeps the app bundle free of NC-encumbered content, avoids shipping 130–180 MB per release, and makes attribution/versioning explicit per source. See §6.
+
+> Could not verify with certainty: the precise commercial/non-commercial status of specific distribution channels (e.g. a future paid app-store SKU). That is a judgment for the maintainer; the license text and CC FAQ are the primary sources.
+
+## 4. Mapping DPD → CST
+
+Two options: **(a)** flatten to the existing `headword \n definition (HTML)` shape, rendering the useful fields (meaning / literal / grammar / root / construction / trimmed example) into a small HTML fragment; or **(b)** adopt a richer structured entry model.
+
+**Recommendation: (a) flattened HTML, for v1.** Rationale:
+- Reuses the entire existing pipeline (IPE normalization, ordinal index, binary-search lookup, duplicate-merge, WebView rendering, `DictionaryEntry.MeaningHtml`) with **zero changes to the matching core**.
+- The agent-facing `IDictionaryTool` is *already* defined around `MeaningHtml` and documented as format-agnostic — a structured model forces a contract change for no v1 benefit.
+- DPD's own consumer exports are themselves flattened HTML; nothing is lost vs GoldenDict/MDict users.
+- Homonyms (`dhamma 1`, `dhamma 2`, …) collapse to one IPE headword and merge with the existing `<hr/>` separator — which the current loader already does for free.
+- A richer model is a **later** option (§8) if the UI later wants collapsible grammar/inflection sections.
+
+Conversion notes:
+- **Headword source:** use DPD's clean lemma (strip the trailing homonym number from `lemma_1`); feed to `Any2Ipe.Convert`. Verify `Any2Ipe` handles the full diacritic set (esp. `ṃ`/`ṁ` niggahita variants).
+- **NFC:** normalize to NFC before IPE conversion (the service already does this for queries; do the same at import).
+- **HTML safety:** sanitize/whitelist the rendered fragment; keep it a self-contained fragment as the contract expects.
+- **Completeness filter:** consider importing only entries with `meaning_1` (or including `degree_of_completion`) to avoid ~29k "incomplete" stubs — a maintainer toggle.
+
+## 5. Proposed external-dictionary import format
+
+Design goals: **one format** that a DPD converter emits *and* a user can hand-author for a small dictionary; expressive enough to carry license/attribution/version; trivial to parse with the existing loader.
+
+### 5.1 On-disk layout (per **source**, not per language)
+```
+dictionaries/
+  vri-en/         (legacy built-in, keeps working; see §7 back-compat)
+  vri-hi/
+  dpd/
+    manifest.json
+    entries.tsv
+  my-glossary/
+    manifest.json
+    entries.tsv
+```
+
+### 5.2 Manifest (`manifest.json`)
+```json
+{
+  "formatVersion": 1,
+  "id": "dpd",
+  "name": "Digital Pāḷi Dictionary",
+  "shortName": "DPD",
+  "languages": ["en"],
+  "sourceLanguage": "pi",
+  "headwordScript": "latin",
+  "meaningFormat": "html",
+  "version": "0.4.20260531",
+  "homepage": "https://dpdict.net",
+  "license": "CC-BY-NC-SA-4.0",
+  "licenseUrl": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+  "attribution": "Digital Pāḷi Dictionary by Bhikkhu Bodhirāsa — CC BY-NC-SA 4.0 — https://dpdict.net",
+  "entriesFile": "entries.tsv",
+  "entryCount": 89050
+}
+```
+- `headwordScript` tells the importer which script the headwords are in **before** IPE conversion (`latin` for DPD, `devanagari` for VRI Hindi). The importer runs `Any2Ipe.Convert` accordingly, so headwords are stored in IPE regardless of source script — preserving the collation invariant.
+- `languages` allows a single source to serve more than one target language.
+- `meaningFormat` = `html` (default) or `text` (importer wraps in `<p>`).
+
+### 5.3 Entry payload (`entries.tsv`)
+Two tab-separated columns, header row, one entry per line — **more robust than the legacy alternating-line format** (no off-by-one corruption, greppable, spreadsheet-editable):
+```
+headword	meaning_html
+dhamma	<p><b>dhamma</b>, <i>masc.</i> the teaching; nature; a mental state…</p><hr/><p><b>dhamma</b> (2)…</p>
+akkhi	<p><b>akkhi</b>, <i>nt.</i> the eye.</p>
+```
+- Headword is authored in the source script (`headwordScript`); the importer IPE-normalizes it. Multiple rows with the same headword merge as today (`<hr/>`).
+- Embedded newlines within a definition are encoded (`\n`) or the cell is HTML with `<br/>`.
+
+**Hand-authoring a tiny dictionary:** a user drops a folder with a 6-line `manifest.json` and a 2-column TSV. That is the whole contract.
+
+**Backward compatibility:** a source directory with **no `manifest.json`** is treated as a *legacy language source* (current alternating-line `.txt` behavior, id/name from the dir name, `meaningFormat=html`, `headwordScript` inferred from language). So `en/` and `hi/` keep working untouched.
+
+> Optional richer variant (deferred): allow `entries.jsonl` (one JSON object per line) with optional structured fields (`pos`, `grammar`, `examples[]`) for sources that want a structured model later. v1 does not require it.
+
+## 6. Delivery
+
+- **Built-in EN/HI:** stay **bundled** (small, VRI-owned, no NC issue), seeded to app-support on first run as today.
+- **DPD:** **on-demand download**, not bundled — size (130–180 MB machine-readable; even flattened, tens of MB), the NC/SA posture (§3), and monthly churn. Fetch the SQLite/TSV from `releases/latest`, convert locally to the import format, write into the user's dictionary store.
+- **Where converted dictionaries live:** under app-support `dictionaries/<sourceId>/`. Treat downloaded/converted DPD data as a **preservation asset** (consistent with the project's rule that downloaded source PDFs are a preservation store, not an evictable cache) — never auto-delete.
+- **Conversion location:** ideally a small offline/CI converter (Python or C#) produces a redistributable `dpd/` folder; the app can also download-and-convert at runtime. Converting **outside** the signed app keeps the bundle free of NC content and avoids adding a SQLite dependency if TSV is used.
+- **Versioning / refresh:** the manifest `version` mirrors DPD's `v[MAJOR].[MINOR].[YYYYMMDD]` tag; a refresh check compares stored vs `releases/latest` (GitHub API).
+
+## 7. Backend model changes (BACKEND ONLY — UI/layout out of scope)
+
+Move from per-**language** to per-**source** selection, keeping everything additive and back-compatible.
+
+1. **Source metadata type** (new): `DictionarySourceInfo { string Id, string Name, IReadOnlyList<string> Languages, string HeadwordScript, string Version, string Attribution, string LicenseId, string Homepage }`, populated from `manifest.json` (or synthesized for legacy dirs).
+
+2. **`IDictionaryService`** — add source-aware members, keep language members:
+   - `IReadOnlyList<DictionarySourceInfo> AvailableSources { get; }`
+   - `Task<IReadOnlyList<DictionaryWord>> LookupAsync(string sourceId, string query)` — per-source.
+   - `Task<IReadOnlyList<DictionaryLookupResult>> LookupAllAsync(string query, IEnumerable<string>? sourceIds = null)` where `DictionaryLookupResult { DictionarySourceInfo Source, IReadOnlyList<DictionaryWord> Entries }` — **combined, sectioned** results with per-source attribution.
+   - Keep `AvailableLanguages` / `LookupAsync(language, …)` as thin wrappers over sources grouped by language, so nothing existing breaks.
+
+3. **Loader** (`DictionaryService`): detect `manifest.json`; if present, parse the 2-column TSV honoring `headwordScript`/`meaningFormat`; else fall back to the legacy alternating-line reader. Cache per **source**. Each `DictionaryIndex` stays as-is (IPE-ordinal, dup-merge).
+
+4. **Agent contract** (`IDictionaryTool` / `DictionaryToolContracts.cs`): stays format-agnostic; extend additively — `Sources { get; }` (keep `Languages`); optional `SourceId`/`SourceIds[]` on `DictionaryRequest` (omitted ⇒ behave as today); optional `SourceId`/`SourceName`/`Attribution` on `DictionaryEntry` so combined results are attributable (existing 2-field construction still compiles).
+
+5. **Combined-search rendering** (sectioned display with source headers) is a UI concern — **out of scope**; the service returns grouped, attributed results.
+
+All additive and unit-testable with `dotnet test` (new tests: manifest parsing, per-source cache, combined lookup ordering, legacy fallback).
+
+## 8. Phasing / proposed child issues
+
+- **v1 — Import format + per-source backend + one importable dictionary (no DPD yet):** define & document `manifest.json` + `entries.tsv`; loader manifest detection + TSV + legacy fallback + per-source caching; additive source-aware API with back-compat wrappers; ship/convert one small importable dictionary end-to-end; tests.
+- **v2 — DPD on-demand:** offline/CI converter (DPD SQLite/TSV → flattened `dpd/` folder, IPE headwords, HTML meanings, completeness filter, stamped with version + CC BY-NC-SA 4.0 attribution); in-app download + refresh check; store as preservation asset; attribution surfaced (UI: maintainer).
+- **v3 — Multi-dictionary combined search:** `LookupAllAsync` sectioned/attributed results; agent-tool multi-source support.
+- **v4 (optional) — Richer entry model + inflected-form resolution:** optional `entries.jsonl`; import DPD's `Lookup` table so inflected forms resolve to lemmas (see §9).
+
+**Suggested #109 breakdown:** #109a "External dictionary import format + per-source backend (v1)"; #109b "DPD converter + on-demand download (v2)"; #109c "Combined multi-source lookup (v3)"; #109d "Structured entries + DPD inflection lookup (v4)".
+
+## 9. Risks & open questions
+
+1. **NC license posture (maintainer decision).** Is CST Reader guaranteed to remain free across all distribution channels (incl. app stores, any future pro tier)? NC forbids commercial use of DPD. Recommend on-demand download + explicit attribution to keep DPD cleanly separable. **Blocking design input needed.**
+2. **SA on the converted file.** The DPD-derived import folder must itself be marked CC BY-NC-SA 4.0. Confirm comfort shipping/hosting a CC-BY-NC-SA data artifact (the app's own code license is unaffected — mere aggregation).
+3. **Inflected-form lookup gap.** DPD's core value includes resolving *inflected forms* (1.4M) and *compound deconstructions* to lemmas via its `Lookup` table. Our IPE prefix/nearest-neighbor search only matches **lemma prefixes**, so a user typing an inflected form may miss. v1–v3 ignore this; v4 should import DPD's `Lookup` mappings. **Biggest UX gap vs. using DPD natively.**
+4. **IPE conversion fidelity for DPD lemmas.** Verify `Any2Ipe.Convert` round-trips all DPD diacritics and niggahita variants; decide homonym-number handling (strip → merge, as recommended).
+5. **Size/perf.** Even flattened, DPD is large (~89k headwords). Validate load time/memory of a single large `DictionaryIndex`; ordinal binary search scales fine, but startup/seed cost and merge behavior should be measured.
+6. **HTML sanitization.** DPD fields contain markup, links, cross-references; ensure the rendered fragment is safe and self-contained for the WebView; decide whether/how to map DPD cross-references to the existing SeeAlso mechanism.
+7. **Converter maintenance.** DPD releases monthly and its schema evolves; the converter must track `DpdHeadword` field changes. Pin to a known-good DPD version and re-verify on bump.
+8. **Language coverage.** DPD is Pāli→English only today; the per-source model handles that, but don't assume future sources are English.
+
+## 10. Sources
+
+- DPD home / docs: https://digitalpalidictionary.github.io/
+- Data + build repo: https://github.com/digitalpalidictionary/dpd-db
+- Releases (formats, sizes, cadence, version tags): https://github.com/digitalpalidictionary/dpd-db/releases
+- License (CC BY-NC-SA 4.0): https://raw.githubusercontent.com/digitalpalidictionary/dpd-db/main/docs/license.md
+- CC BY-NC-SA 4.0 legal text: https://creativecommons.org/licenses/by-nc-sa/4.0/
+- `DpdHeadword` schema (`db/models.py`): https://raw.githubusercontent.com/digitalpalidictionary/dpd-db/main/db/models.py
+- TSV backup (canonical source columns): https://github.com/digitalpalidictionary/dpd-db/tree/main/db/backup_tsv
+- Plain-text exporter (`exporter/txt/`): https://github.com/digitalpalidictionary/dpd-db/tree/main/exporter/txt
+- Web app: https://www.dpdict.net/
+
+*Internal ground truth (this repo):* `docs/features/in-progress/DICTIONARIES.md`; `src/CST.Avalonia/Services/{DictionaryService,IDictionaryService,DictionaryIndex}.cs`; `src/CST.Avalonia/Models/DictionaryWord.cs`; `src/CST.Core/Tools/DictionaryToolContracts.cs`.
+
+---
+
+*Provenance: research spike for [issue #109](https://github.com/fsnow/cst/issues/109).*

--- a/docs/research/DPD_DICTIONARY_INTEGRATION_SPIKE.md
+++ b/docs/research/DPD_DICTIONARY_INTEGRATION_SPIKE.md
@@ -79,7 +79,7 @@ Reported statistics (release `v0.3.20260202`): 88,350 headwords (47,535 complete
 
 Implications for CST Reader (a free reader for VRI texts):
 
-1. **BY (Attribution) — required.** Any shipped/derived DPD data must display attribution: creator **Bhikkhu Bodhirāsa**, title **Digital Pāḷi Dictionary**, the **CC BY-NC-SA 4.0** license (with link), the **version** used, and the homepage **https://dpdict.net**. This belongs in the import manifest and somewhere user-visible (credits — a UI concern, flagged for the maintainer).
+1. **BY (Attribution) — required.** Any shipped/derived DPD data must display attribution: creator **Bhikkhu Bodhirāsa**, title **Digital Pāḷi Dictionary**, the **CC BY-NC-SA 4.0** license (with link), the **version** used, and the homepage **https://dpdict.net**. This belongs in the import manifest and somewhere user-visible (credits — a UI concern, flagged for the maintainer). ([citation guidance](https://buddhistuniversity.net/content/reference/dpd))
 
 2. **NC (NonCommercial) — the main constraint.** DPD may not be used "primarily intended for or directed toward commercial advantage." A genuinely free reader distributing DPD at no charge is squarely in the intended use. Grey areas to decide: paid app-store listings, bundling inside a paid/pro tier, or any future monetization would be **incompatible**. Distributing via free channels is generally fine (CC's NC FAQ treats no-charge distribution as non-commercial), but this is a judgment call — **flag for maintainer**.
 
@@ -222,6 +222,8 @@ All additive and unit-testable with `dotnet test` (new tests: manifest parsing, 
 - TSV backup (canonical source columns): https://github.com/digitalpalidictionary/dpd-db/tree/main/db/backup_tsv
 - Plain-text exporter (`exporter/txt/`): https://github.com/digitalpalidictionary/dpd-db/tree/main/exporter/txt
 - Web app: https://www.dpdict.net/
+- Attribution/citation guidance (creator Bhikkhu Bodhirāsa): https://buddhistuniversity.net/content/reference/dpd
+- Release stats example (`v0.3.20260202`): https://github.com/digitalpalidictionary/dpd-db/releases/tag/v0.3.20260202
 
 *Internal ground truth (this repo):* `docs/features/in-progress/DICTIONARIES.md`; `src/CST.Avalonia/Services/{DictionaryService,IDictionaryService,DictionaryIndex}.cs`; `src/CST.Avalonia/Models/DictionaryWord.cs`; `src/CST.Core/Tools/DictionaryToolContracts.cs`.
 

--- a/docs/research/DPD_DICTIONARY_INTEGRATION_SPIKE.md
+++ b/docs/research/DPD_DICTIONARY_INTEGRATION_SPIKE.md
@@ -5,7 +5,7 @@
 ## Executive summary
 
 - The Digital Pāḷi Dictionary (DPD) is a large, actively maintained (roughly monthly) Pāli→English dictionary. Latest release at time of writing: **`v0.4.20260531`** with **~89,050 headwords** (~47k fully complete).
-- **The data is licensed CC BY-NC-SA 4.0** — Attribution + **NonCommercial** + **ShareAlike**. This is the single most decision-critical fact in this report. Both the **NC** and **SA** clauses have real implications for a distributed reader and argue for **on-demand download with clear attribution rather than bundling**.
+- **The data is licensed CC BY-NC-SA 4.0** — Attribution + **NonCommercial** + **ShareAlike**. The **NC** clause is **not a concern**: CST Reader is non-commercial by principle, and non-commercial use is itself one of the conditions under which the VRI texts are used — so DPD's NonCommercial term is consonant with the whole project. The live considerations are lighter: **BY** (display attribution) and **SA** (the converted DPD file must itself be marked CC BY-NC-SA and kept separable from the app's own code). Delivery still favors **on-demand download** — driven by size and monthly churn, not license risk.
 - DPD ships many consumer formats plus **machine-readable sources**: the full SQLite `dpd.db` (177 MB compressed), a mobile SQLite db (141 MB), a **plain-text export (`dpd-txt.zip`, ~4.2 MB)**, and — inside the git repo — a canonical **50-column TSV backup** of the headwords table. The TSV/SQLite are the right programmatic import sources.
 - DPD entries are **richly structured** (lemma, POS, grammar, meaning, root, construction, examples, inflection data, etc.), far beyond the current `headword \n definition` shape. Recommendation: import DPD as a **flattened HTML fragment per headword** into a slightly generalized version of the existing model, not DPD's full relational schema.
 - Proposed: a **simple, documented external-dictionary import format** (a `manifest.json` + a 2-column TSV payload) that both a DPD converter and hand-made user dictionaries can target, with IPE normalization of headwords at import time.
@@ -70,7 +70,7 @@ Reported statistics (release `v0.3.20260202`): 88,350 headwords (47,535 complete
 - **Cadence:** roughly **monthly** releases.
 - **Version tags:** `v[MAJOR].[MINOR].[YYYYMMDD]` (e.g. `v0.4.20260531`). The embedded date makes "is my copy stale?" a trivial comparison; `DbInfo` inside the db carries version metadata.
 
-## 3. Licensing & attribution (decision-critical)
+## 3. Licensing & attribution
 
 **The DPD data is licensed [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)** (the repo build code carries its own separate open-source terms; the *content* is CC BY-NC-SA 4.0). From `docs/license.md`:
 
@@ -81,13 +81,13 @@ Implications for CST Reader (a free reader for VRI texts):
 
 1. **BY (Attribution) — required.** Any shipped/derived DPD data must display attribution: creator **Bhikkhu Bodhirāsa**, title **Digital Pāḷi Dictionary**, the **CC BY-NC-SA 4.0** license (with link), the **version** used, and the homepage **https://dpdict.net**. This belongs in the import manifest and somewhere user-visible (credits — a UI concern, flagged for the maintainer). ([citation guidance](https://buddhistuniversity.net/content/reference/dpd))
 
-2. **NC (NonCommercial) — the main constraint.** DPD may not be used "primarily intended for or directed toward commercial advantage." A genuinely free reader distributing DPD at no charge is squarely in the intended use. Grey areas to decide: paid app-store listings, bundling inside a paid/pro tier, or any future monetization would be **incompatible**. Distributing via free channels is generally fine (CC's NC FAQ treats no-charge distribution as non-commercial), but this is a judgment call — **flag for maintainer**.
+2. **NC (NonCommercial) — satisfied by the project's non-commercial principle.** DPD may not be used "primarily intended for or directed toward commercial advantage." CST Reader is non-commercial by design, and non-commercial use is one of the few conditions under which the VRI texts themselves are used — so DPD's NC term aligns with the project rather than constraining it. The only standing implication is that the project remains non-commercial (no paid tier / monetization of DPD), which is already the governing principle. Not a blocker.
 
 3. **SA (ShareAlike) — applies to *adaptations*.** A converted/flattened DPD file **is an adaptation** and must be offered under CC BY-NC-SA 4.0 (or compatible). SA attaches to the **adapted DPD data**, *not* to CST Reader's own source code: bundling a separately-licensed data file alongside independently-licensed application code is a **"mere aggregation / collection,"** which SA does not reach. So the app's own license is unaffected, **but** the shipped DPD-derived file must itself be marked CC BY-NC-SA 4.0.
 
-4. **Bundle vs. download.** Because both NC and SA "travel with" the DPD data, the cleanest posture is to **keep the DPD data physically and licensally separate from the app**: download it **on demand** into the user's asset store, tagged with its own manifest carrying the license, rather than embedding it in the signed app bundle. This keeps the app bundle free of NC-encumbered content, avoids shipping 130–180 MB per release, and makes attribution/versioning explicit per source. See §6.
+4. **Bundle vs. download.** The **SA** clause travels with the DPD data (any converted copy must stay CC BY-NC-SA), so the cleanest posture is to keep that data **separable** from the app's own code: download it **on demand** into the user's asset store, tagged with a manifest carrying its license, rather than embedding it in the signed app bundle. This keeps the adapted-data license explicit per source, avoids shipping 130–180 MB per release, and makes versioning/refresh simple. (NC is satisfied by the project's non-commercial principle — item 2 — so it is not a driver here.) See §6.
 
-> Could not verify with certainty: the precise commercial/non-commercial status of specific distribution channels (e.g. a future paid app-store SKU). That is a judgment for the maintainer; the license text and CC FAQ are the primary sources.
+> **Context:** the DPD author has a collegial relationship with the VRI Tipiṭaka Project, so any attribution or coordination question around DPD integration likely has a direct channel — a further reason the licensing side is low-risk.
 
 ## 4. Mapping DPD → CST
 
@@ -166,9 +166,9 @@ akkhi	<p><b>akkhi</b>, <i>nt.</i> the eye.</p>
 ## 6. Delivery
 
 - **Built-in EN/HI:** stay **bundled** (small, VRI-owned, no NC issue), seeded to app-support on first run as today.
-- **DPD:** **on-demand download**, not bundled — size (130–180 MB machine-readable; even flattened, tens of MB), the NC/SA posture (§3), and monthly churn. Fetch the SQLite/TSV from `releases/latest`, convert locally to the import format, write into the user's dictionary store.
+- **DPD:** **on-demand download**, not bundled — size (130–180 MB machine-readable; even flattened, tens of MB), the ShareAlike posture (§3 — keep the CC BY-NC-SA data separable), and monthly churn. Fetch the SQLite/TSV from `releases/latest`, convert locally to the import format, write into the user's dictionary store.
 - **Where converted dictionaries live:** under app-support `dictionaries/<sourceId>/`. Treat downloaded/converted DPD data as a **preservation asset** (consistent with the project's rule that downloaded source PDFs are a preservation store, not an evictable cache) — never auto-delete.
-- **Conversion location:** ideally a small offline/CI converter (Python or C#) produces a redistributable `dpd/` folder; the app can also download-and-convert at runtime. Converting **outside** the signed app keeps the bundle free of NC content and avoids adding a SQLite dependency if TSV is used.
+- **Conversion location:** ideally a small offline/CI converter (Python or C#) produces a redistributable `dpd/` folder; the app can also download-and-convert at runtime. Converting **outside** the signed app keeps the CC BY-NC-SA data cleanly separable from the app's own code and avoids adding a SQLite dependency if TSV is used.
 - **Versioning / refresh:** the manifest `version` mirrors DPD's `v[MAJOR].[MINOR].[YYYYMMDD]` tag; a refresh check compares stored vs `releases/latest` (GitHub API).
 
 ## 7. Backend model changes (BACKEND ONLY — UI/layout out of scope)
@@ -202,7 +202,7 @@ All additive and unit-testable with `dotnet test` (new tests: manifest parsing, 
 
 ## 9. Risks & open questions
 
-1. **NC license posture (maintainer decision).** Is CST Reader guaranteed to remain free across all distribution channels (incl. app stores, any future pro tier)? NC forbids commercial use of DPD. Recommend on-demand download + explicit attribution to keep DPD cleanly separable. **Blocking design input needed.**
+1. **NC — resolved (not a blocker).** CST Reader is non-commercial by principle, and non-commercial use is one of the conditions on the VRI texts, so DPD's NonCommercial clause aligns with the project. Standing implication: keep the project non-commercial (no monetization of DPD) — already the case. The DPD author's collegial relationship with the VRI Tipiṭaka Project further de-risks the licensing/attribution side.
 2. **SA on the converted file.** The DPD-derived import folder must itself be marked CC BY-NC-SA 4.0. Confirm comfort shipping/hosting a CC-BY-NC-SA data artifact (the app's own code license is unaffected — mere aggregation).
 3. **Inflected-form lookup gap.** DPD's core value includes resolving *inflected forms* (1.4M) and *compound deconstructions* to lemmas via its `Lookup` table. Our IPE prefix/nearest-neighbor search only matches **lemma prefixes**, so a user typing an inflected form may miss. v1–v3 ignore this; v4 should import DPD's `Lookup` mappings. **Biggest UX gap vs. using DPD natively.**
 4. **IPE conversion fidelity for DPD lemmas.** Verify `Any2Ipe.Convert` round-trips all DPD diacritics and niggahita variants; decide homonym-number handling (strip → merge, as recommended).

--- a/docs/research/SEARCH_INDEX_SHRINK_SPIKE.md
+++ b/docs/research/SEARCH_INDEX_SHRINK_SPIKE.md
@@ -1,0 +1,119 @@
+# Search Index Shrink — Research Spike (#55)
+
+*Read-only investigation of the Lucene.NET 4.8 index configuration and its consumers, plus on-disk measurement of the live index. No behavior change proposed here — this is the analysis that a later PR would implement.*
+
+## Bottom line up front
+
+The single biggest lever is **term vectors (~45% of the index, ~60 MB)**, which duplicate offset/position data the app *also* reads straight from postings. They are consumed by exactly **one** fallback code path (`BookDisplayViewModel`), which can be migrated to postings. **Norms** and **term-vector payloads** are provably dead weight (no scoring anywhere; no analyzer ever sets a payload) and are safe to drop with zero code changes — but they are small. Every change requires a full reindex.
+
+Net effect of the recommended change: roughly **135 MB → ~75 MB** with no change to search results, counts, occurrences/KWIC, or highlight offsets.
+
+## 1. Current field configuration (verified)
+
+`src/CST.Lucene/BookIndexer.cs`, `IndexBook()`, lines 264–274 — the `"text"` field:
+
+```csharp
+FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);   // not stored
+ft.IsIndexed = true; ft.IsTokenized = true;
+ft.OmitNorms = false;                    // norms ARE written
+ft.StoreTermVectors = true;
+ft.StoreTermVectorOffsets = true;
+ft.StoreTermVectorPayloads = true;       // payloads in term vectors
+ft.StoreTermVectorPositions = true;
+ft.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS;  // postings carry offsets too
+ft.Freeze();
+```
+
+Analyzer at index time is `DevaXmlAnalyzer` → `DevaXmlTokenizer` (BookIndexer.cs:187–188). Other fields (`file`, `matn`, `pitaka`) are `StringField`/`StoredField` and are not at issue. Compound files are enabled (`config.UseCompoundFile = true`), but Lucene keeps the large segments non-compound.
+
+So the field pays simultaneously for postings offsets **and** term-vector offsets/positions/payloads **and** norms. The question is which are actually read.
+
+## 2. What each stored component is used for
+
+| Component | Where it lives | Consumed by / status |
+|---|---|---|
+| **Postings docs+freqs** (`.doc`) | postings | **USED.** `TermsEnum.DocFreq`/`TotalTermFreq` counts-only fast path (`SearchService.GetMatchingTermStats`, `SelectTermsCountsOnly`, 626–684); `Freq` during position walks. |
+| **Postings positions** (`.pos`) | postings | **USED.** Multi-word/phrase/proximity matching reads `dape.NextPosition()` (`SearchMultiWordAsync` 361; `GetTermOccurrencesAsync` 566; `GetTermPositionsAsync` 921; `GetMultiWordPositionsAsync` 997). |
+| **Postings offsets** (`.pay`) | postings | **USED — load-bearing.** `dape.StartOffset`/`EndOffset` drive every KWIC snippet and highlight (SearchService 362–363, 568–569, 923, 998); feeds `TeiSnippetExtractor` and `SearchTool.GetOccurrencesAsync`. Requires `IndexOptions` offsets. |
+| **Norms** (`.nvd`/`.nvm`) | norms | **UNUSED.** No relevance scoring anywhere: no `IndexSearcher` / `TopDocs` / `BM25` / `Similarity` / `Scorer` / `.Search(` in app code. Search is pure term-enumeration + postings position matching. `OmitNorms=false` is dead weight. |
+| **Term-vector offsets + positions** (`.tvd`/`.tvx`) | term vectors | **Used by ONE fallback only.** `BookDisplayViewModel.ApplySearchHighlightingToRawXml` reads `indexReader.GetTermVector(_docId,"text")` then `DocsAndPositions(..., OFFSETS)` (1010, 1037–1049). The primary branch `ApplyHighlightingFromPositions` (987–990) uses positions carried in from search (postings-derived). The KWIC/occurrences path never touches term vectors. |
+| **Term-vector payloads** (inside `.tvd`) | term vectors | **UNUSED — pure waste.** No `PayloadAttribute` is set anywhere. `DevaXmlTokenizer.IncrementToken` sets only term/offset/positionIncrement/type (263–272). `IpeFilter` is entirely commented out. `IpeAnalyzer` is not used for the text field. |
+| **Terms dict** (`.tim`/`.tip`) | terms | **USED** (term enumeration/expansion). Not a shrink target. |
+| **Stored fields** (`.fdt`/`.fdx`) | stored | tiny (`file`/`matn`/`pitaka`); not at issue. |
+
+Key structural fact: because postings already index `DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS`, **term vectors are redundant** for this app's offset/position needs. The usual reason to keep them — Lucene's `FastVectorHighlighter` — does not apply; highlighting is done by manual offset insertion into the raw XML.
+
+## 3. On-disk size breakdown (measured)
+
+Live index: `~/Library/Application Support/CSTReader/index`, 10 segments, **~135.6 MB** (142,229,488 bytes). 3 large segments are non-compound; 6 small merged segments are packed in `.cfs`.
+
+| Category | Ext(s) | Bytes | MB | % of index |
+|---|---|---:|---:|---:|
+| **Term vectors** | `.tvd` + `.tvx` | 59,050,234 | **56.3** | **41.5%** |
+| Postings positions | `.pos` | 31,379,633 | 29.9 | 22.1% |
+| Terms dictionary | `.tim` + `.tip` | 26,778,210 | 25.5 | 18.8% |
+| Compound (mixed) | `.cfs` | 12,464,211 | 11.9 | 8.8% |
+| Postings offsets | `.pay` | 9,925,066 | 9.5 | 7.0% |
+| Postings docs+freqs | `.doc` | 2,624,968 | 2.5 | 1.8% |
+| Norms | `.nvd` + `.nvm` | 486 | ~0 | 0.0003% |
+| Stored/meta | `.fdt/.fdx/.fnm/.si` | 6,680 | ~0 | ~0% |
+
+**Caveat on `.cfs` (8.8%):** the 6 small compound segments hide their internal per-type split. If their composition mirrors the large segments (term vectors ≈ 45% of a segment), then whole-index **term vectors ≈ 60–65 MB ≈ ~45%** and postings offsets ≈ ~10.5 MB. The measured non-compound numbers are exact; the `.cfs` allocation is an estimate.
+
+## 4. Safe shrink levers, ordered (each requires a full reindex of 217 books)
+
+### Lever A — Drop term vectors entirely *(biggest win; needs a one-line consumer migration first)*
+```csharp
+ft.StoreTermVectors = false;
+ft.StoreTermVectorOffsets = false;
+ft.StoreTermVectorPositions = false;
+ft.StoreTermVectorPayloads = false;
+```
+- **Estimated saving:** ~**56 MB visible + ~5 MB inside `.cfs` ≈ ~60 MB ≈ ~45%** of the index.
+- **Why it's safe *after* migration:** the only reader of term vectors is the fallback branch in `BookDisplayViewModel.ApplySearchHighlightingToRawXml` (999–1077). It needs only **offsets**, which are identical in postings. Rewrite that branch to read offsets from postings via `MultiFields.GetTermPositionsEnum(reader, liveDocs, "text", termBytes)` restricted to `_docId` — exactly the pattern `SearchService.GetTermPositionsAsync` (908–935) already uses. After that, no consumer reads term vectors.
+- **Classification:** **RISKY as a pure config change** (would break the fallback highlight path); **SAFE and high-value once the fallback is migrated to postings.** Do the migration + drop together.
+
+### Lever B — Omit norms *(safe, zero code change, tiny)*
+`ft.OmitNorms = true;` — saving ~486 bytes (negligible; ~1 byte/doc/field × 217 docs). No scoring anywhere reads norms. **SAFE, high-confidence**; worth doing for correctness/clarity even though the byte win is trivial.
+
+### Lever C — Drop term-vector payloads *(safe; subsumed by Lever A)*
+`ft.StoreTermVectorPayloads = false;` (only relevant if term vectors are otherwise kept). No analyzer sets payloads. **SAFE**; if Lever A is taken, term vectors and their payloads disappear entirely.
+
+### What must NOT change (load-bearing)
+- `IndexOptions = DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS` — postings offsets (`.pay`) and positions (`.pos`) drive all snippets/highlights/proximity.
+- `.doc`/`.tim`/`.tip` — counts and term expansion.
+
+## 5. Verification plan (parity test before shipping)
+
+Mirror the existing integration style (`IndexStructureTests`, `LocalApiIntegrationTests`, `SearchToolTests`). Build a small fixture (prose + `rend="gatha"` verse + `<note>` footnotes), index it **twice** (today's `FieldType` vs proposed), and assert parity across:
+
+1. **Term expansion** — identical ordered term lists for exact/wildcard/regex.
+2. **Counts** — identical `DocFreq`/`TotalTermFreq` per term (counts-only fast path).
+3. **Postings offsets** — identical `(docId, position, StartOffset, EndOffset)` tuples per term.
+4. **KWIC / occurrences** — identical `Snippet`, `HitStart`/`HitLength`, `Refs`, `Highlights` for single-term, phrase, and proximity queries.
+5. **In-book highlighting** — identical inserted-tag offsets for both the positions branch and the migrated-fallback branch (include a case that exercises the fallback: search terms present, `searchPositions` empty).
+
+Also invert `IndexStructureTests` assertions that currently expect `GetTermVectors` non-null (112–116, 205–206) — an intentional test update, not a regression.
+
+## 6. Recommendation
+
+**First PR (safe, high-confidence):**
+- **Lever A done properly** — migrate the `BookDisplayViewModel` fallback highlight branch (999–1077) from term vectors to postings offsets (reuse the `GetTermPositionsAsync` pattern), then set all four `StoreTermVector*` to `false`. Captures ~45% (~60 MB) with a small, well-understood change under full parity coverage.
+- **Lever B (omit norms)** — bundle in; one line, zero risk.
+
+Gated on a **full reindex** — issue a version bump / index-format marker so existing users rebuild.
+
+**Do second / fold in with review:** confirm whether the term-vector fallback branch is still *reachable* (opening from search always passes positions; the fallback seems to matter only for restored sessions with empty `SearchPositions`). If provably dead, Lever A becomes a pure config change + branch **deletion** — even cleaner. Worth a focused reachability check first.
+
+## 7. Risks & open questions
+
+- **Reindex required & user impact** — all levers change the index format; needs an index-version guard so stale indexes rebuild, not silently mis-read.
+- **`.cfs` attribution is estimated** — re-measure after the change to confirm realized saving.
+- **Fallback reachability** — could not definitively prove the term-vector branch is dead; treated conservatively as live (migrate before drop).
+- **Norms saving is negligible** here (217 docs) — included for correctness, not size.
+- **Offsets are the crux and must stay in postings** — the parity test (§5 steps 3–5) is the guardrail; do not merge without it.
+- **`.pos` (30 MB) and `.tim` (25 MB)** are the next-largest categories but are genuinely used (proximity, term expansion) — no safe lever there without changing search behavior.
+
+---
+
+*Provenance: research spike for [issue #55](https://github.com/fsnow/cst/issues/55). Files cited: `src/CST.Lucene/BookIndexer.cs` (264–274), `DevaXmlTokenizer.cs` (263–272), `DevaXmlAnalyzer.cs`, `IpeFilter.cs` (commented out); `src/CST.Avalonia/Services/SearchService.cs` (362–363, 566–569, 626–684, 908–935, 997–998), `Services/Tools/SearchTool.cs` (97–174); `src/CST.Core/Search/TeiSnippetExtractor.cs`; `src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs` (963–1099), `SearchViewModel.cs` (785–809); `src/CST.Avalonia.Tests/Integration/IndexStructureTests.cs` (70–116, 175–206).*


### PR DESCRIPTION
Two read-only research spikes (run as background subagents), captured under `docs/research/` for review. **Docs only — no code changes.**

## `SEARCH_INDEX_SHRINK_SPIKE.md` (#55)
Traces every consumer of the Lucene `"text"` field. Finding: **term vectors are ~45% (~60 MB) of the ~135 MB index and are redundant** with postings offsets/positions; **norms** and **term-vector payloads** are dead weight (no scoring anywhere; no analyzer sets a payload). Recommends migrating the single term-vector consumer (a `BookDisplayViewModel` fallback highlight branch) to postings, then dropping term vectors + omitting norms (**~135 MB → ~75 MB**), gated on a full reindex, with a concrete parity-test plan. No behavior change. Notes a possible simplification if that fallback branch is dead code.

## `DPD_DICTIONARY_INTEGRATION_SPIKE.md` (#109)
DPD data landscape (formats/sizes/entry structure/cadence), licensing, mapping onto the existing dictionary backend, a proposed `manifest.json` + `entries.tsv` import format that user dictionaries can also target, additive per-source backend changes, and a v1–v4 phasing / child-issue breakdown.

**Licensing:** DPD is CC BY-NC-SA 4.0. The **NonCommercial** clause is **not a blocker** — CST Reader is non-commercial by principle, and non-commercial use is itself a condition on the VRI texts. Remaining considerations are attribution (BY) and keeping the converted data marked/separable (SA). On-demand download is favored for size/churn.

Both indexed in `docs/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)