### PR TITLE
#278 Phase 4: McpEnabled gate + ephemeral API revert + bridge config helper

### DIFF
--- a/src/CST.Avalonia.Tests/Models/AiSettingsTests.cs
+++ b/src/CST.Avalonia.Tests/Models/AiSettingsTests.cs
@@ -19,9 +19,10 @@ namespace CST.Avalonia.Tests.Models
 
             Assert.False(ai.Enabled);                 // master OFF
             Assert.True(ai.LocalApi.Enabled);         // sub-permissions ON...
+            Assert.True(ai.LocalApi.EnableMcpServer);
             Assert.True(ai.LocalApi.AllowRemoteControl);
-            Assert.Equal(LocalApiSettings.DefaultPort, ai.LocalApi.Port);  // fixed default (stable config, #275)
-            Assert.Null(ai.LocalApi.Token);                                // generated + persisted on first start
+            Assert.Equal(0, ai.LocalApi.Port);        // ephemeral by default (#278 Phase 4 reverted the fixed port)
+            Assert.Null(ai.LocalApi.Token);           // per-session token minted at start; not persisted
         }
 
         [Fact]
@@ -43,7 +44,42 @@ namespace CST.Avalonia.Tests.Models
             var ai = new AiSettings { Enabled = true }; // LocalApi defaults on
 
             Assert.True(ai.LocalApiEnabled);
+            Assert.True(ai.McpEnabled);
+            Assert.True(ai.ServerShouldRun);
             Assert.True(ai.RemoteControlAllowed);
+        }
+
+        [Fact]
+        public void Master_off_disables_mcp_and_the_server()
+        {
+            var ai = new AiSettings { Enabled = false };
+
+            Assert.False(ai.McpEnabled);
+            Assert.False(ai.ServerShouldRun);
+        }
+
+        [Fact]
+        public void Mcp_and_rest_are_independent_surfaces_but_either_runs_the_server()
+        {
+            // REST on, MCP off: server runs (for /v1) but /mcp is not exposed.
+            var restOnly = new AiSettings
+            {
+                Enabled = true,
+                LocalApi = new LocalApiSettings { Enabled = true, EnableMcpServer = false }
+            };
+            Assert.True(restOnly.LocalApiEnabled);
+            Assert.False(restOnly.McpEnabled);
+            Assert.True(restOnly.ServerShouldRun);
+
+            // MCP on, REST off: server still runs (for /mcp) even with the /v1 surface disabled.
+            var mcpOnly = new AiSettings
+            {
+                Enabled = true,
+                LocalApi = new LocalApiSettings { Enabled = false, EnableMcpServer = true }
+            };
+            Assert.False(mcpOnly.LocalApiEnabled);
+            Assert.True(mcpOnly.McpEnabled);
+            Assert.True(mcpOnly.ServerShouldRun);
         }
 
         [Fact]
