### PR TITLE
Lemma report: per-form grammatical analysis column (Phase 1)

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -328,6 +328,8 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Contains("Analysis", html);                                       // column header
             Assert.Contains("masculine nominative singular", html);                  // 'dhamma' expanded
             Assert.Contains("masculine nominative singular / masculine vocative singular", html);
+            // lemma 100 is a masc NOUN, so the adjective analysis of 'dhamma' (same headword) is filtered out.
+            Assert.DoesNotContain("feminine nominative singular", html);
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -323,6 +323,11 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Contains("homograph", html);
             // DPD example with <b> markup renders (Latin round-trips the tags).
             Assert.Contains("<b>dhamma</b>", html);
+            // per-form grammatical analysis: abbreviations expanded, filtered to THIS lemma's headword,
+            // multiple analyses of the same form joined.
+            Assert.Contains("Analysis", html);                                       // column header
+            Assert.Contains("masculine nominative singular", html);                  // 'dhamma' expanded
+            Assert.Contains("masculine nominative singular / masculine vocative singular", html);
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Lemma/SqliteLemmaProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Lemma/SqliteLemmaProviderTests.cs
@@ -173,6 +173,9 @@ public sealed class SqliteLemmaProviderTests : IDisposable
     [InlineData("paññāya 1", "paññāya")]
     [InlineData("pajānāti", "pajānāti")]
     [InlineData("paññā 12", "paññā")]
+    [InlineData("dhamma 1.01", "dhamma")]        // DPD dotted sub-numbering
+    [InlineData("dhamma 2.1", "dhamma")]
+    [InlineData("a b", "a b")]                    // non-numeric suffix is not a homonym marker
     public void StripHomonym_removes_trailing_number(string input, string expected)
         => Assert.Equal(expected, SqliteLemmaProvider.StripHomonym(input));
 

--- a/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
+++ b/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
@@ -142,7 +142,12 @@ namespace CST.Avalonia.Tests.TestSupport
                 CREATE TABLE root (root_key TEXT PRIMARY KEY, root_sign TEXT, root_meaning TEXT, root_group INTEGER,
                     sanskrit_root TEXT, sanskrit_root_meaning TEXT, dhatupatha_pali TEXT, dhatupatha_english TEXT);
                 CREATE TABLE form_lemma (form TEXT NOT NULL, lemma_id INTEGER NOT NULL);
+                CREATE TABLE forms (form TEXT PRIMARY KEY, grammar TEXT);
                 CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+                INSERT INTO forms VALUES
+                    ('dhamma','[[""dhamma"",""noun"",""masc nom sg""],[""dhamma"",""noun"",""masc voc sg""]]'),
+                    ('citta','[[""dhamma"",""noun"",""masc acc sg""]]'),
+                    ('kamma','[[""dhamma"",""noun"",""masc instr sg""]]');
                 INSERT INTO lemma
                   (id,lemma,pos,gloss,derived_from,root_key,construction,sanskrit,pattern,ebt_count,example_source,example_sutta,example)
                   VALUES

--- a/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
+++ b/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
@@ -145,7 +145,7 @@ namespace CST.Avalonia.Tests.TestSupport
                 CREATE TABLE forms (form TEXT PRIMARY KEY, grammar TEXT);
                 CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
                 INSERT INTO forms VALUES
-                    ('dhamma','[[""dhamma"",""noun"",""masc nom sg""],[""dhamma"",""noun"",""masc voc sg""]]'),
+                    ('dhamma','[[""dhamma"",""noun"",""masc nom sg""],[""dhamma"",""noun"",""masc voc sg""],[""dhamma"",""adj"",""fem nom sg""]]'),
                     ('citta','[[""dhamma"",""noun"",""masc acc sg""]]'),
                     ('kamma','[[""dhamma"",""noun"",""masc instr sg""]]');
                 INSERT INTO lemma

--- a/src/CST.Avalonia/Services/LemmaReportModels.cs
+++ b/src/CST.Avalonia/Services/LemmaReportModels.cs
@@ -9,7 +9,9 @@ public sealed record ReportRoot(
     string? RootPali, string? RootMeaning, long? RootGroup,
     string? SanskritRoot, string? DhatupathaPali, string? DhatupathaEnglish);   // SanskritRoot: verbatim IAST, not script-converted
 
