### PR TITLE
#191 3c(C): rename includeVariantReadings->includeFootnotes + doc fixes (D-1, paragraph footgun)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
+++ b/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
@@ -31,7 +31,7 @@ namespace CST.Avalonia.Tests.Search
         private static int HitStart(string xml, string term) => xml.IndexOf(term, System.StringComparison.Ordinal);
 
         private static SnippetOptions Deva(int min = 1, int max = 4000, bool notes = false) =>
-            new(OutputScript: Script.Devanagari, IncludeVariantReadings: notes, MinChars: min, MaxChars: max);
+            new(OutputScript: Script.Devanagari, IncludeFootnotes: notes, MinChars: min, MaxChars: max);
 
         [Fact]
         public void GroupCoLocated_merges_hits_in_the_same_sentence()

--- a/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
+++ b/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using CST.Conversion;
 using CST.Navigation;
@@ -31,6 +32,53 @@ namespace CST.Avalonia.Tests.Search
 
         private static SnippetOptions Deva(int min = 1, int max = 4000, bool notes = false) =>
             new(OutputScript: Script.Devanagari, IncludeVariantReadings: notes, MinChars: min, MaxChars: max);
+
+        [Fact]
+        public void GroupCoLocated_merges_hits_in_the_same_sentence()
+        {
+            // Sentence 1 has TWO hits, sentence 2 has ONE. Co-located hits must merge into a single snippet.
+            const string xml =
+                "<body><div id=\"a\" type=\"book\"><p rend=\"bodytext\" n=\"1\">"
+                + "one TARGET two TARGET three\u0964 four TARGET five\u0964"
+                + "</p></div></body>";
+            var markers = BookMarkers.Build(xml);
+            var hits = new List<IReadOnlyList<SnippetMark>>();
+            for (int i = xml.IndexOf("TARGET", System.StringComparison.Ordinal); i >= 0;
+                 i = xml.IndexOf("TARGET", i + 1, System.StringComparison.Ordinal))
+                hits.Add(new[] { new SnippetMark(i, i + "TARGET".Length, true) });
+            Assert.Equal(3, hits.Count);
+
+            var groups = TeiSnippetExtractor.GroupCoLocated(xml, hits);
+            Assert.Equal(2, groups.Count);                        // 2 same-sentence hits merged; 1 separate
+            Assert.Equal(2, groups[0].Count);                     // both sentence-1 marks in one group
+            Assert.Equal(1, groups[0].Count(m => m.IsAnchor));    // exactly one anchor survives the merge
+            Assert.Single(groups[1]);
+
+            var s = TeiSnippetExtractor.Extract(xml, groups[0], markers, Deva());
+            Assert.Equal(2, s.Highlights.Count);                  // one snippet, two highlights (the token win)
+            Assert.Equal(1, s.Highlights.Count(h => h.IsAnchor));
+        }
+
+        [Fact]
+        public void Snippet_never_leaks_markup_across_truncation_budgets()
+        {
+            // A window bound that lands inside `<pb ed="V" n="1.0002"/>` must not leak `ed="V" n=...` as text.
+            // Sweep MaxChars so the truncation start lands mid-tag at some budget. (Code+API friction D-2)
+            const string xml =
+                "<body><div id=\"a\" type=\"book\"><p rend=\"bodytext\" n=\"1\">"
+                + "alpha bravo charlie delta echo foxtrot <pb ed=\"V\" n=\"1.0002\"/> golf hotel TARGET india juliet\u0964"
+                + "</p></div></body>";
+            var markers = BookMarkers.Build(xml);
+            int pos = xml.IndexOf("TARGET", System.StringComparison.Ordinal);
+            for (int max = 6; max <= 60; max += 2)
+            {
+                var s = TeiSnippetExtractor.Extract(xml, pos, "TARGET".Length, markers, Deva(min: 1, max: max));
+                Assert.DoesNotContain("rend", s.Snippet);
+                Assert.DoesNotContain("ed=", s.Snippet);
+                Assert.DoesNotContain("<", s.Snippet);
+                Assert.DoesNotContain(">", s.Snippet);
+            }
+        }
 
         [Fact]
         public void Markers_report_paragraph_and_all_editions_at_hit()

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -19,8 +19,9 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - Pali output is ROMANIZED by DEFAULT. The romanized script token is `"Latin"` (IAST, with diacritics). Pass
   `outputScript` to override (e.g. "Devanagari", "Thai", "Myanmar", "Sinhala"); `GET /v1/scripts` lists every
   valid value.
