### PR TITLE
#310: fix note-boundary corruption in snippet/passage rendering

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiTextNoteBoundaryTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiTextNoteBoundaryTests.cs
@@ -1,0 +1,52 @@
+using CST.Search;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Search
+{
+    /// <summary>
+    /// #310 A4-2: TagName("&lt;/note&gt;") is "note" too, so Clean's note-strip branch used to fire for the CLOSE
+    /// tag and call SkipSubtree on it — entering depth 1 and consuming to the NEXT close tag (or the whole rest of
+    /// the range), leaking the note tail as base text and silently dropping everything after. A close tag must be
+    /// zero-width. ASCII-only fixtures (Devanagari output would be identity here; these assert the raw cleaned text).
+    /// </summary>
+    public class TeiTextNoteBoundaryTests
+    {
+        [Fact]
+        public void Clean_starting_inside_a_note_treats_the_close_tag_as_zero_width_and_keeps_following_text()
+        {
+            // The empirical repro from the review: begin INSIDE the first note's content.
+            const string xml = "<note>variant one</note> ccc ddd <note>variant two</note> eee";
+            int start = xml.IndexOf("ant one", System.StringComparison.Ordinal);   // mid-note
+
+            string cleaned = TeiText.Clean(xml, start, xml.Length, includeNotes: false);
+
+            // Old behavior returned just "ant one" (note tail leaked, everything after dropped). The following
+            // base text ("ccc ddd", "eee") must now survive; the SECOND, fully-enclosed note is still stripped.
+            Assert.Contains("ccc ddd", cleaned);
+            Assert.Contains("eee", cleaned);
+            Assert.DoesNotContain("variant two", cleaned);
+        }
+
+        [Fact]
+        public void Clean_still_strips_a_fully_enclosed_note()
+        {
+            const string xml = "aaa <note>VAR</note> bbb";
+            string cleaned = TeiText.Clean(xml, 0, xml.Length, includeNotes: false);
+            Assert.DoesNotContain("VAR", cleaned);
+            Assert.Contains("aaa", cleaned);
+            Assert.Contains("bbb", cleaned);
+        }
+
+        [Fact]
+        public void CountNotesIntersecting_counts_a_note_the_window_opens_midway_through()
+        {
+            // Window [lo, hi) starts inside note1 and ends inside note2 -> both intersect, even though neither
+            // STARTS in the window. (#310 A4-15)
+            const string xml = "xx <note>one</note> mid <note>two</note> yy";
+            int lo = xml.IndexOf("ne</note>", System.StringComparison.Ordinal);   // inside note1
+            int hi = xml.IndexOf("wo</note>", System.StringComparison.Ordinal);   // inside note2
+
+            Assert.Equal(2, TeiText.CountNotesIntersecting(xml, scanFrom: 0, lo, hi));
+        }
+    }
+}

--- a/src/CST.Core/CST.Core.csproj
+++ b/src/CST.Core/CST.Core.csproj
@@ -8,6 +8,11 @@
     <RootNamespace>CST</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Let the test project exercise internal TEI helpers (TeiText.Clean etc.) directly. -->
