### PR TITLE
#191: MCP surface increment 1 — in-app Streamable HTTP /mcp with the search tool

### DIFF
--- a/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
+++ b/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
@@ -27,6 +27,8 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <!-- MCP client, to round-trip the in-app /mcp endpoint the way Claude Desktop's bridge does (#191). -->
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
   </ItemGroup>
 
   <!-- Needed to run LocalApiServer (hosts ASP.NET Core) in tests. -->

--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -1,9 +1,13 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CST.Avalonia.Tests.TestSupport;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Integration
@@ -124,6 +128,42 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
             using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
             Assert.True(doc.RootElement.GetArrayLength() >= 1, "single-word wildcard should return occurrences");
+        }
+
+        [Fact]
+        public async Task Mcp_endpoint_is_gated_and_serves_the_search_tool()
+        {
+            // Gate: /mcp sits behind the same bearer middleware as /v1 - no token => 401 (it is mounted and
+            // guarded, not a 404). This is what keeps a browser (which also can't set the header) out.
+            using (var noAuth = new HttpClient { BaseAddress = new System.Uri(_api.BaseUrl) })
+            {
+                var resp = await noAuth.PostAsync("/mcp", Json("{}"));
+                Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+            }
+
+            // Happy path: drive the REAL MCP client over the Streamable HTTP transport with the bearer, exactly
+            // as Claude Desktop's mcp-remote bridge does. Proves the initialize -> list -> call handshake
+            // survives our Origin-reject + bearer gate, and that the one wired tool actually runs.
+            var transport = new HttpClientTransport(new HttpClientTransportOptions
+            {
+                Endpoint = new System.Uri(_api.BaseUrl + "/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+                AdditionalHeaders = new Dictionary<string, string> { ["Authorization"] = "Bearer " + _api.Token },
+            });
+            await using var client = await McpClient.CreateAsync(transport);
+
+            var tools = await client.ListToolsAsync();
+            Assert.Contains(tools, t => t.Name == "search");
+
+            var result = await client.CallToolAsync(
+                "search", new Dictionary<string, object?> { ["query"] = "dhamma" });
+
+            Assert.NotEqual(true, result.IsError);
+            // The matched term round-trips as romanized "dhamma" - assert it in whichever channel the SDK used
+            // (text content block and/or structured content).
+            var text = string.Concat(result.Content.OfType<TextContentBlock>().Select(b => b.Text));
+            var structured = result.StructuredContent?.GetRawText() ?? string.Empty;
+            Assert.Contains("dhamma", text + structured);
         }
     }
 }

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -85,6 +85,8 @@
     <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == ''" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="ReactiveUI" Version="23.2.28" />
+    <!-- MCP surface (#191): Streamable HTTP transport mounted in-process at /mcp on the loopback API server. -->
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -20,6 +20,7 @@ using CST;
 using CST.Conversion;
 using CST.Navigation;
 using CST.Tools;
+using CST.Avalonia.Services.LocalApi.Mcp;
 using Serilog;
 
 namespace CST.Avalonia.Services.LocalApi
@@ -99,6 +100,18 @@ namespace CST.Avalonia.Services.LocalApi
                 o.SerializerOptions.Converters.Add(new JsonStringEnumConverter()); // "Latin" not 3, for other enums
             });
 
+            // MCP surface (#191, increment 1): expose the search tool over the Streamable HTTP transport at
+            // /mcp — MCP is just another transport on the same tool layer /v1 uses, not a proxy. A BYO-MCP chat
+            // client (Claude Desktop via the mcp-remote bridge) connects here; code-capable agents keep hitting
+            // /v1 directly. Registered only when the search tool is present, mirroring the /v1 endpoint wiring.
+            if (_search is { } mcpSearch)
+            {
+                builder.Services.AddSingleton(mcpSearch);
+                builder.Services.AddMcpServer()
+                    .WithHttpTransport()
+                    .WithTools<SearchMcpTool>();
+            }
+
             var app = builder.Build();
 
             // Security gate: no browsers, loopback host only, valid bearer token.
@@ -143,6 +156,13 @@ namespace CST.Avalonia.Services.LocalApi
             });
 
             MapToolEndpoints(app);
