### PR TITLE
occurrences: add instanceTotal + clarify mis-readable count/budget fields (MCP report)

### DIFF
--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -208,6 +208,8 @@ namespace CST.Avalonia.Tests.Tools
                     new OccurrenceRequest(book, "tgt", OutputScript: Script.Devanagari, MinChars: 1));
 
                 var o = Assert.Single(occ.Occurrences);
+                Assert.Equal(1, occ.Total);          // one record...
+                Assert.Equal(1, occ.InstanceTotal);  // ...and one raw hit (no co-location to fold)
                 Assert.Contains("TARGET", o.Snippet);
                 Assert.Contains("ccc", o.Snippet);
                 Assert.Contains("ddd", o.Snippet);
@@ -267,6 +269,51 @@ namespace CST.Avalonia.Tests.Tools
                 Assert.Equal("SANKHARA", o.Snippet.Substring(o.Highlights[1].Start, o.Highlights[1].Length));
                 // cursor is the anchor's SOURCE offset (for /v1/passage)
                 Assert.Equal(a, o.Cursor);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task GetOccurrencesAsync_colocated_hits_fold_into_one_record_but_instanceTotal_counts_raw()
+        {
+            // Finding #1 (Desktop MCP report): two hits in ONE sentence merge into a single snippet record with
+            // two highlights, so `total` (records) is 1 while `instanceTotal` (raw hits) is 2 — which ties out to
+            // search's per-book `count`. `total < instanceTotal` means folded hits, not dropped hits.
+            var dir = Path.Combine(Path.GetTempPath(), "cst-occ-colo-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                const string book = "s0101m.mul.xml";
+                string xml =
+                    "<body><div id=\"dn1\" type=\"book\">" +
+                    "<pb ed=\"V\" n=\"1.0003\"/>" +
+                    "<p rend=\"bodytext\" n=\"12\">aaa TARGET bbb TARGET ccc\u0964</p>" +   // two hits, one sentence (danda escaped)
+                    "</div></body>";
+                await File.WriteAllTextAsync(Path.Combine(dir, book), xml, Encoding.Unicode);
+
+                int h1 = xml.IndexOf("TARGET", StringComparison.Ordinal);
+                int h2 = xml.IndexOf("TARGET", h1 + 1, StringComparison.Ordinal);
+                var search = new Mock<ISearchService>();
+                search.Setup(s => s.GetTermPositionsAsync(book, "tgt", It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new List<TermPosition>
+                    {
+                        new TermPosition { StartOffset = h1, EndOffset = h1 + 6, IsFirstTerm = true, Word = "tgt" },
+                        new TermPosition { StartOffset = h2, EndOffset = h2 + 6, IsFirstTerm = true, Word = "tgt" },
+                    });
+
+                var tool = new SearchTool(search.Object, Settings(dir));
+                var occ = await tool.GetOccurrencesAsync(
+                    new OccurrenceRequest(book, "tgt", OutputScript: Script.Devanagari, MinChars: 1));
+
+                var o = Assert.Single(occ.Occurrences);   // one merged record
+                Assert.Equal(2, o.Highlights.Count);      // ...carrying both hits
+                Assert.Equal(1, occ.Total);               // records to page over
+                Assert.Equal(2, occ.InstanceTotal);       // raw hits (matches search's per-book count)
+                Assert.Equal(1, occ.ReturnedCount);
+                Assert.False(occ.HasMore);
             }
             finally
             {

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -112,8 +112,11 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   MULTI-WORD / PROXIMITY search in context: `/v1/search` returns a multi-word match's `term` space-joined
   (e.g. `ekayano ayam`), so pass it straight back here. Words match LITERALLY (as in search), so reuse the SAME wildcards you searched
   with - a bare `avijja` will miss the sandhi forms `avijjaya`/`avijjapaccaya`, whereas `avijj*` catches them.
-  The response is an envelope `{ occurrences, returnedCount, total, hasMore }` - `total` is the term's
-  occurrence count in THAT book (before paging), so page with `skip`/`take` while `hasMore`. Each occurrence is
+  The response is an envelope `{ occurrences, returnedCount, total, instanceTotal, hasMore }` - `total` is the
+  number of snippet RECORDS you page over (`skip`/`take` are against it, page while `hasMore`); `instanceTotal`
+  is the RAW hit count before co-located hits (multiple in one sentence) are merged into a single record with
+  multiple `highlights`. For a single term `instanceTotal` equals that term's per-book `count` from `/v1/search`,
+  so `total < instanceTotal` means hits were FOLDED into records, not dropped. Each occurrence is
   `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedFootnotes, cursor, highlights }`. `snippet` is hit-centered; `highlights` is the ordered set of marked spans in SNIPPET-LOCAL
   offsets - `[{ start, length, isAnchor }]`: a single-term hit has one, a proximity/phrase hit has one PER
   co-occurring word with exactly one `isAnchor:true` (the navigable word; the rest are the co-occurring

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
@@ -32,7 +32,10 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             string? bookCode = null,
             [Description("A page cursor from a prior result; when set, overrides paragraph and reads that exact spot.")]
             int? cursor = null,
-            [Description("Rendered-character budget for the window. May overshoot to reach the next sentence boundary, so the returned text can exceed this.")]
+            [Description("Rendered-character budget for the window — a SOFT floor, not a ceiling. The window extends "
+                + "past it to the next sentence end, and Pali sentences (with '…pe…' peyyala elisions) can be very "
+                + "long, so the overshoot is unbounded and can be a large fraction over budget (occasionally several-"
+                + "fold). Don't rely on maxChars for fixed-size chunking; page with the returned cursor instead.")]
             int maxChars = 1200,
             [Description("Script for the returned text.")]
             OutputScript outputScript = OutputScript.Latin,

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -25,7 +25,11 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             + "forms (e.g. 'satipatthanam') are common. To find a stem's variations, use mode:Wildcard with a "
             + "trailing '*' (e.g. 'satipatthan*'). PHRASE/PROXIMITY (corpus-wide): a space-separated query "
             + "(e.g. 'ekayano ayam') finds those words co-occurring; wrap in quotes (e.g. '\"ekayano ayam\"') for "
-            + "an adjacent phrase. Each match's term is the co-occurring words; pass it to 'occurrences' to read it.")]
+            + "an adjacent phrase. Each match's term is the co-occurring words; pass it to 'occurrences' to read it. "
+            + "TOP-LEVEL COUNTS are page-scoped (over the term-forms on THIS page): 'returnedOccurrenceCount' is a "
+            + "SUM of their corpus frequencies, 'returnedBookCount' is the DISTINCT books they span (deduped, so it "
+            + "is not that sum). 'hasMore' = more term-pages exist (page with skip); 'truncated' = the pattern hit "
+            + "the term-expansion cap (narrow it) — two independent signals.")]
         public static async Task<SearchToolResult> SearchAsync(
             ISearchTool search,
             [Description("The word or pattern to search for, in any script (romanized Latin accepted).")]
@@ -65,7 +69,10 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             + "refs (paragraph number + per-edition pages) and a cursor for reading the full passage. Pass a "
             + "term returned by 'search' (in the same script it came back) and a bookId from its per-book "
             + "breakdown or the 'books' tool. A space-separated multi-word term co-occurs within a proximity "
-            + "window; a quoted run is an adjacent phrase.")]
+            + "window; a quoted run is an adjacent phrase. COUNTS: 'total' is the number of snippet RECORDS you "
+            + "page over (Skip/Take are against it); co-located hits in one sentence merge into one record with "
+            + "multiple highlights, so 'total' can be less than 'instanceTotal' (the raw hit count, which matches "
+            + "search's per-book 'count'). total < instanceTotal means folded hits, NOT dropped hits.")]
         public static async Task<OccurrenceResult> OccurrencesAsync(
             ISearchTool search,
             [Description("The book's id (file name), e.g. from a search result's per-book breakdown or the 'books' tool.")]

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -103,7 +103,7 @@ namespace CST.Avalonia.Services.Tools
             return terms.Select(t => ScriptConverter.Convert(t, Script.Unknown, outputScript)).ToList();
         }
 
