### PR TITLE
Close Batch-6 re-review follow-ups: MaxRecentBooks WhenWritingDefault trap + contentStream disposal

### DIFF
--- a/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
+++ b/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
@@ -227,6 +227,27 @@ public class StateValidationTests
     }
 
     [Fact]
+    public void MaxRecentBooks_zero_survives_a_save_load_round_trip()
+    {
+        // #323 class: MaxRecentBooks' initializer is 10 but its CLR default is 0, so a deliberate 0 ("disable the
+        // recent-books list") would be dropped by WhenWritingDefault and revert to 10 next launch without
+        // [JsonIgnore(Never)].
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+
+        var state = new ApplicationState();
+        state.Preferences.MaxRecentBooks = 0;
+
+        var json = JsonSerializer.Serialize(state, options);
+        Assert.Contains("maxRecentBooks", json);   // NOT dropped despite being the CLR default (0)
+        Assert.Equal(0, JsonSerializer.Deserialize<ApplicationState>(json, options)!.Preferences.MaxRecentBooks);
+    }
+
+    [Fact]
     public void Sanitize_repairs_a_null_Ai_or_null_LocalApi_section()
     {
         // #319 A7-2: an explicit "ai": null (or nested "localApi": null) in settings.json deserializes to null and

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -253,8 +253,12 @@ public class ApplicationPreferences
     public List<RecentBookItem> RecentBooks { get; set; } = new();
 
     /// <summary>
-    /// Maximum number of recent books to remember
+    /// Maximum number of recent books to remember. Forced to always serialize (#323 A9-1 class): the initializer
+    /// is 10 but the CLR default is 0, which the global WhenWritingDefault would DROP — so a deliberate 0 ("disable
+    /// the recent-books list") would be omitted and silently revert to 10 next launch. Same trap the two Script
+    /// enums and the #224 bools fixed.
     /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     public int MaxRecentBooks { get; set; } = 10;
 }
 

--- a/src/CST.Avalonia/Services/SharePointService.cs
+++ b/src/CST.Avalonia/Services/SharePointService.cs
@@ -243,7 +243,7 @@ namespace CST.Avalonia.Services
                 }
 
                 // Download the file content
-                var contentStream = await _graphClient.Drives[driveId].Items[itemPath].Content.GetAsync();
+                using var contentStream = await _graphClient.Drives[driveId].Items[itemPath].Content.GetAsync();
 
                 if (contentStream == null)
                 {


### PR DESCRIPTION
Two small items the Fable re-review of serialization + SharePoint surfaced.

- **NEW-1 (LOW, latent)** — `ApplicationPreferences.MaxRecentBooks` is a live instance of the exact `WhenWritingDefault` trap #323 fixed: initializer `10` but CLR default `0`, so a deliberate `0` ("disable the recent-books list", e.g. a hand-edited `application-state.json`) is omitted on save and silently reverts to `10` next launch. Added `[JsonIgnore(Condition = Never)]`, matching the two `Script` enums and the #224 bools. (The trap-hunt confirmed this is the *only* remaining unguarded initializer≠default property with a meaningful default-value state.)
- **NEW-2 (INFO, pre-existing)** — the Graph content stream in `DownloadPdfAsync` was never disposed. `using var`.

## Tests
- `MaxRecentBooks_zero_survives_a_save_load_round_trip`.
- Full suite: **653 passed**.

Refs #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)