+
+            // Streamable HTTP MCP endpoint. Sits behind the same security middleware as everything else, so it
+            // requires the bearer token and rejects Origin-bearing (browser) requests. (#191)
+            if (_search != null)
+            {
+                app.MapMcp("/mcp");
+            }
 
             await app.StartAsync(ct);
 

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -1,0 +1,60 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Conversion;
+using CST.Tools;
+using ModelContextProtocol.Server;
+
+namespace CST.Avalonia.Services.LocalApi.Mcp
+{
+    /// <summary>
+    /// Increment 1 of the MCP surface (#191): ONE tool — <c>search</c> — exposed over the in-app Streamable
+    /// HTTP transport at <c>/mcp</c>, so a BYO-MCP chat client (Claude Desktop via the <c>mcp-remote</c> bridge)
+    /// can be test-connected before the full read set is built out. The MCP surface is deliberately thin: it
+    /// wraps the same <see cref="ISearchTool"/> the <c>/v1</c> HTTP routes use — MCP is just another transport on
+    /// the shared tool layer, not a proxy — and its tool descriptions point at the served <c>/llms.txt</c> for
+    /// domain context rather than duplicating the contract. (AI_INTEGRATION.md §7)
+    /// </summary>
+    [McpServerToolType]
+    internal sealed class SearchMcpTool
+    {
+        [McpServerTool(Name = "search")]
+        [Description("Search the Pali Tipitaka corpus for a word or pattern; returns matching term-forms with "
+            + "per-book occurrence counts. Fetch /llms.txt from this same server for query modes, scripts, "
+            + "corpus filtering, and paging.")]
+        public static async Task<SearchToolResult> SearchAsync(
+            ISearchTool search,
+            [Description("The word or pattern to search for, in any script (romanized Latin accepted).")]
+            string query,
+            [Description("How to interpret the query: Exact, Wildcard (* and ?), or Regex.")]
+            string mode = "Exact",
+            [Description("Page size: how many matching term-forms to return.")]
+            int maxTerms = 100,
+            [Description("Script for returned Pali terms (e.g. Latin, Devanagari, Thai). Default Latin.")]
+            string outputScript = "Latin",
+            [Description("When true, include each term's per-book breakdown; when false, only bookCount.")]
+            bool includeBooks = false,
+            [Description("How many matching term-forms to skip (paging). Re-request with skip += maxTerms while hasMore is true.")]
+            int skip = 0,
+            CancellationToken ct = default)
+        {
+            var request = new SearchToolRequest(
+                Query: query ?? string.Empty,
+                Mode: ParseMode(mode),
+                MaxTerms: maxTerms,
+                OutputScript: ParseScript(outputScript),
+                Skip: skip,
+                IncludeBooks: includeBooks);
+            return await search.SearchAsync(request, ct).ConfigureAwait(false);
+        }
+
+        private static SearchToolMode ParseMode(string? mode) =>
+            Enum.TryParse<SearchToolMode>(mode, ignoreCase: true, out var m) ? m : SearchToolMode.Exact;
+
+        // Never expose the internal IPE font encoding or Unknown; fall back to Latin like the HTTP surface.
+        private static Script ParseScript(string? name) =>
+            Enum.TryParse<Script>(name, ignoreCase: true, out var s)
+                && s is not (Script.Ipe or Script.Unknown) ? s : Script.Latin;
+    }
+}


### PR DESCRIPTION
Increment 1 of the MCP surface (#191): a Streamable HTTP MCP endpoint mounted **in-process** at `/mcp` on the existing loopback API server, behind the **same** Origin-reject + loopback + bearer gate as `/v1`. MCP is just another transport on the shared tool layer (not a proxy) — the one wired tool, `search`, wraps the same `ISearchTool` the `/v1` routes use. Registered only when the search tool is present, mirroring the `/v1` wiring.

This is deliberately the smallest testable slice: prove that a BYO-MCP chat client can reach the loopback surface before building out the full read set.

## Validated end-to-end ✅
**Claude Desktop in regular Chat mode** (not Code/Cowork) connected via the `mcp-remote` bridge to `http://127.0.0.1:<port>/mcp` with the bearer, loaded the tool schema, and successfully called `search` — verifying all three modes (Exact/Wildcard/Regex, case-insensitive), `skip`/`maxTerms` paging with `hasMore`, `includeBooks`, and `outputScript` conversion. This confirms the research conclusion that a non-code Desktop chat *can* reach a loopback Streamable-HTTP MCP with a static bearer (a data point for #260, cross-harness validation).

Also covered by an automated MCP-client round-trip test in `LocalApiIntegrationTests` (initialize → list tools → call, over the real transport with the bearer, asserting the search tool runs and the term round-trips).

## Follow-ups for increment 2 (from the Desktop friction report — not addressed here by design)
Increment 2 adds the read tool set and folds in these findings:
- **Retrieval** — `occurrences`/KWIC keyed on term+book, `passage`, plus `books`/`convert`/`dictionary`. Counts alone support almost no task; this is the structural gap.
- **Expose `llms.txt` as an MCP resource** — over MCP there's no base URL, so "fetch /llms.txt" is a dead pointer. Exposing it as a resource gives Desktop chats the same orientation HTTP agents get (and fixes the "corpus filtering" reference the single tool doesn't expose).
- **`Exact` = exact inflected form** — the tool description must say so and point to Wildcard for stem searches (an agent searching a dictionary headword like `satipaṭṭhāna` gets 5 hits and wrongly concludes it's rare vs `satipaṭṭhānaṃ` at 199×/39 books).
- **`totalBookCount` bug** — returns `0` in the counts-only path (no book union available) vs the real count with `includeBooks=true`; make it nullable and omit rather than emit a misleading `0` (also affects HTTP `/v1/search`).
- **Schema polish** — `mode`/`outputScript` as real enums; document `truncated` (only true on a >5000 expansion overflow, decoupled from `hasMore`) and `maxTerms` (page size, no ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)