### PR TITLE
#191 3c(A): MCP/HTTP scoping parity + books filter/paging

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -35,6 +35,13 @@ namespace CST.Avalonia.Tests.Integration
             return JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
         }
 
+        private static async Task<JsonDocument> GetDoc(HttpClient http, string path)
+        {
+            var resp = await http.GetAsync(path);
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            return JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        }
+
         [Fact]
         public async Task All_core_endpoints_respond()
         {
@@ -203,6 +210,10 @@ namespace CST.Avalonia.Tests.Integration
             string.Concat(r.Content.OfType<TextContentBlock>().Select(b => b.Text))
             + (r.StructuredContent?.GetRawText() ?? string.Empty);
 
+        // A typed tool return is serialized as JSON in the text content block; parse it for field assertions.
+        private static JsonDocument ToolJson(ModelContextProtocol.Protocol.CallToolResult r) =>
+            JsonDocument.Parse(string.Concat(r.Content.OfType<TextContentBlock>().Select(b => b.Text)));
+
         [Fact]
         public async Task Mcp_lists_the_read_tool_set()
         {
@@ -238,13 +249,64 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
-        public async Task Mcp_books_tool_resolves_ids_to_names()
+        public async Task Mcp_books_tool_resolves_ids_to_names_and_pages()
         {
             await using var client = await ConnectMcpAsync();
-            var books = await client.CallToolAsync("books", new Dictionary<string, object?>());
+            // Envelope { books, returnedCount, total, hasMore }; take:250 covers the whole catalog so the
+            // fixture's mula book (a real catalog file name) is present - an agent can resolve a bookId.
+            var books = await client.CallToolAsync("books", new Dictionary<string, object?> { ["take"] = 250 });
             Assert.NotEqual(true, books.IsError);
-            // The fixture's mula book (a real catalog file name) is listed - so an agent can resolve a bookId.
             Assert.Contains(_api.MulaBook, ToolText(books));
+            using var booksDoc = ToolJson(books);
+            int total = booksDoc.RootElement.GetProperty("total").GetInt32();
+            Assert.True(total > 200, "the full catalog is 217 books");
+
+            // Filtering narrows the catalog (the overflow fix) - Abhidhamma is a small subset.
+            var abhi = await client.CallToolAsync("books",
+                new Dictionary<string, object?> { ["pitaka"] = "Abhidhamma" });
+            using var abhiDoc = ToolJson(abhi);
+            int abhiTotal = abhiDoc.RootElement.GetProperty("total").GetInt32();
+            Assert.True(abhiTotal > 0 && abhiTotal < total, "pitaka filter returns a proper subset");
+        }
+
+        [Fact]
+        public async Task Books_endpoint_filters_and_pages()
+        {
+            using var http = _api.Http();
+            // Paging: take:5 => a 5-book page over the full ~217-book catalog, hasMore true. (Cowork overflow fix)
+            using var page = await GetDoc(http, "/v1/books?take=5");
+            Assert.Equal(5, page.RootElement.GetProperty("returnedCount").GetInt32());
+            Assert.Equal(5, page.RootElement.GetProperty("books").GetArrayLength());
+            Assert.True(page.RootElement.GetProperty("total").GetInt32() > 200);
+            Assert.True(page.RootElement.GetProperty("hasMore").GetBoolean());
+
+            // Filter: pitaka=Abhidhamma is a small, all-Abhidhamma subset.
+            using var abhi = await GetDoc(http, "/v1/books?pitaka=Abhidhamma&take=250");
+            Assert.InRange(abhi.RootElement.GetProperty("total").GetInt32(), 1, 60);
+            foreach (var b in abhi.RootElement.GetProperty("books").EnumerateArray())
+                Assert.Equal("Abhidhamma", b.GetProperty("pitaka").GetString());
+        }
+
+        [Fact]
+        public async Task Mcp_search_filter_scopes_to_book_class()
+        {
+            await using var client = await ConnectMcpAsync();
+            // "dhamma" is in both fixture books (mula + attha). A mula-only filter (a NESTED object param over
+            // MCP) must scope it to just the mula book - proving the MCP search tool now honors the filter.
+            var filtered = await client.CallToolAsync("search", new Dictionary<string, object?>
+            {
+                ["query"] = "dhamma",
+                ["includeBooks"] = true,
+                ["filter"] = new Dictionary<string, object?>
+                {
+                    ["vinaya"] = true, ["sutta"] = true, ["abhidhamma"] = true,
+                    ["mula"] = true, ["atthakatha"] = false, ["tika"] = false, ["other"] = true,
+                },
+            });
+            Assert.NotEqual(true, filtered.IsError);
+            using var doc = ToolJson(filtered);
+            int bookCount = doc.RootElement.GetProperty("terms")[0].GetProperty("bookCount").GetInt32();
+            Assert.Equal(1, bookCount);   // mula only; the attha book is excluded by the filter
         }
 
         [Fact]

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -23,8 +23,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   convention) - normalize/strip U+200C before comparing or matching strings.
 - Cursors (`prevCursor` / `nextCursor` from `/v1/passage`) are INTEGERS, and opaque - pass one back verbatim
   as `cursor` to page; do not interpret them or do arithmetic on them. `null` means the start/end of the book.
-- Response shape is per endpoint: `/v1/search`, `/v1/occurrences`, `/v1/passage`, `/v1/convert`, `/v1/status`
-  return a JSON object; `/v1/dictionary/lookup`, `/v1/books`, `/v1/scripts` return a bare JSON array.
+- Response shape is per endpoint: `/v1/search`, `/v1/occurrences`, `/v1/books`, `/v1/passage`, `/v1/convert`,
+  `/v1/status` return a JSON object; `/v1/dictionary/lookup`, `/v1/scripts` return a bare JSON array.
 - You work entirely in readable Pali (romanized by default). To read a search hit in context, pass the
   term's `term` value (exactly as `/v1/search` returned it, in whatever script you requested) back to
   `/v1/occurrences` as `term`. There is no opaque id to round-trip - the server handles the internal encoding.
@@ -51,11 +51,14 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 ## Endpoints
 
 - `GET  /v1/status` - app version, API version, readiness.
-- `GET  /v1/books` - the catalog. Each: `{ bookId, name, shortName, pitaka, commentaryLevel, bookType, indexed }`.
-  `name`/`shortName` are romanized by default; add `?script=Devanagari` (etc.) to change. Classify with
-  `commentaryLevel` (`Mula`/`Atthakatha`/`Tika`/`Other`) and `pitaka`; `bookType` is a legacy field, often
-  `Unknown` - do not rely on it. The `.mul`/`.att`/`.tik` FILENAME suffix is only a hint and can DISAGREE with
-  `commentaryLevel` (e.g. `e0102n.mul.xml` is `commentaryLevel:"Other"`) - trust the field, not the name.
+- `GET  /v1/books` - the catalog (217 books - LARGE, so it is FILTERABLE and PAGED). Query params:
+  `?pitaka=` (`Vinaya`/`Sutta`/`Abhidhamma`/`Other`), `?commentaryLevel=` (`Mula`/`Atthakatha`/`Tika`/`Other`),
+  `?skip=`/`?take=` (default take 100), `?script=Devanagari` (etc.; names romanized by default). FILTER to
+  avoid pulling all 217 at once (e.g. `?pitaka=Abhidhamma`). Returns `{ books, returnedCount, total, hasMore }`
+  where each book is `{ bookId, name, shortName, pitaka, commentaryLevel, bookType, indexed }`. Classify with
+  `commentaryLevel` and `pitaka`; `bookType` is a legacy field, often `Unknown` - do not rely on it. The
+  `.mul`/`.att`/`.tik` FILENAME suffix is only a hint and can DISAGREE with `commentaryLevel`
+  (e.g. `e0102n.mul.xml` is `commentaryLevel:"Other"`) - trust the field, not the name.
 - `POST /v1/search` - matching terms. Search is over WHOLE-WORD tokens matched as LITERAL character
   patterns, not grammatical inflections. To cover a stem's inflected endings, reach FIRST for a trailing
   `*` WILDCARD (`dhamm*`): the `*` absorbs the case/number endings, so you do NOT need to hand-write a

--- a/src/CST.Avalonia/Services/LocalApi/BookCatalog.cs
+++ b/src/CST.Avalonia/Services/LocalApi/BookCatalog.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using CST;
+using CST.Conversion;
+using CST.Tools;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>
+    /// Shared projection for the book catalog behind BOTH the MCP <c>books</c> tool and the HTTP
+    /// <c>/v1/books</c> route. Optional piṭaka / commentary-level filters + paging keep the 217-book catalog
+    /// from overflowing an agent's context (the Cowork friction report: an unfiltered list was ~121K chars).
+    /// Nav-path names are stored Devanagari; romanized to the requested script.
+    /// </summary>
+    internal static class BookCatalog
+    {
+        public const int DefaultTake = 100;
+
+        public static BookListResult List(
+            Script outputScript, Pitaka? pitaka, CommentaryLevel? commentaryLevel, int skip, int take)
+        {
+            if (skip < 0) skip = 0;
+            if (take < 1) take = DefaultTake;
+
+            var filtered = Books.Inst.Where(b =>
+                (pitaka is null || b.Pitaka == pitaka.Value)
+                && (commentaryLevel is null || b.Matn == commentaryLevel.Value)).ToList();
+
+            var page = filtered.Skip(skip).Take(take)
+                .Select(b => new BookSummary(
+                    b.FileName,
+                    ScriptConverter.Convert(b.LongNavPath, Script.Devanagari, outputScript),
+                    ScriptConverter.Convert(b.ShortNavPath, Script.Devanagari, outputScript),
+                    b.Pitaka, b.Matn, b.BookType, b.DocId >= 0))
+                .ToList();
+
+            return new BookListResult(page, page.Count, filtered.Count, skip + page.Count < filtered.Count);
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -339,14 +339,13 @@ namespace CST.Avalonia.Services.LocalApi
             // Book catalog — agents need book ids to call the other tools. Always available (no service
             // needed). Nav-path names are stored Devanagari; romanize to the requested script (Latin default,
             // like every other endpoint) via ?script=. (#186 cold-agent test: names came back Devanagari.)
-            app.MapGet(v + "/books", (string? script) =>
+            app.MapGet(v + "/books", (string? script, string? pitaka, string? commentaryLevel, int? skip, int? take) =>
             {
                 var outputScript = ParseScript(script);
-                return Results.Json(Books.Inst.Select(b => new BookSummary(
-                    b.FileName,
-                    ScriptConverter.Convert(b.LongNavPath, Script.Devanagari, outputScript),
-                    ScriptConverter.Convert(b.ShortNavPath, Script.Devanagari, outputScript),
-                    b.Pitaka, b.Matn, b.BookType, b.DocId >= 0)).ToList());
+                Pitaka? p = Enum.TryParse<Pitaka>(pitaka, ignoreCase: true, out var pp) ? pp : null;
+                CommentaryLevel? cl = Enum.TryParse<CommentaryLevel>(commentaryLevel, ignoreCase: true, out var cc) ? cc : null;
+                // Filter (pitaka / commentary level) + paging so the 217-book catalog can't overflow a caller. (#191 Cowork)
+                return Results.Json(BookCatalog.List(outputScript, p, cl, skip ?? 0, take ?? BookCatalog.DefaultTake));
             });
 
             // Surface which tool groups got wired, so a missing DI hand-off (e.g. a null IScriptTool leaving

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/BooksMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/BooksMcpTool.cs
@@ -1,8 +1,6 @@
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using CST;
-using CST.Conversion;
+using CST.Avalonia.Services.LocalApi;
 using CST.Tools;
 using ModelContextProtocol.Server;
 
@@ -20,18 +18,20 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         [Description("List the corpus's books: for each, its id (file name — the key the other tools take), its "
             + "full and short names in the requested script, its pitaka / commentary-level / type classification, "
             + "and whether it is indexed. Use this to turn a bookId into a recognizable location, or to find "
-            + "book ids to read.")]
-        public static IReadOnlyList<BookSummary> Books_(
+            + "book ids to read. The full catalog is 217 books and large — FILTER by pitaka and/or commentary "
+            + "level to narrow it (e.g. pitaka:Abhidhamma), and page with skip/take. Returns "
+            + "{ books, returnedCount, total, hasMore }.")]
+        public static BookListResult Books_(
             [Description("Script for the returned book names.")]
-            OutputScript outputScript = OutputScript.Latin)
-        {
-            var target = McpScript.ToScript(outputScript);
-            // Nav-path names are stored Devanagari; romanize to the requested script (like /v1/books).
-            return Books.Inst.Select(b => new BookSummary(
-                b.FileName,
-                ScriptConverter.Convert(b.LongNavPath, Script.Devanagari, target),
-                ScriptConverter.Convert(b.ShortNavPath, Script.Devanagari, target),
-                b.Pitaka, b.Matn, b.BookType, b.DocId >= 0)).ToList();
-        }
+            OutputScript outputScript = OutputScript.Latin,
+            [Description("Restrict to a piṭaka: Vinaya, Sutta, Abhidhamma, or Other. Omit for all.")]
+            Pitaka? pitaka = null,
+            [Description("Restrict to a commentary level: Mula (root), Atthakatha (commentary), Tika (sub-commentary), or Other. Omit for all.")]
+            CommentaryLevel? commentaryLevel = null,
+            [Description("How many books to skip (paging).")]
+            int skip = 0,
+            [Description("How many books to return per page.")]
+            int take = 100)
+            => BookCatalog.List(McpScript.ToScript(outputScript), pitaka, commentaryLevel, skip, take);
     }
 }

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -40,12 +40,20 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             bool includeBooks = false,
             [Description("How many matching term-forms to skip (paging). Re-request with skip += maxTerms while hasMore is true.")]
             int skip = 0,
