### PR TITLE
#275: stable local-API config — fixed port + persisted token (backend + ViewModel)

### DIFF
--- a/src/CST.Avalonia.Tests/Models/AiSettingsTests.cs
+++ b/src/CST.Avalonia.Tests/Models/AiSettingsTests.cs
@@ -20,7 +20,8 @@ namespace CST.Avalonia.Tests.Models
             Assert.False(ai.Enabled);                 // master OFF
             Assert.True(ai.LocalApi.Enabled);         // sub-permissions ON...
             Assert.True(ai.LocalApi.AllowRemoteControl);
-            Assert.Equal(0, ai.LocalApi.Port);        // ephemeral
+            Assert.Equal(LocalApiSettings.DefaultPort, ai.LocalApi.Port);  // fixed default (stable config, #275)
+            Assert.Null(ai.LocalApi.Token);                                // generated + persisted on first start
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
+++ b/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CST.Avalonia.Services.LocalApi;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services
+{
+    /// <summary>
+    /// Stable local-API config (#275): a fixed port + persisted token so a BYO-MCP client keeps a static config
+    /// across restarts. Covers the port-availability check, token generation, the Claude Desktop config helper,
+    /// and that the server actually binds the configured port and reuses the given token.
+    /// </summary>
+    public class StableApiConfigTests
+    {
+        [Fact]
+        public void PortAvailability_ephemeral_is_free_and_a_bound_port_is_not()
+        {
+            Assert.True(PortAvailability.IsAvailable(0));            // ephemeral is always "available"
+            int p = PortAvailability.PickAvailable();
+            Assert.InRange(p, 1, 65535);
+            Assert.True(PortAvailability.IsAvailable(p));
+
+            using var listener = new TcpListener(IPAddress.Loopback, p);
+            listener.Start();
+            Assert.False(PortAvailability.IsAvailable(p));           // now taken -> not available
+        }
+
+        [Fact]
+        public void ApiToken_generates_distinct_urlsafe_tokens()
+        {
+            string a = ApiToken.Generate(), b = ApiToken.Generate();
+            Assert.NotEqual(a, b);
+            Assert.NotEmpty(a);
+            Assert.DoesNotContain('+', a);   // URL-safe base64
+            Assert.DoesNotContain('/', a);
+            Assert.DoesNotContain('=', a);
+        }
+
+        [Fact]
+        public void McpClientConfig_is_valid_json_carrying_the_port_and_token()
+        {
+            string json = McpClientConfig.ClaudeDesktop(8765, "TOKEN123");
+            using var doc = JsonDocument.Parse(json);   // must be valid JSON
+            var args = doc.RootElement.GetProperty("mcpServers").GetProperty("cst-reader").GetProperty("args");
+            string joined = string.Join(" ", args.EnumerateArray().Select(e => e.GetString()));
+            Assert.Contains("mcp-remote", joined);
+            Assert.Contains("http://127.0.0.1:8765/mcp", joined);
+            Assert.Contains("Authorization: Bearer TOKEN123", joined);
+        }
+
+        [Fact]
+        public async Task Server_binds_the_configured_port_and_reuses_the_token()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cst-stablecfg-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            int port = PortAvailability.PickAvailable();
+            const string token = "stable-token-under-test";
+            var server = new LocalApiServer("test", dir, Serilog.Log.Logger, port: port, token: token);
+            try
+            {
+                await server.StartAsync();
+                Assert.Equal($"http://127.0.0.1:{port}", server.BaseUrl);   // fixed port, not ephemeral
+                Assert.Equal(token, server.Token);                          // reused, not regenerated
+            }
+            finally
+            {
+                await server.StopAsync();
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        }
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -45,6 +45,10 @@ public partial class App : Application
 
     // Opt-in loopback API server for AI tools; gated on settings at launch (restart to apply). (#186)
     private CST.Avalonia.Services.LocalApi.LocalApiServer? _localApiServer;
+
+    /// <summary>The configured local-API port when it was already in use at startup (so the API did NOT bind),
+    /// else null. The Settings UI reads this to prompt the user to rotate the port. (#275)</summary>
+    public int? LocalApiPortInUse { get; private set; }
     /// <summary>
     /// True once application shutdown has begun. Floating windows close as part of shutdown too;
     /// consumers (e.g. CstDockFactory.CloseHostWindow's book rescue) use this to distinguish
@@ -327,12 +331,33 @@ public partial class App : Application
                 CST.Avalonia.Constants.AppConstants.AppDataDirectoryName);
             System.IO.Directory.CreateDirectory(dir);
 
+            var localApi = settingsService.Settings.Ai.LocalApi;
+
+            // Persist a stable bearer token on first use, then reuse it across launches so a copied MCP client
+            // config stays valid (#275). Source of truth is settings; it's also copied into local-api.json (0600).
+            if (string.IsNullOrEmpty(localApi.Token))
+            {
+                localApi.Token = CST.Avalonia.Services.LocalApi.ApiToken.Generate();
+                settingsService.RequestSave();
+            }
+
+            int port = localApi.Port;
+            // A FIXED port can already be taken. Check first and, rather than let Kestrel throw and fail the API
+            // silently, warn and skip start so the user can rotate the port in Settings (#275).
+            if (port > 0 && !CST.Avalonia.Services.LocalApi.PortAvailability.IsAvailable(port))
+            {
+                Log.Warning("Local API port {Port} is in use; not starting. Rotate the port in Settings.", port);
+                LocalApiPortInUse = port;   // UI (kestrel) reads this to show a rotate-the-port popup.
+                return;
+            }
+            LocalApiPortInUse = null;
+
             var version = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown";
             // Resolve the tools through the shared factory (covered by AppCompositionTests), so a tool that is
             // registered but forgotten here can't silently 404 an endpoint again.
             _localApiServer = ServiceProvider is { } sp
-                ? CST.Avalonia.Services.LocalApi.LocalApiServer.FromServiceProvider(sp, version, dir, Log.Logger)
-                : new CST.Avalonia.Services.LocalApi.LocalApiServer(version, dir, Log.Logger);
+                ? CST.Avalonia.Services.LocalApi.LocalApiServer.FromServiceProvider(sp, version, dir, Log.Logger, port, localApi.Token)
+                : new CST.Avalonia.Services.LocalApi.LocalApiServer(version, dir, Log.Logger, port: port, token: localApi.Token);
             await _localApiServer.StartAsync();
         }
         catch (Exception ex)

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -51,8 +51,18 @@ namespace CST.Avalonia.Models
         /// <summary>Let agents drive the reader (navigate/highlight) vs. read-only. On by default under the master.</summary>
         public bool AllowRemoteControl { get; set; } = true;
 
