### PR TITLE
#312: dedupe overlapping occurrence marks + page the multi-word search (A4-7, A4-8 pt1)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
+++ b/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
@@ -60,6 +60,29 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void Extract_dedupes_marks_at_the_same_offset()
+        {
+            // #312 A4-7: FindHits' sliding window can emit two hits sharing a word occurrence (A…B…A gives
+            // {A1,B},{B,A2}) — the shared word must render ONCE, not twice with a phantom highlight.
+            const string xml =
+                "<body><div id=\"a\" type=\"book\"><p rend=\"bodytext\" n=\"1\">aaa bbb ccc\u0964</p></div></body>";
+            var markers = BookMarkers.Build(xml);
+            int a = xml.IndexOf("aaa", System.StringComparison.Ordinal);
+            int b = xml.IndexOf("bbb", System.StringComparison.Ordinal);
+            var marks = new[]
+            {
+                new SnippetMark(a, a + 3, true),    // anchor "aaa"
+                new SnippetMark(b, b + 3, false),   // "bbb"
+                new SnippetMark(a, a + 3, false),   // DUPLICATE of "aaa" (the shared occurrence)
+            };
+
+            var s = TeiSnippetExtractor.Extract(xml, marks, markers, Deva());
+
+            Assert.Equal(2, s.Highlights.Count);                  // deduped: two highlights, not three
+            Assert.Equal(1, s.Highlights.Count(h => h.IsAnchor)); // the anchor flag is preserved
+        }
+
+        [Fact]
         public void Snippet_never_leaks_markup_across_truncation_budgets()
         {
             // A window bound that lands inside `<pb ed="V" n="1.0002"/>` must not leak `ed="V" n=...` as text.

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -501,16 +501,29 @@ public class SearchService : ISearchService
             }
         }
 
-        // Step 4: convert results
-        // Order matching combinations alphabetically by their IPE words (word-by-word), matching
-        // CST4 and the single-term path. The '~'-joined key sorts word0, then word1, etc.
-        result.Terms = combos.Values.OrderBy(t => t.Term, StringComparer.Ordinal).ToList();
+        // Step 4: convert results. Order matching combinations alphabetically by their IPE words (word-by-word),
+        // matching CST4 and the single-term path (the '~'-joined key sorts word0, then word1, ...), then apply the
+        // SAME page budget (Skip + PageSize) the single-term path honors. The multi-word path previously IGNORED
+        // paging: Skip>0 returned the full set again and HasMore was never set, and every combo's TermPositions
+        // stayed in the cached result. Both callers already pass PageSize (UI 500, API MaxTerms); honor it. (#312 A4-8)
+        var allTerms = combos.Values.OrderBy(t => t.Term, StringComparer.Ordinal).ToList();
+        int skip = Math.Max(0, query.Skip);
+        int pageSize = query.PageSize > 0 ? query.PageSize : allTerms.Count;
+        result.Terms = allTerms.Skip(skip).Take(pageSize).ToList();
+        result.HasMore = skip + result.Terms.Count < allTerms.Count;
+        // Keep the UI's "showing the first N" message for the first page — but don't clobber a wildcard-expansion
+        // truncation message (that one is the more urgent "narrow the pattern").
+        if (result.HasMore && skip == 0 && !result.ResultsTruncated)
+        {
+            result.ResultsTruncated = true;
+            result.TruncationMessage = $"Showing the first {pageSize:N0} matching words — refine your search to narrow the results.";
+        }
         result.TotalTermCount = result.Terms.Count;
         result.TotalOccurrenceCount = result.Terms.Sum(t => t.TotalCount);
         result.TotalBookCount = result.Terms.SelectMany(t => t.Occurrences).Select(o => o.Book).Distinct().Count();
 
-        _logger.LogInformation("Multi-word search found {ComboCount} unique word combinations, {OccurrenceCount} total occurrences",
-            result.TotalTermCount, result.TotalOccurrenceCount);
+        _logger.LogInformation("Multi-word search found {ComboCount} unique word combinations (page of {Total}), {OccurrenceCount} occurrences on page",
+            allTerms.Count, result.TotalTermCount, result.TotalOccurrenceCount);
 
         return result;
     }

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -27,7 +27,10 @@ namespace CST.Search
         /// </summary>
         public static SnippetResult Extract(string xml, IReadOnlyList<SnippetMark> marks, BookMarkers markers, SnippetOptions opts)
         {
-            // Clamp + sort marks; drop any that clamp to empty. Fall back to a zero-width mark at 0 if none remain.
+            // Clamp marks, then DE-DUPE by (Start,End): MultiWordSearch.FindHits' sliding window can emit two hits
+            // sharing a word occurrence (A…B…A → {A1,B},{B,A2}); merged into one sentence the shared word would be
+            // rendered twice with a phantom highlight ("… b b …"). Collapse duplicates, keeping the anchor flag if
+            // any duplicate carried it. Fall back to a zero-width mark at 0 if none remain. (#312 A4-7)
             var ms = marks
                 .Select(m =>
                 {
@@ -35,6 +38,8 @@ namespace CST.Search
                     int e = Math.Clamp(m.End, s, xml.Length);
                     return new SnippetMark(s, e, m.IsAnchor);
                 })
+                .GroupBy(m => (m.Start, m.End))
+                .Select(g => new SnippetMark(g.Key.Start, g.Key.End, g.Any(x => x.IsAnchor)))
                 .OrderBy(m => m.Start).ThenBy(m => m.End)
                 .ToList();
             if (ms.Count == 0) ms.Add(new SnippetMark(0, 0, true));


### PR DESCRIPTION
## Summary
- **A4-7** — `GroupCoLocated`/`Extract` didn't de-dupe marks, so `MultiWordSearch.FindHits`' sliding window emitting two hits that share a word occurrence (`A…B…A` → `{A1,B},{B,A2}`) rendered the shared word **twice with a phantom highlight** (`… b b …`). `Extract` now collapses marks by `(Start,End)`, keeping the anchor flag if any duplicate carried it.
- **A4-8 (part 1)** — the multi-word/phrase/regex-unit path ignored paging: `Skip>0` returned the full set again, `HasMore` was never set, and every combo's `TermPosition`s stayed in the cached result (`BoundedCache` pinning up to 50 such payloads). It now applies the same `Skip`/`PageSize` budget the single-term path honors — both callers already pass `PageSize` (UI 500, API `MaxTerms`), so this makes multi-word honor what they already request — and sets `HasMore`, bounding the cached payload to one page.

## Deferred (still tracked in #312)
- **A4-8 (part 2)** — stripping `Positions` from cached multi-word results. The UI (`SearchViewModel` / `SearchPanel`) reads `occurrence.Positions` directly for highlighting and book-open, so stripping them from the cache would regress UI highlighting on a cache hit. Paging (part 1) already bounds the cached payload to a page, so the memory concern is largely addressed; the further trim needs a UI-side decision.

## Tests
- `SnippetEngineTests.Extract_dedupes_marks_at_the_same_offset` (two highlights, not three; anchor preserved).
- Multi-word search suites green (paging mirrors the single-term path). Full suite: **638 passed**.

Refs #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)