### PR TITLE
#303: write local-api.json owner-only + atomically (no world-readable token window)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
+++ b/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
@@ -74,6 +74,25 @@ namespace CST.Avalonia.Tests.Services
             => Assert.Null(McpBridge.AppBundleFromExecutablePath(exe));
 
         [Fact]
+        public void Write_creates_the_handshake_owner_only_and_leaves_no_temp()
+        {
+            // #303: the token file must be created 0600 (no world-readable window) and written atomically.
+            var dir = Path.Combine(Path.GetTempPath(), "cst-hs-perms-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                new LocalApiInfo(51515, "SECRET", 123).Write(dir);
+                var path = LocalApiInfo.PathIn(dir);
+
+                Assert.Equal("SECRET", LocalApiInfo.Read(dir)!.Token);          // content round-trips
+                Assert.Empty(Directory.GetFiles(dir, "*.tmp"));                 // atomic rename left no temp
+                if (!OperatingSystem.IsWindows())
+                    Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(path));
+            }
+            finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+        }
+
+        [Fact]
         public void ReadLiveHandshake_ignores_a_stale_dead_pid_handshake()
         {
             // #302: a crash/kill -9 leaves local-api.json behind; attach must treat a dead-pid handshake as stale

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Serilog;
 
 namespace CST.Avalonia.Services.LocalApi
 {
@@ -31,8 +33,22 @@ namespace CST.Avalonia.Services.LocalApi
         public void Write(string directory)
         {
             var path = PathIn(directory);
-            File.WriteAllText(path, JsonSerializer.Serialize(this, Options));
-            TrySetOwnerOnly(path);
+            var json = JsonSerializer.Serialize(this, Options);
+
+            // Write to a temp file created 0600 at open(2) (no world-readable window on macOS/Linux — the token is
+            // a session secret), then atomically rename it over the real path so a concurrently polling client (the
+            // --mcp-bridge relay) never reads torn JSON. (#303)
+            var tmp = path + "." + Environment.ProcessId + ".tmp";
+            var options = new FileStreamOptions { Mode = FileMode.Create, Access = FileAccess.Write };
+            if (!OperatingSystem.IsWindows())
+                options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+            using (var fs = new FileStream(tmp, options))
+            using (var w = new StreamWriter(fs, new UTF8Encoding(false)))
+                w.Write(json);
+
+            File.Move(tmp, path, overwrite: true);   // rename preserves the temp's 0600 mode
+            TrySetOwnerOnly(path);                    // belt-and-suspenders; also fixes a pre-existing file's mode
         }
 
         public static LocalApiInfo? Read(string directory)
@@ -59,7 +75,11 @@ namespace CST.Avalonia.Services.LocalApi
                 if (!OperatingSystem.IsWindows())
                     File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
             }
-            catch { /* best effort */ }
+            catch (Exception ex)
+            {
+                // Don't swallow: a token file left group/world-readable is a real exposure worth a log line. (#303)
+                Log.Warning(ex, "Could not restrict permissions on {Path}; the local-API token may be readable by other local users.", path);
+            }
         }
     }
 }


### PR DESCRIPTION
`Write()` did `File.WriteAllText` (creates 0644 under umask) **then** chmod'd to 0600 with a swallowed `catch` — so the bearer token was briefly **world-readable**, and stayed 0644 **permanently and silently** if the chmod threw. The non-atomic truncate-then-write also let a concurrently polling bridge read torn JSON (A2-9).

Fix: write to a temp file created **0600 at `open(2)`** (`FileStreamOptions.UnixCreateMode`, no window on macOS/Linux), then `File.Move` over the real path (atomic rename preserves the mode + prevents torn reads). The post-hoc `SetUnixFileMode` fallback now **logs** on failure instead of swallowing.

Test: the handshake is owner-only (0600 on Unix), round-trips, and leaves no temp. Full suite **622**. Closes #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)