### PR TITLE
#267 fast-follow: structured apparatus notes on /v1/occurrences

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -347,6 +347,26 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
+        public async Task Occurrences_structuredNotes_returns_brace_free_snippet_and_notes()
+        {
+            using var http = _api.Http();
+            // 'dukkha' sits immediately before the fixture's 'dhamma (si)' note, so the hit snippet includes it.
+            var resp = await http.PostAsync("/v1/occurrences",
+                Json($"{{\"bookId\":\"{_api.MulaBook}\",\"term\":\"dukkha\",\"structuredNotes\":true,\"outputScript\":\"Latin\"}}"));
+            Assert.True(resp.IsSuccessStatusCode);
+            using var doc = System.Text.Json.JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            var occ = doc.RootElement.GetProperty("occurrences").EnumerateArray().First();
+            var snippet = occ.GetProperty("snippet").GetString()!;
+            Assert.DoesNotContain("{", snippet);                                        // clean/quotable snippet
+            var notes = occ.GetProperty("notes").EnumerateArray().ToList();
+            Assert.NotEmpty(notes);                                                     // apparatus as data
+            Assert.Equal("si", notes[0].GetProperty("sigla").GetString());
+            // the highlight still lands on the hit word after brace removal
+            int hs = occ.GetProperty("hitStart").GetInt32(), hl = occ.GetProperty("hitLength").GetInt32();
+            Assert.Equal("dukkha", snippet.Substring(hs, hl));
+        }
+
+        [Fact]
         public async Task Passage_structuredNotes_returns_brace_free_text_and_parsed_notes()
         {
             using var http = _api.Http();

--- a/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
+++ b/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
@@ -83,6 +83,41 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void Extract_structuredNotes_returns_clean_snippet_with_remapped_highlight()
+        {
+            // A note sits BEFORE the hit word; structured mode must return a brace-free snippet AND shift the
+            // highlight so it still points at the hit word in the clean snippet. (#267 f/u)
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<p rend=\"bodytext\" n=\"1\">alpha <note>varr (si)</note> target beta</p>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(xml);
+            int hit = HitStart(xml, "target");
+            var marks = new[] { new SnippetMark(hit, hit + "target".Length, true) };
+            var opts = new SnippetOptions(OutputScript: Script.Latin, MinChars: 1, MaxChars: 4000, StructuredNotes: true);
+
+            var s = TeiSnippetExtractor.Extract(xml, marks, markers, opts);
+
+            Assert.DoesNotContain("{", s.Snippet);
+            Assert.DoesNotContain("}", s.Snippet);
+            Assert.DoesNotContain("varr", s.Snippet);                          // apparatus removed from base text
+            // the highlight still lands exactly on the hit word despite the excised note before it
+            Assert.Equal("target", s.Snippet.Substring(s.HitStart, s.HitLength));
+            var note = Assert.Single(s.Notes);
+            Assert.Equal("varr", note.Reading);
+            Assert.Equal("si", note.Sigla);
+        }
+
+        [Fact]
+        public void Extract_without_structuredNotes_has_no_notes()
+        {
+            var markers = BookMarkers.Build(Prose);
+            int hit = HitStart(Prose, "TARGET");
+            var s = TeiSnippetExtractor.Extract(Prose, new[] { new SnippetMark(hit, hit + 6, true) }, markers, Deva());
+            Assert.Empty(s.Notes);
+        }
+
+        [Fact]
         public void Snippet_never_leaks_markup_across_truncation_budgets()
         {
             // A window bound that lands inside `<pb ed="V" n="1.0002"/>` must not leak `ed="V" n=...` as text.

--- a/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
+++ b/src/CST.Avalonia.Tests/Search/SnippetEngineTests.cs
@@ -118,6 +118,27 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void Extract_structuredNotes_keeps_an_in_note_hit_visible_and_highlighted()
+        {
+            // The hit word is INSIDE a note (note text is indexed). Structured mode must keep it in the snippet
+            // and land the highlight on it — not excise it and leave hitStart out of range. (#267 f/u review)
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\">" +
+                "<p rend=\"bodytext\" n=\"1\">alpha beta <note>varword (si)</note> gamma</p>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(xml);
+            int hit = HitStart(xml, "varword");
+            var marks = new[] { new SnippetMark(hit, hit + "varword".Length, true) };
+            var opts = new SnippetOptions(OutputScript: Script.Latin, MinChars: 1, MaxChars: 4000, StructuredNotes: true);
+
+            var s = TeiSnippetExtractor.Extract(xml, marks, markers, opts);
+
+            Assert.InRange(s.HitStart + s.HitLength, 0, s.Snippet.Length);       // never out of range
+            Assert.Equal("varword", s.Snippet.Substring(s.HitStart, s.HitLength)); // hit visible + highlighted
+            Assert.Single(s.Notes);                                              // the containing note still listed
+        }
+
+        [Fact]
         public void Snippet_never_leaks_markup_across_truncation_budgets()
         {
             // A window bound that lands inside `<pb ed="V" n="1.0002"/>` must not leak `ed="V" n=...` as text.

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -53,12 +53,14 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   LAYER: apparatus lives almost entirely in MULA (root) texts; the ATTHAKATHA and TIKA (commentary /
   sub-commentary) layers carry NONE. So `includeFootnotes` on a commentary is always empty - expected,
   not a bug (and a commentary-restricted search will never surface variants).
-- STRUCTURED apparatus (`structuredNotes: true` on `/v1/passage`) - an alternative to the inline braces: the
-  `text` comes back BRACE-FREE (clean, quotable Pali) and every note is returned as data in `notes[]`, each
-  `{ offset, text, reading, sigla }`. `offset` indexes the returned `text` (where the note anchors); `text` is
-  the whole note; `reading`/`sigla` are split out ONLY for a simple `reading (sigla)` note and are null
-  otherwise (per the no-type-marker caveat above). Prefer this over string-parsing `{...}` yourself when you
-  want to quote the base text and handle variants as data. (`/v1/occurrences` still uses the inline brace form.)
+- STRUCTURED apparatus (`structuredNotes: true` on BOTH `/v1/passage` and `/v1/occurrences`) - an alternative
+  to the inline braces: the `text`/`snippet` comes back BRACE-FREE (clean, quotable Pali) and every note is
+  returned as data in `notes[]`, each `{ offset, text, reading, sigla }`. `offset` indexes the returned
+  brace-free `text`/`snippet` (where the note anchors); `text` is the whole note; `reading`/`sigla` are split
+  out ONLY for a simple `reading (sigla)` note and are null otherwise (per the no-type-marker caveat above). On
+  `/v1/occurrences` the `highlights` (and `hitStart`/`hitLength`) offsets are recomputed for the brace-free
+  snippet, so they stay accurate. Prefer this over string-parsing `{...}` yourself when you want to quote the
+  base text and handle variants as data.
 - Terminology: when writing about the texts, call them "Pali", "the Tipitaka", or "VRI texts".
 
 ## Endpoints

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/SearchMcpTool.cs
@@ -107,6 +107,11 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             bool includeFootnotes = false,
             [Description("For a multi-word/proximity term, the co-occurrence window in words (default 10).")]
             int proximityDistance = 10,
+            [Description("Return the apparatus as DATA instead of inline braces: each snippet comes back "
+                + "brace-free (clean, quotable Pāli, with the highlight offsets recomputed for it) and its notes "
+                + "appear in 'notes' as { offset, text, reading, sigla } (reading/sigla filled only for a simple "
+                + "'reading (sigla)' note). Use this to quote the base text and read variants separately.")]
+            bool structuredNotes = false,
             CancellationToken ct = default)
         {
             var request = new OccurrenceRequest(
@@ -117,7 +122,8 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                 Skip: skip,
                 Take: take,
                 Mode: mode,
-                ProximityDistance: proximityDistance);
+                ProximityDistance: proximityDistance,
+                StructuredNotes: structuredNotes);
             return await search.GetOccurrencesAsync(request, ct).ConfigureAwait(false);
         }
     }

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -88,6 +88,6 @@ namespace CST.Avalonia.Services.Tools
 
         private static PassageResult Empty(PassageRequest request, string note) =>
             new(request.BookId, note, "", Array.Empty<SnippetPageRef>(), null, null, null, null, 0,
-                Array.Empty<CST.Search.PassageNote>());
+                Array.Empty<CST.Search.ApparatusNote>());
     }
 }