+    <InternalsVisibleTo Include="CST.Avalonia.Tests" />
+  </ItemGroup>
+
   <!-- Temporarily removed Lucene.Net dependency to focus on core book data -->
   <!-- <ItemGroup>
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00018" />

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -32,7 +32,11 @@ namespace CST.Search
             if (snapStartToSentence)
             {
                 int floor = EnclosingParagraphStart(startPos, markers);
-                int candidate = SnapBackToSentenceStart(xml, startPos, floor);
+                // Note-aware like the snippet extractor's sentence scans: a danda INSIDE a <note> is apparatus
+                // punctuation, not a base-text sentence boundary, so snapping to it would land the window start
+                // mid-note. (#310 A4-2)
+                var snapNotes = TeiText.NoteRegions(xml, floor, startPos);
+                int candidate = SnapBackToSentenceStart(xml, startPos, floor, snapNotes);
                 if (candidate < startPos
                     && WalkForward(xml, candidate, maxChars, includeVariants, xml.Length) > startPos)
                     readStart = candidate;
@@ -47,15 +51,17 @@ namespace CST.Search
             int? prev = prevStart < readStart ? prevStart : (int?)null;
 
             // Apparatus notes ({…}) in this window — counted from the raw XML regardless of includeVariants, so a
-            // caller knows whether apparatus exists here without a second call. (#293)
-            int noteCount = TeiText.NoteRegions(xml, readStart, end).Count;
+            // caller knows whether apparatus exists here without a second call. (#293) Count notes INTERSECTING the
+            // window (including one opened before readStart), not just those starting in it. (#310 A4-15)
+            int paraStart = EnclosingParagraphStart(readStart, markers);
+            int noteCount = TeiText.CountNotesIntersecting(xml, paraStart, readStart, end);
             var (num, code, pages) = markers.RefsAt(readStart);
             return new PassageWindow(text, prev, next, num, code, pages, noteCount);
         }
 
         // The nearest sentence start at or after <paramref name="minStart"/> and at/before <paramref name="startPos"/>
         // — i.e. just past the closest preceding sentence boundary, without crossing minStart. Tags are skipped.
-        private static int SnapBackToSentenceStart(string xml, int startPos, int minStart)
+        private static int SnapBackToSentenceStart(string xml, int startPos, int minStart, List<(int s, int e)> notes)
         {
             if (minStart < 0) minStart = 0;
             int i = startPos - 1;
@@ -68,7 +74,9 @@ namespace CST.Search
                     i = lt >= minStart ? lt - 1 : minStart - 1;
                     continue;
                 }
-                if (TeiText.IsBoundary(c)) return i + 1;   // begin just past the sentence-ending danda
+                // begin just past the sentence-ending danda — but a danda inside a note is apparatus, not a
+                // base-text boundary. (#310 A4-2)
+                if (TeiText.IsBoundary(c) && !TeiText.InNote(i, notes)) return i + 1;
                 i--;
             }
             return minStart;
@@ -102,7 +110,11 @@ namespace CST.Search
                     string tag = xml.Substring(i, gt - i + 1);
                     string name = TeiText.TagName(tag);
                     if (name == "note" && !includeNotes && !tag.EndsWith("/>", StringComparison.Ordinal))
-                        i = TeiText.SkipSubtree(xml, gt + 1, "note", limit);
+                        // Open <note> strips its subtree; a lone </note> (walk began inside a note) is zero-width,
+                        // never a subtree — else SkipSubtree jumps to the next </note>, silently skipping text. (#310 A4-2)
+                        i = tag.StartsWith("</", StringComparison.Ordinal)
+                            ? gt + 1
+                            : TeiText.SkipSubtree(xml, gt + 1, "note", limit);
                     else if (name == "hi" && TeiText.IsStructuralHi(tag) && !tag.EndsWith("/>", StringComparison.Ordinal))
                         i = TeiText.SkipSubtree(xml, gt + 1, "hi", limit);
                     else i = gt + 1;
@@ -133,8 +145,10 @@ namespace CST.Search
                 }
                 else { rendered++; i--; }
             }
-            for (int j = Math.Max(i, limit); j < start; j++)
-                if (TeiText.IsBoundary(xml[j])) return j + 1;                   // begin at a sentence start
+            int from = Math.Max(i, limit);
+            var notes = TeiText.NoteRegions(xml, from, start);
+            for (int j = from; j < start; j++)
+                if (TeiText.IsBoundary(xml[j]) && !TeiText.InNote(j, notes)) return j + 1;   // sentence start (note-aware, #310)
             return Math.Max(i + 1, limit);
         }
     }

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -58,8 +58,14 @@ namespace CST.Search
             // A window bound can land INSIDE a tag (e.g. SnapToSpace stopping at a space within `<hi rend="dot">`),
             // which would leak the tag's tail (`rend="dot">`) as text since Clean can't see the `<` before it.
             // Nudge the start past the tag and the end before it. Never cross the marks. (Code+API friction D-2)