@@ -92,6 +128,8 @@ namespace CST.Avalonia.Tests.Models
             var json = JsonSerializer.Serialize(new Settings());
 
             Assert.DoesNotContain("localApiEnabled", json, System.StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("mcpEnabled", json, System.StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("serverShouldRun", json, System.StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("remoteControlAllowed", json, System.StringComparison.OrdinalIgnoreCase);
         }
     }

--- a/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
+++ b/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
@@ -2,7 +2,9 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CST.Avalonia.Services.LocalApi;
@@ -71,15 +73,50 @@ namespace CST.Avalonia.Tests.Services
             => Assert.Null(McpBridge.AppBundleFromExecutablePath(exe));
 
         [Fact]
-        public void McpClientConfig_is_valid_json_carrying_the_port_and_token()
+        public void McpClientConfig_emits_the_bridge_command_with_no_secrets()
         {
-            string json = McpClientConfig.ClaudeDesktop(8765, "TOKEN123");
+            // #278 Phase 4: the Copy-config helper emits the --mcp-bridge config — spawn the app binary, no port,
+            // no token (the relay reads the current local-api.json each spawn).
+            const string command = "/Applications/CST Reader.app/Contents/MacOS/CST";
+            string json = McpClientConfig.ClaudeDesktop(command);
             using var doc = JsonDocument.Parse(json);   // must be valid JSON
-            var args = doc.RootElement.GetProperty("mcpServers").GetProperty("cst-reader").GetProperty("args");
-            string joined = string.Join(" ", args.EnumerateArray().Select(e => e.GetString()));
-            Assert.Contains("mcp-remote", joined);
-            Assert.Contains("http://127.0.0.1:8765/mcp", joined);
-            Assert.Contains("Authorization: Bearer TOKEN123", joined);
+            var server = doc.RootElement.GetProperty("mcpServers").GetProperty("cst-reader");
+            Assert.Equal(command, server.GetProperty("command").GetString());
+            var args = server.GetProperty("args").EnumerateArray().Select(e => e.GetString()).ToArray();
+            Assert.Equal(new[] { "--mcp-bridge" }, args);
+            Assert.DoesNotContain("Bearer", json);      // no bearer token
+            Assert.DoesNotContain("mcp-remote", json);  // not the old npx/mcp-remote snippet
+        }
+
+        [Fact]
+        public async Task Mcp_endpoint_is_mounted_only_when_mcpEnabled()
+        {
+            // #278 Phase 4: /mcp is gated by its own permission. With it off the route is absent (404 past the auth
+            // gate); with it on the route exists (any non-404 — the MCP handler answers/negotiates).
+            var dir = Path.Combine(Path.GetTempPath(), "cst-mcpgate-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            const string token = "gate-token-under-test";
+
+            async Task<HttpStatusCode> PostMcpAsync(bool mcpEnabled)
+            {
+                var server = new LocalApiServer("test", dir, Serilog.Log.Logger, port: 0, token: token, mcpEnabled: mcpEnabled);
+                await server.StartAsync();
+                try
+                {
+                    using var http = new HttpClient { BaseAddress = new Uri(server.BaseUrl!) };
+                    http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+                    using var body = new StringContent(
+                        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}", Encoding.UTF8, "application/json");
+                    using var resp = await http.PostAsync("/mcp", body);
+                    return resp.StatusCode;
+                }
+                finally { await server.StopAsync(); }
+            }
+
+            Assert.Equal(HttpStatusCode.NotFound, await PostMcpAsync(mcpEnabled: false));     // route not mapped
+            Assert.NotEqual(HttpStatusCode.NotFound, await PostMcpAsync(mcpEnabled: true));   // route mapped (authorized)
+
+            try { Directory.Delete(dir, recursive: true); } catch { }
         }
 
         [Fact]

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -334,40 +334,28 @@ public partial class App : Application
     {
         try
         {
-            if (!settingsService.Settings.Ai.LocalApiEnabled) return;
+            var ai = settingsService.Settings.Ai;
+            if (!ai.ServerShouldRun) return;
 
             var dir = System.IO.Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                 CST.Avalonia.Constants.AppConstants.AppDataDirectoryName);
             System.IO.Directory.CreateDirectory(dir);
 
-            var localApi = settingsService.Settings.Ai.LocalApi;
-
-            // Persist a stable bearer token on first use, then reuse it across launches so a copied MCP client
-            // config stays valid (#275). Source of truth is settings; it's also copied into local-api.json (0600).
-            if (string.IsNullOrEmpty(localApi.Token))
-            {
-                localApi.Token = CST.Avalonia.Services.LocalApi.ApiToken.Generate();
-                settingsService.RequestSave();
-            }
-
-            int port = localApi.Port;
-            // A FIXED port can already be taken. Check first and, rather than let Kestrel throw and fail the API
-            // silently, warn and skip start so the user can rotate the port in Settings (#275).
-            if (port > 0 && !CST.Avalonia.Services.LocalApi.PortAvailability.IsAvailable(port))
-            {
-                Log.Warning("Local API port {Port} is in use; not starting. Rotate the port in Settings.", port);
-                LocalApiPortInUse = port;   // UI (kestrel) reads this to show a rotate-the-port popup.
-                return;
-            }
+            // #278 Phase 4: the loopback API is EPHEMERAL (OS-assigned port) with a PER-SESSION token — no stable
+            // secret is stored and there's no fixed port to collide. MCP clients don't need one either: the app's
+            // --mcp-bridge relay reads the current local-api.json each spawn. So we pass no port/token (server
+            // mints them) and mount each surface per its own permission.
             LocalApiPortInUse = null;
 
             var version = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown";
             // Resolve the tools through the shared factory (covered by AppCompositionTests), so a tool that is
             // registered but forgotten here can't silently 404 an endpoint again.
             _localApiServer = ServiceProvider is { } sp
-                ? CST.Avalonia.Services.LocalApi.LocalApiServer.FromServiceProvider(sp, version, dir, Log.Logger, port, localApi.Token)
-                : new CST.Avalonia.Services.LocalApi.LocalApiServer(version, dir, Log.Logger, port: port, token: localApi.Token);
+                ? CST.Avalonia.Services.LocalApi.LocalApiServer.FromServiceProvider(
+                    sp, version, dir, Log.Logger, restApiEnabled: ai.LocalApiEnabled, mcpEnabled: ai.McpEnabled)
+                : new CST.Avalonia.Services.LocalApi.LocalApiServer(
+                    version, dir, Log.Logger, restApiEnabled: ai.LocalApiEnabled, mcpEnabled: ai.McpEnabled);
             await _localApiServer.StartAsync();
         }
         catch (Exception ex)

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -33,9 +33,19 @@ namespace CST.Avalonia.Models
 
         public LocalApiSettings LocalApi { get; set; } = new();
 
-        /// <summary>The local API server should run only when the master and the local-API permission are both on.</summary>
+        /// <summary>The REST (/v1) surface runs only when the master and the local-API permission are both on.</summary>
         [JsonIgnore]
         public bool LocalApiEnabled => Enabled && LocalApi.Enabled;
+
+        /// <summary>The MCP (/mcp) surface runs only when the master and the MCP permission are both on. Separate
+        /// from <see cref="LocalApiEnabled"/> so a user can expose the /v1 REST surface (code agents) without the
+        /// /mcp chat-client surface, or vice versa.</summary>
+        [JsonIgnore]
+        public bool McpEnabled => Enabled && LocalApi.EnableMcpServer;
+
+        /// <summary>The loopback Kestrel host runs if EITHER surface is enabled — /v1 and /mcp ride the same server.</summary>
+        [JsonIgnore]
+        public bool ServerShouldRun => LocalApiEnabled || McpEnabled;
 
         /// <summary>Agents may drive the reader only when the local API is enabled and remote control is permitted.</summary>
         [JsonIgnore]
@@ -45,24 +55,23 @@ namespace CST.Avalonia.Models
     /// <summary>Permissions for the loopback API server that exposes the corpus tools to agents (surface C).</summary>
     public class LocalApiSettings
     {
-        /// <summary>Run the local API (corpus data access). On by default under the master switch.</summary>
+        /// <summary>Expose the /v1 REST surface (corpus data access for code-capable agents). On by default under the master.</summary>
         public bool Enabled { get; set; } = true;
+
+        /// <summary>Expose the /mcp MCP surface (for chat clients, via the app's <c>--mcp-bridge</c> relay). On by
+        /// default under the master.</summary>
+        public bool EnableMcpServer { get; set; } = true;
 
         /// <summary>Let agents drive the reader (navigate/highlight) vs. read-only. On by default under the master.</summary>
         public bool AllowRemoteControl { get; set; } = true;
 
-        /// <summary>Loopback port. A FIXED default so a BYO-MCP client can keep a static config across restarts;
-        /// `0` = ephemeral (a fresh OS-assigned port each launch). Rotatable from Settings.</summary>
-        public int Port { get; set; } = DefaultPort;
-
-        /// <summary>The default fixed loopback port (below the OS ephemeral range, so it can't collide with an
-        /// ephemeral allocation). Arbitrary; rotate it if it's already in use.</summary>
-        public const int DefaultPort = 8765;
-
-        /// <summary>The persisted bearer token, reused across launches so a copied MCP config stays valid.
-        /// Null/empty => generate one on first start and persist it here. Rotatable from Settings. NOTE: this is
-        /// a secret living in settings.json - consider tightening that file's permissions.</summary>
-        public string? Token { get; set; }
+        // Deprecated (#278 Phase 4): the API reverted to an EPHEMERAL loopback port + a PER-SESSION token — no
+        // stable secret is stored, and an MCP client no longer needs one (the app's --mcp-bridge relay reads the
+        // current local-api.json each spawn). The runtime ignores these; they remain only so the pre-#280 Settings
+        // UI keeps compiling and #280 removes them.
+        public int Port { get; set; } = 0;                 // 0 => ephemeral (OS-assigned)
+        public const int DefaultPort = 8765;               // legacy fixed default (#276), retained for the UI only
+        public string? Token { get; set; }                 // no longer persisted; per-session token minted at start
     }
     
     public class DeveloperSettings

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -57,6 +57,8 @@ namespace CST.Avalonia.Services.LocalApi
         private readonly IScriptTool? _script;
         private readonly int _port;              // fixed loopback port, or <= 0 for ephemeral
         private readonly string? _configuredToken; // persisted bearer token, or null to generate one
+        private readonly bool _restApiEnabled;   // map the /v1 REST tool endpoints
+        private readonly bool _mcpEnabled;       // register + map the /mcp MCP surface
 
         private WebApplication? _app;
 
@@ -71,7 +73,8 @@ namespace CST.Avalonia.Services.LocalApi
         public LocalApiServer(
             string appVersion, string handshakeDirectory, Serilog.ILogger logger,
             ISearchTool? search = null, IDictionaryTool? dictionary = null, IPassageTool? passage = null,
-            IScriptTool? script = null, int port = 0, string? token = null)
+            IScriptTool? script = null, int port = 0, string? token = null,
+            bool restApiEnabled = true, bool mcpEnabled = true)
         {
             _appVersion = appVersion;
             _handshakeDirectory = handshakeDirectory;
@@ -82,6 +85,8 @@ namespace CST.Avalonia.Services.LocalApi
             _script = script;
             _port = port;
             _configuredToken = token;
+            _restApiEnabled = restApiEnabled;
+            _mcpEnabled = mcpEnabled;
         }
 
         /// <summary>
@@ -92,12 +97,12 @@ namespace CST.Avalonia.Services.LocalApi
         /// </summary>
         public static LocalApiServer FromServiceProvider(
             IServiceProvider services, string appVersion, string handshakeDirectory, Serilog.ILogger logger,
-            int port = 0, string? token = null)
+            int port = 0, string? token = null, bool restApiEnabled = true, bool mcpEnabled = true)
             => new LocalApiServer(appVersion, handshakeDirectory, logger,
                 services.GetService<ISearchTool>(),
                 services.GetService<IDictionaryTool>(),
                 services.GetService<IPassageTool>(),
-                services.GetService<IScriptTool>(), port, token);
+                services.GetService<IScriptTool>(), port, token, restApiEnabled, mcpEnabled);
 
         public async Task StartAsync(CancellationToken ct = default)
         {
@@ -118,35 +123,38 @@ namespace CST.Avalonia.Services.LocalApi
             });
 
             // MCP surface (#191): expose the read tool set over the Streamable HTTP transport at /mcp — MCP is
