### PR TITLE
#191 3c(B): snippet-extractor hardening (D-2 markup residue + co-located merge)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
+++ b/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using CST.Conversion;
 using CST.Navigation;
@@ -31,6 +32,53 @@ namespace CST.Avalonia.Tests.Search
 
         private static SnippetOptions Deva(int min = 1, int max = 4000, bool notes = false) =>
             new(OutputScript: Script.Devanagari, IncludeVariantReadings: notes, MinChars: min, MaxChars: max);
+
+        [Fact]
+        public void GroupCoLocated_merges_hits_in_the_same_sentence()
+        {
+            // Sentence 1 has TWO hits, sentence 2 has ONE. Co-located hits must merge into a single snippet.
+            const string xml =
+                "<body><div id=\"a\" type=\"book\"><p rend=\"bodytext\" n=\"1\">"
+                + "one TARGET two TARGET three\u0964 four TARGET five\u0964"
+                + "</p></div></body>";
+            var markers = BookMarkers.Build(xml);
+            var hits = new List<IReadOnlyList<SnippetMark>>();
+            for (int i = xml.IndexOf("TARGET", System.StringComparison.Ordinal); i >= 0;
+                 i = xml.IndexOf("TARGET", i + 1, System.StringComparison.Ordinal))
+                hits.Add(new[] { new SnippetMark(i, i + "TARGET".Length, true) });
+            Assert.Equal(3, hits.Count);
+
+            var groups = TeiSnippetExtractor.GroupCoLocated(xml, hits);
+            Assert.Equal(2, groups.Count);                        // 2 same-sentence hits merged; 1 separate
+            Assert.Equal(2, groups[0].Count);                     // both sentence-1 marks in one group
+            Assert.Equal(1, groups[0].Count(m => m.IsAnchor));    // exactly one anchor survives the merge
+            Assert.Single(groups[1]);
+
+            var s = TeiSnippetExtractor.Extract(xml, groups[0], markers, Deva());
+            Assert.Equal(2, s.Highlights.Count);                  // one snippet, two highlights (the token win)
+            Assert.Equal(1, s.Highlights.Count(h => h.IsAnchor));
+        }
+
+        [Fact]
+        public void Snippet_never_leaks_markup_across_truncation_budgets()
+        {
+            // A window bound that lands inside `<pb ed="V" n="1.0002"/>` must not leak `ed="V" n=...` as text.
+            // Sweep MaxChars so the truncation start lands mid-tag at some budget. (Code+API friction D-2)
+            const string xml =
+                "<body><div id=\"a\" type=\"book\"><p rend=\"bodytext\" n=\"1\">"
+                + "alpha bravo charlie delta echo foxtrot <pb ed=\"V\" n=\"1.0002\"/> golf hotel TARGET india juliet\u0964"
+                + "</p></div></body>";
+            var markers = BookMarkers.Build(xml);
+            int pos = xml.IndexOf("TARGET", System.StringComparison.Ordinal);
+            for (int max = 6; max <= 60; max += 2)
+            {
+                var s = TeiSnippetExtractor.Extract(xml, pos, "TARGET".Length, markers, Deva(min: 1, max: max));
+                Assert.DoesNotContain("rend", s.Snippet);
+                Assert.DoesNotContain("ed=", s.Snippet);
+                Assert.DoesNotContain("<", s.Snippet);
+                Assert.DoesNotContain(">", s.Snippet);
+            }
+        }
 
         [Fact]
         public void Markers_report_paragraph_and_all_editions_at_hit()

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -156,8 +156,13 @@ namespace CST.Avalonia.Services.Tools
             // Nav paths are stored Devanagari; romanize to the requested script. (#186 cold test)
             string bookName = ScriptConverter.Convert(rawBookName, Script.Devanagari, request.OutputScript);
 
