### PR TITLE
#323: stop Bengali display script resetting every launch (WhenWritingDefault drop)

### DIFF
--- a/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
+++ b/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
@@ -201,6 +201,32 @@ public class StateValidationTests
     }
 
     [Fact]
+    public void Bengali_display_script_survives_a_save_load_round_trip()
+    {
+        // #323 A9-1: Script.Bengali is enum value 0 = default(Script). With the app-state serializer's
+        // WhenWritingDefault, currentScript/bookScript would be OMITTED and reload as their initializers, silently
+        // resetting a Bengali choice every launch. [JsonIgnore(Never)] forces them out.
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+
+        var state = new ApplicationState();
+        state.Preferences.CurrentScript = Script.Bengali;
+        state.BookWindows.Add(new BookWindowState { BookIndex = 0, BookScript = Script.Bengali });
+
+        var json = JsonSerializer.Serialize(state, options);
+        Assert.Contains("currentScript", json);   // NOT dropped despite being the enum default (0)
+        Assert.Contains("bookScript", json);
+
+        var round = JsonSerializer.Deserialize<ApplicationState>(json, options)!;
+        Assert.Equal(Script.Bengali, round.Preferences.CurrentScript);
+        Assert.Equal(Script.Bengali, round.BookWindows[0].BookScript);
+    }
+
+    [Fact]
     public void Sanitize_repairs_a_null_Ai_or_null_LocalApi_section()
     {
         // #319 A7-2: an explicit "ai": null (or nested "localApi": null) in settings.json deserializes to null and

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -158,8 +158,11 @@ public class BookWindowState
     public string BookFileName { get; set; } = string.Empty;
 
     /// <summary>
-    /// Script used for this book display
+    /// Script used for this book display. Forced to always serialize (#323 A9-1): Script.Bengali is enum value 0
+    /// = default(Script), which the global WhenWritingDefault would DROP — so a per-book Bengali choice would be
+    /// omitted and reload as the Devanagari initializer. Same trap the #224 bools fixed.
     /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Script BookScript { get; set; } = Script.Devanagari;
 
@@ -231,8 +234,11 @@ public class BookWindowState
 public class ApplicationPreferences
 {
     /// <summary>
-    /// Current script for Pali text display
+    /// Current script for Pali text display. Forced to always serialize (#323 A9-1): Script.Bengali is enum value
+    /// 0 = default(Script), which the global WhenWritingDefault would DROP — so a Bengali choice would be omitted
+    /// and reload as the Latin initializer, silently resetting every launch. Same trap the #224 bools fixed.
     /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Script CurrentScript { get; set; } = Script.Latin;
 


### PR DESCRIPTION
## Summary
**A9-1.** The app-state serializer uses `DefaultIgnoreCondition = WhenWritingDefault`, which omits any property equal to its CLR default. `Script.Bengali` is enum value **0** = `default(Script)`, and `ApplicationPreferences.CurrentScript` + `BookWindowState.BookScript` had no `[JsonIgnore(Never)]`. So picking **Bengali** saved state that omitted `currentScript`/`bookScript`, and the next launch read the field initializer (`Latin` / `Devanagari`) — silently discarding the choice on every restart.

The #224 series documented and fixed this exact `WhenWritingDefault` trap for the two display-toggle bools but left these two `Script` enums. Fix: `[JsonIgnore(Condition = JsonIgnoreCondition.Never)]` on both.

## Tests
- `Bengali_display_script_survives_a_save_load_round_trip` (serializes with the service's real options; asserts the keys aren't dropped and round-trip to Bengali).
- Full suite: **646 passed**.

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)