### PR TITLE
#313: extraction-core robustness — edge-case crashes + wasteful re-reads (A4-10..16)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiExtractionHardeningTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiExtractionHardeningTests.cs
@@ -1,0 +1,63 @@
+using System;
+using CST.Conversion;
+using CST.Search;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Search
+{
+    /// <summary>
+    /// #313 (A4-10..13): edge-case robustness in the extraction core. ASCII-only fixtures; Devanagari output is
+    /// identity here, so the raw structure is asserted directly.
+    /// </summary>
+    public class TeiExtractionHardeningTests
+    {
+        private static SnippetOptions Deva(int min, int max) =>
+            new(OutputScript: Script.Devanagari, IncludeFootnotes: false, MinChars: min, MaxChars: max);
+
+        [Fact]
+        public void Clean_treats_a_non_structural_hi_as_zero_width()
+        {
+            // #313 A4-10: <hi rend="bold"> mid-word is intra-word to the tokenizer — Clean must not inject a space.
+            const string xml = "sa<hi rend=\"bold\">mmb</hi> foo";
+            string cleaned = TeiText.Clean(xml, 0, xml.Length, includeNotes: false);
+            Assert.Contains("sammb", cleaned);
+            Assert.DoesNotContain("sa mmb", cleaned);
+        }
+
+        [Fact]
+        public void Extract_with_no_marks_does_not_throw()
+        {
+            // #313 A4-11: the empty-marks fallback (a zero-width mark at 0) feeds FindLastPOpen(xml, 0), which used
+            // to call LastIndexOf(-1) and throw.
+            const string xml = "no paragraph tags here just text";
+            var markers = BookMarkers.Build(xml);
+            var ex = Record.Exception(() => TeiSnippetExtractor.Extract(xml, Array.Empty<SnippetMark>(), markers, Deva(1, 400)));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void Extract_without_a_paragraph_and_a_tight_window_does_not_throw()
+        {
+            // #313 A4-12: with no enclosing <p>, pEnd == xml.Length, so SnapToSpace's backward scan can start at
+            // pos == length and index xml[length]. A late hit + a MaxChars below the visible length forces it.
+            const string xml = "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo";
+            var markers = BookMarkers.Build(xml);
+            int hit = xml.IndexOf("juliet", StringComparison.Ordinal);
+            var ex = Record.Exception(() =>
+                TeiSnippetExtractor.Extract(xml, hit, "juliet".Length, markers, Deva(1, 60)));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void ReadWindow_with_int_max_maxchars_returns_the_whole_text_not_one_char()
+        {
+            // #313 A4-13: hardCap = maxChars + maxChars/2 overflowed negative at maxChars=int.MaxValue, so the walk
+            // returned after a single char. Computed in long now.
+            const string xml = "<p>alpha beta gamma delta epsilon</p>";
+            var markers = BookMarkers.Build(xml);
+            var w = TeiPassageReader.ReadWindow(xml, 0, int.MaxValue, includeVariants: false, Script.Devanagari, markers);
+            Assert.Contains("alpha", w.Text);
+            Assert.Contains("epsilon", w.Text);
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -866,8 +866,8 @@ public class SearchService : ISearchService
             reader = AcquireReader();
             var allTerms = new List<string>();
             var fields = MultiFields.GetFields(reader);
-            var terms = fields.GetTerms("text");
-            
+            var terms = fields?.GetTerms("text");   // GetFields returns null on an empty index (#313 A4-14)
+
             if (terms == null) return allTerms;
             
             var termsEnum = terms.GetEnumerator();
@@ -1173,9 +1173,14 @@ public class SearchService : ISearchService
     {
         lock (_readerLock)
         {
-            _indexReader?.Dispose();
+            // Release our OWNER ref rather than force-Dispose: a force-Dispose closes the reader (and the
+            // FSDirectory inputs an in-flight pool-thread search opened from it) out from under that search,
+            // throwing ObjectDisposedException in the shutdown window. DecRef instead — the reader (and its
+            // directory handles) closes once the last in-flight search DecRefs its own ref. The FSDirectory is
+            // left to be reclaimed with the reader it backs; disposing it here, under in-flight searches, is the
+            // very race. (#313 A4-16)
+            _indexReader?.DecRef();
             _indexReader = null;
-            _directory?.Dispose();
             _directory = null;
         }
     }

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -98,7 +98,10 @@ namespace CST.Search
         // boundary (capped) so we never cut mid-sentence. Tags and stripped subtrees cost zero budget.
         private static int WalkForward(string xml, int start, int maxChars, bool includeNotes, int limit)
         {
-            int i = start, rendered = 0, hardCap = maxChars + maxChars / 2;
+            // long: an unclamped client maxChars (e.g. int.MaxValue) would overflow `maxChars + maxChars/2`
+            // negative, tripping `rendered >= hardCap` on the first char. (#313 A4-13; endpoint also clamps, #305)
+            int i = start, rendered = 0;
+            long hardCap = (long)maxChars + maxChars / 2;
             bool budgetReached = false;
             while (i < limit)
             {

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -277,6 +277,7 @@ namespace CST.Search
         private static int FindLastPOpen(string xml, int before)
         {
             int idx = Math.Min(before, xml.Length);
+            if (idx <= 0) return -1;   // no room for "<p" before position 0; guards LastIndexOf(-1) (#313 A4-11)
             while ((idx = xml.LastIndexOf("<p", idx - 1, StringComparison.Ordinal)) >= 0)
             {
                 char c = idx + 2 < xml.Length ? xml[idx + 2] : '\0';
@@ -299,6 +300,9 @@ namespace CST.Search
 
         private static int SnapToSpace(string xml, int pos, int dir, int stopAt)
         {
+            // In the no-enclosing-<p> fallback pEnd == xml.Length, so a backward scan can start at pos == length
+            // and index xml[length]. Clamp the starting index. (#313 A4-12)
+            if (dir < 0 && pos >= xml.Length) pos = xml.Length - 1;
             for (int i = pos; dir > 0 ? i < stopAt : i > stopAt; i += dir)
                 if (xml[i] == ' ' || xml[i] == '\n') return i + (dir > 0 ? 1 : 0);
             return pos;

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -63,6 +63,11 @@ namespace CST.Search
                     }
                     else if (name == "hi" && IsStructuralHi(tag) && !tag.EndsWith("/>", System.StringComparison.Ordinal))
                         i = SkipSubtree(xml, gt + 1, "hi", end);
+                    else if (name == "hi")
+                        // A non-structural <hi>/</hi> (e.g. rend="bold") is intra-word to the tokenizer — treat it
+                        // zero-width (no injected space), else a hit on a bold-containing word renders "sa mmā" and
+                        // the highlight text stops matching the term. (#313 A4-10)
+                        i = gt + 1;
                     else
                     {
                         if (sb.Length > 0 && sb[sb.Length - 1] != ' ') sb.Append(' ');


### PR DESCRIPTION
## Summary
Low-severity robustness fixes in the extraction core (several unreachable from the real corpus, but the `CST.Core` APIs are public):

- **A4-10** (`TeiText.Clean`) — a non-structural `<hi rend="bold">` mid-word injected a space though the tokenizer treats it intra-word, so a hit on a bold-containing word rendered `sa mmā` and the highlight stopped matching. Any non-structural `<hi>`/`</hi>` is now zero-width.
- **A4-11** (`FindLastPOpen`) — threw `ArgumentOutOfRangeException` at position 0 (the documented empty-marks fallback feeds it). Guard `idx <= 0 → -1`.
- **A4-12** (`SnapToSpace`) — could index `xml[xml.Length]` in the no-enclosing-`<p>` fallback. Clamp the backward-scan start.
- **A4-13** (`WalkForward`) — `hardCap = maxChars + maxChars/2` overflowed negative at `maxChars=int.MaxValue` and returned after 1 char. Computed in `long` (the endpoint also clamps, #305).
- **A4-14** (`GetAllTermsAsync`) — missing the `fields?` null-check every other call site has → NRE on an empty index.
- **A4-16** (`Dispose`) — force-`Dispose`d the reader + `FSDirectory` out from under an in-flight pool-thread search → `ObjectDisposedException` in the shutdown window. Now `DecRef`s the owner ref (ref-counted close) and leaves the directory to be reclaimed with the reader it backs.

**A4-17** (info) — the dead `FromDocId` null/throw asymmetry — is unreachable today and only resurfaces if A4-3 is fixed by clearing the DocId map; left with that deferred work (#311), and it would require editing the UTF-16 `Books.cs` for a dead path.

## Tests
- `TeiExtractionHardeningTests`: bold-hi zero-width; no-marks Extract doesn't throw; no-`<p>` tight-window Extract doesn't throw; `int.MaxValue` maxChars returns the whole window.
- Full suite: **642 passed**.

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)