### PR TITLE
Close the #309 ReDoS fallback residual + #313 A4-11 loop residual (re-review)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiExtractionHardeningTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiExtractionHardeningTests.cs
@@ -49,6 +49,19 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void Extract_does_not_throw_when_a_pb_tag_starts_the_buffer()
+        {
+            // #313 A4-11 loop residual: a "<p"-prefixed non-<p> tag (<pb/>) at position 0 must not make
+            // FindLastPOpen search before index 0 (LastIndexOf(..,-1)) and throw.
+            const string xml = "<pb ed=\"V\" n=\"1\"/>alpha TARGET beta gamma\u0964";
+            var markers = BookMarkers.Build(xml);
+            int hit = xml.IndexOf("TARGET", StringComparison.Ordinal);
+            var ex = Record.Exception(() =>
+                TeiSnippetExtractor.Extract(xml, hit, "TARGET".Length, markers, Deva(1, 400)));
+            Assert.Null(ex);
+        }
+
+        [Fact]
         public void ReadWindow_with_int_max_maxchars_returns_the_whole_text_not_one_char()
         {
             // #313 A4-13: hardCap = maxChars + maxChars/2 overflowed negative at maxChars=int.MaxValue, so the walk

--- a/src/CST.Avalonia.Tests/Services/SafeRegexTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SafeRegexTests.cs
@@ -36,6 +36,24 @@ namespace CST.Avalonia.Tests.Services
         }
 
         [Fact]
+        public void Reports_timeout_on_a_fallback_catastrophic_pattern()
+        {
+            // #309 fallback residual: a pattern NonBacktracking can't express (backreference) drops to the timed
+            // backtracking engine; a catastrophic core then times out per-term, and IsMatch must REPORT it so an
+            // expansion scan can abort a pattern that repeatedly times out instead of pinning a core over 500K terms.
+            var regex = SafeRegex.Compile(@"(a)\1(a+)+$");   // backreference → fallback; (a+)+$ → catastrophic
+            var evil = new string('a', 40) + "b";            // no match → catastrophic backtracking → 200ms timeout
+
+            var sw = Stopwatch.StartNew();
+            bool matched = SafeRegex.IsMatch(regex, evil, out bool timedOut);
+            sw.Stop();
+
+            Assert.False(matched);
+            Assert.True(timedOut);
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2), $"took {sw.Elapsed} — should be bounded by the 200ms MatchTimeout");
+        }
+
+        [Fact]
         public void Throws_on_a_genuinely_invalid_pattern()
         {
             // A syntax error still surfaces as a parse exception (upstream "Invalid regex pattern" hint), #59.

--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -319,7 +319,7 @@ public class SearchService : ISearchService
                 var w = unit.Words[s];
                 if (query.Mode == SearchMode.Wildcard && (w.Contains("*") || w.Contains("?")))
                 {
-                    slots[s] = ExpandWildcard(w, reader, out var wasTruncated);
+                    slots[s] = ExpandWildcard(w, reader, out var wasTruncated, cancellationToken);
                     if (wasTruncated) truncatedTermCount++;
                 }
                 else if (query.Mode == SearchMode.Regex)
@@ -327,7 +327,7 @@ public class SearchService : ISearchService
                     // Each unit of a multi-word regex must be expanded to its matching terms, just like the
                     // single-term path uses RegexTermMatcher. Previously regex units fell through to the
                     // literal branch below and matched nothing. (#60)
-                    slots[s] = ExpandRegex(w, reader, out var wasTruncated);
+                    slots[s] = ExpandRegex(w, reader, out var wasTruncated, cancellationToken);
                     if (wasTruncated) truncatedTermCount++;
                 }
                 else
@@ -722,9 +722,15 @@ public class SearchService : ISearchService
     // The matcher is position-based, not cartesian, so this bounds postings work, not E^N.
     private const int WildcardExpansionLimit = 5000;
 
+    // Abort an expansion whose pattern repeatedly hits the 200ms backtracking-FALLBACK timeout (a NonBacktracking-
+    // unsupported pattern — lookaround/backreference — wrapped around a catastrophic core). 25 × 200ms ≈ 5s hard
+    // ceiling on wasted CPU before we give up, so a crafted multi-word regex can't pin a core for the whole
+    // ~500K-term scan. NonBacktracking patterns never time out and never trip this. (#309 fallback residual)
+    private const int MaxFallbackTimeouts = 25;
+
     // Uses the caller's own (ref-counted) reader, not the mutable _indexReader field, so a concurrent
     // reader refresh can't make a single multi-word search mix two index generations. (SRCH-2)