--- a/src/CST.Avalonia/Services/Tools/SearchTool.cs
+++ b/src/CST.Avalonia/Services/Tools/SearchTool.cs
@@ -158,7 +158,8 @@ namespace CST.Avalonia.Services.Tools
                 OutputScript: request.OutputScript,
                 IncludeFootnotes: request.IncludeFootnotes,
                 MinChars: minChars,
-                MaxChars: Math.Clamp(request.MaxChars ?? 320, minChars, MaxSnippetChars));   // bounded; MaxChars >= MinChars
+                MaxChars: Math.Clamp(request.MaxChars ?? 320, minChars, MaxSnippetChars),   // bounded; MaxChars >= MinChars
+                StructuredNotes: request.StructuredNotes);
 
             string rawBookName = Books.Inst
                 .FirstOrDefault(b => string.Equals(b.FileName, request.BookId, StringComparison.OrdinalIgnoreCase))
@@ -191,7 +192,8 @@ namespace CST.Avalonia.Services.Tools
                     Cursor: AnchorStart(marks),
                     Highlights: s.Highlights
                         .Select(h => new OccurrenceHighlight(h.Start, h.Length, h.IsAnchor)).ToList(),
-                    NoteCount: s.NoteCount));
+                    NoteCount: s.NoteCount,
+                    Notes: s.Notes));
             }
             // Envelope (like search): book-scoped totals + hasMore, so an agent paging occurrences isn't blind.
             // Total is the MERGED record count (what you actually page over); InstanceTotal is the raw pre-merge

