### PR TITLE
#290: AI API doc clarifications from the multi-harness friction runs

### DIFF
--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -18,7 +18,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 
 - Pali output is ROMANIZED by DEFAULT. The romanized script token is `"Latin"` (IAST, with diacritics). Pass
   `outputScript` to override (e.g. "Devanagari", "Thai", "Myanmar", "Sinhala"); `GET /v1/scripts` lists every
-  valid value.
+  valid value. All scripts convert losslessly EXCEPT `Cyrillic`, a legacy transliteration with a known
+  non-reversibility (a revision is planned); its output is expected, not a conversion defect - do not report it.
 - Zero-width format chars in output (per script): DEVANAGARI embeds a zero-width JOINER (U+200D) after the
   virama in many consonant conjuncts; SINHALA embeds a zero-width NON-joiner (U+200C). Do NOT assume Devanagari
   uses U+200C - it does not. Strip BOTH U+200C and U+200D before comparing or matching strings.
@@ -44,6 +45,10 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   script-converted to your `outputScript`): `sya`=Thai (Syama), `si`=Sinhala, `kam`/`ka`=Cambodian, `pi`=PTS.
   These are digitized print footnotes - mostly variant readings, but also editorial notes and cross-refs, with
   NO structural type marker, so any "variant vs footnote" split is your interpretation, not the data's.
+  BODY vs APPARATUS: parenthetical `(...)` source citations (e.g. `(m. ni. 1.402)`) also occur in the BASE
+  TEXT itself - those are body content, ALWAYS present, and NOT gated by `includeFootnotes`; only braced
+  `{...}` apparatus is toggled. So identical `includeFootnotes` true/false output means "no `{...}` apparatus
+  here", NOT "no references" - the `(...)` you see may simply be inline citations in the running text.
   LAYER: apparatus lives almost entirely in MULA (root) texts; the ATTHAKATHA and TIKA (commentary /
   sub-commentary) layers carry NONE. So `includeFootnotes` on a commentary is always empty - expected,
   not a bug (and a commentary-restricted search will never surface variants).
@@ -76,7 +81,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   the default `Exact` mode those characters are LITERAL and match nothing (the response `note` flags this).
   PROXIMITY: a multi-word `query` (space-separated) plus `proximityDistance` finds those words co-occurring
   within N words; quote a run - `"a b"` - for an exact adjacent phrase; combine with `mode:"Wildcard"`/`"Regex"`
-  to expand each word before matching.
+  to expand each word before matching. ORDER MATTERS: `a b` and `b a` are SEPARATE co-occurrence forms with
+  their own counts - sum both orderings for an order-agnostic total.
   FILTER: `filter` is an object of booleans, all default true -
   `{ vinaya, sutta, abhidhamma, mula, atthakatha, tika, other }`. The pitaka flags (vinaya/sutta/abhidhamma)
   OR within their group, the text-class flags (mula/atthakatha/tika) OR within theirs, and those two groups
@@ -92,7 +98,10 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   full page can also be the last one; `hasMore` is the signal). No fixed upper bound on how far you can page.
   Terms come back in INDEX (ordinal) order, NOT by frequency, so a COMMON form can sit on a LATER page - to
   gather a stem's COMPLETE family you MUST page while `hasMore`; do not treat page 1 as the whole set.
