### PR TITLE
#268: dictionary source attribution (mechanism; citations TBD)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionaryServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryServiceTests.cs
@@ -51,6 +51,34 @@ public class DictionaryServiceTests : IDisposable
     }
 
     [Fact]
+    public void SourceFor_reads_authoritative_metadata_and_treats_a_blank_placeholder_as_null()
+    {
+        WriteLang("en", "vri-pali-english-dictionary.txt", "buddha", "<p>awakened</p>");
+        WriteLang("hi", "vri-pali-hindi-dictionary.txt", "buddha", "<p>bauddha</p>");
+        // en: real attribution
+        File.WriteAllText(Path.Combine(_root, "en", "source.json"),
+            "{ \"title\": \"Test PED\", \"publisher\": \"VRI\", \"year\": \"2020\" }");
+        // hi: the blank placeholder we ship -> NOT attribution (must be null, never a guess)
+        File.WriteAllText(Path.Combine(_root, "hi", "source.json"),
+            "{ \"title\": \"\", \"compiler\": \"\", \"edition\": \"\", \"year\": \"\", \"publisher\": \"\", \"license\": \"\", \"url\": \"\" }");
+
+        var svc = Service();
+        var en = svc.SourceFor("en");
+        Assert.NotNull(en);
+        Assert.Equal("Test PED", en!.Title);
+        Assert.Equal("VRI", en.Publisher);
+        Assert.Null(svc.SourceFor("hi"));       // blank placeholder collapses to null
+        Assert.Null(svc.SourceFor("zzz"));       // unknown language -> null (and no path traversal)
+    }
+
+    [Fact]
+    public void SourceFor_is_null_when_no_source_file()
+    {
+        WriteLang("en", "vri-pali-english-dictionary.txt", "buddha", "<p>awakened</p>");
+        Assert.Null(Service().SourceFor("en"));   // no source.json -> null, not a filename-derived guess
+    }
+
+    [Fact]
     public void AvailableLanguages_MissingRoot_IsEmpty()
     {
         var svc = new DictionaryService(NullLogger<DictionaryService>.Instance,

--- a/src/CST.Avalonia.Tests/Tools/DictionaryToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/DictionaryToolTests.cs
@@ -19,14 +19,34 @@ namespace CST.Avalonia.Tests.Tools
     public class DictionaryToolTests
     {
         [Fact]
-        public void Languages_passes_through()
+        public void Languages_expose_code_and_source_attribution_or_null()
         {
             var mock = new Mock<IDictionaryService>();
             mock.SetupGet(d => d.AvailableLanguages).Returns(new[] { "en", "hi" });
+            mock.Setup(d => d.SourceFor("en"))
+                .Returns(new DictionarySourceInfo("Test PED", "A. Compiler", "2nd", "2020", "Pub", "CC", null));
+            // hi: SourceFor left unset -> null (an unattributed dictionary is null, never guessed).
 
             var tool = new DictionaryTool(mock.Object);
+            var langs = tool.Languages;
 
-            Assert.Equal(new[] { "en", "hi" }, tool.Languages);
+            Assert.Equal(new[] { "en", "hi" }, langs.Select(l => l.Language).ToArray());
+            Assert.Equal("Test PED", langs.First(l => l.Language == "en").Source?.Title);
+            Assert.Null(langs.First(l => l.Language == "hi").Source);
+        }
+
+        [Fact]
+        public async Task LookupAsync_attaches_the_source_title_to_each_entry()
+        {
+            var mock = new Mock<IDictionaryService>();
+            mock.Setup(d => d.LookupAsync("en", "metta"))
+                .ReturnsAsync(new List<DictionaryWord> { new("abc", "def") });
+            mock.Setup(d => d.SourceFor("en"))
+                .Returns(new DictionarySourceInfo("Test PED", null, null, null, null, null, null));
+
+            var tool = new DictionaryTool(mock.Object);
+            var e = Assert.Single(await tool.LookupAsync(new DictionaryRequest("en", "metta")));
+            Assert.Equal("Test PED", e.Source);
         }
 
         [Fact]

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -194,9 +194,13 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   `refs.paragraphBookCode`) alongside `paragraph` to disambiguate.
 <!--/doc:reading-->
 <!--doc:dictionary-->
-- `GET  /v1/dictionary/languages` - available dictionary language codes (e.g. "en", "hi").
+- `GET  /v1/dictionary/languages` - the available dictionaries: each `{ language, source }`, where `source` is
+  the authoritative citation `{ title, compiler, edition, year, publisher, license, url }` (any field may be
+  null) or `null` when a dictionary has NO recorded attribution. CITE this as the gloss's source; it is never
+  guessed, so `source:null` means "unattributed", not "look it up yourself".
 - `POST /v1/dictionary/lookup` - `{ language, query, outputScript?, maxEntries? }`
-  -> entries `{ headword, meaningHtml }`.
+  -> entries `{ headword, meaningHtml, source }`, where `source` is the dictionary's title for inline
+  attribution (null if unrecorded; the full citation is in `/v1/dictionary/languages`).
 <!--/doc:dictionary-->
 <!--doc:scripts-->
 - `POST /v1/convert` - convert Pali text to another script. Body `{ text, outputScript }` -> `{ text, outputScript }`.

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -9,6 +9,7 @@ using CST.Avalonia.Constants;
 using CST.Avalonia.Models;
 using CST.Avalonia.Search;
 using CST.Conversion;
+using CST.Tools;
 using Microsoft.Extensions.Logging;
 
 namespace CST.Avalonia.Services;
@@ -61,11 +62,10 @@ public sealed class DictionaryService : IDictionaryService
     {
         try
         {
-            // Already populated? (any language subdir with files) -> nothing to do.
-            if (Directory.Exists(_dictionariesDirectory) &&
-                Directory.EnumerateDirectories(_dictionariesDirectory).Any(d => Directory.EnumerateFiles(d).Any()))
-                return;
-
+            // NOTE: we no longer early-return when already populated. The copy loop below only writes MISSING
+            // files, so it's cheap to re-check every launch — and it means a file ADDED to a bundled dictionary
+            // (e.g. a new source.json attribution, #268) reaches an existing install on its next launch, not
+            // just fresh installs. Existing dictionary data is never overwritten.
             var source = ResolveBundledDictionariesDir();
             if (source == null)
             {
@@ -125,6 +125,46 @@ public sealed class DictionaryService : IDictionaryService
                 .ToList();
         }
     }
+
+    private readonly Dictionary<string, DictionarySourceInfo?> _sourceCache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly System.Text.Json.JsonSerializerOptions SourceJsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    public DictionarySourceInfo? SourceFor(string language)
+    {
+        if (string.IsNullOrEmpty(language)) return null;
+        // Confine to an ACTUAL dictionary dir before Path.Combine (path-traversal guard, same as #352).
+        var canonical = AvailableLanguages.FirstOrDefault(
+            l => string.Equals(l, language, StringComparison.OrdinalIgnoreCase));
+        if (canonical is null) return null;
+
+        lock (_sourceCache)
+            if (_sourceCache.TryGetValue(canonical, out var cached)) return cached;
+
+        DictionarySourceInfo? info = null;
+        try
+        {
+            var path = Path.Combine(_dictionariesDirectory, canonical, "source.json");
+            if (File.Exists(path))
+            {
+                info = System.Text.Json.JsonSerializer.Deserialize<DictionarySourceInfo>(
+                    File.ReadAllText(path), SourceJsonOpts);
+                // A placeholder file with every field blank is NOT attribution — report null, never a guess.
+                if (info is not null && IsUnattributed(info)) info = null;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read source.json for dictionary language {Language}", canonical);
+        }
+        lock (_sourceCache) _sourceCache[canonical] = info;
+        return info;
+    }
+
+    private static bool IsUnattributed(DictionarySourceInfo s) =>
+        string.IsNullOrWhiteSpace(s.Title) && string.IsNullOrWhiteSpace(s.Compiler) &&
+        string.IsNullOrWhiteSpace(s.Edition) && string.IsNullOrWhiteSpace(s.Year) &&
+        string.IsNullOrWhiteSpace(s.Publisher) && string.IsNullOrWhiteSpace(s.License) &&
+        string.IsNullOrWhiteSpace(s.Url);
 
     public async Task<IReadOnlyList<DictionaryWord>> LookupAsync(string language, string query, CancellationToken ct = default)
     {

--- a/src/CST.Avalonia/Services/IDictionaryService.cs
+++ b/src/CST.Avalonia/Services/IDictionaryService.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models;
+using CST.Tools;
 
 namespace CST.Avalonia.Services;
 
@@ -17,6 +18,13 @@ public interface IDictionaryService
     /// <c>"hi"</c>). Empty if the dictionaries directory is missing.
     /// </summary>
     IReadOnlyList<string> AvailableLanguages { get; }
+
+    /// <summary>
+    /// The authoritative source citation for a language's dictionary, read verbatim from its
+    /// <c>&lt;lang&gt;/source.json</c>, or <c>null</c> if none is recorded. NEVER inferred from the file name
+    /// or contents — an unattributed dictionary reports null rather than a guess. (#268)
+    /// </summary>
+    DictionarySourceInfo? SourceFor(string language);
 
     /// <summary>
     /// Look up <paramref name="query"/> (typed in any supported script) in the given language. The

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/DictionaryMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/DictionaryMcpTool.cs
@@ -42,7 +42,9 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         }
 
         [McpServerTool(Name = "dictionary_languages")]
-        [Description("List the available dictionary language codes (e.g. 'en', 'hi') for dictionary_lookup.")]
-        public static IReadOnlyList<string> Languages(IDictionaryTool dictionary) => dictionary.Languages;
+        [Description("List the available dictionaries: each language code (for dictionary_lookup) plus its "
+            + "source attribution (title, compiler, edition, publisher, license…) when recorded — cite this as "
+            + "the gloss's source. 'source' is null for a dictionary with no recorded attribution.")]
+        public static IReadOnlyList<DictionaryLanguageInfo> Languages(IDictionaryTool dictionary) => dictionary.Languages;
     }
 }

--- a/src/CST.Avalonia/Services/Tools/DictionaryTool.cs
+++ b/src/CST.Avalonia/Services/Tools/DictionaryTool.cs
@@ -22,7 +22,10 @@ namespace CST.Avalonia.Services.Tools
         // Upper bound on dictionary hits returned in one call — negative asks 0, huge asks are capped. (#305)
         private const int MaxDictEntries = 500;
 
-        public IReadOnlyList<string> Languages => _dictionary.AvailableLanguages;
+        public IReadOnlyList<DictionaryLanguageInfo> Languages =>
+            _dictionary.AvailableLanguages
+                .Select(l => new DictionaryLanguageInfo(l, _dictionary.SourceFor(l)))
+                .ToList();
 
         public async Task<IReadOnlyList<DictionaryEntry>> LookupAsync(
             DictionaryRequest request, CancellationToken ct = default)
@@ -31,11 +34,13 @@ namespace CST.Avalonia.Services.Tools
             var words = await _dictionary.LookupAsync(request.Language, request.Query ?? string.Empty, ct)
                 .ConfigureAwait(false);
 
+            var source = _dictionary.SourceFor(request.Language)?.Title;   // inline attribution; null if unrecorded
             return words
                 .Take(Math.Clamp(request.MaxEntries, 0, MaxDictEntries))
                 .Select(w => new DictionaryEntry(
                     Headword: ScriptConverter.Convert(w.Word, Script.Ipe, request.OutputScript),
-                    MeaningHtml: w.Meaning))
+                    MeaningHtml: w.Meaning,
+                    Source: source))
                 .ToList();
         }
     }