-            winStart = Math.Min(NudgePastTag(xml, winStart), ms[0].Start);
-            winEnd = Math.Max(NudgeBeforeTag(xml, winEnd), ms[ms.Count - 1].End);
+            //
+            // A bound can ALSO land inside a <note> element (SnapToSpace can snap to a space within note content) —
+            // the tag-nudge only fixes bounds inside a tag, not inside a note. So first nudge each bound out of any
+            // note region (start => note end, end => note start), then out of a tag. The clamps keep us from ever
+            // crossing the marks, so a hit that is itself inside a note still renders. (#310 A4-2)
+            var winNotes = TeiText.NoteRegions(xml, pStart, pEnd);
+            winStart = Math.Min(NudgePastTag(xml, NudgePastNote(winStart, winNotes)), ms[0].Start);
+            winEnd = Math.Max(NudgeBeforeTag(xml, NudgeBeforeNote(winEnd, winNotes)), ms[ms.Count - 1].End);
 
             // Render as segments: prefix . before . [mark . gap]* . mark . after . suffix, tracking each mark's
             // snippet-local start as the cumulative rendered length before it. Same length rule as the single-mark
@@ -93,8 +99,10 @@ namespace CST.Search
             var (num, code, pages) = markers.RefsAt(anchor.Start);
             var anchorHl = highlights.FirstOrDefault(h => h.IsAnchor) ?? highlights[0];
             // Apparatus notes ({…}) in this window — counted from the raw XML regardless of IncludeFootnotes, so a
-            // caller can tell "no apparatus here" from "apparatus suppressed" without a second call. (#293)
-            int noteCount = TeiText.NoteRegions(xml, winStart, winEnd).Count;
+            // caller can tell "no apparatus here" from "apparatus suppressed" without a second call. (#293) Count
+            // notes INTERSECTING the window, not just those starting in it, so a note the window opens mid-way
+            // through still counts. (#310 A4-15)
+            int noteCount = TeiText.CountNotesIntersecting(xml, pStart, winStart, winEnd);
             return new SnippetResult(
                 sb.ToString(), anchorHl.Start, anchorHl.Length, num, code, pages, opts.IncludeFootnotes, highlights, noteCount);
         }