--- a/src/CST.Core/Search/SnippetModels.cs
+++ b/src/CST.Core/Search/SnippetModels.cs
@@ -13,11 +13,15 @@ namespace CST.Search
     /// <param name="IncludeFootnotes">Include <c>&lt;note&gt;</c> (variant-reading) text (default off).</param>
     /// <param name="MinChars">Prose floor: extend to neighboring sentences until at least this many rendered chars.</param>
     /// <param name="MaxChars">Prose ceiling: a longer single sentence is trimmed+ellipsized around the hit.</param>
+    /// <param name="StructuredNotes">Return the apparatus as data: the snippet comes back brace-free (and the
+    /// highlight offsets are recomputed for the brace-free text) with each note in <see cref="SnippetResult.Notes"/>.
+    /// Independent of <see cref="IncludeFootnotes"/> (which controls the inline brace form). (#267 f/u)</param>
     public sealed record SnippetOptions(
         Script OutputScript = Script.Latin,
         bool IncludeFootnotes = false,
         int MinChars = 60,
-        int MaxChars = 320);
+        int MaxChars = 320,
+        bool StructuredNotes = false);
 
     /// <summary>A page reference at a hit, in one edition's numbering.</summary>
     public sealed record SnippetPageRef(PageEdition Edition, int Volume, int Number);
@@ -50,5 +54,6 @@ namespace CST.Search
         IReadOnlyList<SnippetPageRef> Pages,
         bool IncludedFootnotes,
         IReadOnlyList<SnippetHighlight> Highlights,
