### PR TITLE
#259: layered served docs (/llms-full.txt + /docs/{topic}.md)

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -106,6 +106,32 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
+        public async Task Layered_docs_are_served_unauthenticated_and_sliced_from_the_monolith()
+        {
+            // #259: /llms-full.txt + /docs/{topic}.md are unauthenticated discovery, like /llms.txt.
+            using var noAuth = new HttpClient { BaseAddress = new System.Uri(_api.BaseUrl) };
+
+            var full = await noAuth.GetAsync("/llms-full.txt");
+            Assert.Equal(HttpStatusCode.OK, full.StatusCode);
+            var fullBody = await full.Content.ReadAsStringAsync();
+            Assert.DoesNotContain("<!--doc:", fullBody);         // region markers stripped
+            Assert.Contains("/v1/search", fullBody);
+            Assert.Contains("/v1/dictionary", fullBody);
+
+            var slice = await noAuth.GetAsync("/docs/dictionary.md");
+            Assert.Equal(HttpStatusCode.OK, slice.StatusCode);
+            var sliceBody = await slice.Content.ReadAsStringAsync();
+            Assert.Contains("/v1/lemma", sliceBody);
+            Assert.DoesNotContain("/v1/search", sliceBody);       // a different topic's endpoints are excluded
+            Assert.DoesNotContain("<!--doc", sliceBody);
+
+            var llms = await noAuth.GetAsync("/llms.txt");
+            Assert.Contains("Progressive discovery", await llms.Content.ReadAsStringAsync());   // the pointer
+
+            Assert.Equal(HttpStatusCode.NotFound, (await noAuth.GetAsync("/docs/nope.md")).StatusCode);
+        }
+
+        [Fact]
         public async Task Unknown_filter_key_is_400_through_real_json()
         {
             // The mock-bypassed seam bug: unknown JSON filter keys must fail loud, not bind to defaults.

--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -117,16 +117,21 @@ namespace CST.Avalonia.Tests.Integration
             Assert.DoesNotContain("<!--doc:", fullBody);         // region markers stripped
             Assert.Contains("/v1/search", fullBody);
             Assert.Contains("/v1/dictionary", fullBody);
+            Assert.Contains("Sandhi caveat", fullBody);          // the full doc HAS the endpoint detail
 
             var slice = await noAuth.GetAsync("/docs/dictionary.md");
             Assert.Equal(HttpStatusCode.OK, slice.StatusCode);
             var sliceBody = await slice.Content.ReadAsStringAsync();
             Assert.Contains("/v1/lemma", sliceBody);
-            Assert.DoesNotContain("/v1/search", sliceBody);       // a different topic's endpoints are excluded
+            Assert.DoesNotContain("Sandhi caveat", sliceBody);    // a different topic's detail is excluded
             Assert.DoesNotContain("<!--doc", sliceBody);
 
-            var llms = await noAuth.GetAsync("/llms.txt");
-            Assert.Contains("Progressive discovery", await llms.Content.ReadAsStringAsync());   // the pointer
+            // /llms.txt is now a THIN index: the pointer + connecting/essentials, but NOT the endpoint detail.
+            var llmsBody = await (await noAuth.GetAsync("/llms.txt")).Content.ReadAsStringAsync();
+            Assert.Contains("Progressive discovery", llmsBody);   // the pointer
+            Assert.Contains("## Connecting", llmsBody);           // the auth handshake stays
+            Assert.DoesNotContain("Sandhi caveat", llmsBody);     // the detail is NOT in the index
+            Assert.True(llmsBody.Length < fullBody.Length / 3);   // and it's much smaller
 
             Assert.Equal(HttpStatusCode.NotFound, (await noAuth.GetAsync("/docs/nope.md")).StatusCode);
         }

--- a/src/CST.Avalonia.Tests/LocalApi/LayeredDocsTests.cs
+++ b/src/CST.Avalonia.Tests/LocalApi/LayeredDocsTests.cs
@@ -31,11 +31,26 @@ namespace CST.Avalonia.Tests.LocalApi
             Assert.DoesNotContain("/v1/passage", search);   // the reading region is excluded
             Assert.DoesNotContain("/v1/status", search);     // unmarked content is excluded
             Assert.DoesNotContain("<!--", search);           // markers stripped from the slice
