### PR TITLE
#317: startup/guard hardening — cross-platform + edge cases (A6-5..9)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/AppConstantsTests.cs
+++ b/src/CST.Avalonia.Tests/Services/AppConstantsTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using CST.Avalonia.Constants;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services
+{
+    /// <summary>
+    /// #317 A6-9: the guard, the --mcp-bridge handshake, and the local-API server all resolve their data dir
+    /// through AppConstants.DataDirectory, so they can never target diverging directories.
+    /// </summary>
+    public class AppConstantsTests
+    {
+        [Fact]
+        public void DataDirectory_is_appdata_plus_the_app_name()
+        {
+            var expected = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                AppConstants.AppDataDirectoryName);
+
+            Assert.Equal(expected, AppConstants.DataDirectory);
+            Assert.EndsWith(AppConstants.AppDataDirectoryName, AppConstants.DataDirectory);
+        }
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -332,9 +332,7 @@ public partial class App : Application
             var ai = settingsService.Settings.Ai;
             if (!ai.ServerShouldRun) return;
 
-            var dir = System.IO.Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                CST.Avalonia.Constants.AppConstants.AppDataDirectoryName);
+            var dir = CST.Avalonia.Constants.AppConstants.DataDirectory;   // single source of truth (#317 A6-9)
             System.IO.Directory.CreateDirectory(dir);
 
             // #278 Phase 4: the loopback API is EPHEMERAL (OS-assigned port) with a PER-SESSION token — no stable

--- a/src/CST.Avalonia/Constants/AppConstants.cs
+++ b/src/CST.Avalonia/Constants/AppConstants.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+
 namespace CST.Avalonia.Constants;
 
 /// <summary>
@@ -10,6 +13,14 @@ public static class AppConstants
     /// Change this in one place to update throughout the application.
     /// </summary>
     public const string AppDataDirectoryName = "CSTReader";
+
+    /// <summary>
+    /// The per-user data directory (<c>&lt;ApplicationData&gt;/CSTReader</c>). Single source of truth so the
+    /// single-instance guard, the <c>--mcp-bridge</c> handshake, and the local-API server can never target
+    /// diverging directories (a future configurable data dir changes only this). (#317 A6-9)
+    /// </summary>
+    public static string DataDirectory => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AppDataDirectoryName);
 
     /// <summary>
     /// The application name for display purposes

--- a/src/CST.Avalonia/Program.cs
+++ b/src/CST.Avalonia/Program.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Threading;
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using CST.Avalonia.Views;
 using Serilog;
@@ -29,7 +30,7 @@ sealed class Program
 
             // Headless MCP bridge: relay this process's STDIO to the running app's /mcp (#278). Handled FIRST,
             // before any UI/logging init. STDOUT is the JSON-RPC stream, so logs go to STDERR only; no GUI.
-            if (args.Length > 0 && args[0] == "--mcp-bridge")
+            if (args.Contains("--mcp-bridge"))
             {
                 // Information (not Warning): the bridge's attach/launch/watcher-exit breadcrumbs are the exact
                 // trace needed to debug launch-or-attach, and stderr-only keeps the JSON-RPC stdout clean. (#307 A2-7)
@@ -38,9 +39,7 @@ sealed class Program
                     .WriteTo.Console(standardErrorFromLevel: Serilog.Events.LogEventLevel.Verbose)
                     .CreateLogger();
 
-                var handshakeDir = System.IO.Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                    CST.Avalonia.Constants.AppConstants.AppDataDirectoryName);
+                var handshakeDir = CST.Avalonia.Constants.AppConstants.DataDirectory;   // (#317 A6-9)
 
                 CST.Avalonia.Services.LocalApi.Mcp.McpBridge
                     .RunFromStdioAsync(handshakeDir, System.Threading.CancellationToken.None)
@@ -49,7 +48,7 @@ sealed class Program
             }
 
             // Check for browse-sharepoint command
-            if (args.Length > 0 && args[0] == "--browse-sharepoint")
+            if (args.Contains("--browse-sharepoint"))
             {
                 // Initialize Serilog for console output
                 Log.Logger = new LoggerConfiguration()
@@ -62,7 +61,7 @@ sealed class Program
             }
 
             // Check for find-start-pages command
-            if (args.Length > 0 && args[0] == "--find-start-pages")
+            if (args.Contains("--find-start-pages"))
             {
                 // Initialize Serilog for console output
                 Log.Logger = new LoggerConfiguration()
@@ -75,7 +74,7 @@ sealed class Program
             }
 
             // Check for download-tika-pdfs command