-        /// <summary>Loopback port; 0 = ephemeral (recommended, advertised via local-api.json). Fixed only for debugging.</summary>
-        public int Port { get; set; } = 0;
+        /// <summary>Loopback port. A FIXED default so a BYO-MCP client can keep a static config across restarts;
+        /// `0` = ephemeral (a fresh OS-assigned port each launch). Rotatable from Settings.</summary>
+        public int Port { get; set; } = DefaultPort;
+
+        /// <summary>The default fixed loopback port (below the OS ephemeral range, so it can't collide with an
+        /// ephemeral allocation). Arbitrary; rotate it if it's already in use.</summary>
+        public const int DefaultPort = 8765;
+
+        /// <summary>The persisted bearer token, reused across launches so a copied MCP config stays valid.
+        /// Null/empty => generate one on first start and persist it here. Rotatable from Settings. NOTE: this is
+        /// a secret living in settings.json - consider tightening that file's permissions.</summary>
+        public string? Token { get; set; }
     }
     
     public class DeveloperSettings

--- a/src/CST.Avalonia/Services/LocalApi/ApiToken.cs
+++ b/src/CST.Avalonia/Services/LocalApi/ApiToken.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Security.Cryptography;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>Bearer-token generation for the loopback API. Shared by the server and the "rotate token" action.</summary>
+    internal static class ApiToken
+    {
+        /// <summary>A URL-safe 256-bit random bearer token.</summary>
+        public static string Generate()
+        {
+            Span<byte> bytes = stackalloc byte[32];
+            RandomNumberGenerator.Fill(bytes);
+            return Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -55,6 +55,8 @@ namespace CST.Avalonia.Services.LocalApi
         private readonly IDictionaryTool? _dictionary;
         private readonly IPassageTool? _passage;
         private readonly IScriptTool? _script;
+        private readonly int _port;              // fixed loopback port, or <= 0 for ephemeral
+        private readonly string? _configuredToken; // persisted bearer token, or null to generate one
 
         private WebApplication? _app;
 
@@ -69,7 +71,7 @@ namespace CST.Avalonia.Services.LocalApi
         public LocalApiServer(
             string appVersion, string handshakeDirectory, Serilog.ILogger logger,
             ISearchTool? search = null, IDictionaryTool? dictionary = null, IPassageTool? passage = null,
-            IScriptTool? script = null)
+            IScriptTool? script = null, int port = 0, string? token = null)
         {
             _appVersion = appVersion;
             _handshakeDirectory = handshakeDirectory;
@@ -78,6 +80,8 @@ namespace CST.Avalonia.Services.LocalApi
             _dictionary = dictionary;
             _passage = passage;
             _script = script;
+            _port = port;
+            _configuredToken = token;
         }
 
         /// <summary>
@@ -87,22 +91,25 @@ namespace CST.Avalonia.Services.LocalApi
         /// and the test both go through here.
         /// </summary>
         public static LocalApiServer FromServiceProvider(
-            IServiceProvider services, string appVersion, string handshakeDirectory, Serilog.ILogger logger)
+            IServiceProvider services, string appVersion, string handshakeDirectory, Serilog.ILogger logger,
+            int port = 0, string? token = null)
             => new LocalApiServer(appVersion, handshakeDirectory, logger,
                 services.GetService<ISearchTool>(),
                 services.GetService<IDictionaryTool>(),
                 services.GetService<IPassageTool>(),
-                services.GetService<IScriptTool>());
+                services.GetService<IScriptTool>(), port, token);
 
         public async Task StartAsync(CancellationToken ct = default)
         {
             if (_app != null) return;
 
-            string token = GenerateToken();
+            // Reuse the persisted token when supplied (stable config across launches), else mint one. (#275)
+            string token = string.IsNullOrEmpty(_configuredToken) ? ApiToken.Generate() : _configuredToken!;
 
             var builder = WebApplication.CreateSlimBuilder();
             builder.Logging.ClearProviders(); // don't spam stdout; the app logs via Serilog
-            builder.WebHost.ConfigureKestrel(k => k.Listen(IPAddress.Loopback, 0)); // 127.0.0.1:ephemeral
+            // Fixed loopback port when configured (so a client config stays valid), else ephemeral. (#275)
+            builder.WebHost.ConfigureKestrel(k => k.Listen(IPAddress.Loopback, _port > 0 ? _port : 0));
             builder.Services.ConfigureHttpJsonOptions(o =>
             {
                 o.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
@@ -275,13 +282,6 @@ namespace CST.Avalonia.Services.LocalApi
             return CryptographicOperations.FixedTimeEquals(
                 Encoding.UTF8.GetBytes(header.Substring("Bearer ".Length)),
                 Encoding.UTF8.GetBytes(token));
-        }
-
-        private static string GenerateToken()
-        {
-            Span<byte> bytes = stackalloc byte[32];
-            RandomNumberGenerator.Fill(bytes);
-            return Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_').TrimEnd('=');
         }
 
         private static int ResolvePort(WebApplication app)

--- a/src/CST.Avalonia/Services/LocalApi/McpClientConfig.cs
+++ b/src/CST.Avalonia/Services/LocalApi/McpClientConfig.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>
+    /// Generates a pre-populated MCP client configuration from the current port + token, for a "Copy MCP
+    /// configuration" affordance in Settings (#275). Currently the Claude Desktop snippet (the `mcp-remote`
+    /// stdio bridge over the loopback `/mcp` endpoint).
+    /// </summary>
+    internal static class McpClientConfig
+    {
+        /// <summary>
+        /// The <c>claude_desktop_config.json</c> snippet that connects Claude Desktop to <c>/mcp</c> via the
+        /// <c>mcp-remote</c> bridge with the given port + bearer token. Paste into that file's <c>mcpServers</c>.
+        /// </summary>
+        public static string ClaudeDesktop(int port, string token, string serverName = "cst-reader")
+        {
+            var config = new JsonObject
+            {
+                ["mcpServers"] = new JsonObject
+                {
+                    [serverName] = new JsonObject
+                    {
+                        ["command"] = "npx",
+                        ["args"] = new JsonArray(
+                            "mcp-remote",
+                            $"http://127.0.0.1:{port}/mcp",
+                            "--transport", "http-only",
+                            "--header", $"Authorization: Bearer {token}"),
+                    },
+                },
+            };
+            return config.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/PortAvailability.cs
+++ b/src/CST.Avalonia/Services/LocalApi/PortAvailability.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>
+    /// Loopback port checks for the stable-config feature (#275): pre-check a FIXED port before Kestrel binds
+    /// (so we can warn the user instead of failing the API start), and pick a fresh available port for the
+    /// "rotate port" action.
+    /// </summary>
+    internal static class PortAvailability
+    {
+        /// <summary>True if a loopback listener can bind <paramref name="port"/> right now. Port 0 (ephemeral)
+        /// is always available. There is an inherent bind-check-then-bind race, but it turns "silent Kestrel
+        /// throw" into "clear warning" for the common in-use case.</summary>
+        public static bool IsAvailable(int port)
+        {
+            if (port <= 0) return true;
+            if (port > 65535) return false;
+            TcpListener? listener = null;
+            try { listener = new TcpListener(IPAddress.Loopback, port); listener.Start(); return true; }
+            catch (SocketException) { return false; }
+            finally { listener?.Stop(); }
+        }
+
+        /// <summary>A random currently-available loopback port below the OS ephemeral range (so it won't clash
+        /// with an OS-assigned one), or 0 (ephemeral) if none is found.</summary>
+        public static int PickAvailable()
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                int p = Random.Shared.Next(1025, 49151);
+                if (IsAvailable(p)) return p;
+            }
+            return 0;
+        }
+    }
+}

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -807,6 +807,7 @@ namespace CST.Avalonia.ViewModels
         private bool _localApiEnabled;
         private bool _allowRemoteControl;
         private int _port;
+        private string _token = string.Empty;
 
         public AiSettingsViewModel(ISettingsService settingsService)
         {
@@ -817,6 +818,13 @@ namespace CST.Avalonia.ViewModels
             _localApiEnabled = ai.LocalApi.Enabled;
             _allowRemoteControl = ai.LocalApi.AllowRemoteControl;
             _port = ai.LocalApi.Port;
+            _token = ai.LocalApi.Token ?? string.Empty;
+
+            // Rotate icons (password-generator style); both apply on the next API (re)start. (#275)
+            RotatePortCommand = ReactiveCommand.Create(() =>
+                { Port = CST.Avalonia.Services.LocalApi.PortAvailability.PickAvailable(); });
+            RotateTokenCommand = ReactiveCommand.Create(() =>
+                { Token = CST.Avalonia.Services.LocalApi.ApiToken.Generate(); });
         }
 
         /// <summary>Master switch — "Enable AI Features". Everything AI-related is gated behind this (default OFF).</summary>
@@ -860,7 +868,8 @@ namespace CST.Avalonia.ViewModels
             }
         }
 