-  Each term is `{ term, totalCount, bookCount, books }`. Per-term `totalCount`/`bookCount` are CORPUS-WIDE.
+  Each term is `{ term, totalCount, bookCount, books }`. Per-term `totalCount`/`bookCount` are the COMPLETE
+  counts across the SEARCHED SCOPE - corpus-wide with no filter, but NARROWED to the filtered subset when you
+  pass a `filter` (so you can read a term's per-Pitaka footprint by filtering). Distinct from the page-scoped
+  `returned*` roll-ups below.
   `books` (the per-book `{ bookId, bookName, count }` breakdown) is `null` unless you pass `includeBooks: true`
   (null = "not requested"; it is the bulk of the payload); `bookCount` (how many books the term is in) is
   ALWAYS present. A multi-word/phrase `term` comes back space-joined (e.g. `ekayano ayam`) - pass it verbatim to

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
@@ -40,7 +40,9 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             [Description("Script for the returned text.")]
             OutputScript outputScript = OutputScript.Latin,
             [Description("Include the print-edition footnotes (the braced {…} apparatus — variant readings, "
-                + "cross-references, editorial notes) in the text.")]
+                + "cross-references, editorial notes) in the text. ONLY the {…} apparatus is toggled — parenthetical "
+                + "(…) source citations in the body are always present; identical true/false output means no {…} "
+                + "apparatus here, not 'no references'. Apparatus lives almost only in MULA texts.")]
             bool includeFootnotes = false,
             CancellationToken ct = default)
         {

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/ScriptMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/ScriptMcpTool.cs
@@ -15,7 +15,9 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
     {
         [McpServerTool(Name = "convert")]
         [Description("Transliterate Pali text to another script. The input script is auto-detected (mixed-script "
-            + "input is handled), so you only name the desired output.")]
+            + "input is handled), so you only name the desired output. All scripts convert losslessly EXCEPT "
+            + "Cyrillic, a legacy transliteration with a known non-reversibility (revision planned) — its output "
+            + "is expected, not a defect.")]
         public static ConvertResult Convert(
             IScriptTool script,
             [Description("The Pali text to convert (any script; auto-detected).")]

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -34,7 +34,10 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             ISearchTool search,
             [Description("The word or pattern to search for, in any script (romanized Latin accepted).")]
             string query,
-            [Description("How to interpret the query. Exact = exact inflected form; Wildcard = * (any run) and ? (one char); Regex.")]
+            [Description("How to interpret the query. Exact = exact inflected form; Wildcard = * (any run, a "
+                + "prefix match) and ? (one char); Regex = .NET regex matched ANYWHERE in a term-form (substring) "
+                + "— anchor with ^…$ to match the whole form, e.g. ^pañña.{0,3}$ (unanchored sweeps in compounds "
+                + "and homographs like paññāsa='fifty').")]
             SearchToolMode mode = SearchToolMode.Exact,
             [Description("Page size: how many matching term-forms to return per page. No fixed ceiling; page with skip.")]
             int maxTerms = 100,
@@ -44,11 +47,15 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             bool includeBooks = false,
             [Description("How many matching term-forms to skip (paging). Re-request with skip += maxTerms while hasMore is true.")]
             int skip = 0,
-            [Description("Restrict the search to parts of the corpus. Pitaka flags (vinaya/sutta/abhidhamma) OR "
-                + "within their group; text-class flags (mula/atthakatha/tika) OR within theirs; the two groups "
-                + "AND together. E.g. commentaries-only = { mula:false, atthakatha:true, tika:true, other:false }. Omit for the whole corpus.")]
+            [Description("Restrict the search to parts of the corpus. ALL flags default TRUE. Pitaka flags "
+                + "(vinaya/sutta/abhidhamma) OR within their group; text-class flags (mula/atthakatha/tika) OR "
+                + "within theirs; the two groups AND together. All-false in a group means NO constraint from that "
+                + "group (not 'exclude all'), so set the flags you WANT. 'other' is separate + additive (unions the "
+                + "non-canonical books). Commentaries-only = { mula:false, atthakatha:true, tika:true, other:false }; "
+                + "to isolate ONLY 'other', set every other flag false. Omit for the whole corpus.")]
             ToolBookFilter? filter = null,
-            [Description("For a multi-word/proximity query, the co-occurrence window in words (default 10).")]
+            [Description("For a multi-word/proximity query, the co-occurrence window in words (default 10). Order "
+                + "matters: 'a b' and 'b a' are separate forms with separate counts.")]
             int proximityDistance = 10,
             CancellationToken ct = default)
         {
@@ -79,7 +86,8 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             string bookId,
             [Description("The term to locate in context, in any script (e.g. a term from a prior 'search').")]
             string term,
-            [Description("How to interpret the term: Exact, Wildcard (* and ?), or Regex (expands per word).")]
+            [Description("How to interpret the term: Exact, Wildcard (* and ?), or Regex — matched ANYWHERE in a "
+                + "term-form (substring); anchor with ^…$ to match the whole form.")]
             SearchToolMode mode = SearchToolMode.Exact,
             [Description("Script for the returned snippet text.")]
             OutputScript outputScript = OutputScript.Latin,
@@ -88,7 +96,10 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             [Description("How many occurrences to return.")]
             int take = 50,
             [Description("Include the print-edition footnotes (the braced {…} apparatus — variant readings, "
-                + "cross-references, editorial notes) in the snippet.")]
+                + "cross-references, editorial notes) in the snippet. ONLY the {…} apparatus is toggled — "
+                + "parenthetical (…) source citations in the body text are always present; identical true/false "
+                + "output means no {…} apparatus here, not 'no references'. Apparatus lives almost only in MULA "
+                + "texts; commentaries carry ~none.")]
             bool includeFootnotes = false,
             [Description("For a multi-word/proximity term, the co-occurrence window in words (default 10).")]
             int proximityDistance = 10,

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -82,7 +82,8 @@ namespace CST.Tools
     /// <param name="ReturnedTermCount">How many matching term-forms are IN THIS PAGE (= <c>Terms.Count</c>), NOT
     /// the corpus-wide match count. Use <c>HasMore</c> to page; there is no cheap whole-result term total.</param>
     /// <param name="ReturnedOccurrenceCount">Sum of <c>TotalCount</c> over the terms IN THIS PAGE (not the whole
