### PR TITLE
#266: expose Multi-book sub-book codes (bookCodes) in the books catalog

### DIFF
--- a/src/CST.Avalonia.Tests/Search/BookMarkersTests.cs
+++ b/src/CST.Avalonia.Tests/Search/BookMarkersTests.cs
@@ -1,0 +1,30 @@
+using CST.Search;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Search
+{
+    public class BookMarkersTests
+    {
+        [Fact]
+        public void DistinctBookCodes_lists_each_sub_book_once_in_order()
+        {
+            // A Multi book: paragraphs live under <div type="book" id="..."> sub-books (#266).
+            var xml =
+                "<div type=\"book\" id=\"an5\"><p n=\"1\">a</p><p n=\"2\">b</p></div>" +
+                "<div type=\"book\" id=\"an6\"><p n=\"1\">c</p></div>" +
+                "<div type=\"book\" id=\"an7\"><p n=\"1\">d</p><p n=\"2\">e</p></div>";
+
+            var codes = BookMarkers.Build(xml).DistinctBookCodes();
+
+            Assert.Equal(new[] { "an5", "an6", "an7" }, codes);   // first-appearance order, de-duplicated
+        }
+
+        [Fact]
+        public void DistinctBookCodes_is_empty_for_a_non_multi_book()
+        {
+            // No enclosing book div → paragraphs carry no sub-book code.
+            var xml = "<div type=\"chapter\" id=\"c1\"><p n=\"1\">a</p><p n=\"2\">b</p></div>";
+            Assert.Empty(BookMarkers.Build(xml).DistinctBookCodes());
+        }
+    }
+}

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -66,7 +66,11 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   `commentaryLevel` and `pitaka`; `bookType` is a legacy field, often `Unknown` - do not rely on it. For a
   Multi book (several works in one file), `bookCodes` lists its valid sub-book codes, e.g.
   `["an5","an6","an7"]` - pass one as `bookCode` on `/v1/passage` to target the right sub-book (a paragraph
-  number alone is ambiguous across them). `bookCodes` is empty `[]` for ordinary single-work books. The
+  number alone is ambiguous across them). `bookCodes` is empty `[]` for ordinary single-work books - AND for a
+  few Multi books that have no internal book divisions to enumerate. So empty `bookCodes` does NOT guarantee
+  paragraph numbers are unique: when a `bookType:"Multi"` book returns no codes, paragraph numbers can still
+  repeat inside it, so prefer an occurrence `cursor` (from `/v1/occurrences`) over a bare paragraph number to
+  pin the exact passage. The
   `.mul`/`.att`/`.tik` FILENAME suffix is only a hint and can DISAGREE with `commentaryLevel`
   (e.g. `e0102n.mul.xml` is `commentaryLevel:"Other"`) - trust the field, not the name.
 - `POST /v1/search` - matching terms. Search is over WHOLE-WORD tokens matched as LITERAL character

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -62,8 +62,11 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   `?pitaka=` (`Vinaya`/`Sutta`/`Abhidhamma`/`Other`), `?commentaryLevel=` (`Mula`/`Atthakatha`/`Tika`/`Other`),
   `?skip=`/`?take=` (default take 100), `?script=Devanagari` (etc.; names romanized by default). FILTER to
   avoid pulling all 217 at once (e.g. `?pitaka=Abhidhamma`). Returns `{ books, returnedCount, total, hasMore }`
-  where each book is `{ bookId, name, shortName, pitaka, commentaryLevel, bookType }`. Classify with
-  `commentaryLevel` and `pitaka`; `bookType` is a legacy field, often `Unknown` - do not rely on it. The
+  where each book is `{ bookId, name, shortName, pitaka, commentaryLevel, bookType, bookCodes }`. Classify with
+  `commentaryLevel` and `pitaka`; `bookType` is a legacy field, often `Unknown` - do not rely on it. For a
+  Multi book (several works in one file), `bookCodes` lists its valid sub-book codes, e.g.
+  `["an5","an6","an7"]` - pass one as `bookCode` on `/v1/passage` to target the right sub-book (a paragraph
+  number alone is ambiguous across them). `bookCodes` is empty `[]` for ordinary single-work books. The
   `.mul`/`.att`/`.tik` FILENAME suffix is only a hint and can DISAGREE with `commentaryLevel`
   (e.g. `e0102n.mul.xml` is `commentaryLevel:"Other"`) - trust the field, not the name.
 - `POST /v1/search` - matching terms. Search is over WHOLE-WORD tokens matched as LITERAL character

--- a/src/CST.Avalonia/Services/LocalApi/BookCatalog.cs
+++ b/src/CST.Avalonia/Services/LocalApi/BookCatalog.cs
@@ -31,7 +31,7 @@ namespace CST.Avalonia.Services.LocalApi
                     b.FileName,
                     ScriptConverter.Convert(b.LongNavPath, Script.Devanagari, outputScript),
                     ScriptConverter.Convert(b.ShortNavPath, Script.Devanagari, outputScript),