-        private static readonly OccurrenceResult EmptyOccurrences = new(Array.Empty<Occurrence>(), 0, 0, false);
+        private static readonly OccurrenceResult EmptyOccurrences = new(Array.Empty<Occurrence>(), 0, 0, 0, false);
 
         public async Task<OccurrenceResult> GetOccurrencesAsync(
             OccurrenceRequest request, CancellationToken ct = default)
@@ -180,12 +180,15 @@ namespace CST.Avalonia.Services.Tools
                     Highlights: s.Highlights
                         .Select(h => new OccurrenceHighlight(h.Start, h.Length, h.IsAnchor)).ToList()));
             }
-            // Envelope (like search): book-scoped total + hasMore, so an agent paging occurrences isn't blind.
-            // Total is the MERGED snippet count (what you actually page over), not the raw hit count.
+            // Envelope (like search): book-scoped totals + hasMore, so an agent paging occurrences isn't blind.
+            // Total is the MERGED record count (what you actually page over); InstanceTotal is the raw pre-merge
+            // hit count — for a single term it ties out to search's per-book count, so `Total < InstanceTotal`
+            // reads as "folded co-located hits", not "dropped hits". (Desktop MCP friction report, finding #1.)
             return new OccurrenceResult(
                 Occurrences: occurrences,
                 ReturnedCount: occurrences.Count,
                 Total: groups.Count,
+                InstanceTotal: perOccurrence.Count,
                 HasMore: request.Skip + occurrences.Count < groups.Count);
 
             static int AnchorStart(IReadOnlyList<SnippetMark> m)

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -176,12 +176,20 @@ namespace CST.Tools
     /// </summary>
     /// <param name="Occurrences">This page of occurrences (after <c>Skip</c>/<c>Take</c>).</param>
     /// <param name="ReturnedCount">How many occurrences are in this page (= <c>Occurrences.Count</c>).</param>
