### PR TITLE
docs(local-api): fix unattested aorist in verb-stem hint (paññāsi → paññāya)

### DIFF
--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -188,10 +188,10 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
    /v1/search note above.)
    VERBS ARE HARDER: the stem-truncation trick works for a NOUN because its consonant stem stays CONSTANT
    across the declension. A VERB's stem ALTERNATES across its conjugation (reduplication, aorist, root
-   grades), so often NO single wildcard or regex spans it - e.g. for `pajānāti` the present is `pajān-`
-   (`pajānāti`, `pajānanti`) but the aorist and absolutive are `paññ-` (`paññāsi`, `paññāya`); no common
-   searchable stem. Enumerate the forms explicitly with an alternation, or use lemma lookup if/when the API
-   offers it.
+   grades), so often NO single wildcard or regex spans it - e.g. for `pajānāti` the present stem is `pajān-`
+   (`pajānāti`, `pajānanti`) but the -ya absolutive is `paññ-` (`paññāya` - itself the homograph noted just
+   below); no common searchable stem. Enumerate the forms explicitly with an alternation, or use lemma lookup
+   if/when the API offers it.
    COUNTS ARE LITERAL TOKEN FORMS, NOT LEMMAS: the engine tallies surface strings, so a HOMOGRAPH conflates
    two distinct words under ONE count that CANNOT be split by form alone - e.g. `paññāya` is both the noun
    (instr./loc. of `paññā`) AND the absolutive of `pajānāti`, tallied together.


### PR DESCRIPTION
## What
Correct a factual error in the verb-conjugation caveat shipped in #360: it cited `paññāsi` as the aorist of *pajānāti*, but that form **does not occur in the corpus**.

## How it was found
A blank-slate cold-agent coverage run (Opus 4.8, no CST memory, API-only) was asked to count the full conjugation of *pajānāti*. It read the API's `llms.txt`, followed the new hint to probe the `paññ-` stem, and reported that `paññāsi` returns zero — `paññās*` is entirely `paññāsa` ("fifty") and `paññā` ("wisdom") compounds.

Verified directly against the live API:
- `paññāsi` (Exact) → **no term** (unattested)
- `paññās*` (Wildcard) → 100 terms, all `paññāsa`/compounds — no verb aorist
- `paññāya` (-ya absolutive) and `pajānitvā` (present-stem absolutive) → **attested**

## Fix
Drop the fabricated aorist; illustrate the stem alternation with the **attested** -ya absolutive `paññāya` — which is also the homograph described in the very next caveat, so the two now reinforce each other. The general lesson (a verb's stem alternates across its conjugation, so no single wildcard spans it) is unchanged.

## Note
This is the coverage harness working as intended: the hint added in #360 successfully steered the agent to probe the alternate stem, and that probe surfaced the doc's own bad example. The run also independently confirmed the homograph caveat (B) and the declension-truncation guidance (A) behave as documented.

## Test
- `dotnet build` clean.
- `LocalApiIntegrationTests`: 22 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)