-        /// <summary>Loopback port; 0 = ephemeral (recommended). Fixed only for debugging.</summary>
+        /// <summary>Loopback port. A FIXED default so a BYO-MCP config stays valid across restarts; 0 = ephemeral.
+        /// Applies on the next API (re)start.</summary>
         public int Port
         {
             get => _port;
@@ -869,8 +878,34 @@ namespace CST.Avalonia.ViewModels
                 this.RaiseAndSetIfChanged(ref _port, value);
                 _settingsService.Settings.Ai.LocalApi.Port = value;
                 _settingsService.RequestSave();
+                this.RaisePropertyChanged(nameof(McpClientConfigJson));
             }
         }
+
+        /// <summary>The persisted bearer token, reused across launches. Surfaced so it can be copied into an MCP
+        /// client config; rotate to invalidate the old one. Applies on the next API (re)start. (#275)</summary>
+        public string Token
+        {
+            get => _token;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _token, value);
+                _settingsService.Settings.Ai.LocalApi.Token = value;
+                _settingsService.RequestSave();
+                this.RaisePropertyChanged(nameof(McpClientConfigJson));
+            }
+        }
+
+        /// <summary>Rotate to a fresh AVAILABLE loopback port (rotate icon). (#275)</summary>
+        public ReactiveCommand<Unit, Unit> RotatePortCommand { get; }
+
+        /// <summary>Rotate (regenerate) the bearer token (rotate icon). (#275)</summary>
+        public ReactiveCommand<Unit, Unit> RotateTokenCommand { get; }
+
+        /// <summary>Pre-populated Claude Desktop MCP config for the current port + token, for a
+        /// "Copy MCP configuration" button. Uses the fixed default port when the port is set to ephemeral. (#275)</summary>
+        public string McpClientConfigJson => CST.Avalonia.Services.LocalApi.McpClientConfig.ClaudeDesktop(
+            _port > 0 ? _port : CST.Avalonia.Models.LocalApiSettings.DefaultPort, _token);
 
         /// <summary>The local-API sub-permissions are editable only when the master switch is on.</summary>
         public bool SubPermissionsEnabled => AiEnabled;


