### PR TITLE
#289: single-instance guard — one CST Reader GUI per data directory

### DIFF
--- a/src/CST.Avalonia.Tests/Services/SingleInstanceGuardTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SingleInstanceGuardTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using CST.Avalonia;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services
+{
+    /// <summary>
+    /// #289: one CST Reader per data directory. The lock lives in the data dir (not the bundle), releases on
+    /// process death, and is exposed here via <see cref="SingleInstanceGuard.TryOpenLock"/> so a second holder
+    /// can be exercised in-process.
+    /// </summary>
+    public class SingleInstanceGuardTests
+    {
+        [Fact]
+        public void Only_one_holder_of_the_data_dir_lock_and_it_frees_on_release()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cst-lock-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                var first = SingleInstanceGuard.TryOpenLock(dir);
+                Assert.NotNull(first);                                 // this "instance" acquires
+
+                Assert.Null(SingleInstanceGuard.TryOpenLock(dir));     // a second is blocked while the first holds it
+
+                first!.Dispose();                                      // release (process death frees it the same way)
+
+                var third = SingleInstanceGuard.TryOpenLock(dir);
+                Assert.NotNull(third);                                 // available again once released
+                third!.Dispose();
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        }
+    }
+}

--- a/src/CST.Avalonia/Program.cs
+++ b/src/CST.Avalonia/Program.cs
@@ -94,6 +94,19 @@ sealed class Program
                 return;
             }
 
+            // Single-instance guard (#289): only one GUI per data directory. The --mcp-bridge relay and the CLI
+            // utility flags above have already returned, so this gates only a real GUI launch. Two instances would
+            // clobber the shared settings / app-state / index and race on local-api.json.
+            var appDataDir = System.IO.Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                CST.Avalonia.Constants.AppConstants.AppDataDirectoryName);
+            if (!SingleInstanceGuard.TryAcquire(appDataDir))
+            {
+                _logger.Information("Another CST Reader instance already owns {Dir}; activating it and exiting.", appDataDir);
+                SingleInstanceGuard.ActivateRunningInstance();
+                return;
+            }
+
             // Build the Avalonia app without starting it yet
             var app = BuildAvaloniaApp();
 

