### PR TITLE
#268: en dictionary source = Childers (1875)

### DIFF
--- a/src/CST.Avalonia/dictionaries/en/source.json
+++ b/src/CST.Avalonia/dictionaries/en/source.json
@@ -1,9 +1,9 @@
 {
-  "title": "",
-  "compiler": "",
+  "title": "A Dictionary of the Pali Language",
+  "compiler": "Robert Cæsar Childers",
   "edition": "",
-  "year": "",
-  "publisher": "",
-  "license": "",
+  "year": "1875",
+  "publisher": "Trübner & Co., London",
+  "license": "Public domain",
   "url": ""
 }


### PR DESCRIPTION
Populates dictionaries/en/source.json with the verified citation: Childers, A Dictionary of the Pali Language (1875), public domain. Verified verbatim against Childers (not CPED/PTS). Follow-up #378 tracks an unedited-Childers comparison for any VRI edits.