### PR TITLE
#308: harden tool adapters (cancel dict load, cache book re-reads, normalize literal term — A3)

### DIFF
--- a/src/CST.Avalonia.Tests/Tools/BookTextCacheTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/BookTextCacheTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Services.Tools;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Tools
+{
+    /// <summary>
+    /// #308 A3-6: the shared book-text cache returns the same decoded XML on a hit (no re-read while paging one
+    /// book) and re-reads when the file's mtime changes (a re-downloaded/updated book invalidates the entry).
+    /// </summary>
+    public class BookTextCacheTests
+    {
+        [Fact]
+        public async Task GetAsync_caches_by_path_and_invalidates_on_mtime_change()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "cst-btc-" + Guid.NewGuid().ToString("N") + ".xml");
+            await File.WriteAllTextAsync(path, "<book><p n=\"1\">one</p></book>", Encoding.Unicode);
+            try
+            {
+                var a = await BookTextCache.GetAsync(path, CancellationToken.None);
+                var b = await BookTextCache.GetAsync(path, CancellationToken.None);
+                Assert.Same(a.Xml, b.Xml);              // cache hit hands back the SAME decoded string (no re-read)
+
+                // A changed mtime (re-downloaded book) must invalidate: fresh read, new content.
+                await File.WriteAllTextAsync(path, "<book><p n=\"2\">two</p></book>", Encoding.Unicode);
+                File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddSeconds(5));
+
+                var c = await BookTextCache.GetAsync(path, CancellationToken.None);
+                Assert.NotSame(a.Xml, c.Xml);
+                Assert.Contains("two", c.Xml);
+            }
+            finally { try { File.Delete(path); } catch { } }
+        }
+    }
+}

--- a/src/CST.Avalonia.Tests/Tools/DictionaryToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/DictionaryToolTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models;
 using CST.Avalonia.Services;
@@ -80,6 +81,21 @@ namespace CST.Avalonia.Tests.Tools
             var entries = await tool.LookupAsync(new DictionaryRequest("en", "d", MaxEntries: -5));
 
             Assert.Empty(entries);
+        }
+
+        [Fact]
+        public async Task LookupAsync_forwards_the_cancellation_token_to_the_service()
+        {
+            // #308 A3-5: the tool must thread ct through so a client timeout can cancel a first-touch load.
+            using var cts = new CancellationTokenSource();
+            var mock = new Mock<IDictionaryService>();
+            mock.Setup(d => d.LookupAsync("en", "x", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<DictionaryWord>());
+
+            var tool = new DictionaryTool(mock.Object);
+            await tool.LookupAsync(new DictionaryRequest("en", "x"), cts.Token);
+
+            mock.Verify(d => d.LookupAsync("en", "x", cts.Token), Times.Once);
         }
     }
 }

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -126,12 +126,12 @@ public sealed class DictionaryService : IDictionaryService
         }
     }
 
-    public async Task<IReadOnlyList<DictionaryWord>> LookupAsync(string language, string query)
+    public async Task<IReadOnlyList<DictionaryWord>> LookupAsync(string language, string query, CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(language) || string.IsNullOrEmpty(query))
             return Array.Empty<DictionaryWord>();
 
-        var index = await GetOrLoadIndexAsync(language).ConfigureAwait(false);
+        var index = await GetOrLoadIndexAsync(language, ct).ConfigureAwait(false);
         if (index == null)
             return Array.Empty<DictionaryWord>();
 
@@ -144,7 +144,7 @@ public sealed class DictionaryService : IDictionaryService
         return index.Lookup(ipeQuery);
     }
 
-    private async Task<DictionaryIndex?> GetOrLoadIndexAsync(string language)
+    private async Task<DictionaryIndex?> GetOrLoadIndexAsync(string language, CancellationToken ct)
     {
         lock (_cache)
         {
@@ -152,7 +152,7 @@ public sealed class DictionaryService : IDictionaryService
                 return cached;
         }
 
-        await _loadLock.WaitAsync().ConfigureAwait(false);
+        await _loadLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             lock (_cache)
@@ -161,7 +161,7 @@ public sealed class DictionaryService : IDictionaryService
                     return cached;
             }
 
-            var index = await LoadLanguageAsync(language).ConfigureAwait(false);
+            var index = await LoadLanguageAsync(language, ct).ConfigureAwait(false);
             if (index != null)
             {
                 lock (_cache)
@@ -177,7 +177,7 @@ public sealed class DictionaryService : IDictionaryService
         }
     }
 
