### PR TITLE
#318/#320: close MCP consent gap + AI settings hygiene

### DIFF
--- a/src/CST.Avalonia/Models/SettingsValidator.cs
+++ b/src/CST.Avalonia/Models/SettingsValidator.cs
@@ -92,6 +92,20 @@ public static class SettingsValidator
         if (settings.Ai == null) { settings.Ai = new AiSettings(); fixes.Add("ai settings were null; reset to default"); }
         if (settings.Ai.LocalApi == null) { settings.Ai.LocalApi = new LocalApiSettings(); fixes.Add("ai.localApi settings were null; reset to default"); }
 
+        // #320 (A7-3): the local-API port + bearer token are per-session at runtime (ephemeral port; token
+        // minted at start) and runtime-ignored since #278 Phase 4. Clear any historical persisted values on
+        // load so a plaintext token can't linger in settings.json and a stale fixed port can't be reused.
+        if (!string.IsNullOrEmpty(settings.Ai.LocalApi.Token))
+        {
+            settings.Ai.LocalApi.Token = null;
+            fixes.Add("cleared persisted ai.localApi.token (runtime mints a per-session token)");
+        }
+        if (settings.Ai.LocalApi.Port != 0)
+        {
+            settings.Ai.LocalApi.Port = 0;
+            fixes.Add("reset ai.localApi.port to ephemeral (runtime ignores a fixed port)");
+        }
+
         // XML update repository fields
         var xml = settings.XmlUpdateSettings ??= new XmlUpdateSettings();
         if (string.IsNullOrWhiteSpace(xml.XmlRepositoryOwner)) { xml.XmlRepositoryOwner = "VipassanaTech"; fixes.Add("xml repo owner -> VipassanaTech"); }

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -821,10 +821,19 @@ namespace CST.Avalonia.ViewModels
             _token = ai.LocalApi.Token ?? string.Empty;
 
             // Rotate icons (password-generator style); both apply on the next API (re)start. (#275)
+            // #320 (A7-5): PickAvailable() runs TcpListener probes whose non-SocketException failures (e.g. a
+            // sandbox/entitlement SecurityException) would otherwise escape a ReactiveCommand with no
+            // ThrownExceptions subscriber and crash via RxApp's default handler. Contain them here.
             RotatePortCommand = ReactiveCommand.Create(() =>
-                { Port = CST.Avalonia.Services.LocalApi.PortAvailability.PickAvailable(); });
+            {
+                try { Port = CST.Avalonia.Services.LocalApi.PortAvailability.PickAvailable(); }
+                catch (Exception ex) { Log.Warning(ex, "Rotate port failed"); }
+            });
             RotateTokenCommand = ReactiveCommand.Create(() =>
-                { Token = CST.Avalonia.Services.LocalApi.ApiToken.Generate(); });
+            {
+                try { Token = CST.Avalonia.Services.LocalApi.ApiToken.Generate(); }
+                catch (Exception ex) { Log.Warning(ex, "Rotate token failed"); }
+            });
         }
 
         /// <summary>Master switch — "Enable AI Features". Everything AI-related is gated behind this (default OFF).</summary>