-            // just another transport on the same tool layer /v1 uses, not a proxy. A BYO-MCP chat client (Claude
-            // Desktop via the mcp-remote bridge) connects here; code-capable agents keep hitting /v1 directly.
-            // Tool groups are registered only when their backing service is present (mirroring the /v1 wiring);
-            // 'books' needs no service, so /mcp is always available when the server runs.
-            var mcp = builder.Services.AddMcpServer().WithHttpTransport();
-            mcp.WithTools<BooksMcpTool>(McpJson);
-            if (_search is { } mcpSearch)
+            // just another transport on the same tool layer /v1 uses, not a proxy. A chat client connects via the
+            // app's --mcp-bridge relay; code-capable agents keep hitting /v1 directly. Registered only when the
+            // MCP permission is on (#278 Phase 4) — separate from the /v1 surface. Tool groups are registered only
+            // when their backing service is present (mirroring the /v1 wiring); 'books' needs no service.
+            if (_mcpEnabled)
             {
-                builder.Services.AddSingleton(mcpSearch);
-                mcp.WithTools<SearchMcpTool>(McpJson);
+                var mcp = builder.Services.AddMcpServer().WithHttpTransport();
+                mcp.WithTools<BooksMcpTool>(McpJson);
+                if (_search is { } mcpSearch)
+                {
+                    builder.Services.AddSingleton(mcpSearch);
+                    mcp.WithTools<SearchMcpTool>(McpJson);
+                }
+                if (_passage is { } mcpPassage)
+                {
+                    builder.Services.AddSingleton(mcpPassage);
+                    mcp.WithTools<PassageMcpTool>(McpJson);
+                }
+                if (_script is { } mcpScript)
+                {
+                    builder.Services.AddSingleton(mcpScript);
+                    mcp.WithTools<ScriptMcpTool>(McpJson);
+                }
+                if (_dictionary is { } mcpDictionary)
+                {
+                    builder.Services.AddSingleton(mcpDictionary);
+                    mcp.WithTools<DictionaryMcpTool>(McpJson);
+                }
+                // Expose llms.txt as an MCP resource — an MCP client has no base URL to "fetch /llms.txt", so give
+                // it the same version-stamped orientation as a readable resource. (Desktop MCP friction report)
+                mcp.WithResources(new[] { BuildLlmsResource() });
             }
