### PR TITLE
#267: structured apparatus notes on /v1/passage (structuredNotes)

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -347,6 +347,24 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
+        public async Task Passage_structuredNotes_returns_brace_free_text_and_parsed_notes()
+        {
+            using var http = _api.Http();
+            var resp = await http.PostAsync("/v1/passage",
+                Json($"{{\"bookId\":\"{_api.MulaBook}\",\"paragraph\":1,\"structuredNotes\":true,\"outputScript\":\"Latin\"}}"));
+            Assert.True(resp.IsSuccessStatusCode);
+            using var doc = System.Text.Json.JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            var root = doc.RootElement;
+            var text = root.GetProperty("text").GetString()!;
+            Assert.DoesNotContain("{", text);                               // clean/quotable base text
+            var notes = root.GetProperty("notes").EnumerateArray().ToList();
+            Assert.NotEmpty(notes);                                         // the fixture's 'dhamma (si)' note as data
+            var note = notes[0];
+            Assert.Equal("si", note.GetProperty("sigla").GetString());      // witness sigla parsed out
+            Assert.InRange(note.GetProperty("offset").GetInt32(), 0, text.Length);
+        }
+
+        [Fact]
         public async Task Lemma_report_unknown_id_is_404()
         {
             using var http = _api.Http();

--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -85,6 +85,69 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void ReadWindow_structuredNotes_returns_brace_free_text_plus_parsed_notes()
+        {
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<pb ed=\"V\" n=\"1.0001\"/>" +
+                "<p rend=\"bodytext\" n=\"5\">alpha bravo <note>varreading (si)</note> charlie</p>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(xml);
+            int start = markers.PositionOfParagraph(5);
+
+            var w = TeiPassageReader.ReadWindow(xml, start, maxChars: 10000, includeVariants: false,
+                outputScript: Script.Latin, markers, structuredNotes: true);
+
+            // Text is clean/quotable: no braces, and the apparatus reading is NOT in the base text.
+            Assert.DoesNotContain("{", w.Text);
+            Assert.DoesNotContain("}", w.Text);
+            Assert.DoesNotContain("varreading", w.Text);
+            Assert.Contains("alpha bravo", w.Text);
+            Assert.Contains("charlie", w.Text);
+
+            // The note is returned as data, parsed into reading + sigla, anchored inside the text.
+            var note = Assert.Single(w.Notes);
+            Assert.Equal("varreading", note.Reading);
+            Assert.Equal("si", note.Sigla);
+            Assert.Contains("(si)", note.Text);
+            Assert.InRange(note.Offset, 0, w.Text.Length);
+        }
+
+        [Fact]
+        public void ReadWindow_structuredNotes_leaves_reading_sigla_null_for_a_non_variant_note()
+        {
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<p rend=\"bodytext\" n=\"5\">alpha <note>see also elsewhere</note> bravo</p>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(xml);
+            int start = markers.PositionOfParagraph(5);
+
+            var w = TeiPassageReader.ReadWindow(xml, start, maxChars: 10000, includeVariants: false,
+                outputScript: Script.Latin, markers, structuredNotes: true);
+
+            var note = Assert.Single(w.Notes);
+            Assert.Null(note.Reading);          // no "reading (sigla)" shape
+            Assert.Null(note.Sigla);
+            Assert.Contains("see also", note.Text);
+        }
+
+        [Fact]
+        public void ReadWindow_without_structuredNotes_has_no_notes()
+        {
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<p rend=\"bodytext\" n=\"5\">alpha <note>varreading (si)</note> bravo</p>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(xml);
+            int start = markers.PositionOfParagraph(5);
+
+            var w = TeiPassageReader.ReadWindow(xml, start, maxChars: 10000, includeVariants: true,
+                outputScript: Script.Latin, markers);   // structuredNotes defaults false
+            Assert.Empty(w.Notes);
+        }
+
+        [Fact]
         public void ReadWindow_cursor_snaps_start_back_to_the_enclosing_sentence()
         {
             // A cursor from `occurrences` points AT the hit, mid-sentence. The window START must snap back to the

--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -133,6 +133,45 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void ReadWindow_structuredNotes_hugs_punctuation_after_an_excised_note()
+        {
+            // 41% of corpus notes are immediately followed by punctuation; excising the note must not leave a
+            // stray space before it in the "clean, quotable" text. (#267 review, Defect 1)
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<p rend=\"bodytext\" n=\"5\">alpha <note>varreading (si)</note>, bravo</p>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(xml);
+            int start = markers.PositionOfParagraph(5);
+
+            var w = TeiPassageReader.ReadWindow(xml, start, maxChars: 10000, includeVariants: false,
+                outputScript: Script.Latin, markers, structuredNotes: true);
+
+            Assert.DoesNotContain(" ,", w.Text);          // no stray space before the comma
+            Assert.Contains("alpha, bravo", w.Text);
+            Assert.Equal("si", Assert.Single(w.Notes).Sigla);
+        }
+
+        [Fact]
+        public void ReadWindow_structuredNotes_never_cuts_mid_note_even_with_footnotes()
+        {
+            // A tiny budget + includeVariants would let the window end inside a note; a structured window must
+            // still return brace-free text (no unmatched '{'/'}'). (#267 review, Defect 2)
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<p rend=\"bodytext\" n=\"5\">alpha bravo <note>a very long apparatus note that exceeds the budget (si)</note> charlie</p>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(xml);
+            int start = markers.PositionOfParagraph(5);
+
+            var w = TeiPassageReader.ReadWindow(xml, start, maxChars: 15, includeVariants: true,
+                outputScript: Script.Latin, markers, structuredNotes: true);
+
+            Assert.DoesNotContain("{", w.Text);
+            Assert.DoesNotContain("}", w.Text);
+        }
+
+        [Fact]
         public void ReadWindow_without_structuredNotes_has_no_notes()
         {
             const string xml =

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -53,6 +53,12 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   LAYER: apparatus lives almost entirely in MULA (root) texts; the ATTHAKATHA and TIKA (commentary /
   sub-commentary) layers carry NONE. So `includeFootnotes` on a commentary is always empty - expected,
   not a bug (and a commentary-restricted search will never surface variants).
+- STRUCTURED apparatus (`structuredNotes: true` on `/v1/passage`) - an alternative to the inline braces: the
+  `text` comes back BRACE-FREE (clean, quotable Pali) and every note is returned as data in `notes[]`, each
+  `{ offset, text, reading, sigla }`. `offset` indexes the returned `text` (where the note anchors); `text` is
+  the whole note; `reading`/`sigla` are split out ONLY for a simple `reading (sigla)` note and are null
+  otherwise (per the no-type-marker caveat above). Prefer this over string-parsing `{...}` yourself when you
+  want to quote the base text and handle variants as data. (`/v1/occurrences` still uses the inline brace form.)
 - Terminology: when writing about the texts, call them "Pali", "the Tipitaka", or "VRI texts".
 
 ## Endpoints

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -430,7 +430,7 @@ namespace CST.Avalonia.Services.LocalApi
                         ? new NavigationReference.Paragraph(n, req.BookCode)
                         : new NavigationReference.WholeBook();
                     var pr = new PassageRequest(req.BookId, reference, req.Cursor, req.MaxChars,
-                        req.OutputScript, req.IncludeFootnotes);
+                        req.OutputScript, req.IncludeFootnotes, req.StructuredNotes);
                     return Results.Json(await passage.FetchPassageAsync(pr, ct));
                 });
             }