-        int NoteCount);
+        int NoteCount,
+        IReadOnlyList<ApparatusNote> Notes);
 }

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -46,7 +46,7 @@ namespace CST.Search
             // (and thus nextCursor) can't land mid-note and leave an unmatched brace / apparatus in the clean
             // base text — even if includeFootnotes is also set. (#267 review, Defect 2)
             int end = WalkForward(xml, readStart, maxChars, includeNotes: includeVariants && !structuredNotes, xml.Length);
-            IReadOnlyList<PassageNote> notes = System.Array.Empty<PassageNote>();
+            IReadOnlyList<ApparatusNote> notes = System.Array.Empty<ApparatusNote>();
             string text;
             if (structuredNotes)
             {
@@ -76,65 +76,12 @@ namespace CST.Search
             return new PassageWindow(text, prev, next, num, code, pages, noteCount, notes);
         }
 
-        // Strip the {reading (sigla)} apparatus spans out of already-rendered text into structured notes,
-        // returning the brace-free text and the notes anchored by offset into it. The braces never occur in the
-        // corpus, so they are unambiguous delimiters. A doubled space at the excised anchor is collapsed. (#267)
-        private static (string Text, IReadOnlyList<PassageNote> Notes) SplitBracedNotes(string braced)
+        // Strip the {reading (sigla)} apparatus spans out of already-rendered text into structured notes
+        // (shared with the snippet path). (#267)
+        private static (string Text, IReadOnlyList<ApparatusNote> Notes) SplitBracedNotes(string braced)
         {
-            if (braced.IndexOf('{') < 0) return (braced, System.Array.Empty<PassageNote>());
-            var sb = new System.Text.StringBuilder(braced.Length);
-            var raw = new List<(int Offset, string Inner)>();
-            int i = 0;
-            while (i < braced.Length)
-            {
-                char c = braced[i];
-                if (c == '{')
-                {
-                    int close = braced.IndexOf('}', i + 1);
-                    if (close < 0) { sb.Append(braced, i, braced.Length - i); break; }   // malformed: keep verbatim
-                    string inner = braced.Substring(i + 1, close - i - 1).Trim();
-                    i = close + 1;
-                    // Clean always puts a space before '{'. If close punctuation follows the excised note, that
-                    // punctuation must hug the preceding word — Clean's #292 rule couldn't fire because '}' sat
-                    // before it — so drop the space. Otherwise, if the note was flanked by spaces, drop one to
-                    // avoid a double space at the seam. Anchor the note AFTER this adjustment. (#267 review, D1)
-                    if (sb.Length > 0 && sb[sb.Length - 1] == ' ')
-                    {
-                        if (i < braced.Length && TeiText.IsClosePunctuation(braced[i])) sb.Length--;
-                        else if (i < braced.Length && braced[i] == ' ') i++;
-                    }
-                    raw.Add((sb.Length, inner));
-                }
-                else { sb.Append(c); i++; }
-            }
-
-            // A note at the window edge can leave a leading/trailing space (the .Trim() upstream ran on the
-            // braced string, before excision); trim it and shift the note offsets to match. (#267 review, D3)
-            string text = sb.ToString();
-            int lead = 0; while (lead < text.Length && char.IsWhiteSpace(text[lead])) lead++;
-            int tail = text.Length; while (tail > lead && char.IsWhiteSpace(text[tail - 1])) tail--;
-            text = text.Substring(lead, tail - lead);
-
-            var notes = new List<PassageNote>(raw.Count);
-            foreach (var (offset, inner) in raw)
-            {
-                var (reading, sigla) = ParseNote(inner);
-                notes.Add(new PassageNote(Math.Clamp(offset - lead, 0, text.Length), inner, reading, sigla));
-            }
+            var (text, notes, _) = TeiText.SplitApparatus(braced);
             return (text, notes);
-        }
-
-        // Split "reading (sigla)" only when there is exactly one trailing parenthetical and nothing else in
-        // parens — the notes are digitized print footnotes, not a clean apparatus, so anything more complex
-        // (multiple readings, no sigla, freeform) is left as raw Text with null reading/sigla. (#267)
-        private static (string? Reading, string? Sigla) ParseNote(string t)
-        {
-            if (!t.EndsWith(")", System.StringComparison.Ordinal)) return (null, null);
-            int open = t.IndexOf('(');
-            if (open <= 0 || t.IndexOf('(', open + 1) >= 0) return (null, null);   // zero or >1 '('
-            string reading = t.Substring(0, open).Trim();
-            string sigla = t.Substring(open + 1, t.Length - open - 2).Trim();
-            return reading.Length > 0 && sigla.Length > 0 ? (reading, sigla) : (null, null);
         }
 
         // The nearest sentence start at or after <paramref name="minStart"/> and at/before <paramref name="startPos"/>