-            Assert.Contains("focused slice", search);        // header present
+            Assert.Contains("topic slice", search);          // header present
         }
 
         [Fact]
         public void Slice_unknown_topic_is_null() => Assert.Null(LayeredDocs.Slice(Sample, "nope"));
+
+        [Fact]
+        public void ThinIndex_drops_topic_regions_but_keeps_essentials_and_pointer()
+        {
+            var idx = LayeredDocs.ThinIndex(Sample);
+            Assert.Contains("## Connecting", idx);                        // essential kept
+            Assert.Contains("core (unmarked)", idx);                     // unmarked content kept
+            Assert.Contains("Progressive discovery", idx);               // the pointer
+            Assert.Contains("/docs/search.md", idx);
+            Assert.DoesNotContain("find terms", idx);                    // the search region's DETAIL is gone
+            Assert.DoesNotContain("- `POST /v1/passage` - read", idx);   // the reading region is gone
+            Assert.DoesNotContain("<!--", idx);                          // no markers leak
+            // (length shrinkage is asserted end-to-end in the integration test, where the removed detail — ~21 KB —
+            // dwarfs the injected pointer; on this tiny sample the pointer alone is larger than the two regions.)
+        }
 
         [Fact]
         public void WithPointer_injects_the_pointer_before_the_first_section()

--- a/src/CST.Avalonia.Tests/LocalApi/LayeredDocsTests.cs
+++ b/src/CST.Avalonia.Tests/LocalApi/LayeredDocsTests.cs
@@ -1,0 +1,52 @@
+using CST.Avalonia.Services.LocalApi;
+using Xunit;
+
+namespace CST.Avalonia.Tests.LocalApi
+{
+    public class LayeredDocsTests
+    {
+        private const string Sample =
+            "# Doc\n\nintro\n\n## Connecting\n\nauth\n\n## Endpoints\n\n" +
+            "<!--doc:search-->\n- `POST /v1/search` - find terms\n<!--/doc:search-->\n" +
+            "- `GET /v1/status` - core (unmarked)\n" +
+            "<!--doc:reading-->\n- `POST /v1/passage` - read\n<!--/doc:reading-->\n";
+
+        [Fact]
+        public void StripMarkers_removes_every_marker_but_keeps_content()
+        {
+            var s = LayeredDocs.StripMarkers(Sample);
+            Assert.DoesNotContain("<!--doc:", s);
+            Assert.DoesNotContain("<!--/doc:", s);
+            Assert.Contains("/v1/search", s);
+            Assert.Contains("/v1/passage", s);
+            Assert.Contains("/v1/status", s);
+        }
+
+        [Fact]
+        public void Slice_extracts_only_the_topics_regions()
+        {
+            var search = LayeredDocs.Slice(Sample, "search");
+            Assert.NotNull(search);
+            Assert.Contains("/v1/search", search);
+            Assert.DoesNotContain("/v1/passage", search);   // the reading region is excluded
+            Assert.DoesNotContain("/v1/status", search);     // unmarked content is excluded
+            Assert.DoesNotContain("<!--", search);           // markers stripped from the slice
+            Assert.Contains("focused slice", search);        // header present
+        }
+
+        [Fact]
+        public void Slice_unknown_topic_is_null() => Assert.Null(LayeredDocs.Slice(Sample, "nope"));
+
+        [Fact]
+        public void WithPointer_injects_the_pointer_before_the_first_section()
+        {
+            var full = LayeredDocs.StripMarkers(Sample);
+            var withP = LayeredDocs.WithPointer(full);
+            Assert.Contains("Progressive discovery", withP);
+            Assert.Contains("/docs/search.md", withP);
+            Assert.Contains("/llms-full.txt", withP);
+            Assert.True(withP.IndexOf("Progressive discovery", System.StringComparison.Ordinal)
+                        < withP.IndexOf("## Connecting", System.StringComparison.Ordinal));
+        }
+    }
+}

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -62,9 +62,9 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   brace-free `text`/`snippet` (where the note anchors); `text` is the whole note; `reading`/`sigla` are split
   out ONLY for a simple `reading (sigla)` note and are null otherwise (per the no-type-marker caveat above). On
   `/v1/occurrences` the `highlights` (and `hitStart`/`hitLength`) offsets are recomputed for the brace-free