@@ -521,6 +521,7 @@ namespace CST.Avalonia.Services.LocalApi
             int? Cursor = null,
             int MaxChars = 1200,
             Script OutputScript = Script.Latin,
-            bool IncludeFootnotes = false);
+            bool IncludeFootnotes = false,
+            bool StructuredNotes = false);
     }
 }

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
@@ -46,6 +46,11 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                 + "(…) source citations in the body are always present; identical true/false output means no {…} "
                 + "apparatus here, not 'no references'. Apparatus lives almost only in MULA texts.")]
             bool includeFootnotes = false,
+            [Description("Return the apparatus as DATA instead of inline braces: 'text' comes back brace-free "
+                + "(clean, quotable Pāli) and each note appears in 'notes' with { offset, text, reading, sigla } "
+                + "(reading/sigla filled only for a simple 'reading (sigla)' note). Use this to quote the base "
+                + "text and read the variants separately, rather than string-parsing braces out of 'text'.")]
+            bool structuredNotes = false,
             CancellationToken ct = default)
         {
             NavigationReference reference = paragraph is int n
@@ -57,7 +62,8 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                 Cursor: cursor,
                 MaxChars: maxChars,
                 OutputScript: McpScript.ToScript(outputScript),
-                IncludeFootnotes: includeFootnotes);
+                IncludeFootnotes: includeFootnotes,
+                StructuredNotes: structuredNotes);
             return await passage.FetchPassageAsync(request, ct).ConfigureAwait(false);
         }
     }

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -57,7 +57,8 @@ namespace CST.Avalonia.Services.Tools
             var w = TeiPassageReader.ReadWindow(
                 xml, startPos, Math.Clamp(request.MaxChars, 1, MaxPassageChars),
                 request.IncludeFootnotes, request.OutputScript, markers,
-                snapStartToSentence: request.Cursor.HasValue);
+                snapStartToSentence: request.Cursor.HasValue,
+                structuredNotes: request.StructuredNotes);
 
             return new PassageResult(
                 BookId: request.BookId,
@@ -68,7 +69,8 @@ namespace CST.Avalonia.Services.Tools
                 ParagraphBookCode: w.ParagraphBookCode,
                 PrevCursor: w.PrevCursor,
                 NextCursor: w.NextCursor,
-                NoteCount: w.NoteCount);
+                NoteCount: w.NoteCount,
+                Notes: w.Notes);
         }
 
         private static int ResolveStart(NavigationReference? reference, BookMarkers markers) => reference switch
