### PR TITLE
#352: fix path traversal via dictionary 'language' param (arbitrary directory read)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionaryServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryServiceTests.cs
@@ -70,6 +70,32 @@ public class DictionaryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Lookup_ConfinesLanguage_RejectsTraversalAndReadsNothingOutsideRoot()
+    {
+        // #352: a client-supplied `language` must be confined to a real dictionary subdirectory. An absolute or
+        // "../" path that would otherwise make LoadLanguageAsync read arbitrary files must return empty and load
+        // nothing — while a genuine language still resolves (case-insensitively).
+        WriteLang("en", "d.txt", "buddha", "<p>awakened</p>");
+
+        var secretDir = Path.Combine(Path.GetTempPath(), "cst-dict-secret-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(secretDir);
+        File.WriteAllLines(Path.Combine(secretDir, "s.txt"), new[] { "topsecret", "<p>classified</p>" });
+        try
+        {
+            var svc = Service();
+
+            // Absolute path — Path.Combine would discard the dictionaries root and read secretDir.
+            Assert.Empty(await svc.LookupAsync(secretDir, "topsecret"));
+            // Relative traversal to the same place (both are siblings under the temp dir).
+            Assert.Empty(await svc.LookupAsync(Path.Combine("..", Path.GetFileName(secretDir)), "topsecret"));
+
+            // A real language still works, case-insensitively.
+            Assert.Single(await svc.LookupAsync("EN", "buddha"));
+        }
+        finally { try { Directory.Delete(secretDir, recursive: true); } catch { } }
+    }
+
+    [Fact]
     public async Task Lookup_LatinQuery_IsCaseInsensitive()
     {
         WriteLang("en", "d.txt", "buddha", "<p>awakened one</p>");

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -131,7 +131,16 @@ public sealed class DictionaryService : IDictionaryService
         if (string.IsNullOrEmpty(language) || string.IsNullOrEmpty(query))
             return Array.Empty<DictionaryWord>();
 
-        var index = await GetOrLoadIndexAsync(language, ct).ConfigureAwait(false);
+        // SECURITY (#352): confine `language` to an ACTUAL dictionary subdirectory before it ever reaches
+        // Path.Combine in LoadLanguageAsync — a rooted path or "../" would otherwise escape the dictionaries root
+        // and read arbitrary files. Exact catalog match (mirrors PassageTool.IsCatalogBook, #301); use the
+        // canonical directory name, never the raw client value.
+        var canonical = AvailableLanguages.FirstOrDefault(
+            l => string.Equals(l, language, StringComparison.OrdinalIgnoreCase));
+        if (canonical == null)
+            return Array.Empty<DictionaryWord>();
+
+        var index = await GetOrLoadIndexAsync(canonical, ct).ConfigureAwait(false);
         if (index == null)
             return Array.Empty<DictionaryWord>();
 


### PR DESCRIPTION
## Summary
**HIGH / security.** The same path-traversal class as #301 (`bookId`), reproduced in the dictionary **`language`** parameter — missed by the original review, surfaced by the Fable re-review of the tool adapters.

`DictionaryService.LoadLanguageAsync` did `Path.Combine(_dictionariesDirectory, language)` with a client-supplied, unvalidated `language` (from `POST /v1/dictionary/lookup` and the MCP dictionary tool). A rooted path or `../` escaped the dictionaries root; `LoadLanguageAsync` then read **every file in the target directory** and returned odd lines verbatim as `MeaningHtml` → arbitrary readable-file enumeration/exfiltration.

## Fix
Confine `language` to an actual dictionary subdirectory — exact match against `AvailableLanguages` (mirroring `PassageTool.IsCatalogBook`, #301) — before it ever reaches `Path.Combine`, in `DictionaryService.LookupAsync` so it covers both the HTTP and MCP transports. Uses the canonical directory name, never the raw client value.

## Tests
- `Lookup_ConfinesLanguage_RejectsTraversalAndReadsNothingOutsideRoot` — an absolute path and a `../` traversal both return empty and read nothing outside the root (the test would fail — leak the secret file — without the fix); a real language still resolves case-insensitively.
- Full suite: **650 passed**.

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)