--- a/src/CST.Avalonia/SingleInstanceGuard.cs
+++ b/src/CST.Avalonia/SingleInstanceGuard.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace CST.Avalonia
+{
+    /// <summary>
+    /// #289: ensure only ONE CST Reader GUI runs against a given data directory. Two instances would clobber the
+    /// shared settings / app-state / Lucene index and race on <c>local-api.json</c>. The lock is a file in the
+    /// DATA DIRECTORY (not the bundle), so it also blocks two copies installed at different paths — the
+    /// granularity is one instance per data directory (a future configurable data dir would coexist, correctly).
+    /// The OS releases the lock when the process dies — crash and <c>kill -9</c> included — so there is no
+    /// stale-lock failure mode. The <c>--mcp-bridge</c> relay and the CLI utility flags never reach this (they
+    /// return earlier in <see cref="Program.Main"/>). Bypass for development with <c>CST_ALLOW_MULTIPLE=1</c>.
+    /// </summary>
+    internal static class SingleInstanceGuard
+    {
+        internal const string LockFileName = "instance.lock";
+
+        // Held for the process lifetime; closing it (or the process dying) releases the lock.
+        private static FileStream? _held;
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int flock(int fd, int operation);
+        private const int LOCK_EX = 2, LOCK_NB = 4;
+
+        /// <summary>True if this process became THE instance for <paramref name="dataDirectory"/> (or the guard is
+        /// bypassed via <c>CST_ALLOW_MULTIPLE=1</c>); false if another instance already holds the lock.</summary>
+        public static bool TryAcquire(string dataDirectory)
+        {
+            if (Environment.GetEnvironmentVariable("CST_ALLOW_MULTIPLE") == "1")
+                return true;
+
+            var held = TryOpenLock(dataDirectory);
+            if (held is null) return false;
+            _held = held;   // keep the handle (and thus the lock) alive for the process lifetime
+            return true;
+        }
+
+        /// <summary>
+        /// Open the per-data-dir lock file exclusively; null if another holder has it. Uses <c>FileShare.None</c>
+        /// (authoritative on Windows) plus an explicit advisory <c>flock</c> on Unix, where .NET's FileShare
+        /// enforcement is unreliable for cross-process locking. Exposed for tests.
+        /// </summary>
+        internal static FileStream? TryOpenLock(string dataDirectory)
+        {
+            FileStream fs;
+            try
+            {
+                Directory.CreateDirectory(dataDirectory);
+                var path = Path.Combine(dataDirectory, LockFileName);
+                fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch (IOException)
+            {
+                return null;   // already held where FileShare.None is enforced (e.g. Windows)
+            }
+
+            if (!OperatingSystem.IsWindows())
+            {
+                int fd = (int)fs.SafeFileHandle.DangerousGetHandle();
+                if (flock(fd, LOCK_EX | LOCK_NB) != 0)
+                {
+                    fs.Dispose();
+                    return null;   // another instance holds the advisory lock
+                }
+            }
+            return fs;
+        }
+
+        /// <summary>Best-effort: bring the already-running instance to the foreground (macOS <c>open</c> the
+        /// enclosing <c>.app</c> bundle, which LaunchServices activates rather than relaunching). No-op in dev /
+        /// outside a bundle, so it can never spawn a second GUI.</summary>
+        public static void ActivateRunningInstance()
+        {
+            if (!OperatingSystem.IsMacOS()) return;
+            try
+            {
+                var dir = Path.GetDirectoryName(Environment.ProcessPath);
+                while (!string.IsNullOrEmpty(dir) && !dir.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
+                    dir = Path.GetDirectoryName(dir);
+                if (string.IsNullOrEmpty(dir)) return;
+
+                var psi = new ProcessStartInfo("open") { UseShellExecute = false };
+                psi.ArgumentList.Add(dir);
+                using var _ = Process.Start(psi);
+            }
+            catch { /* best effort */ }
+        }
+    }
+}


### PR DESCRIPTION
Two GUI instances sharing `~/Library/Application Support/CSTReader` would clobber `settings.json` / app-state / the **Lucene index** and race on `local-api.json` (a second instance overwrites the first's port/token/pid, so the `--mcp-bridge` relay and its pid-watcher would follow the wrong process). macOS LaunchServices single-instances a *normal* launch, but not direct-binary launches, `dotnet run`, or **two bundle copies at different paths**.

## Guard
An **OS file lock in the DATA DIRECTORY** (not the bundle — so it also blocks two copies at different paths; the granularity is *one instance per data directory*, and a future configurable data dir would coexist correctly).
- **`FileShare.None`** (authoritative on Windows) **plus an explicit advisory `flock`** on Unix, where .NET's FileShare enforcement is unreliable for cross-process locking.
- **Auto-released on process death** — crash and `kill -9` included — so there's no stale-lock failure mode (the reason a bare pid-file would be wrong here).
- Checked in `Program.Main` **after** the CLI short-circuits, so `--mcp-bridge` and the utility flags are exempt.
- A blocked second launch **activates the running instance** (`open` the bundle — LaunchServices brings it forward, never relaunches, so no cascade) and exits.
- **Dev bypass:** `CST_ALLOW_MULTIPLE=1`.

## Tests
A second `TryOpenLock` on the same dir is blocked while the first is held, and succeeds again after release (validates the `flock` exclusion in-process). Full suite **617 passed**.

## Worth a manual check on a signed build (kestrel)
Runtime behavior only reproducible outside the test harness: (1) normal launch still works; (2) a second **direct-binary** launch is blocked and brings the first window forward; (3) `CST_ALLOW_MULTIPLE=1` lets two run. The in-process test confirms the lock mechanics but not the LaunchServices activation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)