@@ -243,11 +190,11 @@ namespace CST.Search
         string? ParagraphBookCode,
         IReadOnlyList<SnippetPageRef> Pages,
         int NoteCount,
-        IReadOnlyList<PassageNote> Notes);
+        IReadOnlyList<ApparatusNote> Notes);
 
     /// <summary>One apparatus note (a digitized print footnote — usually a variant reading) as structured data:
     /// its character <paramref name="Offset"/> into the returned brace-free <c>Text</c>, its full converted
     /// <paramref name="Text"/> (e.g. "anupāyinī (ka.)"), and — when it matches the simple <c>reading (sigla)</c>
     /// shape — the split <paramref name="Reading"/> and witness <paramref name="Sigla"/> (else both null). (#267)</summary>
-    public sealed record PassageNote(int Offset, string Text, string? Reading, string? Sigla);
+    public sealed record ApparatusNote(int Offset, string Text, string? Reading, string? Sigla);
 }

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -121,7 +121,13 @@ namespace CST.Search
                 var (clean, split, remapped) = TeiText.SplitApparatus(snippet, highlights.Select(h => h.Start).ToList());
                 snippet = clean;
                 notes = split;
-                highlights = highlights.Select((h, k) => h with { Start = remapped[k] }).ToList();
+                // Remap each highlight to its brace-free offset; clamp defensively so Start+Length can never
+                // exceed the snippet (a consumer's Substring must not throw). (#267 f/u review)
+                highlights = highlights.Select((h, k) =>
+                {
+                    int start = Math.Clamp(remapped[k], 0, snippet.Length);
+                    return h with { Start = start, Length = Math.Clamp(h.Length, 0, snippet.Length - start) };
+                }).ToList();
             }
 
             var anchorHl = highlights.FirstOrDefault(h => h.IsAnchor) ?? highlights[0];

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -78,38 +78,55 @@ namespace CST.Search
             var sb = new StringBuilder();
             var highlights = new List<SnippetHighlight>(ms.Count);
 