-                    b.Pitaka, b.Matn, b.BookType))
+                    b.Pitaka, b.Matn, b.BookType, MultiBookCodes.For(b.FileName, b.BookType == BookType.Multi)))
                 .ToList();
 
             return new BookListResult(page, page.Count, filtered.Count, skip + page.Count < filtered.Count);

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -82,7 +82,8 @@ namespace CST.Avalonia.Services.LocalApi
             string appVersion, string handshakeDirectory, Serilog.ILogger logger,
             ISearchTool? search = null, IDictionaryTool? dictionary = null, IPassageTool? passage = null,
             IScriptTool? script = null, ILemmaSearchService? lemma = null, ILemmaReportService? lemmaReport = null,
-            int port = 0, string? token = null, bool restApiEnabled = true, bool mcpEnabled = true)
+            int port = 0, string? token = null, bool restApiEnabled = true, bool mcpEnabled = true,
+            string? xmlBooksDirectory = null)
         {
             _appVersion = appVersion;
             _handshakeDirectory = handshakeDirectory;
@@ -97,7 +98,11 @@ namespace CST.Avalonia.Services.LocalApi
             _configuredToken = token;
             _restApiEnabled = restApiEnabled;
             _mcpEnabled = mcpEnabled;
+            _xmlBooksDirectory = xmlBooksDirectory;
         }
+
+        // Corpus dir, used once at startup to prime the Multi-book sub-book codes (#266); null → codes stay empty.
+        private readonly string? _xmlBooksDirectory;
 
         /// <summary>
         /// Build a server by resolving EVERY tool adapter from the DI container. This is the single place the
@@ -114,7 +119,8 @@ namespace CST.Avalonia.Services.LocalApi
                 services.GetService<IPassageTool>(),
                 services.GetService<IScriptTool>(),
                 services.GetService<ILemmaSearchService>(),