-- Devanagari output embeds a zero-width non-joiner (U+200C) inside SOME consonant conjuncts (a ligature
-  convention) - normalize/strip U+200C before comparing or matching strings.
+- Zero-width format chars in output (per script): DEVANAGARI embeds a zero-width JOINER (U+200D) after the
+  virama in many consonant conjuncts; SINHALA embeds a zero-width NON-joiner (U+200C). Do NOT assume Devanagari
+  uses U+200C - it does not. Strip BOTH U+200C and U+200D before comparing or matching strings.
 - Cursors (`prevCursor` / `nextCursor` from `/v1/passage`) are INTEGERS, and opaque - pass one back verbatim
   as `cursor` to page; do not interpret them or do arithmetic on them. `null` means the start/end of the book.
 - Response shape is per endpoint: `/v1/search`, `/v1/occurrences`, `/v1/books`, `/v1/passage`, `/v1/convert`,
@@ -33,7 +34,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - Books are identified by file name (e.g. `s0101m.mul.xml`). Get the list from `GET /v1/books`.
 - References: the paragraph number is the primary citation unit; page numbers exist per edition
   (VRI / Myanmar / PTS / Thai). Search occurrences report both.
-- Variant readings / apparatus (`includeVariantReadings: true` on `/v1/occurrences` and `/v1/passage`): the
+- Footnotes / apparatus (`includeFootnotes: true` on `/v1/occurrences` and `/v1/passage`): the
   texts carry the print editions' FOOTNOTES (Myanmar 1955-57 / VRI 1995-96), rendered INLINE and wrapped in
   curly braces `{...}`. Curly braces occur nowhere else in the corpus, so they reliably delimit apparatus from
   base text - split on `{...}` to extract each note. Inside a note, position disambiguates: a `(...)` group
@@ -44,7 +45,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   These are digitized print footnotes - mostly variant readings, but also editorial notes and cross-refs, with
   NO structural type marker, so any "variant vs footnote" split is your interpretation, not the data's.
   LAYER: apparatus lives almost entirely in MULA (root) texts; the ATTHAKATHA and TIKA (commentary /
-  sub-commentary) layers carry NONE. So `includeVariantReadings` on a commentary is always empty - expected,
+  sub-commentary) layers carry NONE. So `includeFootnotes` on a commentary is always empty - expected,
   not a bug (and a commentary-restricted search will never surface variants).
 - Terminology: when writing about the texts, call them "Pali", "the Tipitaka", or "VRI texts".
 
@@ -104,7 +105,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   wildcard/regex overflowed the engine's expansion limit so some forms are UNREACHABLE (NARROW the pattern;
   paging will not recover them).
 - `POST /v1/occurrences` - "search results in context": KWIC snippets plus citation refs for one query in one