@@ -85,6 +87,7 @@ namespace CST.Avalonia.Services.Tools
             : $"paragraph {number} ({bookCode})";
 
         private static PassageResult Empty(PassageRequest request, string note) =>
-            new(request.BookId, note, "", Array.Empty<SnippetPageRef>(), null, null, null, null, 0);
+            new(request.BookId, note, "", Array.Empty<SnippetPageRef>(), null, null, null, null, 0,
+                Array.Empty<CST.Search.PassageNote>());
     }
 }

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -18,7 +18,7 @@ namespace CST.Search
     {
         public static PassageWindow ReadWindow(
             string xml, int startPos, int maxChars, bool includeVariants, Script outputScript, BookMarkers markers,
-            bool snapStartToSentence = false)
+            bool snapStartToSentence = false, bool structuredNotes = false)
         {
             startPos = Math.Clamp(startPos, 0, xml.Length);
             if (maxChars < 1) maxChars = 1;
@@ -43,8 +43,22 @@ namespace CST.Search
             }
 
             int end = WalkForward(xml, readStart, maxChars, includeVariants, xml.Length);
-            string text = TeiText.Collapse(
-                TeiText.Convert(TeiText.Clean(xml, readStart, end, includeVariants), outputScript)).Trim();
+            IReadOnlyList<PassageNote> notes = System.Array.Empty<PassageNote>();
+            string text;
+            if (structuredNotes)
+            {
+                // Render WITH brace delimiters through the SAME convert/collapse/trim pipeline, then split the
+                // {reading (sigla)} spans out into structured notes and return brace-free text. The note text is
+                // therefore already in the output script and offsets index the returned brace-free text. (#267)
+                string braced = TeiText.Collapse(
+                    TeiText.Convert(TeiText.Clean(xml, readStart, end, includeNotes: true), outputScript)).Trim();
+                (text, notes) = SplitBracedNotes(braced);
+            }
+            else
+            {
+                text = TeiText.Collapse(
+                    TeiText.Convert(TeiText.Clean(xml, readStart, end, includeVariants), outputScript)).Trim();
+            }
 
             int? next = end < xml.Length ? end : (int?)null;
             int prevStart = WalkBackward(xml, readStart, maxChars, 0);
