### PR TITLE
#191: MCP increment 3b — response-shape fixes (counts rename, occurrences envelope, books null)

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -89,10 +89,10 @@ namespace CST.Avalonia.Tests.Integration
             int leanBooks = leanTerm.GetProperty("bookCount").GetInt32();
             Assert.Equal(2, leanBooks);                                       // dhamma occurs in both fixture books
             Assert.True(leanTotal >= 2);
-            Assert.Equal(0, leanTerm.GetProperty("books").GetArrayLength());  // per-book breakdown omitted
-            // Page-level totalBookCount is NULL in the counts-only path (no book union available) - not a
+            Assert.Equal(JsonValueKind.Null, leanTerm.GetProperty("books").ValueKind);  // null (not []) when omitted
+            // Page-level returnedBookCount is NULL in the counts-only path (no book union available) - not a
             // misleading 0. (Desktop MCP friction report)
-            Assert.Equal(JsonValueKind.Null, lean.RootElement.GetProperty("totalBookCount").ValueKind);
+            Assert.Equal(JsonValueKind.Null, lean.RootElement.GetProperty("returnedBookCount").ValueKind);
 
             // includeBooks => the POSTINGS path, with the per-book breakdown. Counts must AGREE across paths.
             using var full = await PostDoc(http, "/v1/search",
@@ -101,8 +101,8 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Equal(2, fullTerm.GetProperty("books").GetArrayLength());
             Assert.Equal(leanTotal, fullTerm.GetProperty("totalCount").GetInt32());
             Assert.Equal(leanBooks, fullTerm.GetProperty("bookCount").GetInt32());
-            // With includeBooks, totalBookCount is the real distinct-book union over the page.
-            Assert.Equal(2, full.RootElement.GetProperty("totalBookCount").GetInt32());
+            // With includeBooks, returnedBookCount is the real distinct-book union over the page.
+            Assert.Equal(2, full.RootElement.GetProperty("returnedBookCount").GetInt32());
         }
 
         [Fact]
@@ -149,7 +149,11 @@ namespace CST.Avalonia.Tests.Integration
                 Json($"{{\"bookId\":\"{_api.MulaBook}\",\"term\":\"dhamm*\",\"mode\":\"Wildcard\"}}"));
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
             using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
-            Assert.True(doc.RootElement.GetArrayLength() >= 1, "single-word wildcard should return occurrences");
+            // /v1/occurrences now returns an envelope { occurrences, returnedCount, total, hasMore }, not a bare array.
+            var occ = doc.RootElement.GetProperty("occurrences");
+            Assert.True(occ.GetArrayLength() >= 1, "single-word wildcard should return occurrences");
+            Assert.Equal(occ.GetArrayLength(), doc.RootElement.GetProperty("returnedCount").GetInt32());
+            Assert.True(doc.RootElement.GetProperty("total").GetInt32() >= 1);
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApiEndpointTests.cs
@@ -33,7 +33,7 @@ namespace CST.Avalonia.Tests.Services
             search.Setup(t => t.SearchAsync(It.IsAny<SearchToolRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new SearchToolResult(
                     new List<SearchTermResult> { new("dhamma", 5, new List<BookHitSummary>()) },
-                    TotalTermCount: 1, TotalOccurrenceCount: 5, TotalBookCount: 1, Truncated: false, Note: null));
+                    ReturnedTermCount: 1, ReturnedOccurrenceCount: 5, ReturnedBookCount: 1, Truncated: false, Note: null));
 
             _server = new LocalApiServer("5.0.0-test", _dir, Serilog.Log.Logger,
                 search.Object, dictionary: null, passage: null, script: new ScriptTool());

--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -111,7 +111,7 @@ namespace CST.Avalonia.Tests.Tools
             // Default: the per-book breakdown is omitted, but bookCount and hasMore are always present.
             var lean = await tool.SearchAsync(new SearchToolRequest("q"));
             var t = Assert.Single(lean.Terms);