-            if (_passage is { } mcpPassage)
-            {
-                builder.Services.AddSingleton(mcpPassage);
-                mcp.WithTools<PassageMcpTool>(McpJson);
-            }
-            if (_script is { } mcpScript)
-            {
-                builder.Services.AddSingleton(mcpScript);
-                mcp.WithTools<ScriptMcpTool>(McpJson);
-            }
-            if (_dictionary is { } mcpDictionary)
-            {
-                builder.Services.AddSingleton(mcpDictionary);
-                mcp.WithTools<DictionaryMcpTool>(McpJson);
-            }
-            // Expose llms.txt as an MCP resource — an MCP client has no base URL to "fetch /llms.txt", so give
-            // it the same version-stamped orientation as a readable resource. (Desktop MCP friction report)
-            mcp.WithResources(new[] { BuildLlmsResource() });
 
             var app = builder.Build();
 
@@ -185,12 +193,14 @@ namespace CST.Avalonia.Services.LocalApi
             // Version-stamped so it can't be mistaken for a different build's surface.
             app.MapGet("/llms.txt", () => Results.Text(BuildLlmsText(), "text/markdown; charset=utf-8"));
 
-            MapToolEndpoints(app);
+            if (_restApiEnabled)
+                MapToolEndpoints(app);
 
             // Streamable HTTP MCP endpoint (read tool set + llms.txt resource). Behind the same security
             // middleware as everything else: requires the bearer token and rejects Origin-bearing requests.
