### PR TITLE
Lemma report (dossier): report-grade DPD-lemma asset + LemmaReportService/renderer + /v1/lemma-report

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using CST.Avalonia.Services.LocalApi;
 using CST.Avalonia.Services.LocalApi.Mcp;
 using CST.Avalonia.Tests.TestSupport;
+using CST.Conversion;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -318,6 +319,24 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Contains("masculine", html);              // pos 'masc' expanded
             Assert.Contains("Word family", html);
             Assert.Contains("DPD candidates", html);         // synthetic/attested split (dhammani is synthetic)
+            // 'dhamma' is shared with lemma 101 ('dhamma 2'), a DIFFERENT word (out of family) -> homograph.
+            Assert.Contains("homograph", html);
+            // DPD example with <b> markup renders (Latin round-trips the tags).
+            Assert.Contains("<b>dhamma</b>", html);
+        }
+
+        [Fact]
+        public async Task Lemma_report_preserves_example_markup_in_non_latin_scripts()
+        {
+            using var http = _api.Http();
+            var resp = await http.GetAsync("/v1/lemma-report/100?script=Devanagari");
+            Assert.True(resp.IsSuccessStatusCode);
+            var html = await resp.Content.ReadAsStringAsync();
+            // The DPD example carries <b>…</b>. The tags must survive the IPE->Devanagari render LITERALLY
+            // (the bug converted the tag letter 'b' too, mangling <b> into '<ब्>'), and the enclosed word must
+            // itself be converted to Devanagari. Generated via ScriptConverter (no non-Latin literals in source).
+            var devDhamma = ScriptConverter.Convert("dhamma", Script.Latin, Script.Devanagari);
+            Assert.Contains("<b>" + devDhamma + "</b>", html);
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -305,6 +305,30 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
+        public async Task Lemma_report_renders_the_dossier_html()
+        {
+            using var http = _api.Http();
+            var resp = await http.GetAsync("/v1/lemma-report/100?script=Latin");
+            Assert.True(resp.IsSuccessStatusCode);
+            Assert.Equal("text/html", resp.Content.Headers.ContentType!.MediaType);
+            var html = await resp.Content.ReadAsStringAsync();
+            Assert.Contains("dhamma", html);                 // the lemma
+            Assert.Contains("hold", html);                   // root meaning (etymology from the root table)
+            Assert.Contains("attested paradigm", html);      // paradigm section
+            Assert.Contains("masculine", html);              // pos 'masc' expanded
+            Assert.Contains("Word family", html);
+            Assert.Contains("DPD candidates", html);         // synthetic/attested split (dhammani is synthetic)
+        }
+
+        [Fact]
+        public async Task Lemma_report_unknown_id_is_404()
+        {
+            using var http = _api.Http();
+            var resp = await http.GetAsync("/v1/lemma-report/999999");
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, resp.StatusCode);
+        }
+
+        [Fact]
         public async Task Mcp_occurrences_and_passage_read_the_corpus()
         {
             await using var client = await ConnectMcpAsync();

--- a/src/CST.Avalonia.Tests/Lemma/SqliteLemmaProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Lemma/SqliteLemmaProviderTests.cs
@@ -140,6 +140,19 @@ public sealed class SqliteLemmaProviderTests : IDisposable
     }
 
     [Fact]
+    public void ExpandLemma_from_a_bottom_member_reaches_a_numbered_parent()
+    {
+        using var p = new SqliteLemmaProvider(_dbPath);
+        // Focus 'paññāya 2' (40071) is derived_from 'paññā', whose headword is the NUMBERED homonym
+        // 'paññā 1' (39994). The parent lookup must climb via the homonym GLOB, not exact match, so the
+        // parent is reached and 'paññāya' (shared with the parent) is not mis-flagged as a homograph.
+        var e = p.ExpandLemma(40071, includeFamily: true);
+        Assert.NotNull(e!.Family);
+        Assert.Contains(e.Family!, x => x.LemmaId == 40071);   // self
+        Assert.Contains(e.Family!, x => x.LemmaId == 39994);   // numbered parent 'paññā 1'
+    }
+
+    [Fact]
     public void ExpandLemma_unknown_id_is_null()
     {
         using var p = new SqliteLemmaProvider(_dbPath);

--- a/src/CST.Avalonia.Tests/Lemma/SqliteLemmaProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Lemma/SqliteLemmaProviderTests.cs
@@ -121,15 +121,22 @@ public sealed class SqliteLemmaProviderTests : IDisposable
     }
 
     [Fact]
-    public void ExpandLemma_with_family_includes_derived_from_children()
+    public void ExpandLemma_with_family_is_the_bidirectional_cluster()
     {
         using var p = new SqliteLemmaProvider(_dbPath);
+        // Focus 'paññā 1' (39994) is a deverbal noun derived_from 'pajānāti'. Its family must reach BOTH
+        // directions: UP to its parent verb 39702 and across to the verb's other derivations (35708, 40070),
+        // and DOWN to its own child 40071 (derived_from 'paññā'). Before the fix the family was computed
+        // downward-only, so the parent verb 39702 was missing and its shared forms were mis-flagged as
+        // homographs of the noun.
         var e = p.ExpandLemma(39994, includeFamily: true);
         Assert.NotNull(e);
         Assert.NotNull(e!.Family);
-        // baseName "paññā": self (39994) + children whose derived_from == "paññā" (40071)
-        Assert.Contains(e.Family!, x => x.LemmaId == 39994);
-        Assert.Contains(e.Family!, x => x.LemmaId == 40071);
+        Assert.Contains(e.Family!, x => x.LemmaId == 39994);   // self
+        Assert.Contains(e.Family!, x => x.LemmaId == 39702);   // parent verb (the fix)
+        Assert.Contains(e.Family!, x => x.LemmaId == 40070);   // sibling under pajānāti (paññāya 1, ger)
+        Assert.Contains(e.Family!, x => x.LemmaId == 35708);   // sibling under pajānāti (nappajānāti)
+        Assert.Contains(e.Family!, x => x.LemmaId == 40071);   // own child (paññāya 2, derived_from paññā)
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
+++ b/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
@@ -118,10 +118,13 @@ namespace CST.Avalonia.Tests.TestSupport
             // corpus-attested forms (dhamma, citta, kamma) + one synthetic form (dhammani, absent from the corpus).
             string dpdLemmaPath = Path.Combine(root, "dpd-lemma.db");
             BuildLemmaFixture(dpdLemmaPath);
-            var lemmaSearch = new LemmaSearchService(new SqliteLemmaProvider(dpdLemmaPath), searchService);
+            var lemmaProvider = new SqliteLemmaProvider(dpdLemmaPath);
+            var lemmaSearch = new LemmaSearchService(lemmaProvider, searchService);
+            var lemmaReport = new LemmaReportService(lemmaProvider, lemmaSearch);
 
             var server = new LocalApiServer("test", handshakeDir, Serilog.Log.Logger,
-                searchTool, dictionary: null, passage: passageTool, script: scriptTool, lemma: lemmaSearch);
+                searchTool, dictionary: null, passage: passageTool, script: scriptTool,
+                lemma: lemmaSearch, lemmaReport: lemmaReport);
             await server.StartAsync();
 
             return new LocalApiTestServer(root, server, mula.FileName, attha.FileName);
@@ -133,12 +136,19 @@ namespace CST.Avalonia.Tests.TestSupport
             c.Open();
             void Exec(string sql) { using var cmd = c.CreateCommand(); cmd.CommandText = sql; cmd.ExecuteNonQuery(); }
             Exec(@"
-                CREATE TABLE lemma (id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT);
+                CREATE TABLE lemma (id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT,
+                    root_key TEXT, construction TEXT, sanskrit TEXT, meaning_lit TEXT, pattern TEXT, ebt_count INTEGER,
+                    example_source TEXT, example_sutta TEXT, example TEXT, synonym TEXT, antonym TEXT);
+                CREATE TABLE root (root_key TEXT PRIMARY KEY, root_sign TEXT, root_meaning TEXT, root_group INTEGER,
+                    sanskrit_root TEXT, sanskrit_root_meaning TEXT, dhatupatha_pali TEXT, dhatupatha_english TEXT);
                 CREATE TABLE form_lemma (form TEXT NOT NULL, lemma_id INTEGER NOT NULL);
                 CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
-                INSERT INTO lemma VALUES
-                    (100,'dhamma 1','masc','nature; a teaching',NULL),
-                    (101,'dhamma 2','masc','a phenomenon',NULL);
+                INSERT INTO lemma
+                  (id,lemma,pos,gloss,derived_from,root_key,construction,sanskrit,pattern,ebt_count,example_source,example_sutta,example)
+                  VALUES
+                    (100,'dhamma 1','masc','nature; a teaching',NULL,'√dhar','dhar + a','dharma','a masc',77,'DN1','brahmajalasutta','so <b>dhamma</b> passati'),
+                    (101,'dhamma 2','masc','a phenomenon',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
+                INSERT INTO root VALUES ('√dhar','dhar','hold; support',1,'√dhṛ','hold','dharaṇe','holding');
                 INSERT INTO form_lemma VALUES
                     ('dhamma',100),('citta',100),('kamma',100),('dhammani',100),
                     ('dhamma',101);

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1003,6 +1003,7 @@ public partial class App : Application
             AppConstants.AppDataDirectoryName, "dpd-lemma", "dpd-lemma.db");
         services.AddSingleton<CST.Lemma.ILemmaProvider>(_ => new CST.Lemma.SqliteLemmaProvider(dpdLemmaPath));
         services.AddSingleton<ILemmaSearchService, LemmaSearchService>();
+        services.AddSingleton<ILemmaReportService, LemmaReportService>();
 
         // Surface-C tool wrappers (exposed over the local API). (#186)
         services.AddSingleton<CST.Tools.ISearchTool, Services.Tools.SearchTool>();

--- a/src/CST.Avalonia/Services/LemmaReportModels.cs
+++ b/src/CST.Avalonia/Services/LemmaReportModels.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace CST.Avalonia.Services;
+
+// The structured lemma report ("dossier"). Every *Pali field is stored in IPE (script-neutral, so the report
+// caches once and renders to any script); English fields are verbatim. The renderer converts only the Pali ones.
+
+public sealed record ReportRoot(
+    string? RootPali, string? RootMeaning, long? RootGroup,
+    string? SanskritRootPali, string? DhatupathaPali, string? DhatupathaEnglish);
+
+public sealed record ReportForm(string FormPali, int Count, int BookCount, bool Homograph);
+
+public sealed record ReportFamilyMember(
+    long LemmaId, string LemmaPali, string? Pos, string? Gloss, int TotalOccurrences, string Group);
+
+public sealed record ReportHomographSense(long LemmaId, string LemmaPali, string? Pos, string? Gloss, string? DerivedFromPali);
+
+public sealed record LemmaReport(
+    long LemmaId, string LemmaPali, string? Pos, string? Gloss, string? MeaningLit, string? DerivedFromPali,
+    // etymology
+    string? ConstructionPali, string? SanskritPali, string? Pattern, ReportRoot? Root, long? EbtCount,
+    // corpus paradigm (this lemma)
+    IReadOnlyList<ReportForm> Forms, int TotalOccurrences, int AttestedFormCount, int CandidateFormCount, bool ExpansionCapped,
+    // DPD-cited example
+    string? ExamplePali, string? ExampleSource, string? ExampleSutta,
+    // word family (derived_from siblings, grouped) + the family:true union totals
+    IReadOnlyList<ReportFamilyMember> Family, int FamilyTotalOccurrences, int FamilyFormCount,
+    // homograph focus (the top form shared with other lemmas)
+    string? HomographFormPali, IReadOnlyList<ReportHomographSense> HomographSenses,
+    // provenance
+    string DpdVersion, string Attribution);

--- a/src/CST.Avalonia/Services/LemmaReportModels.cs
+++ b/src/CST.Avalonia/Services/LemmaReportModels.cs
@@ -7,7 +7,7 @@ namespace CST.Avalonia.Services;
 
 public sealed record ReportRoot(
     string? RootPali, string? RootMeaning, long? RootGroup,
-    string? SanskritRootPali, string? DhatupathaPali, string? DhatupathaEnglish);
+    string? SanskritRoot, string? DhatupathaPali, string? DhatupathaEnglish);   // SanskritRoot: verbatim IAST, not script-converted
 
 public sealed record ReportForm(string FormPali, int Count, int BookCount, bool Homograph);
 
