### PR TITLE
#247 Phase 2: enclitic +iti grammatical analysis in the lemma report

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -318,13 +318,13 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Equal(100, root.GetProperty("lemmaId").GetInt64());
             var forms = root.GetProperty("forms").EnumerateArray()
                 .Select(f => f.GetProperty("form").GetString()).ToHashSet();
-            // dhamma/citta/kamma occur in the corpus; the synthetic 'dhammani' must be omitted.
+            // dhamma/citta/kamma/cittāti occur in the corpus; the synthetic 'dhammani' must be omitted.
             Assert.Contains("dhamma", forms);
             Assert.Contains("citta", forms);
             Assert.Contains("kamma", forms);
             Assert.DoesNotContain("dhammani", forms);
-            Assert.Equal(4, root.GetProperty("candidateFormCount").GetInt32());
-            Assert.Equal(3, root.GetProperty("attestedFormCount").GetInt32());
+            Assert.Equal(5, root.GetProperty("candidateFormCount").GetInt32());   // +cittāti (enclitic)
+            Assert.Equal(4, root.GetProperty("attestedFormCount").GetInt32());
             Assert.True(root.GetProperty("totalOccurrences").GetInt32() > 0);
         }
 
@@ -359,6 +359,8 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Contains("Analysis", html);                                       // column header
             Assert.Contains("masculine nominative singular", html);                  // 'dhamma' expanded
             Assert.Contains("masculine nominative singular / masculine vocative singular", html);
+            // enclitic form 'cittāti' (= citta + iti) has no direct grammar — resolved via its base. (#247 Phase 2)
+            Assert.Contains("masculine accusative singular, + iti", html);
             // lemma 100 is a masc NOUN, so the adjective analysis of 'dhamma' (same headword) is filtered out.
             Assert.DoesNotContain("feminine nominative singular", html);
         }

--- a/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
+++ b/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
@@ -83,7 +83,7 @@ namespace CST.Avalonia.Tests.TestSupport
             string mulaXml =
                 "<body><div id=\"dn1\" type=\"book\">" +
                 "<pb ed=\"V\" n=\"1.0001\"/>" +
-                "<p rend=\"bodytext\" n=\"1\">" + Deva("dhamma", "citta", "kamma", "dukkha") +
+                "<p rend=\"bodytext\" n=\"1\">" + Deva("dhamma", "citta", "kamma", "dukkha", "cittāti") +
                 " <note>" + Deva("dhamma") + " (si)</note></p>" +
                 "</div></body>";
             string atthaXml =
@@ -142,12 +142,15 @@ namespace CST.Avalonia.Tests.TestSupport
                 CREATE TABLE root (root_key TEXT PRIMARY KEY, root_sign TEXT, root_meaning TEXT, root_group INTEGER,
                     sanskrit_root TEXT, sanskrit_root_meaning TEXT, dhatupatha_pali TEXT, dhatupatha_english TEXT);
                 CREATE TABLE form_lemma (form TEXT NOT NULL, lemma_id INTEGER NOT NULL);
-                CREATE TABLE forms (form TEXT PRIMARY KEY, grammar TEXT);
+                CREATE TABLE forms (form TEXT PRIMARY KEY, grammar TEXT, deconstructor TEXT);
                 CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
-                INSERT INTO forms VALUES
+                INSERT INTO forms(form,grammar) VALUES
                     ('dhamma','[[""dhamma"",""noun"",""masc nom sg""],[""dhamma"",""noun"",""masc voc sg""],[""dhamma"",""adj"",""fem nom sg""]]'),
                     ('citta','[[""dhamma"",""noun"",""masc acc sg""]]'),
                     ('kamma','[[""dhamma"",""noun"",""masc instr sg""]]');
