### PR TITLE
#278: bridge exits when its CST Reader GUI goes away (no lone-bridge dangle)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
+++ b/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Services.LocalApi;
 using CST.Avalonia.Services.LocalApi.Mcp;
@@ -71,6 +72,38 @@ namespace CST.Avalonia.Tests.Services
         [InlineData(null)]
         public void AppBundleFromExecutablePath_is_null_outside_a_bundle(string? exe)
             => Assert.Null(McpBridge.AppBundleFromExecutablePath(exe));
+
+        [Fact]
+        public async Task Liveness_watcher_trips_when_the_watched_process_is_gone()
+        {
+            // The GUI's pid isn't running -> the watcher cancels its token so the relay unwinds and the bridge
+            // exits (one -> zero, never a lone bridge). A pid far above the OS max is guaranteed not running. (#278)
+            const int deadPid = 2_000_000_000;
+            using var onGone = new CancellationTokenSource();
+            var watch = McpBridge.WatchProcessLivenessAsync(deadPid, onGone, pollMs: 20, onGone.Token);
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            while (!onGone.IsCancellationRequested && sw.Elapsed < System.TimeSpan.FromSeconds(2))
+                await Task.Delay(20);
+
+            Assert.True(onGone.IsCancellationRequested);
+            await watch;
+        }
+
+        [Fact]
+        public async Task Liveness_watcher_stays_quiet_while_the_process_is_alive()
+        {
+            // Our own process is alive -> the watcher must NOT trip. (#278)
+            using var onGone = new CancellationTokenSource();
+            var watch = McpBridge.WatchProcessLivenessAsync(
+                System.Environment.ProcessId, onGone, pollMs: 20, onGone.Token);
+
+            await Task.Delay(300);
+            Assert.False(onGone.IsCancellationRequested);
+
+            onGone.Cancel();   // stop the watcher
+            await watch;
+        }
 
         [Fact]
         public void McpClientConfig_emits_the_bridge_command_with_no_secrets()

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
@@ -35,6 +35,9 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         private const int LaunchPollAttempts = 90;
         private const int LaunchPollDelayMs = 500;   // ~45s total
 
+        // While attached, poll the GUI's liveness this often. When it dies, the bridge exits (see the watcher).
+        private const int AppLivenessPollMs = 1000;
+
         private const string NotReadyMessage =
             "CST Reader did not become ready for MCP. Make sure it is installed and that AI features are enabled " +
             "in CST Reader → Settings → AI. If it was just launched it may still be starting — try again in a moment.";
@@ -72,7 +75,57 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                 return;
             }
 
-            await RunAsync(clientSide, BuildHttpOptions(info), httpClient: null, ct).ConfigureAwait(false);
+            // Relay until stdin EOF OR the app's stream ends OR the app PROCESS goes away. The last is the key
+            // case: if the user closes/kills CST Reader, the bridge must NOT dangle as a backend-less process, and
+            // it must NOT resurrect a window the user deliberately closed. So it watches the GUI's pid and, when it
+            // dies (clean quit, crash, or kill -9 — hence pid, not the handshake file which a kill -9 leaves stale),
+            // tears the relay down and exits. Net: it's always zero or two processes, never a lone bridge. (#278)
+            using var appGoneCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            var watcher = info.Pid > 0
+                ? WatchProcessLivenessAsync(info.Pid, appGoneCts, AppLivenessPollMs, appGoneCts.Token)
+                : Task.CompletedTask;
+            try
+            {
+                await RunAsync(clientSide, BuildHttpOptions(info), httpClient: null, appGoneCts.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                appGoneCts.Cancel();                              // stop the watcher if the relay ended for another reason
+                try { await watcher.ConfigureAwait(false); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// Poll <paramref name="pid"/> (the attached CST Reader GUI, from <c>local-api.json</c>); when it is no
+        /// longer running, cancel <paramref name="onGone"/> so the relay unwinds and the bridge process exits.
+        /// Deliberately does NOT relaunch the app — a user closing it is authoritative. Checking the pid (not the
+        /// handshake file) catches every death: clean quit, crash, and <c>kill -9</c> (which leaves the file stale).
+        /// </summary>
+        internal static async Task WatchProcessLivenessAsync(
+            int pid, CancellationTokenSource onGone, int pollMs, CancellationToken ct)
+        {
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    if (!IsProcessAlive(pid))
+                    {
+                        Log.Information("--mcp-bridge: CST Reader (pid {Pid}) is gone; shutting the bridge down.", pid);
+                        onGone.Cancel();
+                        return;
+                    }
+                    await Task.Delay(pollMs, ct).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        /// <summary>True while a process with <paramref name="pid"/> exists. <see cref="Process.GetProcessById(int)"/>
+        /// throws <see cref="ArgumentException"/> when it doesn't — the canonical cross-platform liveness check.</summary>
+        private static bool IsProcessAlive(int pid)
+        {
+            try { using var _ = Process.GetProcessById(pid); return true; }
+            catch (ArgumentException) { return false; }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes the dangling-bridge state observed on Kestrel: Claude Desktop spawned the bridge → launch-or-attach brought up the GUI → the user **closed the GUI** → the bridge kept running as a backend-less orphan parked in stdin `read()`.

## The rule
Zero or two processes (nothing, or GUI + bridge), **never a lone bridge**. Going one→two — resurrecting a window the user deliberately closed — is the surprising move, so the fix is **one→zero**: the bridge tears itself down when its GUI is gone.

## What changed
While attached, the bridge polls the GUI's **pid** (from `local-api.json`) and, when it's gone, cancels the relay so the process exits.
- **PID, not the handshake file** — a `kill -9`/crash leaves `local-api.json` stale, so watching the file would miss a force-kill. The pid check catches clean quit, crash, and `kill -9` alike.
- **Never relaunches** — the user closing the app is authoritative; the bridge won't pop the window back open.
- Closes the **idle gap**: the active-call and stdin-EOF paths already unwound the relay, but an idle attached bridge never noticed its backend die. This adds that.

## Tests
- Watcher trips promptly for a non-running pid → the relay's token cancels (one→zero).
- Watcher stays quiet while the process is alive (our own pid).
- Full suite: **614 passed**.

## Deliberately out of scope (follow-up)
The **not-ready** path (GUI never came up at all) still *drains* rather than exits — the other lone-bridge state. Whether it should exit-after-erroring depends on how Claude Desktop treats a server that **exits** vs one that **hangs** — which is still **untested** (across Chat's whole session the bridge was always alive, so we have no data on the exit case). Holding that until the manual `kill <bridge PID>` test on real Desktop tells us whether Desktop respawns on exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)