### PR TITLE
Default the display script to Latin (Roman)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/ScriptServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/ScriptServiceTests.cs
@@ -27,32 +27,32 @@ public class ScriptServiceTests
     }
 
     [Fact]
-    public void Default_IsDevanagari()
-        => Assert.Equal(Script.Devanagari, Create().svc.CurrentScript);
+    public void Default_IsLatin()
+        => Assert.Equal(Script.Latin, Create().svc.CurrentScript);
 
     [Fact]
     public void InitializeFromState_RestoresSavedScript_AndFiresEvent()
     {
-        var (svc, _, _) = Create(Script.Latin);
+        var (svc, _, _) = Create(Script.Devanagari); // differs from the Latin default -> restored + fires
         Script? fired = null;
         svc.ScriptChanged += s => fired = s;
 
         svc.InitializeFromState();
 
-        Assert.Equal(Script.Latin, svc.CurrentScript);
-        Assert.Equal(Script.Latin, fired);
+        Assert.Equal(Script.Devanagari, svc.CurrentScript);
+        Assert.Equal(Script.Devanagari, fired);
     }
 
     [Fact]
-    public void InitializeFromState_SavedDevanagari_NoChangeNoEvent()
+    public void InitializeFromState_SavedMatchesDefault_NoChangeNoEvent()
     {
-        var (svc, _, _) = Create(Script.Devanagari);
+        var (svc, _, _) = Create(Script.Latin); // saved == default -> nothing to restore
         bool fired = false;
         svc.ScriptChanged += _ => fired = true;
 
         svc.InitializeFromState();
 
-        Assert.Equal(Script.Devanagari, svc.CurrentScript);
+        Assert.Equal(Script.Latin, svc.CurrentScript);
         Assert.False(fired);
     }
 
@@ -71,11 +71,11 @@ public class ScriptServiceTests
     }
 
     [Fact]
-    public void NoStateService_InitializeIsNoOp_DefaultsDevanagari()
+    public void NoStateService_InitializeIsNoOp_DefaultsLatin()
     {
         var svc = new ScriptService(NullLogger<ScriptService>.Instance, null);
         svc.InitializeFromState(); // must not throw with no state service
-        Assert.Equal(Script.Devanagari, svc.CurrentScript);
+        Assert.Equal(Script.Latin, svc.CurrentScript);
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class ScriptServiceTests
         bool fired = false;
         svc.ScriptChanged += _ => fired = true;
 
-        svc.CurrentScript = Script.Devanagari; // unchanged from default
+        svc.CurrentScript = Script.Latin; // unchanged from default
 
         Assert.False(fired);
         mock.Verify(s => s.MarkDirty(), Times.Never);

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -234,7 +234,7 @@ public class ApplicationPreferences
     /// Current script for Pali text display
     /// </summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public Script CurrentScript { get; set; } = Script.Devanagari;
+    public Script CurrentScript { get; set; } = Script.Latin;
 
     /// <summary>
     /// UI language (for future localization)

--- a/src/CST.Avalonia/Services/ScriptService.cs
+++ b/src/CST.Avalonia/Services/ScriptService.cs
@@ -13,7 +13,7 @@ public class ScriptService : IScriptService
 {
     private readonly ILogger<ScriptService> _logger;
     private readonly IApplicationStateService? _stateService;
-    private Script _currentScript = Script.Devanagari;
+    private Script _currentScript = Script.Latin;
 
     public ScriptService(ILogger<ScriptService> logger, IApplicationStateService? stateService = null)
     {
@@ -67,7 +67,7 @@ public class ScriptService : IScriptService
     /// The single, deterministic initialization path: set the current script from the loaded application
     /// state. Called once after state load. Idempotent - a second call is a no-op when already in sync, and
     /// it fires <see cref="ScriptChanged"/> only when the restored script actually differs from the current
-    /// (default Devanagari) value. (#81)
+    /// (default Latin) value. (#81)
     /// </summary>
     public void InitializeFromState()
     {


### PR DESCRIPTION
New / wiped installs now display Pāli in **Latin (Roman)** by default, instead of Devanagari.

## Change
Two authoritative fresh-install defaults flipped to `Script.Latin`:
- `ScriptService._currentScript` — the in-memory fallback used before application state loads.
- `ApplicationPreferences.CurrentScript` — the persisted default written into a fresh state file.

A newly opened book already takes its script from `ScriptService.CurrentScript` (`CstDockFactory`), and any **saved** preference still wins via `InitializeFromState`. So only the no-prior-state path (fresh/wiped `CSTReader` dir) changes behavior — existing users keep whatever script they last selected.

## Tests
`ScriptServiceTests` updated to the new default:
- default / no-state / same-script no-op cases now assert Latin;
- the restore-fires-event case saves **Devanagari** (which now differs from the Latin default) so it still exercises the change-and-fire path.

Full suite: **602 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)