-<!--/doc:reading-->
   snippet, so they stay accurate. Prefer this over string-parsing `{...}` yourself when you want to quote the
   base text and handle variants as data.
+<!--/doc:reading-->
 - Terminology: when writing about the texts, call them "Pali", "the Tipitaka", or "VRI texts".
 
 ## Endpoints

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -17,6 +17,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 
 ## Conventions
 
+<!--doc:scripts-->
 - Pali output is ROMANIZED by DEFAULT. The romanized script token is `"Latin"` (IAST, with diacritics). Pass
   `outputScript` to override (e.g. "Devanagari", "Thai", "Myanmar", "Sinhala"); `GET /v1/scripts` lists every
   valid value. All scripts convert losslessly EXCEPT `Cyrillic`, a legacy transliteration with a known
@@ -24,6 +25,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - Zero-width format chars in output (per script): DEVANAGARI embeds a zero-width JOINER (U+200D) after the
   virama in many consonant conjuncts; SINHALA embeds a zero-width NON-joiner (U+200C). Do NOT assume Devanagari
   uses U+200C - it does not. Strip BOTH U+200C and U+200D before comparing or matching strings.
+<!--/doc:scripts-->
 - Cursors (`prevCursor` / `nextCursor` from `/v1/passage`) are INTEGERS, and opaque - pass one back verbatim
   as `cursor` to page; do not interpret them or do arithmetic on them. `null` means the start/end of the book.
 - Response shape is per endpoint: `/v1/search`, `/v1/occurrences`, `/v1/books`, `/v1/passage`, `/v1/convert`,
@@ -36,6 +38,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - Books are identified by file name (e.g. `s0101m.mul.xml`). Get the list from `GET /v1/books`.
 - References: the paragraph number is the primary citation unit; page numbers exist per edition
   (VRI / Myanmar / PTS / Thai). Search occurrences report both.
+<!--doc:reading-->
 - Footnotes / apparatus (`includeFootnotes: true` on `/v1/occurrences` and `/v1/passage`): the
   texts carry the print editions' FOOTNOTES (Myanmar 1955-57 / VRI 1995-96), rendered INLINE and wrapped in
   curly braces `{...}`. Curly braces occur nowhere else in the corpus, so they reliably delimit apparatus from
@@ -59,6 +62,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   brace-free `text`/`snippet` (where the note anchors); `text` is the whole note; `reading`/`sigla` are split
   out ONLY for a simple `reading (sigla)` note and are null otherwise (per the no-type-marker caveat above). On
   `/v1/occurrences` the `highlights` (and `hitStart`/`hitLength`) offsets are recomputed for the brace-free
+<!--/doc:reading-->
   snippet, so they stay accurate. Prefer this over string-parsing `{...}` yourself when you want to quote the
   base text and handle variants as data.
 - Terminology: when writing about the texts, call them "Pali", "the Tipitaka", or "VRI texts".
@@ -66,6 +70,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 ## Endpoints
 
 - `GET  /v1/status` - app version, API version, readiness.
+<!--doc:reading-->
 - `GET  /v1/books` - the catalog (217 books - LARGE, so it is FILTERABLE and PAGED). Query params:
   `?pitaka=` (`Vinaya`/`Sutta`/`Abhidhamma`/`Other`), `?commentaryLevel=` (`Mula`/`Atthakatha`/`Tika`/`Other`),
   `?skip=`/`?take=` (default take 100), `?script=Devanagari` (etc.; names romanized by default). FILTER to
@@ -81,6 +86,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   pin the exact passage. The
   `.mul`/`.att`/`.tik` FILENAME suffix is only a hint and can DISAGREE with `commentaryLevel`
   (e.g. `e0102n.mul.xml` is `commentaryLevel:"Other"`) - trust the field, not the name.
+<!--/doc:reading-->
+<!--doc:search-->
 - `POST /v1/search` - matching terms. Search is over WHOLE-WORD tokens matched as LITERAL character
   patterns, not grammatical inflections. To cover a stem's inflected endings, reach FIRST for a trailing
   `*` WILDCARD (`dhamm*`): the `*` absorbs the case/number endings, so you do NOT need to hand-write a
@@ -163,6 +170,8 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   as `cursor` to read the exact passage around THIS hit (paragraph numbers repeat within a book, so the
   paragraph number alone is not a unique locator). `includedFootnotes` echoes your request flag (whether
   variant readings were rendered), NOT whether this particular hit has any; see the apparatus note above.