-    private async Task<DictionaryIndex?> LoadLanguageAsync(string language)
+    private async Task<DictionaryIndex?> LoadLanguageAsync(string language, CancellationToken ct)
     {
         var languageDir = Path.Combine(_dictionariesDirectory, language);
         if (!Directory.Exists(languageDir))
@@ -194,7 +194,8 @@ public sealed class DictionaryService : IDictionaryService
 
             foreach (var file in Directory.GetFiles(languageDir).OrderBy(f => f, StringComparer.Ordinal))
             {
-                var lines = await File.ReadAllLinesAsync(file).ConfigureAwait(false);
+                ct.ThrowIfCancellationRequested();   // a client timeout stops the load, not just the caller's await
+                var lines = await File.ReadAllLinesAsync(file, ct).ConfigureAwait(false);
 
                 // Lines come in (headword, definition) pairs; skip a pair if either side is empty.
                 for (int i = 0; i + 1 < lines.Length; i += 2)
@@ -216,6 +217,7 @@ public sealed class DictionaryService : IDictionaryService
                 index.Count, language, languageDir);
             return index;
         }
+        catch (OperationCanceledException) { throw; }   // cancellation isn't a load failure — let it propagate
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error loading '{Language}' dictionary from {Path}", language, languageDir);

--- a/src/CST.Avalonia/Services/IDictionaryService.cs
+++ b/src/CST.Avalonia/Services/IDictionaryService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models;
 
@@ -22,6 +23,8 @@ public interface IDictionaryService
     /// query is IPE-normalized internally, so it matches regardless of input script. The language's
     /// data is loaded and cached on first use. Returns matching entries in display order (see
     /// <see cref="DictionaryIndex.Lookup"/>); empty for an unknown language, empty query, or no match.
+    /// The first-touch load (read + IPE-convert every file) honors <paramref name="ct"/>, so a client
+    /// timeout stops it instead of holding the load lock past the deadline.
     /// </summary>
-    Task<IReadOnlyList<DictionaryWord>> LookupAsync(string language, string query);
+    Task<IReadOnlyList<DictionaryWord>> LookupAsync(string language, string query, CancellationToken ct = default);
 }

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -901,8 +901,10 @@ public class SearchService : ISearchService
             }
 
             // term is a display-script term (e.g. the romanized Latin term from a prior search); convert it
-            // to IPE for the index lookup. Any2Ipe auto-detects the input script.
-            var ipeTerm = Any2Ipe.Convert(term);
+            // to IPE for the index lookup. Any2Ipe auto-detects the input script. Strip a pasted zero-width
+            // joiner FIRST (Any2Ipe doesn't) — same normalization the expanding/multi-word paths apply — else an
+            // exact term that `search` reported hits for can look up 0 occurrences here. (#308 A3-8)
+            var ipeTerm = Any2Ipe.Convert(MultiWordSearch.StripJoiners(term));
             var termBytes = new BytesRef(Encoding.UTF8.GetBytes(ipeTerm));
             var liveDocs = MultiFields.GetLiveDocs(reader);
             var dape = MultiFields.GetTermPositionsEnum(reader, liveDocs, "text", termBytes);

