### PR TITLE
POC scaffold: /v1/lemma + /v1/forms endpoint shapes (stub provider)

### DIFF
--- a/src/CST.Avalonia.Tests/LocalApi/LemmaStubProviderTests.cs
+++ b/src/CST.Avalonia.Tests/LocalApi/LemmaStubProviderTests.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using CST.Avalonia.Services.LocalApi.Lemma;
+using Xunit;
+
+namespace CST.Avalonia.Tests.LocalApi
+{
+    // POC scaffold tests (#247 lemma map). These pin the RESPONSE SHAPE the endpoints return; the data is
+    // stubbed. When a dpd.db-backed ILemmaProvider replaces the stub, these assertions describe the contract
+    // a real provider must satisfy for the seeded forms.
+    public class LemmaStubProviderTests
+    {
+        private readonly ILemmaProvider _p = new LemmaStubProvider();
+
+        [Fact]
+        public void Resolve_simple_form_returns_single_candidate()
+        {
+            var r = _p.Resolve("pajānāti");
+            var c = Assert.Single(r.Candidates);
+            Assert.Equal(39702, c.LemmaId);
+            Assert.Equal("pajānāti", c.Lemma);
+            Assert.Equal("pr", c.Pos);
+        }
+
+        [Fact]
+        public void Resolve_homograph_returns_multiple_candidates_split_by_derivation()
+        {
+            var r = _p.Resolve("paññāya");
+            Assert.True(r.Candidates.Count > 1, "paññāya is a homograph — expect multiple candidates");
+            // The gerund sense derives from the verb; the noun sense derives from paññā — the split we want.
+            Assert.Contains(r.Candidates, c => c.Pos == "ger" && c.DerivedFrom == "pajānāti");
+            Assert.Contains(r.Candidates, c => c.DerivedFrom == "paññā");
+        }
+
+        [Fact]
+        public void Resolve_sandhi_form_exposes_deconstructions()
+        {
+            var r = _p.Resolve("sammappajānāti");
+            Assert.Contains("samma + pajānāti", r.Deconstructions);
+        }
+
+        [Fact]
+        public void Resolve_unseeded_form_is_empty_but_well_formed()
+        {
+            var r = _p.Resolve("zzznotaword");
+            Assert.Empty(r.Candidates);
+            Assert.Contains("STUB", r.Note);
+        }
+
+        [Fact]
+        public void Forms_returns_paradigm_and_family_only_when_requested()
+        {
+            var withFamily = _p.Forms(39702, includeFamily: true);
+            Assert.NotEmpty(withFamily.Forms);
+            Assert.All(withFamily.Forms, f => Assert.StartsWith("pajān", f.Form));
+            Assert.NotNull(withFamily.Family);
+            Assert.Contains(withFamily.Family!, c => c.Lemma == "pajānitvā");
+
+            var noFamily = _p.Forms(39702, includeFamily: false);
+            Assert.Null(noFamily.Family);
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/Lemma/LemmaContracts.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Lemma/LemmaContracts.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+
+namespace CST.Avalonia.Services.LocalApi.Lemma
+{
+    // ---------------------------------------------------------------------------------------------
+    // POC SCAFFOLD for the morphological lemma-map API (issue #247). STUB DATA ONLY — the wiring is
+    // real (routes + DTOs + response shape), the resolver is canned. Drop-in point: replace
+    // ILemmaProvider/LemmaStubProvider with a dpd.db-backed provider.
+    //
+    // The exact SQLite queries + schema are documented in ~/dpd-poc/TASK1_dpd_inspection.md. In short:
+    //   (1) form -> candidates : SELECT headwords, grammar FROM lookup WHERE lookup_key = :form
+    //   (2) headword -> gloss  : SELECT lemma_1,pos,stem,pattern,meaning_1 FROM dpd_headwords WHERE id=:id
+    //   (3) headword -> forms  : SELECT lookup_key FROM lookup
+    //                              WHERE json_valid(headwords) AND EXISTS(SELECT 1 FROM json_each(headwords) WHERE value=:id)
+    //   (4) verb -> family     : SELECT id,lemma_1,pos,meaning_1 FROM dpd_headwords WHERE derived_from=:lemma OR id=:baseId
+    //
+    // Contract note: `lookup` gives the CANDIDATE lemmas for a surface form; it does not assign a
+    // specific corpus occurrence to one candidate (per-occurrence disambiguation is the #247
+    // extension). Per-form corpus counts come from OUR Lucene index, not DPD (null in the stub).
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>One lemma a surface form could belong to (DPD headword + the analysis for this form).</summary>
+    public sealed record LemmaCandidate(
+        long LemmaId,          // dpd_headwords.id
+        string Lemma,          // dpd_headwords.lemma_1 (with homonym number, e.g. "paññāya 1")
+        string Pos,            // dpd_headwords.pos ("pr", "abs", "ger", "fem", "adj", "aor", ...)
+        string Grammar,        // the inflection analysis of THIS form (lookup.grammar), e.g. "fem instr sg"
+        string? Gloss,         // dpd_headwords.meaning_1
+        string? DerivedFrom);  // dpd_headwords.derived_from — the key that regroups a scattered verb family
+
+    /// <summary>Response for <c>GET /v1/lemma/{form}</c> — form → candidate lemmas + sandhi splits.</summary>
+    public sealed record LemmaResponse(
+        string Form,
+        IReadOnlyList<LemmaCandidate> Candidates,
+        IReadOnlyList<string> Deconstructions,  // lookup.deconstructor: ordered candidate sandhi splits
+        string Note);
+
+    /// <summary>One attested surface form of a lemma, with its corpus count (from our index; null in stub).</summary>
+    public sealed record FormEntry(string Form, int? Count);
+
+    /// <summary>Response for <c>GET /v1/forms/{lemmaId}</c> — a lemma's attested paradigm (+ optional family).</summary>
+    public sealed record FormsResponse(
+        long LemmaId,
+        string Lemma,
+        IReadOnlyList<FormEntry> Forms,            // strict paradigm of this one headword (query 3)
+        IReadOnlyList<LemmaCandidate>? Family,     // derived_from family when ?family=true (query 4)
+        string Note);
+
+    /// <summary>The seam the POC fills with a real dpd.db-backed implementation.</summary>
+    public interface ILemmaProvider
+    {
+        LemmaResponse Resolve(string form);
+        FormsResponse Forms(long lemmaId, bool includeFamily);
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/Lemma/LemmaStubProvider.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Lemma/LemmaStubProvider.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CST.Avalonia.Services.LocalApi.Lemma
+{
+    /// <summary>
+    /// POC stub for <see cref="ILemmaProvider"/>. Returns canned data (verbatim from the real dpd.db
+    /// v0.4.20260531 rows — see ~/dpd-poc/TASK1_dpd_inspection.md) for a couple of seeded forms so the
+    /// endpoint wiring can be exercised end-to-end. Replace with a dpd.db-backed provider; the response
+    /// shapes are the intended contract.
+    /// </summary>
+    public sealed class LemmaStubProvider : ILemmaProvider
+    {
+        private const string StubNote =
+            "POC STUB — canned DPD v0.4.20260531 data for seeded forms only (pajānāti, paññāya, nappajānāti). " +
+            "Replace LemmaStubProvider with a dpd.db-backed ILemmaProvider.";
+
+        // Seeded lookup rows (form -> candidate lemmas), taken from the real DPD lookup table.
+        private static readonly Dictionary<string, LemmaResponse> SeededForms = new()
+        {
+            ["pajānāti"] = new LemmaResponse("pajānāti", new[]
+            {
+                new LemmaCandidate(39702, "pajānāti", "pr", "pr 3rd sg",
+                    "knows; knows clearly; understands; distinguishes", null),
+            }, System.Array.Empty<string>(), StubNote),
+
+            // The homograph — surface paññāya splits across many headwords, resolved by derived_from.
+            ["paññāya"] = new LemmaResponse("paññāya", new[]
+            {
+                new LemmaCandidate(40070, "paññāya 1", "ger", "ger", "knowing; understanding", "pajānāti"),
+                new LemmaCandidate(40071, "paññāya 2", "fem", "fem instr sg", "by wisdom; with intelligence", "paññā"),
+                new LemmaCandidate(39994, "paññā 1", "fem", "fem instr/dat/abl/gen/loc sg",
+                    "wisdom; knowledge; understanding; insight", "pajānāti"),
+            }, System.Array.Empty<string>(), StubNote),
+
+            ["nappajānāti"] = new LemmaResponse("nappajānāti", new[]
+            {
+                new LemmaCandidate(35708, "nappajānāti", "pr", "pr 3rd sg",
+                    "does not know; does not clearly understand", "pajānāti"),
+            }, System.Array.Empty<string>(), StubNote),
+
+            // A sandhi example, to exercise the deconstructor field.
+            ["sammappajānāti"] = new LemmaResponse("sammappajānāti", System.Array.Empty<LemmaCandidate>(),
+                new[] { "sammappajāna + iti", "sammappajānā + iti", "samma + pajānāti" }, StubNote),
+        };
+
+        // Seeded paradigm (headword 39702) — a representative subset of the 34 attested pajān- forms.
+        private static readonly string[] PajanatiForms =
+        {
+            "pajānāti", "pajānanti", "pajānāmi", "pajānāma", "pajānāsi", "pajānātha",
+            "pajāneyya", "pajāneyyaṃ", "pajānissati", "pajānissāmi", "pajānāhi", "pajānātu", "pajāna",
+        };
+
+        // Seeded derived_from family for pajānāti — a representative subset of the 36 headwords.
+        private static readonly LemmaCandidate[] PajanatiFamily =
+        {
+            new(39702, "pajānāti", "pr", "", "knows; understands", null),
+            new(39703, "pajānitvā", "abs", "", "having clearly understood", "pajānāti"),
+            new(40070, "paññāya 1", "ger", "", "knowing; understanding", "pajānāti"),
+            new(40072, "paññāyati 1", "pr", "", "is clearly known; is evident", "pajānāti"),
+            new(35708, "nappajānāti", "pr", "", "does not know", "pajānāti"),
+            new(39994, "paññā 1", "fem", "", "wisdom; knowledge; understanding", "pajānāti"),
+            new(40010, "paññāta 1", "pp", "", "well known; famous", "pajānāti"),
+        };
+
+        public LemmaResponse Resolve(string form) =>
+            SeededForms.TryGetValue(form, out var r)
+                ? r
+                : new LemmaResponse(form, System.Array.Empty<LemmaCandidate>(),
+                    System.Array.Empty<string>(),
+                    StubNote + " (form not seeded in the stub)");
+
+        public FormsResponse Forms(long lemmaId, bool includeFamily)
+        {
+            if (lemmaId == 39702)
+            {
+                return new FormsResponse(39702, "pajānāti",
+                    PajanatiForms.Select(f => new FormEntry(f, null)).ToList(),
+                    includeFamily ? PajanatiFamily : null,
+                    StubNote + " Per-form Count is null in the stub — it comes from the Lucene index, not DPD.");
+            }
+            return new FormsResponse(lemmaId, "?", System.Array.Empty<FormEntry>(), null,
+                StubNote + " (lemmaId not seeded in the stub)");
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -21,6 +21,7 @@ using CST;
 using CST.Conversion;
 using CST.Navigation;
 using CST.Tools;
+using CST.Avalonia.Services.LocalApi.Lemma;
 using CST.Avalonia.Services.LocalApi.Mcp;
 using ModelContextProtocol.Server;
 using Serilog;
@@ -431,6 +432,16 @@ namespace CST.Avalonia.Services.LocalApi
                 // Filter (pitaka / commentary level) + paging so the 217-book catalog can't overflow a caller. (#191 Cowork)
                 return Results.Json(BookCatalog.List(outputScript, p, cl, skip ?? 0, take ?? BookCatalog.DefaultTake));
             });
+
+            // POC SCAFFOLD (#247 morphological lemma map). Wiring is real; the provider is a stub with
+            // canned DPD data (see LemmaStubProvider / ~/dpd-poc/TASK1_dpd_inspection.md). Swap the stub for
+            // a dpd.db-backed ILemmaProvider (route + response shapes are the intended contract).
+            //   GET /v1/lemma/{form}          -> form -> candidate lemmas (+ sandhi deconstructions)
+            //   GET /v1/forms/{lemmaId}?family=true -> a lemma's attested paradigm (+ derived_from family)
+            ILemmaProvider lemma = new LemmaStubProvider();
+            app.MapGet(v + "/lemma/{form}", (string form) => Results.Json(lemma.Resolve(form)));
+            app.MapGet(v + "/forms/{lemmaId:long}",
+                (long lemmaId, bool? family) => Results.Json(lemma.Forms(lemmaId, family ?? false)));
 
             // Surface which tool groups got wired, so a missing DI hand-off (e.g. a null IScriptTool leaving
             // /v1/scripts + /v1/convert unmapped -> 404) is visible in the log instead of only at call time.


### PR DESCRIPTION
The lemma-map API scaffold: `/v1/lemma/{form}` + `/v1/forms/{lemmaId}` endpoints with an `ILemmaProvider` seam and a stub provider returning canned DPD data. Establishes the endpoint shapes; the real provider (`CST.Lemma`) and the search wiring land in the `feat/dpd-lemma-search` stages, which then replace the stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)