### PR TITLE
#304: reject undefined/out-of-range script values (IPE leak, empty output, 500)

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -78,6 +78,24 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
+        public async Task Invalid_outputScript_is_400_not_500_or_empty()
+        {
+            // #304: an out-of-range/undefined or Ipe outputScript must be a clean 400 — not a 500 (non-string
+            // token) and not silently-empty converted text.
+            using var http = _api.Http();
+            foreach (var body in new[]
+            {
+                "{\"text\":\"dhamma\",\"outputScript\":99}",       // undefined ordinal (number token)
+                "{\"text\":\"dhamma\",\"outputScript\":15}",       // Script.Ipe ordinal (number token)
+                "{\"text\":\"dhamma\",\"outputScript\":\"Ipe\"}",  // Ipe by name
+            })
+            {
+                var resp = await http.PostAsync("/v1/convert", Json(body));
+                Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+            }
+        }
+
+        [Fact]
         public async Task Requires_the_bearer_token()
         {
             using var http = new HttpClient { BaseAddress = new System.Uri(_api.BaseUrl) };

--- a/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
+++ b/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Services.LocalApi;
 using CST.Avalonia.Services.LocalApi.Mcp;
+using CST.Conversion;
 using ModelContextProtocol.Client;
 using Xunit;
 
@@ -142,6 +143,16 @@ namespace CST.Avalonia.Tests.Services
 
             onGone.Cancel();   // stop the watcher
             await watch;
+        }
+
+        [Fact]
+        public void McpScript_ToScript_rejects_undefined_outputScript_ordinals()
+        {
+            // #304: the MCP SDK accepts integer enum values; OutputScript is 0-13 but Script has Ipe=15 — an
+            // out-of-range value must be rejected, not mapped into Script.Ipe (IPE leak) or empty output.
+            Assert.Equal(Script.Sinhala, McpScript.ToScript(OutputScript.Sinhala));   // defined → mapped by name
+            Assert.Throws<System.ArgumentException>(() => McpScript.ToScript((OutputScript)15));  // Script.Ipe ordinal
+            Assert.Throws<System.ArgumentException>(() => McpScript.ToScript((OutputScript)99));
         }
 
         [Fact]

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -258,6 +258,7 @@ namespace CST.Avalonia.Services.LocalApi
 
         private static Script ParseScript(string? name) =>
             Enum.TryParse<Script>(name, ignoreCase: true, out var script)
+                && Enum.IsDefined(script)                         // reject undefined ordinals like "99" (→ empty output)
                 && script is not (Script.Ipe or Script.Unknown)   // never expose the internal IPE font encoding
                 ? script : Script.Latin;
 

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpScript.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpScript.cs
@@ -28,8 +28,14 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
 
     internal static class McpScript
     {
-        /// <summary>Map an agent-facing <see cref="OutputScript"/> to the internal <see cref="Script"/>
-        /// (names match, so parse by name).</summary>
-        public static Script ToScript(OutputScript s) => Enum.Parse<Script>(s.ToString());
+        /// <summary>Map an agent-facing <see cref="OutputScript"/> to the internal <see cref="Script"/> (names
+        /// match, so parse by name). The MCP SDK's enum converter accepts INTEGERS, so an out-of-range value like
+        /// <c>15</c> would otherwise <c>ToString()</c> to <c>"15"</c> and <c>Enum.Parse</c> into a wrong/undefined
+        /// <see cref="Script"/> — including <see cref="Script.Ipe"/> (ordinal 15), leaking the internal encoding.
+        /// Reject anything not a defined <see cref="OutputScript"/>. (#304)</summary>
+        public static Script ToScript(OutputScript s) =>
+            Enum.IsDefined(s)
+                ? Enum.Parse<Script>(s.ToString())
+                : throw new ArgumentException($"Unknown outputScript value '{(int)s}'. Use the 'scripts' tool for valid values.", nameof(s));
     }
 }

--- a/src/CST.Avalonia/Services/LocalApi/ScriptJsonConverter.cs
+++ b/src/CST.Avalonia/Services/LocalApi/ScriptJsonConverter.cs
@@ -17,8 +17,15 @@ namespace CST.Avalonia.Services.LocalApi
     {
         public override Script Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            // A non-string token (e.g. `"outputScript": 15`) throws InvalidOperationException from GetString(),
+            // which the minimal-API binding surfaces as a 500 rather than the intended 400 — so reject it here. (#304)
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException("outputScript must be a script name (a string). See GET /v1/scripts for valid values.");
             string? name = reader.GetString();
+            // Enum.TryParse accepts numeric strings ("99"), yielding an UNDEFINED Script that isn't Ipe/Unknown and
+            // falls through the converter to empty output — require a DEFINED value. (#304)
             if (!Enum.TryParse<Script>(name, ignoreCase: true, out var script)
+                || !Enum.IsDefined(script)
                 || script is Script.Ipe or Script.Unknown)
                 throw new JsonException($"Unknown or unsupported script '{name}'. See GET /v1/scripts for valid values.");
             return script;


### PR DESCRIPTION
Undefined `Script` ordinals slipped through validation on three paths (the MCP SDK + `Enum.TryParse` accept integers, and `OutputScript`(0–13) vs `Script`(…,`Unknown=14`,`Ipe=15`) don't align):
- **`McpScript.ToScript`** — `outputScript:15` → `Script.Ipe` → **IPE font encoding leaked to the client**; `16+` → empty output.
- **`ScriptJsonConverter.Read`** — `"99"` → an undefined `Script` (not Ipe/Unknown) → `ScriptConverter` returns `""` (silently empty); a **non-string** token (`15`) threw `InvalidOperationException` → **500** not 400.
- **`ParseScript`** (`?script=`) — same undefined-ordinal acceptance.

Fix: `Enum.IsDefined` guards in all three + a `TokenType == String` check before `GetString()`.

Tests: `McpScript.ToScript` rejects `(OutputScript)15/99`; `POST /v1/convert` with `outputScript` `99` / `15` / `"Ipe"` all return **400**. Full suite **624**. Closes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)