@@ -56,7 +70,48 @@ namespace CST.Search
             int paraStart = EnclosingParagraphStart(readStart, markers);
             int noteCount = TeiText.CountNotesIntersecting(xml, paraStart, readStart, end);
             var (num, code, pages) = markers.RefsAt(readStart);
-            return new PassageWindow(text, prev, next, num, code, pages, noteCount);
+            return new PassageWindow(text, prev, next, num, code, pages, noteCount, notes);
+        }
+
+        // Strip the {reading (sigla)} apparatus spans out of already-rendered text into structured notes,
+        // returning the brace-free text and the notes anchored by offset into it. The braces never occur in the
+        // corpus, so they are unambiguous delimiters. A doubled space at the excised anchor is collapsed. (#267)
+        private static (string Text, IReadOnlyList<PassageNote> Notes) SplitBracedNotes(string braced)
+        {
+            if (braced.IndexOf('{') < 0) return (braced, System.Array.Empty<PassageNote>());
+            var sb = new System.Text.StringBuilder(braced.Length);
+            var notes = new List<PassageNote>();
+            int i = 0;
+            while (i < braced.Length)
+            {
+                char c = braced[i];
+                if (c == '{')
+                {
+                    int close = braced.IndexOf('}', i + 1);
+                    if (close < 0) { sb.Append(braced, i, braced.Length - i); break; }   // malformed: keep verbatim
+                    string inner = braced.Substring(i + 1, close - i - 1).Trim();
+                    var (reading, sigla) = ParseNote(inner);
+                    notes.Add(new PassageNote(sb.Length, inner, reading, sigla));
+                    i = close + 1;
+                    if (i < braced.Length && braced[i] == ' ' && sb.Length > 0 && sb[sb.Length - 1] == ' ')
+                        i++;   // drop the space that flanked the excised span so the anchor isn't a double space
+                }
+                else { sb.Append(c); i++; }
+            }
+            return (sb.ToString(), notes);
+        }
+
+        // Split "reading (sigla)" only when there is exactly one trailing parenthetical and nothing else in
+        // parens — the notes are digitized print footnotes, not a clean apparatus, so anything more complex
+        // (multiple readings, no sigla, freeform) is left as raw Text with null reading/sigla. (#267)
+        private static (string? Reading, string? Sigla) ParseNote(string t)
+        {
+            if (!t.EndsWith(")", System.StringComparison.Ordinal)) return (null, null);
+            int open = t.IndexOf('(');
+            if (open <= 0 || t.IndexOf('(', open + 1) >= 0) return (null, null);   // zero or >1 '('
+            string reading = t.Substring(0, open).Trim();
+            string sigla = t.Substring(open + 1, t.Length - open - 2).Trim();
+            return reading.Length > 0 && sigla.Length > 0 ? (reading, sigla) : (null, null);
         }
 
         // The nearest sentence start at or after <paramref name="minStart"/> and at/before <paramref name="startPos"/>
@@ -164,5 +219,12 @@ namespace CST.Search
         int? ParagraphNumber,
         string? ParagraphBookCode,
         IReadOnlyList<SnippetPageRef> Pages,
