### PR TITLE
#247 family: collapse DPD homonyms into one row per headword (union count)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
@@ -110,6 +110,28 @@ public sealed class LemmaSearchServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ExpandAndSearchSet_unions_several_lemmas_forms_in_one_query()
+    {
+        var fake = new FakeSearchService();
+        var svc = NewService(fake);
+
+        // Homonyms 'paññāya 1' (40070) + 'paññāya 2' (40071): their forms are UNIONed into ONE search, so a
+        // collapsed family row counts the shared forms once. (#247 family)
+        var result = await svc.ExpandAndSearchSetAsync(new long[] { 40070, 40071 }, Script.Ipe);
+
+        Assert.NotNull(result);
+        Assert.Contains("paññāya", fake.LastQuery!.QueryText);
+        Assert.Contains("paññāhi", fake.LastQuery.QueryText);   // pulled from the 2nd homonym, unioned in
+    }
+
+    [Fact]
+    public async Task ExpandAndSearchSet_empty_is_null()
+    {
+        var svc = NewService(new FakeSearchService());
+        Assert.Null(await svc.ExpandAndSearchSetAsync(System.Array.Empty<long>()));
+    }
+
+    [Fact]
     public async Task ExpandAndSearch_unknown_lemma_is_null()
     {
         var svc = NewService(new FakeSearchService());

--- a/src/CST.Avalonia/Services/ILemmaSearchService.cs
+++ b/src/CST.Avalonia/Services/ILemmaSearchService.cs
@@ -48,4 +48,11 @@ public interface ILemmaSearchService
         BookFilter? filter = null,
         Script outputScript = Script.Latin,
         CancellationToken ct = default);
+
+    /// <summary>Expand and search the DE-DUPLICATED UNION of several lemmas' forms in ONE query — used to count
+    /// a collapsed family row (the homonyms of one headword) without double-counting their shared forms. (#247)</summary>
+    Task<LemmaSearchResult?> ExpandAndSearchSetAsync(
+        IReadOnlyList<long> lemmaIds,
+        Script outputScript = Script.Latin,
+        CancellationToken ct = default);
 }

--- a/src/CST.Avalonia/Services/LemmaReportService.cs
+++ b/src/CST.Avalonia/Services/LemmaReportService.cs
@@ -95,15 +95,26 @@ public sealed class LemmaReportService : ILemmaReportService
         }
         homographs = homographs.OrderByDescending(h => h.Count).ToList();
 
-        // Word family — derived_from siblings, each with its own corpus total, grouped by pos category.
+        // Word family — the derived_from cluster, COLLAPSED so each distinct WORD (headword) is ONE row, not one
+        // per DPD homonym. A headword's homonyms share their surface forms, so their union is counted ONCE (not
+        // summed, which would double-count); the row is grouped by the homonyms' dominant part-of-speech, so a
+        // word like paññāṇa (adj + nt homonyms) is a single row, not split across buckets. (#247 family)
         var family = new List<ReportFamilyMember>();
         if (exp?.Family is { } siblings)
         {
-            foreach (var m in siblings)
+            foreach (var g in siblings.Where(m => m.LemmaId != lemmaId)
+                                      .GroupBy(m => StripHomonym(m.Lemma), StringComparer.Ordinal))
             {
-                if (m.LemmaId == lemmaId) continue;
-                var mr = await _search.ExpandAndSearchAsync(m.LemmaId, false, null, Script.Ipe, ct).ConfigureAwait(false);
-                family.Add(new ReportFamilyMember(m.LemmaId, ToIpe(m.Lemma), m.Pos, m.Gloss, mr?.TotalOccurrences ?? 0, PosGroup(m.Pos)));
+                var members = g.ToList();
+                // dominant pos = the most common among the homonyms; the representative sense is the first
+                // homonym of that pos.
+                var repPos = members.GroupBy(m => m.Pos)
+                    .OrderByDescending(x => x.Count()).ThenBy(x => x.Key, StringComparer.Ordinal).First().Key;
+                var rep = members.FirstOrDefault(m => m.Pos == repPos) ?? members[0];
+                var mr = await _search.ExpandAndSearchSetAsync(members.Select(m => m.LemmaId).ToList(), Script.Ipe, ct)
+                    .ConfigureAwait(false);
+                family.Add(new ReportFamilyMember(
+                    rep.LemmaId, ToIpe(g.Key), rep.Pos, rep.Gloss, mr?.TotalOccurrences ?? 0, PosGroup(repPos)));
             }
         }
         family = family.OrderByDescending(m => m.TotalOccurrences).ToList();

--- a/src/CST.Avalonia/Services/LemmaSearchService.cs
+++ b/src/CST.Avalonia/Services/LemmaSearchService.cs
@@ -69,13 +69,39 @@ public sealed class LemmaSearchService : ILemmaSearchService
             }
         }
 
+        return await SearchFormsAsync(lemma, forms, filter, outputScript, ct).ConfigureAwait(false);
+    }
+
+    public async Task<LemmaSearchResult?> ExpandAndSearchSetAsync(
+        IReadOnlyList<long> lemmaIds, Script outputScript = Script.Latin, CancellationToken ct = default)
+    {
+        if (!IsAvailable || lemmaIds.Count == 0) return null;
+        // Union the forms of several lemmas (typically the homonyms of ONE headword) and search them ONCE — so a
+        // collapsed family row counts the shared surface forms a single time, not once per homonym. (#247 family)
+        LemmaCandidate? lemma = null;
+        var forms = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var id in lemmaIds)
+        {
+            var e = _lemma.ExpandLemma(id, includeFamily: false);
+            if (e is null) continue;
+            lemma ??= new LemmaCandidate(e.LemmaId, e.Lemma, e.Pos, e.Gloss, e.DerivedFrom);
+            foreach (var f in e.Forms) forms.Add(f);
+        }
+        return lemma is null ? null
+            : await SearchFormsAsync(lemma, forms, null, outputScript, ct).ConfigureAwait(false);
+    }
+
+    // Search a de-duplicated form set as one anchored IAST alternation (converted to IPE by the search path)
+    // and project the attested terms with corpus counts.
+    private async Task<LemmaSearchResult> SearchFormsAsync(
+        LemmaCandidate lemma, SortedSet<string> forms, BookFilter? filter, Script outputScript, CancellationToken ct)
+    {
         if (forms.Count == 0)
             return new LemmaSearchResult(lemma, Array.Empty<LemmaSearchForm>(), 0, 0, 0, false);
 
         bool capped = forms.Count > MaxAlternationForms;
         var searchForms = capped ? forms.Take(MaxAlternationForms).ToList() : forms.ToList();
 
-        // IAST anchored alternation → ordinary Regex search path (SearchService converts it to IPE).
         string alternation = "^(" + string.Join("|", searchForms) + ")$";
         var query = new SearchQuery
         {


### PR DESCRIPTION
The Word-family list showed each DPD homonym separately — paññāyati 1–5 all at 5,038 (inflated), paññāṇa split across Adjectives/Nouns. Now one row per distinct headword: forms unioned and counted ONCE (ExpandAndSearchSetAsync), grouped by the homonyms' dominant pos. Live: pajānāti family 40→19 clean rows. Unit tests for the union search. 700 pass (+ the flaky perf test).