### PR TITLE
#316: make startup failures visible — bootstrap logger + delete dead #277 dialog

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -48,9 +48,6 @@ public partial class App : Application
     // Opt-in loopback API server for AI tools; gated on settings at launch (restart to apply). (#186)
     private CST.Avalonia.Services.LocalApi.LocalApiServer? _localApiServer;
 
-    /// <summary>The configured local-API port when it was already in use at startup (so the API did NOT bind),
-    /// else null. The Settings UI reads this to prompt the user to rotate the port. (#275)</summary>
-    public int? LocalApiPortInUse { get; private set; }
     /// <summary>
     /// True once application shutdown has begun. Floating windows close as part of shutdown too;
     /// consumers (e.g. CstDockFactory.CloseHostWindow's book rescue) use this to distinguish
@@ -189,14 +186,6 @@ public partial class App : Application
                 // Load settings first - MUST complete before indexing
                 Dispatcher.UIThread.Post(() => welcomeViewModel?.SetStartupStatus("Loading settings..."));
                 await LoadSettingsAsync();
-
-                // #277: if the configured local-API port was already taken, the API did NOT start. Prompt
-                // the user (once, non-blocking) to rotate the port in Settings. Post so the rest of init
-                // (indexing, fonts) doesn't wait on the modal.
-                if (LocalApiPortInUse is int portInUse)
-                {
-                    Dispatcher.UIThread.Post(() => _ = ShowPortInUseDialogAsync(portInUse));
-                }
 
                 // Load application state
                 Dispatcher.UIThread.Post(() => welcomeViewModel?.SetStartupStatus("Loading application state..."));
@@ -352,8 +341,6 @@ public partial class App : Application
             // secret is stored and there's no fixed port to collide. MCP clients don't need one either: the app's
             // --mcp-bridge relay reads the current local-api.json each spawn. So we pass no port/token (server
             // mints them) and mount each surface per its own permission.
-            LocalApiPortInUse = null;
-
             var version = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown";
             // Resolve the tools through the shared factory (covered by AppCompositionTests), so a tool that is
             // registered but forgotten here can't silently 404 an endpoint again.
@@ -363,76 +350,22 @@ public partial class App : Application
                 : new CST.Avalonia.Services.LocalApi.LocalApiServer(
                     version, dir, Log.Logger, restApiEnabled: ai.LocalApiEnabled, mcpEnabled: ai.McpEnabled);
             await _localApiServer.StartAsync();
+            LocalApiStartFailed = false;
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Failed to start local API server");
+            // #316 A6-4: the API is EPHEMERAL now, so there is no "port in use" case — but ANY StartAsync failure
+            // (loopback bind blocked by security software, a DI fault) leaves AI shown as enabled while the server
+            // never started and every bridge spawn fails. Log it loudly and record the state so a Settings
+            // indicator can surface it (the old #277 port-in-use dialog was dead code and is removed).
+            LocalApiStartFailed = true;
+            Log.Error(ex, "Local API server failed to start — AI agent access will not work this session despite being enabled in Settings");
         }
     }
 
-    /// <summary>
-    /// #277: notify the user that the local API could not start because its configured port was already in
-    /// use, and offer to open Settings (where they can rotate the port). Modal over the main window.
-    /// </summary>
-    private async Task ShowPortInUseDialogAsync(int port)
-    {
-        try
-        {
-            if (MainWindow == null) return;
-
-            var openSettings = false;
-
-            var dialog = new Window
-            {
-                Title = "Local API not started",
-                Width = 460,
-                SizeToContent = SizeToContent.Height,
-                CanResize = false,
-                WindowStartupLocation = WindowStartupLocation.CenterOwner,
-                ShowInTaskbar = false,
-            };
-
-            var message = new TextBlock
-            {
-                Text = $"The local API server could not start because port {port} is already in use, " +
-                       "so AI agent access is off.\n\nOpen Settings to rotate the port to a free one, " +
-                       "then restart CST Reader.",
-                TextWrapping = TextWrapping.Wrap,
-            };
-
-            var laterBtn = new Button { Content = "Not now", IsCancel = true };
-            laterBtn.Click += (_, _) => dialog.Close();
-
-            var openBtn = new Button { Content = "Open Settings…", IsDefault = true };
-            openBtn.Click += (_, _) => { openSettings = true; dialog.Close(); };
-
-            var buttons = new StackPanel
-            {
-                Orientation = global::Avalonia.Layout.Orientation.Horizontal,
-                HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
-                Margin = new Thickness(0, 16, 0, 0),
-            };
-            buttons.Children.Add(laterBtn);
-            buttons.Children.Add(openBtn);
-
-            var root = new StackPanel { Margin = new Thickness(20) };
-            root.Children.Add(message);
-            root.Children.Add(buttons);
-            dialog.Content = root;
-
-            await dialog.ShowDialog(MainWindow);
-
-            if (openSettings)
-            {
-                await ShowSettingsWindow();
-            }
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Failed to show port-in-use dialog");
-        }
-    }
+    /// <summary>True when the loopback API was enabled but <c>StartAsync</c> threw, so AI access is silently
+    /// non-functional this session. Surfaced for a Settings status indicator. (#316 A6-4)</summary>
+    public bool LocalApiStartFailed { get; private set; }
 
     /// <summary>
     /// Pre-load fonts for all scripts to avoid UI delays in settings