-        int NoteCount);
+        int NoteCount,
+        IReadOnlyList<PassageNote> Notes);
+
+    /// <summary>One apparatus note (a digitized print footnote — usually a variant reading) as structured data:
+    /// its character <paramref name="Offset"/> into the returned brace-free <c>Text</c>, its full converted
+    /// <paramref name="Text"/> (e.g. "anupāyinī (ka.)"), and — when it matches the simple <c>reading (sigla)</c>
+    /// shape — the split <paramref name="Reading"/> and witness <paramref name="Sigla"/> (else both null). (#267)</summary>
+    public sealed record PassageNote(int Offset, string Text, string? Reading, string? Sigla);
 }

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -42,7 +42,10 @@ namespace CST.Search
                     readStart = candidate;
             }
 
-            int end = WalkForward(xml, readStart, maxChars, includeVariants, xml.Length);
+            // When returning structured notes, size the window with notes SKIPPED (never entered), so the end
+            // (and thus nextCursor) can't land mid-note and leave an unmatched brace / apparatus in the clean
+            // base text — even if includeFootnotes is also set. (#267 review, Defect 2)
+            int end = WalkForward(xml, readStart, maxChars, includeNotes: includeVariants && !structuredNotes, xml.Length);
             IReadOnlyList<PassageNote> notes = System.Array.Empty<PassageNote>();
             string text;
             if (structuredNotes)
@@ -80,7 +83,7 @@ namespace CST.Search
         {
             if (braced.IndexOf('{') < 0) return (braced, System.Array.Empty<PassageNote>());
             var sb = new System.Text.StringBuilder(braced.Length);
-            var notes = new List<PassageNote>();
+            var raw = new List<(int Offset, string Inner)>();
             int i = 0;
             while (i < braced.Length)
             {
@@ -90,15 +93,35 @@ namespace CST.Search
                     int close = braced.IndexOf('}', i + 1);
                     if (close < 0) { sb.Append(braced, i, braced.Length - i); break; }   // malformed: keep verbatim
                     string inner = braced.Substring(i + 1, close - i - 1).Trim();
-                    var (reading, sigla) = ParseNote(inner);
-                    notes.Add(new PassageNote(sb.Length, inner, reading, sigla));
                     i = close + 1;
-                    if (i < braced.Length && braced[i] == ' ' && sb.Length > 0 && sb[sb.Length - 1] == ' ')
-                        i++;   // drop the space that flanked the excised span so the anchor isn't a double space
+                    // Clean always puts a space before '{'. If close punctuation follows the excised note, that
+                    // punctuation must hug the preceding word — Clean's #292 rule couldn't fire because '}' sat
+                    // before it — so drop the space. Otherwise, if the note was flanked by spaces, drop one to
+                    // avoid a double space at the seam. Anchor the note AFTER this adjustment. (#267 review, D1)
+                    if (sb.Length > 0 && sb[sb.Length - 1] == ' ')
+                    {
+                        if (i < braced.Length && TeiText.IsClosePunctuation(braced[i])) sb.Length--;
+                        else if (i < braced.Length && braced[i] == ' ') i++;
+                    }
+                    raw.Add((sb.Length, inner));
                 }
                 else { sb.Append(c); i++; }
             }
-            return (sb.ToString(), notes);
+
+            // A note at the window edge can leave a leading/trailing space (the .Trim() upstream ran on the
+            // braced string, before excision); trim it and shift the note offsets to match. (#267 review, D3)
+            string text = sb.ToString();
+            int lead = 0; while (lead < text.Length && char.IsWhiteSpace(text[lead])) lead++;
+            int tail = text.Length; while (tail > lead && char.IsWhiteSpace(text[tail - 1])) tail--;
+            text = text.Substring(lead, tail - lead);
+
+            var notes = new List<PassageNote>(raw.Count);
+            foreach (var (offset, inner) in raw)
+            {
+                var (reading, sigla) = ParseNote(inner);
+                notes.Add(new PassageNote(Math.Clamp(offset - lead, 0, text.Length), inner, reading, sigla));
+            }
+            return (text, notes);
         }
 
         // Split "reading (sigla)" only when there is exactly one trailing parenthetical and nothing else in

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -89,7 +89,7 @@ namespace CST.Search
         }
 
         // Punctuation that should sit directly after the preceding word (no space before it).