-                services.GetService<ILemmaReportService>(), port, token, restApiEnabled, mcpEnabled);
+                services.GetService<ILemmaReportService>(), port, token, restApiEnabled, mcpEnabled,
+                services.GetService<ISettingsService>()?.Settings?.XmlBooksDirectory);
 
         public async Task StartAsync(CancellationToken ct = default)
         {
@@ -259,6 +265,10 @@ namespace CST.Avalonia.Services.LocalApi
             // Mapped only when the MCP permission is on (#278 Phase 4). (#191)
             if (_mcpEnabled)
                 app.MapMcp("/mcp");
+
+            // Prime the Multi-book sub-book codes for the `books` catalog (#266) — parses the 7 Multi books once
+            // off the shared cache. Best-effort: a missing/unreadable corpus just leaves those codes empty.
+            await MultiBookCodes.PrimeAsync(_xmlBooksDirectory, ct);
 
             await app.StartAsync(ct);
             started = true;

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/BooksMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/BooksMcpTool.cs
@@ -20,7 +20,8 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             + "classification. Use this to turn a bookId into a recognizable location, or to find "
             + "book ids to read. The full catalog is 217 books and large — FILTER by pitaka and/or commentary "
             + "level to narrow it (e.g. pitaka:Abhidhamma), and page with skip/take. Returns "
-            + "{ books, returnedCount, total, hasMore }.")]
+            + "{ books, returnedCount, total, hasMore }; each book also carries bookCodes — a Multi book's valid "
+            + "sub-book codes (e.g. [\"an5\",\"an6\",\"an7\"]) to pass as bookCode when reading a passage, empty otherwise.")]
         public static BookListResult Books_(
             [Description("Script for the returned book names.")]
             OutputScript outputScript = OutputScript.Latin,

--- a/src/CST.Avalonia/Services/LocalApi/MultiBookCodes.cs
+++ b/src/CST.Avalonia/Services/LocalApi/MultiBookCodes.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CST;
+using CST.Avalonia.Services.Tools;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>
+    /// The distinct sub-book codes of each Multi book (e.g. <c>s0403a.att.xml</c> → <c>["an5","an6","an7"]</c>),
+    /// so the <c>books</c> catalog can advertise the valid <c>bookCode</c>s for a Multi book instead of leaving
+    /// an agent to guess (a wrong guess dead-ends with no recovery). (#266)
+    ///
+    /// The codes come from the book div structure in the TEI XML, so they need the corpus. The map is primed
+    /// once, at API-server startup, off the shared <see cref="BookTextCache"/> (the same decode + parse the
+    /// passage tool uses); the <c>books</c> tool itself stays static and dependency-free — it just reads this
+    /// ready cache, and reports empty codes for any book if the corpus was unavailable at prime time.
+    /// </summary>
+    internal static class MultiBookCodes
+    {
+        private static readonly Dictionary<string, IReadOnlyList<string>> _codes = new(StringComparer.Ordinal);
+        private static readonly object _gate = new();
+
+        /// <summary>Parse the sub-book codes of every Multi book once. Safe to call when the XML dir is missing
+        /// or a book can't be read — those books simply get no codes.</summary>
+        public static async Task PrimeAsync(string? xmlDir, CancellationToken ct = default)
+        {
+            if (string.IsNullOrEmpty(xmlDir)) return;
+            foreach (var book in Books.Inst)
+            {
+                if (book.BookType != BookType.Multi) continue;
+                ct.ThrowIfCancellationRequested();
+                var path = Path.Combine(xmlDir!, book.FileName);
+                if (!File.Exists(path)) continue;
+                try
+                {
+                    var entry = await BookTextCache.GetAsync(path, ct).ConfigureAwait(false);
+                    var codes = entry.Markers.DistinctBookCodes();
+                    lock (_gate) _codes[book.FileName] = codes;
+                }
+                catch (OperationCanceledException) { throw; }
+                catch { /* unreadable/corrupt book → no codes, never fail startup */ }
+            }
+        }
+
+        /// <summary>The Multi book's sub-book codes, or an empty list (non-Multi, un-primed, or unreadable).
+        /// Takes primitives (not a Book) to stay clear of the CST.Book / CST.Avalonia.Services.Book name clash.</summary>
+        public static IReadOnlyList<string> For(string fileName, bool isMulti)
+        {
+            if (!isMulti) return Array.Empty<string>();
+            lock (_gate)
+                return _codes.TryGetValue(fileName, out var codes) ? codes : Array.Empty<string>();
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/MultiBookCodes.cs
+++ b/src/CST.Avalonia/Services/LocalApi/MultiBookCodes.cs
@@ -23,8 +23,9 @@ namespace CST.Avalonia.Services.LocalApi
         private static readonly Dictionary<string, IReadOnlyList<string>> _codes = new(StringComparer.Ordinal);
         private static readonly object _gate = new();
 
-        /// <summary>Parse the sub-book codes of every Multi book once. Safe to call when the XML dir is missing
-        /// or a book can't be read — those books simply get no codes.</summary>
+        /// <summary>Parse the sub-book codes of each Multi book once. (A few Multi books have no internal book
+        /// divisions and so yield no codes — that is correct, not a failure.) Safe to call when the XML dir is
+        /// missing or a book can't be read — those books simply get no codes.</summary>
         public static async Task PrimeAsync(string? xmlDir, CancellationToken ct = default)
         {
             if (string.IsNullOrEmpty(xmlDir)) return;

--- a/src/CST.Core/Search/BookMarkers.cs
+++ b/src/CST.Core/Search/BookMarkers.cs
@@ -84,6 +84,16 @@ namespace CST.Search
             return (number, code, pages);
         }
 
+        /// <summary>The distinct sub-book codes in this book, in first-appearance order (empty for a non-Multi
+        /// book, whose paragraphs carry no book-div code).</summary>
+        public IReadOnlyList<string> DistinctBookCodes()
+        {
+            var codes = new List<string>();
+            foreach (var p in _paras)
+                if (p.BookCode is { } code && !codes.Contains(code)) codes.Add(code);
+            return codes;
+        }
+
         // Largest index+1 whose predicate holds over an ascending-sorted list (i.e. count of leading trues).
         private static int UpperBound(int count, System.Func<int, bool> leadingTrue)
         {

--- a/src/CST.Core/Tools/NavigationToolContracts.cs
+++ b/src/CST.Core/Tools/NavigationToolContracts.cs
@@ -27,14 +27,17 @@ namespace CST.Tools
         BookAnchors? ListAnchors(string bookId);
     }
 
-    /// <summary>A book as seen by an agent: its id (file name), names, and classification.</summary>
+    /// <summary>A book as seen by an agent: its id (file name), names, and classification. For a Multi book,
+    /// <see cref="BookCodes"/> lists its valid sub-book codes (e.g. ["an5","an6","an7"]) so a paragraph
+    /// reference can target the right sub-book; empty for non-Multi books. (#266)</summary>
     public sealed record BookSummary(
         string BookId,
         string Name,
         string ShortName,
         Pitaka Pitaka,
         CommentaryLevel CommentaryLevel,
-        BookType BookType);
+        BookType BookType,
+        IReadOnlyList<string> BookCodes);
 
     /// <summary>
     /// A page of the book catalog. The 217-book catalog is large, so the listing is filterable (by piṭaka /


### PR DESCRIPTION
Closes the agent dead-end where a Multi book (e.g. `s0403a.att.xml`) advertised `bookType:"Multi"` but never revealed its valid sub-book codes (`an5`/`an6`/`an7`), so a `bookCode` for `/v1/passage` could only be guessed — and a wrong guess dead-ended with no recovery.

- `BookMarkers.DistinctBookCodes()` enumerates the distinct `<div type="book" id>` codes already indexed during passage parsing.
- `MultiBookCodes` primes them once at API-server startup off the shared `BookTextCache` (awaited before Kestrel listens), so the static `books` tool just reads a ready cache; missing/unreadable corpus → empty codes, never a startup failure.
- `BookSummary` gains `bookCodes` (empty `[]` for non-Multi). llms.txt + MCP tool description document it.

Fable review found one real doc-contract issue (a Multi book with no book divs — `vin02t.tik.xml` — legitimately reports empty codes; llms.txt now says empty codes don't guarantee unique paragraph numbers, prefer an occurrence cursor). Verified against the real corpus (`s0403a.att.xml → ["an5","an6","an7"]`). Unit tests cover extraction + the empty case. 681 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)