-            Assert.Empty(t.Books);
+            Assert.Null(t.Books);                      // null (not []) when the per-book breakdown wasn't requested
             Assert.Equal(2, t.BookCount);
             Assert.True(lean.HasMore);
 
@@ -131,7 +131,7 @@ namespace CST.Avalonia.Tests.Tools
             // OutputScript defaults to Latin; opt into the per-book breakdown to verify bookName romanization.
             var result = await tool.SearchAsync(new SearchToolRequest("q", IncludeBooks: true));
 
-            Assert.Equal(1, result.TotalTermCount);
+            Assert.Equal(1, result.ReturnedTermCount);
             Assert.True(result.Truncated);
             Assert.Equal("capped", result.Note);
 
@@ -207,7 +207,7 @@ namespace CST.Avalonia.Tests.Tools
                 var occ = await tool.GetOccurrencesAsync(
                     new OccurrenceRequest(book, "tgt", OutputScript: Script.Devanagari, MinChars: 1));
 
-                var o = Assert.Single(occ);
+                var o = Assert.Single(occ.Occurrences);
                 Assert.Contains("TARGET", o.Snippet);
                 Assert.Contains("ccc", o.Snippet);
                 Assert.Contains("ddd", o.Snippet);
@@ -258,7 +258,7 @@ namespace CST.Avalonia.Tests.Tools
                 var occ = await tool.GetOccurrencesAsync(new OccurrenceRequest(
                     book, "avijja sankhara", OutputScript: Script.Devanagari, MinChars: 1, ProximityDistance: 5));
 
-                var o = Assert.Single(occ);
+                var o = Assert.Single(occ.Occurrences);
                 Assert.Equal(2, o.Highlights.Count);
                 Assert.Equal(1, o.Highlights.Count(h => h.IsAnchor));   // exactly one navigable anchor
                 Assert.True(o.Highlights[0].IsAnchor);                  // AVIJJA (first by offset) is the anchor
@@ -304,7 +304,7 @@ namespace CST.Avalonia.Tests.Tools
                 var occ = await tool.GetOccurrencesAsync(new OccurrenceRequest(
                     book, "avij*", OutputScript: Script.Devanagari, MinChars: 1, Mode: SearchToolMode.Wildcard));
 
-                var o = Assert.Single(occ);
+                var o = Assert.Single(occ.Occurrences);
                 Assert.Equal("AVIJJA", o.Snippet.Substring(o.HitStart, o.HitLength));
                 search.Verify(s => s.GetTermPositionsAsync(It.IsAny<string>(), It.IsAny<string>(),
                     It.IsAny<CancellationToken>()), Times.Never);   // NOT the literal path
@@ -355,7 +355,7 @@ namespace CST.Avalonia.Tests.Tools
             var tool = new SearchTool(search.Object, Settings("/nonexistent"));
             var occ = await tool.GetOccurrencesAsync(new OccurrenceRequest("x.xml", "t"));
 
-            Assert.Empty(occ);
+            Assert.Empty(occ.Occurrences);
         }
     }
 }

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -23,8 +23,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   convention) - normalize/strip U+200C before comparing or matching strings.
 - Cursors (`prevCursor` / `nextCursor` from `/v1/passage`) are INTEGERS, and opaque - pass one back verbatim
   as `cursor` to page; do not interpret them or do arithmetic on them. `null` means the start/end of the book.
-- Response shape is per endpoint: `/v1/search`, `/v1/passage`, `/v1/convert`, `/v1/status` return a JSON
-  object; `/v1/occurrences`, `/v1/dictionary/lookup`, `/v1/books`, `/v1/scripts` return a bare JSON array.
+- Response shape is per endpoint: `/v1/search`, `/v1/occurrences`, `/v1/passage`, `/v1/convert`, `/v1/status`
+  return a JSON object; `/v1/dictionary/lookup`, `/v1/books`, `/v1/scripts` return a bare JSON array.
 - You work entirely in readable Pali (romanized by default). To read a search hit in context, pass the
   term's `term` value (exactly as `/v1/search` returned it, in whatever script you requested) back to
   `/v1/occurrences` as `term`. There is no opaque id to round-trip - the server handles the internal encoding.