-public sealed record ReportForm(string FormPali, int Count, int BookCount, bool Homograph);
+// Grammar: the form's grammatical analysis for THIS lemma (English, already abbreviation-expanded — e.g.
+// "present 3rd singular"); null when the asset carries no analysis for the form (e.g. an enclitic form).
+public sealed record ReportForm(string FormPali, int Count, int BookCount, bool Homograph, string? Grammar);
 
 public sealed record ReportFamilyMember(
     long LemmaId, string LemmaPali, string? Pos, string? Gloss, int TotalOccurrences, string Group);

--- a/src/CST.Avalonia/Services/LemmaReportRenderer.cs
+++ b/src/CST.Avalonia/Services/LemmaReportRenderer.cs
@@ -72,12 +72,13 @@ public static class LemmaReportRenderer
         // ---- paradigm ----
         sb.Append("<section class=\"card\"><div class=\"card-h\"><h2>In this corpus — attested paradigm</h2>")
           .Append($"<div class=\"meta\"><b>{r.TotalOccurrences:N0}</b> occurrences · <b>{r.AttestedFormCount}</b>/{r.CandidateFormCount} forms</div></div>");
-        sb.Append("<div class=\"tbl-scroll\"><table><thead><tr><th>Form</th><th></th><th style=\"text-align:right\">Count</th><th style=\"text-align:right\">Books</th></tr></thead><tbody>");
+        sb.Append("<div class=\"tbl-scroll\"><table><thead><tr><th>Form</th><th>Analysis</th><th></th><th style=\"text-align:right\">Count</th><th style=\"text-align:right\">Books</th></tr></thead><tbody>");
         int max = r.Forms.Count > 0 ? r.Forms.Max(f => f.Count) : 1;
         foreach (var f in r.Forms.OrderByDescending(f => f.Count))
         {
             string homo = f.Homograph ? " <span class=\"tag\">homograph</span>" : "";
             sb.Append($"<tr><td class=\"form pali\">{P(f.FormPali)}{homo}</td>")
+              .Append($"<td class=\"gram\">{Esc(f.Grammar ?? "")}</td>")
               .Append($"<td class=\"barcell\"><div class=\"bar\"><i style=\"width:{(max > 0 ? f.Count * 100.0 / max : 0):F1}%\"></i></div></td>")
               .Append($"<td class=\"c\">{f.Count:N0}</td><td class=\"books\">{f.BookCount}</td></tr>");
         }
@@ -172,7 +173,8 @@ header{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;
 .card-h{display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding:13px 18px 9px;border-bottom:1px solid var(--hair)}.card-h h2{margin:0;font-size:.76rem;text-transform:uppercase;letter-spacing:.1em;color:var(--muted);font-weight:700}.card-h .meta{font-size:.8rem;color:var(--faint)}.card-h .meta b{color:var(--jade);font-family:var(--mono)}
 table{width:100%;border-collapse:collapse;font-size:.92rem}.tbl-scroll{overflow-x:auto}tbody tr{border-top:1px solid var(--hair)}td,th{padding:6px 18px;text-align:left}th{font-size:.64rem;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);font-weight:700}
 td.form{font-family:var(--pali);font-size:1rem}td.c{text-align:right;font-family:var(--mono);font-variant-numeric:tabular-nums}td.books{text-align:right;font-family:var(--mono);color:var(--muted)}
-.barcell{width:32%}.bar{height:7px;border-radius:4px;background:var(--jade-soft)}.bar>i{display:block;height:7px;border-radius:4px;background:var(--jade);opacity:.85}
+td.gram{font-size:.8rem;color:var(--muted);white-space:nowrap}
+.barcell{width:22%}.bar{height:7px;border-radius:4px;background:var(--jade-soft)}.bar>i{display:block;height:7px;border-radius:4px;background:var(--jade);opacity:.85}
 .tag{font-size:.58rem;font-weight:700;text-transform:uppercase;letter-spacing:.04em;padding:1px 6px;border-radius:999px;margin-left:8px;color:var(--pos-noun);background:color-mix(in srgb,var(--pos-noun) 12%,transparent)}
 .foot-note{padding:9px 18px 13px;font-size:.8rem;color:var(--muted);border-top:1px solid var(--hair)}.foot-note b{color:var(--ink)}
 .stat-row{display:flex;gap:16px;flex-wrap:wrap;padding:9px 18px 2px;font-size:.8rem;color:var(--muted)}.stat b{font-family:var(--mono);color:var(--ink)}.stat.syn b{color:var(--amber)}