+            [Description("Restrict the search to parts of the corpus. Pitaka flags (vinaya/sutta/abhidhamma) OR "
+                + "within their group; text-class flags (mula/atthakatha/tika) OR within theirs; the two groups "
+                + "AND together. E.g. commentaries-only = { mula:false, atthakatha:true, tika:true, other:false }. Omit for the whole corpus.")]
+            ToolBookFilter? filter = null,
+            [Description("For a multi-word/proximity query, the co-occurrence window in words (default 10).")]
+            int proximityDistance = 10,
             CancellationToken ct = default)
         {
             var request = new SearchToolRequest(
                 Query: query ?? string.Empty,
                 Mode: mode,
+                Filter: filter,
                 MaxTerms: maxTerms,
+                ProximityDistance: proximityDistance,
                 OutputScript: McpScript.ToScript(outputScript),
                 Skip: skip,
                 IncludeBooks: includeBooks);
@@ -74,6 +82,8 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             int take = 50,
             [Description("Include apparatus/variant readings (braced) in the snippet.")]
             bool includeVariantReadings = false,
+            [Description("For a multi-word/proximity term, the co-occurrence window in words (default 10).")]
+            int proximityDistance = 10,
             CancellationToken ct = default)
         {
             var request = new OccurrenceRequest(
@@ -83,7 +93,8 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                 OutputScript: McpScript.ToScript(outputScript),
                 Skip: skip,
                 Take: take,
-                Mode: mode);
+                Mode: mode,
+                ProximityDistance: proximityDistance);
             return await search.GetOccurrencesAsync(request, ct).ConfigureAwait(false);
         }
     }