-            if (args.Length > 0 && args[0] == "--download-tika-pdfs")
+            if (args.Contains("--download-tika-pdfs"))
             {
                 // Initialize Serilog for console output
                 Log.Logger = new LoggerConfiguration()
@@ -88,7 +87,7 @@ sealed class Program
             }
 
             // Check for download-anya-pdfs command
-            if (args.Length > 0 && args[0] == "--download-anya-pdfs")
+            if (args.Contains("--download-anya-pdfs"))
             {
                 // Initialize Serilog for console output
                 Log.Logger = new LoggerConfiguration()
@@ -112,9 +111,7 @@ sealed class Program
             // Single-instance guard (#289): only one GUI per data directory. The --mcp-bridge relay and the CLI
             // utility flags above have already returned, so this gates only a real GUI launch. Two instances would
             // clobber the shared settings / app-state / index and race on local-api.json.
-            var appDataDir = System.IO.Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                CST.Avalonia.Constants.AppConstants.AppDataDirectoryName);
+            var appDataDir = CST.Avalonia.Constants.AppConstants.DataDirectory;   // (#317 A6-9)
             if (!SingleInstanceGuard.TryAcquire(appDataDir))
             {
                 Logger.Information("Another CST Reader instance already owns {Dir}; activating it and exiting.", appDataDir);

--- a/src/CST.Avalonia/SingleInstanceGuard.cs
+++ b/src/CST.Avalonia/SingleInstanceGuard.cs
@@ -120,17 +120,30 @@ namespace CST.Avalonia
         /// outside a bundle, so it can never spawn a second GUI.</summary>
         public static void ActivateRunningInstance()
         {
-            if (!OperatingSystem.IsMacOS()) return;
+            if (!OperatingSystem.IsMacOS())
+            {
+                // No foreground-activation path on Windows/Linux yet — say so (to the now-real logger, #316 A6-3)
+                // instead of a silent no-op that looks broken. (#317 A6-6)
+                Log.Information("SingleInstanceGuard: another instance is running; activation is macOS-only, so just exiting.");
+                return;
+            }
             try
             {
                 var dir = Path.GetDirectoryName(Environment.ProcessPath);
-                while (!string.IsNullOrEmpty(dir) && !dir.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
+                // Require a REAL bundle: the name ends .app AND it has Contents/Info.plist — not merely any dir
+                // whose name happens to end .app. (#317 A6-7)
+                while (!string.IsNullOrEmpty(dir) &&
+                       !(dir.EndsWith(".app", StringComparison.OrdinalIgnoreCase) &&
+                         File.Exists(Path.Combine(dir, "Contents", "Info.plist"))))
                     dir = Path.GetDirectoryName(dir);
                 if (string.IsNullOrEmpty(dir)) return;
 
+                // `open` asks LaunchServices to activate the registered instance. WaitForExit so LS has acted
+                // before Main exits — shrinks the flash/relaunch race against a dev (unregistered) holder. (#317 A6-5)
                 var psi = new ProcessStartInfo("open") { UseShellExecute = false };
                 psi.ArgumentList.Add(dir);
-                using var _ = Process.Start(psi);
+                using var p = Process.Start(psi);
+                p?.WaitForExit(5000);
             }
             catch { /* best effort */ }
         }


### PR DESCRIPTION
## Summary
Lower-severity findings in the startup/guard path (several Windows/Linux, designed-in but untested):

- **A6-5** — `ActivateRunningInstance` now `WaitForExit`s the `open` call so LaunchServices has acted before `Main` exits, shrinking the flash/relaunch race against an unregistered (`dotnet run`) dev holder.
- **A6-6** — a blocked launch on Windows/Linux was a silent no-op (looked broken). It now logs (to the real bootstrap logger from #316 → stderr) that foreground-activation is macOS-only.
- **A6-7** — the `.app` ancestor walk-up matched any dir whose *name* ends `.app`; it now also requires `Contents/Info.plist`, so a spurious `.app`-named dir isn't `open`ed.
- **A6-8** — CLI flags were matched only at `args[0]`, so `--mcp-bridge` in any later position (a wrapper prepending args) fell through to the GUI+guard path and the client saw a cryptic EOF. All flags now match via `args.Contains`.
- **A6-9** — added `AppConstants.DataDirectory` as the single source of truth and wired the guard, the `--mcp-bridge` handshake, and the local-API server through it, so those three can't target diverging directories. (The ~14 other unrelated `ApplicationData` sites are per-subsystem and out of scope; a real Windows activation path is left for when that platform is exercised.)

## Tests
- `AppConstantsTests.DataDirectory_is_appdata_plus_the_app_name`; guard tests still green.
- Full suite: **644 passed**.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)