--- a/src/CST.Avalonia/Services/LemmaReportRenderer.cs
+++ b/src/CST.Avalonia/Services/LemmaReportRenderer.cs
@@ -173,7 +173,7 @@ header{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;
 .card-h{display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding:13px 18px 9px;border-bottom:1px solid var(--hair)}.card-h h2{margin:0;font-size:.76rem;text-transform:uppercase;letter-spacing:.1em;color:var(--muted);font-weight:700}.card-h .meta{font-size:.8rem;color:var(--faint)}.card-h .meta b{color:var(--jade);font-family:var(--mono)}
 table{width:100%;border-collapse:collapse;font-size:.92rem}.tbl-scroll{overflow-x:auto}tbody tr{border-top:1px solid var(--hair)}td,th{padding:6px 18px;text-align:left}th{font-size:.64rem;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);font-weight:700}
 td.form{font-family:var(--pali);font-size:1rem}td.c{text-align:right;font-family:var(--mono);font-variant-numeric:tabular-nums}td.books{text-align:right;font-family:var(--mono);color:var(--muted)}
-td.gram{font-size:.8rem;color:var(--muted);white-space:nowrap}
+td.gram{font-size:.8rem;color:var(--muted)}
 .barcell{width:22%}.bar{height:7px;border-radius:4px;background:var(--jade-soft)}.bar>i{display:block;height:7px;border-radius:4px;background:var(--jade);opacity:.85}
 .tag{font-size:.58rem;font-weight:700;text-transform:uppercase;letter-spacing:.04em;padding:1px 6px;border-radius:999px;margin-left:8px;color:var(--pos-noun);background:color-mix(in srgb,var(--pos-noun) 12%,transparent)}
 .foot-note{padding:9px 18px 13px;font-size:.8rem;color:var(--muted);border-top:1px solid var(--hair)}.foot-note b{color:var(--ink)}

--- a/src/CST.Avalonia/Services/LemmaReportService.cs
+++ b/src/CST.Avalonia/Services/LemmaReportService.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Search;
@@ -71,11 +73,13 @@ public sealed class LemmaReportService : ILemmaReportService
         var homographs = new List<ReportHomograph>();
         if (focus is not null)
         {
+            var focusHeadword = StripHomonym(d.Lemma);
             foreach (var f in focus.AttestedForms)
             {
                 var res = _lemma.ResolveForm(ScriptConverter.Convert(f.Ipe, Script.Ipe, Script.Latin));
                 bool homo = res is not null && res.Candidates.Any(c => !familyIds.Contains(c.LemmaId));
-                forms.Add(new ReportForm(f.Ipe, f.Count, f.BookCount, homo));
+                string? grammar = GrammarFor(res?.Grammar, focusHeadword);
+                forms.Add(new ReportForm(f.Ipe, f.Count, f.BookCount, homo, grammar));
                 if (homo)
                 {
                     var senses = res!.Candidates
@@ -134,6 +138,57 @@ public sealed class LemmaReportService : ILemmaReportService
             else if (part.Length > 0) sb.Append(Any2Ipe.Convert(part));
         }
         return sb.ToString();
+    }
+
+    // The form's grammatical analysis restricted to THIS lemma. forms.grammar is a JSON array of
+    // [headword, pos, grammar] triples — a single surface form can analyse to several headwords (its own
+    // lemma, homographs, participles) — so we keep only the analyses whose headword is the focus lemma's,
+    // expand the abbreviations, and join distinct results (a form may be, e.g., both present and imperative).
+    private static string? GrammarFor(string? grammarJson, string focusHeadword)
+    {
+        if (string.IsNullOrEmpty(grammarJson)) return null;
+        List<string>? outp = null;
+        try
+        {
+            using var doc = JsonDocument.Parse(grammarJson!);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) return null;
+            foreach (var triple in doc.RootElement.EnumerateArray())
+            {
+                if (triple.ValueKind != JsonValueKind.Array || triple.GetArrayLength() < 3) continue;
+                if (triple[0].GetString() != focusHeadword) continue;
+                var gram = triple[2].GetString();
+                if (string.IsNullOrWhiteSpace(gram)) continue;
+                var expanded = ExpandGrammar(gram!);
+                outp ??= new List<string>();
+                if (!outp.Contains(expanded)) outp.Add(expanded);
+            }
+        }
+        catch (JsonException) { return null; }
+        return outp is { Count: > 0 } ? string.Join(" / ", outp) : null;
+    }
+
+    private static string ExpandGrammar(string gram) =>
+        string.Join(' ', gram.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                             .Select(t => GrammarTokens.TryGetValue(t, out var v) ? v : t));
+
+    // DPD grammar abbreviations → full words. Unknown tokens (1st/2nd/3rd, rare tags) pass through as-is.
+    private static readonly Dictionary<string, string> GrammarTokens = new()
+    {
+        ["pr"] = "present", ["fut"] = "future", ["aor"] = "aorist", ["imp"] = "imperative",
+        ["opt"] = "optative", ["cond"] = "conditional", ["imperf"] = "imperfect", ["perf"] = "perfect",
+        ["reflx"] = "reflexive", ["caus"] = "causative", ["pass"] = "passive", ["denom"] = "denominative",
+        ["desid"] = "desiderative", ["intens"] = "intensive",
+        ["sg"] = "singular", ["pl"] = "plural", ["dual"] = "dual",
+        ["nom"] = "nominative", ["acc"] = "accusative", ["instr"] = "instrumental", ["dat"] = "dative",
+        ["abl"] = "ablative", ["gen"] = "genitive", ["loc"] = "locative", ["voc"] = "vocative",
+        ["masc"] = "masculine", ["fem"] = "feminine", ["nt"] = "neuter",
+    };
+
+    // "paññāya 1" → "paññāya" (strips a trailing homonym number, mirroring the provider).
+    private static string StripHomonym(string lemma)
+    {
+        int sp = lemma.LastIndexOf(' ');
+        return sp > 0 && int.TryParse(lemma.AsSpan(sp + 1), out _) ? lemma[..sp] : lemma;
     }
 
     // Broad pos → family grouping (pos alone can't separate causative/passive from finite verbs — DPD tags