### PR DESCRIPTION
Backend + ViewModel for **#275** — lets a BYO-MCP client (Claude Desktop via `mcp-remote`) keep a **static config across restarts**. The View is a follow-up on kestrel (issue linked below).

## What changed
- **Port is now honored.** `LocalApiServer` binds the configured port (was hardcoded `Listen(…, 0)` — the `Settings.LocalApi.Port` write was dead). Default is a **fixed `8765`** (below the OS ephemeral range so it can't collide); `0` still = ephemeral.
- **Token is persisted.** Stored in `Settings.Ai.LocalApi.Token`, generated once on first start and reused across launches (still copied into the `0600` `local-api.json`). Was regenerated every launch — the root cause of stale configs.
- **Pre-bind availability check.** App tests the fixed port *before* starting; if it's in use it logs, sets `App.LocalApiPortInUse`, and skips start (no silent Kestrel throw) so the UI can prompt a rotate.
- **Helpers:** `PortAvailability` (`IsAvailable`/`PickAvailable`), `ApiToken` (generate), `McpClientConfig` (Claude Desktop `mcp-remote` snippet from port+token).
- **`AiSettingsViewModel`:** `Token` property, `RotatePortCommand`/`RotateTokenCommand` (password-generator style), `McpClientConfigJson` for a "Copy MCP configuration" button.

## Tests
Port availability, token generation, config-JSON shape, and the server binding the configured port + reusing the token. Full suite green (599).

## Remaining UI (kestrel) — filed separately
The Settings **View**: token field, the two rotate icon-buttons, the Copy-config button, and the port-in-use popup (reads `App.LocalApiPortInUse`). ViewModel surface is all in place to bind to.

## Note
`settings.json` now holds a secret (the token) — worth tightening its file perms (`0600`); small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)