### PR TITLE
#278 Phase 1: MCP bridge relay core (transparent stdio<->/mcp pump) + in-process test

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -1,13 +1,18 @@
 using System.Collections.Generic;
+using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
+using CST.Avalonia.Services.LocalApi.Mcp;
 using CST.Avalonia.Tests.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Integration
@@ -307,6 +312,80 @@ namespace CST.Avalonia.Tests.Integration
             using var doc = ToolJson(filtered);
             int bookCount = doc.RootElement.GetProperty("terms")[0].GetProperty("bookCount").GetInt32();
             Assert.Equal(1, bookCount);   // mula only; the attha book is excluded by the filter
+        }
+
+        [Fact]
+        public async Task Mcp_bridge_relays_list_and_call_to_the_real_mcp()
+        {
+            // The --mcp-bridge relay (#278 Phase 1): an MCP client drives the bridge over in-memory pipes; the
+            // bridge transparently forwards to the REAL /mcp. Proves the transport pump handshakes (initialize
+            // through the relay) + round-trips list/call end-to-end.
+            var toServer = new Pipe();   // client writes -> bridge(server) reads
+            var toClient = new Pipe();   // bridge writes -> client reads
+
+            var clientSide = new StreamServerTransport(
+                toServer.Reader.AsStream(), toClient.Writer.AsStream(), "cst-reader-bridge", NullLoggerFactory.Instance);
+
+            var httpOptions = new HttpClientTransportOptions
+            {
+                Endpoint = new System.Uri(_api.BaseUrl + "/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+                AdditionalHeaders = new Dictionary<string, string> { ["Authorization"] = "Bearer " + _api.Token },
+            };
+
+            using var cts = new CancellationTokenSource(System.TimeSpan.FromSeconds(30));
+            var relay = McpBridge.RunAsync(clientSide, httpOptions, httpClient: null, cts.Token);
+
+            var clientTransport = new StreamClientTransport(
+                toServer.Writer.AsStream(), toClient.Reader.AsStream(), NullLoggerFactory.Instance);
+            await using var client = await McpClient.CreateAsync(clientTransport, cancellationToken: cts.Token);
+
+            // Handshake, list, and call all traverse the relay.
+            var tools = await client.ListToolsAsync(cancellationToken: cts.Token);
+            Assert.Contains(tools, t => t.Name == "search");
+
+            var result = await client.CallToolAsync(
+                "search", new Dictionary<string, object?> { ["query"] = "dhamma" }, cancellationToken: cts.Token);
+            Assert.NotEqual(true, result.IsError);
+            Assert.Contains("dhamma",
+                string.Concat(result.Content.OfType<TextContentBlock>().Select(b => b.Text)));
+
+            cts.Cancel();
+            try { await relay; } catch { /* relay unwinds on cancel */ }
+        }
+
+        [Fact]
+        public async Task Mcp_bridge_errors_fast_not_hangs_on_a_bad_token()
+        {
+            // must-have #2: when a forwarded request fails (here a 401 from a wrong token), the relay synthesizes
+            // a JsonRpcError for the waiting client instead of leaving it to hang. (#278)
+            var toServer = new Pipe();
+            var toClient = new Pipe();
+            var clientSide = new StreamServerTransport(
+                toServer.Reader.AsStream(), toClient.Writer.AsStream(), "cst-reader-bridge", NullLoggerFactory.Instance);
+            var httpOptions = new HttpClientTransportOptions
+            {
+                Endpoint = new System.Uri(_api.BaseUrl + "/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+                AdditionalHeaders = new Dictionary<string, string> { ["Authorization"] = "Bearer WRONG-TOKEN" },
+            };
+            using var cts = new CancellationTokenSource(System.TimeSpan.FromSeconds(30));
+            var relay = McpBridge.RunAsync(clientSide, httpOptions, httpClient: null, cts.Token);
+
+            var clientTransport = new StreamClientTransport(
+                toServer.Writer.AsStream(), toClient.Reader.AsStream(), NullLoggerFactory.Instance);
+
+            // The `initialize` request is forwarded, 401s, and comes back as a JsonRpcError -> CreateAsync fails
+            // FAST (not a spawn-timeout hang). Assert it throws well before the 30s guard.
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            await Assert.ThrowsAnyAsync<System.Exception>(async () =>
+            {
+                await using var client = await McpClient.CreateAsync(clientTransport, cancellationToken: cts.Token);
+            });
+            Assert.True(sw.Elapsed < System.TimeSpan.FromSeconds(10), $"errored in {sw.Elapsed} — should be fast, not a hang");
+
+            cts.Cancel();
+            try { await relay; } catch { }
         }
 
         [Fact]

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace CST.Avalonia.Services.LocalApi.Mcp
+{
+    /// <summary>
+    /// The <c>--mcp-bridge</c> relay (#278): a TRANSPARENT stdio ↔ <c>/mcp</c> pump. An MCP chat client (Claude
+    /// Desktop) spawns CST Reader with <c>--mcp-bridge</c> and pipes its stdio; this relays JSON-RPC between that
+    /// stdio and the running app's loopback <c>/mcp</c> (Streamable HTTP + bearer). So the client config carries
+    /// no port/token and the API can stay ephemeral. Transparent = no tool re-declaration: the client's own
+    /// <c>initialize</c> bootstraps the session and the HTTP transport manages <c>Mcp-Session-Id</c> + the SSE
+    /// stream around it (verified against the SDK internals — <c>ConnectAsync</c> does no handshake).
+    /// </summary>
+    internal static class McpBridge
+    {
+        // JSON-RPC "server error" code, synthesized when the bridge can't reach the app so a waiting client
+        // request never hangs.
+        private const int UnreachableErrorCode = -32000;
+
+        /// <summary>
+        /// Pump <see cref="JsonRpcMessage"/>s between <paramref name="clientSide"/> (stdio in production;
+        /// in-memory streams in tests) and the running app's <c>/mcp</c>. Returns when either side ends
+        /// (stdin EOF, or the app going away). Does not dispose <paramref name="clientSide"/> (the caller owns it).
+        /// </summary>
+        public static async Task RunAsync(
+            ITransport clientSide, HttpClientTransportOptions httpOptions, HttpClient? httpClient, CancellationToken ct)
+        {
+            var httpTransport = httpClient is null
+                ? new HttpClientTransport(httpOptions, NullLoggerFactory.Instance)
+                : new HttpClientTransport(httpOptions, httpClient, NullLoggerFactory.Instance, ownsHttpClient: false);
+            // Disposing at the end sends a DELETE to end the server session (else it lingers to the idle timeout).
+            await using var serverSide = await httpTransport.ConnectAsync(ct).ConfigureAwait(false);
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            var inFlight = new ConcurrentDictionary<Task, byte>();
+
+            // client -> server: each message on its OWN task. A sequential `await SendMessageAsync` here would
+            // serialize concurrent tool calls, block `notifications/cancelled` mid-call, and can DEADLOCK on a
+            // server->client request. (Fable review, must-have #1.)
+            async Task ClientToServer()
+            {
+                try
+                {
+                    await foreach (var msg in clientSide.MessageReader.ReadAllAsync(cts.Token).ConfigureAwait(false))
+                    {
+                        var task = ForwardAsync(msg);
+                        inFlight[task] = 0;
+                        _ = task.ContinueWith(t => inFlight.TryRemove(t, out _), TaskScheduler.Default);
+                    }
+                }
+                catch (OperationCanceledException) { }
+            }
+
+            // server -> client: sequential is fine (the stdio/stream send path is internally serialized).
+            async Task ServerToClient()
+            {
+                try
+                {
+                    await foreach (var msg in serverSide.MessageReader.ReadAllAsync(cts.Token).ConfigureAwait(false))
+                        await clientSide.SendMessageAsync(msg, cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { }
+                catch { /* server stream ended (app gone) */ }
+            }
+
+            // Forward one client->server message; if it was a request and the send throws (stale token 401,
+            // connection refused), synthesize a JsonRpcError so the client doesn't hang. (must-have #2.)
+            async Task ForwardAsync(JsonRpcMessage msg)
+            {
+                try
+                {
+                    await serverSide.SendMessageAsync(msg, cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception ex)
+                {
+                    if (msg is JsonRpcRequest req)
+                    {
+                        var error = new JsonRpcError
+                        {
+                            Id = req.Id,
+                            Error = new JsonRpcErrorDetail
+                            {
+                                Code = UnreachableErrorCode,
+                                Message = "CST Reader is not reachable (is it running with AI features enabled?): " + ex.Message,
+                            },
+                        };
+                        try { await clientSide.SendMessageAsync(error, cts.Token).ConfigureAwait(false); }
+                        catch { /* client side gone too */ }
+                    }
+                }
+            }
+
+            var c2s = ClientToServer();
+            var s2c = ServerToClient();
+            await Task.WhenAny(c2s, s2c).ConfigureAwait(false);
+            cts.Cancel();
+            try { await Task.WhenAll(inFlight.Keys.ToArray()).ConfigureAwait(false); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Phase 1 of the `--mcp-bridge` work (#278) — the **relay core**, which is the piece Fable's design review flagged as the make-or-break unknown. **Verdict confirmed: the transparent transport-pump works** — the in-process test round-trips a full `initialize` handshake + `tools/list` + `tools/call` through the bridge to a real `/mcp`.

## What's here
`McpBridge.RunAsync` — pumps `JsonRpcMessage`s between a client-side `ITransport` (stdio in production; in-memory streams in tests) and the running app's loopback `/mcp` (Streamable HTTP + bearer). **Transparent** — no tool re-declaration; the client's own `initialize` bootstraps the session and the HTTP transport manages `Mcp-Session-Id` + the SSE stream around it.

The four must-haves from the review, in the initial relay:
1. **Concurrent per-message forwarding** (client→server on its own task) — a sequential `await` would serialize tool calls, block `notifications/cancelled`, and deadlock on a server→client request mid-call.
2. **`JsonRpcError` synthesized** (same id) when a forwarded request throws (401 / connection refused), so a waiting client never hangs.
3. **Streamable HTTP mode + bearer** via the caller's `HttpClientTransportOptions`.
4. stderr-only logging lives in the `--mcp-bridge` *entry point* → Phase 2.

Disposes the HTTP side on exit (DELETE ends the server session).

## Tests (in-process — no subprocess)
`StreamClientTransport` is public in `.Protocol`, so a real `McpClient` drives the bridge over `System.IO.Pipelines` pipes, relaying to a **real** `/mcp` (`LocalApiTestServer`):
- handshake + `tools/list` + `tools/call` round-trip;
- a wrong-token **401 comes back as a `JsonRpcError` fast, not a hang** (must-have #2).

Full suite green (601).

## Next (still #278)
Phase 2: `--mcp-bridge` entry point in `Program.cs` + `local-api.json` read + stderr logging + error paths. Phase 3: launch-or-attach (via `open`, reuse running). Phase 4: `McpEnabled` gate + ephemeral reversion + bridge config helper → then the UI rework (#280, kestrel). A concurrent-forwarding (cancel-mid-slow-call) regression test is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)