### PR TITLE
#291: make the books `indexed` flag accurate (warm the DocId map at API start)

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -78,6 +78,19 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
+        public async Task Books_report_indexed_true_after_the_server_maps_the_index()
+        {
+            // #291: BookIndexer doesn't set DocIds; they used to sync lazily on the FIRST search, so `books`
+            // called before any search reported indexed:false for searchable books. The server now warms the
+            // DocId map at startup, so `indexed` is truthful up front.
+            using var http = _api.Http();
+            using var doc = await GetDoc(http, "/v1/books?take=250");
+            var mula = doc.RootElement.GetProperty("books").EnumerateArray()
+                .First(b => b.GetProperty("bookId").GetString() == _api.MulaBook);
+            Assert.True(mula.GetProperty("indexed").GetBoolean());
+        }
+
+        [Fact]
         public async Task Requires_the_bearer_token()
         {
             using var http = new HttpClient { BaseAddress = new System.Uri(_api.BaseUrl) };

--- a/src/CST.Avalonia/Services/ISearchService.cs
+++ b/src/CST.Avalonia/Services/ISearchService.cs
@@ -22,4 +22,11 @@ public interface ISearchService
     /// </summary>
     Task<List<List<TermPosition>>> GetMultiWordPositionsAsync(
         string bookFileName, string query, SearchMode mode, int proximityDistance, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sync the index→catalog DocId map now, instead of lazily on the first search, so the <c>books</c> catalog's
+    /// <c>indexed</c> flag is accurate up front (#291). Best-effort and idempotent; a no-op if the index isn't
+    /// configured/ready yet (DocIds then still sync on the first search).
+    /// </summary>
+    void EnsureIndexMapped();
 }

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -234,6 +234,10 @@ namespace CST.Avalonia.Services.LocalApi
             Token = token;
             BaseUrl = $"http://127.0.0.1:{port}";
 
+            // Warm the index→catalog DocId map now, so the `books` catalog's `indexed` flag is truthful before
+            // any search runs (otherwise it lazily syncs on the first search). Best-effort. (#291)
+            _search?.EnsureIndexMapped();
+
             new LocalApiInfo(port, token, Environment.ProcessId).Write(_handshakeDirectory);
             _logger.Information("Local API listening on {BaseUrl} (rest={Rest}, mcp={Mcp})",
                 BaseUrl, _restApiEnabled, _mcpEnabled);

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -1102,6 +1102,26 @@ public class SearchService : ISearchService
         }
     }
 
+    /// <inheritdoc />
+    public void EnsureIndexMapped()
+    {
+        DirectoryReader? reader = null;
+        try
+        {
+            reader = AcquireReader();
+            EnsureDocIds(reader, Books.Inst);   // same sync the first search does, just without a search (#291)
+        }
+        catch (Exception ex)
+        {
+            // Index not configured/ready yet — DocIds will sync on the first search instead.
+            _logger.LogDebug(ex, "EnsureIndexMapped: index not ready; DocIds will sync on first search.");
+        }
+        finally
+        {
+            reader?.DecRef();
+        }
+    }
+
     private string ConvertToDisplayScript(string ipeTerm)
     {
         _logger.LogDebug("Converting term to display script: {IpeTerm}", ipeTerm);

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -31,6 +31,9 @@ namespace CST.Avalonia.Services.Tools
             _settings = settings;
         }
 
+        /// <inheritdoc />
+        public void EnsureIndexMapped() => _search.EnsureIndexMapped();
+
         public async Task<SearchToolResult> SearchAsync(SearchToolRequest request, CancellationToken ct = default)
         {
             var query = new SearchQuery

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -31,6 +31,14 @@ namespace CST.Tools
         /// both the agent loop (scan → cite/fetch) and the human concordance panel.
         /// </summary>
         Task<OccurrenceResult> GetOccurrencesAsync(OccurrenceRequest request, CancellationToken ct = default);
+
+        /// <summary>
+        /// Eagerly map the index to the catalog (DocIds), so the <c>books</c> catalog's <c>indexed</c> flag is
+        /// truthful before any search runs. Otherwise DocIds sync lazily on the first search, and a books call
+        /// before that reports <c>indexed:false</c> for books that are in fact searchable (#291). Best-effort +
+        /// idempotent; a no-op if the index isn't ready yet.
+        /// </summary>
+        void EnsureIndexMapped();
     }
 
     /// <summary>How the query text is interpreted.</summary>


### PR DESCRIPTION
`GET /v1/books` reported `"indexed": false` for books that search fine — the report saw all 25 Abhidhamma books as `indexed:false` while they returned thousands of hits.

## Cause
`indexed` is derived from `b.DocId >= 0` (`BookCatalog.cs:34`), but **`BookIndexer` never sets DocIds** — they sync *lazily on the first search* (`EnsureDocIds`, once per reader generation). So `books` called before any search sees `DocId == -1` everywhere → `indexed:false`, even though the books are indexed and searchable.

## Fix
The API server **warms the index→catalog DocId map when it starts**, via a new `ISearchService.EnsureIndexMapped()` — the same `AcquireReader` + `EnsureDocIds` the search path runs, just without a search (best-effort, idempotent, a no-op if the index isn't ready). `LocalApiServer.StartAsync` calls it, so `indexed` is truthful before the first search for both `/v1/books` and the MCP `books` tool (they read the shared global catalog).

## DocIds stay internal
Only the derived boolean `indexed` is exposed — the DocId value itself (an **unstable Lucene index position** that changes on rebuild) never reaches the API/MCP. The stable public ids remain the `bookId` filename and the char-offset `cursor`.

## Test
`/v1/books` reports `indexed:true` for the fixture book on a fresh server with **no prior search** — and since `BookIndexer` doesn't set DocIds, only the warm-up could have. Full suite **618 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)