### PR TITLE
#278 Phase 3: --mcp-bridge launch-or-attach + not-ready error path

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -389,6 +389,39 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
+        public async Task Mcp_bridge_answers_initialize_with_an_error_when_the_app_is_not_ready()
+        {
+            // Phase 3 (#278): when CST Reader never becomes ready (not installed / still starting / AI off), the
+            // bridge must NOT exit silently — it answers the client's `initialize` with a JsonRpcError so Desktop
+            // shows a reason instead of a bare "Server disconnected". Here `clientSide` has no server behind it;
+            // AnswerRequestsWithErrorAsync stands in for the not-ready path.
+            var toServer = new Pipe();
+            var toClient = new Pipe();
+            var clientSide = new StreamServerTransport(
+                toServer.Reader.AsStream(), toClient.Writer.AsStream(), "cst-reader-bridge", NullLoggerFactory.Instance);
+
+            using var cts = new CancellationTokenSource(System.TimeSpan.FromSeconds(30));
+            const string message = "CST Reader did not become ready for MCP.";
+            var pump = McpBridge.AnswerRequestsWithErrorAsync(clientSide, message, cts.Token);
+
+            var clientTransport = new StreamClientTransport(
+                toServer.Writer.AsStream(), toClient.Reader.AsStream(), NullLoggerFactory.Instance);
+
+            // `initialize` is answered with a JsonRpcError -> CreateAsync fails FAST (not a spawn-timeout hang),
+            // and the not-ready reason should surface in the error.
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var ex = await Assert.ThrowsAnyAsync<System.Exception>(async () =>
+            {
+                await using var client = await McpClient.CreateAsync(clientTransport, cancellationToken: cts.Token);
+            });
+            Assert.True(sw.Elapsed < System.TimeSpan.FromSeconds(10), $"errored in {sw.Elapsed} — should be fast, not a hang");
+            Assert.Contains("did not become ready", ex.ToString());
+
+            cts.Cancel();
+            try { await pump; } catch { }
+        }
+
+        [Fact]
         public async Task Mcp_exposes_the_llms_txt_resource()
         {
             await using var client = await ConnectMcpAsync();

--- a/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
+++ b/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
@@ -55,6 +55,21 @@ namespace CST.Avalonia.Tests.Services
             Assert.Equal("Bearer TESTTOKEN", opts.AdditionalHeaders!["Authorization"]);
         }
 