@@ -88,13 +88,15 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   full page can also be the last one; `hasMore` is the signal). No fixed upper bound on how far you can page.
   Terms come back in INDEX (ordinal) order, NOT by frequency, so a COMMON form can sit on a LATER page - to
   gather a stem's COMPLETE family you MUST page while `hasMore`; do not treat page 1 as the whole set.
-  Each term is `{ term, totalCount, bookCount, books }`. `books` (the per-book `{ bookId, bookName, count }`
-  breakdown) is OMITTED unless you pass `includeBooks: true` - it is the bulk of the payload; `bookCount` (how
-  many books the term is in) is ALWAYS present. Returns
-  `{ terms, totalTermCount, totalOccurrenceCount, totalBookCount, hasMore, truncated, note }`. NOTE: the
-  `total*` fields are per-PAGE sums, not whole-result-set totals - for a stem's true footprint, page through
-  and add, or run an Exact query per form. (`totalBookCount` is populated only with `includeBooks:true`; the
-  default fast path returns it as `null` - use the per-term `bookCount` instead.) `hasMore` and `truncated` are DIFFERENT signals: a normal large
+  Each term is `{ term, totalCount, bookCount, books }`. Per-term `totalCount`/`bookCount` are CORPUS-WIDE.
+  `books` (the per-book `{ bookId, bookName, count }` breakdown) is `null` unless you pass `includeBooks: true`
+  (null = "not requested"; it is the bulk of the payload); `bookCount` (how many books the term is in) is
+  ALWAYS present. A multi-word/phrase `term` comes back space-joined (e.g. `ekayano ayam`) - pass it verbatim to
+  `/v1/occurrences`. Returns
+  `{ terms, returnedTermCount, returnedOccurrenceCount, returnedBookCount, hasMore, truncated, note }`. NOTE: the
+  `returned*` fields are THIS PAGE's counts, NOT whole-result-set totals - for a stem's true footprint, page
+  through and add, or run an Exact query per form. (`returnedBookCount` is the page's distinct-book union, and
+  is `null` on the default fast path - use the per-term `bookCount` instead.) `hasMore` and `truncated` are DIFFERENT signals: a normal large
   result set is `hasMore:true, truncated:false` (just page it) - `truncated:true` means a very broad
   wildcard/regex overflowed the engine's expansion limit so some forms are UNREACHABLE (NARROW the pattern;
   paging will not recover them).