-    private List<string> ExpandWildcard(string pattern, DirectoryReader reader, out bool truncated, int maxResults = WildcardExpansionLimit)
+    private List<string> ExpandWildcard(string pattern, DirectoryReader reader, out bool truncated, CancellationToken ct, int maxResults = WildcardExpansionLimit)
     {
         truncated = false;
 
@@ -748,6 +754,7 @@ public class SearchService : ISearchService
 
         var termsEnum = terms.GetEnumerator();
         var results = new List<string>();
+        int timeouts = 0;
 
         if (literalPrefix.Length > 0)
         {
@@ -756,14 +763,16 @@ public class SearchService : ISearchService
             {
                 do
                 {
+                    ct.ThrowIfCancellationRequested();   // the scan can be ~500K terms — stay cancellable (#309 fallback)
                     var term = termsEnum.Term.Utf8ToString();
                     if (!term.StartsWith(literalPrefix, StringComparison.Ordinal))
                         break; // sorted: past the prefix range, nothing more can match
-                    if (SafeRegex.IsMatch(regex, term))
+                    if (SafeRegex.IsMatch(regex, term, out bool to))
                     {
                         if (results.Count >= maxResults) { truncated = true; break; }
                         results.Add(term);
                     }
+                    if (to && ++timeouts >= MaxFallbackTimeouts) { truncated = true; break; }
                 } while (termsEnum.MoveNext());
             }
         }
@@ -771,12 +780,14 @@ public class SearchService : ISearchService
         {
             while (termsEnum.MoveNext())
             {
+                ct.ThrowIfCancellationRequested();
                 var term = termsEnum.Term.Utf8ToString();
-                if (SafeRegex.IsMatch(regex, term))
+                if (SafeRegex.IsMatch(regex, term, out bool to))
                 {
                     if (results.Count >= maxResults) { truncated = true; break; }
                     results.Add(term);
                 }
+                if (to && ++timeouts >= MaxFallbackTimeouts) { truncated = true; break; }
             }
         }
 
@@ -794,7 +805,7 @@ public class SearchService : ISearchService
     // (^lit...), seek to its literal prefix to avoid scanning all ~500K terms; otherwise full-scan. An
     // invalid pattern throws RegexParseException, surfaced upstream as the quiet "Invalid regex pattern"
     // hint (#59). (#60)
-    private List<string> ExpandRegex(string pattern, DirectoryReader reader, out bool truncated, int maxResults = WildcardExpansionLimit)
+    private List<string> ExpandRegex(string pattern, DirectoryReader reader, out bool truncated, CancellationToken ct, int maxResults = WildcardExpansionLimit)
     {
         truncated = false;
 
@@ -811,6 +822,7 @@ public class SearchService : ISearchService
 
         var termsEnum = terms.GetEnumerator();
         var results = new List<string>();
+        int timeouts = 0;
 
         if (literalPrefix.Length > 0)
         {
@@ -819,14 +831,16 @@ public class SearchService : ISearchService
             {
                 do
                 {
+                    ct.ThrowIfCancellationRequested();   // ~500K-term scan — stay cancellable (#309 fallback)
                     var term = termsEnum.Term.Utf8ToString();
                     if (!term.StartsWith(literalPrefix, StringComparison.Ordinal))
                         break; // sorted: past the prefix range, nothing more can match
-                    if (SafeRegex.IsMatch(regex, term))
+                    if (SafeRegex.IsMatch(regex, term, out bool to))
                     {
                         if (results.Count >= maxResults) { truncated = true; break; }
                         results.Add(term);
                     }
+                    if (to && ++timeouts >= MaxFallbackTimeouts) { truncated = true; break; }
                 } while (termsEnum.MoveNext());
             }
         }
@@ -834,12 +848,14 @@ public class SearchService : ISearchService
         {
             while (termsEnum.MoveNext())
             {
+                ct.ThrowIfCancellationRequested();
                 var term = termsEnum.Term.Utf8ToString();
-                if (SafeRegex.IsMatch(regex, term))
+                if (SafeRegex.IsMatch(regex, term, out bool to))
                 {
                     if (results.Count >= maxResults) { truncated = true; break; }
                     results.Add(term);
                 }
+                if (to && ++timeouts >= MaxFallbackTimeouts) { truncated = true; break; }
             }
         }
 
@@ -1011,8 +1027,8 @@ public class SearchService : ISearchService
                     cancellationToken.ThrowIfCancellationRequested();
                     var w = unit.Words[s];
                     List<string> expansions =
-                        mode == SearchMode.Wildcard && (w.Contains('*') || w.Contains('?')) ? ExpandWildcard(w, reader, out _)
-                        : mode == SearchMode.Regex ? ExpandRegex(w, reader, out _)
+                        mode == SearchMode.Wildcard && (w.Contains('*') || w.Contains('?')) ? ExpandWildcard(w, reader, out _, cancellationToken)
+                        : mode == SearchMode.Regex ? ExpandRegex(w, reader, out _, cancellationToken)
                         : new List<string> { w };
 
                     var positions = new List<TermPosition>();
@@ -1261,12 +1277,17 @@ internal static class SafeRegex
     }
 
     /// <summary>IsMatch that treats a fallback-timeout as "no match" (skip that term) instead of letting the
-    /// exception abort the whole scan — one pathological term shouldn't kill the search.</summary>
-    public static bool IsMatch(System.Text.RegularExpressions.Regex regex, string input)
+    /// exception abort the whole scan — one pathological term shouldn't kill the search. <paramref name="timedOut"/>
+    /// reports whether the (backtracking-fallback) match hit its per-term timeout, so a caller scanning many terms
+    /// can abort a pattern that repeatedly times out. NonBacktracking never times out (no MatchTimeout set).</summary>
+    public static bool IsMatch(System.Text.RegularExpressions.Regex regex, string input, out bool timedOut)
     {
+        timedOut = false;
         try { return regex.IsMatch(input); }
-        catch (System.Text.RegularExpressions.RegexMatchTimeoutException) { return false; }
+        catch (System.Text.RegularExpressions.RegexMatchTimeoutException) { timedOut = true; return false; }
     }
+
+    public static bool IsMatch(System.Text.RegularExpressions.Regex regex, string input) => IsMatch(regex, input, out _);
 }
 
 internal class WildcardTermMatcher : ITermMatcher

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -277,8 +277,10 @@ namespace CST.Search
         private static int FindLastPOpen(string xml, int before)
         {
             int idx = Math.Min(before, xml.Length);
-            if (idx <= 0) return -1;   // no room for "<p" before position 0; guards LastIndexOf(-1) (#313 A4-11)
-            while ((idx = xml.LastIndexOf("<p", idx - 1, StringComparison.Ordinal)) >= 0)
+            // The `idx > 0` guard on EACH iteration (not just entry) is what prevents `LastIndexOf(..., -1)`: if a
+            // match lands at position 0 that isn't a real `<p>` tag (e.g. `<pb .../>` at the start of the buffer),
+            // the next iteration would otherwise search before 0 and throw. (#313 A4-11 loop residual)
+            while (idx > 0 && (idx = xml.LastIndexOf("<p", idx - 1, StringComparison.Ordinal)) >= 0)
             {
                 char c = idx + 2 < xml.Length ? xml[idx + 2] : '\0';
                 if (c == ' ' || c == '>' || c == '\t' || c == '\n' || c == '\r') return idx;


### PR DESCRIPTION
Two residuals the Fable re-review of the search core found in already-merged fixes.

## #309 fallback residual — MED (DoS)
`SafeRegex` closed the NonBacktracking path, but a pattern NonBacktracking rejects (lookaround/backreference) drops to the timed backtracking fallback. That's fine **per term**, but `ExpandRegex`/`ExpandWildcard` and `GetMultiWordPositionsAsync` scanned all ~500K terms with **no `CancellationToken` in the loop** — so `POST /v1/search {"query":"x (?<=a)(.+)+Z","mode":"Regex"}` could pin a core for hours, uninterruptible by cancellation.

Fix: thread `ct` into `ExpandRegex`/`ExpandWildcard` (`ThrowIfCancellationRequested` per term) and abort after `MaxFallbackTimeouts` (25 × 200ms ≈ 5 s) cumulative fallback timeouts. `SafeRegex.IsMatch` gains an `out bool timedOut` overload so the scan can count timeouts; NonBacktracking never times out and never trips it.

## #313 A4-11 loop residual — LOW
`FindLastPOpen`'s entry guard fixed `pos<=0`, but the loop could still call `LastIndexOf(.., -1)` and throw when a `<p`-prefixed non-`<p>` tag (e.g. `<pb/>`) sits at position 0. Guard `idx > 0` on each iteration.

## Tests
- `SafeRegexTests.Reports_timeout_on_a_fallback_catastrophic_pattern`; `TeiExtractionHardeningTests.Extract_does_not_throw_when_a_pb_tag_starts_the_buffer`.
- Full suite: **652 passed**.

Refs #309, #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)