@@ -171,6 +179,22 @@ namespace CST.Search
         private static int NudgeBeforeTag(string xml, int pos)
         {
             if (InsideTag(xml, pos)) { int lt = xml.LastIndexOf('<', Math.Max(0, pos - 1)); if (lt >= 0) return lt; }
+            return pos;
+        }
+
+        // A window START inside a note region moves past the note (to its end); a stripped/apparatus note should
+        // not open the visible window mid-content. (#310 A4-2)
+        private static int NudgePastNote(int pos, List<(int s, int e)> notes)
+        {
+            foreach (var (s, e) in notes) if (pos >= s && pos < e) return e;
+            return pos;
+        }
+
+        // A window END (exclusive) inside a note region pulls back to that note's start, so the window never ends
+        // partway through note content. (#310 A4-2)
+        private static int NudgeBeforeNote(int pos, List<(int s, int e)> notes)
+        {
+            foreach (var (s, e) in notes) if (pos > s && pos < e) return s;
             return pos;
         }
 

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -43,15 +43,19 @@ namespace CST.Search
                     string name = TagName(tag);
                     if (name == "note" && !tag.EndsWith("/>", System.StringComparison.Ordinal))
                     {
+                        // TagName("</note>") is "note" too, so this branch fires for BOTH open and close. A close
+                        // tag means the range began INSIDE a note — it must be zero-width, never a subtree: calling
+                        // SkipSubtree on a lone </note> enters depth 1 and consumes to the NEXT </note> (or the whole
+                        // rest of the window), silently dropping the following base text. (#310 A4-2)
+                        bool isClose = tag.StartsWith("</", System.StringComparison.Ordinal);
                         if (!includeNotes)
-                            i = SkipSubtree(xml, gt + 1, "note", end);
+                            i = isClose ? gt + 1 : SkipSubtree(xml, gt + 1, "note", end);
                         else
                         {
                             // Delimit an included note with curly braces (which never occur in the corpus - 0
                             // across all 217 files) so a consumer can tell injected footnote/variant apparatus
                             // from the base text; the parentheses the notes carry are otherwise indistinguishable
                             // from the text's own. Open tag => '{', close tag => '}'; inside stays `reading (sigla)`.
-                            bool isClose = tag.StartsWith("</", System.StringComparison.Ordinal);
                             if (!isClose && sb.Length > 0 && sb[sb.Length - 1] != ' ') sb.Append(' ');
                             sb.Append(isClose ? '}' : '{');
                             i = gt + 1;
@@ -103,6 +107,18 @@ namespace CST.Search
         {
             foreach (var (s, e) in notes) if (pos >= s && pos < e) return true;
             return false;
+        }
+
+        /// <summary>Count notes that INTERSECT the window <c>[lo, hi)</c>, including one that opened before
+        /// <paramref name="lo"/> and extends into it. <see cref="NoteRegions"/> only finds notes that START in a
+        /// range, so scan from <paramref name="scanFrom"/> (&lt;= lo — e.g. the enclosing paragraph start) and keep
+        /// those overlapping the window. (#310 A4-15)</summary>
+        internal static int CountNotesIntersecting(string xml, int scanFrom, int lo, int hi)
+        {
+            int count = 0;
+            foreach (var (s, e) in NoteRegions(xml, Math.Min(scanFrom, lo), hi))
+                if (s < hi && e > lo) count++;
+            return count;
         }
 
         // Position just past the matching close tag for an already-open element.


### PR DESCRIPTION
## Summary
**HIGH.** `TagName("</note>")` returns `"note"`, so `TeiText.Clean`'s note-strip branch (and `TeiPassageReader.WalkForward`'s) fired for the **close** tag and called `SkipSubtree` on it — entering depth 1 and consuming to the *next* `</note>` (or the whole rest of the window). A rendered range that **begins inside a note** therefore leaked the note tail as base text and silently **dropped everything after it**. Empirically: cleaning from inside `<note>variant one</note> ccc ddd <note>variant two</note> eee` returned just `"ant one"`.

Note text *is* indexed (the tokenizer doesn't strip notes), so this is reachable via a hit inside a note, a long-sentence `SnapToSpace` landing in a note, and the passage reader's non-note-aware sentence snaps.

## Fix
- **(a)** `Clean` + `WalkForward` — a close tag (`tag.StartsWith("</")`) in the strip branch is now **zero-width**, never a subtree.
- **(b)** `TeiSnippetExtractor` — nudge window bounds out of `<note>` regions (`NudgePastNote` / `NudgeBeforeNote`), like they're already nudged out of tags. The clamps still never cross the marks, so a hit inside a note still renders.
- **(c)** `TeiPassageReader` — `SnapBackToSentenceStart` and `WalkBackward`'s boundary scan are now note-aware (a danda inside a note is apparatus, not a base-text boundary).
- **A4-15** — `NoteCount` counts notes **intersecting** the window (`CountNotesIntersecting`), not just those starting in it.

## Tests
- `TeiTextNoteBoundaryTests` (direct on `TeiText.Clean` via new `InternalsVisibleTo`): the empirical repro keeps following base text and still strips enclosed notes; intersection counting.
- SnippetEngine + PassageReader suites: green (no regression). Full suite: 637 passed.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)