@@ -103,18 +105,22 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   minChars?, maxChars? }`. `term` is EITHER a single `term` from a prior `/v1/search`, OR a MULTI-WORD /
   PROXIMITY query - space-separated words that co-occur within `proximityDistance`, or a quoted run for an
   adjacent phrase (`mode` expands wildcard/regex per word, same as `/v1/search`). This is how you read a
-  PROXIMITY search in context: its `~`-joined search `term` does NOT round-trip here, so pass the ORIGINAL
-  multi-word query instead. Words match LITERALLY (as in search), so reuse the SAME wildcards you searched
+  MULTI-WORD / PROXIMITY search in context: `/v1/search` returns a multi-word match's `term` space-joined
+  (e.g. `ekayano ayam`), so pass it straight back here. Words match LITERALLY (as in search), so reuse the SAME wildcards you searched
   with - a bare `avijja` will miss the sandhi forms `avijjaya`/`avijjapaccaya`, whereas `avijj*` catches them.
-  Each occurrence is `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedVariants, cursor,
-  highlights }`. `snippet` is hit-centered; `highlights` is the ordered set of marked spans in SNIPPET-LOCAL
+  The response is an envelope `{ occurrences, returnedCount, total, hasMore }` - `total` is the term's
+  occurrence count in THAT book (before paging), so page with `skip`/`take` while `hasMore`. Each occurrence is
+  `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedVariants, cursor, highlights }`. `snippet` is hit-centered; `highlights` is the ordered set of marked spans in SNIPPET-LOCAL
   offsets - `[{ start, length, isAnchor }]`: a single-term hit has one, a proximity/phrase hit has one PER
   co-occurring word with exactly one `isAnchor:true` (the navigable word; the rest are the co-occurring
-  context). `hitStart`/`hitLength` mirror the anchor. Citation data is NESTED
+  context). `hitStart`/`hitLength` mirror the anchor. All snippet offsets (`hitStart`/`hitLength`/`highlights`)
+  are relative to the RETURNED text in the requested `outputScript` - do not reuse them across a script change.
+  Citation data is NESTED
   under `refs` (NOT top-level as on `/v1/passage`): `refs.paragraphNumber`, `refs.paragraphBookCode`
   (the Multi sub-book code, e.g. "kn17"), and `refs.pages[]` where each page is `{ edition, volume, number }`
   - e.g. `{ "edition": "Vri", "volume": 3, "number": 196 }`, conventionally cited "VRI 3:196" (edition
-  values: `Vri`, `Myanmar`, `Pts`, `Thai`; `volume` is `0` for a single-volume edition). `cursor` is the
+  values: `Vri`, `Myanmar`, `Pts`, `Thai`; `volume` is `0` for a single-volume edition; `pages` CAN be empty,
+  e.g. at a section's first paragraph before any page break). `cursor` is the
   hit's unique locator - pass it to `/v1/passage`
   as `cursor` to read the exact passage around THIS hit (paragraph numbers repeat within a book, so the
   paragraph number alone is not a unique locator). `includedVariants` echoes your request flag (whether
@@ -122,7 +128,10 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
   Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeVariantReadings? }`.
   Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, ... }`. Page by passing back the
-  integer `prevCursor` / `nextCursor` as `cursor` (see the cursor note above). NOTE: `paragraph:N` opens at the
+  integer `prevCursor` / `nextCursor` as `cursor` (see the cursor note above). A `cursor` (from occurrences or
+  passage) reads the ENCLOSING SENTENCE: the window start is snapped back so you get the governing clause, not a
+  mid-sentence fragment. `maxChars` is a SOFT budget - the window OVERSHOOTS to the next sentence boundary, so
+  returned text can exceed it. NOTE: `paragraph:N` opens at the
   START of paragraph N but the window is bounded by `maxChars`, so a long paragraph spans several windows and
   `nextCursor` may still be INSIDE the same paragraph - keep paging until `normalizedReference` changes, or
   raise `maxChars`.
@@ -136,7 +145,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 ## A typical research flow
 
 1. `POST /v1/search` for a word -> keep each `term` you want. NOTE: `mode: "Exact"` matches ONE literal
-   whole-word form, so its `totalOccurrenceCount` is that single form's count, NOT the stem's whole
+   whole-word form, so its `returnedOccurrenceCount` is that single form's count, NOT the stem's whole
    footprint. To gather a stem's inflectional family (nominative, accusative, instrumental... together),
    follow up with a length-bounded anchored regex - `{ "query": "^metta.{1,4}$", "mode": "Regex" }`
    returns each case-form (`metta`, `mettam`, `mettaya`, `mettena`, ...) as its own `term` with its own

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -58,7 +58,7 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             + "term returned by 'search' (in the same script it came back) and a bookId from its per-book "
             + "breakdown or the 'books' tool. A space-separated multi-word term co-occurs within a proximity "
             + "window; a quoted run is an adjacent phrase.")]
-        public static async Task<IReadOnlyList<Occurrence>> OccurrencesAsync(
+        public static async Task<OccurrenceResult> OccurrencesAsync(
             ISearchTool search,
             [Description("The book's id (file name), e.g. from a search result's per-book breakdown or the 'books' tool.")]
             string bookId,

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -63,7 +63,8 @@ namespace CST.Avalonia.Services.Tools
                         // Nav paths are stored Devanagari; romanize to the requested script like everything else. (#186 cold test)
                         BookName: ScriptConverter.Convert(o.Book?.LongNavPath ?? string.Empty, Script.Devanagari, request.OutputScript),
                         Count: o.Count)).ToList()
-                    : (IReadOnlyList<BookHitSummary>)Array.Empty<BookHitSummary>(),
+                    // null (not []) when not requested, so "not asked for" is unambiguous vs an empty result.
+                    : null,
                 // Counts-only path sets BookCount from the index (Occurrences empty); the postings path leaves
                 // BookCount 0, so fall back to the per-book count it computed.
                 BookCount: t.BookCount > 0 ? t.BookCount : t.Occurrences.Count)).ToList();
@@ -78,11 +79,13 @@ namespace CST.Avalonia.Services.Tools
 
             return new SearchToolResult(
                 Terms: terms,
-                TotalTermCount: result.TotalTermCount,
-                TotalOccurrenceCount: result.TotalOccurrenceCount,
+                // Page-scoped counts, named "returned*" so they aren't mistaken for corpus-wide totals
+                // (per-term TotalCount/BookCount ARE corpus-wide). (Desktop MCP friction report)
+                ReturnedTermCount: result.TotalTermCount,
+                ReturnedOccurrenceCount: result.TotalOccurrenceCount,
                 // The counts-only fast path (IncludeBooks=false) doesn't enumerate books, so its distinct-book
                 // union is 0 — report null instead of a misleading 0. (Desktop MCP friction report)
-                TotalBookCount: request.IncludeBooks ? result.TotalBookCount : (int?)null,
+                ReturnedBookCount: request.IncludeBooks ? result.TotalBookCount : (int?)null,
                 // `truncated` means ONLY that the pattern overflowed the expansion cap (narrow it) — a normal
                 // large result is `hasMore:true, truncated:false` (page it). Don't leak the UI's page-cap
                 // "refine your search" message as the note; only the genuine cap message.
@@ -100,13 +103,15 @@ namespace CST.Avalonia.Services.Tools
             return terms.Select(t => ScriptConverter.Convert(t, Script.Unknown, outputScript)).ToList();
         }
 
-        public async Task<IReadOnlyList<Occurrence>> GetOccurrencesAsync(
+        private static readonly OccurrenceResult EmptyOccurrences = new(Array.Empty<Occurrence>(), 0, 0, false);
+
+        public async Task<OccurrenceResult> GetOccurrencesAsync(
             OccurrenceRequest request, CancellationToken ct = default)
         {
             var dir = _settings.Settings?.XmlBooksDirectory;
-            if (string.IsNullOrEmpty(dir)) return Array.Empty<Occurrence>();
+            if (string.IsNullOrEmpty(dir)) return EmptyOccurrences;
             var path = Path.Combine(dir, request.BookId);
-            if (!File.Exists(path)) return Array.Empty<Occurrence>();
+            if (!File.Exists(path)) return EmptyOccurrences;
 
             // Route to the EXPANDING path (GetMultiWordPositionsAsync) for anything that needs term expansion or
             // co-occurrence: a phrase, 2+ units, OR a single Wildcard/Regex word — which must be EXPANDED, not
@@ -134,7 +139,7 @@ namespace CST.Avalonia.Services.Tools
                     .Select(p => new List<SnippetMark> { new SnippetMark(p.StartOffset, p.EndOffset, true) })
                     .ToList();
             }
-            if (perOccurrence.Count == 0) return Array.Empty<Occurrence>();
+            if (perOccurrence.Count == 0) return EmptyOccurrences;
 
             // Char offsets index the decoded (BOM-stripped) UTF-16 text — read it the same way.
             string xml = await File.ReadAllTextAsync(path, Encoding.Unicode, ct).ConfigureAwait(false);
@@ -170,7 +175,12 @@ namespace CST.Avalonia.Services.Tools
                     Highlights: s.Highlights
                         .Select(h => new OccurrenceHighlight(h.Start, h.Length, h.IsAnchor)).ToList()));
             }
-            return occurrences;
+            // Envelope (like search): book-scoped total + hasMore, so an agent paging occurrences isn't blind.
+            return new OccurrenceResult(
+                Occurrences: occurrences,
+                ReturnedCount: occurrences.Count,
+                Total: perOccurrence.Count,
+                HasMore: request.Skip + occurrences.Count < perOccurrence.Count);
 
             static int AnchorStart(List<SnippetMark> m)
             {

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -30,7 +30,7 @@ namespace CST.Tools
         /// Pass the <c>Term</c> from a prior search (in whatever script it came back). This is the data behind
         /// both the agent loop (scan → cite/fetch) and the human concordance panel.
         /// </summary>
-        Task<IReadOnlyList<Occurrence>> GetOccurrencesAsync(OccurrenceRequest request, CancellationToken ct = default);
+        Task<OccurrenceResult> GetOccurrencesAsync(OccurrenceRequest request, CancellationToken ct = default);
     }
 
     /// <summary>How the query text is interpreted.</summary>
@@ -79,20 +79,22 @@ namespace CST.Tools
         bool IncludeBooks = false);
 
     /// <summary>Search results: matching terms (token-frugal — per-book breakdown and positions are opt-in).</summary>
-    /// <param name="TotalOccurrenceCount">Sum over the terms IN THIS PAGE (not the whole result set).</param>
-    /// <param name="TotalBookCount">Distinct books over the terms IN THIS PAGE (not the whole result set).
-    /// <b>Null when <c>IncludeBooks</c> is false</c></b> — the counts-only fast path does not enumerate books,
-    /// so the distinct-book union is not available and is reported as null (not a misleading 0). Per-term
-    /// <c>BookCount</c> is always present.</param>
+    /// <param name="ReturnedTermCount">How many matching term-forms are IN THIS PAGE (= <c>Terms.Count</c>), NOT
+    /// the corpus-wide match count. Use <c>HasMore</c> to page; there is no cheap whole-result term total.</param>
+    /// <param name="ReturnedOccurrenceCount">Sum of <c>TotalCount</c> over the terms IN THIS PAGE (not the whole
+    /// result set). Per-term <c>TotalCount</c> is corpus-wide; this page sum is not.</param>
+    /// <param name="ReturnedBookCount">Distinct books over the terms IN THIS PAGE. <b>Null when
+    /// <c>IncludeBooks</c> is false</b> — the counts-only fast path does not enumerate books, so the union is
+    /// unavailable and reported as null (not a misleading 0). Per-term <c>BookCount</c> is always present.</param>
     /// <param name="HasMore">True if at least one more matching term exists after this page — request the next
     /// page with <c>Skip += MaxTerms</c>. This, not the page length, is the paging signal.</param>
     /// <param name="Truncated">The pattern overflowed the engine's expansion limit (very broad wildcard/regex);
     /// distinct from <see cref="HasMore"/>.</param>
     public sealed record SearchToolResult(
         IReadOnlyList<SearchTermResult> Terms,
-        int TotalTermCount,
-        int TotalOccurrenceCount,
-        int? TotalBookCount,
+        int ReturnedTermCount,
+        int ReturnedOccurrenceCount,
+        int? ReturnedBookCount,
         bool Truncated,
         bool HasMore = false,
         string? Note = null);
@@ -101,11 +103,12 @@ namespace CST.Tools
     /// <param name="Term">The term in the requested output script — pass it back verbatim as
     /// <c>OccurrenceRequest.Term</c> to read it in context.</param>
     /// <param name="BookCount">How many books this term occurs in (always present — the spread, without the list).</param>
-    /// <param name="Books">Per-book breakdown; empty unless <c>SearchToolRequest.IncludeBooks</c> was true.</param>
+    /// <param name="Books">Per-book breakdown; <b>null</b> unless <c>SearchToolRequest.IncludeBooks</c> was true
+    /// (null = "not requested", unambiguous vs. an empty result).</param>
     public sealed record SearchTermResult(
         string Term,
         int TotalCount,
-        IReadOnlyList<BookHitSummary> Books,
+        IReadOnlyList<BookHitSummary>? Books,
         int BookCount = 0);
 
     /// <summary>A term's occurrence count within one book (call <c>GetOccurrencesAsync</c> for the snippets).</summary>
@@ -165,4 +168,20 @@ namespace CST.Tools
         bool IncludedVariants,
         int Cursor,
         IReadOnlyList<OccurrenceHighlight> Highlights);
+
+    /// <summary>
+    /// A page of a term's in-context occurrences within one book — the same envelope shape as
+    /// <see cref="SearchToolResult"/>, so the tool family is consistent and an agent isn't left paging blind
+    /// over a bare array. (Desktop MCP friction report)
+    /// </summary>
+    /// <param name="Occurrences">This page of occurrences (after <c>Skip</c>/<c>Take</c>).</param>
+    /// <param name="ReturnedCount">How many occurrences are in this page (= <c>Occurrences.Count</c>).</param>
+    /// <param name="Total">Total occurrences of the term in this book (before paging) — book-scoped.</param>
+    /// <param name="HasMore">True if more occurrences remain after this page; request the next with
+    /// <c>Skip += Take</c>.</param>
+    public sealed record OccurrenceResult(
+        IReadOnlyList<Occurrence> Occurrences,
+        int ReturnedCount,
+        int Total,
+        bool HasMore);
 }


### PR DESCRIPTION
The **response-shape** changes from friction report #2, grouped for one focused review. All three are **shared with the HTTP `/v1` surface** (MCP wraps the same tool layer), and **`llms.txt` is updated in lockstep** so the Code+API front door stays truthful.

## Changes
- **Counts rename (P2).** The page-scoped result counts were named like corpus totals, while per-term `totalCount`/`bookCount` genuinely are corpus-wide — that inconsistency is what misled the agent (it nearly reported a page sum as the canon-wide count). Renamed `SearchToolResult.{TotalTermCount, TotalOccurrenceCount, TotalBookCount}` → `{ReturnedTermCount, ReturnedOccurrenceCount, ReturnedBookCount}`. → `/v1/search` + MCP `search`.
- **`occurrences` envelope (P3).** Was a bare array with no paging signal; now `{ occurrences, returnedCount, total, hasMore }`, matching `search`, so an agent paging occurrences isn't blind. `total` is the term's book-scoped occurrence count. → `/v1/occurrences` + MCP `occurrences`.
- **`books: []` → `null` (P4).** `SearchTermResult.Books` is `null` when `includeBooks:false`, so "not requested" is unambiguous vs. an empty result. → `/v1/search` + MCP `search`.
- **`llms.txt` in lockstep** — renamed fields, the occurrences envelope + corrected object/array response list, the space-joined phrase-term round-trip, plus the deferred doc one-liners (offsets are script-relative; `pages` can be empty; a cursor reads the enclosing sentence; `maxChars` overshoots).

## HTTP `/v1` impact (for the re-test decision)
Breaking-ish for any existing HTTP consumer: `/v1/search` field renames + `books:null`, and `/v1/occurrences` array→object. This is the increment I flagged as the reason to hold the Code+API round until now — the surface is settled and the doc matches.

## Deferred to increment 3c
Merge co-located duplicate snippets (the biggest token win) — an algorithmic change to snippet grouping that deserves its own focused review + tests.

## Tests
Updated the search-tool, endpoint, and integration tests for the new shapes (counts rename, `books` null, occurrences envelope + `returnedCount`/`total`). Full suite green (591).

🤖 Generated with [Claude Code](https://claude.com/claude-code)