### PR TITLE
#319: repair a null ai/localApi settings section instead of bricking Settings

### DIFF
--- a/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
+++ b/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
@@ -201,6 +201,25 @@ public class StateValidationTests
     }
 
     [Fact]
+    public void Sanitize_repairs_a_null_Ai_or_null_LocalApi_section()
+    {
+        // #319 A7-2: an explicit "ai": null (or nested "localApi": null) in settings.json deserializes to null and
+        // would NRE AiSettingsViewModel's ctor, permanently bricking the Settings window. Repair like every other
+        // section.
+        var s1 = new Settings();
+        s1.Ai = null!;
+        var fixes1 = SettingsValidator.Sanitize(s1);
+        Assert.NotNull(s1.Ai);
+        Assert.NotNull(s1.Ai.LocalApi);
+        Assert.Contains(fixes1, f => f.Contains("ai settings were null"));
+
+        var s2 = new Settings();
+        s2.Ai.LocalApi = null!;
+        SettingsValidator.Sanitize(s2);
+        Assert.NotNull(s2.Ai.LocalApi);
+    }
+
+    [Fact]
     public void Sanitize_IsIdempotent()
     {
         var state = new ApplicationState();

--- a/src/CST.Avalonia/Models/SettingsValidator.cs
+++ b/src/CST.Avalonia/Models/SettingsValidator.cs
@@ -85,6 +85,13 @@ public static class SettingsValidator
             fixes.Add($"log level '{bad}' -> Information");
         }
 
+        // AI settings: an explicit "ai": null (or "ai": {"localApi": null}) in a hand-edited settings.json
+        // overwrites the `= new()` initializer and deserializes to null, so AiSettingsViewModel's ctor NREs on
+        // ai.LocalApi.Enabled and ShowSettingsWindow's catch swallows it — the Settings window then never opens
+        // again, and Settings is the only repair path. Repair like every other section. (#319 A7-2)
+        if (settings.Ai == null) { settings.Ai = new AiSettings(); fixes.Add("ai settings were null; reset to default"); }
+        if (settings.Ai.LocalApi == null) { settings.Ai.LocalApi = new LocalApiSettings(); fixes.Add("ai.localApi settings were null; reset to default"); }
+
         // XML update repository fields
         var xml = settings.XmlUpdateSettings ??= new XmlUpdateSettings();
         if (string.IsNullOrWhiteSpace(xml.XmlRepositoryOwner)) { xml.XmlRepositoryOwner = "VipassanaTech"; fixes.Add("xml repo owner -> VipassanaTech"); }


### PR DESCRIPTION
## Summary
**A7-2.** `SettingsValidator.Sanitize` repaired `DeveloperSettings`/`XmlUpdateSettings`/`FontSettings` with `??=` but **not** `settings.Ai` or `settings.Ai.LocalApi`. A hand-edited/corrupted `settings.json` with `"ai": null` (or `"ai": {"localApi": null}`) deserializes to null (the explicit null overwrites the `= new()` initializer). `AiSettingsViewModel`'s ctor then NREs on `ai.LocalApi.Enabled`, `ShowSettingsWindow`'s catch swallows it, and the **Settings window silently never opens again** — and Settings is the only repair path, so the user is stuck until they hand-edit the file.

Fix: `settings.Ai ??= new AiSettings(); settings.Ai.LocalApi ??= new LocalApiSettings();` (matches every other section).

## Tests
- `Sanitize_repairs_a_null_Ai_or_null_LocalApi_section`.
- Full suite: **645 passed**.

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)