--- a/src/CST.Avalonia/Program.cs
+++ b/src/CST.Avalonia/Program.cs
@@ -11,7 +11,11 @@ namespace CST.Avalonia;
 sealed class Program
 {
     // Logger instance for Program class
-    private static readonly ILogger _logger = Log.ForContext<Program>();
+    // A PROPERTY, not a field captured at static-init: at type-load Log.Logger is still Serilog's silent default,
+    // so a captured contextual logger would swallow every Program-level message forever (the guard's "another
+    // instance owns {dir}", the "shutting down" line). Re-resolving each use picks up the bootstrap logger set in
+    // Main and, later, App DI's full logger. (#316 A6-3)
+    private static ILogger Logger => Log.ForContext<Program>();
     
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
@@ -96,6 +100,15 @@ sealed class Program
                 return;
             }
 
+            // Bootstrap logger for the GUI path: until App DI installs the full logger, Log.Logger is still the
+            // silent default, so the guard / blocked-launch / early-startup lines would vanish. Install a minimal
+            // one here (App DI replaces it). Goes to stderr — this path never carries the bridge's JSON-RPC
+            // stdout (that returned above). (#316 A6-3)
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Information()
+                .WriteTo.Console(standardErrorFromLevel: Serilog.Events.LogEventLevel.Verbose)
+                .CreateLogger();
+
             // Single-instance guard (#289): only one GUI per data directory. The --mcp-bridge relay and the CLI
             // utility flags above have already returned, so this gates only a real GUI launch. Two instances would
             // clobber the shared settings / app-state / index and race on local-api.json.
@@ -104,7 +117,7 @@ sealed class Program
                 CST.Avalonia.Constants.AppConstants.AppDataDirectoryName);
             if (!SingleInstanceGuard.TryAcquire(appDataDir))
             {
-                _logger.Information("Another CST Reader instance already owns {Dir}; activating it and exiting.", appDataDir);
+                Logger.Information("Another CST Reader instance already owns {Dir}; activating it and exiting.", appDataDir);
                 SingleInstanceGuard.ActivateRunningInstance();
                 return;
             }
@@ -126,7 +139,7 @@ sealed class Program
         finally
         {
             // No cleanup needed for WebView
-            _logger.Information("Application shutting down");
+            Logger.Information("Application shutting down");
         }
     }
     
@@ -139,7 +152,7 @@ sealed class Program
             .LogToTrace()
             .AfterSetup(_ => 
             {
-                _logger.Information("WebView-based CST application starting");
+                Logger.Information("WebView-based CST application starting");
             });
     }
 }


### PR DESCRIPTION
## Summary
**A6-3 / A6-4.** Startup failures were invisible.

- **A6-3** — `_logger` was `private static readonly ILogger _logger = Log.ForContext<Program>()`, captured at **static-field init** when `Log.Logger` is still Serilog's silent default (the real logger is only installed later in App DI, and never on the blocked-launch path). So the guard's "another instance owns {dir}" and the `finally`'s "shutting down" went to a silent logger — no trace anywhere when debugging "the app won't open" (which compounds the #315 guard issue). Now a **re-resolving property**, plus a **bootstrap logger** (stderr) installed at the top of the GUI path *before* the guard; App DI still replaces it with the full logger.
- **A6-4** — `LocalApiPortInUse` was assigned exactly once, to `null` (leftover from #277, orphaned by the Phase 4 ephemeral revert), so the `is int` check could never be true and `ShowPortInUseDialogAsync` was **dead code** — both deleted. The `StartAsync` catch swallowed **any** start failure (loopback bind blocked by security software, a DI fault) with only a log line while the UI still showed AI enabled. It now logs loudly and records a public `LocalApiStartFailed` flag.

## Note on the UI indicator
The Settings visual indicator that binds `LocalApiStartFailed` is left to the Settings UI (kestrel). The backend seam is done: the failure now logs loudly *to a real logger* and the state is exposed — the core "invisible" defect (no log, silent logger) is fixed.

## Tests
- Full suite: **643 passed**. (Bootstrap-logging + dead-code removal aren't unit-testable in isolation; no test referenced the deleted members.)

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)