+                -- enclitic form: no direct grammar, but decomposes to 'citta + iti' (#247 Phase 2)
+                INSERT INTO forms(form,grammar,deconstructor) VALUES
+                    ('cittāti', NULL, '[""citta + iti""]');
                 INSERT INTO lemma
                   (id,lemma,pos,gloss,derived_from,root_key,construction,sanskrit,pattern,ebt_count,example_source,example_sutta,example)
                   VALUES
@@ -155,7 +158,7 @@ namespace CST.Avalonia.Tests.TestSupport
                     (101,'dhamma 2','masc','a phenomenon',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
                 INSERT INTO root VALUES ('√dhar','dhar','hold; support',1,'√dhṛ','hold','dharaṇe','holding');
                 INSERT INTO form_lemma VALUES
-                    ('dhamma',100),('citta',100),('kamma',100),('dhammani',100),
+                    ('dhamma',100),('citta',100),('kamma',100),('dhammani',100),('cittāti',100),
                     ('dhamma',101);
                 INSERT INTO meta VALUES ('scope','mid'),('dpd_version','test');");
         }

--- a/src/CST.Avalonia/Services/LemmaReportService.cs
+++ b/src/CST.Avalonia/Services/LemmaReportService.cs
@@ -79,6 +79,10 @@ public sealed class LemmaReportService : ILemmaReportService
                 var res = _lemma.ResolveForm(ScriptConverter.Convert(f.Ipe, Script.Ipe, Script.Latin));
                 bool homo = res is not null && res.Candidates.Any(c => !familyIds.Contains(c.LemmaId));
                 string? grammar = GrammarFor(res?.Grammar, focusHeadword, d.Pos);
+                // No direct grammar? An enclitic form (e.g. pajānātīti = pajānāti + iti) decomposes to a base
+                // form whose grammar IS known — resolve it and append the enclitic. (#247 Phase 2)
+                if (grammar is null && res?.Deconstructor is { } decon)
+                    grammar = EncliticGrammar(decon, focusHeadword, d.Pos);
                 forms.Add(new ReportForm(f.Ipe, f.Count, f.BookCount, homo, grammar));
                 if (homo)
                 {
@@ -202,6 +206,45 @@ public sealed class LemmaReportService : ILemmaReportService
         ["abl"] = "ablative", ["gen"] = "genitive", ["loc"] = "locative", ["voc"] = "vocative",
         ["masc"] = "masculine", ["fem"] = "feminine", ["nt"] = "neuter",
     };
+
+    // An enclitic form (pajānātīti) carries no direct grammar; its deconstructor gives "base + enclitic"
+    // (e.g. "pajānāti + iti"). Resolve the BASE form's grammar (filtered to THIS lemma) and append the enclitic,
+    // yielding e.g. "present 3rd singular, + iti". Multiple base analyses join with " / ". (#247 Phase 2)
+    private string? EncliticGrammar(string deconJson, string focusHeadword, string? focusPos)
+    {
+        List<string>? results = null;
+        try
+        {
+            using var doc = JsonDocument.Parse(deconJson);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) return null;
+            foreach (var el in doc.RootElement.EnumerateArray())
+            {
+                if (el.ValueKind != JsonValueKind.String) continue;
+                var (baseForm, enclitic) = SplitEnclitic(el.GetString()!);
+                if (baseForm is null) continue;
+                var baseGrammar = GrammarFor(_lemma.ResolveForm(baseForm)?.Grammar, focusHeadword, focusPos);
+                if (baseGrammar is null) continue;
+                var combined = $"{baseGrammar}, + {enclitic}";
+                results ??= new List<string>();
+                if (!results.Contains(combined)) results.Add(combined);
+            }
+        }
+        catch (JsonException) { return null; }
+        return results is { Count: > 0 } ? string.Join(" / ", results) : null;
+    }
+
+    // Common Pāli enclitic particles that attach to a fully-inflected base word.
+    private static readonly HashSet<string> Enclitics = new(StringComparer.Ordinal)
+        { "iti", "ti", "ca", "pi", "api", "eva", "ceva", "va", "hi", "kho", "su", "nu", "no", "ve" };
+
+    // "pajānāti + iti" → ("pajānāti", "iti"), but ONLY for a 2-part split whose tail is a known enclitic
+    // (so a multi-word sandhi compound is never mistaken for an enclitic). Else (null, null).
+    private static (string? Base, string? Enclitic) SplitEnclitic(string decon)
+    {
+        var parts = decon.Split(" + ", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length == 2 && Enclitics.Contains(parts[1]) && parts[0].Length > 0
+            ? (parts[0], parts[1]) : (null, null);
+    }
 
     // "paññāya 1" → "paññāya"; also DPD's DOTTED sub-numbering "dhamma 1.01" → "dhamma" (mirrors the
     // provider). A trailing token of only digits and dots is a homonym marker; anything else is kept.

--- a/src/CST.Lemma/LemmaModels.cs
+++ b/src/CST.Lemma/LemmaModels.cs
@@ -13,7 +13,11 @@ public sealed record LemmaCandidate(long LemmaId, string Lemma, string? Pos, str
 /// more than one candidate; the caller (or user) disambiguates. <see cref="Grammar"/> is the form's raw
 /// grammatical analysis (JSON), for the disambiguation display; null when the asset omits it (lean scope).
 /// </summary>
-public sealed record FormResolution(string Form, IReadOnlyList<LemmaCandidate> Candidates, string? Grammar);
+/// <param name="Deconstructor">For an enclitic/sandhi form that carries no direct <paramref name="Grammar"/>,
+/// the DPD deconstruction JSON (e.g. <c>["pajānāti + iti"]</c>) — used to resolve the base form's grammar and
+/// append the enclitic ("present 3rd singular, + iti"). Null when unrecorded. (#247 Phase 2)</param>
+public sealed record FormResolution(
+    string Form, IReadOnlyList<LemmaCandidate> Candidates, string? Grammar, string? Deconstructor);
 
 /// <summary>
 /// Forward expansion of one lemma: its attested surface forms (IAST) and, when requested, its

--- a/src/CST.Lemma/SqliteLemmaProvider.cs
+++ b/src/CST.Lemma/SqliteLemmaProvider.cs
@@ -11,6 +11,7 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
 {
     private readonly string? _connString;
     private readonly bool _hasFormsTable;
+    private readonly bool _hasDecon;    // forms.deconstructor column (enclitic +iti resolution, #247 Phase 2)
     private readonly bool _hasReport;   // report-grade columns (root_key on lemma + a root table)
 
     public bool IsAvailable { get; }
@@ -37,6 +38,7 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
             if (!TableExists(c, "lemma") || !TableExists(c, "form_lemma"))
                 return;
             _hasFormsTable = TableExists(c, "forms");
+            _hasDecon = _hasFormsTable && ColumnExists(c, "forms", "deconstructor");
             _hasReport = TableExists(c, "root") && ColumnExists(c, "lemma", "root_key");
             Meta = LoadMeta(c);
             _connString = connString;
@@ -74,15 +76,22 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
         }
         if (candidates.Count == 0) return null;
 
-        string? grammar = null;
+        string? grammar = null, deconstructor = null;
         if (_hasFormsTable)
         {
             using var cmd = c.CreateCommand();
-            cmd.CommandText = "SELECT grammar FROM forms WHERE form = $f";
+            cmd.CommandText = _hasDecon
+                ? "SELECT grammar, deconstructor FROM forms WHERE form = $f"
+                : "SELECT grammar FROM forms WHERE form = $f";
             cmd.Parameters.AddWithValue("$f", form);
-            grammar = cmd.ExecuteScalar() as string;
+            using var r = cmd.ExecuteReader();
+            if (r.Read())
+            {
+                grammar = Str(r, 0);
+                if (_hasDecon) deconstructor = Str(r, 1);
+            }
         }
-        return new FormResolution(form, candidates, grammar);
+        return new FormResolution(form, candidates, grammar, deconstructor);
     }
 
     public LemmaExpansion? ExpandLemma(long lemmaId, bool includeFamily = false)

--- a/tools/DpdLemmaBuilder/Program.cs
+++ b/tools/DpdLemmaBuilder/Program.cs
@@ -44,8 +44,32 @@ string srcPath = positional.Count > 0 ? positional[0] : "/Users/fsnow/dpd-poc/dp
 string outPath = positional.Count > 1 ? positional[1] : "/Users/fsnow/dpd-poc/dpd-lemma.db";
 
 bool includeForms = scope != "lean";      // the forms (grammar) table
-bool includeDecon = scope == "full";      // sandhi deconstructor column
+bool includeDecon = scope == "full";      // the FULL sandhi deconstructor (every decomposable form)
 bool includeReport = scope != "lean";     // report-grade per-lemma columns (etymology/example/…) + root table
+bool deconColumn = includeReport;         // the forms.deconstructor column exists for mid + full
+
+// Enclitic particles that attach to a fully-inflected base word. A form whose deconstructor is entirely
+// "base + <enclitic>" (2-part) is a RESOLVABLE enclitic (e.g. pajānātīti = pajānāti + iti) — mid keeps its
+// deconstructor (so the report resolves "base grammar, + iti") while dropping the multi-word sandhi bulk. (#247 Phase 2)
+var enclitics = new HashSet<string>(StringComparer.Ordinal)
+    { "iti", "ti", "ca", "pi", "api", "eva", "ceva", "va", "hi", "kho", "su", "nu", "no", "ve" };
+bool IsResolvableEnclitic(string deconJson)
+{
+    try
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse(deconJson);
+        if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0)
+            return false;
+        foreach (var el in doc.RootElement.EnumerateArray())
+        {
+            if (el.ValueKind != System.Text.Json.JsonValueKind.String) return false;
+            var parts = el.GetString()!.Split(" + ", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length != 2 || !enclitics.Contains(parts[1])) return false;
+        }
+        return true;
+    }
+    catch { return false; }
+}
 
 if (!File.Exists(srcPath))
 {
@@ -95,7 +119,7 @@ if (includeReport)
         root_key TEXT PRIMARY KEY, root_sign TEXT, root_meaning TEXT, root_group INTEGER,
         sanskrit_root TEXT, sanskrit_root_meaning TEXT, dhatupatha_pali TEXT, dhatupatha_english TEXT );");
 if (includeForms)
