### PR TITLE
Remove the books `indexed` field (and revert #291's DocId warm-up)

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -78,19 +78,6 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
-        public async Task Books_report_indexed_true_after_the_server_maps_the_index()
-        {
-            // #291: BookIndexer doesn't set DocIds; they used to sync lazily on the FIRST search, so `books`
-            // called before any search reported indexed:false for searchable books. The server now warms the
-            // DocId map at startup, so `indexed` is truthful up front.
-            using var http = _api.Http();
-            using var doc = await GetDoc(http, "/v1/books?take=250");
-            var mula = doc.RootElement.GetProperty("books").EnumerateArray()
-                .First(b => b.GetProperty("bookId").GetString() == _api.MulaBook);
-            Assert.True(mula.GetProperty("indexed").GetBoolean());
-        }
-
-        [Fact]
         public async Task Requires_the_bearer_token()
         {
             using var http = new HttpClient { BaseAddress = new System.Uri(_api.BaseUrl) };

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -61,7 +61,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   `?pitaka=` (`Vinaya`/`Sutta`/`Abhidhamma`/`Other`), `?commentaryLevel=` (`Mula`/`Atthakatha`/`Tika`/`Other`),
   `?skip=`/`?take=` (default take 100), `?script=Devanagari` (etc.; names romanized by default). FILTER to
   avoid pulling all 217 at once (e.g. `?pitaka=Abhidhamma`). Returns `{ books, returnedCount, total, hasMore }`
-  where each book is `{ bookId, name, shortName, pitaka, commentaryLevel, bookType, indexed }`. Classify with
+  where each book is `{ bookId, name, shortName, pitaka, commentaryLevel, bookType }`. Classify with
   `commentaryLevel` and `pitaka`; `bookType` is a legacy field, often `Unknown` - do not rely on it. The
   `.mul`/`.att`/`.tik` FILENAME suffix is only a hint and can DISAGREE with `commentaryLevel`
   (e.g. `e0102n.mul.xml` is `commentaryLevel:"Other"`) - trust the field, not the name.

--- a/src/CST.Avalonia/Services/ISearchService.cs
+++ b/src/CST.Avalonia/Services/ISearchService.cs
@@ -22,11 +22,4 @@ public interface ISearchService
     /// </summary>
     Task<List<List<TermPosition>>> GetMultiWordPositionsAsync(
         string bookFileName, string query, SearchMode mode, int proximityDistance, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Sync the index→catalog DocId map now, instead of lazily on the first search, so the <c>books</c> catalog's
-    /// <c>indexed</c> flag is accurate up front (#291). Best-effort and idempotent; a no-op if the index isn't
-    /// configured/ready yet (DocIds then still sync on the first search).
-    /// </summary>
-    void EnsureIndexMapped();
 }

--- a/src/CST.Avalonia/Services/LocalApi/BookCatalog.cs
+++ b/src/CST.Avalonia/Services/LocalApi/BookCatalog.cs
@@ -31,7 +31,7 @@ namespace CST.Avalonia.Services.LocalApi
                     b.FileName,
                     ScriptConverter.Convert(b.LongNavPath, Script.Devanagari, outputScript),
                     ScriptConverter.Convert(b.ShortNavPath, Script.Devanagari, outputScript),
-                    b.Pitaka, b.Matn, b.BookType, b.DocId >= 0))
+                    b.Pitaka, b.Matn, b.BookType))
                 .ToList();
 
             return new BookListResult(page, page.Count, filtered.Count, skip + page.Count < filtered.Count);

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -234,10 +234,6 @@ namespace CST.Avalonia.Services.LocalApi
             Token = token;
             BaseUrl = $"http://127.0.0.1:{port}";
 
-            // Warm the index→catalog DocId map now, so the `books` catalog's `indexed` flag is truthful before
-            // any search runs (otherwise it lazily syncs on the first search). Best-effort. (#291)
-            _search?.EnsureIndexMapped();
-
             new LocalApiInfo(port, token, Environment.ProcessId).Write(_handshakeDirectory);
             _logger.Information("Local API listening on {BaseUrl} (rest={Rest}, mcp={Mcp})",
                 BaseUrl, _restApiEnabled, _mcpEnabled);

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/BooksMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/BooksMcpTool.cs
@@ -16,8 +16,8 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
     {
         [McpServerTool(Name = "books")]
         [Description("List the corpus's books: for each, its id (file name — the key the other tools take), its "
-            + "full and short names in the requested script, its pitaka / commentary-level / type classification, "
-            + "and whether it is indexed. Use this to turn a bookId into a recognizable location, or to find "
+            + "full and short names in the requested script, and its pitaka / commentary-level / type "
+            + "classification. Use this to turn a bookId into a recognizable location, or to find "
             + "book ids to read. The full catalog is 217 books and large — FILTER by pitaka and/or commentary "
             + "level to narrow it (e.g. pitaka:Abhidhamma), and page with skip/take. Returns "
             + "{ books, returnedCount, total, hasMore }.")]

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -1102,26 +1102,6 @@ public class SearchService : ISearchService
         }
     }
 
