### PR TITLE
docs(local-api): a single proximity query already returns both word orders (don't swap-and-sum)

### DIFF
--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -81,8 +81,10 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   the default `Exact` mode those characters are LITERAL and match nothing (the response `note` flags this).
   PROXIMITY: a multi-word `query` (space-separated) plus `proximityDistance` finds those words co-occurring
   within N words; quote a run - `"a b"` - for an exact adjacent phrase; combine with `mode:"Wildcard"`/`"Regex"`
-  to expand each word before matching. ORDER MATTERS: `a b` and `b a` are SEPARATE co-occurrence forms with
-  their own counts - sum both orderings for an order-agnostic total.
+  to expand each word before matching. ORDER: ONE query already finds BOTH directions - whichever of `a b` /
+  `b a` actually occur within the window come back as SEPARATE forms with their own counts. Re-querying with the
+  words SWAPPED returns the SAME set, so do NOT run both word orders and add them (that DOUBLE-COUNTS). For an
+  order-agnostic total, sum those form-rows WITHIN the single result.
   FILTER: `filter` is an object of booleans, all default true -
   `{ vinaya, sutta, abhidhamma, mula, atthakatha, tika, other }`. The pitaka flags (vinaya/sutta/abhidhamma)
   OR within their group, the text-class flags (mula/atthakatha/tika) OR within theirs, and those two groups

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -54,8 +54,9 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                 + "non-canonical books). Commentaries-only = { mula:false, atthakatha:true, tika:true, other:false }; "
                 + "to isolate ONLY 'other', set every other flag false. Omit for the whole corpus.")]
             ToolBookFilter? filter = null,
-            [Description("For a multi-word/proximity query, the co-occurrence window in words (default 10). Order "
-                + "matters: 'a b' and 'b a' are separate forms with separate counts.")]
+            [Description("For a multi-word/proximity query, the co-occurrence window in words (default 10). One "
+                + "query already returns BOTH directions: 'a b' and 'b a' come back as separate forms with their "
+                + "own counts, so do NOT re-query with the words swapped and sum (that double-counts).")]
             int proximityDistance = 10,
             CancellationToken ct = default)
         {


### PR DESCRIPTION
## What
Reword the `PROXIMITY` note in the loopback API's self-documentation so an agent doesn't re-query with the two words swapped and sum the results (double-counting).

## Why
In the cold-agent API-coverage friction test, an agent read the old llms.txt line —

> ORDER MATTERS: `a b` and `b a` are SEPARATE co-occurrence forms with their own counts — **sum both orderings for an order-agnostic total.**

— as an instruction to run the proximity query twice (once per word order) and add the counts. But a single space-separated proximity query **already finds both directions** and returns whichever orders actually occur within the window as separate form-rows. Re-querying with the words swapped returns the **same set**, so summing across two queries double-counts.

This was a docs-clarity nit, not a search bug — the engine behaves correctly.

## Changes
- `Resources/LocalApi/llms.txt` — rewrote the `PROXIMITY` `ORDER` note: one query finds both directions; swapping words yields the same set; for an order-agnostic total, sum the form-rows *within the single result*.
- `Services/LocalApi/Mcp/SearchMcpTool.cs` — same clarification on the MCP `proximityDistance` parameter description (the other agent-facing contract).

## Test
- `dotnet build` clean.
- `LocalApiIntegrationTests` + `SearchToolTests`: 35 passed, 0 failed. (Text-only doc change; no content assertion touches the edited lines.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)