--- a/src/CST.Avalonia/dictionaries/en/source.json
+++ b/src/CST.Avalonia/dictionaries/en/source.json
@@ -1,0 +1,9 @@
+{
+  "title": "",
+  "compiler": "",
+  "edition": "",
+  "year": "",
+  "publisher": "",
+  "license": "",
+  "url": ""
+}

--- a/src/CST.Avalonia/dictionaries/hi/source.json
+++ b/src/CST.Avalonia/dictionaries/hi/source.json
@@ -1,0 +1,9 @@
+{
+  "title": "",
+  "compiler": "",
+  "edition": "",
+  "year": "",
+  "publisher": "",
+  "license": "",
+  "url": ""
+}

--- a/src/CST.Core/Tools/DictionaryToolContracts.cs
+++ b/src/CST.Core/Tools/DictionaryToolContracts.cs
@@ -12,8 +12,10 @@ namespace CST.Tools
     /// </summary>
     public interface IDictionaryTool
     {
-        /// <summary>Available dictionary language codes (e.g. "en", "hi").</summary>
-        IReadOnlyList<string> Languages { get; }
+        /// <summary>Available dictionaries, each with its language code and source attribution (#268), so an
+        /// agent producing scholarly output can cite the gloss and weigh its authority. <c>Source</c> is null
+        /// when a dictionary carries no authoritative metadata — it is never inferred/guessed.</summary>
+        IReadOnlyList<DictionaryLanguageInfo> Languages { get; }
 
         /// <summary>
         /// Look up a headword (exact match plus the prefix run, or the nearest-neighbor run on a miss).
@@ -21,6 +23,20 @@ namespace CST.Tools
         /// </summary>
         Task<IReadOnlyList<DictionaryEntry>> LookupAsync(DictionaryRequest request, CancellationToken ct = default);
     }