-        private static bool IsClosePunctuation(char c) =>
+        internal static bool IsClosePunctuation(char c) =>
             c == ',' || c == ';' || c == '.' || c == '!' || c == '?' || c == Danda || c == DoubleDanda;
 
         internal static List<(int s, int e)> NoteRegions(string xml, int lo, int hi)

--- a/src/CST.Core/Tools/PassageToolContracts.cs
+++ b/src/CST.Core/Tools/PassageToolContracts.cs
@@ -27,13 +27,18 @@ namespace CST.Tools
     /// </summary>
     /// <param name="Cursor">A page cursor from a prior <see cref="PassageResult"/>; overrides <see cref="Reference"/> when set.</param>
     /// <param name="MaxChars">Rendered-character budget for the window.</param>
+    /// <param name="StructuredNotes">Return the apparatus as DATA instead of embedded braces: the <c>Text</c>
+    /// comes back brace-free (clean, quotable Pāli) and each note appears in <see cref="PassageResult.Notes"/>
+    /// with its offset, reading, and sigla. Independent of <c>IncludeFootnotes</c> (which controls the inline
+    /// brace form). (#267)</param>
     public sealed record PassageRequest(
         string BookId,
         NavigationReference? Reference = null,
         int? Cursor = null,
         int MaxChars = 1200,
         Script OutputScript = Script.Latin,
-        bool IncludeFootnotes = false);
+        bool IncludeFootnotes = false,
+        bool StructuredNotes = false);
 
     /// <summary>
     /// A reading window: the text, the citation refs at its start, and cursors to page through. Pass a cursor
@@ -45,6 +50,8 @@ namespace CST.Tools
     /// <param name="NoteCount">How many print-edition apparatus notes (<c>{…}</c>) fall in this window. Counted
     /// regardless of <c>IncludeFootnotes</c>, so <c>NoteCount &gt; 0</c> means apparatus is present here (re-read
     /// with <c>includeFootnotes:true</c> to see it). Apparatus lives almost only in MULA texts.</param>
+    /// <param name="Notes">The apparatus notes as structured data (offset into <c>Text</c>, full text, and
+    /// reading/sigla when simple), populated only when <c>StructuredNotes</c> was requested; empty otherwise. (#267)</param>
     public sealed record PassageResult(
         string BookId,
         string NormalizedReference,
@@ -54,5 +61,6 @@ namespace CST.Tools
         string? ParagraphBookCode,
         int? PrevCursor,
         int? NextCursor,
-        int NoteCount);
+        int NoteCount,
+        IReadOnlyList<PassageNote> Notes);
 }


### PR DESCRIPTION
`includeFootnotes` delivers the apparatus as braces embedded in the running text (`{anupāyinī (ka.)}`), forcing an agent that wants clean quotable Pāli to string-parse the braces out. New opt-in **`structuredNotes:true`** returns the text brace-free plus the apparatus as data.

- `PassageResult.notes[]`: each `{ offset, text, reading?, sigla? }`. `offset` indexes the returned (script-converted) text; `reading`/`sigla` split out only for a simple `reading (sigla)` note (else null — the notes are digitized print footnotes, not a clean variant apparatus).
- Implemented by rendering with braces through the **same** convert/collapse/trim pipeline, then splitting the `{…}` spans out — so note text is already in the output script and offsets are correct despite conversion not being length-preserving.
- Wired through the contract, `/v1/passage`, and the MCP `passage` tool; llms.txt documents it.
- Named `notes[]` (per [[corpus-notes-are-print-footnotes]] + existing `NoteCount`/`{…}` terms). Occurrences keeps the inline brace form (fast-follow).

Unit + integration tests (brace-free text, parsed reading/sigla, null for non-variant notes, empty when not requested, HTTP path). 685 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)