-    /// <param name="Total">Total occurrences of the term in this book (before paging) — book-scoped.</param>
-    /// <param name="HasMore">True if more occurrences remain after this page; request the next with
+    /// <param name="Total">Number of snippet RECORDS you page over — book-scoped. Co-located hits (multiple
+    /// instances sharing one enclosing sentence) are merged into a single record with multiple
+    /// <see cref="Occurrence.Highlights"/>, so this can be LESS than <see cref="InstanceTotal"/>. Page with
+    /// <c>Skip</c>/<c>Take</c> against THIS number, not the raw instance count.</param>
+    /// <param name="InstanceTotal">Total RAW term instances in this book before co-located merging — book-scoped.
+    /// For a single term this equals the search tool's per-book <c>count</c>; the gap <c>InstanceTotal - Total</c>
+    /// is how many hits shared a record. (So an agent that saw <c>count: 7</c> in <c>search</c> and <c>Total: 5</c>
+    /// here isn't looking at 2 dropped hits — they were folded into records.) Invariant: <c>Total ≤ InstanceTotal</c>.</param>
+    /// <param name="HasMore">True if more records remain after this page; request the next with
     /// <c>Skip += Take</c>.</param>
     public sealed record OccurrenceResult(
         IReadOnlyList<Occurrence> Occurrences,
         int ReturnedCount,
         int Total,
+        int InstanceTotal,
         bool HasMore);
 }


### PR DESCRIPTION
Addresses the actionable findings from the black-box MCP friction report. Per the report's own conclusion these are **contract/ergonomics, not behavior bugs** — but three response fields read as something they aren't, and #1 in particular looks like silent data loss.

## Finding #1 (High) — `occurrences.total` reads like dropped hits → add `instanceTotal`
`occurrences.total` is the **merged snippet-record** count (co-located hits sharing a sentence fold into one record with multiple highlights), so for a term like `satipaṭṭhānaṃ` it comes back **lower** than `search`'s per-book `count` (raw instances) — reading as "the server dropped 2 hits."

Fix: add **`instanceTotal`** (the raw pre-merge hit count) to the occurrences envelope. For a single term it ties out to `search.count`, so `total < instanceTotal` now unambiguously means *folded*, not *dropped*. Bonus: the `total ≤ instanceTotal` invariant makes any **real** future offset-mapping drop visible instead of silent. The value was already computed (`perOccurrence.Count`) — this just surfaces it.

## Findings #2 / #4 (search) — documented the mis-readable roll-ups
The top-level counts are **page-scoped** and aggregate **differently**: `returnedOccurrenceCount` is a **sum** of the page's term frequencies; `returnedBookCount` is **distinct** books (deduped). And `hasMore` (more term-pages) vs `truncated` (expansion cap hit) are **independent** signals. Both are now spelled out in the `search` tool description (the semantics were already correct in code; they just weren't documented for the agent).

## Finding #3 (passage) — quantified the soft budget
`maxChars` doc upgraded from "may overshoot" to: **soft floor, not a ceiling**; overshoot is unbounded (Pali `…pe…` sentences can run several-fold over) — page with the returned cursor, don't chunk on `maxChars`.

## Finding #5 — already tracked as #266 (expose sub-book codes in the catalog).

## Where
Contract XML docs (`SearchToolContracts.OccurrenceResult`), MCP `[Description]`s (`search`, `occurrences`, `passage`), and `llms.txt` all updated to match.

## Tests
- Co-located: two hits in one sentence → one record with two highlights, `total = 1`, `instanceTotal = 2`, ties to the raw count.
- Single hit: `total == instanceTotal == 1`.

Full suite green (the one failure on a full run was the pre-existing timing-flaky `IndexingPerformanceTests` — passes in isolation; unrelated to these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)