+            // Structured notes need the apparatus rendered (as braces) so we can split it out afterwards, even
+            // if the caller left includeFootnotes off; the braces are then stripped and offsets recomputed. (#267 f/u)
+            bool renderBraces = opts.IncludeFootnotes || opts.StructuredNotes;
+
             sb.Append(ellipsisStart ? "... " : "");
             sb.Append(TeiText.Collapse(TeiText.Convert(
-                TeiText.Clean(xml, winStart, ms[0].Start, opts.IncludeFootnotes), opts.OutputScript)).TrimStart());
+                TeiText.Clean(xml, winStart, ms[0].Start, renderBraces), opts.OutputScript)).TrimStart());
 
             for (int i = 0; i < ms.Count; i++)
             {
                 string markText = TeiText.Convert(
-                    TeiText.Clean(xml, ms[i].Start, ms[i].End, opts.IncludeFootnotes), opts.OutputScript).Trim();
+                    TeiText.Clean(xml, ms[i].Start, ms[i].End, renderBraces), opts.OutputScript).Trim();
                 highlights.Add(new SnippetHighlight(sb.Length, markText.Length, ms[i].IsAnchor));
                 sb.Append(markText);
 
                 if (i < ms.Count - 1)
                 {
                     string gap = TeiText.Collapse(TeiText.Convert(
-                        TeiText.Clean(xml, ms[i].End, ms[i + 1].Start, opts.IncludeFootnotes), opts.OutputScript));
+                        TeiText.Clean(xml, ms[i].End, ms[i + 1].Start, renderBraces), opts.OutputScript));
                     sb.Append(gap.Length == 0 ? " " : gap); // never fuse two distinct marked words
                 }
             }
 
             sb.Append(TeiText.Collapse(TeiText.Convert(
-                TeiText.Clean(xml, ms[ms.Count - 1].End, winEnd, opts.IncludeFootnotes), opts.OutputScript)).TrimEnd());
+                TeiText.Clean(xml, ms[ms.Count - 1].End, winEnd, renderBraces), opts.OutputScript)).TrimEnd());
             sb.Append(ellipsisEnd ? " ..." : "");
 
             var (num, code, pages) = markers.RefsAt(anchor.Start);
-            var anchorHl = highlights.FirstOrDefault(h => h.IsAnchor) ?? highlights[0];
             // Apparatus notes ({…}) in this window — counted from the raw XML regardless of IncludeFootnotes, so a
             // caller can tell "no apparatus here" from "apparatus suppressed" without a second call. (#293) Count
             // notes INTERSECTING the window, not just those starting in it, so a note the window opens mid-way
             // through still counts. (#310 A4-15)
             int noteCount = TeiText.CountNotesIntersecting(xml, pStart, winStart, winEnd);
+
+            string snippet = sb.ToString();
+            IReadOnlyList<ApparatusNote> notes = Array.Empty<ApparatusNote>();
+            if (opts.StructuredNotes)
+            {
+                // Strip the braces to a clean snippet and remap the highlight starts (a note in the prefix shifts
+                // the hit word's offset). Highlight lengths are unchanged — a hit word carries no apparatus. (#267 f/u)
+                var (clean, split, remapped) = TeiText.SplitApparatus(snippet, highlights.Select(h => h.Start).ToList());
+                snippet = clean;
+                notes = split;
+                highlights = highlights.Select((h, k) => h with { Start = remapped[k] }).ToList();
+            }
+
+            var anchorHl = highlights.FirstOrDefault(h => h.IsAnchor) ?? highlights[0];
             return new SnippetResult(
-                sb.ToString(), anchorHl.Start, anchorHl.Length, num, code, pages, opts.IncludeFootnotes, highlights, noteCount);
+                snippet, anchorHl.Start, anchorHl.Length, num, code, pages, opts.IncludeFootnotes, highlights, noteCount, notes);
         }
 
         /// <summary>

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -92,6 +92,81 @@ namespace CST.Search
         internal static bool IsClosePunctuation(char c) =>
             c == ',' || c == ';' || c == '.' || c == '!' || c == '?' || c == Danda || c == DoubleDanda;
 