+        [Theory]
+        // Inside the signed bundle the bridge exe is …/CST Reader.app/Contents/MacOS/CST.Avalonia -> the .app dir.
+        [InlineData("/Applications/CST Reader.app/Contents/MacOS/CST.Avalonia", "/Applications/CST Reader.app")]
+        [InlineData("/Users/x/Desktop/CST Reader.app/Contents/MacOS/CST.Avalonia", "/Users/x/Desktop/CST Reader.app")]
+        public void AppBundleFromExecutablePath_finds_the_enclosing_app_bundle(string exe, string expected)
+            => Assert.Equal(expected, McpBridge.AppBundleFromExecutablePath(exe));
+
+        [Theory]
+        // Dev / non-bundle layouts (e.g. `dotnet run`) have no .app ancestor -> launch-or-attach can't auto-launch.
+        [InlineData("/Users/x/repo/src/CST.Avalonia/bin/Debug/net10.0/CST.Avalonia")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void AppBundleFromExecutablePath_is_null_outside_a_bundle(string? exe)
+            => Assert.Null(McpBridge.AppBundleFromExecutablePath(exe));
+
         [Fact]
         public void McpClientConfig_is_valid_json_carrying_the_port_and_token()
         {

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -27,27 +29,126 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         // request never hangs.
         private const int UnreachableErrorCode = -32000;
 
+        // After launching the app, poll for its handshake. A cold start (CEF init + a possible first-run index
+        // build) can take a while, so keep a generous window — but stay under a typical MCP client's spawn
+        // timeout (~60s) with margin.
+        private const int LaunchPollAttempts = 90;
+        private const int LaunchPollDelayMs = 500;   // ~45s total
+
+        private const string NotReadyMessage =
+            "CST Reader did not become ready for MCP. Make sure it is installed and that AI features are enabled " +
+            "in CST Reader → Settings → AI. If it was just launched it may still be starting — try again in a moment.";
+
         /// <summary>
         /// Entry point for the <c>--mcp-bridge</c> process: relays this process's STDIO to the running app's
         /// <c>/mcp</c>, using the port + token from <c>local-api.json</c> in <paramref name="handshakeDirectory"/>.
         /// Captures the real stdout for the JSON-RPC transport BEFORE redirecting <see cref="Console.Out"/> away
         /// from fd 1, so stray writes in shared code can't corrupt the stream (must-have #4). Returns on stdin EOF.
+        ///
+        /// Launch-or-attach (#278 Phase 3): if no instance has published a handshake, <c>open</c> the app bundle —
+        /// which reuses a running instance or launches a fresh windowed one — then wait for it to come up, so the
+        /// user gets the UI and the agent on one instance. If it still never becomes ready (not installed, still
+        /// starting, or AI features off), answer the client's <c>initialize</c> with a clear error rather than
+        /// exiting silently.
         /// </summary>
         public static async Task RunFromStdioAsync(string handshakeDirectory, CancellationToken ct)
         {
             await using var clientSide = new StdioServerTransport("cst-reader", NullLoggerFactory.Instance);
             Console.SetOut(Console.Error);   // any stray Console.Out goes to stderr, never onto the JSON-RPC stdout
 
-            var info = await ReadHandshakeWithRetryAsync(handshakeDirectory, ct).ConfigureAwait(false);
+            var info = LocalApiInfo.Read(handshakeDirectory);   // attach: a running instance already published its handshake
             if (info is null)
             {
-                // Phase 2: the app must already be running. (Phase 3 adds launch-or-attach; Phase 4 can answer
-                // the client's `initialize` with an error instead of exiting.)
-                Log.Warning("--mcp-bridge: CST Reader is not running (no {File}); exiting.", LocalApiInfo.FileName);
+                Log.Information("--mcp-bridge: no {File}; launching CST Reader and waiting for it to come up…", LocalApiInfo.FileName);
+                TryLaunchApp();
+                info = await ReadHandshakeWithRetryAsync(handshakeDirectory, ct, LaunchPollAttempts, LaunchPollDelayMs)
+                    .ConfigureAwait(false);
+            }
+
+            if (info is null)
+            {
+                Log.Warning("--mcp-bridge: CST Reader did not become ready; erroring the client's requests.");
+                await AnswerRequestsWithErrorAsync(clientSide, NotReadyMessage, ct).ConfigureAwait(false);
                 return;
             }
 
             await RunAsync(clientSide, BuildHttpOptions(info), httpClient: null, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Bring up CST Reader so it publishes its handshake. macOS only: <c>open &lt;bundle&gt;</c> reuses a running
+        /// instance or launches a fresh windowed one (LaunchServices single-instancing — sidesteps the #279
+        /// multi-instance ambiguity). Deliberately NOT passed <c>--mcp-bridge</c>: the launched instance is the
+        /// normal GUI app. Best-effort — on any failure we fall through to the not-ready error path.
+        /// </summary>
+        private static void TryLaunchApp()
+        {
+            if (!OperatingSystem.IsMacOS())
+            {
+                Log.Warning("--mcp-bridge: auto-launch is macOS-only; start CST Reader manually.");
+                return;
+            }
+
+            var bundle = AppBundleFromExecutablePath(Environment.ProcessPath);
+            if (bundle is null)
+            {
+                Log.Warning("--mcp-bridge: could not locate the .app bundle from {Path}; start CST Reader manually.",
+                    Environment.ProcessPath);
+                return;
+            }
+
+            try
+            {
+                var psi = new ProcessStartInfo("open") { UseShellExecute = false };
+                psi.ArgumentList.Add(bundle);
+                using var _ = Process.Start(psi);
+                Log.Information("--mcp-bridge: `open`ed {Bundle} (reuses a running instance or launches one).", bundle);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "--mcp-bridge: failed to launch CST Reader via `open`.");
+            }
+        }
+
+        /// <summary>
+        /// Walk up from the bridge executable (…/CST Reader.app/Contents/MacOS/CST.Avalonia) to the enclosing
+        /// <c>.app</c> bundle. Returns null outside a bundle (e.g. <c>dotnet run</c> in dev). Pure/testable.
+        /// </summary>
+        internal static string? AppBundleFromExecutablePath(string? executablePath)
+        {
+            var dir = string.IsNullOrEmpty(executablePath) ? null : Path.GetDirectoryName(executablePath);
+            while (!string.IsNullOrEmpty(dir))
+            {
+                if (dir.EndsWith(".app", StringComparison.OrdinalIgnoreCase)) return dir;
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The app isn't reachable: read from <paramref name="clientSide"/> and answer every JSON-RPC <em>request</em>
+        /// (starting with the client's <c>initialize</c>) with a <see cref="JsonRpcError"/> carrying
+        /// <paramref name="message"/>, so the chat client surfaces the reason instead of a silent spawn-timeout.
+        /// Notifications (no id) are ignored. Returns on stdin EOF.
+        /// </summary>
+        internal static async Task AnswerRequestsWithErrorAsync(ITransport clientSide, string message, CancellationToken ct)
+        {
+            try
+            {
+                await foreach (var msg in clientSide.MessageReader.ReadAllAsync(ct).ConfigureAwait(false))
+                {
+                    if (msg is not JsonRpcRequest req) continue;
+                    var error = new JsonRpcError
+                    {
+                        Id = req.Id,
+                        Error = new JsonRpcErrorDetail { Code = UnreachableErrorCode, Message = message },
+                    };
+                    try { await clientSide.SendMessageAsync(error, ct).ConfigureAwait(false); }
+                    catch { break; }   // client side gone
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch { /* stdin closed */ }
         }
 
         /// <summary>The Streamable-HTTP transport options for the running app's <c>/mcp</c> — explicit mode
@@ -59,14 +160,15 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             AdditionalHeaders = new Dictionary<string, string> { ["Authorization"] = "Bearer " + info.Token },
         };
 
-        // The app may be mid-startup writing a fresh handshake file; give it a short grace window.
-        private static async Task<LocalApiInfo?> ReadHandshakeWithRetryAsync(string dir, CancellationToken ct)
+        // Poll for the handshake file while the app starts up (or finishes writing a fresh one).
+        private static async Task<LocalApiInfo?> ReadHandshakeWithRetryAsync(
+            string dir, CancellationToken ct, int attempts, int delayMs)
         {
-            for (int i = 0; i < 12 && !ct.IsCancellationRequested; i++)
+            for (int i = 0; i < attempts && !ct.IsCancellationRequested; i++)
             {
                 var info = LocalApiInfo.Read(dir);
                 if (info is not null) return info;
-                try { await Task.Delay(250, ct).ConfigureAwait(false); }
+                try { await Task.Delay(delayMs, ct).ConfigureAwait(false); }
                 catch (OperationCanceledException) { return null; }
             }
             return LocalApiInfo.Read(dir);


### PR DESCRIPTION
Phase 3 of #278. Closes the gap the Kestrel test surfaced: on `main` (Phase 2) the relay only **attaches** to an already-running instance, so with no `local-api.json` it exits silently and Claude Desktop shows a bare "Server disconnected."

## Behavior
1. **Attach** — read `local-api.json`; a running instance (AI enabled) is used directly, as before.
2. **Launch-or-attach** — if there's no handshake, `open` the enclosing `.app` bundle. macOS LaunchServices **reuses a running instance or launches a fresh windowed one** (single-instance for free — sidesteps the #279 multi-instance ambiguity), so the user gets the UI *and* the agent on one instance. Then poll the handshake on a generous window (~45s, under a typical MCP client's ~60s spawn timeout). The launched instance is the **normal GUI app** — it is *not* passed `--mcp-bridge`. macOS-only; derives the bundle from the executable path and no-ops in dev / non-bundle layouts.
3. **Not-ready error** — if it still never comes up (not installed, still starting, or AI off), answer the client's `initialize` (and any request) with a clear `JsonRpcError` ("enable AI features in Settings…") instead of exiting silently, so Desktop surfaces the reason.

## Known limitation (by design; firmed up in Phase 4)
AI features default **off**, and a bridge can't flip a consent toggle — so the very first setup still returns the not-ready error until the user enables AI in Settings. Per discussion we're assuming the user has enabled AI before configuring the MCP server; the `McpEnabled` gate + ephemeral-API reversion land in Phase 4.

## Tests (+6, full suite 608 passed)
- `AppBundleFromExecutablePath` resolves the `.app` from a bundle exe path and returns null outside one (dev / empty / null).
- The not-ready path answers `initialize` with a `JsonRpcError` **fast** (no spawn-timeout hang) that carries the reason (`McpClient.CreateAsync` throws, message propagates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)