### PR TITLE
#305: clamp & validate API request size/paging params

### DIFF
--- a/src/CST.Avalonia.Tests/Tools/DictionaryToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/DictionaryToolTests.cs
@@ -63,5 +63,23 @@ namespace CST.Avalonia.Tests.Tools
 
             Assert.Equal(2, entries.Count);
         }
+
+        [Fact]
+        public async Task LookupAsync_clamps_a_negative_MaxEntries_to_zero()
+        {
+            // #305: a negative MaxEntries must not throw or wrap into a huge Take — it yields no entries.
+            var mock = new Mock<IDictionaryService>();
+            mock.Setup(d => d.LookupAsync("en", "d"))
+                .ReturnsAsync(new List<DictionaryWord>
+                {
+                    new DictionaryWord("a", "1"),
+                    new DictionaryWord("b", "2")
+                });
+
+            var tool = new DictionaryTool(mock.Object);
+            var entries = await tool.LookupAsync(new DictionaryRequest("en", "d", MaxEntries: -5));
+
+            Assert.Empty(entries);
+        }
     }
 }

--- a/src/CST.Avalonia/Services/Tools/DictionaryTool.cs
+++ b/src/CST.Avalonia/Services/Tools/DictionaryTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -18,6 +19,9 @@ namespace CST.Avalonia.Services.Tools
 
         public DictionaryTool(IDictionaryService dictionary) => _dictionary = dictionary;
 
+        // Upper bound on dictionary hits returned in one call — negative asks 0, huge asks are capped. (#305)
+        private const int MaxDictEntries = 500;
+
         public IReadOnlyList<string> Languages => _dictionary.AvailableLanguages;
 
         public async Task<IReadOnlyList<DictionaryEntry>> LookupAsync(
@@ -28,7 +32,7 @@ namespace CST.Avalonia.Services.Tools
                 .ConfigureAwait(false);
 
             return words
-                .Take(request.MaxEntries)
+                .Take(Math.Clamp(request.MaxEntries, 0, MaxDictEntries))
                 .Select(w => new DictionaryEntry(
                     Headword: ScriptConverter.Convert(w.Word, Script.Ipe, request.OutputScript),
                     MeaningHtml: w.Meaning))

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -24,6 +24,10 @@ namespace CST.Avalonia.Services.Tools
 
         public PassageTool(ISettingsService settings) => _settings = settings;
 
+        // Upper bound on a single passage read — a client asking for MaxChars:2_000_000_000 shouldn't pin a
+        // 4 GB substring off a corpus file. (#305)
+        private const int MaxPassageChars = 20_000;
+
         /// <summary>True only for a bookId that is an exact catalog file name — the confinement check that keeps
         /// a client-supplied bookId from escaping the corpus directory. (#301)</summary>
         internal static bool IsCatalogBook(string? bookId) =>
@@ -52,7 +56,7 @@ namespace CST.Avalonia.Services.Tools
             // A cursor points AT a hit (mid-sentence); snap the window start back to the enclosing sentence so
             // the hit is read with its governing clause. A paragraph reference already starts clean - no snap.
             var w = TeiPassageReader.ReadWindow(
-                xml, startPos, Math.Max(1, request.MaxChars),
+                xml, startPos, Math.Clamp(request.MaxChars, 1, MaxPassageChars),
                 request.IncludeFootnotes, request.OutputScript, markers,
                 snapStartToSentence: request.Cursor.HasValue);
 

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -31,13 +31,19 @@ namespace CST.Avalonia.Services.Tools
             _settings = settings;
         }
 
+        // Caps on client-supplied sizes/paging: bound per-request work so an agent fan-out can't self-DoS the
+        // in-process thread pool the UI shares (or blow memory). (#305)
+        private const int MaxPageSize = 1000;
+        private const int MaxTake = 500;
+        private const int MaxSnippetChars = 20_000;
+
         public async Task<SearchToolResult> SearchAsync(SearchToolRequest request, CancellationToken ct = default)
         {
             var query = new SearchQuery
             {
                 QueryText = request.Query ?? string.Empty,
                 Mode = MapMode(request.Mode),
-                PageSize = request.MaxTerms,
+                PageSize = Math.Clamp(request.MaxTerms, 1, MaxPageSize),
                 Skip = request.Skip,
                 // No per-book breakdown requested => let the engine take counts straight from the index (no
                 // postings) when the search is also unfiltered.
@@ -147,11 +153,12 @@ namespace CST.Avalonia.Services.Tools
             // Char offsets index the decoded (BOM-stripped) UTF-16 text — read it the same way.
             string xml = await File.ReadAllTextAsync(path, Encoding.Unicode, ct).ConfigureAwait(false);
             var markers = BookMarkers.Build(xml);
+            int minChars = Math.Clamp(request.MinChars ?? 60, 1, MaxSnippetChars);
             var opts = new SnippetOptions(
                 OutputScript: request.OutputScript,
                 IncludeFootnotes: request.IncludeFootnotes,
-                MinChars: request.MinChars ?? 60,
-                MaxChars: request.MaxChars ?? 320);
+                MinChars: minChars,
+                MaxChars: Math.Clamp(request.MaxChars ?? 320, minChars, MaxSnippetChars));   // bounded; MaxChars >= MinChars
 
             string rawBookName = Books.Inst
                 .FirstOrDefault(b => string.Equals(b.FileName, request.BookId, StringComparison.OrdinalIgnoreCase))
@@ -164,8 +171,10 @@ namespace CST.Avalonia.Services.Tools
             // (Desktop MCP friction report — the snippet de-dup / token win.)
             var groups = TeiSnippetExtractor.GroupCoLocated(xml, perOccurrence);
 
+            int skip = Math.Max(0, request.Skip);
+            int take = Math.Clamp(request.Take, 0, MaxTake);
             var occurrences = new List<Occurrence>();
-            foreach (var marks in groups.Skip(request.Skip).Take(request.Take))
+            foreach (var marks in groups.Skip(skip).Take(take))
             {
                 ct.ThrowIfCancellationRequested();
                 var s = TeiSnippetExtractor.Extract(xml, marks, markers, opts);
@@ -193,7 +202,7 @@ namespace CST.Avalonia.Services.Tools
                 ReturnedCount: occurrences.Count,
                 Total: groups.Count,
                 InstanceTotal: perOccurrence.Count,
-                HasMore: request.Skip + occurrences.Count < groups.Count);
+                HasMore: skip + occurrences.Count < groups.Count);
 
             static int AnchorStart(IReadOnlyList<SnippetMark> m)
             {


### PR DESCRIPTION
## Summary
Bounds client-supplied sizes/paging at the surface-C adapter boundary so an agent fan-out can't self-DoS the shared in-process pool (`take:100000`), and negative/inverted params can no longer silently misbehave.

- **SearchTool** — `MaxTerms` → `[1, 1000]` page size; occurrence `Take` → `[0, 500]`, `Skip` → `>= 0` (clamped values used consistently in both paging and `HasMore`); snippet `MinChars` → `[1, 20000]`, `MaxChars` → `[MinChars, 20000]` (guarantees `MaxChars >= MinChars`).
- **PassageTool** — `MaxChars` → `[1, 20000]` (was `Math.Max(1, .)` with no upper bound → a 2 GB substring ask).
- **DictionaryTool** — `MaxEntries` → `[0, 500]` (a negative ask yields no entries instead of wrapping into a huge `Take`).

## Tests
- `DictionaryToolTests.LookupAsync_clamps_a_negative_MaxEntries_to_zero`
- Full suite: **625 passed**.

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)