### PR TITLE
#278 Phase 2: --mcp-bridge entry point + local-api.json read + stderr logging

### DIFF
--- a/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
+++ b/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
@@ -6,6 +6,8 @@ using System.Net.Sockets;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CST.Avalonia.Services.LocalApi;
+using CST.Avalonia.Services.LocalApi.Mcp;
+using ModelContextProtocol.Client;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services
@@ -39,6 +41,18 @@ namespace CST.Avalonia.Tests.Services
             Assert.DoesNotContain('+', a);   // URL-safe base64
             Assert.DoesNotContain('/', a);
             Assert.DoesNotContain('=', a);
+        }
+
+        [Fact]
+        public void McpBridge_maps_the_handshake_to_the_mcp_endpoint()
+        {
+            // The --mcp-bridge entry reads local-api.json and points the relay at /mcp with the bearer,
+            // explicit Streamable HTTP (not AutoDetect, which can fall back to disabled legacy SSE). (#278)
+            var info = new LocalApiInfo(Port: 51515, Token: "TESTTOKEN", Pid: 999);
+            var opts = McpBridge.BuildHttpOptions(info);
+            Assert.Equal(new System.Uri("http://127.0.0.1:51515/mcp"), opts.Endpoint);
+            Assert.Equal(HttpTransportMode.StreamableHttp, opts.TransportMode);
+            Assert.Equal("Bearer TESTTOKEN", opts.AdditionalHeaders!["Authorization"]);
         }
 
         [Fact]

--- a/src/CST.Avalonia/Program.cs
+++ b/src/CST.Avalonia/Program.cs
@@ -23,6 +23,25 @@ sealed class Program
             // Handle library conflicts on macOS by suppressing duplicate class warnings
             Environment.SetEnvironmentVariable("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES");
 
+            // Headless MCP bridge: relay this process's STDIO to the running app's /mcp (#278). Handled FIRST,
+            // before any UI/logging init. STDOUT is the JSON-RPC stream, so logs go to STDERR only; no GUI.
+            if (args.Length > 0 && args[0] == "--mcp-bridge")
+            {
+                Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Warning()
+                    .WriteTo.Console(standardErrorFromLevel: Serilog.Events.LogEventLevel.Verbose)
+                    .CreateLogger();
+
+                var handshakeDir = System.IO.Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    CST.Avalonia.Constants.AppConstants.AppDataDirectoryName);
+
+                CST.Avalonia.Services.LocalApi.Mcp.McpBridge
+                    .RunFromStdioAsync(handshakeDir, System.Threading.CancellationToken.None)
+                    .GetAwaiter().GetResult();
+                return;
+            }
+
             // Check for browse-sharepoint command
             if (args.Length > 0 && args[0] == "--browse-sharepoint")
             {

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -7,6 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Serilog;
 
 namespace CST.Avalonia.Services.LocalApi.Mcp
 {
@@ -23,6 +26,51 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         // JSON-RPC "server error" code, synthesized when the bridge can't reach the app so a waiting client
         // request never hangs.
         private const int UnreachableErrorCode = -32000;
+
+        /// <summary>
+        /// Entry point for the <c>--mcp-bridge</c> process: relays this process's STDIO to the running app's
+        /// <c>/mcp</c>, using the port + token from <c>local-api.json</c> in <paramref name="handshakeDirectory"/>.
+        /// Captures the real stdout for the JSON-RPC transport BEFORE redirecting <see cref="Console.Out"/> away
+        /// from fd 1, so stray writes in shared code can't corrupt the stream (must-have #4). Returns on stdin EOF.
+        /// </summary>
+        public static async Task RunFromStdioAsync(string handshakeDirectory, CancellationToken ct)
+        {
+            await using var clientSide = new StdioServerTransport("cst-reader", NullLoggerFactory.Instance);
+            Console.SetOut(Console.Error);   // any stray Console.Out goes to stderr, never onto the JSON-RPC stdout
+
+            var info = await ReadHandshakeWithRetryAsync(handshakeDirectory, ct).ConfigureAwait(false);
+            if (info is null)
+            {
+                // Phase 2: the app must already be running. (Phase 3 adds launch-or-attach; Phase 4 can answer
+                // the client's `initialize` with an error instead of exiting.)
+                Log.Warning("--mcp-bridge: CST Reader is not running (no {File}); exiting.", LocalApiInfo.FileName);
+                return;
+            }
+
+            await RunAsync(clientSide, BuildHttpOptions(info), httpClient: null, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>The Streamable-HTTP transport options for the running app's <c>/mcp</c> — explicit mode
+        /// (not AutoDetect, which can fall back to disabled legacy SSE) + the bearer from the handshake file.</summary>
+        internal static HttpClientTransportOptions BuildHttpOptions(LocalApiInfo info) => new()
+        {
+            Endpoint = new Uri($"http://127.0.0.1:{info.Port}/mcp"),
+            TransportMode = HttpTransportMode.StreamableHttp,
+            AdditionalHeaders = new Dictionary<string, string> { ["Authorization"] = "Bearer " + info.Token },
+        };
+
+        // The app may be mid-startup writing a fresh handshake file; give it a short grace window.
+        private static async Task<LocalApiInfo?> ReadHandshakeWithRetryAsync(string dir, CancellationToken ct)
+        {
+            for (int i = 0; i < 12 && !ct.IsCancellationRequested; i++)
+            {
+                var info = LocalApiInfo.Read(dir);
+                if (info is not null) return info;
+                try { await Task.Delay(250, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { return null; }
+            }
+            return LocalApiInfo.Read(dir);
+        }
 
         /// <summary>
         /// Pump <see cref="JsonRpcMessage"/>s between <paramref name="clientSide"/> (stdio in production;


### PR DESCRIPTION
Phase 2 of #278 — wires the relay core (Phase 1, #281) to a real entry point.

## Changes
- **`Program.cs`**: a `--mcp-bridge` branch, handled **first** (before any UI/logging init, matching the existing `--browse-sharepoint` etc. subcommands). Logs to **stderr only** (stdout is the JSON-RPC stream); no GUI. Computes the app-support handshake dir and runs the relay.
- **`McpBridge.RunFromStdioAsync`**: constructs the `StdioServerTransport` (capturing the real stdout) and redirects `Console.Out` to stderr **first**, so a stray write can't corrupt the JSON-RPC stream (must-have #4). Reads `local-api.json` (port+token) with a short retry grace window, then relays. If the app is down, the relay already answers a forwarded request with a `JsonRpcError` (not a hang); if the file never appears, it logs to stderr and exits.
- **`BuildHttpOptions`**: explicit `StreamableHttp` mode (not AutoDetect, which can fall back to the disabled legacy SSE) + the bearer from the handshake file.

## Tests
Unit test for the handshake → `/mcp` options mapping (endpoint / mode / bearer). The stdio entry itself is manually verified (Claude Desktop against a running app); the relay + round-trip are covered by the Phase 1 in-process tests. Full suite green (602).

## Manual check available now
With this + the current fixed-port model, you can point Claude Desktop at `command: <app exe>, args: ["--mcp-bridge"]` against a running instance to verify end-to-end before the ephemeral reversion.

## Next (still #278)
Phase 3: **launch-or-attach** (via `open`, reuse a running instance). Phase 4: `McpEnabled` gate + **ephemeral reversion** + bridge config helper → then the UI rework (#280, kestrel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)