+            // Merge hits that share an enclosing sentence into ONE snippet with multiple highlights, so N
+            // co-located hits aren't N byte-identical snippets. Paging + total are over the merged groups.
+            // (Desktop MCP friction report — the snippet de-dup / token win.)
+            var groups = TeiSnippetExtractor.GroupCoLocated(xml, perOccurrence);
+
             var occurrences = new List<Occurrence>();
-            foreach (var marks in perOccurrence.Skip(request.Skip).Take(request.Take))
+            foreach (var marks in groups.Skip(request.Skip).Take(request.Take))
             {
                 ct.ThrowIfCancellationRequested();
                 var s = TeiSnippetExtractor.Extract(xml, marks, markers, opts);
@@ -176,13 +181,14 @@ namespace CST.Avalonia.Services.Tools
                         .Select(h => new OccurrenceHighlight(h.Start, h.Length, h.IsAnchor)).ToList()));
             }
             // Envelope (like search): book-scoped total + hasMore, so an agent paging occurrences isn't blind.
+            // Total is the MERGED snippet count (what you actually page over), not the raw hit count.
             return new OccurrenceResult(
                 Occurrences: occurrences,
                 ReturnedCount: occurrences.Count,
-                Total: perOccurrence.Count,
-                HasMore: request.Skip + occurrences.Count < perOccurrence.Count);
+                Total: groups.Count,
+                HasMore: request.Skip + occurrences.Count < groups.Count);
 
