### PR TITLE
#279: cap concurrent tool-call load on the loopback API (request limiter)

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -64,6 +64,20 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
+        public async Task Concurrent_tool_calls_all_succeed_under_the_limiter()
+        {
+            // #279: the concurrency cap must QUEUE excess tool-call POSTs, not reject them — a 503 would itself be
+            // the fatal one-error for a chat client. Fire well past the permit count at once; every one is 200.
+            using var http = _api.Http();
+            var tasks = Enumerable.Range(0, 32)
+                .Select(_ => http.PostAsync("/v1/search", Json("{\"query\":\"dhamma\"}")))
+                .ToArray();
+            var responses = await Task.WhenAll(tasks);
+            Assert.All(responses, r => Assert.Equal(HttpStatusCode.OK, r.StatusCode));
+            foreach (var r in responses) r.Dispose();
+        }
+
+        [Fact]
         public async Task Requires_the_bearer_token()
         {
             using var http = new HttpClient { BaseAddress = new System.Uri(_api.BaseUrl) };

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
+using System.Threading.RateLimiting;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -156,6 +157,27 @@ namespace CST.Avalonia.Services.LocalApi
                 mcp.WithResources(new[] { BuildLlmsResource() });
             }
 
+            // Concurrency cap (#279): the API runs IN-PROCESS with the Avalonia UI and Kestrel is otherwise
+            // unbounded, so a subagent fan-out (or Chat + Cowork + Code at once) can saturate the thread pool and
+            // starve the UI — and, because Claude Desktop is one-error-and-done, a single load-induced timeout
+            // permanently kills that client's session. Gate the heavy tool CALLS (POSTs to /v1 + /mcp) to
+            // ~ProcessorCount-1 concurrent and QUEUE the rest (FIFO). GETs — discovery, books, and the long-lived
+            // MCP SSE stream — are left unlimited so a stream can't hold a permit forever. Queue is deep because a
+            // 503 rejection would itself be the fatal one-error; we queue rather than reject under realistic load.
+            int toolPermits = Math.Max(1, Environment.ProcessorCount - 1);
+            builder.Services.AddRateLimiter(options =>
+            {
+                options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(ctx =>
+                    HttpMethods.IsPost(ctx.Request.Method)
+                        ? RateLimitPartition.GetConcurrencyLimiter("tool-calls", _ => new ConcurrencyLimiterOptions
+                        {
+                            PermitLimit = toolPermits,
+                            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                            QueueLimit = 1024,
+                        })
+                        : RateLimitPartition.GetNoLimiter<string>("unlimited"));
+            });
+
             var app = builder.Build();
 
             // Security gate: no browsers, loopback host only, valid bearer token.
@@ -180,6 +202,9 @@ namespace CST.Avalonia.Services.LocalApi
                 }
                 await next();
             });
+
+            // Apply the concurrency cap AFTER the security gate, so unauthorized requests never consume a permit.
+            app.UseRateLimiter();
 
             // Unauthenticated root pointer, so an agent that connects via local-api.json isn't left staring at
             // an empty "/" — it names where the docs and status live. (Cold-agent test finding.)


### PR DESCRIPTION
The API runs in-process with the Avalonia UI and Kestrel was otherwise **unbounded**. Under the three-harness concurrent run this bit for real: a Chat tool call got slow enough to time out, and because Claude Desktop is **one-error-and-done**, that single blip *permanently killed the Chat session* while Code/Cowork sailed on.

## Fix
An ASP.NET Core rate limiter (global `ConcurrencyLimiter`) that gates the heavy tool **CALLS** — POSTs to `/v1` and `/mcp` — to **~`ProcessorCount-1`** concurrent and **queues** the rest (FIFO):
- **GETs are unlimited** — discovery, `/v1/books`, and crucially the long-lived MCP **SSE stream**, so a stream can't hold a permit forever and self-starve.
- **Deep queue (1024), not a shallow one** — a `503` rejection would *itself* be the fatal one-error for a chat client, so under realistic fan-out we queue rather than reject.

## `BoundedCache` (the other #279 item) — verified, no change
Thread-safe by inspection: every `TryGet`/`Set`/`Clear`/`Count` is `lock`-guarded, and the check-then-act at the call sites is a benign same-key double-compute (identical result), not corruption.

## Not included — fast-follow: per-client fairness
The observed failure was one client (likely Code's fan-out) starving another. A global cap fixes the thread-pool **thrash** that made everything crawl, so waits become bounded — but it doesn't guarantee Chat isn't queued behind 50 of Code's requests. Round-robin / per-session headroom would close that; worth a follow-up given starvation is fatal here.

## Tests
- 32 concurrent `search` POSTs all return **200** (queued, not rejected).
- The existing `/mcp` relay + all endpoint tests still pass (SSE stream unaffected).
- Full suite green — the lone failure on a full run is the pre-existing timing-flaky `IndexingPerformanceTests` (passes in isolation, unrelated to this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)