-            // Always mapped — the 'books' tool needs no backing service. (#191)
-            app.MapMcp("/mcp");
+            // Mapped only when the MCP permission is on (#278 Phase 4). (#191)
+            if (_mcpEnabled)
+                app.MapMcp("/mcp");
 
             await app.StartAsync(ct);
 
@@ -200,7 +210,8 @@ namespace CST.Avalonia.Services.LocalApi
             BaseUrl = $"http://127.0.0.1:{port}";
 
             new LocalApiInfo(port, token, Environment.ProcessId).Write(_handshakeDirectory);
-            _logger.Information("Local API listening on {BaseUrl}", BaseUrl);
+            _logger.Information("Local API listening on {BaseUrl} (rest={Rest}, mcp={Mcp})",
+                BaseUrl, _restApiEnabled, _mcpEnabled);
         }
 
         public async Task StopAsync()

--- a/src/CST.Avalonia/Services/LocalApi/McpClientConfig.cs
+++ b/src/CST.Avalonia/Services/LocalApi/McpClientConfig.cs
@@ -4,17 +4,19 @@ using System.Text.Json.Nodes;
 namespace CST.Avalonia.Services.LocalApi
 {
     /// <summary>
-    /// Generates a pre-populated MCP client configuration from the current port + token, for a "Copy MCP
-    /// configuration" affordance in Settings (#275). Currently the Claude Desktop snippet (the `mcp-remote`
-    /// stdio bridge over the loopback `/mcp` endpoint).
+    /// Generates a pre-populated MCP client configuration for a "Copy MCP configuration" affordance in Settings.
+    /// Emits the #278 <c>--mcp-bridge</c> config: the chat client spawns CST Reader's own (signed) binary with
+    /// <c>--mcp-bridge</c>, and that relay reads the current <c>local-api.json</c> — so the config carries NO port
+    /// or token and survives every restart while the API stays ephemeral + per-session.
     /// </summary>
     internal static class McpClientConfig
     {
         /// <summary>
-        /// The <c>claude_desktop_config.json</c> snippet that connects Claude Desktop to <c>/mcp</c> via the
-        /// <c>mcp-remote</c> bridge with the given port + bearer token. Paste into that file's <c>mcpServers</c>.
+        /// The <c>claude_desktop_config.json</c> snippet that launches the CST Reader <c>--mcp-bridge</c> relay.
+        /// <paramref name="command"/> is the path to the app executable (e.g. <c>Environment.ProcessPath</c>, or
+        /// the bundle's launch wrapper). Paste into that file's <c>mcpServers</c>.
         /// </summary>
-        public static string ClaudeDesktop(int port, string token, string serverName = "cst-reader")
+        public static string ClaudeDesktop(string command, string serverName = "cst-reader")
         {
             var config = new JsonObject
             {
@@ -22,12 +24,8 @@ namespace CST.Avalonia.Services.LocalApi
                 {
                     [serverName] = new JsonObject
                     {
-                        ["command"] = "npx",
-                        ["args"] = new JsonArray(
-                            "mcp-remote",
-                            $"http://127.0.0.1:{port}/mcp",
-                            "--transport", "http-only",
-                            "--header", $"Authorization: Bearer {token}"),
+                        ["command"] = command,
+                        ["args"] = new JsonArray("--mcp-bridge"),
                     },
                 },
             };

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -902,10 +902,10 @@ namespace CST.Avalonia.ViewModels
         /// <summary>Rotate (regenerate) the bearer token (rotate icon). (#275)</summary>
         public ReactiveCommand<Unit, Unit> RotateTokenCommand { get; }
 
-        /// <summary>Pre-populated Claude Desktop MCP config for the current port + token, for a
-        /// "Copy MCP configuration" button. Uses the fixed default port when the port is set to ephemeral. (#275)</summary>
+        /// <summary>Pre-populated Claude Desktop MCP config for the "Copy MCP configuration" button. Emits the
+        /// #278 bridge config (spawn this app with --mcp-bridge); carries no port/token. (#280 reworks the UI.)</summary>
         public string McpClientConfigJson => CST.Avalonia.Services.LocalApi.McpClientConfig.ClaudeDesktop(
-            _port > 0 ? _port : CST.Avalonia.Models.LocalApiSettings.DefaultPort, _token);
+            System.Environment.ProcessPath ?? "CST Reader");
 
         /// <summary>The local-API sub-permissions are editable only when the master switch is on.</summary>
         public bool SubPermissionsEnabled => AiEnabled;


### PR DESCRIPTION
Completes the Path B backend (#278). Three changes:

## 1. `McpEnabled` gate (separate MCP toggle)
`/v1` (REST, for code agents) and `/mcp` (MCP, for chat clients) are now **independent surfaces** on the one loopback host — answering the earlier "do we need a separate MCP toggle?" question.
- New `LocalApiSettings.EnableMcpServer` (default on under master) + computed `AiSettings.McpEnabled` and `ServerShouldRun`.
- The Kestrel host runs if **either** surface is enabled; each surface is registered/mapped only when its own permission is set (`restApiEnabled` / `mcpEnabled` on `LocalApiServer`).

## 2. Revert the API to ephemeral + per-session
The stable-config machinery from #276 is no longer needed — the `--mcp-bridge` relay reads the current `local-api.json` each spawn, so the API can stay locked down.
- Startup always binds an **OS-assigned port** and mints a **fresh per-session token**, written only to `local-api.json` (0600). No fixed port, no persisted token — secrets are once again never stored in `settings.json`.
- Drops the port-in-use warning/popup path (ephemeral can't collide).

## 3. Bridge config helper
`McpClientConfig.ClaudeDesktop(command)` now emits the `--mcp-bridge` config (spawn the app binary; **no port, no token**) instead of the `npx`/`mcp-remote` snippet.

## Deprecated-but-retained
`LocalApiSettings.Port` / `Token` / `DefaultPort` remain as **vestigial** fields (runtime ignores them) so the pre-#280 Settings UI keeps compiling. The UI rework is **#280 (kestrel)**: drop the port/token fields + rotate icons, add the MCP on/off toggle + a top-of-panel MCP mention; Copy-config already emits the bridge config via this helper.

## Tests (+3, full suite 611 passed)
- MCP/REST independence and `ServerShouldRun` semantics.
- `/mcp` is mounted **only** when `mcpEnabled` (404 past the auth gate when off; a live route when on).
- Copy-config emits the bridge command with no secrets (no `Bearer`, no `mcp-remote`).

After this + #280, a first-time user: enable AI in Settings → Copy MCP configuration → paste into Claude Desktop → the relay auto-launches CST Reader and attaches, with the API fully ephemeral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)