### PR TITLE
#191: MCP surface increment 2 — read tool set + llms.txt resource + friction fixes

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -90,6 +90,9 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Equal(2, leanBooks);                                       // dhamma occurs in both fixture books
             Assert.True(leanTotal >= 2);
             Assert.Equal(0, leanTerm.GetProperty("books").GetArrayLength());  // per-book breakdown omitted
+            // Page-level totalBookCount is NULL in the counts-only path (no book union available) - not a
+            // misleading 0. (Desktop MCP friction report)
+            Assert.Equal(JsonValueKind.Null, lean.RootElement.GetProperty("totalBookCount").ValueKind);
 
             // includeBooks => the POSTINGS path, with the per-book breakdown. Counts must AGREE across paths.
             using var full = await PostDoc(http, "/v1/search",
@@ -98,6 +101,8 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Equal(2, fullTerm.GetProperty("books").GetArrayLength());
             Assert.Equal(leanTotal, fullTerm.GetProperty("totalCount").GetInt32());
             Assert.Equal(leanBooks, fullTerm.GetProperty("bookCount").GetInt32());
+            // With includeBooks, totalBookCount is the real distinct-book union over the page.
+            Assert.Equal(2, full.RootElement.GetProperty("totalBookCount").GetInt32());
         }
 
         [Fact]
@@ -144,13 +149,7 @@ namespace CST.Avalonia.Tests.Integration
             // Happy path: drive the REAL MCP client over the Streamable HTTP transport with the bearer, exactly
             // as Claude Desktop's mcp-remote bridge does. Proves the initialize -> list -> call handshake
             // survives our Origin-reject + bearer gate, and that the one wired tool actually runs.
-            var transport = new HttpClientTransport(new HttpClientTransportOptions
-            {
-                Endpoint = new System.Uri(_api.BaseUrl + "/mcp"),
-                TransportMode = HttpTransportMode.StreamableHttp,
-                AdditionalHeaders = new Dictionary<string, string> { ["Authorization"] = "Bearer " + _api.Token },
-            });
-            await using var client = await McpClient.CreateAsync(transport);
+            await using var client = await ConnectMcpAsync();
 
             var tools = await client.ListToolsAsync();
             Assert.Contains(tools, t => t.Name == "search");
@@ -164,6 +163,80 @@ namespace CST.Avalonia.Tests.Integration
             var text = string.Concat(result.Content.OfType<TextContentBlock>().Select(b => b.Text));
             var structured = result.StructuredContent?.GetRawText() ?? string.Empty;
             Assert.Contains("dhamma", text + structured);