-    /// result set). Per-term <c>TotalCount</c> is corpus-wide; this page sum is not.</param>
+    /// result set). Per-term <c>TotalCount</c> is the complete count across the searched scope (corpus-wide when
+    /// unfiltered, narrowed to the filter when one is applied); this page sum is not.</param>
     /// <param name="ReturnedBookCount">Distinct books over the terms IN THIS PAGE. <b>Null when
     /// <c>IncludeBooks</c> is false</b> — the counts-only fast path does not enumerate books, so the union is
     /// unavailable and reported as null (not a misleading 0). Per-term <c>BookCount</c> is always present.</param>


### PR DESCRIPTION
Doc-only. Closes #290. Every item was verified against source as **correct behavior the docs didn't explain** (or, for `totalCount`, actively mis-stated). `llms.txt` was already strong on the filter model, regex-unanchored, and hasMore/truncated — so the real work was the one wording bug plus mirroring the traps into the **terse MCP tool `[Description]`s** that the tool-using harnesses (Cowork/Chat) actually read (Code read `llms.txt` directly).

## Changes
- **`totalCount`/`bookCount` scope (the one real fix):** "CORPUS-WIDE" is wrong under a `filter` — they narrow to the filtered subset. Reworded in `llms.txt` + `SearchToolContracts` to "complete count across the *searched scope* (narrows with a filter)."
- **Regex is unanchored substring matching:** added to the `mode` `[Description]`s (search + occurrences) — anchor with `^…$`; unanchored sweeps in compounds/homographs (`paññāsa`="fifty"). (Already in `llms.txt`.)
- **Filter model:** the search `filter` `[Description]` now spells out all-default-`true`, all-false-in-a-group = *no constraint*, `other` additive, and the isolate-only-Other recipe — Cowork's §B footgun.
- **Apparatus `{…}` vs body `(…)` cross-refs:** `llms.txt` + both `includeFootnotes` `[Description]`s now state parenthetical body citations are always present and **not** toggled; identical true/false output means "no `{…}` here," not "no references." (All three harnesses tripped on this.)
- **Proximity is order-sensitive:** `a b` ≠ `b a`; noted in `llms.txt` + the `proximityDistance` `[Description]`.
- **Cyrillic:** `llms.txt` + the `convert` `[Description]` note it's the one non-lossless legacy transliteration (revision planned) — expected output, not a defect, so agents stop false-flagging it. Myanmar gets no note (it's just correct Unicode).

## Tests
No behavior change; full suite **615 passed**. (`llms.txt` serving tests only assert the endpoint list / auth handshake / version stamp — untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)