-  book. Body: `{ bookId, term, mode?, proximityDistance?, includeVariantReadings?, outputScript?, skip?, take?,
+  book. Body: `{ bookId, term, mode?, proximityDistance?, includeFootnotes?, outputScript?, skip?, take?,
   minChars?, maxChars? }`. `term` is EITHER a single `term` from a prior `/v1/search`, OR a MULTI-WORD /
   PROXIMITY query - space-separated words that co-occur within `proximityDistance`, or a quoted run for an
   adjacent phrase (`mode` expands wildcard/regex per word, same as `/v1/search`). This is how you read a
@@ -113,7 +114,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   with - a bare `avijja` will miss the sandhi forms `avijjaya`/`avijjapaccaya`, whereas `avijj*` catches them.
   The response is an envelope `{ occurrences, returnedCount, total, hasMore }` - `total` is the term's
   occurrence count in THAT book (before paging), so page with `skip`/`take` while `hasMore`. Each occurrence is
-  `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedVariants, cursor, highlights }`. `snippet` is hit-centered; `highlights` is the ordered set of marked spans in SNIPPET-LOCAL
+  `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedFootnotes, cursor, highlights }`. `snippet` is hit-centered; `highlights` is the ordered set of marked spans in SNIPPET-LOCAL
   offsets - `[{ start, length, isAnchor }]`: a single-term hit has one, a proximity/phrase hit has one PER
   co-occurring word with exactly one `isAnchor:true` (the navigable word; the rest are the co-occurring
   context). `hitStart`/`hitLength` mirror the anchor. All snippet offsets (`hitStart`/`hitLength`/`highlights`)
@@ -126,10 +127,10 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   e.g. at a section's first paragraph before any page break). `cursor` is the
   hit's unique locator - pass it to `/v1/passage`
   as `cursor` to read the exact passage around THIS hit (paragraph numbers repeat within a book, so the
-  paragraph number alone is not a unique locator). `includedVariants` echoes your request flag (whether
+  paragraph number alone is not a unique locator). `includedFootnotes` echoes your request flag (whether
   variant readings were rendered), NOT whether this particular hit has any; see the apparatus note above.
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
-  Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeVariantReadings? }`.
+  Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeFootnotes? }`.
   Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, ... }`. Page by passing back the
   integer `prevCursor` / `nextCursor` as `cursor` (see the cursor note above). A `cursor` (from occurrences or
   passage) reads the ENCLOSING SENTENCE: the window start is snapped back so you get the governing clause, not a
@@ -138,6 +139,10 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   START of paragraph N but the window is bounded by `maxChars`, so a long paragraph spans several windows and
   `nextCursor` may still be INSIDE the same paragraph - keep paging until `normalizedReference` changes, or
   raise `maxChars`.
+  PARAGRAPH NUMBERS ARE NOT GLOBALLY UNIQUE: in a multi-section book they RESTART per section, so `paragraph:N`
+  can land on a DIFFERENT paragraph N than the one an `occurrences` hit reported. For exact addressing use the
+  hit's `cursor` (unique); if you must go by number, pass the `bookCode` (the sub-book, from the occurrence's
+  `refs.paragraphBookCode`) alongside `paragraph` to disambiguate.
 - `GET  /v1/dictionary/languages` - available dictionary language codes (e.g. "en", "hi").
 - `POST /v1/dictionary/lookup` - `{ language, query, outputScript?, maxEntries? }`
   -> entries `{ headword, meaningHtml }`.

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -324,7 +324,7 @@ namespace CST.Avalonia.Services.LocalApi
                         ? new NavigationReference.Paragraph(n, req.BookCode)
                         : new NavigationReference.WholeBook();
                     var pr = new PassageRequest(req.BookId, reference, req.Cursor, req.MaxChars,
-                        req.OutputScript, req.IncludeVariantReadings);
+                        req.OutputScript, req.IncludeFootnotes);
                     return Results.Json(await passage.FetchPassageAsync(pr, ct));
                 });
             }
@@ -368,6 +368,6 @@ namespace CST.Avalonia.Services.LocalApi
             int? Cursor = null,
             int MaxChars = 1200,
             Script OutputScript = Script.Latin,
-            bool IncludeVariantReadings = false);
+            bool IncludeFootnotes = false);
     }
 }

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
@@ -36,8 +36,9 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             int maxChars = 1200,
             [Description("Script for the returned text.")]
             OutputScript outputScript = OutputScript.Latin,
-            [Description("Include apparatus/variant readings (braced) in the text.")]
-            bool includeVariantReadings = false,
+            [Description("Include the print-edition footnotes (the braced {…} apparatus — variant readings, "
+                + "cross-references, editorial notes) in the text.")]
+            bool includeFootnotes = false,
             CancellationToken ct = default)
         {
             NavigationReference reference = paragraph is int n
@@ -49,7 +50,7 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                 Cursor: cursor,
                 MaxChars: maxChars,
                 OutputScript: McpScript.ToScript(outputScript),
-                IncludeVariantReadings: includeVariantReadings);
+                IncludeFootnotes: includeFootnotes);
             return await passage.FetchPassageAsync(request, ct).ConfigureAwait(false);
         }
     }

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -80,8 +80,9 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             int skip = 0,
             [Description("How many occurrences to return.")]
             int take = 50,