@@ -850,6 +859,11 @@ namespace CST.Avalonia.ViewModels
             {
                 this.RaiseAndSetIfChanged(ref _localApiEnabled, value);
                 _settingsService.Settings.Ai.LocalApi.Enabled = value;
+                // #318 (A7-1): this single "Run the local API server" checkbox controls the WHOLE loopback
+                // server (both /v1 REST and /mcp), matching its label. EnableMcpServer has no separate UI yet
+                // (that lands in the #280 rework), so gate it here too — otherwise unchecking this leaves /mcp
+                // running (ServerShouldRun = LocalApiEnabled || McpEnabled) and silently ignores the opt-out.
+                _settingsService.Settings.Ai.LocalApi.EnableMcpServer = value;
                 _settingsService.RequestSave();
                 // Remote control is only reachable when the local API is on.
                 this.RaisePropertyChanged(nameof(RemoteControlEnabled));

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -362,7 +362,7 @@
                                                 <TextBlock Text="⟳" FontSize="14"/>
                                             </Button>
                                         </Grid>
-                                        <TextBlock Text="Fixed port (default 8765) so a copied client config keeps working across restarts. 0 = automatic. Applies on the next start of the API server."
+                                        <TextBlock Text="Loopback port; 0 = automatic (ephemeral). The MCP config launches the app's --mcp-bridge relay, which reads the live port at spawn, so it needn't match. Applies on the next start of the API server."
                                                   Classes="SettingDescription" Margin="0,4,0,0"/>
 
                                         <!-- Token: the persisted bearer secret. Masked by default; the 👁 toggle reveals it
@@ -392,11 +392,12 @@
                                                 <TextBlock Text="⟳" FontSize="14"/>
                                             </Button>
                                         </Grid>
-                                        <TextBlock Text="Bearer token agents use to authenticate. Rotating it invalidates any previously-copied client config — re-copy below. Applies on the next start of the API server."
+                                        <TextBlock Text="Bearer token agents authenticate with. Applies on the next start of the API server."
                                                   Classes="SettingDescription" Margin="0,4,0,0"/>
 
-                                        <!-- Copy the ready-made Claude Desktop MCP config for the current port + token.
-                                             Clipboard is done in code-behind (OnCopyMcpConfig) since the VM has no TopLevel. -->
+                                        <!-- Copy the ready-made Claude Desktop MCP config: it launches CST Reader's
+                                             mcp-bridge relay and carries no port/token. Clipboard is done in
+                                             code-behind (OnCopyMcpConfig) since the VM has no TopLevel. -->
                                         <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                                             <Button Content="Copy MCP configuration"
                                                     Click="OnCopyMcpConfig"
@@ -406,7 +407,7 @@
                                                       Foreground="{DynamicResource DockApplicationAccentBrushLow}"
                                                       VerticalAlignment="Center" Margin="10,0,0,0" IsVisible="False"/>
                                         </StackPanel>
-                                        <TextBlock Text="Paste into ~/Library/Application Support/Claude/claude_desktop_config.json under &quot;mcpServers&quot;. Requires Node.js (npx). Re-copy after rotating the port or token."
+                                        <TextBlock Text="Paste into the Claude Desktop config (~/Library/Application Support/Claude/claude_desktop_config.json) under &quot;mcpServers&quot;. It launches CST Reader's --mcp-bridge relay and embeds no port or token — copy it once (no Node, and no re-copy after rotating)."
                                                   Classes="SettingDescription" Margin="0,4,0,0"/>
 
                                         <Expander Header="Show configuration" Margin="0,4,0,0">


### PR DESCRIPTION
Fixes the AI-settings findings from the Fable-led review: the live consent gap (#318) and the hygiene items (#320). Interim fixes that stand independent of the larger #280 rework.

## #318 (A7-1) — consent gap: unchecking "Run the local API server" left `/mcp` running
`ServerShouldRun = LocalApiEnabled || McpEnabled`, and `EnableMcpServer` defaults **true** with no UI control, but the checkbox only wrote `LocalApi.Enabled`. So unchecking it (master still on) left `McpEnabled` true → the loopback host still bound a port and served `/mcp` — the opt-out was silently ignored.

Fix (`SettingsViewModel.cs`): the `LocalApiEnabled` setter now also writes `EnableMcpServer`, so the single "Run the local API server" checkbox governs the whole server (both surfaces), matching its label. (The proper split into a separate MCP toggle is #280.)

## #320 — AI settings hygiene
- **A7-3** (`SettingsValidator.Sanitize`): the port + bearer token are per-session/runtime-ignored since #278 Phase 4, but rotating the token still wrote a 256-bit secret to plaintext `settings.json`. Sanitize now nulls `Token` and zeroes `Port` on load, so no plaintext secret lingers and no stale fixed port survives a restart.
- **A7-4** (`SettingsWindow.axaml`): corrected the Copy-config captions that went stale when #278 swapped to `--mcp-bridge` — dropped "Requires Node.js (npx)" and "Re-copy after rotating the port or token" (the emitted config carries no port/token and needs no Node), and fixed the "for the current port + token" comment and the port/token descriptions.
- **A7-5** (`SettingsViewModel.cs`): wrapped the rotate commands so a non-`SocketException` failure from `PortAvailability` (e.g. a sandbox/entitlement `SecurityException`) can't escape a `ReactiveCommand` with no `ThrownExceptions` subscriber and crash via RxApp's default handler.

## Verification
- Build: clean (0 errors).
- Runtime smoke (uncheck "Run the local API server" → restart → confirm no `/mcp`; rotate → confirm no token left in `settings.json` after a reload; captions read correctly): to follow.

Closes #318
Closes #320