-    /// <inheritdoc />
-    public void EnsureIndexMapped()
-    {
-        DirectoryReader? reader = null;
-        try
-        {
-            reader = AcquireReader();
-            EnsureDocIds(reader, Books.Inst);   // same sync the first search does, just without a search (#291)
-        }
-        catch (Exception ex)
-        {
-            // Index not configured/ready yet — DocIds will sync on the first search instead.
-            _logger.LogDebug(ex, "EnsureIndexMapped: index not ready; DocIds will sync on first search.");
-        }
-        finally
-        {
-            reader?.DecRef();
-        }
-    }
-
     private string ConvertToDisplayScript(string ipeTerm)
     {
         _logger.LogDebug("Converting term to display script: {IpeTerm}", ipeTerm);

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -31,9 +31,6 @@ namespace CST.Avalonia.Services.Tools
             _settings = settings;
         }
 
-        /// <inheritdoc />
-        public void EnsureIndexMapped() => _search.EnsureIndexMapped();
-
         public async Task<SearchToolResult> SearchAsync(SearchToolRequest request, CancellationToken ct = default)
         {
             var query = new SearchQuery

--- a/src/CST.Core/Tools/NavigationToolContracts.cs
+++ b/src/CST.Core/Tools/NavigationToolContracts.cs
@@ -27,15 +27,14 @@ namespace CST.Tools
         BookAnchors? ListAnchors(string bookId);
     }
 
-    /// <summary>A book as seen by an agent: its id (file name), names, classification, and index state.</summary>
+    /// <summary>A book as seen by an agent: its id (file name), names, and classification.</summary>
     public sealed record BookSummary(
         string BookId,
         string Name,
         string ShortName,
         Pitaka Pitaka,
         CommentaryLevel CommentaryLevel,
-        BookType BookType,
-        bool Indexed);
+        BookType BookType);
 
     /// <summary>
     /// A page of the book catalog. The 217-book catalog is large, so the listing is filterable (by piṭaka /

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -31,14 +31,6 @@ namespace CST.Tools
         /// both the agent loop (scan → cite/fetch) and the human concordance panel.
         /// </summary>
         Task<OccurrenceResult> GetOccurrencesAsync(OccurrenceRequest request, CancellationToken ct = default);
-
-        /// <summary>
-        /// Eagerly map the index to the catalog (DocIds), so the <c>books</c> catalog's <c>indexed</c> flag is
-        /// truthful before any search runs. Otherwise DocIds sync lazily on the first search, and a books call
-        /// before that reports <c>indexed:false</c> for books that are in fact searchable (#291). Best-effort +
-        /// idempotent; a no-op if the index isn't ready yet.
-        /// </summary>
-        void EnsureIndexMapped();
     }
 
     /// <summary>How the query text is interpreted.</summary>


### PR DESCRIPTION
`BookIndexer.IndexAll` indexes the **entire catalog** — every book in `Books.Inst` — so all 217 books are indexed in normal operation. `indexed` was therefore a **near-constant `true`**, derived from an internal Lucene DocId. Its only `false` case is an operational failure (corrupt/missing XML that failed to index), which an agent can't act on and can already observe (that book returns no hits). So the field carried no usable information — and it read as a bug to every harness that saw it `false`.

## Removed
- `BookSummary.Indexed` + the `b.DocId >= 0` in `BookCatalog`.
- The **#291 plumbing that existed only to make it accurate**: `ISearchService`/`ISearchTool.EnsureIndexMapped`, the `SearchService` implementation, the `SearchTool` delegate, and the `LocalApiServer.StartAsync` warm-up call.
- Docs (`llms.txt` books shape + the `books` tool description) and the #291 integration test.

## Kept
DocIds stay internal — the search path still syncs them lazily on the first search for its own book↔doc mapping. Nothing internal depended on the removed field.

Supersedes #291 (this reverts it, per discussion — the fix was disproportionate plumbing for a field nobody can use). Full suite **618**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)