### PR TITLE
#302: --mcp-bridge treats a stale/dead-PID handshake as not-attached (relaunch after a crash)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
+++ b/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
@@ -74,6 +74,26 @@ namespace CST.Avalonia.Tests.Services
             => Assert.Null(McpBridge.AppBundleFromExecutablePath(exe));
 
         [Fact]
+        public void ReadLiveHandshake_ignores_a_stale_dead_pid_handshake()
+        {
+            // #302: a crash/kill -9 leaves local-api.json behind; attach must treat a dead-pid handshake as stale
+            // (null) so it falls through to launch, not attach + immediately get killed by the pid-watcher.
+            var dir = Path.Combine(Path.GetTempPath(), "cst-livehs-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                new LocalApiInfo(51515, "TOK", 2_000_000_000).Write(dir);   // pid far above OS max = not running
+                Assert.Null(McpBridge.ReadLiveHandshake(dir));
+
+                new LocalApiInfo(51515, "TOK", Environment.ProcessId).Write(dir);   // a live pid
+                var info = McpBridge.ReadLiveHandshake(dir);
+                Assert.NotNull(info);
+                Assert.Equal(Environment.ProcessId, info!.Pid);
+            }
+            finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+        }
+
+        [Fact]
         public async Task Liveness_watcher_trips_when_the_watched_process_is_gone()
         {
             // The GUI's pid isn't running -> the watcher cancels its token so the relay unwinds and the bridge

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
@@ -59,7 +59,7 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             await using var clientSide = new StdioServerTransport("cst-reader", NullLoggerFactory.Instance);
             Console.SetOut(Console.Error);   // any stray Console.Out goes to stderr, never onto the JSON-RPC stdout
 
-            var info = LocalApiInfo.Read(handshakeDirectory);   // attach: a running instance already published its handshake
+            var info = ReadLiveHandshake(handshakeDirectory);   // attach: a RUNNING instance already published its handshake
             if (info is null)
             {
                 Log.Information("--mcp-bridge: no {File}; launching CST Reader and waiting for it to come up…", LocalApiInfo.FileName);
@@ -219,12 +219,26 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         {
             for (int i = 0; i < attempts && !ct.IsCancellationRequested; i++)
             {
-                var info = LocalApiInfo.Read(dir);
+                var info = ReadLiveHandshake(dir);
                 if (info is not null) return info;
                 try { await Task.Delay(delayMs, ct).ConfigureAwait(false); }
                 catch (OperationCanceledException) { return null; }
             }
-            return LocalApiInfo.Read(dir);
+            return ReadLiveHandshake(dir);
+        }
+
+        /// <summary>
+        /// Read the handshake, but treat one whose GUI process is gone as STALE (null). A crash / <c>kill -9</c>
+        /// leaves <c>local-api.json</c> behind (only a clean shutdown deletes it), so without this the bridge would
+        /// attach to a dead instance and the pid-watcher would immediately cancel the relay — defeating
+        /// launch-or-attach in exactly the crash-recovery case. Ignoring the stale file lets attach fall through to
+        /// launch, and the poll then waits for the fresh instance to overwrite it with a live pid. (#302)
+        /// </summary>
+        internal static LocalApiInfo? ReadLiveHandshake(string dir)
+        {
+            var info = LocalApiInfo.Read(dir);
+            if (info is not null && info.Pid > 0 && !IsProcessAlive(info.Pid)) return null;
+            return info;
         }
 
         /// <summary>


### PR DESCRIPTION
`RunFromStdioAsync` attached on **any** parseable `local-api.json`. After a crash/`kill -9` (which leaves the file — only clean `StopAsync` deletes it), the bridge took the attach path, then the pid-watcher's first check saw the dead pid and cancelled → the bridge **exited without launching the app**, defeating launch-or-attach in the crash-recovery case.

Fix: `ReadLiveHandshake` reads the handshake but returns `null` when its `Pid` is no longer running — used by both the attach read and the launch-poll retry. A stale file is ignored → attach falls through to `TryLaunchApp`, and the poll waits for the fresh instance to overwrite it with a live pid.

The pid-**reuse** edge (a stale file whose pid was recycled — A2-3) still needs an identity check; noted as a smaller follow-up.

Test: `ReadLiveHandshake` → null for a dead-pid handshake, the info for a live-pid one. Full suite **621**. Closes #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)