### PR TITLE
#301: confine tool file access to catalog books (fix path traversal via MCP passage)

### DIFF
--- a/src/CST.Avalonia.Tests/Tools/PassageToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/PassageToolTests.cs
@@ -68,5 +68,33 @@ namespace CST.Avalonia.Tests.Tools
             Assert.Equal("", r.Text);
             Assert.Null(r.NextCursor);
         }
+
+        [Fact]
+        public async Task FetchPassage_rejects_a_bookId_outside_the_catalog_no_arbitrary_read()
+        {
+            // #301: a bookId that isn't an exact catalog file name must never be opened — an ABSOLUTE path makes
+            // Path.Combine discard the corpus dir, so without the catalog guard this would read an arbitrary file.
+            var dir = Path.Combine(Path.GetTempPath(), "cst-pass-trav-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            var secret = Path.Combine(Path.GetTempPath(), "cst-secret-" + Guid.NewGuid().ToString("N") + ".txt");
+            await File.WriteAllTextAsync(secret, "SECRETDATA", Encoding.Unicode);
+            try
+            {
+                var tool = new PassageTool(Settings(dir));
+
+                var abs = await tool.FetchPassageAsync(new PassageRequest(secret, new NavigationReference.WholeBook()));
+                Assert.Equal("unknown book", abs.NormalizedReference);
+                Assert.Equal("", abs.Text);                    // file never read
+                Assert.DoesNotContain("SECRET", abs.Text);
+
+                var rel = await tool.FetchPassageAsync(new PassageRequest("../../etc/hosts", new NavigationReference.WholeBook()));
+                Assert.Equal("unknown book", rel.NormalizedReference);
+            }
+            finally
+            {
+                try { File.Delete(secret); } catch { }
+                Directory.Delete(dir, recursive: true);
+            }
+        }
     }
 }

--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -437,6 +437,22 @@ namespace CST.Avalonia.Tests.Tools
         }
 
         [Fact]
+        public async Task GetOccurrencesAsync_rejects_a_bookId_outside_the_catalog()
+        {
+            // #301: a non-catalog bookId (traversal / absolute path) returns empty WITHOUT touching the file or search.
+            var search = new Mock<ISearchService>();
+            var tool = new SearchTool(search.Object, Settings("/tmp"));
+
+            var occ = await tool.GetOccurrencesAsync(new OccurrenceRequest("/etc/passwd", "x"));
+
+            Assert.Empty(occ.Occurrences);
+            Assert.Equal(0, occ.Total);
+            search.Verify(s => s.GetTermPositionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            search.Verify(s => s.GetMultiWordPositionsAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<SearchMode>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
         public async Task GetOccurrencesAsync_empty_when_no_positions()
         {
             var search = new Mock<ISearchService>();

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using CST;
 using CST.Navigation;
 using CST.Search;
 using CST.Tools;
@@ -22,11 +24,21 @@ namespace CST.Avalonia.Services.Tools
 
         public PassageTool(ISettingsService settings) => _settings = settings;
 
+        /// <summary>True only for a bookId that is an exact catalog file name — the confinement check that keeps
+        /// a client-supplied bookId from escaping the corpus directory. (#301)</summary>
+        internal static bool IsCatalogBook(string? bookId) =>
+            !string.IsNullOrEmpty(bookId) &&
+            Books.Inst.Any(b => string.Equals(b.FileName, bookId, StringComparison.OrdinalIgnoreCase));
+
         public async Task<PassageResult> FetchPassageAsync(PassageRequest request, CancellationToken ct = default)
         {
             var dir = _settings.Settings?.XmlBooksDirectory;
-            var path = string.IsNullOrEmpty(dir) ? null : Path.Combine(dir, request.BookId);
-            if (path == null || !File.Exists(path))
+            // Confine file access to catalog books: NEVER Path.Combine an unvalidated bookId — an absolute path
+            // makes Combine discard `dir`, and `..` escapes the corpus dir (path traversal / arbitrary read). (#301)
+            if (string.IsNullOrEmpty(dir) || !IsCatalogBook(request.BookId))
+                return Empty(request, "unknown book");
+            var path = Path.Combine(dir, request.BookId);
+            if (!File.Exists(path))
                 return Empty(request, "book not available");
 
             // Char offsets index the decoded (BOM-stripped) UTF-16 text — read it the same way.

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -110,6 +110,9 @@ namespace CST.Avalonia.Services.Tools
         {
             var dir = _settings.Settings?.XmlBooksDirectory;
             if (string.IsNullOrEmpty(dir)) return EmptyOccurrences;
+            // Confine file access to catalog books before any Path.Combine — don't rely on the position lookup
+            // downstream to reject a traversal/abs-path bookId (defense-in-depth with the HTTP BookExists gate). (#301)
+            if (!PassageTool.IsCatalogBook(request.BookId)) return EmptyOccurrences;
             var path = Path.Combine(dir, request.BookId);
             if (!File.Exists(path)) return EmptyOccurrences;
 


### PR DESCRIPTION
The HTTP `/v1/passage` handler gated on `BookExists`, but the **MCP `passage` tool** called `PassageTool.FetchPassageAsync` directly — `Path.Combine(dir, bookId)` + `File.ReadAllTextAsync` with **no catalog validation** → a token-authed agent could read arbitrary files (an absolute `bookId` makes `Path.Combine` discard the corpus dir; `..` escapes it).

Fix: validate `bookId` against `Books.Inst` (exact `FileName`, ordinal-ignore-case) **inside the adapters** before any `Path.Combine` — in `PassageTool.FetchPassageAsync` and, defense-in-depth, `SearchTool.GetOccurrencesAsync` (previously only *incidentally* safe via the downstream position lookup).

Tests: a non-catalog `bookId` (absolute path to a secret file; `..` traversal) is rejected with **no file read and no search call**. Full suite **620**.

Closes #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)