### PR TITLE
#321: Footnotes toggle anchor-cache rebuild + Highlight/bridge-injection race

### DIFF
--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -1811,6 +1811,18 @@ public partial class BookDisplayView : UserControl
                                 pendingScroll = pending.scroll;
                             }
 
+                            // #321 (A8-2): honor a highlight-visibility intent that C# requested BEFORE this
+                            // object existed. ApplySearchTermsVisibility can run while SetupJavaScriptBridge is
+                            // still deferred behind the shared JS lock, so its setHighlightsVisible() call would
+                            // hit an undefined object and be lost - then this fresh object would default to
+                            // visible:true and paint every hit despite the toggle/persisted state saying off.
+                            // The intent is queued on window.__cstPendingHighlightsVisible; consume it before the
+                            // first styling pass so the initial paint is correct (also restores the off state on
+                            // reload, where the object is recreated with the true default).
+                            if (typeof window.__cstPendingHighlightsVisible === 'boolean') {
+                                this.highlightsVisible = window.__cstPendingHighlightsVisible;
+                            }
+
                             this.updateHighlightStyles();
 
                             if (pendingScroll) {
@@ -1862,6 +1874,9 @@ public partial class BookDisplayView : UserControl
                         // showHits, which hid the words via display:none — wrong semantics.)
                         setHighlightsVisible: function(visible) {
                             this.highlightsVisible = visible;
+                            // #321 (A8-2): persist the intent so a later re-injection of this object (reload)
+                            // initializes from it instead of the visible:true default.
+                            window.__cstPendingHighlightsVisible = visible;
                             this.updateHighlightStyles();
                         }
                     };
@@ -2064,7 +2079,26 @@ public partial class BookDisplayView : UserControl
         try
         {
             var display = visible ? "''" : "'none'";
-            _webView.ExecuteScript($"document.querySelectorAll('.note').forEach(function(n){{ n.style.display = {display}; }});");
+            // #321 (A8-1): toggling notes reflows the document, which invalidates cstAnchorCache's absolute
+            // pixel positions (chapter/para/page tracking + the persisted scroll anchor read from them).
+            // Rebuild the cache after the toggle, and keep the viewport steady by holding a reference anchor
+            // at its pre-toggle offset so the content doesn't jump under the reader.
+            var script = $@"
+                (function() {{
+                    var refName = (window.cstAnchorCache && window.cstAnchorCache.getCurrentAnchor)
+                        ? window.cstAnchorCache.getCurrentAnchor(window.pageYOffset) : null;
+                    var refEl = refName ? document.querySelector('a[name=""' + refName + '""]') : null;
+                    var refOffset = refEl ? refEl.getBoundingClientRect().top : null;
+
+                    document.querySelectorAll('.note').forEach(function(n) {{ n.style.display = {display}; }});
+
+                    if (window.cstAnchorCache && window.cstAnchorCache.build) {{ window.cstAnchorCache.build(); }}
+
+                    if (refEl && refOffset !== null) {{
+                        window.scrollBy(0, refEl.getBoundingClientRect().top - refOffset);
+                    }}
+                }})();";
+            _webView.ExecuteScript(script);
         }
         catch (Exception ex)
         {
@@ -2086,7 +2120,13 @@ public partial class BookDisplayView : UserControl
         }
         try
         {
-            _webView.ExecuteScript($"window.cstSearchHighlights?.setHighlightsVisible({visible.ToString().ToLower()});");
+            // #321 (A8-2): always queue the intent on the window so a not-yet-injected cstSearchHighlights
+            // still picks it up in init() (the bridge can be deferred behind the shared JS lock); apply it
+            // immediately too when the object is already present.
+            var v = visible.ToString().ToLower();
+            _webView.ExecuteScript(
+                $"window.__cstPendingHighlightsVisible = {v}; " +
+                $"if (window.cstSearchHighlights) {{ window.cstSearchHighlights.setHighlightsVisible({v}); }}");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Fixes the two real bugs in #321 (Fable-led review of the #224 per-book toggles), both in `BookDisplayView.axaml.cs`.

## A8-1 — Footnotes toggle desynced the anchor cache
Toggling `.note` visibility reflows the document, but nothing rebuilt `window.cstAnchorCache` (absolute pixel positions). After a manual toggle, chapter tracking / page-ref / the persisted scroll anchor read stale offsets → wrong chapter in the dropdown and a materially wrong restored scroll on next launch.

Fix: `ApplyFootnotesVisibility` now, after the toggle, calls `cstAnchorCache.build()` and holds a reference anchor at its pre-toggle viewport offset (`scrollBy` the delta) so the content doesn't jump under the reader.

## A8-2 — Highlight toggle raced the bridge injection
`ApplySearchTermsVisibility` called `cstSearchHighlights?.setHighlightsVisible(false)` lock-free; if the bridge hadn't injected yet (it defers 100 ms behind the shared JS lock that `GetCurrentParagraphAnchorAsync` can hold up to ~1 s), the `?.` silently no-oped and the freshly-injected object defaulted to `visible:true` → highlights painted while the toggle/persisted state said off (repro: multi-book session restore).

Fix: mirror the existing `__cstPendingHit` pattern — the intent is queued unconditionally on `window.__cstPendingHighlightsVisible`; `cstSearchHighlights.init()` consumes it before its first styling pass (also restores the off state on reload, where the object is recreated with the `true` default); `setHighlightsVisible` persists it for later re-injections.

## Verification
- Build: clean (0 errors).
- Runtime smoke (toggle footnotes → chapter readout stays correct; restore a search-opened book with highlights off → stays off): to follow in a combined UI pass with #344 (#322).

Closes #321