@@ -21,8 +21,8 @@ public sealed record ReportHomograph(string FormPali, int Count, IReadOnlyList<R
 
 public sealed record LemmaReport(
     long LemmaId, string LemmaPali, string? Pos, string? Gloss, string? MeaningLit, string? DerivedFromPali,
-    // etymology
-    string? ConstructionPali, string? SanskritPali, string? Pattern, ReportRoot? Root, long? EbtCount,
+    // etymology  (Sanskrit: verbatim IAST — outside the Pāli IPE inventory, so NOT script-converted)
+    string? ConstructionPali, string? Sanskrit, string? Pattern, ReportRoot? Root, long? EbtCount,
     // corpus paradigm (this lemma)
     IReadOnlyList<ReportForm> Forms, int TotalOccurrences, int AttestedFormCount, int CandidateFormCount, bool ExpansionCapped,
     // DPD-cited example

--- a/src/CST.Avalonia/Services/LemmaReportModels.cs
+++ b/src/CST.Avalonia/Services/LemmaReportModels.cs
@@ -16,6 +16,9 @@ public sealed record ReportFamilyMember(
 
 public sealed record ReportHomographSense(long LemmaId, string LemmaPali, string? Pos, string? Gloss, string? DerivedFromPali);
 
+/// <summary>One paradigm form that is a homograph, with every lemma the surface string belongs to.</summary>
+public sealed record ReportHomograph(string FormPali, int Count, IReadOnlyList<ReportHomographSense> Senses);
+
 public sealed record LemmaReport(
     long LemmaId, string LemmaPali, string? Pos, string? Gloss, string? MeaningLit, string? DerivedFromPali,
     // etymology
@@ -26,7 +29,7 @@ public sealed record LemmaReport(
     string? ExamplePali, string? ExampleSource, string? ExampleSutta,
     // word family (derived_from siblings, grouped) + the family:true union totals
     IReadOnlyList<ReportFamilyMember> Family, int FamilyTotalOccurrences, int FamilyFormCount,
-    // homograph focus (the top form shared with other lemmas)
-    string? HomographFormPali, IReadOnlyList<ReportHomographSense> HomographSenses,
+    // homographs — EVERY paradigm form shared with other lemmas (its count can't be split)
+    IReadOnlyList<ReportHomograph> Homographs,
     // provenance
     string DpdVersion, string Attribution);

--- a/src/CST.Avalonia/Services/LemmaReportRenderer.cs
+++ b/src/CST.Avalonia/Services/LemmaReportRenderer.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using CST.Conversion;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Renders a (script-neutral, IPE) <see cref="LemmaReport"/> to a self-contained HTML document in a target
+/// script — the "dossier" shown in a WebView. Pāli fields are converted IPE → <paramref name="script"/>;
+/// English fields (glosses, pos labels, section chrome) are verbatim. pos abbreviations are expanded.
+/// </summary>
+public static class LemmaReportRenderer
+{
+    public static string Render(LemmaReport r, Script script)
+    {
+        // Pāli IPE -> target script, HTML-escaped for text nodes.
+        string P(string? ipe) => string.IsNullOrEmpty(ipe) ? "" : Esc(ScriptConverter.Convert(ipe!, Script.Ipe, script));
+        // Pāli that is trusted DPD markup (example carries <b>…</b>): convert, keep tags.
+        string PMarkup(string? ipe) => string.IsNullOrEmpty(ipe) ? "" : ScriptConverter.Convert(ipe!, Script.Ipe, script);
+
+        var sb = new StringBuilder(8192);
+        sb.Append("<style>").Append(Css).Append("</style>");
+        sb.Append("<div class=\"wrap\">");
+
+        // ---- header ----
+        sb.Append("<header><div>")
+          .Append($"<div class=\"lemma pali\">{P(r.LemmaPali)}<small>{r.LemmaId}</small>")
+          .Append($"<span class=\"pos-badge\">{Esc(PosFull(r.Pos))}</span></div>");
+        if (!string.IsNullOrEmpty(r.Gloss)) sb.Append($"<div class=\"gloss\">{Esc(r.Gloss!)}</div>");
+        sb.Append("</div>");
+        sb.Append("<div class=\"script-ctl\"><label>Script</label>")
+          .Append("<select onchange=\"location.search='?script='+encodeURIComponent(this.value)\">");
+        foreach (var s in Scripts)
+            sb.Append($"<option{(s == script.ToString() ? " selected" : "")}>{s}</option>");
+        sb.Append("</select></div></header>");
+
+        // ---- etymology band ----
+        if (r.Root is { } root || !string.IsNullOrEmpty(r.ConstructionPali) || !string.IsNullOrEmpty(r.SanskritPali))
+        {
+            sb.Append("<div class=\"etym\">");
+            if (r.Root?.RootPali is { } rp) sb.Append($"<span class=\"root pali\">{P(rp)}</span>");
+            if (r.Root?.RootMeaning is { } rm)
+            {
+                string dp = r.Root.DhatupathaPali is { } d ? $" — <span class=\"pali\">{P(d)}</span>" : "";
+                string de = r.Root.DhatupathaEnglish is { } e ? $" “{Esc(e)}”" : "";
+                string grp = r.Root.RootGroup is { } g ? $" (class {g})" : "";
+                sb.Append($"<div class=\"kv\"><span class=\"k\">Root sense</span><span class=\"v\">{Esc(rm)}{dp}{de}{grp}</span></div>");
+            }
+            if (r.ConstructionPali is { } con) sb.Append($"<div class=\"kv\"><span class=\"k\">Construction</span><span class=\"v pali\">{P(con)}</span></div>");
+            if (r.SanskritPali is { } skt) sb.Append($"<div class=\"kv\"><span class=\"k\">Sanskrit</span><span class=\"v pali\">{P(skt)}</span></div>");
+            if (r.Pattern is { } pat) sb.Append($"<div class=\"kv\"><span class=\"k\">Pattern</span><span class=\"v\">{Esc(pat)}</span></div>");
+            sb.Append("</div>");
+        }
+
+        sb.Append("<div class=\"grid\">");
+
+        // ---- paradigm ----
+        sb.Append("<section class=\"card\"><div class=\"card-h\"><h2>In this corpus — attested paradigm</h2>")
+          .Append($"<div class=\"meta\"><b>{r.TotalOccurrences:N0}</b> occurrences · <b>{r.AttestedFormCount}</b>/{r.CandidateFormCount} forms</div></div>");
+        sb.Append("<div class=\"tbl-scroll\"><table><thead><tr><th>Form</th><th></th><th style=\"text-align:right\">Count</th><th style=\"text-align:right\">Books</th></tr></thead><tbody>");
+        int max = r.Forms.Count > 0 ? r.Forms.Max(f => f.Count) : 1;
+        foreach (var f in r.Forms.OrderByDescending(f => f.Count))
+        {
+            string homo = f.Homograph ? " <span class=\"tag\">homograph</span>" : "";
+            sb.Append($"<tr><td class=\"form pali\">{P(f.FormPali)}{homo}</td>")
+              .Append($"<td class=\"barcell\"><div class=\"bar\"><i style=\"width:{(max > 0 ? f.Count * 100.0 / max : 0):F1}%\"></i></div></td>")
+              .Append($"<td class=\"c\">{f.Count:N0}</td><td class=\"books\">{f.BookCount}</td></tr>");
+        }
+        sb.Append("</tbody></table></div>");
+        int synthetic = r.CandidateFormCount - r.AttestedFormCount;
+        sb.Append("<div class=\"stat-row\">")
+          .Append($"<span class=\"stat\"><b>{r.AttestedFormCount}</b> attested</span>")
+          .Append($"<span class=\"stat syn\"><b>{synthetic}</b> synthetic · omitted</span>")
+          .Append($"<span class=\"stat\"><b>{r.CandidateFormCount}</b> DPD candidates</span></div>");
+        sb.Append($"<div class=\"foot-note\">Forms of this lemma (<b>{Esc(PosFull(r.Pos))}</b>) only — its participle, absolutive &amp; deverbal-noun forms are separate lemmas → see <b>Word family</b>.</div>");
+        sb.Append("</section>");
+
+        // ---- word family ----
+        sb.Append("<section class=\"card\"><div class=\"card-h\"><h2>Word family</h2></div><div class=\"fam\">");
+        foreach (var grp in r.Family.GroupBy(m => m.Group))
+        {
+            sb.Append($"<div class=\"fam-group\"><h3>{Esc(grp.Key)}</h3>");
+            foreach (var m in grp)
+                sb.Append($"<div class=\"fam-row\"><span class=\"fam-lemma pali\">{P(m.LemmaPali)}</span>")
+                  .Append($"<span class=\"fam-gloss\">{Esc(m.Gloss ?? "")} ({Esc(PosFull(m.Pos))})</span>")
+                  .Append($"<span class=\"fam-count\">{m.TotalOccurrences:N0}</span></div>");
+            sb.Append("</div>");
+        }
+        sb.Append("</div>");
+        if (r.FamilyTotalOccurrences > 0)
+            sb.Append($"<div class=\"foot-note\"><b>Whole family</b> (de-duplicated union): <b class=\"num\">{r.FamilyTotalOccurrences:N0}</b> across {r.FamilyFormCount} forms — broader than the conjugation.</div>");
+        sb.Append("</section></div>");
+
+        // ---- lower row: example + homograph ----
+        sb.Append("<div class=\"lower\">");
+        if (!string.IsNullOrEmpty(r.ExamplePali))
+        {
+            sb.Append("<section class=\"card\" style=\"padding:18px 20px 20px\"><div class=\"card-h\" style=\"padding:0 0 12px\"><h2>Attested in the canon</h2><div class=\"meta\">DPD-cited</div></div>")
+              .Append($"<blockquote class=\"pali\">{PMarkup(r.ExamplePali)}</blockquote>");
+            string cite = string.Join(" · ", new[] { r.ExampleSource, r.ExampleSutta }.Where(x => !string.IsNullOrEmpty(x)).Select(Esc!));
+            if (cite.Length > 0) sb.Append($"<div class=\"ex-cite\">{cite}</div>");
+            sb.Append("</section>");
+        }
+        if (r.HomographFormPali is { } hf && r.HomographSenses.Count > 1)
+        {
+            sb.Append("<section class=\"card homo\"><div class=\"card-h\" style=\"padding:0 0 10px\"><h2>Homograph — one form, many words</h2></div>")
+              .Append($"<p>The form <span class=\"hform pali\">{P(hf)}</span> belongs to several lemmas; a surface-string count can’t be split between them.</p><table><tbody>");
+            foreach (var s in r.HomographSenses)
+                sb.Append($"<tr><td class=\"pali\">{P(s.LemmaPali)} <span class=\"tag\">{Esc(PosFull(s.Pos))}</span></td><td>{Esc(s.Gloss ?? "")}</td></tr>");
+            sb.Append("</tbody></table><div class=\"warn\"><span>⚠</span><span>Excluded from the total — an irreducible limit of a surface-string index.</span></div></section>");
+        }
+        sb.Append("</div>");
+
+        // ---- footer ----
+        sb.Append($"<footer><span>{Esc(r.Attribution)}</span><span class=\"num\">dpd-lemma · {Esc(r.DpdVersion)}</span></footer>");
+        sb.Append("</div>");
+        return sb.ToString();
+    }
+
+    private static string Esc(string s) => WebUtility.HtmlEncode(s);
+
+    private static readonly string[] Scripts = { "Devanagari", "Latin", "Sinhala", "Thai", "Myanmar" };
+
+    private static readonly Dictionary<string, string> PosLabels = new()
+    {
+        ["pr"] = "present", ["aor"] = "aorist", ["fut"] = "future", ["opt"] = "optative", ["imp"] = "imperative",
+        ["cond"] = "conditional", ["prp"] = "present participle", ["app"] = "active participle", ["abs"] = "absolutive",
+        ["ger"] = "gerund", ["inf"] = "infinitive", ["pp"] = "past participle", ["ptp"] = "gerundive",
+        ["fpp"] = "future passive participle", ["caus"] = "causative", ["pass"] = "passive", ["denom"] = "denominative",
+        ["masc"] = "masculine", ["fem"] = "feminine", ["nt"] = "neuter", ["adj"] = "adjective", ["adv"] = "adverb",
+        ["ind"] = "indeclinable", ["pron"] = "pronoun", ["card"] = "cardinal", ["ordin"] = "ordinal",
+        ["prefix"] = "prefix", ["suffix"] = "suffix", ["idiom"] = "idiom",
+    };
+    private static string PosFull(string? pos) => pos is null ? "" : (PosLabels.TryGetValue(pos, out var v) ? v : pos);
+
+    private const string Css = @"
+:root{--ground:#FBF9F4;--surface:#FFFFFF;--surface-2:#F5F2EA;--ink:#242019;--muted:#6A6357;--faint:#948C7C;--hair:#E5DFD2;--jade:#1F6F5C;--jade-soft:rgba(31,111,92,.10);--jade-line:rgba(31,111,92,.28);--amber:#A6712A;--amber-soft:rgba(166,113,42,.10);--pos-noun:#8A5A9E;--pali:'Iowan Old Style','Palatino Linotype','Book Antiqua',Palatino,Georgia,serif;--ui:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;--mono:'SF Mono','JetBrains Mono',ui-monospace,Menlo,monospace;}
+@media(prefers-color-scheme:dark){:root{--ground:#171410;--surface:#211D16;--surface-2:#2A2519;--ink:#EEE8DC;--muted:#A79E8C;--faint:#7C7362;--hair:#352F22;--jade:#5FBBA1;--jade-soft:rgba(95,187,161,.12);--jade-line:rgba(95,187,161,.30);--amber:#D6A24E;--amber-soft:rgba(214,162,78,.12);--pos-noun:#C79BDA;}}
+*{box-sizing:border-box}body{margin:0;background:var(--ground);color:var(--ink);font-family:var(--ui);line-height:1.5}
+.pali{font-family:var(--pali)}.wrap{max-width:1140px;margin:0 auto;padding:24px 28px 40px}.num{font-family:var(--mono);font-variant-numeric:tabular-nums}
+header{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;flex-wrap:wrap;padding-bottom:16px;border-bottom:1px solid var(--hair)}
+.lemma{font-family:var(--pali);font-size:2.8rem;line-height:1;font-weight:600}.lemma small{font-size:1rem;color:var(--faint);font-weight:400;vertical-align:.55em;margin-left:.3em}
+.gloss{margin-top:8px;font-size:1.02rem;color:var(--muted);max-width:60ch}
+.pos-badge{display:inline-block;font-size:.68rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--jade);border:1px solid currentColor;border-radius:999px;padding:2px 9px;vertical-align:.55em;margin-left:.5em}
+.script-ctl{display:flex;align-items:center;gap:8px;font-size:.8rem;color:var(--muted)}.script-ctl label{text-transform:uppercase;letter-spacing:.07em;font-size:.66rem;font-weight:700;color:var(--faint)}
+.script-ctl select{font-family:var(--ui);font-size:.85rem;color:var(--ink);background:var(--surface);border:1px solid var(--hair);border-radius:8px;padding:6px 10px}
+.etym{margin-top:18px;background:var(--amber-soft);border:1px solid color-mix(in srgb,var(--amber) 24%,transparent);border-radius:12px;padding:14px 18px;display:flex;flex-wrap:wrap;gap:10px 26px;align-items:baseline}
+.etym .root{font-family:var(--pali);font-size:1.3rem;color:var(--amber);font-weight:600}.etym .kv{display:flex;flex-direction:column;gap:1px}.etym .k{font-size:.62rem;text-transform:uppercase;letter-spacing:.08em;color:var(--faint);font-weight:700}.etym .v{font-size:.95rem}
+.grid{display:grid;grid-template-columns:1.35fr 1fr;gap:20px;margin-top:22px}@media(max-width:820px){.grid{grid-template-columns:1fr}}
+.card{background:var(--surface);border:1px solid var(--hair);border-radius:14px;overflow:hidden}
+.card-h{display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding:13px 18px 9px;border-bottom:1px solid var(--hair)}.card-h h2{margin:0;font-size:.76rem;text-transform:uppercase;letter-spacing:.1em;color:var(--muted);font-weight:700}.card-h .meta{font-size:.8rem;color:var(--faint)}.card-h .meta b{color:var(--jade);font-family:var(--mono)}
+table{width:100%;border-collapse:collapse;font-size:.92rem}.tbl-scroll{overflow-x:auto}tbody tr{border-top:1px solid var(--hair)}td,th{padding:6px 18px;text-align:left}th{font-size:.64rem;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);font-weight:700}
+td.form{font-family:var(--pali);font-size:1rem}td.c{text-align:right;font-family:var(--mono);font-variant-numeric:tabular-nums}td.books{text-align:right;font-family:var(--mono);color:var(--muted)}
+.barcell{width:32%}.bar{height:7px;border-radius:4px;background:var(--jade-soft)}.bar>i{display:block;height:7px;border-radius:4px;background:var(--jade);opacity:.85}
+.tag{font-size:.58rem;font-weight:700;text-transform:uppercase;letter-spacing:.04em;padding:1px 6px;border-radius:999px;margin-left:8px;color:var(--pos-noun);background:color-mix(in srgb,var(--pos-noun) 12%,transparent)}
+.foot-note{padding:9px 18px 13px;font-size:.8rem;color:var(--muted);border-top:1px solid var(--hair)}.foot-note b{color:var(--ink)}
+.stat-row{display:flex;gap:16px;flex-wrap:wrap;padding:9px 18px 2px;font-size:.8rem;color:var(--muted)}.stat b{font-family:var(--mono);color:var(--ink)}.stat.syn b{color:var(--amber)}
+.fam{padding:4px 6px 10px}.fam-group{padding:9px 12px 3px}.fam-group>h3{margin:0 0 5px;font-size:.64rem;text-transform:uppercase;letter-spacing:.08em;color:var(--faint);font-weight:700}
+.fam-row{display:flex;align-items:baseline;gap:10px;padding:4px 6px;border-radius:8px}.fam-lemma{font-family:var(--pali);font-size:1rem;min-width:8em}.fam-gloss{flex:1;font-size:.8rem;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.fam-count{font-family:var(--mono);font-variant-numeric:tabular-nums;font-size:.8rem;color:var(--jade)}
+.lower{display:grid;grid-template-columns:1.35fr 1fr;gap:20px;margin-top:20px}@media(max-width:820px){.lower{grid-template-columns:1fr}}
+blockquote{margin:0;font-family:var(--pali);font-size:1.1rem;line-height:1.6}blockquote b{color:var(--jade)}
+.ex-cite{margin-top:10px;font-size:.8rem;color:var(--faint)}.homo{padding:16px 18px}.homo p{margin:0 0 10px;font-size:.85rem;color:var(--muted)}.homo .hform{font-size:1.2rem}.homo td{padding:5px 0;font-size:.85rem}.homo td:first-child{padding-right:14px}
+.warn{margin-top:10px;font-size:.78rem;color:var(--amber);display:flex;gap:7px}
+footer{margin-top:28px;padding-top:14px;border-top:1px solid var(--hair);display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-size:.74rem;color:var(--faint)}";
+}

--- a/src/CST.Avalonia/Services/LemmaReportRenderer.cs
+++ b/src/CST.Avalonia/Services/LemmaReportRenderer.cs
@@ -17,8 +17,20 @@ public static class LemmaReportRenderer
     {
         // Pāli IPE -> target script, HTML-escaped for text nodes.
         string P(string? ipe) => string.IsNullOrEmpty(ipe) ? "" : Esc(ScriptConverter.Convert(ipe!, Script.Ipe, script));
-        // Pāli that is trusted DPD markup (example carries <b>…</b>): convert, keep tags.
-        string PMarkup(string? ipe) => string.IsNullOrEmpty(ipe) ? "" : ScriptConverter.Convert(ipe!, Script.Ipe, script);
+        // Pāli carrying trusted DPD markup (the example's <b>…</b>): convert + HTML-escape ONLY the text runs
+        // to the target script; re-emit the <b>/</b> tags literally (converting a tag would mangle it to
+        // e.g. <ब्> in Devanagari; escaping the text runs also closes the sole raw-output path).
+        string PMarkup(string? ipe)
+        {
+            if (string.IsNullOrEmpty(ipe)) return "";
+            var o = new StringBuilder(ipe!.Length);
+            foreach (var part in System.Text.RegularExpressions.Regex.Split(ipe!, "(</?b>)"))
+            {
+                if (part is "<b>" or "</b>") o.Append(part);
+                else if (part.Length > 0) o.Append(Esc(ScriptConverter.Convert(part, Script.Ipe, script)));
+            }
+            return o.ToString();
+        }
 
         var sb = new StringBuilder(8192);
         sb.Append("<style>").Append(Css).Append("</style>");
@@ -37,7 +49,8 @@ public static class LemmaReportRenderer
         sb.Append("</select></div></header>");
 
         // ---- etymology band ----
-        if (r.Root is { } root || !string.IsNullOrEmpty(r.ConstructionPali) || !string.IsNullOrEmpty(r.SanskritPali))
+        if (r.Root is { } root || !string.IsNullOrEmpty(r.ConstructionPali) || !string.IsNullOrEmpty(r.Sanskrit)
+            || !string.IsNullOrEmpty(r.Pattern))
         {
             sb.Append("<div class=\"etym\">");
             if (r.Root?.RootPali is { } rp) sb.Append($"<span class=\"root pali\">{P(rp)}</span>");
@@ -49,7 +62,7 @@ public static class LemmaReportRenderer
                 sb.Append($"<div class=\"kv\"><span class=\"k\">Root sense</span><span class=\"v\">{Esc(rm)}{dp}{de}{grp}</span></div>");
             }
             if (r.ConstructionPali is { } con) sb.Append($"<div class=\"kv\"><span class=\"k\">Construction</span><span class=\"v pali\">{P(con)}</span></div>");
-            if (r.SanskritPali is { } skt) sb.Append($"<div class=\"kv\"><span class=\"k\">Sanskrit</span><span class=\"v pali\">{P(skt)}</span></div>");
+            if (r.Sanskrit is { } skt) sb.Append($"<div class=\"kv\"><span class=\"k\">Sanskrit</span><span class=\"v pali\">{Esc(skt)}</span></div>");
             if (r.Pattern is { } pat) sb.Append($"<div class=\"kv\"><span class=\"k\">Pattern</span><span class=\"v\">{Esc(pat)}</span></div>");
             sb.Append("</div>");
         }

--- a/src/CST.Avalonia/Services/LemmaReportRenderer.cs
+++ b/src/CST.Avalonia/Services/LemmaReportRenderer.cs
@@ -103,13 +103,19 @@ public static class LemmaReportRenderer
             if (cite.Length > 0) sb.Append($"<div class=\"ex-cite\">{cite}</div>");
             sb.Append("</section>");
         }
-        if (r.HomographFormPali is { } hf && r.HomographSenses.Count > 1)
+        if (r.Homographs.Count > 0)
         {
-            sb.Append("<section class=\"card homo\"><div class=\"card-h\" style=\"padding:0 0 10px\"><h2>Homograph — one form, many words</h2></div>")
-              .Append($"<p>The form <span class=\"hform pali\">{P(hf)}</span> belongs to several lemmas; a surface-string count can’t be split between them.</p><table><tbody>");
-            foreach (var s in r.HomographSenses)
-                sb.Append($"<tr><td class=\"pali\">{P(s.LemmaPali)} <span class=\"tag\">{Esc(PosFull(s.Pos))}</span></td><td>{Esc(s.Gloss ?? "")}</td></tr>");
-            sb.Append("</tbody></table><div class=\"warn\"><span>⚠</span><span>Excluded from the total — an irreducible limit of a surface-string index.</span></div></section>");
+            int n = r.Homographs.Count;
+            sb.Append($"<section class=\"card homo\"><div class=\"card-h\" style=\"padding:0 0 10px\"><h2>Homographs — {n} form{(n == 1 ? "" : "s")} shared with other words</h2></div>")
+              .Append("<p>These paradigm forms are spelled identically to other lemmas; the index tallies surface strings, so a form’s count can’t be split between them.</p>");
+            foreach (var h in r.Homographs)
+            {
+                sb.Append($"<div class=\"homo-item\"><div class=\"homo-head\"><span class=\"hform pali\">{P(h.FormPali)}</span><span class=\"homo-count\">{h.Count:N0}</span></div><table><tbody>");
+                foreach (var s in h.Senses)
+                    sb.Append($"<tr><td class=\"pali\">{P(s.LemmaPali)} <span class=\"tag\">{Esc(PosFull(s.Pos))}</span></td><td>{Esc(s.Gloss ?? "")}</td></tr>");
+                sb.Append("</tbody></table></div>");
+            }
+            sb.Append("<div class=\"warn\"><span>⚠</span><span>Their counts are included in the paradigm above but overlap these other lemmas — a surface-string index can’t separate them.</span></div></section>");
         }
         sb.Append("</div>");
 
@@ -161,7 +167,8 @@ td.form{font-family:var(--pali);font-size:1rem}td.c{text-align:right;font-family
 .fam-row{display:flex;align-items:baseline;gap:10px;padding:4px 6px;border-radius:8px}.fam-lemma{font-family:var(--pali);font-size:1rem;min-width:8em}.fam-gloss{flex:1;font-size:.8rem;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.fam-count{font-family:var(--mono);font-variant-numeric:tabular-nums;font-size:.8rem;color:var(--jade)}
 .lower{display:grid;grid-template-columns:1.35fr 1fr;gap:20px;margin-top:20px}@media(max-width:820px){.lower{grid-template-columns:1fr}}
 blockquote{margin:0;font-family:var(--pali);font-size:1.1rem;line-height:1.6}blockquote b{color:var(--jade)}
-.ex-cite{margin-top:10px;font-size:.8rem;color:var(--faint)}.homo{padding:16px 18px}.homo p{margin:0 0 10px;font-size:.85rem;color:var(--muted)}.homo .hform{font-size:1.2rem}.homo td{padding:5px 0;font-size:.85rem}.homo td:first-child{padding-right:14px}
+.ex-cite{margin-top:10px;font-size:.8rem;color:var(--faint)}.homo{padding:16px 18px}.homo p{margin:0 0 10px;font-size:.85rem;color:var(--muted)}.homo .hform{font-size:1.15rem}.homo td{padding:4px 0;font-size:.85rem}.homo td:first-child{padding-right:14px}
+.homo-item{padding:8px 0;border-top:1px solid var(--hair)}.homo-item:first-of-type{border-top:none}.homo-head{display:flex;justify-content:space-between;align-items:baseline}.homo-count{font-family:var(--mono);font-variant-numeric:tabular-nums;color:var(--faint);font-size:.8rem}
 .warn{margin-top:10px;font-size:.78rem;color:var(--amber);display:flex;gap:7px}
 footer{margin-top:28px;padding-top:14px;border-top:1px solid var(--hair);display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-size:.74rem;color:var(--faint)}";
 }

--- a/src/CST.Avalonia/Services/LemmaReportService.cs
+++ b/src/CST.Avalonia/Services/LemmaReportService.cs
@@ -106,19 +106,35 @@ public sealed class LemmaReportService : ILemmaReportService
         var meta = _lemma.Meta;
         return new LemmaReport(
             d.LemmaId, ToIpe(d.Lemma), d.Pos, d.Gloss, d.MeaningLit, ToIpeOrNull(d.DerivedFrom),
-            ToIpeOrNull(d.Construction), ToIpeOrNull(d.Sanskrit), d.Pattern, MapRoot(d.Root), d.EbtCount,
+            ToIpeOrNull(d.Construction), d.Sanskrit, d.Pattern, MapRoot(d.Root), d.EbtCount,
             forms, focus?.TotalOccurrences ?? 0, focus?.AttestedFormCount ?? 0, focus?.CandidateFormCount ?? 0, focus?.ExpansionCapped ?? false,
-            ToIpeOrNull(d.Example), d.ExampleSource, d.ExampleSutta,
+            ToIpeMarkupOrNull(d.Example), d.ExampleSource, d.ExampleSutta,
             family, famAll?.TotalOccurrences ?? 0, famAll?.AttestedFormCount ?? 0,
             homographs,
             meta?.DpdVersion ?? string.Empty, meta?.Attribution ?? string.Empty);
     }
 
+    // Sanskrit cognates carry characters outside the Pāli IPE inventory (ṛ ṝ ś ṣ …) that Any2Ipe can't
+    // round-trip, so Sanskrit stays verbatim IAST (rendered as-is, not script-converted).
     private static ReportRoot? MapRoot(RootDetail? r) => r is null ? null
-        : new ReportRoot(ToIpe(r.RootKey), r.RootMeaning, r.RootGroup, ToIpeOrNull(r.SanskritRoot), ToIpeOrNull(r.DhatupathaPali), r.DhatupathaEnglish);
+        : new ReportRoot(ToIpe(r.RootKey), r.RootMeaning, r.RootGroup, r.SanskritRoot, ToIpeOrNull(r.DhatupathaPali), r.DhatupathaEnglish);
 
     private static string ToIpe(string iast) => Any2Ipe.Convert(iast);
     private static string? ToIpeOrNull(string? iast) => string.IsNullOrEmpty(iast) ? iast : Any2Ipe.Convert(iast!);
+
+    // Like ToIpeOrNull but tag-aware: the DPD example carries <b>…</b> markup. Convert only the text runs
+    // to IPE; re-emit the tags literally so they survive the later IPE→script render un-mangled.
+    private static string? ToIpeMarkupOrNull(string? iast)
+    {
+        if (string.IsNullOrEmpty(iast)) return iast;
+        var sb = new System.Text.StringBuilder(iast!.Length);
+        foreach (var part in System.Text.RegularExpressions.Regex.Split(iast!, "(</?b>)"))
+        {
+            if (part is "<b>" or "</b>") sb.Append(part);
+            else if (part.Length > 0) sb.Append(Any2Ipe.Convert(part));
+        }
+        return sb.ToString();
+    }
 
     // Broad pos → family grouping (pos alone can't separate causative/passive from finite verbs — DPD tags
     // both as 'pr' — so this is a coarse-but-defensible three-way split).

--- a/src/CST.Avalonia/Services/LemmaReportService.cs
+++ b/src/CST.Avalonia/Services/LemmaReportService.cs
@@ -55,7 +55,16 @@ public sealed class LemmaReportService : ILemmaReportService
         var d = _lemma.GetDetail(lemmaId);
         if (d is null) return null;
 
-        // Focus paradigm — forms with corpus counts (in IPE). Flag each form that is a homograph.
+        // The focus lemma's word-family (its derived_from cluster). Used to tell a REAL homograph (a form
+        // shared with a DIFFERENT word) from a mere in-family overlap — e.g. a form the finite verb shares
+        // with its own present participle (pajānantīti = pajānanti+iti OR pajānantī+iti), which is not a
+        // meaningful ambiguity.
+        var exp = _lemma.ExpandLemma(lemmaId, includeFamily: true);
+        var familyIds = new HashSet<long> { lemmaId };
+        if (exp?.Family is { } famMembers) foreach (var m in famMembers) familyIds.Add(m.LemmaId);
+
+        // Focus paradigm — forms with corpus counts (in IPE). A form is a homograph only if it also belongs
+        // to a lemma OUTSIDE this word-family.
         var focus = await _search.ExpandAndSearchAsync(lemmaId, includeFamily: false, filter: null, outputScript: Script.Ipe, ct: ct)
             .ConfigureAwait(false);
         var forms = new List<ReportForm>();
@@ -65,7 +74,7 @@ public sealed class LemmaReportService : ILemmaReportService
             foreach (var f in focus.AttestedForms)
             {
                 var res = _lemma.ResolveForm(ScriptConverter.Convert(f.Ipe, Script.Ipe, Script.Latin));
-                bool homo = res is not null && res.Candidates.Count > 1;
+                bool homo = res is not null && res.Candidates.Any(c => !familyIds.Contains(c.LemmaId));
                 forms.Add(new ReportForm(f.Ipe, f.Count, f.BookCount, homo));
                 if (homo)
                 {
@@ -80,7 +89,6 @@ public sealed class LemmaReportService : ILemmaReportService
 
         // Word family — derived_from siblings, each with its own corpus total, grouped by pos category.
         var family = new List<ReportFamilyMember>();
-        var exp = _lemma.ExpandLemma(lemmaId, includeFamily: true);
         if (exp?.Family is { } siblings)
         {
             foreach (var m in siblings)

--- a/src/CST.Avalonia/Services/LemmaReportService.cs
+++ b/src/CST.Avalonia/Services/LemmaReportService.cs
@@ -59,9 +59,7 @@ public sealed class LemmaReportService : ILemmaReportService
         var focus = await _search.ExpandAndSearchAsync(lemmaId, includeFamily: false, filter: null, outputScript: Script.Ipe, ct: ct)
             .ConfigureAwait(false);
         var forms = new List<ReportForm>();
-        string? homographForm = null;
-        int homographCount = -1;
-        var homoSenses = new List<ReportHomographSense>();
+        var homographs = new List<ReportHomograph>();
         if (focus is not null)
         {
             foreach (var f in focus.AttestedForms)
@@ -69,16 +67,16 @@ public sealed class LemmaReportService : ILemmaReportService
                 var res = _lemma.ResolveForm(ScriptConverter.Convert(f.Ipe, Script.Ipe, Script.Latin));
                 bool homo = res is not null && res.Candidates.Count > 1;
                 forms.Add(new ReportForm(f.Ipe, f.Count, f.BookCount, homo));
-                if (homo && f.Count > homographCount)
+                if (homo)
                 {
-                    homographCount = f.Count;
-                    homographForm = f.Ipe;
-                    homoSenses = res!.Candidates
+                    var senses = res!.Candidates
                         .Select(c => new ReportHomographSense(c.LemmaId, ToIpe(c.Lemma), c.Pos, c.Gloss, ToIpeOrNull(c.DerivedFrom)))
                         .ToList();
+                    homographs.Add(new ReportHomograph(f.Ipe, f.Count, senses));
                 }
             }
         }
+        homographs = homographs.OrderByDescending(h => h.Count).ToList();
 
         // Word family — derived_from siblings, each with its own corpus total, grouped by pos category.
         var family = new List<ReportFamilyMember>();
@@ -104,7 +102,7 @@ public sealed class LemmaReportService : ILemmaReportService
             forms, focus?.TotalOccurrences ?? 0, focus?.AttestedFormCount ?? 0, focus?.CandidateFormCount ?? 0, focus?.ExpansionCapped ?? false,
             ToIpeOrNull(d.Example), d.ExampleSource, d.ExampleSutta,
             family, famAll?.TotalOccurrences ?? 0, famAll?.AttestedFormCount ?? 0,
-            homographForm, homoSenses,
+            homographs,
             meta?.DpdVersion ?? string.Empty, meta?.Attribution ?? string.Empty);
     }
 

--- a/src/CST.Avalonia/Services/LemmaReportService.cs
+++ b/src/CST.Avalonia/Services/LemmaReportService.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Search;
+using CST.Conversion;
+using CST.Lemma;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Assembles the structured lemma report (dossier) and caches it. The cached report is script-neutral (all
+/// Pāli in IPE), so the script picker is a pure re-render (in the renderer), never a recompute. Assembly does
+/// several corpus searches (the focus paradigm + each family sibling's total + the family:true union), which
+/// is why the cache matters. Invalidate on a corpus re-index or asset swap.
+/// </summary>
+public interface ILemmaReportService
+{
+    bool IsAvailable { get; }
+    Task<LemmaReport?> BuildAsync(long lemmaId, CancellationToken ct = default);
+    void InvalidateCache();
+}
+
+public sealed class LemmaReportService : ILemmaReportService
+{
+    private const int CacheCapacity = 32;
+
+    private readonly ILemmaProvider _lemma;
+    private readonly ILemmaSearchService _search;
+    private readonly BoundedCache<long, LemmaReport> _cache = new(CacheCapacity);
+    private readonly object _lock = new();
+
+    public LemmaReportService(ILemmaProvider lemma, ILemmaSearchService search)
+    {
+        _lemma = lemma;
+        _search = search;
+    }
+
+    public bool IsAvailable => _lemma.IsAvailable;
+
+    public void InvalidateCache() { lock (_lock) _cache.Clear(); }
+
+    public async Task<LemmaReport?> BuildAsync(long lemmaId, CancellationToken ct = default)
+    {
+        if (!IsAvailable) return null;
+        lock (_lock) { if (_cache.TryGet(lemmaId, out var hit) && hit is not null) return hit; }
+
+        var report = await AssembleAsync(lemmaId, ct).ConfigureAwait(false);
+        if (report is not null) lock (_lock) _cache.Set(lemmaId, report);
+        return report;
+    }
+
+    private async Task<LemmaReport?> AssembleAsync(long lemmaId, CancellationToken ct)
+    {
+        var d = _lemma.GetDetail(lemmaId);
+        if (d is null) return null;
+
+        // Focus paradigm — forms with corpus counts (in IPE). Flag each form that is a homograph.
+        var focus = await _search.ExpandAndSearchAsync(lemmaId, includeFamily: false, filter: null, outputScript: Script.Ipe, ct: ct)
+            .ConfigureAwait(false);
+        var forms = new List<ReportForm>();
+        string? homographForm = null;
+        int homographCount = -1;
+        var homoSenses = new List<ReportHomographSense>();
+        if (focus is not null)
+        {
+            foreach (var f in focus.AttestedForms)
+            {
+                var res = _lemma.ResolveForm(ScriptConverter.Convert(f.Ipe, Script.Ipe, Script.Latin));
+                bool homo = res is not null && res.Candidates.Count > 1;
+                forms.Add(new ReportForm(f.Ipe, f.Count, f.BookCount, homo));
+                if (homo && f.Count > homographCount)
+                {
+                    homographCount = f.Count;
+                    homographForm = f.Ipe;
+                    homoSenses = res!.Candidates
+                        .Select(c => new ReportHomographSense(c.LemmaId, ToIpe(c.Lemma), c.Pos, c.Gloss, ToIpeOrNull(c.DerivedFrom)))
+                        .ToList();
+                }
+            }
+        }
+
+        // Word family — derived_from siblings, each with its own corpus total, grouped by pos category.
+        var family = new List<ReportFamilyMember>();
+        var exp = _lemma.ExpandLemma(lemmaId, includeFamily: true);
+        if (exp?.Family is { } siblings)
+        {
+            foreach (var m in siblings)
+            {
+                if (m.LemmaId == lemmaId) continue;
+                var mr = await _search.ExpandAndSearchAsync(m.LemmaId, false, null, Script.Ipe, ct).ConfigureAwait(false);
+                family.Add(new ReportFamilyMember(m.LemmaId, ToIpe(m.Lemma), m.Pos, m.Gloss, mr?.TotalOccurrences ?? 0, PosGroup(m.Pos)));
+            }
+        }
+        family = family.OrderByDescending(m => m.TotalOccurrences).ToList();
+
+        // family:true de-duplicated union totals (the whole word-family, counted once).
+        var famAll = await _search.ExpandAndSearchAsync(lemmaId, includeFamily: true, null, Script.Ipe, ct).ConfigureAwait(false);
+
+        var meta = _lemma.Meta;
+        return new LemmaReport(
+            d.LemmaId, ToIpe(d.Lemma), d.Pos, d.Gloss, d.MeaningLit, ToIpeOrNull(d.DerivedFrom),
+            ToIpeOrNull(d.Construction), ToIpeOrNull(d.Sanskrit), d.Pattern, MapRoot(d.Root), d.EbtCount,
+            forms, focus?.TotalOccurrences ?? 0, focus?.AttestedFormCount ?? 0, focus?.CandidateFormCount ?? 0, focus?.ExpansionCapped ?? false,
+            ToIpeOrNull(d.Example), d.ExampleSource, d.ExampleSutta,
+            family, famAll?.TotalOccurrences ?? 0, famAll?.AttestedFormCount ?? 0,
+            homographForm, homoSenses,
+            meta?.DpdVersion ?? string.Empty, meta?.Attribution ?? string.Empty);
+    }
+
+    private static ReportRoot? MapRoot(RootDetail? r) => r is null ? null
+        : new ReportRoot(ToIpe(r.RootKey), r.RootMeaning, r.RootGroup, ToIpeOrNull(r.SanskritRoot), ToIpeOrNull(r.DhatupathaPali), r.DhatupathaEnglish);
+
+    private static string ToIpe(string iast) => Any2Ipe.Convert(iast);
+    private static string? ToIpeOrNull(string? iast) => string.IsNullOrEmpty(iast) ? iast : Any2Ipe.Convert(iast!);
+
+    // Broad pos → family grouping (pos alone can't separate causative/passive from finite verbs — DPD tags
+    // both as 'pr' — so this is a coarse-but-defensible three-way split).
+    private static string PosGroup(string? pos) => pos switch
+    {
+        "pr" or "aor" or "fut" or "opt" or "imp" or "cond" or "prp" or "app" or "abs" or "ger" or "inf"
+            or "pp" or "ptp" or "fpp" or "caus" or "pass" or "denom" => "Verbs & participles",
+        "masc" or "fem" or "nt" => "Nouns",
+        _ => "Adjectives & other",
+    };
+}

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -476,10 +476,13 @@ namespace CST.Avalonia.Services.LocalApi
 
             // Lemma dossier (rendered HTML). The GUI renders it in-process; this endpoint gives agents/humans
             // the same report. `script` selects the render script (default Latin). HTML only (no IPE leak).
-            if (_lemmaReport is { IsAvailable: true } report)
+            if (_lemmaReport is { } report)
             {
                 app.MapGet(v + "/lemma-report/{lemmaId:long}", async (long lemmaId, string? script, CancellationToken ct) =>
                 {
+                    // Same asset-absent contract as the sibling lemma endpoints: a 503 JSON, not a bare 404.
+                    if (!report.IsAvailable) return Results.Json(
+                        new { error = "The DPD-lemma dataset is not installed; lemma search is unavailable." }, statusCode: 503);
                     var rep = await report.BuildAsync(lemmaId, ct);
                     return rep is null
                         ? Results.NotFound(new { error = $"Unknown lemmaId {lemmaId}." })

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -58,6 +58,7 @@ namespace CST.Avalonia.Services.LocalApi
         private readonly IPassageTool? _passage;
         private readonly IScriptTool? _script;
         private readonly ILemmaSearchService? _lemma;   // DPD-lemma back-lookup + forward-expansion (may be null / asset-absent)
+        private readonly ILemmaReportService? _lemmaReport;   // the rendered lemma dossier
         private readonly int _port;              // fixed loopback port, or <= 0 for ephemeral
         private readonly string? _configuredToken; // persisted bearer token, or null to generate one
         private readonly bool _restApiEnabled;   // map the /v1 REST tool endpoints
@@ -80,8 +81,8 @@ namespace CST.Avalonia.Services.LocalApi
         public LocalApiServer(
             string appVersion, string handshakeDirectory, Serilog.ILogger logger,
             ISearchTool? search = null, IDictionaryTool? dictionary = null, IPassageTool? passage = null,
-            IScriptTool? script = null, ILemmaSearchService? lemma = null, int port = 0, string? token = null,
-            bool restApiEnabled = true, bool mcpEnabled = true)
+            IScriptTool? script = null, ILemmaSearchService? lemma = null, ILemmaReportService? lemmaReport = null,
+            int port = 0, string? token = null, bool restApiEnabled = true, bool mcpEnabled = true)
         {
             _appVersion = appVersion;
             _handshakeDirectory = handshakeDirectory;
@@ -91,6 +92,7 @@ namespace CST.Avalonia.Services.LocalApi
             _passage = passage;
             _script = script;
             _lemma = lemma;
+            _lemmaReport = lemmaReport;
             _port = port;
             _configuredToken = token;
             _restApiEnabled = restApiEnabled;
@@ -111,7 +113,8 @@ namespace CST.Avalonia.Services.LocalApi
                 services.GetService<IDictionaryTool>(),
                 services.GetService<IPassageTool>(),
                 services.GetService<IScriptTool>(),
-                services.GetService<ILemmaSearchService>(), port, token, restApiEnabled, mcpEnabled);
+                services.GetService<ILemmaSearchService>(),
+                services.GetService<ILemmaReportService>(), port, token, restApiEnabled, mcpEnabled);
 
         public async Task StartAsync(CancellationToken ct = default)
         {
@@ -468,6 +471,19 @@ namespace CST.Avalonia.Services.LocalApi
                     return res is null
                         ? Results.NotFound(new { error = $"Unknown lemmaId {lemmaId}." })
                         : Results.Json(LemmaApi.ToForms(res, outputScript));
+                });
+            }
+
+            // Lemma dossier (rendered HTML). The GUI renders it in-process; this endpoint gives agents/humans
+            // the same report. `script` selects the render script (default Latin). HTML only (no IPE leak).
+            if (_lemmaReport is { IsAvailable: true } report)
+            {
+                app.MapGet(v + "/lemma-report/{lemmaId:long}", async (long lemmaId, string? script, CancellationToken ct) =>
+                {
+                    var rep = await report.BuildAsync(lemmaId, ct);
+                    return rep is null
+                        ? Results.NotFound(new { error = $"Unknown lemmaId {lemmaId}." })
+                        : Results.Content(LemmaReportRenderer.Render(rep, ParseScript(script)), "text/html; charset=utf-8");
                 });
             }
 

--- a/src/CST.Lemma/ILemmaProvider.cs
+++ b/src/CST.Lemma/ILemmaProvider.cs
@@ -24,4 +24,7 @@ public interface ILemmaProvider : IDisposable
 
     /// <summary>A single lemma's metadata, or null if the id is unknown.</summary>
     LemmaCandidate? GetLemma(long lemmaId);
+
+    /// <summary>Report-grade detail (etymology/example/frequency/root) for one lemma; null if the id is unknown. Enriched fields are null on a non-report asset.</summary>
+    LemmaDetail? GetDetail(long lemmaId);
 }

--- a/src/CST.Lemma/LemmaModels.cs
+++ b/src/CST.Lemma/LemmaModels.cs
@@ -36,3 +36,19 @@ public sealed record DpdLemmaMeta(
     string SchemaVersion,
     string License,
     string Attribution);
+
+/// <summary>Root (dhātu) detail for the report's etymology band (present only in report-grade assets).</summary>
+public sealed record RootDetail(
+    string RootKey, string? RootMeaning, long? RootGroup,
+    string? SanskritRoot, string? SanskritRootMeaning, string? DhatupathaPali, string? DhatupathaEnglish);
+
+/// <summary>
+/// Report-grade detail for one lemma (etymology, example, frequency, root) — the extra per-lemma columns a
+/// report-scope asset carries. On a lean/mid-without-report asset the enriched fields come back null.
+/// Pāli strings are IAST (as stored); the caller converts.
+/// </summary>
+public sealed record LemmaDetail(
+    long LemmaId, string Lemma, string? Pos, string? Gloss, string? DerivedFrom,
+    string? MeaningLit, string? Construction, string? Sanskrit, string? Pattern, long? EbtCount,
+    string? ExampleSource, string? ExampleSutta, string? Example, string? Synonym, string? Antonym,
+    RootDetail? Root);

--- a/src/CST.Lemma/SqliteLemmaProvider.cs
+++ b/src/CST.Lemma/SqliteLemmaProvider.cs
@@ -106,13 +106,34 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
         if (includeFamily)
         {
             family = new List<LemmaCandidate>();
-            var baseName = StripHomonym(head.Lemma);
+            // The whole word-family (cluster), keyed on the family BASE — not just the focus's own
+            // children. The base is the focus's derived_from when the focus is itself a derived member,
+            // else the focus's own (homonym-stripped) headword. This makes the family SYMMETRIC: building
+            // it from the base verb or from any derived member (participle, absolutive, deverbal noun)
+            // yields the same cluster. So a form the finite verb shares with its own participle is
+            // correctly in-family (not a homograph), regardless of which member the report focuses on.
+            // The family is the DERIVATIONAL cluster around the focus, taken in BOTH directions so it is
+            // symmetric regardless of which member the report focuses on:
+            //   • $base = the focus's parent (its derived_from) when the focus is itself derived, else its
+            //     own headword. `lemma = $base` pulls in the parent headword and `derived_from = $base`
+            //     pulls in the co-derived siblings (e.g. from a participle, back up to its finite verb and
+            //     across to the verb's other derivations).
+            //   • $self = the focus's own headword; `derived_from = $self` pulls in the focus's own
+            //     children (e.g. from a deverbal noun, down to that noun's declensional derivations).
+            //   • `id = $id` guarantees the focus is always present (even a numbered homonym base).
+            // Deliberately NOT grouped by shared spelling: homonyms like 'dhamma 1' / 'dhamma 2' are
+            // DIFFERENT words (their shared forms are genuine homographs), so there is no GLOB 'base [0-9]*'.
+            string? df = string.IsNullOrEmpty(head.DerivedFrom) ? null : head.DerivedFrom;
+            var self = StripHomonym(head.Lemma);
+            var baseName = StripHomonym(df ?? head.Lemma);
             using var cmd = c.CreateCommand();
             cmd.CommandText =
                 @"SELECT id, lemma, pos, gloss, derived_from FROM lemma
-                  WHERE id = $id OR derived_from = $base ORDER BY id";
+                  WHERE id = $id OR lemma = $base OR derived_from = $base OR derived_from = $self
+                  ORDER BY id";
             cmd.Parameters.AddWithValue("$id", lemmaId);
             cmd.Parameters.AddWithValue("$base", baseName);
+            cmd.Parameters.AddWithValue("$self", self);
             using var r = cmd.ExecuteReader();
             while (r.Read())
                 family.Add(new LemmaCandidate(r.GetInt64(0), r.GetString(1), Str(r, 2), Str(r, 3), Str(r, 4)));

--- a/src/CST.Lemma/SqliteLemmaProvider.cs
+++ b/src/CST.Lemma/SqliteLemmaProvider.cs
@@ -11,6 +11,7 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
 {
     private readonly string? _connString;
     private readonly bool _hasFormsTable;
+    private readonly bool _hasReport;   // report-grade columns (root_key on lemma + a root table)
 
     public bool IsAvailable { get; }
     public DpdLemmaMeta? Meta { get; }
@@ -36,6 +37,7 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
             if (!TableExists(c, "lemma") || !TableExists(c, "form_lemma"))
                 return;
             _hasFormsTable = TableExists(c, "forms");
+            _hasReport = TableExists(c, "root") && ColumnExists(c, "lemma", "root_key");
             Meta = LoadMeta(c);
             _connString = connString;
             IsAvailable = true;
@@ -126,6 +128,45 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
         return ReadLemma(c, lemmaId);
     }
 
+    public LemmaDetail? GetDetail(long lemmaId)
+    {
+        if (!IsAvailable) return null;
+        using var c = Open();
+        using var cmd = c.CreateCommand();
+        cmd.CommandText = _hasReport
+            ? @"SELECT id,lemma,pos,gloss,derived_from,meaning_lit,construction,sanskrit,pattern,ebt_count,
+                  example_source,example_sutta,example,synonym,antonym,root_key FROM lemma WHERE id=$id"
+            : "SELECT id,lemma,pos,gloss,derived_from FROM lemma WHERE id=$id";
+        cmd.Parameters.AddWithValue("$id", lemmaId);
+        using var r = cmd.ExecuteReader();
+        if (!r.Read()) return null;
+
+        long id = r.GetInt64(0);
+        string lemma = r.GetString(1);
+        string? pos = Str(r, 2), gloss = Str(r, 3), df = Str(r, 4);
+        if (!_hasReport)
+            return new LemmaDetail(id, lemma, pos, gloss, df, null, null, null, null, null, null, null, null, null, null, null);
+
+        long? ebt = r.IsDBNull(9) ? null : r.GetInt64(9);
+        string? rootKey = Str(r, 15);
+        RootDetail? root = rootKey is null ? null : ReadRoot(c, rootKey);
+        return new LemmaDetail(id, lemma, pos, gloss, df,
+            Str(r, 5), Str(r, 6), Str(r, 7), Str(r, 8), ebt,
+            Str(r, 10), Str(r, 11), Str(r, 12), Str(r, 13), Str(r, 14), root);
+    }
+
+    private static RootDetail? ReadRoot(SqliteConnection c, string rootKey)
+    {
+        using var cmd = c.CreateCommand();
+        cmd.CommandText = @"SELECT root_key,root_meaning,root_group,sanskrit_root,sanskrit_root_meaning,
+            dhatupatha_pali,dhatupatha_english FROM root WHERE root_key=$rk";
+        cmd.Parameters.AddWithValue("$rk", rootKey);
+        using var r = cmd.ExecuteReader();
+        if (!r.Read()) return null;
+        long? grp = r.IsDBNull(2) ? null : r.GetInt64(2);
+        return new RootDetail(r.GetString(0), Str(r, 1), grp, Str(r, 3), Str(r, 4), Str(r, 5), Str(r, 6));
+    }
+
     private static LemmaCandidate? ReadLemma(SqliteConnection c, long id)
     {
         using var cmd = c.CreateCommand();
@@ -154,6 +195,15 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
         using var cmd = c.CreateCommand();
         cmd.CommandText = "SELECT 1 FROM sqlite_master WHERE type='table' AND name = $n LIMIT 1";
         cmd.Parameters.AddWithValue("$n", name);
+        return cmd.ExecuteScalar() is not null;
+    }
+
+    // table is a fixed literal (no injection); pragma_table_info can't be parameterized on the table name.
+    private static bool ColumnExists(SqliteConnection c, string table, string column)
+    {
+        using var cmd = c.CreateCommand();
+        cmd.CommandText = $"SELECT 1 FROM pragma_table_info('{table}') WHERE name = $n LIMIT 1";
+        cmd.Parameters.AddWithValue("$n", column);
         return cmd.ExecuteScalar() is not null;
     }
 

--- a/src/CST.Lemma/SqliteLemmaProvider.cs
+++ b/src/CST.Lemma/SqliteLemmaProvider.cs
@@ -112,28 +112,40 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
             // it from the base verb or from any derived member (participle, absolutive, deverbal noun)
             // yields the same cluster. So a form the finite verb shares with its own participle is
             // correctly in-family (not a homograph), regardless of which member the report focuses on.
-            // The family is the DERIVATIONAL cluster around the focus, taken in BOTH directions so it is
-            // symmetric regardless of which member the report focuses on:
-            //   • $base = the focus's parent (its derived_from) when the focus is itself derived, else its
-            //     own headword. `lemma = $base` pulls in the parent headword and `derived_from = $base`
-            //     pulls in the co-derived siblings (e.g. from a participle, back up to its finite verb and
-            //     across to the verb's other derivations).
-            //   • $self = the focus's own headword; `derived_from = $self` pulls in the focus's own
-            //     children (e.g. from a deverbal noun, down to that noun's declensional derivations).
-            //   • `id = $id` guarantees the focus is always present (even a numbered homonym base).
-            // Deliberately NOT grouped by shared spelling: homonyms like 'dhamma 1' / 'dhamma 2' are
-            // DIFFERENT words (their shared forms are genuine homographs), so there is no GLOB 'base [0-9]*'.
+            // The family is the DERIVATIONAL cluster around the focus. `id = $id` always keeps the focus,
+            // and `derived_from = $self` (self = the focus's own headword) pulls in the focus's own children
+            // (e.g. from a deverbal noun, down to its declensional derivations).
+            //
+            // When the focus is ITSELF derived, we also climb to its parent cluster, keyed on the focus's
+            // derived_from ($base): `derived_from = $base` gets the co-derived siblings, and the parent
+            // headword is `lemma = $base` OR — because DPD stores homonymous headwords numbered ('paññā 1')
+            // while derived_from is unnumbered ('paññā') — `lemma GLOB 'base [0-9]*'`. This homonym GLOB is
+            // used ONLY for the parent lookup: derived_from cannot say which numbered homonym is the parent,
+            // so we (coarsely) include them all. It is deliberately NOT applied to a base lemma's own name,
+            // so genuinely different words that merely share a spelling ('dhamma 1' / 'dhamma 2', both with
+            // derived_from NULL) stay distinct and their shared forms remain true homographs.
             string? df = string.IsNullOrEmpty(head.DerivedFrom) ? null : head.DerivedFrom;
             var self = StripHomonym(head.Lemma);
-            var baseName = StripHomonym(df ?? head.Lemma);
             using var cmd = c.CreateCommand();
-            cmd.CommandText =
-                @"SELECT id, lemma, pos, gloss, derived_from FROM lemma
-                  WHERE id = $id OR lemma = $base OR derived_from = $base OR derived_from = $self
-                  ORDER BY id";
             cmd.Parameters.AddWithValue("$id", lemmaId);
-            cmd.Parameters.AddWithValue("$base", baseName);
             cmd.Parameters.AddWithValue("$self", self);
+            if (df is null)
+            {
+                cmd.CommandText =
+                    @"SELECT id, lemma, pos, gloss, derived_from FROM lemma
+                      WHERE id = $id OR derived_from = $self ORDER BY id";
+            }
+            else
+            {
+                var parentBase = StripHomonym(df);
+                cmd.CommandText =
+                    @"SELECT id, lemma, pos, gloss, derived_from FROM lemma
+                      WHERE id = $id OR derived_from = $self
+                         OR derived_from = $base OR lemma = $base OR lemma GLOB $baseGlob
+                      ORDER BY id";
+                cmd.Parameters.AddWithValue("$base", parentBase);
+                cmd.Parameters.AddWithValue("$baseGlob", parentBase + " [0-9]*");
+            }
             using var r = cmd.ExecuteReader();
             while (r.Read())
                 family.Add(new LemmaCandidate(r.GetInt64(0), r.GetString(1), Str(r, 2), Str(r, 3), Str(r, 4)));

--- a/tools/DpdLemmaBuilder/Program.cs
+++ b/tools/DpdLemmaBuilder/Program.cs
@@ -22,8 +22,8 @@ using Microsoft.Data.Sqlite;
 // Usage: DpdLemmaBuilder [<dpd.db path> [<output dpd-lemma.db path>]] [--scope lean|mid|full]
 // =====================================================================================================
 
-const string ConverterVersion = "1";
-const string SchemaVersion = "1";
+const string ConverterVersion = "2";   // v2: report-grade per-lemma columns + root table
+const string SchemaVersion = "2";
 
 // ---- args ----
 var positional = new List<string>();
@@ -45,6 +45,7 @@ string outPath = positional.Count > 1 ? positional[1] : "/Users/fsnow/dpd-poc/dp
 
 bool includeForms = scope != "lean";      // the forms (grammar) table
 bool includeDecon = scope == "full";      // sandhi deconstructor column
+bool includeReport = scope != "lean";     // report-grade per-lemma columns (etymology/example/…) + root table
 
 if (!File.Exists(srcPath))
 {
@@ -79,12 +80,20 @@ if (File.Exists(outPath)) File.Delete(outPath);
 using var outDb = new SqliteConnection($"Data Source={outPath}");
 outDb.Open();
 Exec(outDb, "PRAGMA journal_mode=OFF; PRAGMA synchronous=OFF; PRAGMA temp_store=MEMORY;");
+Exec(outDb, includeReport
+    ? @"CREATE TABLE lemma (
+        id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT,
+        root_key TEXT, construction TEXT, sanskrit TEXT, meaning_lit TEXT, pattern TEXT, ebt_count INTEGER,
+        example_source TEXT, example_sutta TEXT, example TEXT, synonym TEXT, antonym TEXT );"
+    : @"CREATE TABLE lemma (
+        id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT );");
 Exec(outDb, @"
-    CREATE TABLE lemma (
-        id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT
-    );
     CREATE TABLE form_lemma ( form TEXT NOT NULL, lemma_id INTEGER NOT NULL );
     CREATE TABLE meta ( key TEXT PRIMARY KEY, value TEXT );");
+if (includeReport)
+    Exec(outDb, @"CREATE TABLE root (
+        root_key TEXT PRIMARY KEY, root_sign TEXT, root_meaning TEXT, root_group INTEGER,
+        sanskrit_root TEXT, sanskrit_root_meaning TEXT, dhatupatha_pali TEXT, dhatupatha_english TEXT );");
 if (includeForms)
     Exec(outDb, includeDecon
         ? "CREATE TABLE forms ( form TEXT PRIMARY KEY, grammar TEXT, deconstructor TEXT );"
@@ -95,15 +104,43 @@ long lemmaCount = 0;
 using (var tx = outDb.BeginTransaction())
 {
     using var ins = outDb.CreateCommand();
-    ins.CommandText = "INSERT INTO lemma(id,lemma,pos,gloss,derived_from) VALUES($id,$lemma,$pos,$gloss,$df)";
+    using var read = src.CreateCommand();
+    if (includeReport)
+    {
+        ins.CommandText = @"INSERT INTO lemma
+            (id,lemma,pos,gloss,derived_from,root_key,construction,sanskrit,meaning_lit,pattern,ebt_count,
+             example_source,example_sutta,example,synonym,antonym)
+            VALUES ($id,$lemma,$pos,$gloss,$df,$rk,$con,$skt,$lit,$pat,$ebt,$exs,$exu,$ex,$syn,$ant)";
+        read.CommandText = @"SELECT id,lemma_1,pos,meaning_1,derived_from,root_key,construction,sanskrit,
+            meaning_lit,pattern,ebt_count,source_1,sutta_1,example_1,synonym,antonym FROM dpd_headwords";
+    }
+    else
+    {
+        ins.CommandText = "INSERT INTO lemma(id,lemma,pos,gloss,derived_from) VALUES($id,$lemma,$pos,$gloss,$df)";
+        read.CommandText = "SELECT id, lemma_1, pos, meaning_1, derived_from FROM dpd_headwords";
+    }
     var pId = ins.Parameters.Add("$id", SqliteType.Integer);
     var pLemma = ins.Parameters.Add("$lemma", SqliteType.Text);
     var pPos = ins.Parameters.Add("$pos", SqliteType.Text);
     var pGloss = ins.Parameters.Add("$gloss", SqliteType.Text);
     var pDf = ins.Parameters.Add("$df", SqliteType.Text);
+    SqliteParameter pRk = null!, pCon = null!, pSkt = null!, pLit = null!, pPat = null!, pEbt = null!,
+                    pExs = null!, pExu = null!, pEx = null!, pSyn = null!, pAnt = null!;
+    if (includeReport)
+    {
+        pRk = ins.Parameters.Add("$rk", SqliteType.Text);
+        pCon = ins.Parameters.Add("$con", SqliteType.Text);
+        pSkt = ins.Parameters.Add("$skt", SqliteType.Text);
+        pLit = ins.Parameters.Add("$lit", SqliteType.Text);
+        pPat = ins.Parameters.Add("$pat", SqliteType.Text);
+        pEbt = ins.Parameters.Add("$ebt", SqliteType.Integer);
+        pExs = ins.Parameters.Add("$exs", SqliteType.Text);
+        pExu = ins.Parameters.Add("$exu", SqliteType.Text);
+        pEx = ins.Parameters.Add("$ex", SqliteType.Text);
+        pSyn = ins.Parameters.Add("$syn", SqliteType.Text);
+        pAnt = ins.Parameters.Add("$ant", SqliteType.Text);
+    }
 
-    using var read = src.CreateCommand();
-    read.CommandText = "SELECT id, lemma_1, pos, meaning_1, derived_from FROM dpd_headwords";
     using var r = read.ExecuteReader();
     while (r.Read())
     {
@@ -112,12 +149,64 @@ using (var tx = outDb.BeginTransaction())
         pPos.Value = NullIfEmpty(r.GetString(2));
         pGloss.Value = NullIfEmpty(r.GetString(3));
         pDf.Value = NullIfEmpty(r.GetString(4));
+        if (includeReport)
+        {
+            pRk.Value = NullIfEmpty(r.GetString(5));
+            pCon.Value = NullIfEmpty(r.GetString(6));
+            pSkt.Value = NullIfEmpty(r.GetString(7));
+            pLit.Value = NullIfEmpty(r.GetString(8));
+            pPat.Value = NullIfEmpty(r.GetString(9));
+            pEbt.Value = r.IsDBNull(10) ? DBNull.Value : r.GetValue(10);
+            pExs.Value = NullIfEmpty(r.GetString(11));
+            pExu.Value = NullIfEmpty(r.GetString(12));
+            pEx.Value = NullIfEmpty(r.GetString(13));
+            pSyn.Value = NullIfEmpty(r.GetString(14));
+            pAnt.Value = NullIfEmpty(r.GetString(15));
+        }
         ins.ExecuteNonQuery();
         lemmaCount++;
     }
     tx.Commit();
 }
 Console.WriteLine($"  lemma rows: {lemmaCount:N0}  ({sw.Elapsed.TotalSeconds:F1}s)");
+
+// ---- 1b. root layer (report scope) ----
+if (includeReport)
+{
+    using var tx = outDb.BeginTransaction();
+    using var ins = outDb.CreateCommand();
+    ins.CommandText = @"INSERT OR IGNORE INTO root
+        (root_key,root_sign,root_meaning,root_group,sanskrit_root,sanskrit_root_meaning,dhatupatha_pali,dhatupatha_english)
+        VALUES ($rk,$rs,$rm,$rg,$sr,$srm,$dp,$de)";
+    var a = ins.Parameters.Add("$rk", SqliteType.Text);
+    var b = ins.Parameters.Add("$rs", SqliteType.Text);
+    var c2 = ins.Parameters.Add("$rm", SqliteType.Text);
+    var d = ins.Parameters.Add("$rg", SqliteType.Integer);
+    var e = ins.Parameters.Add("$sr", SqliteType.Text);
+    var f = ins.Parameters.Add("$srm", SqliteType.Text);
+    var g = ins.Parameters.Add("$dp", SqliteType.Text);
+    var h = ins.Parameters.Add("$de", SqliteType.Text);
+    using var read = src.CreateCommand();
+    read.CommandText = @"SELECT root,root_sign,root_meaning,root_group,sanskrit_root,sanskrit_root_meaning,
+        dhatupatha_pali,dhatupatha_english FROM dpd_roots";
+    using var r = read.ExecuteReader();
+    long rootCount = 0;
+    while (r.Read())
+    {
+        a.Value = r.GetString(0);
+        b.Value = NullIfEmpty(r.GetString(1));
+        c2.Value = NullIfEmpty(r.GetString(2));
+        d.Value = r.IsDBNull(3) ? DBNull.Value : r.GetValue(3);
+        e.Value = NullIfEmpty(r.GetString(4));
+        f.Value = NullIfEmpty(r.GetString(5));
+        g.Value = NullIfEmpty(r.GetString(6));
+        h.Value = NullIfEmpty(r.GetString(7));
+        ins.ExecuteNonQuery();
+        rootCount++;
+    }
+    tx.Commit();
+    Console.WriteLine($"  root rows: {rootCount:N0}  ({sw.Elapsed.TotalSeconds:F1}s)");
+}
 
 // ---- 2. explode lookup -> form_lemma (+ forms) ----
 long formCount = 0, edgeCount = 0, skipped = 0;


### PR DESCRIPTION
## What

Adds the **lemma report / dossier** on top of the merged lemma-search backend (stages 1–3, #364/#366/#367). A word-family "dossier" for a chosen lemma: etymology, attested declension/conjugation table with corpus counts, word-family, DPD-cited example, and a homograph map — rendered to any script from a single cached IPE assembly.

## Commits
1. **DpdLemmaBuilder (v2, report-grade):** etymology / example / frequency columns + a `root` table (753 rows). Enriched `dpd-lemma.db` ≈ 109 MB uncompressed / ~23 MB zst (mid was 20 MB). Validated against known DPD facts.
2. **LemmaReportService** — assembles the report ONCE with every Pāli field in IPE (script-neutral) and caches it in a `BoundedCache` (cap 32). The script picker becomes a pure re-render, never a recompute (cache-hit ~0.0009 s).
3. **LemmaReportRenderer** — self-contained HTML, per-field IPE→script conversion, pos-abbreviation expansion, both themes.
4. **`GET /v1/lemma-report/{lemmaId}?script=`** — HTML only (no IPE leak).
5. **Homograph refinement** — a paradigm form is flagged a homograph ONLY when a candidate lemma sits OUTSIDE the focus's `derived_from` family (a genuinely different word), and the section lists ALL shared forms, not just the top one. For `pajānāti` this correctly empties the homograph section; homonyms (`dhamma` 1 vs 2) still flag.

## Design notes
- Not gated by `Ai.Enabled` — lemma search is a core reading feature; the API surface lives under the loopback server like every other endpoint.
- Labels stay English (DPD semantics are English); only Pāli follows the script dropdown.

## Tests
Full suite green: **675 passed / 0 failed**. New coverage: report HTML renders, unknown-id 404s, homograph resolution, attested-declension counts.

## Deferred (follow-ups, tracked separately)
- Per-form grammar column with enclitic decomposition (`pajānantīti` → "present, 3rd plural, + iti").
- Family-grouping rework (coarse 3-way pos split).
- Derivation diagram in the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)