-            [Description("Include apparatus/variant readings (braced) in the snippet.")]
-            bool includeVariantReadings = false,
+            [Description("Include the print-edition footnotes (the braced {…} apparatus — variant readings, "
+                + "cross-references, editorial notes) in the snippet.")]
+            bool includeFootnotes = false,
             [Description("For a multi-word/proximity term, the co-occurrence window in words (default 10).")]
             int proximityDistance = 10,
             CancellationToken ct = default)
@@ -89,7 +90,7 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             var request = new OccurrenceRequest(
                 BookId: bookId ?? string.Empty,
                 Term: term ?? string.Empty,
-                IncludeVariantReadings: includeVariantReadings,
+                IncludeFootnotes: includeFootnotes,
                 OutputScript: McpScript.ToScript(outputScript),
                 Skip: skip,
                 Take: take,

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -41,7 +41,7 @@ namespace CST.Avalonia.Services.Tools
             // the hit is read with its governing clause. A paragraph reference already starts clean - no snap.
             var w = TeiPassageReader.ReadWindow(
                 xml, startPos, Math.Max(1, request.MaxChars),
-                request.IncludeVariantReadings, request.OutputScript, markers,
+                request.IncludeFootnotes, request.OutputScript, markers,
                 snapStartToSentence: request.Cursor.HasValue);
 
             return new PassageResult(

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -156,8 +156,13 @@ namespace CST.Avalonia.Services.Tools
             // Nav paths are stored Devanagari; romanize to the requested script. (#186 cold test)
             string bookName = ScriptConverter.Convert(rawBookName, Script.Devanagari, request.OutputScript);
 
+            // Merge hits that share an enclosing sentence into ONE snippet with multiple highlights, so N
+            // co-located hits aren't N byte-identical snippets. Paging + total are over the merged groups.
+            // (Desktop MCP friction report — the snippet de-dup / token win.)
+            var groups = TeiSnippetExtractor.GroupCoLocated(xml, perOccurrence);
+
             var occurrences = new List<Occurrence>();
-            foreach (var marks in perOccurrence.Skip(request.Skip).Take(request.Take))
+            foreach (var marks in groups.Skip(request.Skip).Take(request.Take))
             {
                 ct.ThrowIfCancellationRequested();
                 var s = TeiSnippetExtractor.Extract(xml, marks, markers, opts);
@@ -176,13 +181,14 @@ namespace CST.Avalonia.Services.Tools
                         .Select(h => new OccurrenceHighlight(h.Start, h.Length, h.IsAnchor)).ToList()));
             }
             // Envelope (like search): book-scoped total + hasMore, so an agent paging occurrences isn't blind.
+            // Total is the MERGED snippet count (what you actually page over), not the raw hit count.
             return new OccurrenceResult(
                 Occurrences: occurrences,
                 ReturnedCount: occurrences.Count,
-                Total: perOccurrence.Count,
-                HasMore: request.Skip + occurrences.Count < perOccurrence.Count);
+                Total: groups.Count,
+                HasMore: request.Skip + occurrences.Count < groups.Count);
 