+
+    /// <summary>A dictionary's language code and its source attribution (null if none is recorded). (#268)</summary>
+    public sealed record DictionaryLanguageInfo(string Language, DictionarySourceInfo? Source);
+
+    /// <summary>Authoritative citation for a dictionary — populated verbatim from the dictionary's own
+    /// <c>source.json</c>, never inferred. Every field is optional; an unpopulated source is null. (#268)</summary>
+    public sealed record DictionarySourceInfo(
+        string? Title,
+        string? Compiler,
+        string? Edition,
+        string? Year,
+        string? Publisher,
+        string? License,
+        string? Url);
 
     /// <summary>A dictionary lookup request.</summary>
     public sealed record DictionaryRequest(
@@ -32,7 +48,10 @@ namespace CST.Tools
     /// <summary>One dictionary entry.</summary>
     /// <param name="Headword">The headword in the requested output script.</param>
     /// <param name="MeaningHtml">The definition as an HTML fragment (the source format).</param>
+    /// <param name="Source">The dictionary's title, for inline attribution (null when unrecorded); the full
+    /// citation for this language is in <see cref="IDictionaryTool.Languages"/>. (#268)</param>
     public sealed record DictionaryEntry(
         string Headword,
-        string MeaningHtml);
+        string MeaningHtml,
+        string? Source);
 }


### PR DESCRIPTION
Adds source attribution to dictionary_lookup/dictionary_languages, NEVER inferred: a per-dictionary source.json (title/compiler/edition/year/publisher/license/url) read verbatim; missing or all-blank → null (an unattributed dictionary is null, not a filename guess). /v1/dictionary/languages returns [{language, source}]; each entry gains a source title. Shipped en/hi source.json are blank placeholders for VRI to populate. Seeding fix so added files reach existing installs. 701 tests pass.