--- a/src/CST.Core/Tools/NavigationToolContracts.cs
+++ b/src/CST.Core/Tools/NavigationToolContracts.cs
@@ -37,6 +37,17 @@ namespace CST.Tools
         BookType BookType,
         bool Indexed);
 
+    /// <summary>
+    /// A page of the book catalog. The 217-book catalog is large, so the listing is filterable (by piṭaka /
+    /// commentary level) and paged — an unfiltered, unpaged list can overflow an agent's context. (Cowork
+    /// friction report)
+    /// </summary>
+    public sealed record BookListResult(
+        IReadOnlyList<BookSummary> Books,
+        int ReturnedCount,
+        int Total,
+        bool HasMore);
+
     /// <summary>Which books to list. Defaults include everything.</summary>
     public sealed record BookListFilter(
         bool Vinaya = true,


### PR DESCRIPTION
**Group A of the combined friction-report pass** (from the Cowork+MCP report). Focus: the MCP tools were a *reduced* subset of the HTTP surface, and `books` overflowed an agent's context.

## Changes
- **MCP `search` gains `filter` + `proximityDistance`; MCP `occurrences` gains `proximityDistance`.** The HTTP `/v1` surface already had both — this closes the parity gap. It's the exact gap that forced the Cowork agent to post-filter commentaries client-side (T3) and left the proximity window unsettable. `filter` is the same pitaka/text-class `ToolBookFilter`, passed as a nested-object MCP param.
- **`books` is now filterable + paged** (MCP tool *and* `GET /v1/books`): `?pitaka=` / `?commentaryLevel=` / `?skip=` / `?take=` (default 100), returning `{ books, returnedCount, total, hasMore }`. The full 217-book catalog was ~121K chars and overflowed a chat/cowork context ("biggest friction"); filtering (e.g. `pitaka=Abhidhamma`) or paging keeps it bounded. Shared projection extracted into `BookCatalog` so the tool and route can't drift.

## Deferred (within #266)
Per-book `bookCodes` for Multi books needs per-book anchor enumeration (or a precomputed catalog) — out of scope for a bulk listing.

## Tests
MCP nested-`filter` binds and scopes (mula-only ⇒ `bookCount 1`); `books` filter + paging envelope (`total`/`hasMore`, Abhidhamma subset all-Abhidhamma). Full suite green (593).

## Stacking
First of three stacked PRs (A→B→C) from the combined Code+API / Cowork+MCP triage. **Merge A first.** B (snippet hardening) and C (rename + doc fixes) branch off this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)