### PR TITLE
#315: SingleInstanceGuard — distinguish contention from failure; catch UnauthorizedAccess

### DIFF
--- a/src/CST.Avalonia.Tests/Services/SingleInstanceGuardTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SingleInstanceGuardTests.cs
@@ -18,16 +18,39 @@ namespace CST.Avalonia.Tests.Services
             var dir = Path.Combine(Path.GetTempPath(), "cst-lock-" + Guid.NewGuid().ToString("N"));
             try
             {
-                var first = SingleInstanceGuard.TryOpenLock(dir);
-                Assert.NotNull(first);                                 // this "instance" acquires
+                var (r1, first) = SingleInstanceGuard.TryOpenLock(dir);
+                Assert.Equal(SingleInstanceGuard.LockResult.Acquired, r1);   // this "instance" acquires
+                Assert.NotNull(first);
 
-                Assert.Null(SingleInstanceGuard.TryOpenLock(dir));     // a second is blocked while the first holds it
+                var (r2, second) = SingleInstanceGuard.TryOpenLock(dir);     // a second is CONTENDED while first holds it
+                Assert.Equal(SingleInstanceGuard.LockResult.Contended, r2);
+                Assert.Null(second);
 
-                first!.Dispose();                                      // release (process death frees it the same way)
+                first!.Dispose();                                            // release (process death frees it the same way)
 
-                var third = SingleInstanceGuard.TryOpenLock(dir);
-                Assert.NotNull(third);                                 // available again once released
+                var (r3, third) = SingleInstanceGuard.TryOpenLock(dir);
+                Assert.Equal(SingleInstanceGuard.LockResult.Acquired, r3);   // available again once released
                 third!.Dispose();
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void A_non_contention_failure_is_Failed_not_Contended()
+        {
+            // #315 A6-1/A6-2: a failure that is NOT another instance (here `instance.lock` existing as a DIRECTORY,
+            // so the file open throws) must be reported as Failed — proceed unguarded — never Contended, which
+            // would wrongly activate/relaunch and could loop.
+            var dir = Path.Combine(Path.GetTempPath(), "cst-lock-fail-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(dir, SingleInstanceGuard.LockFileName));   // lock path is a dir
+            try
+            {
+                var (result, stream) = SingleInstanceGuard.TryOpenLock(dir);
+                Assert.Equal(SingleInstanceGuard.LockResult.Failed, result);
+                Assert.Null(stream);
             }
             finally
             {

--- a/src/CST.Avalonia/Program.cs
+++ b/src/CST.Avalonia/Program.cs
@@ -114,6 +114,15 @@ sealed class Program
 
             app.StartWithClassicDesktopLifetime(args);
         }
+        catch (Exception ex)
+        {
+            // Last-resort: an early-startup failure (e.g. the single-instance guard on an unwritable data dir)
+            // would otherwise be an unhandled crash with no window and — if it happened before logging init — no
+            // log. Make it visible on stderr, and log if Serilog is up. (#315 A6-2)
+            Console.Error.WriteLine($"CST Reader failed to start: {ex}");
+            try { Serilog.Log.Fatal(ex, "Fatal startup error"); } catch { /* logging may not be configured yet */ }
+            throw;
+        }
         finally
         {
             // No cleanup needed for WebView

--- a/src/CST.Avalonia/SingleInstanceGuard.cs
+++ b/src/CST.Avalonia/SingleInstanceGuard.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using Serilog;
 
 namespace CST.Avalonia
 {
@@ -25,25 +26,45 @@ namespace CST.Avalonia
         private static extern int flock(int fd, int operation);
         private const int LOCK_EX = 2, LOCK_NB = 4;
 
+        // flock() sets errno EWOULDBLOCK (== EAGAIN) for a genuine "another holder has it" — 35 on macOS, 11 on
+        // Linux. Any OTHER errno (ENOTSUP/ENOLCK on NFS, ENOMEM, ...) is NOT contention. (#315 A6-1)
+        private const int EWOULDBLOCK_MacOS = 35;
+        private const int EAGAIN_Linux = 11;
+
+        /// <summary>Outcome of trying to take the lock: we got it, another instance holds it, or the attempt failed
+        /// for a reason that is NOT contention (unwritable/networked data dir, flock unsupported, ...).</summary>
+        internal enum LockResult { Acquired, Contended, Failed }
+
         /// <summary>True if this process became THE instance for <paramref name="dataDirectory"/> (or the guard is
-        /// bypassed via <c>CST_ALLOW_MULTIPLE=1</c>); false if another instance already holds the lock.</summary>
+        /// bypassed via <c>CST_ALLOW_MULTIPLE=1</c>); false ONLY if another instance already holds the lock. A
+        /// non-contention failure (can't create/lock the file) is logged and treated as "proceed unguarded"
+        /// (returns true, no activation) — never misdiagnosed as another instance, which would relaunch/loop.</summary>
         public static bool TryAcquire(string dataDirectory)
         {
             if (Environment.GetEnvironmentVariable("CST_ALLOW_MULTIPLE") == "1")
                 return true;
 
-            var held = TryOpenLock(dataDirectory);
-            if (held is null) return false;
-            _held = held;   // keep the handle (and thus the lock) alive for the process lifetime
-            return true;
+            var (result, held) = TryOpenLock(dataDirectory);
+            switch (result)
+            {
+                case LockResult.Acquired:
+                    _held = held;   // keep the handle (and thus the lock) alive for the process lifetime
+                    return true;
+                case LockResult.Contended:
+                    return false;   // another instance owns it → caller activates that one and exits
+                default:
+                    return true;    // couldn't lock for a non-contention reason → run unguarded (already logged)
+            }
         }
 
         /// <summary>
-        /// Open the per-data-dir lock file exclusively; null if another holder has it. Uses <c>FileShare.None</c>
-        /// (authoritative on Windows) plus an explicit advisory <c>flock</c> on Unix, where .NET's FileShare
-        /// enforcement is unreliable for cross-process locking. Exposed for tests.
+        /// Try to open the per-data-dir lock file exclusively. Uses <c>FileShare.None</c> (authoritative on Windows)
+        /// plus an explicit advisory <c>flock</c> on Unix, where .NET's FileShare enforcement is unreliable for
+        /// cross-process locking. Distinguishes genuine contention (<see cref="LockResult.Contended"/>) from any
+        /// other failure (<see cref="LockResult.Failed"/>), inspecting errno / HResult rather than assuming every
+        /// error is another instance. Exposed for tests.
         /// </summary>
-        internal static FileStream? TryOpenLock(string dataDirectory)
+        internal static (LockResult result, FileStream? stream) TryOpenLock(string dataDirectory)
         {
             FileStream fs;
             try
@@ -52,9 +73,17 @@ namespace CST.Avalonia
                 var path = Path.Combine(dataDirectory, LockFileName);
                 fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
             }
-            catch (IOException)
+            catch (IOException ex) when (IsSharingViolation(ex))
             {
-                return null;   // already held where FileShare.None is enforced (e.g. Windows)
+                return (LockResult.Contended, null);   // another holder where FileShare.None is enforced (Windows)
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+            {
+                // NOT contention: unwritable/networked data dir, a read-only or directory `instance.lock`, disk
+                // full, AV-held handle, ... Proceed unguarded rather than misdiagnose as another instance and
+                // relaunch/loop or die silently. (#315 A6-1/A6-2)
+                Log.Warning(ex, "SingleInstanceGuard: could not open the lock file in {Dir}; running WITHOUT the single-instance guard.", dataDirectory);
+                return (LockResult.Failed, null);
             }
 
             if (!OperatingSystem.IsWindows())
@@ -62,11 +91,28 @@ namespace CST.Avalonia
                 int fd = (int)fs.SafeFileHandle.DangerousGetHandle();
                 if (flock(fd, LOCK_EX | LOCK_NB) != 0)
                 {
+                    int err = Marshal.GetLastPInvokeError();
                     fs.Dispose();
-                    return null;   // another instance holds the advisory lock
+                    if (err == EWOULDBLOCK_MacOS || err == EAGAIN_Linux)
+                        return (LockResult.Contended, null);   // genuine "another instance holds the advisory lock"
+                    // ENOTSUP/ENOLCK (NFS/AFS home), ENOMEM, ... — advisory locking unavailable, not contention.
+                    Log.Warning("SingleInstanceGuard: flock failed (errno {Errno}) in {Dir}; running WITHOUT the single-instance guard.", err, dataDirectory);
+                    return (LockResult.Failed, null);
                 }
             }
-            return fs;
+            return (LockResult.Acquired, fs);
+        }
+
+        // FileShare.None contention surfaces as an IOException whose HResult low bits are the OS error code:
+        // Windows ERROR_SHARING_VIOLATION (32) / ERROR_LOCK_VIOLATION (33); on Unix .NET encodes the raw errno,
+        // and the FileShare.None conflict is EWOULDBLOCK/EAGAIN (35 macOS / 11 Linux). Any OTHER code is a real
+        // error (permission, is-a-directory, disk full), NOT contention. (#315 A6-1)
+        private static bool IsSharingViolation(IOException ex)
+        {
+            int code = ex.HResult & 0xFFFF;
+            return OperatingSystem.IsWindows()
+                ? code == 32 || code == 33
+                : code == EWOULDBLOCK_MacOS || code == EAGAIN_Linux;
         }
 
         /// <summary>Best-effort: bring the already-running instance to the foreground (macOS <c>open</c> the


### PR DESCRIPTION
## Summary
**A6-1 / A6-2.** The guard treated **every** lock failure as "another instance is running": `catch(IOException)→null` and `flock != 0 → null`, never inspecting errno/HResult. On a networked home (`flock` `ENOTSUP`/`ENOLCK`), a disk-full/AV-held lock, or `instance.lock` existing as a directory, no instance is running yet `TryAcquire` returned false → `ActivateRunningInstance` → `open` finds nothing → **launches a fresh copy** → same error → possible relaunch loop or a silently unlaunchable app. And `Directory.CreateDirectory` / the `FileStream` ctor throw `UnauthorizedAccessException` (unwritable data dir), which escaped the `IOException`-only catch → **unhandled crash** in `Main` (no catch), with no log or dialog.

## Fix
- `TryOpenLock` now returns `(LockResult, FileStream?)` — `Acquired` / `Contended` / `Failed`. Only a genuine sharing violation (Windows `ERROR_SHARING_VIOLATION`/`LOCK_VIOLATION`) or an `flock`/ctor `EWOULDBLOCK`/`EAGAIN` (35 macOS / 11 Linux, read from the HResult low bits or `GetLastPInvokeError()`) is `Contended`; any other error is logged loudly and `Failed`.
- `TryAcquire`: `Acquired`/`Failed` → run (`Failed` = **unguarded, never activate**); `Contended` → false (activate the other instance).
- Also catches `UnauthorizedAccessException`/`NotSupportedException` in the non-contention branch.
- `Program.Main` gets a top-level `catch` writing to stderr + Serilog before rethrow, so an early-startup failure is visible instead of a silent crash.

## Note
macOS surfaces `FileShare.None` contention as an `IOException` whose HResult low bits are the raw errno (35), so contention detection is platform-aware (Windows 32/33 vs Unix 35/11). Confirmed empirically.

## Tests
- Guard: contention is `Contended`, releases on dispose; a non-contention failure (`instance.lock` as a directory) is `Failed`, not `Contended`.
- Full suite: **643 passed**.

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)