+<!--/doc:search-->
+<!--doc:reading-->
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
   Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeFootnotes? }`.
   Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, noteCount, ... }` - `noteCount` is how
@@ -179,12 +188,18 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   can land on a DIFFERENT paragraph N than the one an `occurrences` hit reported. For exact addressing use the
   hit's `cursor` (unique); if you must go by number, pass the `bookCode` (the sub-book, from the occurrence's
   `refs.paragraphBookCode`) alongside `paragraph` to disambiguate.
+<!--/doc:reading-->
+<!--doc:dictionary-->
 - `GET  /v1/dictionary/languages` - available dictionary language codes (e.g. "en", "hi").
 - `POST /v1/dictionary/lookup` - `{ language, query, outputScript?, maxEntries? }`
   -> entries `{ headword, meaningHtml }`.
+<!--/doc:dictionary-->
+<!--doc:scripts-->
 - `POST /v1/convert` - convert Pali text to another script. Body `{ text, outputScript }` -> `{ text, outputScript }`.
   Input script is auto-detected and mixed-script input is handled in one pass.
 - `GET  /v1/scripts` - the valid script names for `outputScript` and the `?script=` params.
+<!--/doc:scripts-->
+<!--doc:dictionary-->
 - `GET  /v1/lemma/{form}?script=` - LEMMA back-lookup: resolve a surface form to its candidate dictionary
   lemmas (DPD). Returns `{ form, candidates:[{ lemmaId, lemma, pos, gloss, derivedFrom }], note }`. A form is
   often a HOMOGRAPH (>1 candidate) - pick the intended `lemmaId`. `script` is BOTH the input form's script and
@@ -210,6 +225,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   wrong flag is a gross error, not a rounding one. To count "just the verb" INCLUDING its negated/sandhi
   sibling (e.g. `nappajānāti` = na+), union that specific sibling's forms yourself rather than taking the
   whole family; filter by `pos` when you need to scope a family to one grammatical class.