+        /// <summary>
+        /// Split the <c>{reading (sigla)}</c> apparatus spans out of already-rendered text into structured notes.
+        /// Returns the brace-FREE text, the notes anchored by offset into it, and — for each input position in
+        /// <paramref name="positions"/> (e.g. snippet highlight starts) — its remapped offset into the brace-free
+        /// text. Braces never occur in the corpus, so they are unambiguous delimiters; a note's flanking space is
+        /// collapsed (and dropped entirely before close punctuation, so the base text stays quotable), and a
+        /// leading/trailing space left by an edge note is trimmed with all offsets shifted to match. (#267, #267 f/u)
+        /// </summary>
+        internal static (string Text, List<ApparatusNote> Notes, int[] Positions) SplitApparatus(
+            string braced, IReadOnlyList<int>? positions = null)
+        {
+            int pn = positions?.Count ?? 0;
+            var mapped = new int[pn];
+            var pdone = new bool[pn];
+
+            if (braced.IndexOf('{') < 0)
+            {
+                for (int k = 0; k < pn; k++) mapped[k] = positions![k];
+                return (braced, new List<ApparatusNote>(), mapped);
+            }
+
+            var sb = new StringBuilder(braced.Length);
+            var raw = new List<(int Offset, string Inner)>();
+            int i = 0;
+            while (i < braced.Length)
+            {
+                for (int k = 0; k < pn; k++)
+                    if (!pdone[k] && i >= positions![k]) { mapped[k] = sb.Length; pdone[k] = true; }
+
+                if (braced[i] == '{')
+                {
+                    int close = braced.IndexOf('}', i + 1);
+                    if (close < 0) { sb.Append(braced, i, braced.Length - i); break; }   // malformed: keep verbatim
+                    string inner = braced.Substring(i + 1, close - i - 1).Trim();
+                    i = close + 1;
+                    if (sb.Length > 0 && sb[sb.Length - 1] == ' ')
+                    {
+                        if (i < braced.Length && IsClosePunctuation(braced[i])) sb.Length--;   // hug the punctuation
+                        else if (i < braced.Length && braced[i] == ' ') i++;                    // avoid a double space
+                    }
+                    raw.Add((sb.Length, inner));
+                }
+                else { sb.Append(braced[i]); i++; }
+            }
+            for (int k = 0; k < pn; k++) if (!pdone[k]) { mapped[k] = sb.Length; pdone[k] = true; }
+
+            // Trim a leading/trailing space an edge note can leave, and shift every offset to match.
+            string text = sb.ToString();
+            int lead = 0; while (lead < text.Length && char.IsWhiteSpace(text[lead])) lead++;
+            int tail = text.Length; while (tail > lead && char.IsWhiteSpace(text[tail - 1])) tail--;
+            text = text.Substring(lead, tail - lead);
+
+            var notes = new List<ApparatusNote>(raw.Count);
+            foreach (var (offset, inner) in raw)
+            {
+                var (reading, sigla) = ParseApparatusNote(inner);
+                notes.Add(new ApparatusNote(System.Math.Clamp(offset - lead, 0, text.Length), inner, reading, sigla));
+            }
+            for (int k = 0; k < pn; k++) mapped[k] = System.Math.Clamp(mapped[k] - lead, 0, text.Length);
+            return (text, notes, mapped);
+        }
+
+        // Split "reading (sigla)" only when there is exactly one trailing parenthetical and nothing else in
+        // parens — the notes are digitized print footnotes, not a clean apparatus, so anything more complex
+        // (multiple readings, no sigla, freeform) is left as raw text with null reading/sigla. (#267)
+        internal static (string? Reading, string? Sigla) ParseApparatusNote(string t)
+        {
+            if (!t.EndsWith(")", System.StringComparison.Ordinal)) return (null, null);
+            int open = t.IndexOf('(');
+            if (open <= 0 || t.IndexOf('(', open + 1) >= 0) return (null, null);   // zero or >1 '('
+            string reading = t.Substring(0, open).Trim();
+            string sigla = t.Substring(open + 1, t.Length - open - 2).Trim();
+            return reading.Length > 0 && sigla.Length > 0 ? (reading, sigla) : (null, null);
+        }
+
         internal static List<(int s, int e)> NoteRegions(string xml, int lo, int hi)
         {
             var list = new List<(int, int)>();

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -126,13 +126,39 @@ namespace CST.Search
                     int close = braced.IndexOf('}', i + 1);
                     if (close < 0) { sb.Append(braced, i, braced.Length - i); break; }   // malformed: keep verbatim
                     string inner = braced.Substring(i + 1, close - i - 1).Trim();
-                    i = close + 1;
-                    if (sb.Length > 0 && sb[sb.Length - 1] == ' ')
+
+                    // If a tracked position (a snippet highlight) falls INSIDE this note, the hit itself is a
+                    // variant reading (note text is indexed). Keep the note's text INLINE so the hit stays
+                    // visible and its offset remaps char-by-char — never excise the hit into notes[] and leave
+                    // an out-of-range highlight. The note is still listed. (#267 f/u review)
+                    bool holdsHit = false;
+                    for (int k = 0; k < pn; k++)
+                        if (!pdone[k] && positions![k] > i && positions![k] < close) { holdsHit = true; break; }
+
+                    if (holdsHit)
                     {
-                        if (i < braced.Length && IsClosePunctuation(braced[i])) sb.Length--;   // hug the punctuation
-                        else if (i < braced.Length && braced[i] == ' ') i++;                    // avoid a double space
+                        int noteOffset = sb.Length;
+                        i++;                                  // past '{'
+                        while (i < close)
+                        {
+                            for (int k = 0; k < pn; k++)
+                                if (!pdone[k] && i >= positions![k]) { mapped[k] = sb.Length; pdone[k] = true; }
+                            sb.Append(braced[i]);
+                            i++;
+                        }
+                        i = close + 1;                        // past '}'
+                        raw.Add((noteOffset, inner));
                     }
-                    raw.Add((sb.Length, inner));
+                    else
+                    {
+                        i = close + 1;
+                        if (sb.Length > 0 && sb[sb.Length - 1] == ' ')
+                        {
+                            if (i < braced.Length && IsClosePunctuation(braced[i])) sb.Length--;   // hug the punctuation
+                            else if (i < braced.Length && braced[i] == ' ') i++;                    // avoid a double space
+                        }
+                        raw.Add((sb.Length, inner));
+                    }
                 }
                 else { sb.Append(braced[i]); i++; }
             }