-            static int AnchorStart(List<SnippetMark> m)
+            static int AnchorStart(IReadOnlyList<SnippetMark> m)
             {
                 var a = m.FirstOrDefault(x => x.IsAnchor);
                 return a?.Start ?? (m.Count > 0 ? m[0].Start : 0);

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -146,7 +146,7 @@ namespace CST.Avalonia.Services.Tools
             var markers = BookMarkers.Build(xml);
             var opts = new SnippetOptions(
                 OutputScript: request.OutputScript,
-                IncludeVariantReadings: request.IncludeVariantReadings,
+                IncludeFootnotes: request.IncludeFootnotes,
                 MinChars: request.MinChars ?? 60,
                 MaxChars: request.MaxChars ?? 320);
 
@@ -173,7 +173,7 @@ namespace CST.Avalonia.Services.Tools
                     HitStart: s.HitStart,
                     HitLength: s.HitLength,
                     Refs: new OccurrenceRefs(s.ParagraphNumber, s.ParagraphBookCode, s.Pages),
-                    IncludedVariants: s.IncludedVariants,
+                    IncludedFootnotes: s.IncludedFootnotes,
                     // The anchor's char offset — a unique locator to read the exact passage via /v1/passage
                     // (paragraph numbers repeat within a book). (#186 cold test)
                     Cursor: AnchorStart(marks),

--- a/src/CST.Core/Search/SnippetModels.cs
+++ b/src/CST.Core/Search/SnippetModels.cs
@@ -10,12 +10,12 @@ namespace CST.Search
     /// excluded, footnotes are transparent and don't count).
     /// </summary>
     /// <param name="OutputScript">Script for the snippet text (default romanized Latin).</param>
-    /// <param name="IncludeVariantReadings">Include <c>&lt;note&gt;</c> (variant-reading) text (default off).</param>
+    /// <param name="IncludeFootnotes">Include <c>&lt;note&gt;</c> (variant-reading) text (default off).</param>
     /// <param name="MinChars">Prose floor: extend to neighboring sentences until at least this many rendered chars.</param>
     /// <param name="MaxChars">Prose ceiling: a longer single sentence is trimmed+ellipsized around the hit.</param>
     public sealed record SnippetOptions(
         Script OutputScript = Script.Latin,
-        bool IncludeVariantReadings = false,
+        bool IncludeFootnotes = false,
         int MinChars = 60,
         int MaxChars = 320);
 
@@ -48,6 +48,6 @@ namespace CST.Search
         int? ParagraphNumber,
         string? ParagraphBookCode,
         IReadOnlyList<SnippetPageRef> Pages,
-        bool IncludedVariants,
+        bool IncludedFootnotes,
         IReadOnlyList<SnippetHighlight> Highlights);
 }

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -55,6 +55,12 @@ namespace CST.Search
                 (winStart, winEnd, ellipsisStart, ellipsisEnd) =
                     ProseWindow(xml, pStart, pEnd, spanStart, spanEnd, opts);
 
+            // A window bound can land INSIDE a tag (e.g. SnapToSpace stopping at a space within `<hi rend="dot">`),
+            // which would leak the tag's tail (`rend="dot">`) as text since Clean can't see the `<` before it.
+            // Nudge the start past the tag and the end before it. Never cross the marks. (Code+API friction D-2)
+            winStart = Math.Min(NudgePastTag(xml, winStart), ms[0].Start);
+            winEnd = Math.Max(NudgeBeforeTag(xml, winEnd), ms[ms.Count - 1].End);
+
             // Render as segments: prefix . before . [mark . gap]* . mark . after . suffix, tracking each mark's
             // snippet-local start as the cumulative rendered length before it. Same length rule as the single-mark
             // markStart, accumulated over the marks.
@@ -88,6 +94,81 @@ namespace CST.Search
             var anchorHl = highlights.FirstOrDefault(h => h.IsAnchor) ?? highlights[0];
             return new SnippetResult(
                 sb.ToString(), anchorHl.Start, anchorHl.Length, num, code, pages, opts.IncludeVariantReadings, highlights);