--- a/src/CST.Avalonia/Services/Tools/BookTextCache.cs
+++ b/src/CST.Avalonia/Services/Tools/BookTextCache.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Search;
+
+namespace CST.Avalonia.Services.Tools
+{
+    /// <summary>
+    /// A tiny bounded cache of a book's decoded XML + its <see cref="BookMarkers"/>, keyed by file path and
+    /// last-write time, shared by the occurrences and passage adapters. Paging one book would otherwise re-read
+    /// the whole UTF-16 file and rebuild <see cref="BookMarkers"/> on every call. Bounded LRU so it can't grow
+    /// with the 217-file corpus; a changed mtime (a re-downloaded / updated book) invalidates the entry. Both
+    /// values are read-only after construction (the XML is an immutable string; markers are only queried), so a
+    /// shared entry is safe to hand to concurrent callers. (#308 A3-6)
+    /// </summary>
+    internal static class BookTextCache
+    {
+        internal readonly record struct Entry(string Xml, BookMarkers Markers);
+
+        private const int Capacity = 6;
+        private static readonly object Gate = new();
+        private static readonly Dictionary<string, (long Mtime, Entry Entry)> Map = new(StringComparer.Ordinal);
+        private static readonly LinkedList<string> Lru = new();   // most-recent at the front
+
+        /// <summary>Get the (XML, markers) for <paramref name="path"/>, reading + parsing on a miss or a changed
+        /// mtime. The read/parse happens OUTSIDE the lock (I/O + parse are slow; don't serialize all books behind
+        /// one lock) — two concurrent misses for the same book just do the work twice, last write wins.</summary>
+        public static async Task<Entry> GetAsync(string path, CancellationToken ct)
+        {
+            long mtime = File.GetLastWriteTimeUtc(path).Ticks;
+            lock (Gate)
+            {
+                if (Map.TryGetValue(path, out var hit) && hit.Mtime == mtime)
+                {
+                    Touch(path);
+                    return hit.Entry;
+                }
+            }
+
+            // Char offsets index the decoded (BOM-stripped) UTF-16 text — read it the same way both adapters do.
+            string xml = await File.ReadAllTextAsync(path, Encoding.Unicode, ct).ConfigureAwait(false);
+            var entry = new Entry(xml, BookMarkers.Build(xml));
+
+            lock (Gate)
+            {
+                Map[path] = (mtime, entry);
+                Touch(path);
+                while (Lru.Count > Capacity)
+                {
+                    var oldest = Lru.Last!.Value;
+                    Lru.RemoveLast();
+                    Map.Remove(oldest);
+                }
+            }
+            return entry;
+        }
+
+        // Move (or add) path to the most-recent end. O(n) over the value, but n <= Capacity.
+        private static void Touch(string path)
+        {
+            Lru.Remove(path);
+            Lru.AddFirst(path);
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/Tools/DictionaryTool.cs
+++ b/src/CST.Avalonia/Services/Tools/DictionaryTool.cs
@@ -28,7 +28,7 @@ namespace CST.Avalonia.Services.Tools
             DictionaryRequest request, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
-            var words = await _dictionary.LookupAsync(request.Language, request.Query ?? string.Empty)
+            var words = await _dictionary.LookupAsync(request.Language, request.Query ?? string.Empty, ct)
                 .ConfigureAwait(false);
 
             return words

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -45,9 +45,8 @@ namespace CST.Avalonia.Services.Tools
             if (!File.Exists(path))
                 return Empty(request, "book not available");
 
-            // Char offsets index the decoded (BOM-stripped) UTF-16 text — read it the same way.
-            string xml = await File.ReadAllTextAsync(path, Encoding.Unicode, ct).ConfigureAwait(false);
-            var markers = BookMarkers.Build(xml);
+            // Read + parse via the shared bounded cache so paging one book doesn't re-read + re-parse it. (#308 A3-6)
+            var (xml, markers) = await BookTextCache.GetAsync(path, ct).ConfigureAwait(false);
 
             int startPos = request.Cursor ?? ResolveStart(request.Reference, markers);
             if (startPos < 0) return Empty(request, "reference not found");

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -150,9 +150,9 @@ namespace CST.Avalonia.Services.Tools
             }
             if (perOccurrence.Count == 0) return EmptyOccurrences;
 
-            // Char offsets index the decoded (BOM-stripped) UTF-16 text — read it the same way.
-            string xml = await File.ReadAllTextAsync(path, Encoding.Unicode, ct).ConfigureAwait(false);
-            var markers = BookMarkers.Build(xml);
+            // Char offsets index the decoded (BOM-stripped) UTF-16 text; read + parse via the shared bounded
+            // cache so paging one book doesn't re-read + re-parse it each call. (#308 A3-6)
+            var (xml, markers) = await BookTextCache.GetAsync(path, ct).ConfigureAwait(false);
             int minChars = Math.Clamp(request.MinChars ?? 60, 1, MaxSnippetChars);
             var opts = new SnippetOptions(
                 OutputScript: request.OutputScript,


### PR DESCRIPTION
## Summary
Lower-severity findings from the Fable-led adapter review:

- **A3-5** — `DictionaryTool` dropped `ct`, so a first-touch dictionary load (read + IPE-convert every file) couldn't be cancelled and held the load lock + a queue permit past a client timeout. `ct` now threads through `IDictionaryService.LookupAsync` → `GetOrLoadIndexAsync` (`WaitAsync(ct)`) → `LoadLanguageAsync` (`ThrowIfCancellationRequested` + `ReadAllLinesAsync(ct)`); cancellation propagates rather than being swallowed as a load failure.
- **A3-6** — the occurrences and passage adapters each re-read the whole UTF-16 book and rebuilt `BookMarkers` on every call, so paging one book re-parsed it N times. New bounded (capacity 6) LRU **`BookTextCache`** keyed by path + last-write time, shared by both paths. Values are read-only after build, so a shared entry is safe for concurrent callers; the read/parse happens outside the lock.
- **A3-8** (`SearchService.GetTermPositionsAsync`) — the literal single-term path didn't `StripJoiners` before IPE conversion like the expanding/multi-word paths, so an exact term with a pasted zero-width joiner could look up 0 occurrences though `search` reported hits. (Verified `Any2Ipe` doesn't strip joiners itself — the multi-word path strips before converting.)

## Tests
- `BookTextCacheTests.GetAsync_caches_by_path_and_invalidates_on_mtime_change`
- `DictionaryToolTests.LookupAsync_forwards_the_cancellation_token_to_the_service`
- Full suite: **631 passed**.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)