### PR TITLE
#191: MCP increment 3 — correctness + docs from the Chat+MCP friction report

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -123,6 +123,23 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
+        public async Task Search_does_corpus_wide_phrase_and_returns_a_round_trippable_term()
+        {
+            using var http = _api.Http();
+            // "dhamma magga" is adjacent in the attha fixture book. A phrase query on the corpus-wide `search`
+            // tool must find it (not just per-book `occurrences`), and the returned term must be space-joined
+            // ("dhamma magga"), never the internal "~"-combo key. (Desktop MCP friction report)
+            using var doc = await PostDoc(http, "/v1/search",
+                "{\"query\":\"\\\"dhamma magga\\\"\",\"includeBooks\":true}");
+            var term = doc.RootElement.GetProperty("terms")[0];
+            var termText = term.GetProperty("term").GetString();
+            Assert.Equal("dhamma magga", termText);              // readable + round-trippable, no '~'
+            Assert.DoesNotContain("~", termText!);
+            Assert.Equal(1, term.GetProperty("bookCount").GetInt32());
+            Assert.Contains(_api.AtthaBook, term.GetProperty("books")[0].GetProperty("bookId").GetString());
+        }
+
+        [Fact]
         public async Task Occurrences_single_word_wildcard_expands_not_empty()
         {
             // batch-9 regression: a single-word wildcard on /v1/occurrences must EXPAND (dhamm* -> dhamma),

--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -65,6 +65,30 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void ReadWindow_cursor_snaps_start_back_to_the_enclosing_sentence()
+        {
+            // A cursor from `occurrences` points AT the hit, mid-sentence. The window START must snap back to the
+            // enclosing sentence so the hit is read with its head, not from the hit. (Desktop MCP friction, P1)
+            var markers = BookMarkers.Build(Xml);
+            int cursor = Xml.IndexOf("foxtrot", System.StringComparison.Ordinal);   // mid 3rd sentence "echo foxtrot"
+            Assert.True(cursor > 0);
+
+            // Without snapping, the window opens at the hit - the sentence head "echo" is lost.
+            var raw = TeiPassageReader.ReadWindow(Xml, cursor, maxChars: 100, includeVariants: false,
+                outputScript: Script.Devanagari, markers, snapStartToSentence: false);
+            Assert.Contains("foxtrot", raw.Text);
+            Assert.DoesNotContain("echo", raw.Text);
+
+            // With snapping, the window starts at the sentence start "echo"...
+            var snapped = TeiPassageReader.ReadWindow(Xml, cursor, maxChars: 100, includeVariants: false,
+                outputScript: Script.Devanagari, markers, snapStartToSentence: true);
+            Assert.Contains("echo", snapped.Text);
+            Assert.Contains("foxtrot", snapped.Text);
+            // ...but does NOT bleed back across the sentence boundary into the previous sentence.
+            Assert.DoesNotContain("charlie", snapped.Text);
+        }
+
+        [Fact]
         public void ReadWindow_large_budget_reaches_end()
         {
             var markers = BookMarkers.Build(Xml);

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/DictionaryMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/DictionaryMcpTool.cs
@@ -17,8 +17,10 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
     {
         [McpServerTool(Name = "dictionary_lookup")]
         [Description("Look up a Pali headword in a dictionary: returns the exact match plus the surrounding "
-            + "prefix run (or the nearest-neighbor run on a miss), each as a headword + definition (HTML). "
-            + "Query may be in any script; headwords come back in the requested output script.")]
+            + "prefix run, or — on a near miss — the nearest headwords that share a leading prefix with the "
+            + "query (each a headword + definition HTML). A query that shares no leading prefix with any "
+            + "headword returns an empty list. Query may be in any script; headwords come back in the requested "
+            + "output script.")]
         public static async Task<IReadOnlyList<DictionaryEntry>> LookupAsync(
             IDictionaryTool dictionary,
             [Description("The headword to look up, in any script.")]

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
@@ -18,8 +18,10 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         [McpServerTool(Name = "passage")]
         [Description("Read a bounded window of a book's text, in the requested script. Provide a paragraph to "
             + "start there, or a cursor from a prior 'occurrences'/'passage' result to read the exact spot / "
-            + "page forward. The window ends at a sentence boundary; use the returned nextCursor/prevCursor to "
-            + "page. With neither paragraph nor cursor, reads from the book start.")]
+            + "page forward. Both ends snap to sentence boundaries: a cursor (which points AT a hit) is pulled "
+            + "back to the start of its enclosing sentence, and the window extends to the next sentence end — so "
+            + "the hit is read with its full governing clause, never mid-sentence. Use the returned "
+            + "nextCursor/prevCursor to page. With neither paragraph nor cursor, reads from the book start.")]
         public static async Task<PassageResult> PassageAsync(
             IPassageTool passage,
             [Description("The book's id (file name), e.g. from the 'books' tool or a search result.")]
@@ -30,7 +32,7 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             string? bookCode = null,
             [Description("A page cursor from a prior result; when set, overrides paragraph and reads that exact spot.")]
             int? cursor = null,
-            [Description("Rendered-character budget for the window.")]
+            [Description("Rendered-character budget for the window. May overshoot to reach the next sentence boundary, so the returned text can exceed this.")]
             int maxChars = 1200,
             [Description("Script for the returned text.")]
             OutputScript outputScript = OutputScript.Latin,

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -23,7 +23,9 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             + "IMPORTANT: mode:Exact matches the EXACT inflected surface form, not a lemma or stem. The corpus "
             + "uses heavy sandhi, so a dictionary headword (e.g. 'satipatthana') may be rare while its inflected "
             + "forms (e.g. 'satipatthanam') are common. To find a stem's variations, use mode:Wildcard with a "
-            + "trailing '*' (e.g. 'satipatthan*').")]
+            + "trailing '*' (e.g. 'satipatthan*'). PHRASE/PROXIMITY (corpus-wide): a space-separated query "
+            + "(e.g. 'ekayano ayam') finds those words co-occurring; wrap in quotes (e.g. '\"ekayano ayam\"') for "
+            + "an adjacent phrase. Each match's term is the co-occurring words; pass it to 'occurrences' to read it.")]
         public static async Task<SearchToolResult> SearchAsync(
             ISearchTool search,
             [Description("The word or pattern to search for, in any script (romanized Latin accepted).")]

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -37,9 +37,12 @@ namespace CST.Avalonia.Services.Tools
             if (startPos < 0) return Empty(request, "reference not found");
             startPos = Math.Clamp(startPos, 0, xml.Length);
 
+            // A cursor points AT a hit (mid-sentence); snap the window start back to the enclosing sentence so
+            // the hit is read with its governing clause. A paragraph reference already starts clean - no snap.
             var w = TeiPassageReader.ReadWindow(
                 xml, startPos, Math.Max(1, request.MaxChars),
-                request.IncludeVariantReadings, request.OutputScript, markers);
+                request.IncludeVariantReadings, request.OutputScript, markers,
+                snapStartToSentence: request.Cursor.HasValue);
 
             return new PassageResult(
                 BookId: request.BookId,

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -50,7 +50,11 @@ namespace CST.Avalonia.Services.Tools
             var result = await _search.SearchAsync(query, ct).ConfigureAwait(false);
 
             var terms = result.Terms.Select(t => new SearchTermResult(
-                Term: ScriptConverter.Convert(t.Term, Script.Ipe, request.OutputScript),
+                // A multi-word/phrase match's Term is the internal "~"-joined combo key; render it space-joined
+                // so it reads naturally AND round-trips straight into occurrences. Single terms are unaffected
+                // (no "~"). (Desktop MCP friction report)
+                Term: string.Join(" ", (t.Term ?? string.Empty).Split('~')
+                    .Select(w => ScriptConverter.Convert(w, Script.Ipe, request.OutputScript))),
                 TotalCount: t.TotalCount,
                 // Per-book breakdown is opt-in (it's the payload weight); bookCount is always cheap to include.
                 Books: request.IncludeBooks

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -7,28 +7,80 @@ namespace CST.Search
     /// <summary>
     /// Reads a bounded, paged "reading window" from a book — the level-2 zoom above a snippet. From a start
     /// position it returns up to <c>maxChars</c> of rendered text (tags transparent; footnotes/paranum
-    /// stripped by default), extended to the next sentence boundary so it never cuts mid-sentence, romanized
-    /// to the requested script — plus prev/next cursors (character positions) to page through the surrounding
-    /// text, and the citation refs at the start. A wall-of-text paragraph just becomes page 1 of N.
+    /// stripped by default), snapped at BOTH ends to sentence boundaries so it never cuts mid-sentence,
+    /// romanized to the requested script — plus prev/next cursors (character positions) to page through the
+    /// surrounding text, and the citation refs at the start. A wall-of-text paragraph just becomes page 1 of N.
+    /// When <paramref name="snapStartToSentence"/> is set (a cursor pointing AT a hit, which lands mid-sentence),
+    /// the window START is pulled back to the enclosing sentence's start so the hit is read with its governing
+    /// clause, not from the hit itself.
     /// </summary>
     public static class TeiPassageReader
     {
         public static PassageWindow ReadWindow(
-            string xml, int startPos, int maxChars, bool includeVariants, Script outputScript, BookMarkers markers)
+            string xml, int startPos, int maxChars, bool includeVariants, Script outputScript, BookMarkers markers,
+            bool snapStartToSentence = false)
         {
             startPos = Math.Clamp(startPos, 0, xml.Length);
             if (maxChars < 1) maxChars = 1;
 
-            int end = WalkForward(xml, startPos, maxChars, includeVariants, xml.Length);
+            // A cursor from `occurrences` points at the hit (mid-sentence); pull the start back to the enclosing
+            // sentence start so the reader gets the governing clause, not a headless predicate. Bounded by the
+            // enclosing paragraph so it can't bleed into the previous paragraph, and only applied if the
+            // sentence-aligned window still reaches past the cursor — otherwise a hard-capped over-long-sentence
+            // paging cursor would snap back onto itself and loop. (Desktop MCP friction report, P1)
+            int readStart = startPos;
+            if (snapStartToSentence)
+            {
+                int floor = EnclosingParagraphStart(startPos, markers);
+                int candidate = SnapBackToSentenceStart(xml, startPos, floor);
+                if (candidate < startPos
+                    && WalkForward(xml, candidate, maxChars, includeVariants, xml.Length) > startPos)
+                    readStart = candidate;
+            }
+
+            int end = WalkForward(xml, readStart, maxChars, includeVariants, xml.Length);
             string text = TeiText.Collapse(
-                TeiText.Convert(TeiText.Clean(xml, startPos, end, includeVariants), outputScript)).Trim();
+                TeiText.Convert(TeiText.Clean(xml, readStart, end, includeVariants), outputScript)).Trim();
 
             int? next = end < xml.Length ? end : (int?)null;
-            int prevStart = WalkBackward(xml, startPos, maxChars, 0);
-            int? prev = prevStart < startPos ? prevStart : (int?)null;
+            int prevStart = WalkBackward(xml, readStart, maxChars, 0);
+            int? prev = prevStart < readStart ? prevStart : (int?)null;
 
-            var (num, code, pages) = markers.RefsAt(startPos);
+            var (num, code, pages) = markers.RefsAt(readStart);
             return new PassageWindow(text, prev, next, num, code, pages);
+        }
+
+        // The nearest sentence start at or after <paramref name="minStart"/> and at/before <paramref name="startPos"/>
+        // — i.e. just past the closest preceding sentence boundary, without crossing minStart. Tags are skipped.
+        private static int SnapBackToSentenceStart(string xml, int startPos, int minStart)
+        {
+            if (minStart < 0) minStart = 0;
+            int i = startPos - 1;
+            while (i >= minStart)
+            {
+                char c = xml[i];
+                if (c == '>')
+                {
+                    int lt = xml.LastIndexOf('<', i);
+                    i = lt >= minStart ? lt - 1 : minStart - 1;
+                    continue;
+                }
+                if (TeiText.IsBoundary(c)) return i + 1;   // begin just past the sentence-ending danda
+                i--;
+            }
+            return minStart;
+        }
+
+        // Start position of the paragraph enclosing <paramref name="startPos"/> (the backward-snap floor), or 0.
+        private static int EnclosingParagraphStart(int startPos, BookMarkers markers)
+        {
+            var (num, code, _) = markers.RefsAt(startPos);
+            if (num is int n)
+            {
+                int p = markers.PositionOfParagraph(n, code);
+                if (p >= 0 && p <= startPos) return p;
+            }
+            return 0;
         }
 
         // Raw end position after accumulating ~maxChars rendered chars, then extending to the next sentence


### PR DESCRIPTION
The **correctness and documentation** fixes from friction report #2 (Claude Desktop, regular Chat, doing the full `books → search → occurrences → passage` research loop). Response-*shape* changes are deliberately held for a focused **increment 3b** (see below).

## Fixes
- **P1 — `passage` start-boundary snap.** A cursor from `occurrences` points *at* the hit (mid-sentence); `TeiPassageReader.ReadWindow` snapped only the window *end*, so cursor-driven reads lost the head of the first sentence — its governing clause. Now the **start** snaps back to the enclosing sentence, **bounded by the enclosing paragraph** (so it can't bleed into the previous one), with a guard so an over-long-sentence paging cursor can't loop. Applied to cursor reads only (paragraph refs already start clean). Fixes the core `occurrences → passage` handoff on **both** HTTP and MCP.
- **Phrase search surfaced + round-trippable.** It was already corpus-wide (`SearchMultiWordAsync` powers the UI) — the tool just framed itself as term-only and leaked the internal `~`-joined combo key. Now multi-word terms render **space-joined** (`dhamma magga`), so they read naturally *and* feed straight back into `occurrences`; the `search` description documents phrase/proximity.
- **`dictionary_lookup` description made honest.** The nearest-neighbor fallback only fires for misses sharing a leading prefix; a zero-overlap query (`zzqqx`) correctly returns `[]`. Fixed the over-promising description rather than changing the UI-shared index.
- **`passage` docs** now state both ends snap to sentence boundaries and that `maxChars` may overshoot to the next boundary.

## Tests
Passage cursor start-snap (including *not* bleeding past the sentence boundary into the previous sentence); corpus-wide phrase search returns a `~`-free, round-trippable term in the correct book. Full suite green.

## Deferred to increment 3b (response-shape — grouped for focused review)
- `totalTermCount`/`totalOccurrenceCount` → `returned*` rename (page-scoped, misnamed)
- `occurrences` bare array → envelope with `hasMore` + book-scoped total
- Merge co-located duplicate snippets into one record with multiple `highlights` (the biggest token win)
- `books: []` → `null` when `includeBooks:false`
- Remaining doc one-liners (`note`, script-relative offsets, `pages:[]`, `paragraphBookCode`, whitespace residue)

## Still separate feature issues (not yet filed)
Corpus-wide `bookCodes` for Multi books · structured `variants[]` · dictionary source attribution (→ #109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)