-    Exec(outDb, includeDecon
+    Exec(outDb, deconColumn
         ? "CREATE TABLE forms ( form TEXT PRIMARY KEY, grammar TEXT, deconstructor TEXT );"
         : "CREATE TABLE forms ( form TEXT PRIMARY KEY, grammar TEXT );");
 
@@ -222,12 +246,12 @@ using (var tx = outDb.BeginTransaction())
     if (includeForms)
     {
         insForm = outDb.CreateCommand();
-        insForm.CommandText = includeDecon
+        insForm.CommandText = deconColumn
             ? "INSERT OR IGNORE INTO forms(form,grammar,deconstructor) VALUES($f,$g,$d)"
             : "INSERT OR IGNORE INTO forms(form,grammar) VALUES($f,$g)";
         fF = insForm.Parameters.Add("$f", SqliteType.Text);
         fG = insForm.Parameters.Add("$g", SqliteType.Text);
-        if (includeDecon) fD = insForm.Parameters.Add("$d", SqliteType.Text);
+        if (deconColumn) fD = insForm.Parameters.Add("$d", SqliteType.Text);
     }
 
     using var read = src.CreateCommand();
@@ -249,13 +273,18 @@ using (var tx = outDb.BeginTransaction())
 
         if (includeForms)
         {
-            // mid: a forms row only when there's grammar to carry; full: whenever kept.
-            bool wantForm = includeDecon || !string.IsNullOrWhiteSpace(grammar);
+            bool grammarPresent = !string.IsNullOrWhiteSpace(grammar);
+            // A resolvable enclitic (ids>0, no direct grammar, decon entirely "base + <enclitic>") is kept so
+            // the report can render "base grammar, + iti". FULL keeps every decon; MID keeps only enclitics.
+            bool enclitic = !grammarPresent && hasDecon && ids.Length > 0 && IsResolvableEnclitic(decon);
+            bool wantForm = includeDecon || grammarPresent || enclitic;
             if (wantForm)
             {
                 fF.Value = form;
                 fG.Value = NullIfEmpty(grammar);
-                if (includeDecon) fD.Value = hasDecon ? decon : DBNull.Value;
+                if (deconColumn)
+                    fD.Value = includeDecon ? (hasDecon ? decon : (object)DBNull.Value)
+                                            : (enclitic ? decon : (object)DBNull.Value);
                 insForm!.ExecuteNonQuery();
                 formCount++;
             }
@@ -344,7 +373,12 @@ Check("lemma 35708 derived_from == pajānāti", DerivedFrom(35708) == "pajānāt
 long fwd = Scalar("SELECT COUNT(*) FROM form_lemma WHERE lemma_id=39702");
 Check("forward expansion 39702 -> 34 forms", fwd == 34, fwd.ToString());
 if (scope == "mid")
+{
     Check("per-form grammar present (pajānāti)", Scalar("SELECT COUNT(*) FROM forms WHERE form='pajānāti' AND grammar IS NOT NULL") == 1);
+    // enclitic decon kept (pajānātīti = pajānāti + iti), but NOT a non-enclitic sandhi decon (sammappajānāti).
+    Check("enclitic decon retained (pajānātīti)", Scalar("SELECT COUNT(*) FROM forms WHERE form='pajānātīti' AND deconstructor IS NOT NULL") == 1);
+    Check("non-enclitic decon dropped in mid (sammappajānāti)", Scalar("SELECT COUNT(*) FROM forms WHERE form='sammappajānāti' AND deconstructor IS NOT NULL") == 0);
+}
 if (scope == "full")
     Check("sandhi preserved (sammappajānāti)", Scalar("SELECT COUNT(*) FROM forms WHERE form='sammappajānāti' AND deconstructor IS NOT NULL") == 1);
 


### PR DESCRIPTION
Fills the Analysis column for enclitic forms (pajānātīti, pajānāmīti, pajānātiyeva…) that carry no direct DPD grammar, by resolving via the deconstructor: "base + <enclitic>" → the base form's grammar + the enclitic. So `pajānātīti` → **"present 3rd singular, + iti"**, `pajānantīti` → "present 3rd plural, + iti", `pajānātiyeva` → "present 3rd singular, + eva".

- Generator keeps `forms.deconstructor` in mid/report scope for RESOLVABLE enclitics only (2-part `base + <enclitic>`, fixed particle set) — not the multi-word sandhi bulk. Asset 109→118 MB (+8.6 MB); new validation asserts the split.
- Provider exposes the deconstructor; `LemmaReportService.EncliticGrammar` resolves the base's grammar (filtered to this lemma) and appends the enclitic.

Live-validated on real pajānāti data — every previously-blank +iti/+eva row is now filled (0 blanks). 701 tests pass. Fixture gains an attested enclitic form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)