### PR TITLE
#292: drop stray space before punctuation from stripped inline tags

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -41,6 +41,24 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void ReadWindow_drops_the_space_a_stripped_inline_tag_leaves_before_punctuation()
+        {
+            // A page-break tag sits between a word and its comma; stripping it must not leave "alpha ," (#292).
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<pb ed=\"V\" n=\"1.0001\"/>" +
+                "<p rend=\"bodytext\" n=\"5\">alpha<pb ed=\"V\" n=\"1.0002\"/>, bravo charlie\u0964</p>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(xml);
+            int start = markers.PositionOfParagraph(5);
+            var w = TeiPassageReader.ReadWindow(xml, start, maxChars: 200, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("alpha,", w.Text);        // punctuation hugs the word...
+            Assert.DoesNotContain("alpha ,", w.Text);  // ...no stray space from the stripped <pb/>
+        }
+
+        [Fact]
         public void ReadWindow_wraps_included_notes_in_braces()
         {
             const string xml =

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -65,10 +65,23 @@ namespace CST.Search
                         i = gt + 1;
                     }
                 }
-                else { sb.Append(c); i++; }
+                else
+                {
+                    // A stripped inline tag (page break, dot-hi, a not-included note) — or a stray space in the
+                    // source — can leave a space in front of clause/sentence punctuation (e.g. "…upaneti ,").
+                    // That punctuation should hug the preceding word, so drop the dangling space. (#292)
+                    if (IsClosePunctuation(c) && sb.Length > 0 && sb[sb.Length - 1] == ' ')
+                        sb.Length--;
+                    sb.Append(c);
+                    i++;
+                }
             }
             return sb.ToString();
         }
+
+        // Punctuation that should sit directly after the preceding word (no space before it).
+        private static bool IsClosePunctuation(char c) =>
+            c == ',' || c == ';' || c == '.' || c == '!' || c == '?' || c == Danda || c == DoubleDanda;
 
         internal static List<(int s, int e)> NoteRegions(string xml, int lo, int hi)
         {


### PR DESCRIPTION
`/v1/passage` (and snippets) returned `…उपनेति ,` — a space wedged between a word and its comma (Cowork §C).

## Cause
`TeiText.Clean` inserts a space whenever it strips a **generic inline tag** — e.g. a `<pb/>` page break sitting between the word and the comma → `alpha<pb/>,` becomes `alpha ,`. `Collapse` only squashes whitespace *runs*, so the lone space survived in front of the punctuation.

## Fix
In `Clean` (so both the passage and snippet paths benefit): before appending clause/sentence punctuation ( `,` `;` `.` `!` `?` danda U+0964, double-danda U+0965 ), drop a dangling space so the punctuation hugs the preceding word. Also cleans up the rarer case of a stray source space before punctuation.

Not dropped footnotes — the stripped element is a non-note inline tag; the report's `includeFootnotes` true/false being identical in that region confirmed there's no `{…}` apparatus there (#293 tracks the has-apparatus signal).

## Test
A `<pb/>` between `alpha` and its comma now yields `alpha,` not `alpha ,`. Full suite **616 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)