### PR TITLE
#311: sync DocIds in occurrence endpoints + skip stale-reader cache writes (A4-4, A4-5)

### DIFF
--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -143,8 +143,14 @@ public class SearchService : ISearchService
             stopwatch.Stop();
             result.SearchDuration = stopwatch.Elapsed;
 
-            // Cache the result (bounded; FIFO eviction)
-            _searchCache.Set(cacheKey, result);
+            // Cache the result (bounded; FIFO eviction) — but ONLY if the reader we searched is still the live
+            // one. A concurrent re-index reopen calls _searchCache.Clear() inside AcquireReader; Setting an
+            // old-reader result after that Clear would serve stale hits until FIFO eviction. (#311 A4-5)
+            lock (_readerLock)
+            {
+                if (ReferenceEquals(reader, _indexReader))
+                    _searchCache.Set(cacheKey, result);
+            }
 
             _logger.LogInformation("Search completed in {Duration}ms with {TermCount} terms, {OccurrenceCount} occurrences",
                 stopwatch.ElapsedMilliseconds, result.TotalTermCount, result.TotalOccurrenceCount);
@@ -890,6 +896,10 @@ public class SearchService : ISearchService
         try
         {
             reader = AcquireReader();
+            // Sync DocIds to THIS reader generation before reading book.DocId — else after a re-index this
+            // endpoint targets a stale/deleted doc and returns empty/wrong positions (only SearchAsync synced
+            // before this). (#311 A4-4)
+            EnsureDocIds(reader, Books.Inst);
             // Books' string indexer throws on an unknown file name; use a safe lookup so a bad bookId can't
             // become an unhandled 500 in the occurrences endpoint. (#186 cold test)
             var book = Books.Inst.FirstOrDefault(b =>
@@ -962,6 +972,7 @@ public class SearchService : ISearchService
         try
         {
             reader = AcquireReader();
+            EnsureDocIds(reader, Books.Inst);   // sync DocIds to this reader generation before reading book.DocId (#311 A4-4)
             var book = Books.Inst.FirstOrDefault(b =>
                 string.Equals(b.FileName, bookFileName, StringComparison.OrdinalIgnoreCase));
             if (book == null || book.DocId < 0) return Task.FromResult(empty);


### PR DESCRIPTION
## Summary
Two concrete re-index/consistency fixes from the search-internals review (partial fix for #311):

- **A4-4** — `GetTermPositionsAsync` / `GetMultiWordPositionsAsync` read `book.DocId` against a freshly-acquired reader but never called `EnsureDocIds` (only `SearchAsync` did). After a re-index, `/v1/occurrences` therefore targeted a stale/deleted doc → empty or wrong positions. Both now sync DocIds to the acquired reader generation before reading `book.DocId`.
- **A4-5** — an in-flight search on the *old* reader would `Set` its result into the cache **after** a concurrent reopen already `Clear`ed it (in `AcquireReader`), serving stale hits until FIFO eviction. Now only caches when the reader we searched is still `_indexReader` (checked under `_readerLock`).

## Deferred (still tracked in #311)
- **A4-3** — replacing the mutable `Books.Inst` DocId singleton with a per-reader immutable map (`ConditionalWeakTable<DirectoryReader, …>`). This reworks the DocId model shared with the core `Books` class (UTF-16, also used by CST4) and is an architectural decision better made deliberately than rushed before a review.
- **A4-6** — counts-only `DocFreq`/`TotalTermFreq` vs postings `liveDocs` double-count under unmerged deletions. The finding itself is flagged "needs verification against a real incremental update"; deferring until that's confirmed.

## Tests
- Search / occurrence / integration suites: 124 green; full suite **637 passed**. (The guards are concurrency-timing behaviors exercised by the existing search paths; a deterministic mid-re-index race test isn't added here.)

Refs #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)