-            static int AnchorStart(List<SnippetMark> m)
+            static int AnchorStart(IReadOnlyList<SnippetMark> m)
             {
                 var a = m.FirstOrDefault(x => x.IsAnchor);
                 return a?.Start ?? (m.Count > 0 ? m[0].Start : 0);

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -55,6 +55,12 @@ namespace CST.Search
                 (winStart, winEnd, ellipsisStart, ellipsisEnd) =
                     ProseWindow(xml, pStart, pEnd, spanStart, spanEnd, opts);
 
+            // A window bound can land INSIDE a tag (e.g. SnapToSpace stopping at a space within `<hi rend="dot">`),
+            // which would leak the tag's tail (`rend="dot">`) as text since Clean can't see the `<` before it.
+            // Nudge the start past the tag and the end before it. Never cross the marks. (Code+API friction D-2)
+            winStart = Math.Min(NudgePastTag(xml, winStart), ms[0].Start);
+            winEnd = Math.Max(NudgeBeforeTag(xml, winEnd), ms[ms.Count - 1].End);
+
             // Render as segments: prefix . before . [mark . gap]* . mark . after . suffix, tracking each mark's
             // snippet-local start as the cumulative rendered length before it. Same length rule as the single-mark
             // markStart, accumulated over the marks.
@@ -88,6 +94,81 @@ namespace CST.Search
             var anchorHl = highlights.FirstOrDefault(h => h.IsAnchor) ?? highlights[0];
             return new SnippetResult(
                 sb.ToString(), anchorHl.Start, anchorHl.Length, num, code, pages, opts.IncludeVariantReadings, highlights);
+        }
+
+        /// <summary>
+        /// Group hits that fall in the SAME enclosing sentence into one mark-set (so co-located hits render as a
+        /// single snippet with multiple highlights, not N byte-identical snippets). Each group keeps exactly one
+        /// anchor (the first hit's); the rest become plain highlights. Ordered by anchor position. The caller
+        /// pages over the returned groups and calls <see cref="Extract(string,IReadOnlyList{SnippetMark},BookMarkers,SnippetOptions)"/>
+        /// on each. (Desktop MCP friction report — the snippet de-dup / token win.)
+        /// </summary>
+        public static List<IReadOnlyList<SnippetMark>> GroupCoLocated(
+            string xml, IReadOnlyList<IReadOnlyList<SnippetMark>> hits)
+        {
+            var ordered = hits
+                .Where(h => h.Count > 0)
+                .Select(h => (marks: h, anchor: (h.FirstOrDefault(m => m.IsAnchor) ?? h[0]).Start))
+                .OrderBy(x => x.anchor)
+                .ToList();
+
+            var groups = new List<IReadOnlyList<SnippetMark>>();
+            List<SnippetMark>? current = null;
+            int currentSentence = int.MinValue;
+            foreach (var (marks, anchor) in ordered)
+            {
+                int sentence = EnclosingSentenceStart(xml, anchor);
+                if (current == null || sentence != currentSentence)
+                {
+                    current = new List<SnippetMark>();
+                    groups.Add(current);
+                    currentSentence = sentence;
+                }
+                current.AddRange(marks);
+            }
+            // Collapse each group to a single anchor (the earliest), demoting the rest to plain highlights, so the
+            // "exactly one anchor" invariant holds for the merged snippet.
+            return groups.Select(WithSingleAnchor).ToList();
+        }
+
+        private static IReadOnlyList<SnippetMark> WithSingleAnchor(IReadOnlyList<SnippetMark> marks)
+        {
+            bool anchored = false;
+            var result = new List<SnippetMark>(marks.Count);
+            foreach (var m in marks)
+            {
+                if (m.IsAnchor && !anchored) { anchored = true; result.Add(m); }
+                else if (m.IsAnchor) result.Add(new SnippetMark(m.Start, m.End, false));
+                else result.Add(m);
+            }
+            return result;
+        }
+
+        private static int EnclosingSentenceStart(string xml, int pos)
+        {
+            var (_, pStart, pEnd, _) = FindEnclosingP(xml, pos);
+            if (pStart < 0) { pStart = 0; pEnd = xml.Length; }
+            var notes = TeiText.NoteRegions(xml, pStart, pEnd);
+            return SentenceStart(xml, pStart, pos, notes);
+        }
+
+        // True if pos sits inside a start/end tag (an unclosed '<' precedes it without a matching '>').
+        private static bool InsideTag(string xml, int pos)
+        {
+            if (pos <= 0 || pos > xml.Length) return false;
+            return xml.LastIndexOf('<', pos - 1) > xml.LastIndexOf('>', pos - 1);
+        }
+
+        private static int NudgePastTag(string xml, int pos)
+        {
+            if (InsideTag(xml, pos)) { int gt = xml.IndexOf('>', pos); if (gt >= 0) return gt + 1; }
+            return pos;
+        }
+
+        private static int NudgeBeforeTag(string xml, int pos)
+        {
+            if (InsideTag(xml, pos)) { int lt = xml.LastIndexOf('<', Math.Max(0, pos - 1)); if (lt >= 0) return lt; }
+            return pos;
         }
 
         private static (int start, int end, bool ellStart, bool ellEnd) ProseWindow(


### PR DESCRIPTION
**Group B — snippet-extractor hardening** (second of the three-part combined friction-report pass; Group A merged in #271).

## Changes
- **D-2 (Code+API friction): no more leaked markup.** A snippet window bound could land *inside* a tag — `SnapToSpace` stopping at a space within `<hi rend="dot">` or `<pb ed="V" n="1.0002"/>` — leaking the tag's tail (`rend="dot">`, `ed="V" n=...`) as text, because `Clean` can't see the `<` before the bound. The window start now nudges past the tag and the end before it (never crossing the marks).
- **Co-located snippet merge (the token win).** Hits sharing an enclosing sentence merge into **one** snippet with multiple `highlights` instead of N byte-identical snippets differing only in `hitStart`. New `TeiSnippetExtractor.GroupCoLocated` groups hits by sentence (exactly one anchor per group); `SearchTool` pages + totals over the merged groups (occurrences `total`/`hasMore` are now the merged count).

## Tests
Same-sentence hits merge to one group/snippet (two highlights, one anchor); a sweep of truncation budgets never leaks markup residue.

## Deferred
Orphaned whitespace before punctuation (P4) — a `Collapse` change with danda-in-regex + over-normalization risk; left for a focused follow-up.

Group C (rename + doc fixes) branches off this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)