### PR TITLE
#322 follow-up: fix Window-menu checkmark going stale (track IsActive)

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -14,6 +14,7 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
+using Avalonia.Reactive;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using CST.Avalonia.ViewModels;
@@ -1253,8 +1254,14 @@ public partial class App : Application
         if (windowItem?.Menu is not NativeMenu submenu) return;
 
         _windowMenus[owner] = submenu;
-        owner.Closed += (_, _) => { _windowMenus.Remove(owner); RebuildWindowMenus(); };
-        owner.Activated += (_, _) => RebuildWindowMenus();   // keep the active-window checkmark current
+
+        // #322 follow-up: the active-window checkmark renders win.IsActive, so refresh whenever ANY window's
+        // active state changes. The Activated event alone was insufficient — it never fired on focus LOSS and
+        // its timing vs. IsActive was unreliable — and once A8-5 removed the incidental title-path rebuilds
+        // that used to paper over the gap, the checkmark went stale until an unrelated rebuild (e.g. a global
+        // script change). Tracking IsActive directly is the exact signal, and fires on both sides of a switch.
+        var activeSub = owner.GetObservable(Window.IsActiveProperty).Subscribe(new AnonymousObserver<bool>(_ => RebuildWindowMenus()));
+        owner.Closed += (_, _) => { activeSub.Dispose(); _windowMenus.Remove(owner); RebuildWindowMenus(); };
     }
 
     // The windows to list, in order: main window first ("CST Reader"), then floating book/tool windows


### PR DESCRIPTION
Follow-up to #322 (PR #344): fixes the Window-menu **checkmark** on the active window going stale — "sometimes there, sometimes not," reappearing after an unrelated change like switching the global script.

## Cause
The checkmark renders `win.IsActive`, refreshed only when `RebuildWindowMenus()` runs. Before #322, that ran on nearly every focus flap (the title path rebuilt on each `ActiveDockable`/`FocusedDockable` change). #322's A8-5 short-circuit intentionally removed that churn — correct for the title, but it also removed the incidental refreshes the checkmark was riding on. The remaining `owner.Activated` handler was insufficient: it never fires on focus **loss**, and its timing relative to `IsActive` settling was unreliable, so the checkmark drifted until the next unrelated rebuild.

## Fix (`App.axaml.cs`, `RegisterWindowMenu`)
Subscribe to each window's `Window.IsActiveProperty` instead of the `Activated` event — that's the exact property the checkmark reflects, and it fires on **both** sides of every focus transition (gain and loss). Disposed on `window.Closed`. No title churn is reintroduced (`IsActive` changes only on real focus transitions, far less often than the per-dockable churn A8-5 removed).

## Verification
- Build: clean.
- Manual: switch between the main window and floating windows repeatedly, open the Window menu each time → the checkmark should always sit on the frontmost window, with no need to trigger a script change to "fix" it.
