### PR TITLE
#293: apparatus-presence signal — noteCount on occurrences + passage

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -73,6 +73,7 @@ namespace CST.Avalonia.Tests.Search
                 outputScript: Script.Devanagari, markers);
             Assert.DoesNotContain("VAR", off.Text);   // note stripped by default
             Assert.DoesNotContain("{", off.Text);
+            Assert.Equal(1, off.NoteCount);            // ...but noteCount reports it's there (#293)
 
             var on = TeiPassageReader.ReadWindow(xml, start, maxChars: 10000, includeVariants: true,
                 outputScript: Script.Devanagari, markers);
@@ -80,6 +81,7 @@ namespace CST.Avalonia.Tests.Search
             int close = on.Text.IndexOf('}');
             Assert.True(open >= 0 && close > open, "note should be wrapped in { }");
             Assert.Contains("VAR", on.Text.Substring(open, close - open));
+            Assert.Equal(1, on.NoteCount);             // same count whether or not it's rendered
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -229,6 +229,50 @@ namespace CST.Avalonia.Tests.Tools
         }
 
         [Fact]
+        public async Task GetOccurrencesAsync_reports_noteCount_regardless_of_includeFootnotes()
+        {
+            // #293: an agent must be able to tell "this hit HAS apparatus" without a second call — noteCount is
+            // the count of {…} notes in the window, computed from the raw XML whether or not they're rendered.
+            var dir = Path.Combine(Path.GetTempPath(), "cst-occ-note-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                const string book = "s0101m.mul.xml";
+                string xml =
+                    "<body><div id=\"dn1\" type=\"book\">" +
+                    "<pb ed=\"V\" n=\"1.0003\"/>" +
+                    "<p rend=\"bodytext\" n=\"12\">aaa\u0964 ccc TARGET <note>VAR (si)</note> ddd\u0964 eee\u0964</p>" +
+                    "</div></body>";
+                await File.WriteAllTextAsync(Path.Combine(dir, book), xml, Encoding.Unicode);
+
+                int hit = xml.IndexOf("TARGET", StringComparison.Ordinal);
+                var search = new Mock<ISearchService>();
+                search.Setup(s => s.GetTermPositionsAsync(book, "tgt", It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new List<TermPosition>
+                    {
+                        new TermPosition { StartOffset = hit, EndOffset = hit + 6, IsFirstTerm = true, Word = "tgt" }
+                    });
+                var tool = new SearchTool(search.Object, Settings(dir));
+
+                var without = await tool.GetOccurrencesAsync(
+                    new OccurrenceRequest(book, "tgt", IncludeFootnotes: false, OutputScript: Script.Devanagari, MinChars: 1));
+                var with = await tool.GetOccurrencesAsync(
+                    new OccurrenceRequest(book, "tgt", IncludeFootnotes: true, OutputScript: Script.Devanagari, MinChars: 1));
+
+                var o1 = Assert.Single(without.Occurrences);
+                var o2 = Assert.Single(with.Occurrences);
+                Assert.Equal(1, o1.NoteCount);              // apparatus present even though NOT rendered...
+                Assert.Equal(1, o2.NoteCount);              // ...and the same when it IS rendered
+                Assert.DoesNotContain("VAR", o1.Snippet);   // stripped when off
+                Assert.Contains("VAR", o2.Snippet);         // shown when on
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
         public async Task GetOccurrencesAsync_multiword_marks_each_cooccurring_word()
         {
             var dir = Path.Combine(Path.GetTempPath(), "cst-occ-mw-" + Guid.NewGuid().ToString("N"));

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -126,7 +126,11 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   is the RAW hit count before co-located hits (multiple in one sentence) are merged into a single record with
   multiple `highlights`. For a single term `instanceTotal` equals that term's per-book `count` from `/v1/search`,
   so `total < instanceTotal` means hits were FOLDED into records, not dropped. Each occurrence is
-  `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedFootnotes, cursor, highlights }`. `snippet` is hit-centered; `highlights` is the ordered set of marked spans in SNIPPET-LOCAL
+  `{ bookId, bookName, snippet, hitStart, hitLength, refs, includedFootnotes, cursor, highlights, noteCount }`.
+  `noteCount` is how many `{...}` apparatus notes fall in this snippet's window, counted REGARDLESS of
+  `includeFootnotes` - so `noteCount > 0` tells you this hit HAS variants/notes (re-read with
+  `includeFootnotes:true`, or via `/v1/passage`, to see them) WITHOUT a second probe call; `0` means none here.
+  `snippet` is hit-centered; `highlights` is the ordered set of marked spans in SNIPPET-LOCAL
   offsets - `[{ start, length, isAnchor }]`: a single-term hit has one, a proximity/phrase hit has one PER
   co-occurring word with exactly one `isAnchor:true` (the navigable word; the rest are the co-occurring
   context). `hitStart`/`hitLength` mirror the anchor. All snippet offsets (`hitStart`/`hitLength`/`highlights`)
@@ -143,7 +147,9 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   variant readings were rendered), NOT whether this particular hit has any; see the apparatus note above.
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
   Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeFootnotes? }`.
-  Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, ... }`. Page by passing back the
+  Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, noteCount, ... }` - `noteCount` is how
+  many `{...}` apparatus notes fall in the window (counted regardless of `includeFootnotes`; `>0` = apparatus
+  present here). Page by passing back the
   integer `prevCursor` / `nextCursor` as `cursor` (see the cursor note above). A `cursor` (from occurrences or
   passage) reads the ENCLOSING SENTENCE: the window start is snapped back so you get the governing clause, not a
   mid-sentence fragment. `maxChars` is a SOFT budget - the window OVERSHOOTS to the next sentence boundary, so

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
@@ -21,7 +21,9 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             + "page forward. Both ends snap to sentence boundaries: a cursor (which points AT a hit) is pulled "
             + "back to the start of its enclosing sentence, and the window extends to the next sentence end — so "
             + "the hit is read with its full governing clause, never mid-sentence. Use the returned "
-            + "nextCursor/prevCursor to page. With neither paragraph nor cursor, reads from the book start.")]
+            + "nextCursor/prevCursor to page. With neither paragraph nor cursor, reads from the book start. "
+            + "'noteCount' is how many {…} apparatus notes fall in the window (counted regardless of "
+            + "includeFootnotes) — noteCount>0 means apparatus is present here.")]
         public static async Task<PassageResult> PassageAsync(
             IPassageTool passage,
             [Description("The book's id (file name), e.g. from the 'books' tool or a search result.")]

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -79,7 +79,10 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             + "window; a quoted run is an adjacent phrase. COUNTS: 'total' is the number of snippet RECORDS you "
             + "page over (Skip/Take are against it); co-located hits in one sentence merge into one record with "
             + "multiple highlights, so 'total' can be less than 'instanceTotal' (the raw hit count, which matches "
-            + "search's per-book 'count'). total < instanceTotal means folded hits, NOT dropped hits.")]
+            + "search's per-book 'count'). total < instanceTotal means folded hits, NOT dropped hits. Each "
+            + "occurrence's 'noteCount' is how many {…} apparatus notes (variant readings / editorial notes) fall "
+            + "in its window, counted regardless of includeFootnotes — noteCount>0 means this hit HAS apparatus "
+            + "(re-read with includeFootnotes:true to see it), so you needn't fetch twice to check.")]
         public static async Task<OccurrenceResult> OccurrencesAsync(
             ISearchTool search,
             [Description("The book's id (file name), e.g. from a search result's per-book breakdown or the 'books' tool.")]

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -52,7 +52,8 @@ namespace CST.Avalonia.Services.Tools
                 ParagraphNumber: w.ParagraphNumber,
                 ParagraphBookCode: w.ParagraphBookCode,
                 PrevCursor: w.PrevCursor,
-                NextCursor: w.NextCursor);
+                NextCursor: w.NextCursor,
+                NoteCount: w.NoteCount);
         }
 
         private static int ResolveStart(NavigationReference? reference, BookMarkers markers) => reference switch
@@ -69,6 +70,6 @@ namespace CST.Avalonia.Services.Tools
             : $"paragraph {number} ({bookCode})";
 
         private static PassageResult Empty(PassageRequest request, string note) =>
-            new(request.BookId, note, "", Array.Empty<SnippetPageRef>(), null, null, null, null);
+            new(request.BookId, note, "", Array.Empty<SnippetPageRef>(), null, null, null, null, 0);
     }
 }

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -181,7 +181,8 @@ namespace CST.Avalonia.Services.Tools
                     // (paragraph numbers repeat within a book). (#186 cold test)
                     Cursor: AnchorStart(marks),
                     Highlights: s.Highlights
-                        .Select(h => new OccurrenceHighlight(h.Start, h.Length, h.IsAnchor)).ToList()));
+                        .Select(h => new OccurrenceHighlight(h.Start, h.Length, h.IsAnchor)).ToList(),
+                    NoteCount: s.NoteCount));
             }
             // Envelope (like search): book-scoped totals + hasMore, so an agent paging occurrences isn't blind.
             // Total is the MERGED record count (what you actually page over); InstanceTotal is the raw pre-merge

--- a/src/CST.Core/Search/SnippetModels.cs
+++ b/src/CST.Core/Search/SnippetModels.cs
@@ -49,5 +49,6 @@ namespace CST.Search
         string? ParagraphBookCode,
         IReadOnlyList<SnippetPageRef> Pages,
         bool IncludedFootnotes,
-        IReadOnlyList<SnippetHighlight> Highlights);
+        IReadOnlyList<SnippetHighlight> Highlights,
+        int NoteCount);
 }

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -46,8 +46,11 @@ namespace CST.Search
             int prevStart = WalkBackward(xml, readStart, maxChars, 0);
             int? prev = prevStart < readStart ? prevStart : (int?)null;
 
+            // Apparatus notes ({…}) in this window — counted from the raw XML regardless of includeVariants, so a
+            // caller knows whether apparatus exists here without a second call. (#293)
+            int noteCount = TeiText.NoteRegions(xml, readStart, end).Count;
             var (num, code, pages) = markers.RefsAt(readStart);
-            return new PassageWindow(text, prev, next, num, code, pages);
+            return new PassageWindow(text, prev, next, num, code, pages, noteCount);
         }
 
         // The nearest sentence start at or after <paramref name="minStart"/> and at/before <paramref name="startPos"/>
@@ -143,5 +146,6 @@ namespace CST.Search
         int? NextCursor,
         int? ParagraphNumber,
         string? ParagraphBookCode,
-        IReadOnlyList<SnippetPageRef> Pages);
+        IReadOnlyList<SnippetPageRef> Pages,
+        int NoteCount);
 }

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -92,8 +92,11 @@ namespace CST.Search
 
             var (num, code, pages) = markers.RefsAt(anchor.Start);
             var anchorHl = highlights.FirstOrDefault(h => h.IsAnchor) ?? highlights[0];
+            // Apparatus notes ({…}) in this window — counted from the raw XML regardless of IncludeFootnotes, so a
+            // caller can tell "no apparatus here" from "apparatus suppressed" without a second call. (#293)
+            int noteCount = TeiText.NoteRegions(xml, winStart, winEnd).Count;
             return new SnippetResult(
-                sb.ToString(), anchorHl.Start, anchorHl.Length, num, code, pages, opts.IncludeFootnotes, highlights);
+                sb.ToString(), anchorHl.Start, anchorHl.Length, num, code, pages, opts.IncludeFootnotes, highlights, noteCount);
         }
 
         /// <summary>

--- a/src/CST.Core/Tools/PassageToolContracts.cs
+++ b/src/CST.Core/Tools/PassageToolContracts.cs
@@ -42,6 +42,9 @@ namespace CST.Tools
     /// <param name="NormalizedReference">Short human-readable reference at the window start (e.g. "paragraph 123 (an5)").</param>
     /// <param name="Text">The passage text in the requested script.</param>
     /// <param name="Pages">The per-edition page(s) at the window start, for citation.</param>
+    /// <param name="NoteCount">How many print-edition apparatus notes (<c>{…}</c>) fall in this window. Counted
+    /// regardless of <c>IncludeFootnotes</c>, so <c>NoteCount &gt; 0</c> means apparatus is present here (re-read
+    /// with <c>includeFootnotes:true</c> to see it). Apparatus lives almost only in MULA texts.</param>
     public sealed record PassageResult(
         string BookId,
         string NormalizedReference,
@@ -50,5 +53,6 @@ namespace CST.Tools
         int? ParagraphNumber,
         string? ParagraphBookCode,
         int? PrevCursor,
-        int? NextCursor);
+        int? NextCursor,
+        int NoteCount);
 }

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -167,6 +167,11 @@ namespace CST.Tools
     /// <param name="Cursor">The anchor's unique locator — pass it to <c>/v1/passage</c> as <c>cursor</c> to read
     /// the exact passage around <em>this</em> occurrence. (Paragraph numbers repeat within a book, so they are
     /// not a unique locator.)</param>
+    /// <param name="NoteCount">How many print-edition apparatus notes (<c>{…}</c> — variant readings / editorial
+    /// notes) fall in this snippet's window. Counted regardless of <c>IncludeFootnotes</c>, so
+    /// <c>NoteCount &gt; 0</c> tells you this hit HAS apparatus (re-read with <c>includeFootnotes:true</c>, or via
+    /// <c>/v1/passage</c>, to see it) without a second probe call. Apparatus lives almost only in MULA texts, so
+    /// this is usually 0 in commentaries.</param>
     public sealed record Occurrence(
         string BookId,
         string BookName,
@@ -176,7 +181,8 @@ namespace CST.Tools
         OccurrenceRefs Refs,
         bool IncludedFootnotes,
         int Cursor,
-        IReadOnlyList<OccurrenceHighlight> Highlights);
+        IReadOnlyList<OccurrenceHighlight> Highlights,
+        int NoteCount);
 
     /// <summary>
     /// A page of a term's in-context occurrences within one book — the same envelope shape as


### PR DESCRIPTION
All three harness reports hit the same falsifiability gap: no way to tell **"this hit has no `{…}` apparatus"** from **"apparatus was suppressed"** without a second call — Chat literally byte-compared `includeFootnotes` true vs false to find out.

## Change
Add **`noteCount`** to `occurrences` (each `Occurrence`) and `passage` (`PassageResult`): the number of `{…}` apparatus notes (variant readings / editorial notes) in the returned window, counted from the raw XML via `TeiText.NoteRegions` **regardless of `includeFootnotes`**.

So `noteCount > 0` tells an agent the hit **has** apparatus — re-read with `includeFootnotes:true` (or via `/v1/passage`) to see it — in **one call**. And KWIC snippets being too narrow to reveal `{…}` no longer hides its existence. Apparatus lives almost only in MULA texts, so it's usually `0` in commentaries.

Threaded through `SnippetResult` (occurrences) and `PassageWindow` (passage) from the extractor/reader into the `Occurrence` / `PassageResult` contracts; MCP tool descriptions + `llms.txt` updated.

## Tests
A `{…}` note in the window counts as `1` for both occurrences and passage, **identical whether `includeFootnotes` is on or off**, while the text still strips vs. renders it. Full suite **619** (the lone full-run failure was the pre-existing timing-flaky `IndexingPerformanceTests` — green on re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)