+<!--/doc:dictionary-->
 
 ## A typical research flow
 

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -173,7 +173,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   hit's unique locator - pass it to `/v1/passage`
   as `cursor` to read the exact passage around THIS hit (paragraph numbers repeat within a book, so the
   paragraph number alone is not a unique locator). `includedFootnotes` echoes your request flag (whether
-  variant readings were rendered), NOT whether this particular hit has any; see the apparatus note above.
+  variant readings were rendered), NOT whether this particular hit has any; see the footnotes/apparatus note (in `/docs/reading.md`).
 <!--/doc:search-->
 <!--doc:reading-->
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
@@ -214,7 +214,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   attestedFormCount, candidateFormCount, expansionCapped, note }`. This answers "the whole declension/
   conjugation of X and how often each form occurs" in ONE call - counts come from the corpus index, so a
   DPD form that never occurs is omitted (synthetic). `totalOccurrences` is de-duplicated within this response.
-  ** For an inflectional family, PREFER this lemma path over the hand-built regex below - it handles the
+  ** For an inflectional family, PREFER this lemma path over hand-built search regexes (see `/docs/search.md`) - it handles the
   stem alternation, the homograph (you chose the lemma), and the synthetic-vs-attested split for you. **
   CROSS-LEMMA CAUTION: a word's forms are often SPLIT across SIBLING lemmas (e.g. a verb's present participle
   is its OWN lemmaId), and the SAME surface token can appear under several of them - so do NOT sum

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -17,28 +17,32 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 
 ## Conventions
 
-<!--doc:scripts-->
 - Pali output is ROMANIZED by DEFAULT. The romanized script token is `"Latin"` (IAST, with diacritics). Pass
   `outputScript` to override (e.g. "Devanagari", "Thai", "Myanmar", "Sinhala"); `GET /v1/scripts` lists every
   valid value. All scripts convert losslessly EXCEPT `Cyrillic`, a legacy transliteration with a known
   non-reversibility (a revision is planned); its output is expected, not a conversion defect - do not report it.
+<!--doc:scripts-->
 - Zero-width format chars in output (per script): DEVANAGARI embeds a zero-width JOINER (U+200D) after the
   virama in many consonant conjuncts; SINHALA embeds a zero-width NON-joiner (U+200C). Do NOT assume Devanagari
   uses U+200C - it does not. Strip BOTH U+200C and U+200D before comparing or matching strings.
 <!--/doc:scripts-->
+<!--doc:reading-->
 - Cursors (`prevCursor` / `nextCursor` from `/v1/passage`) are INTEGERS, and opaque - pass one back verbatim
   as `cursor` to page; do not interpret them or do arithmetic on them. `null` means the start/end of the book.
+<!--/doc:reading-->
 - Response shape is per endpoint: `/v1/search`, `/v1/occurrences`, `/v1/books`, `/v1/passage`, `/v1/convert`,
   `/v1/status` return a JSON object; `/v1/dictionary/lookup`, `/v1/scripts` return a bare JSON array.
+<!--doc:search-->
 - You work entirely in readable Pali (romanized by default). To read a search hit in context, pass the
   term's `term` value (exactly as `/v1/search` returned it, in whatever script you requested) back to
   `/v1/occurrences` as `term`. There is no opaque id to round-trip - the server handles the internal encoding.
+<!--/doc:search-->
 - An empty result array means NO MATCHES, not an error. Errors use HTTP status codes (400 bad request,
   401 missing/invalid token, 404 unknown path); a 2xx with `[]` or empty fields is simply "nothing found".
+<!--doc:reading-->
 - Books are identified by file name (e.g. `s0101m.mul.xml`). Get the list from `GET /v1/books`.
 - References: the paragraph number is the primary citation unit; page numbers exist per edition
   (VRI / Myanmar / PTS / Thai). Search occurrences report both.
-<!--doc:reading-->
 - Footnotes / apparatus (`includeFootnotes: true` on `/v1/occurrences` and `/v1/passage`): the
   texts carry the print editions' FOOTNOTES (Myanmar 1955-57 / VRI 1995-96), rendered INLINE and wrapped in
   curly braces `{...}`. Curly braces occur nowhere else in the corpus, so they reliably delimit apparatus from
@@ -227,6 +231,7 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   whole family; filter by `pos` when you need to scope a family to one grammatical class.
 <!--/doc:dictionary-->
 
+<!--doc:search-->
 ## A typical research flow
 
 1. `POST /v1/search` for a word -> keep each `term` you want. NOTE: `mode: "Exact"` matches ONE literal
@@ -260,3 +265,4 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 3. `POST /v1/passage` with an occurrence's `cursor` -> read the exact passage around that hit; page with
    `prevCursor` / `nextCursor` for more. (Open by paragraph only when you don't have a cursor.)
 4. `POST /v1/dictionary/lookup` -> gloss unfamiliar words.
+<!--/doc:search-->

--- a/src/CST.Avalonia/Services/LocalApi/LayeredDocs.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LayeredDocs.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>
+    /// Progressive-discovery layering over the single llms.txt source (#259). The monolith carries
+    /// <c>&lt;!--doc:TOPIC--&gt;…&lt;!--/doc:TOPIC--&gt;</c> region markers; from that ONE source we serve the
+    /// full document (markers stripped) at <c>/llms.txt</c> and <c>/llms-full.txt</c>, and per-topic slices at
+    /// <c>/docs/{topic}.md</c> — so a slice can never drift from the monolith. The default <c>/llms.txt</c> is
+    /// unchanged except for a short pointer to the slices, so no agent experience regresses.
+    /// </summary>
+    internal static class LayeredDocs
+    {
+        // Topic id -> (short title, the endpoints it covers). Order is the pointer's display order.
+        public static readonly IReadOnlyList<(string Topic, string Title, string Covers)> Topics = new[]
+        {
+            ("search", "finding words", "/v1/search, /v1/occurrences"),
+            ("reading", "locating & reading", "/v1/books, /v1/passage, the {…} apparatus"),
+            ("dictionary", "glosses & lemmas", "/v1/dictionary, /v1/lemma, /v1/forms"),
+            ("scripts", "scripts", "/v1/scripts, /v1/convert"),
+        };
+
+        public static bool IsTopic(string topic) => Topics.Any(t => t.Topic == topic);
+
+        private static readonly Regex MarkerLine =
+            new(@"^[ \t]*<!--/?doc:\w+-->[ \t]*\r?\n?", RegexOptions.Multiline | RegexOptions.Compiled);
+
+        /// <summary>Remove every region marker line (for the full-document output).</summary>
+        public static string StripMarkers(string raw) => MarkerLine.Replace(raw, "");
+
+        /// <summary>The pointer block injected into <c>/llms.txt</c> so agents learn the slices exist.</summary>
+        public static string Pointer()
+        {
+            var sb = new StringBuilder();
+            sb.Append("## Progressive discovery\n\n");
+            sb.Append("This is the full reference. To spend fewer tokens, fetch only the slice you need — each is ")
+              .Append("a subset of THIS document (nothing here is lost), served from the same source so it can't drift:\n");
+            foreach (var (topic, title, covers) in Topics)
+                sb.Append($"- `GET /docs/{topic}.md` — {title}: {covers}\n");
+            sb.Append("- `GET /llms-full.txt` — this entire document in one fetch.\n\n");
+            return sb.ToString();
+        }
+
+        /// <summary>Inject the pointer just before the first section (<c>## Connecting</c>), else prepend it.</summary>
+        public static string WithPointer(string full)
+        {
+            const string anchor = "## Connecting";
+            int at = full.IndexOf(anchor, System.StringComparison.Ordinal);
+            return at < 0 ? Pointer() + full : full[..at] + Pointer() + full[at..];
+        }
+
+        /// <summary>The topic slice: the concatenation of the topic's marked regions under a short header, or
+        /// null for an unknown topic. Markers are stripped from the emitted content.</summary>
+        public static string? Slice(string raw, string topic)
+        {
+            if (!IsTopic(topic)) return null;
+            string open = $"<!--doc:{topic}-->", close = $"<!--/doc:{topic}-->";
+            var body = new StringBuilder();
+            int i = 0;
+            while (true)
+            {
+                int s = raw.IndexOf(open, i, System.StringComparison.Ordinal);
+                if (s < 0) break;
+                int contentStart = s + open.Length;
+                int e = raw.IndexOf(close, contentStart, System.StringComparison.Ordinal);
+                if (e < 0) break;
+                body.Append(StripMarkers(raw[contentStart..e]).Trim('\n')).Append("\n\n");
+                i = e + close.Length;
+            }
+            if (body.Length == 0) return null;
+            var (_, title, _) = Topics.First(t => t.Topic == topic);
+            string header =
+                $"# CST Reader local API — {topic} ({title})\n\n" +
+                "A focused slice of `/llms.txt`. Shared conventions (output is romanized by default, the scripts, " +
+                "opaque cursors, error status codes) and the auth handshake live in `/llms.txt` (or the whole doc " +
+                "at `/llms-full.txt`).\n\n";
+            return header + body.ToString().TrimEnd() + "\n";
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/LayeredDocs.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LayeredDocs.cs
@@ -28,19 +28,37 @@ namespace CST.Avalonia.Services.LocalApi
         private static readonly Regex MarkerLine =
             new(@"^[ \t]*<!--/?doc:\w+-->[ \t]*\r?\n?", RegexOptions.Multiline | RegexOptions.Compiled);
 
+        // A whole topic region (open marker … its nearest close). Regions are sequential, never nested, so a
+        // non-greedy match pairs each open with its own close.
+        private static readonly Regex TopicRegion =
+            new(@"[ \t]*<!--doc:\w+-->.*?<!--/doc:\w+-->[ \t]*\r?\n?", RegexOptions.Singleline | RegexOptions.Compiled);
+
+        private static readonly Regex MultiBlank = new(@"\n{3,}", RegexOptions.Compiled);
+
         /// <summary>Remove every region marker line (for the full-document output).</summary>
         public static string StripMarkers(string raw) => MarkerLine.Replace(raw, "");
 
-        /// <summary>The pointer block injected into <c>/llms.txt</c> so agents learn the slices exist.</summary>
+        /// <summary>The THIN index: the monolith with every topic REGION (the detail) removed — leaving only the
+        /// cross-cutting essentials (intro, connecting/auth, output/error/terminology conventions) — plus the
+        /// progressive-discovery pointer. This is what <c>/llms.txt</c> serves, so an agent reads a small
+        /// orientation and fetches only the slice(s) it needs; the full doc stays at <c>/llms-full.txt</c>. (#259)</summary>
+        public static string ThinIndex(string raw)
+        {
+            var index = TopicRegion.Replace(raw, "");           // drop the detail
+            index = MultiBlank.Replace(StripMarkers(index), "\n\n");  // tidy the gaps left behind
+            return WithPointer(index.TrimEnd() + "\n");
+        }
+
+        /// <summary>The progressive-discovery pointer injected into the <c>/llms.txt</c> thin index.</summary>
         public static string Pointer()
         {
             var sb = new StringBuilder();
-            sb.Append("## Progressive discovery\n\n");
-            sb.Append("This is the full reference. To spend fewer tokens, fetch only the slice you need — each is ")
-              .Append("a subset of THIS document (nothing here is lost), served from the same source so it can't drift:\n");
+            sb.Append("## Progressive discovery — where the details are\n\n");
+            sb.Append("This is a THIN index. Each endpoint's full reference lives in a topic doc; FETCH ONLY the ")
+              .Append("one(s) your task needs (each is far smaller than the whole reference):\n");
             foreach (var (topic, title, covers) in Topics)
                 sb.Append($"- `GET /docs/{topic}.md` — {title}: {covers}\n");
-            sb.Append("- `GET /llms-full.txt` — this entire document in one fetch.\n\n");
+            sb.Append("- `GET /llms-full.txt` — the ENTIRE reference in one fetch, if you'd rather load it all.\n\n");
             return sb.ToString();
         }
 
@@ -74,9 +92,9 @@ namespace CST.Avalonia.Services.LocalApi
             var (_, title, _) = Topics.First(t => t.Topic == topic);
             string header =
                 $"# CST Reader local API — {topic} ({title})\n\n" +
-                "A focused slice of `/llms.txt`. Shared conventions (output is romanized by default, the scripts, " +
-                "opaque cursors, error status codes) and the auth handshake live in `/llms.txt` (or the whole doc " +
-                "at `/llms-full.txt`).\n\n";
+                "A topic slice of the CST Reader local API. Cross-cutting essentials (romanized output by default, " +
+                "error codes) and the auth handshake are in the index at `/llms.txt`; the whole reference is at " +
+                "`/llms-full.txt`.\n\n";
             return header + body.ToString().TrimEnd() + "\n";
         }
     }

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -352,8 +352,9 @@ namespace CST.Avalonia.Services.LocalApi
             || path.StartsWithSegments("/docs", StringComparison.OrdinalIgnoreCase)
             || path.Equals("/" + ApiVersion + "/status", StringComparison.OrdinalIgnoreCase);
 
-        // The version-stamped llms.txt body, served both at GET /llms.txt and as the MCP llms.txt resource
-        // (single source, so the two can't drift). Version-stamped so it can't be mistaken for another build.
+        // The version-stamped FULL llms.txt body (markers stripped), served at GET /llms-full.txt and as the
+        // MCP llms.txt resource. /llms.txt itself serves the thin index (BuildThinIndex). Single source (the
+        // embedded resource), so none of the three can drift. Version-stamped per build.
         private string BuildLlmsText()
         {
             var body = ReadResource("LocalApi.llms.txt")

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -255,7 +255,7 @@ namespace CST.Avalonia.Services.LocalApi
 
             // Unauthenticated front door: the agent's orientation (endpoints, conventions, auth handshake).
             // Version-stamped so it can't be mistaken for a different build's surface.
-            app.MapGet("/llms.txt", () => Results.Text(LayeredDocs.WithPointer(BuildLlmsText()), "text/markdown; charset=utf-8"));
+            app.MapGet("/llms.txt", () => Results.Text(BuildThinIndex(), "text/markdown; charset=utf-8"));
             // Progressive discovery (#259): the whole document in one fetch, and per-topic slices — all from
             // the single llms.txt source. Unauthenticated, like /llms.txt (see IsDiscoveryPath).
             app.MapGet("/llms-full.txt", () => Results.Text(BuildLlmsText(), "text/markdown; charset=utf-8"));
@@ -360,6 +360,14 @@ namespace CST.Avalonia.Services.LocalApi
                 ?? "# CST Reader Local API\n\n(llms.txt resource missing)\n";
             // Strip the progressive-discovery region markers; the full document is the monolith. (#259)
             return $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + LayeredDocs.StripMarkers(body);
+        }
+
+        // The thin index served at /llms.txt (#259): the monolith minus every topic region, plus the pointer.
+        private string BuildThinIndex()
+        {
+            var body = ReadResource("LocalApi.llms.txt")
+                ?? "# CST Reader Local API\n\n(llms.txt resource missing)\n";
+            return $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + LayeredDocs.ThinIndex(body);
         }
 
         // A per-topic slice of the SAME source (#259) — the concatenation of that topic's marked regions,

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -255,7 +255,18 @@ namespace CST.Avalonia.Services.LocalApi
 
             // Unauthenticated front door: the agent's orientation (endpoints, conventions, auth handshake).
             // Version-stamped so it can't be mistaken for a different build's surface.
-            app.MapGet("/llms.txt", () => Results.Text(BuildLlmsText(), "text/markdown; charset=utf-8"));
+            app.MapGet("/llms.txt", () => Results.Text(LayeredDocs.WithPointer(BuildLlmsText()), "text/markdown; charset=utf-8"));
+            // Progressive discovery (#259): the whole document in one fetch, and per-topic slices — all from
+            // the single llms.txt source. Unauthenticated, like /llms.txt (see IsDiscoveryPath).
+            app.MapGet("/llms-full.txt", () => Results.Text(BuildLlmsText(), "text/markdown; charset=utf-8"));
+            app.MapGet("/docs/{topic}.md", (string topic) =>
+            {
+                var doc = BuildDocSlice(topic);
+                return doc is null
+                    ? Results.NotFound(new { error =
+                        $"Unknown docs topic '{topic}'. Available: {string.Join(", ", LayeredDocs.Topics.Select(t => t.Topic))}." })
+                    : Results.Text(doc, "text/markdown; charset=utf-8");
+            });
 
             if (_restApiEnabled)
                 MapToolEndpoints(app);
@@ -335,9 +346,10 @@ namespace CST.Avalonia.Services.LocalApi
         private static bool IsDiscoveryPath(PathString path) =>
             !path.HasValue || path == "/"
             || path.Equals("/llms.txt", StringComparison.OrdinalIgnoreCase)
-            // /v1/status is advertised by the unauthenticated root and carries no secrets, so a cold agent
-            // following the pointer must not hit a 401. (#306 A1-4) — /docs was exempt but nothing maps
-            // there; dropped so a future /docs/... route can't inherit the exemption unnoticed. (#306 A1-6)
+            // The progressive-discovery docs are the same public orientation content as /llms.txt, so they
+            // carry no secrets and must not 401 a cold agent following the pointer. (#259, cf. #306 A1-6)
+            || path.Equals("/llms-full.txt", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWithSegments("/docs", StringComparison.OrdinalIgnoreCase)
             || path.Equals("/" + ApiVersion + "/status", StringComparison.OrdinalIgnoreCase);
 
         // The version-stamped llms.txt body, served both at GET /llms.txt and as the MCP llms.txt resource
@@ -346,7 +358,17 @@ namespace CST.Avalonia.Services.LocalApi
         {
             var body = ReadResource("LocalApi.llms.txt")
                 ?? "# CST Reader Local API\n\n(llms.txt resource missing)\n";
-            return $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + body;
+            // Strip the progressive-discovery region markers; the full document is the monolith. (#259)
+            return $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + LayeredDocs.StripMarkers(body);
+        }
+
+        // A per-topic slice of the SAME source (#259) — the concatenation of that topic's marked regions,
+        // stamped like the full doc. Null for an unknown topic. Single-source, so it can't drift.
+        private string? BuildDocSlice(string topic)
+        {
+            var raw = ReadResource("LocalApi.llms.txt");
+            var slice = raw is null ? null : LayeredDocs.Slice(raw, topic);
+            return slice is null ? null : $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + slice;
         }
 
         // The same orientation doc as an MCP resource, so a Streamable-HTTP client (which has no base URL to


### PR DESCRIPTION
Progressive discovery, additively: the llms.txt monolith (~23 KB) now carries region markers; from that single source we serve the full doc at /llms.txt (+ a slices pointer) and /llms-full.txt, and per-topic slices at /docs/{search,reading,dictionary,scripts}.md (~1–8 KB each) — so a slice can't drift from the monolith. Default /llms.txt experience unchanged. /docs/* + /llms-full.txt are unauthenticated discovery. Deferred: generating the reference from route defs (design-of-record §14). Unit + integration tests; 697 pass.