+        }
+
+        /// <summary>
+        /// Group hits that fall in the SAME enclosing sentence into one mark-set (so co-located hits render as a
+        /// single snippet with multiple highlights, not N byte-identical snippets). Each group keeps exactly one
+        /// anchor (the first hit's); the rest become plain highlights. Ordered by anchor position. The caller
+        /// pages over the returned groups and calls <see cref="Extract(string,IReadOnlyList{SnippetMark},BookMarkers,SnippetOptions)"/>
+        /// on each. (Desktop MCP friction report — the snippet de-dup / token win.)
+        /// </summary>
+        public static List<IReadOnlyList<SnippetMark>> GroupCoLocated(
+            string xml, IReadOnlyList<IReadOnlyList<SnippetMark>> hits)
+        {
+            var ordered = hits
+                .Where(h => h.Count > 0)
+                .Select(h => (marks: h, anchor: (h.FirstOrDefault(m => m.IsAnchor) ?? h[0]).Start))
+                .OrderBy(x => x.anchor)
+                .ToList();
+
+            var groups = new List<IReadOnlyList<SnippetMark>>();
+            List<SnippetMark>? current = null;
+            int currentSentence = int.MinValue;
+            foreach (var (marks, anchor) in ordered)
+            {
+                int sentence = EnclosingSentenceStart(xml, anchor);
+                if (current == null || sentence != currentSentence)
+                {
+                    current = new List<SnippetMark>();
+                    groups.Add(current);
+                    currentSentence = sentence;
+                }
+                current.AddRange(marks);
+            }
+            // Collapse each group to a single anchor (the earliest), demoting the rest to plain highlights, so the
+            // "exactly one anchor" invariant holds for the merged snippet.
+            return groups.Select(WithSingleAnchor).ToList();
+        }
+
+        private static IReadOnlyList<SnippetMark> WithSingleAnchor(IReadOnlyList<SnippetMark> marks)
+        {
+            bool anchored = false;
+            var result = new List<SnippetMark>(marks.Count);
+            foreach (var m in marks)
+            {
+                if (m.IsAnchor && !anchored) { anchored = true; result.Add(m); }
+                else if (m.IsAnchor) result.Add(new SnippetMark(m.Start, m.End, false));
+                else result.Add(m);
+            }
+            return result;
+        }
+
+        private static int EnclosingSentenceStart(string xml, int pos)
+        {
+            var (_, pStart, pEnd, _) = FindEnclosingP(xml, pos);
+            if (pStart < 0) { pStart = 0; pEnd = xml.Length; }
+            var notes = TeiText.NoteRegions(xml, pStart, pEnd);
+            return SentenceStart(xml, pStart, pos, notes);
+        }
+
+        // True if pos sits inside a start/end tag (an unclosed '<' precedes it without a matching '>').
+        private static bool InsideTag(string xml, int pos)
+        {
+            if (pos <= 0 || pos > xml.Length) return false;
+            return xml.LastIndexOf('<', pos - 1) > xml.LastIndexOf('>', pos - 1);
+        }
+
+        private static int NudgePastTag(string xml, int pos)
+        {
+            if (InsideTag(xml, pos)) { int gt = xml.IndexOf('>', pos); if (gt >= 0) return gt + 1; }
+            return pos;
+        }
+
+        private static int NudgeBeforeTag(string xml, int pos)
+        {
+            if (InsideTag(xml, pos)) { int lt = xml.LastIndexOf('<', Math.Max(0, pos - 1)); if (lt >= 0) return lt; }
+            return pos;
         }
 
         private static (int start, int end, bool ellStart, bool ellEnd) ProseWindow(

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -69,31 +69,31 @@ namespace CST.Search
 
             sb.Append(ellipsisStart ? "... " : "");
             sb.Append(TeiText.Collapse(TeiText.Convert(
-                TeiText.Clean(xml, winStart, ms[0].Start, opts.IncludeVariantReadings), opts.OutputScript)).TrimStart());
+                TeiText.Clean(xml, winStart, ms[0].Start, opts.IncludeFootnotes), opts.OutputScript)).TrimStart());
 
             for (int i = 0; i < ms.Count; i++)
             {
                 string markText = TeiText.Convert(
-                    TeiText.Clean(xml, ms[i].Start, ms[i].End, opts.IncludeVariantReadings), opts.OutputScript).Trim();
+                    TeiText.Clean(xml, ms[i].Start, ms[i].End, opts.IncludeFootnotes), opts.OutputScript).Trim();
                 highlights.Add(new SnippetHighlight(sb.Length, markText.Length, ms[i].IsAnchor));
                 sb.Append(markText);
 
                 if (i < ms.Count - 1)
                 {
                     string gap = TeiText.Collapse(TeiText.Convert(
-                        TeiText.Clean(xml, ms[i].End, ms[i + 1].Start, opts.IncludeVariantReadings), opts.OutputScript));
+                        TeiText.Clean(xml, ms[i].End, ms[i + 1].Start, opts.IncludeFootnotes), opts.OutputScript));
                     sb.Append(gap.Length == 0 ? " " : gap); // never fuse two distinct marked words
                 }
             }
 
             sb.Append(TeiText.Collapse(TeiText.Convert(
-                TeiText.Clean(xml, ms[ms.Count - 1].End, winEnd, opts.IncludeVariantReadings), opts.OutputScript)).TrimEnd());
+                TeiText.Clean(xml, ms[ms.Count - 1].End, winEnd, opts.IncludeFootnotes), opts.OutputScript)).TrimEnd());
             sb.Append(ellipsisEnd ? " ..." : "");
 
             var (num, code, pages) = markers.RefsAt(anchor.Start);
             var anchorHl = highlights.FirstOrDefault(h => h.IsAnchor) ?? highlights[0];
             return new SnippetResult(
-                sb.ToString(), anchorHl.Start, anchorHl.Length, num, code, pages, opts.IncludeVariantReadings, highlights);
+                sb.ToString(), anchorHl.Start, anchorHl.Length, num, code, pages, opts.IncludeFootnotes, highlights);
         }
 
         /// <summary>