+        }
+
+        // Connects the real MCP client over Streamable HTTP with the bearer, as Claude Desktop's mcp-remote
+        // bridge does.
+        private async Task<McpClient> ConnectMcpAsync()
+        {
+            var transport = new HttpClientTransport(new HttpClientTransportOptions
+            {
+                Endpoint = new System.Uri(_api.BaseUrl + "/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+                AdditionalHeaders = new Dictionary<string, string> { ["Authorization"] = "Bearer " + _api.Token },
+            });
+            return await McpClient.CreateAsync(transport);
+        }
+
+        private static string ToolText(ModelContextProtocol.Protocol.CallToolResult r) =>
+            string.Concat(r.Content.OfType<TextContentBlock>().Select(b => b.Text))
+            + (r.StructuredContent?.GetRawText() ?? string.Empty);
+
+        [Fact]
+        public async Task Mcp_lists_the_read_tool_set()
+        {
+            await using var client = await ConnectMcpAsync();
+            var names = (await client.ListToolsAsync()).Select(t => t.Name).ToHashSet();
+            // The read tools wired by the test server (search+occurrences via ISearchTool, passage, script,
+            // books). Dictionary is not wired in the test server, so it is (correctly) absent.
+            foreach (var expected in new[] { "search", "occurrences", "passage", "books", "convert", "scripts" })
+                Assert.Contains(expected, names);
+        }
+
+        [Fact]
+        public async Task Mcp_occurrences_and_passage_read_the_corpus()
+        {
+            await using var client = await ConnectMcpAsync();
+
+            // occurrences: hit-in-context snippet for a term in a specific book. Pass the mode/outputScript
+            // ENUMS as strings to exercise the closed-enum schema binding (Desktop MCP friction: bare strings).
+            var occ = await client.CallToolAsync("occurrences",
+                new Dictionary<string, object?>
+                {
+                    ["bookId"] = _api.MulaBook, ["term"] = "dhamma",
+                    ["mode"] = "Exact", ["outputScript"] = "Latin",
+                });
+            Assert.NotEqual(true, occ.IsError);
+            Assert.Contains("dhamma", ToolText(occ), System.StringComparison.OrdinalIgnoreCase);
+
+            // passage: read the book's text (romanized), turning a bookId + count into readable source.
+            var pass = await client.CallToolAsync("passage",
+                new Dictionary<string, object?> { ["bookId"] = _api.MulaBook });
+            Assert.NotEqual(true, pass.IsError);
+            Assert.Contains("dhamma", ToolText(pass), System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task Mcp_books_tool_resolves_ids_to_names()
+        {
+            await using var client = await ConnectMcpAsync();
+            var books = await client.CallToolAsync("books", new Dictionary<string, object?>());
+            Assert.NotEqual(true, books.IsError);
+            // The fixture's mula book (a real catalog file name) is listed - so an agent can resolve a bookId.
+            Assert.Contains(_api.MulaBook, ToolText(books));
+        }
+
+        [Fact]
+        public async Task Mcp_exposes_the_llms_txt_resource()
+        {
+            await using var client = await ConnectMcpAsync();
+            // An MCP client has no base URL to "fetch /llms.txt" - it must be discoverable + readable as a resource.
+            var resources = await client.ListResourcesAsync();
+            Assert.Contains(resources, r => r.Uri == "cst:///llms.txt");
+
+            var read = await client.ReadResourceAsync("cst:///llms.txt");
+            var body = string.Concat(read.Contents.OfType<TextResourceContents>().Select(c => c.Text));
+            Assert.Contains("CST Reader", body);   // the version stamp / orientation doc
         }
     }
 }

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -94,7 +94,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, hasMore, truncated, note }`. NOTE: the
   `total*` fields are per-PAGE sums, not whole-result-set totals - for a stem's true footprint, page through
   and add, or run an Exact query per form. (`totalBookCount` is populated only with `includeBooks:true`; the
-  default fast path leaves it 0 - use the per-term `bookCount` instead.) `hasMore` and `truncated` are DIFFERENT signals: a normal large
+  default fast path returns it as `null` - use the per-term `bookCount` instead.) `hasMore` and `truncated` are DIFFERENT signals: a normal large
   result set is `hasMore:true, truncated:false` (just page it) - `truncated:true` means a very broad
   wildcard/regex overflowed the engine's expansion limit so some forms are UNREACHABLE (NARROW the pattern;
   paging will not recover them).

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -21,6 +21,7 @@ using CST.Conversion;
 using CST.Navigation;
 using CST.Tools;
 using CST.Avalonia.Services.LocalApi.Mcp;
+using ModelContextProtocol.Server;
 using Serilog;
 
 namespace CST.Avalonia.Services.LocalApi
@@ -37,6 +38,15 @@ namespace CST.Avalonia.Services.LocalApi
     public sealed class LocalApiServer : IAsyncDisposable
     {
         private const string ApiVersion = "v1";
+
+        // JSON for MCP tool results/params: camelCase + string enums (e.g. page editions, pitaka, scripts),
+        // so results are agent-readable like the /v1 surface.
+        private static readonly JsonSerializerOptions McpJson = new(JsonSerializerDefaults.Web)
+        {
+            // The MCP SDK freezes these options; a reflection-based resolver must be set first (non-AOT app).
+            TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
+            Converters = { new JsonStringEnumConverter() }
+        };
 
         private readonly string _appVersion;
         private readonly string _handshakeDirectory;
@@ -100,17 +110,36 @@ namespace CST.Avalonia.Services.LocalApi
                 o.SerializerOptions.Converters.Add(new JsonStringEnumConverter()); // "Latin" not 3, for other enums
             });
 
-            // MCP surface (#191, increment 1): expose the search tool over the Streamable HTTP transport at
-            // /mcp — MCP is just another transport on the same tool layer /v1 uses, not a proxy. A BYO-MCP chat
-            // client (Claude Desktop via the mcp-remote bridge) connects here; code-capable agents keep hitting
-            // /v1 directly. Registered only when the search tool is present, mirroring the /v1 endpoint wiring.
+            // MCP surface (#191): expose the read tool set over the Streamable HTTP transport at /mcp — MCP is
+            // just another transport on the same tool layer /v1 uses, not a proxy. A BYO-MCP chat client (Claude
+            // Desktop via the mcp-remote bridge) connects here; code-capable agents keep hitting /v1 directly.
+            // Tool groups are registered only when their backing service is present (mirroring the /v1 wiring);
+            // 'books' needs no service, so /mcp is always available when the server runs.
+            var mcp = builder.Services.AddMcpServer().WithHttpTransport();
+            mcp.WithTools<BooksMcpTool>(McpJson);
             if (_search is { } mcpSearch)
             {
                 builder.Services.AddSingleton(mcpSearch);
-                builder.Services.AddMcpServer()
-                    .WithHttpTransport()
-                    .WithTools<SearchMcpTool>();
+                mcp.WithTools<SearchMcpTool>(McpJson);
             }
+            if (_passage is { } mcpPassage)
+            {
+                builder.Services.AddSingleton(mcpPassage);
+                mcp.WithTools<PassageMcpTool>(McpJson);
+            }
+            if (_script is { } mcpScript)
+            {
+                builder.Services.AddSingleton(mcpScript);
+                mcp.WithTools<ScriptMcpTool>(McpJson);
+            }
+            if (_dictionary is { } mcpDictionary)
+            {
+                builder.Services.AddSingleton(mcpDictionary);
+                mcp.WithTools<DictionaryMcpTool>(McpJson);
+            }
+            // Expose llms.txt as an MCP resource — an MCP client has no base URL to "fetch /llms.txt", so give
+            // it the same version-stamped orientation as a readable resource. (Desktop MCP friction report)
+            mcp.WithResources(new[] { BuildLlmsResource() });
 
             var app = builder.Build();
 
@@ -147,22 +176,14 @@ namespace CST.Avalonia.Services.LocalApi
 
             // Unauthenticated front door: the agent's orientation (endpoints, conventions, auth handshake).
             // Version-stamped so it can't be mistaken for a different build's surface.
-            app.MapGet("/llms.txt", () =>
-            {
-                var body = ReadResource("LocalApi.llms.txt")
-                    ?? "# CST Reader Local API\n\n(llms.txt resource missing)\n";
-                var stamped = $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + body;
-                return Results.Text(stamped, "text/markdown; charset=utf-8");
-            });
+            app.MapGet("/llms.txt", () => Results.Text(BuildLlmsText(), "text/markdown; charset=utf-8"));
 
             MapToolEndpoints(app);
 
-            // Streamable HTTP MCP endpoint. Sits behind the same security middleware as everything else, so it
-            // requires the bearer token and rejects Origin-bearing (browser) requests. (#191)
-            if (_search != null)
-            {
-                app.MapMcp("/mcp");
-            }
+            // Streamable HTTP MCP endpoint (read tool set + llms.txt resource). Behind the same security
+            // middleware as everything else: requires the bearer token and rejects Origin-bearing requests.
+            // Always mapped — the 'books' tool needs no backing service. (#191)
+            app.MapMcp("/mcp");
 
             await app.StartAsync(ct);
 
@@ -205,6 +226,34 @@ namespace CST.Avalonia.Services.LocalApi
             !path.HasValue || path == "/"
             || path.Equals("/llms.txt", StringComparison.OrdinalIgnoreCase)
             || path.StartsWithSegments("/docs", StringComparison.OrdinalIgnoreCase);
+
+        // The version-stamped llms.txt body, served both at GET /llms.txt and as the MCP llms.txt resource
+        // (single source, so the two can't drift). Version-stamped so it can't be mistaken for another build.
+        private string BuildLlmsText()
+        {
+            var body = ReadResource("LocalApi.llms.txt")
+                ?? "# CST Reader Local API\n\n(llms.txt resource missing)\n";
+            return $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + body;
+        }
+
+        // The same orientation doc as an MCP resource, so a Streamable-HTTP client (which has no base URL to
+        // "fetch /llms.txt") can read it. Built from a closure over the stamped text — no DI/static needed.
+        private McpServerResource BuildLlmsResource()
+        {
+            string text = BuildLlmsText();
+            return McpServerResource.Create(
+                () => text,
+                new McpServerResourceCreateOptions
+                {
+                    UriTemplate = "cst:///llms.txt",
+                    Name = "llms.txt",
+                    Title = "CST Reader local API — orientation (llms.txt)",
+                    Description = "Orientation for the CST Reader local API: query modes (Exact = exact inflected "
+                        + "form; Wildcard/Regex), sandhi/compound guidance, the output scripts, apparatus "
+                        + "conventions, paging, and the tool set. Read this first.",
+                    MimeType = "text/markdown",
+                });
+        }
 
         private static string? ReadResource(string endsWith)
         {

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/BooksMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/BooksMcpTool.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using CST;
+using CST.Conversion;
+using CST.Tools;
+using ModelContextProtocol.Server;
+
+namespace CST.Avalonia.Services.LocalApi.Mcp
+{
+    /// <summary>
+    /// MCP <c>books</c> tool — the corpus catalog, so an agent can resolve a bookId (file name) it got from
+    /// search/occurrences into a human-readable name + classification, and discover ids to read. No service
+    /// dependency (the catalog is static), so this tool is always available. (#191)
+    /// </summary>
+    [McpServerToolType]
+    internal sealed class BooksMcpTool
+    {
+        [McpServerTool(Name = "books")]
+        [Description("List the corpus's books: for each, its id (file name — the key the other tools take), its "
+            + "full and short names in the requested script, its pitaka / commentary-level / type classification, "
+            + "and whether it is indexed. Use this to turn a bookId into a recognizable location, or to find "
+            + "book ids to read.")]
+        public static IReadOnlyList<BookSummary> Books_(
+            [Description("Script for the returned book names.")]
+            OutputScript outputScript = OutputScript.Latin)
+        {
+            var target = McpScript.ToScript(outputScript);
+            // Nav-path names are stored Devanagari; romanize to the requested script (like /v1/books).
+            return Books.Inst.Select(b => new BookSummary(
+                b.FileName,
+                ScriptConverter.Convert(b.LongNavPath, Script.Devanagari, target),
+                ScriptConverter.Convert(b.ShortNavPath, Script.Devanagari, target),
+                b.Pitaka, b.Matn, b.BookType, b.DocId >= 0)).ToList();
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/DictionaryMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/DictionaryMcpTool.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Tools;
+using ModelContextProtocol.Server;
+
+namespace CST.Avalonia.Services.LocalApi.Mcp
+{
+    /// <summary>
+    /// MCP dictionary tools over <see cref="IDictionaryTool"/> — <c>dictionary_lookup</c> (headword definition)
+    /// and <c>dictionary_languages</c> (available dictionaries). Format-agnostic: the underlying service owns
+    /// the dictionary format; headwords are returned in the requested output script. (#191)
+    /// </summary>
+    [McpServerToolType]
+    internal sealed class DictionaryMcpTool
+    {
+        [McpServerTool(Name = "dictionary_lookup")]
+        [Description("Look up a Pali headword in a dictionary: returns the exact match plus the surrounding "
+            + "prefix run (or the nearest-neighbor run on a miss), each as a headword + definition (HTML). "
+            + "Query may be in any script; headwords come back in the requested output script.")]
+        public static async Task<IReadOnlyList<DictionaryEntry>> LookupAsync(
+            IDictionaryTool dictionary,
+            [Description("The headword to look up, in any script.")]
+            string word,
+            [Description("Dictionary language code (see dictionary_languages), e.g. 'en'.")]
+            string language = "en",
+            [Description("Script for returned headwords.")]
+            OutputScript outputScript = OutputScript.Latin,
+            [Description("Maximum entries to return.")]
+            int maxEntries = 25,
+            CancellationToken ct = default)
+        {
+            var request = new DictionaryRequest(
+                Language: language ?? string.Empty,
+                Query: word ?? string.Empty,
+                OutputScript: McpScript.ToScript(outputScript),
+                MaxEntries: maxEntries);
+            return await dictionary.LookupAsync(request, ct).ConfigureAwait(false);
+        }
+
+        [McpServerTool(Name = "dictionary_languages")]
+        [Description("List the available dictionary language codes (e.g. 'en', 'hi') for dictionary_lookup.")]
+        public static IReadOnlyList<string> Languages(IDictionaryTool dictionary) => dictionary.Languages;
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpScript.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpScript.cs
@@ -1,0 +1,35 @@
+using System;
+using CST.Conversion;
+
+namespace CST.Avalonia.Services.LocalApi.Mcp
+{
+    /// <summary>
+    /// Agent-facing output scripts — the corpus's 14 scripts + Latin. Excludes the internal IPE font encoding
+    /// and the auto-detect sentinel, so the MCP tool schema advertises a closed <c>enum</c> (findable by a
+    /// small model) instead of a bare string. Member names match <see cref="Script"/> exactly.
+    /// </summary>
+    internal enum OutputScript
+    {
+        Latin,
+        Devanagari,
+        Bengali,
+        Cyrillic,
+        Gujarati,
+        Gurmukhi,
+        Kannada,
+        Khmer,
+        Malayalam,
+        Myanmar,
+        Sinhala,
+        Telugu,
+        Thai,
+        Tibetan
+    }
+
+    internal static class McpScript
+    {
+        /// <summary>Map an agent-facing <see cref="OutputScript"/> to the internal <see cref="Script"/>
+        /// (names match, so parse by name).</summary>
+        public static Script ToScript(OutputScript s) => Enum.Parse<Script>(s.ToString());
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Navigation;
+using CST.Tools;
+using ModelContextProtocol.Server;
+
+namespace CST.Avalonia.Services.LocalApi.Mcp
+{
+    /// <summary>
+    /// MCP <c>passage</c> tool over <see cref="IPassageTool"/> — reads a bounded window of a book's TEXT (the
+    /// level-2 zoom above a search snippet), so an agent gets grounded source it can quote/cite. Start at a
+    /// paragraph, or continue from a <c>cursor</c> returned by a prior passage / occurrence. (#191)
+    /// </summary>
+    [McpServerToolType]
+    internal sealed class PassageMcpTool
+    {
+        [McpServerTool(Name = "passage")]
+        [Description("Read a bounded window of a book's text, in the requested script. Provide a paragraph to "
+            + "start there, or a cursor from a prior 'occurrences'/'passage' result to read the exact spot / "
+            + "page forward. The window ends at a sentence boundary; use the returned nextCursor/prevCursor to "
+            + "page. With neither paragraph nor cursor, reads from the book start.")]
+        public static async Task<PassageResult> PassageAsync(
+            IPassageTool passage,
+            [Description("The book's id (file name), e.g. from the 'books' tool or a search result.")]
+            string bookId,
+            [Description("Paragraph number to start reading at. Omit to use cursor, or to start at the book's beginning.")]
+            int? paragraph = null,
+            [Description("Sub-book code for a Multi-type volume (e.g. 'an5'); usually omit.")]
+            string? bookCode = null,
+            [Description("A page cursor from a prior result; when set, overrides paragraph and reads that exact spot.")]
+            int? cursor = null,
+            [Description("Rendered-character budget for the window.")]
+            int maxChars = 1200,
+            [Description("Script for the returned text.")]
+            OutputScript outputScript = OutputScript.Latin,
+            [Description("Include apparatus/variant readings (braced) in the text.")]
+            bool includeVariantReadings = false,
+            CancellationToken ct = default)
+        {
+            NavigationReference reference = paragraph is int n
+                ? new NavigationReference.Paragraph(n, bookCode)
+                : new NavigationReference.WholeBook();
+            var request = new PassageRequest(
+                BookId: bookId ?? string.Empty,
+                Reference: reference,
+                Cursor: cursor,
+                MaxChars: maxChars,
+                OutputScript: McpScript.ToScript(outputScript),
+                IncludeVariantReadings: includeVariantReadings);
+            return await passage.FetchPassageAsync(request, ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/ScriptMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/ScriptMcpTool.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using CST.Tools;
+using ModelContextProtocol.Server;
+
+namespace CST.Avalonia.Services.LocalApi.Mcp
+{
+    /// <summary>
+    /// MCP script tools over <see cref="IScriptTool"/> — <c>convert</c> (transliterate Pali between scripts,
+    /// input auto-detected) and <c>scripts</c> (list the available output scripts). A thin, stateless wrapper
+    /// over the converter; no corpus. (#191)
+    /// </summary>
+    [McpServerToolType]
+    internal sealed class ScriptMcpTool
+    {
+        [McpServerTool(Name = "convert")]
+        [Description("Transliterate Pali text to another script. The input script is auto-detected (mixed-script "
+            + "input is handled), so you only name the desired output.")]
+        public static ConvertResult Convert(
+            IScriptTool script,
+            [Description("The Pali text to convert (any script; auto-detected).")]
+            string text,
+            [Description("The script to convert the text into.")]
+            OutputScript outputScript = OutputScript.Latin)
+            => script.Convert(new ConvertRequest(text ?? string.Empty, McpScript.ToScript(outputScript)));
+
+        [McpServerTool(Name = "scripts")]
+        [Description("List the script names that can be requested as an output script by the other tools.")]
+        public static IReadOnlyList<string> Scripts(IScriptTool script) => script.Scripts;
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -1,39 +1,40 @@
-using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
-using CST.Conversion;
 using CST.Tools;
 using ModelContextProtocol.Server;
 
 namespace CST.Avalonia.Services.LocalApi.Mcp
 {
     /// <summary>
-    /// Increment 1 of the MCP surface (#191): ONE tool — <c>search</c> — exposed over the in-app Streamable
-    /// HTTP transport at <c>/mcp</c>, so a BYO-MCP chat client (Claude Desktop via the <c>mcp-remote</c> bridge)
-    /// can be test-connected before the full read set is built out. The MCP surface is deliberately thin: it
-    /// wraps the same <see cref="ISearchTool"/> the <c>/v1</c> HTTP routes use — MCP is just another transport on
-    /// the shared tool layer, not a proxy — and its tool descriptions point at the served <c>/llms.txt</c> for
-    /// domain context rather than duplicating the contract. (AI_INTEGRATION.md §7)
+    /// MCP tools over the app's <see cref="ISearchTool"/> — <c>search</c> (term-index) and <c>occurrences</c>
+    /// (search results in context). MCP is another transport on the shared tool layer the <c>/v1</c> routes
+    /// use, not a proxy. Enum params give a closed schema; descriptions are self-sufficient (no base-URL
+    /// pointer, since an MCP client has none — deeper orientation is the <c>llms.txt</c> resource). (#191)
     /// </summary>
     [McpServerToolType]
     internal sealed class SearchMcpTool
     {
         [McpServerTool(Name = "search")]
-        [Description("Search the Pali Tipitaka corpus for a word or pattern; returns matching term-forms with "
-            + "per-book occurrence counts. Fetch /llms.txt from this same server for query modes, scripts, "
-            + "corpus filtering, and paging.")]
+        [Description("Search the Pali Tipitaka corpus's TERM INDEX for a word or pattern; returns matching "
+            + "surface forms (term-forms), each with its total occurrence count and the number of books it "
+            + "appears in. This is not full-text retrieval — use the 'occurrences' tool to read hits in context. "
+            + "IMPORTANT: mode:Exact matches the EXACT inflected surface form, not a lemma or stem. The corpus "
+            + "uses heavy sandhi, so a dictionary headword (e.g. 'satipatthana') may be rare while its inflected "
+            + "forms (e.g. 'satipatthanam') are common. To find a stem's variations, use mode:Wildcard with a "
+            + "trailing '*' (e.g. 'satipatthan*').")]
         public static async Task<SearchToolResult> SearchAsync(
             ISearchTool search,
             [Description("The word or pattern to search for, in any script (romanized Latin accepted).")]
             string query,
-            [Description("How to interpret the query: Exact, Wildcard (* and ?), or Regex.")]
-            string mode = "Exact",
-            [Description("Page size: how many matching term-forms to return.")]
+            [Description("How to interpret the query. Exact = exact inflected form; Wildcard = * (any run) and ? (one char); Regex.")]
+            SearchToolMode mode = SearchToolMode.Exact,
+            [Description("Page size: how many matching term-forms to return per page. No fixed ceiling; page with skip.")]
             int maxTerms = 100,
-            [Description("Script for returned Pali terms (e.g. Latin, Devanagari, Thai). Default Latin.")]
-            string outputScript = "Latin",
-            [Description("When true, include each term's per-book breakdown; when false, only bookCount.")]
+            [Description("Script for returned Pali terms.")]
+            OutputScript outputScript = OutputScript.Latin,
+            [Description("When true, include each term's per-book breakdown; when false, only bookCount (lighter).")]
             bool includeBooks = false,
             [Description("How many matching term-forms to skip (paging). Re-request with skip += maxTerms while hasMore is true.")]
             int skip = 0,
@@ -41,20 +42,47 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         {
             var request = new SearchToolRequest(
                 Query: query ?? string.Empty,
-                Mode: ParseMode(mode),
+                Mode: mode,
                 MaxTerms: maxTerms,
-                OutputScript: ParseScript(outputScript),
+                OutputScript: McpScript.ToScript(outputScript),
                 Skip: skip,
                 IncludeBooks: includeBooks);
             return await search.SearchAsync(request, ct).ConfigureAwait(false);
         }
 
-        private static SearchToolMode ParseMode(string? mode) =>
-            Enum.TryParse<SearchToolMode>(mode, ignoreCase: true, out var m) ? m : SearchToolMode.Exact;
-
-        // Never expose the internal IPE font encoding or Unknown; fall back to Latin like the HTTP surface.
-        private static Script ParseScript(string? name) =>
-            Enum.TryParse<Script>(name, ignoreCase: true, out var s)
-                && s is not (Script.Ipe or Script.Unknown) ? s : Script.Latin;
+        [McpServerTool(Name = "occurrences")]
+        [Description("Read a term's occurrences IN CONTEXT within one book: hit-centered snippets plus citation "
+            + "refs (paragraph number + per-edition pages) and a cursor for reading the full passage. Pass a "
+            + "term returned by 'search' (in the same script it came back) and a bookId from its per-book "
+            + "breakdown or the 'books' tool. A space-separated multi-word term co-occurs within a proximity "
+            + "window; a quoted run is an adjacent phrase.")]
+        public static async Task<IReadOnlyList<Occurrence>> OccurrencesAsync(
+            ISearchTool search,
+            [Description("The book's id (file name), e.g. from a search result's per-book breakdown or the 'books' tool.")]
+            string bookId,
+            [Description("The term to locate in context, in any script (e.g. a term from a prior 'search').")]
+            string term,
+            [Description("How to interpret the term: Exact, Wildcard (* and ?), or Regex (expands per word).")]
+            SearchToolMode mode = SearchToolMode.Exact,
+            [Description("Script for the returned snippet text.")]
+            OutputScript outputScript = OutputScript.Latin,
+            [Description("How many occurrences to skip (paging).")]
+            int skip = 0,
+            [Description("How many occurrences to return.")]
+            int take = 50,
+            [Description("Include apparatus/variant readings (braced) in the snippet.")]
+            bool includeVariantReadings = false,
+            CancellationToken ct = default)
+        {
+            var request = new OccurrenceRequest(
+                BookId: bookId ?? string.Empty,
+                Term: term ?? string.Empty,
+                IncludeVariantReadings: includeVariantReadings,
+                OutputScript: McpScript.ToScript(outputScript),
+                Skip: skip,
+                Take: take,
+                Mode: mode);
+            return await search.GetOccurrencesAsync(request, ct).ConfigureAwait(false);
+        }
     }
 }

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -76,7 +76,9 @@ namespace CST.Avalonia.Services.Tools
                 Terms: terms,
                 TotalTermCount: result.TotalTermCount,
                 TotalOccurrenceCount: result.TotalOccurrenceCount,
-                TotalBookCount: result.TotalBookCount,
+                // The counts-only fast path (IncludeBooks=false) doesn't enumerate books, so its distinct-book
+                // union is 0 — report null instead of a misleading 0. (Desktop MCP friction report)
+                TotalBookCount: request.IncludeBooks ? result.TotalBookCount : (int?)null,
                 // `truncated` means ONLY that the pattern overflowed the expansion cap (narrow it) — a normal
                 // large result is `hasMore:true, truncated:false` (page it). Don't leak the UI's page-cap
                 // "refine your search" message as the note; only the genuine cap message.

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -80,7 +80,10 @@ namespace CST.Tools
 
     /// <summary>Search results: matching terms (token-frugal — per-book breakdown and positions are opt-in).</summary>
     /// <param name="TotalOccurrenceCount">Sum over the terms IN THIS PAGE (not the whole result set).</param>
-    /// <param name="TotalBookCount">Distinct books over the terms IN THIS PAGE (not the whole result set).</param>
+    /// <param name="TotalBookCount">Distinct books over the terms IN THIS PAGE (not the whole result set).
+    /// <b>Null when <c>IncludeBooks</c> is false</c></b> — the counts-only fast path does not enumerate books,
+    /// so the distinct-book union is not available and is reported as null (not a misleading 0). Per-term
+    /// <c>BookCount</c> is always present.</param>
     /// <param name="HasMore">True if at least one more matching term exists after this page — request the next
     /// page with <c>Skip += MaxTerms</c>. This, not the page length, is the paging signal.</param>
     /// <param name="Truncated">The pattern overflowed the engine's expansion limit (very broad wildcard/regex);
@@ -89,7 +92,7 @@ namespace CST.Tools
         IReadOnlyList<SearchTermResult> Terms,
         int TotalTermCount,
         int TotalOccurrenceCount,
-        int TotalBookCount,
+        int? TotalBookCount,
         bool Truncated,
         bool HasMore = false,
         string? Note = null);


### PR DESCRIPTION
Builds on increment 1 (single `search` tool, merged). Expands the in-app MCP surface at `/mcp` to the full read tool set and folds in every finding from the Claude Desktop (regular Chat) friction report.

## New MCP tools (each thin over the same tool layer `/v1` uses)
- **`search` + `occurrences`** (`ISearchTool`) — `occurrences` is the retrieval the report called *the structural gap*: hit-centered KWIC snippets keyed on term + book, with citation refs and a `cursor`.
- **`passage`** (`IPassageTool`) — read a bounded window of a book's text (turns a bookId + count into readable, quotable source).
- **`books`** (no service) — resolve a `bookId` into a human name + classification, or discover ids. Always available, so `/mcp` now mounts whenever the server runs.
- **`convert` + `scripts`** (`IScriptTool`); **`dictionary_lookup` + `dictionary_languages`** (`IDictionaryTool`). Each group is registered only when its backing service is present (mirrors the `/v1` wiring).

## Friction-report fixes
- **Self-sufficient descriptions** — no dead "fetch /llms.txt" base-URL pointer (an MCP client has none), and the `search` description now states **Exact matches the exact inflected surface form**, pointing to Wildcard for stems (the `satipaṭṭhāna` → 5-hits trap).
- **`llms.txt` as an MCP resource** (`cst:///llms.txt`) — version-stamped and single-sourced with `GET /llms.txt`, so a Desktop chat with no base URL still gets full orientation.
- **Closed enums** — `mode` (`SearchToolMode`) and `outputScript` (a curated `OutputScript` that excludes the internal IPE/Unknown) are now schema enums, not bare strings.
- **`totalBookCount` bug** — now nullable; returned as `null` in the counts-only fast path (no book union available) instead of a misleading `0`. Fixes HTTP `/v1/search` too; per-term `bookCount` unchanged.

MCP tool results serialize enums as strings (page editions, pitaka, scripts) to match `/v1`.

## Tests
MCP-client round-trips for the tool set, the `occurrences`/`passage` retrieval, `books` id→name, the `llms.txt` resource (list + read), enum string-binding, and the `totalBookCount` null-vs-value split. Full suite green (aside from the one known-flaky perf test, which passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)