--- a/src/CST.Core/Tools/PassageToolContracts.cs
+++ b/src/CST.Core/Tools/PassageToolContracts.cs
@@ -62,5 +62,5 @@ namespace CST.Tools
         int? PrevCursor,
         int? NextCursor,
         int NoteCount,
-        IReadOnlyList<PassageNote> Notes);
+        IReadOnlyList<ApparatusNote> Notes);
 }

--- a/src/CST.Core/Tools/SearchToolContracts.cs
+++ b/src/CST.Core/Tools/SearchToolContracts.cs
@@ -137,7 +137,8 @@ namespace CST.Tools
         int? MinChars = null,
         int? MaxChars = null,
         SearchToolMode Mode = SearchToolMode.Exact,
-        int ProximityDistance = 10);
+        int ProximityDistance = 10,
+        bool StructuredNotes = false);
 
     /// <summary>Citation refs at a hit: the paragraph (with Multi sub-book code) and the page in each edition.</summary>
     public sealed record OccurrenceRefs(
@@ -174,7 +175,8 @@ namespace CST.Tools
         bool IncludedFootnotes,
         int Cursor,
         IReadOnlyList<OccurrenceHighlight> Highlights,
-        int NoteCount);
+        int NoteCount,
+        IReadOnlyList<CST.Search.ApparatusNote> Notes);
 
     /// <summary>
     /// A page of a term's in-context occurrences within one book — the same envelope shape as


### PR DESCRIPTION
Extends structuredNotes to occurrences: brace-free snippets + notes[]. The hard part — snippet highlights are offset-based, so stripping braces shifts them; the #267 brace-splitter is factored into a shared TeiText.SplitApparatus that also remaps the highlight starts, keeping hitStart/hitLength and all highlights accurate. Renames the shared note record PassageNote→ApparatusNote. Unit (remap) + integration (HTTP) tests; #267 passage tests pass unchanged through the shared helper. 691 pass.