--- a/src/CST.Core/Tools/PassageToolContracts.cs
+++ b/src/CST.Core/Tools/PassageToolContracts.cs
@@ -33,7 +33,7 @@ namespace CST.Tools
         int? Cursor = null,
         int MaxChars = 1200,
         Script OutputScript = Script.Latin,
-        bool IncludeVariantReadings = false);
+        bool IncludeFootnotes = false);
 
     /// <summary>
     /// A reading window: the text, the citation refs at its start, and cursors to page through. Pass a cursor

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -129,7 +129,7 @@ namespace CST.Tools
     public sealed record OccurrenceRequest(
         string BookId,
         string Term,
-        bool IncludeVariantReadings = false,
+        bool IncludeFootnotes = false,
         Script OutputScript = Script.Latin,
         int Skip = 0,
         int Take = 50,
@@ -165,7 +165,7 @@ namespace CST.Tools
         int HitStart,
         int HitLength,
         OccurrenceRefs Refs,
-        bool IncludedVariants,
+        bool IncludedFootnotes,
         int Cursor,
         IReadOnlyList<OccurrenceHighlight> Highlights);
 


### PR DESCRIPTION
**Group C — rename + doc fixes** (third of the three-part pass). Stacked on Group B (#272); base is `snippet-hardening` and auto-retargets to main once B merges. **Merge order: A (#271, merged) → B (#272) → C.**

## Changes
- **`includeVariantReadings` → `includeFootnotes`** (and `includedVariants` → `includedFootnotes`). The `<note>` apparatus is digitized print **footnotes** — variant readings *and* cross-references *and* editorial notes (the Code+API report's Task 4 showed both in one `{…}`), so the old name undersold it. Renamed across the tool DTOs, MCP params, the snippet engine (`SnippetOptions`/`SnippetResult`), and `llms.txt`. Shared `/v1` rename (`/v1/occurrences`, `/v1/passage`). **No behavior change** — braces and layer semantics unchanged.
- **D-1 (verified from runtime bytes): the zero-width note was wrong.** Devanagari output uses a zero-width **JOINER (U+200D)**, not the non-joiner (U+200C) the doc claimed; Sinhala uses U+200C. A consumer stripping U+200C from Devanagari would silently fail to match. Corrected to name both, per script.
- **Paragraph numbers aren't globally unique (Cowork friction).** In multi-section books they restart per section, so `passage(paragraph:N)` can land on a different N than an `occurrences` hit reported. Documented; steer to the hit's `cursor` for exact addressing, or pass `bookCode` to disambiguate.

## Tests
Full suite green (595) — the rename flowed through the snippet/passage tests; behavior unchanged.

Note: feature issue #267 (structured apparatus) should be reworded "variant readings → footnotes" to match; I'll do that when we pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)