--- a/src/CST.Avalonia/Services/LemmaReportService.cs
+++ b/src/CST.Avalonia/Services/LemmaReportService.cs
@@ -78,7 +78,7 @@ public sealed class LemmaReportService : ILemmaReportService
             {
                 var res = _lemma.ResolveForm(ScriptConverter.Convert(f.Ipe, Script.Ipe, Script.Latin));
                 bool homo = res is not null && res.Candidates.Any(c => !familyIds.Contains(c.LemmaId));
-                string? grammar = GrammarFor(res?.Grammar, focusHeadword);
+                string? grammar = GrammarFor(res?.Grammar, focusHeadword, d.Pos);
                 forms.Add(new ReportForm(f.Ipe, f.Count, f.BookCount, homo, grammar));
                 if (homo)
                 {
@@ -144,9 +144,10 @@ public sealed class LemmaReportService : ILemmaReportService
     // [headword, pos, grammar] triples — a single surface form can analyse to several headwords (its own
     // lemma, homographs, participles) — so we keep only the analyses whose headword is the focus lemma's,
     // expand the abbreviations, and join distinct results (a form may be, e.g., both present and imperative).
-    private static string? GrammarFor(string? grammarJson, string focusHeadword)
+    private static string? GrammarFor(string? grammarJson, string focusHeadword, string? focusPos)
     {
         if (string.IsNullOrEmpty(grammarJson)) return null;
+        var focusBucket = PosBucket(focusPos);
         List<string>? outp = null;
         try
         {
@@ -155,7 +156,14 @@ public sealed class LemmaReportService : ILemmaReportService
             foreach (var triple in doc.RootElement.EnumerateArray())
             {
                 if (triple.ValueKind != JsonValueKind.Array || triple.GetArrayLength() < 3) continue;
+                // Guard against a future DPD shape where an element isn't a string (GetString would throw
+                // InvalidOperationException, not JsonException) — degrade to a blank cell, never crash.
+                if (triple[0].ValueKind != JsonValueKind.String || triple[2].ValueKind != JsonValueKind.String) continue;
                 if (triple[0].GetString() != focusHeadword) continue;
+                // A surface form can analyse under one headword as different parts of speech (noun vs adj);
+                // keep only the analyses matching the focus lemma's broad category, so a masculine noun's
+                // paradigm doesn't show the adjective's "feminine nominative singular".
+                if (focusBucket is not null && PosBucket(triple[1].GetString()) is { } tb && tb != focusBucket) continue;
                 var gram = triple[2].GetString();
                 if (string.IsNullOrWhiteSpace(gram)) continue;
                 var expanded = ExpandGrammar(gram!);
@@ -166,6 +174,17 @@ public sealed class LemmaReportService : ILemmaReportService
         catch (JsonException) { return null; }
         return outp is { Count: > 0 } ? string.Join(" / ", outp) : null;
     }
+
+    // Coarse part-of-speech bucket shared by lemma pos ('masc'/'pr'/…) and DPD grammar-triple pos
+    // ('noun'/'adj'/'verb'/…). Returns null for anything we shouldn't discriminate on (participles,
+    // cardinals, pronouns…), so those analyses are never wrongly filtered out.
+    private static string? PosBucket(string? pos) => pos switch
+    {
+        "masc" or "fem" or "nt" or "noun" => "noun",
+        "adj" => "adj",
+        "pr" or "aor" or "fut" or "opt" or "imp" or "cond" or "imperf" or "perf" or "verb" => "verb",
+        _ => null,
+    };
 
     private static string ExpandGrammar(string gram) =>
         string.Join(' ', gram.Split(' ', StringSplitOptions.RemoveEmptyEntries)
@@ -184,11 +203,15 @@ public sealed class LemmaReportService : ILemmaReportService
         ["masc"] = "masculine", ["fem"] = "feminine", ["nt"] = "neuter",
     };
 
-    // "paññāya 1" → "paññāya" (strips a trailing homonym number, mirroring the provider).
+    // "paññāya 1" → "paññāya"; also DPD's DOTTED sub-numbering "dhamma 1.01" → "dhamma" (mirrors the
+    // provider). A trailing token of only digits and dots is a homonym marker; anything else is kept.
     private static string StripHomonym(string lemma)
     {
         int sp = lemma.LastIndexOf(' ');
-        return sp > 0 && int.TryParse(lemma.AsSpan(sp + 1), out _) ? lemma[..sp] : lemma;
+        if (sp <= 0 || sp + 1 >= lemma.Length) return lemma;
+        for (int i = sp + 1; i < lemma.Length; i++)
+            if (!char.IsDigit(lemma[i]) && lemma[i] != '.') return lemma;
+        return lemma[..sp];
     }
 
     // Broad pos → family grouping (pos alone can't separate causative/passive from finite verbs — DPD tags

--- a/src/CST.Lemma/SqliteLemmaProvider.cs
+++ b/src/CST.Lemma/SqliteLemmaProvider.cs
@@ -242,11 +242,15 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
 
     private static string? Str(SqliteDataReader r, int i) => r.IsDBNull(i) ? null : r.GetString(i);
 
-    /// <summary>"paññāya 1" → "paññāya"; "pajānāti" → "pajānāti" (strips a trailing homonym number).</summary>
+    /// <summary>"paññāya 1" → "paññāya"; DPD's dotted sub-numbering "dhamma 1.01" → "dhamma";
+    /// "pajānāti" → "pajānāti". A trailing token of only digits and dots is a homonym marker.</summary>
     internal static string StripHomonym(string lemma)
     {
         int sp = lemma.LastIndexOf(' ');
-        return sp > 0 && int.TryParse(lemma.AsSpan(sp + 1), out _) ? lemma[..sp] : lemma;
+        if (sp <= 0 || sp + 1 >= lemma.Length) return lemma;
+        for (int i = sp + 1; i < lemma.Length; i++)
+            if (!char.IsDigit(lemma[i]) && lemma[i] != '.') return lemma;
+        return lemma[..sp];
     }
 
     public void Dispose()


### PR DESCRIPTION
Adds an **Analysis** column to the attested-paradigm table: each form's declension/
conjugation for the focus lemma — e.g. `pajānanti` → "present 3rd plural",
`pajānāmi` → "present 1st singular / imperative 1st singular".

Source is the DPD-lemma `forms.grammar` already in the asset (JSON `[headword, pos,
grammar]` triples). We keep only analyses whose headword is the focus lemma's,
expand DPD abbreviations to full words, and join a form's multiple analyses with " / ".
English label → not script-converted.

**Phase 2 (follow-up, needs asset regen):** enclitic `+iti` forms (`pajānātīti`) carry
no analysis in the asset — they need the DPD deconstructor retained by the generator
to render "… + iti". They render blank today.

Live-validated against real `pajānāti` data (Devanagari). 677 tests pass; fixture
gains a `forms` table and the dossier test asserts the expanded, headword-filtered,
multi-analysis label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)