### PR TITLE
#383 sandhi decomposer: word→parts via /v1/deconstruct + MCP sandhi_split (API-first)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LemmaDeconstructTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LemmaDeconstructTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.IO;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.LocalApi.Lemma;
+using CST.Conversion;
+using CST.Lemma;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+// Deconstruction tests for the sandhi decomposer (#383). Uses a real SqliteLemmaProvider over a tiny fixture
+// with a full-scope `forms` table (deconstructor populated for non-enclitic compounds too). Covers the four
+// shapes: pure sandhi (split, no headword), enclitic split, compound-stored-as-lemma (direct, no split), and
+// a plain word with neither.
+public sealed class LemmaDeconstructTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public LemmaDeconstructTests() : this("full") { }
+
+    private LemmaDeconstructTests(string scope)
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"dpd-lemma-dc-{Guid.NewGuid():N}.db");
+        using var c = new SqliteConnection($"Data Source={_dbPath}");
+        c.Open();
+        Exec(c, $@"
+            CREATE TABLE lemma (id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT);
+            CREATE TABLE form_lemma (form TEXT NOT NULL, lemma_id INTEGER NOT NULL);
+            CREATE TABLE forms ( form TEXT PRIMARY KEY, grammar TEXT, deconstructor TEXT );
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+            INSERT INTO lemma VALUES
+                (1,'pajānāti','pr','knows',NULL),
+                (2,'sammāsambuddha','masc','fully self-awakened one',NULL),
+                (3,'gacchati','pr','goes',NULL);
+            -- pajānāti is a headword; sammāsambuddho is a headword (compound stored as lemma); gacchati plain.
+            INSERT INTO form_lemma VALUES
+                ('pajānāti',1),
+                ('sammāsambuddho',2),
+                ('gacchati',3);
+            -- forms.deconstructor: pure sandhi (no form_lemma), enclitic, and the plain word (no decon).
+            INSERT INTO forms VALUES
+                ('satthakosakaraṇatthāya', NULL, '[""sattha + kosa + karaṇatthāya"",""satthako + usa + karaṇatthāya""]'),
+                ('pajānātīti', NULL, '[""pajānāti + iti""]'),
+                ('sammāsambuddho', 'masc nom sg', NULL),
+                ('gacchati', 'pr 3rd sg', NULL);
+            INSERT INTO meta VALUES ('scope','{scope}'),('dpd_version','test');");
+    }
+
+    private static void Exec(SqliteConnection c, string sql)
+    {
+        using var cmd = c.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    private LemmaSearchService NewService() => new(new SqliteLemmaProvider(_dbPath), new FakeSearch());
+
+    [Fact]
+    public void PureSandhi_returns_ranked_splits_and_no_direct_lemma()
+    {
+        var res = NewService().Deconstruct("satthakosakaraṇatthāya", Script.Latin);
+
+        Assert.NotNull(res);
+        Assert.Empty(res!.DirectLemmas);            // no headword — this word only exists as a split
+        Assert.Equal(2, res.Splits.Count);
+        // array order is the rank; element 0 is DPD's best
+        Assert.Equal(0, res.Splits[0].Rank);
+        Assert.Equal(new[] { "sattha", "kosa", "karaṇatthāya" }, res.Splits[0].Parts.ToArray());
+        Assert.Equal(1, res.Splits[1].Rank);
+        Assert.Equal(new[] { "satthako", "usa", "karaṇatthāya" }, res.Splits[1].Parts.ToArray());
+    }
+
+    [Fact]
+    public void Enclitic_splits_into_base_plus_particle()
+    {
+        var res = NewService().Deconstruct("pajānātīti", Script.Latin);
+
+        Assert.NotNull(res);
+        Assert.Single(res!.Splits);
+        Assert.Equal(new[] { "pajānāti", "iti" }, res.Splits[0].Parts.ToArray());
+    }
+
+    [Fact]
+    public void CompoundStoredAsLemma_falls_through_to_direct_lemma_no_split()
+    {
+        var res = NewService().Deconstruct("sammāsambuddho", Script.Latin);
+
+        Assert.NotNull(res);
+        Assert.Empty(res!.Splits);                  // no deconstructor — it's a headword
+        Assert.Single(res.DirectLemmas);
+        Assert.Equal("sammāsambuddha", res.DirectLemmas[0].Lemma);
+    }
+
+    [Fact]
+    public void PlainWord_with_neither_split_nor_extra_is_still_returned_via_direct_lemma()
+    {
+        // gacchati has a form_lemma row but no deconstructor: returned with the direct lemma, empty splits.
+        var res = NewService().Deconstruct("gacchati", Script.Latin);
+
+        Assert.NotNull(res);
+        Assert.Empty(res!.Splits);
+        Assert.Single(res.DirectLemmas);
+    }
+
+    [Fact]
+    public void Unknown_word_is_null()
+    {
+        Assert.Null(NewService().Deconstruct("nonesuchword", Script.Latin));
+    }
+
+    [Fact]
+    public void Unavailable_asset_is_null()
+    {
+        var svc = new LemmaSearchService(new SqliteLemmaProvider("nope.db"), new FakeSearch());
+        Assert.Null(svc.Deconstruct("pajānātīti", Script.Latin));
+    }
+
+    [Fact]
+    public void Dto_note_flags_multi_split_ambiguity_and_chain()
+    {
+        var res = NewService().Deconstruct("satthakosakaraṇatthāya", Script.Latin);
+        var dto = LemmaApi.ToDeconstruct("satthakosakaraṇatthāya", res!, Script.Latin);
+
+        Assert.Equal(2, dto.Splits.Count);
+        Assert.Contains("ALTERNATIVE", dto.Note);          // ambiguity warning
+        Assert.Contains("/v1/lemma/", dto.Note);            // the resolve-each-part chain
+        Assert.Empty(dto.DirectLemmas);
+    }
+
+    [Fact]
+    public void Dto_note_for_headword_only_word_points_at_directLemmas()
+    {
+        var res = NewService().Deconstruct("sammāsambuddho", Script.Latin);
+        var dto = LemmaApi.ToDeconstruct("sammāsambuddho", res!, Script.Latin);
+
+        Assert.Empty(dto.Splits);
+        Assert.Single(dto.DirectLemmas);
+        Assert.Contains("headword", dto.Note);
+    }
+
+    [Fact]
+    public void MidScope_note_hints_full_asset_when_no_split()
+    {
+        using var mid = new LemmaDeconstructTests("mid");
+        // gacchati: no split; on a mid asset the note should hint the full-scope asset covers compounds.
+        var res = mid.NewService().Deconstruct("gacchati", Script.Latin);
+        var dto = LemmaApi.ToDeconstruct("gacchati", res!, Script.Latin);
+        Assert.Contains("full-scope", dto.Note);
+    }
+
+    [Fact]
+    public void NotFoundNote_is_scope_aware_and_points_at_lemma_fallback()
+    {
+        // full scope: no full-asset upsell, just the lemma-fallback pointer.
+        var full = LemmaApi.DeconstructNotFoundNote("xyz", "full");
+        Assert.Contains("/v1/lemma/xyz", full);
+        Assert.DoesNotContain("full-scope", full);
+
+        // mid scope: the missing-compound case DOES get the "install full-scope asset" hint.
+        var mid = LemmaApi.DeconstructNotFoundNote("xyz", "mid");
+        Assert.Contains("/v1/lemma/xyz", mid);
+        Assert.Contains("full-scope", mid);
+
+        // empty/unknown scope (meta row absent) must NOT print a bare "scope ''" hint.
+        var empty = LemmaApi.DeconstructNotFoundNote("xyz", "");
+        Assert.DoesNotContain("scope ''", empty);
+        Assert.DoesNotContain("full-scope", empty);
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { /* best effort */ }
+    }
+
+    // Minimal ISearchService — deconstruct never touches the corpus, so this is never called.
+    private sealed class FakeSearch : ISearchService
+    {
+        public System.Threading.Tasks.Task<SearchResult> SearchAsync(SearchQuery query, System.Threading.CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<string>> GetAllTermsAsync(string prefix = "", int limit = 100, System.Threading.CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public System.Threading.Tasks.Task<SearchResult> GetNextPageAsync(string continuationToken, System.Threading.CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<TermPosition>> GetTermPositionsAsync(string bookFileName, string term, System.Threading.CancellationToken ct = default)
+            => throw new NotSupportedException();
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<System.Collections.Generic.List<TermPosition>>> GetMultiWordPositionsAsync(string bookFileName, string query, SearchMode mode, int proximityDistance, System.Threading.CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+}

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -233,6 +233,15 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   wrong flag is a gross error, not a rounding one. To count "just the verb" INCLUDING its negated/sandhi
   sibling (e.g. `nappajānāti` = na+), union that specific sibling's forms yourself rather than taking the
   whole family; filter by `pos` when you need to scope a family to one grammatical class.
+- `GET  /v1/deconstruct/{word}?script=` - SANDHI/COMPOUND deconstruction: a word -> its constituent PARTS
+  (DPD deconstructor). Returns `{ word, splits:[{ rank, parts:[…] }], directLemmas:[…], note }`. `splits` are
+  DPD's RANKED ALTERNATIVE analyses (rank 0 = best), NOT sequential pieces - Pāli sandhi is ambiguous, so the
+  top rank is not guaranteed correct; a genuine compound stored as its own headword (e.g. `sammāsambuddho`)
+  comes back with `directLemmas` and no split. This is the word->PARTS step only: each part is a surface form,
+  so chain it - `GET /v1/lemma/{part}` for the part's lemma(s) (a part is often a HOMOGRAPH), then
+  `/v1/dictionary/lookup` for glosses. `{word}` is a PATH segment, so PERCENT-ENCODE diacritics. `script` is
+  BOTH the input and output script. (Present only when the DPD-lemma dataset is installed; 503 if not. Full
+  compound coverage needs the full-scope asset; a mid-scope asset splits only enclitics like `…ti`/`…iti`.)
 <!--/doc:dictionary-->
 
 <!--doc:search-->

--- a/src/CST.Avalonia/Services/ILemmaSearchService.cs
+++ b/src/CST.Avalonia/Services/ILemmaSearchService.cs
@@ -27,6 +27,24 @@ public sealed record LemmaSearchResult(
     int AttestedFormCount,
     bool ExpansionCapped);
 
+/// <summary>One alternative sandhi/compound split of a word: its constituent parts (IAST) and DPD's rank
+/// (0 = best-ranked). The splits are ALTERNATIVES, not sequential pieces — Pāli sandhi is ambiguous, so DPD
+/// returns several ranked candidate analyses. (sandhi decomposer, #383)</summary>
+public sealed record WordSplit(int Rank, IReadOnlyList<string> Parts);
+
+/// <summary>
+/// Result of deconstructing a compound/sandhi word: DPD's ranked alternative <see cref="Splits"/>, plus any
+/// <see cref="DirectLemmas"/> the whole word is itself a headword of (fall-through — a compound like
+/// <c>sammāsambuddho</c> is stored as a lemma, not a split). Parts/lemmas are IAST; the caller converts to the
+/// output script. <see cref="Scope"/> is the loaded asset's scope (only a <c>full</c> asset carries every
+/// compound's split; <c>mid</c> carries only enclitics), for a scope-aware caller note.
+/// </summary>
+public sealed record WordDeconstruction(
+    string Word,
+    IReadOnlyList<LemmaCandidate> DirectLemmas,
+    IReadOnlyList<WordSplit> Splits,
+    string? Scope);
+
 /// <summary>
 /// The lemma-search seam: back-lookup a word to its candidate lemmas, then forward-expand a chosen lemma
 /// and search the corpus for its (attested) forms. Called in-process by the GUI and (later) the local API.
@@ -40,6 +58,13 @@ public interface ILemmaSearchService
 
     /// <summary>Back-lookup: any-script word → candidate lemmas (null if unresolvable). The word is normalized to IAST for the DPD lookup.</summary>
     FormResolution? ResolveWord(string word, Script sourceScript = Script.Ipe);
+
+    /// <summary>Sandhi/compound deconstruction: any-script word → DPD's ranked alternative splits (parts as
+    /// surface forms) + any direct lemma(s) the word is itself a headword of. Null when unresolvable or the
+    /// asset carries no deconstructor. The word is normalized to IAST for the lookup; parts stay IAST for the
+    /// caller to convert. This is the word→parts primitive only; resolve each part with <see cref="ResolveWord"/>
+    /// for its lemma(s). (sandhi decomposer, #383)</summary>
+    WordDeconstruction? Deconstruct(string word, Script sourceScript = Script.Ipe);
 
     /// <summary>Forward-expand a chosen lemma (optionally its derived_from family) and search the corpus for the forms.</summary>
     Task<LemmaSearchResult?> ExpandAndSearchAsync(

--- a/src/CST.Avalonia/Services/LemmaSearchService.cs
+++ b/src/CST.Avalonia/Services/LemmaSearchService.cs
@@ -43,6 +43,39 @@ public sealed class LemmaSearchService : ILemmaSearchService
         return _lemma.ResolveForm(iast);
     }
 
+    public WordDeconstruction? Deconstruct(string word, Script sourceScript = Script.Ipe)
+    {
+        if (!IsAvailable || string.IsNullOrWhiteSpace(word)) return null;
+        string iast = sourceScript == Script.Latin ? word : ScriptConverter.Convert(word, sourceScript, Script.Latin);
+        var fd = _lemma.Deconstruct(iast);
+        if (fd is null) return null;
+        return new WordDeconstruction(iast, fd.DirectLemmas, ParseSplits(fd.Deconstructor), _lemma.Meta?.Scope);
+    }
+
+    // The DPD deconstructor is a JSON array of ranked alternative splits, each a " + "-joined string
+    // (e.g. ["sattha + kosa + karaṇatthāya", "satthako + usa + karaṇatthāya"]). Project to ranked WordSplits
+    // (array order IS the rank; element 0 is DPD's best). Malformed JSON degrades to what parsed so far.
+    private static IReadOnlyList<WordSplit> ParseSplits(string? deconJson)
+    {
+        if (string.IsNullOrWhiteSpace(deconJson)) return Array.Empty<WordSplit>();
+        var splits = new List<WordSplit>();
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(deconJson);
+            if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Array) return splits;
+            int rank = 0;
+            foreach (var el in doc.RootElement.EnumerateArray())
+            {
+                if (el.ValueKind != System.Text.Json.JsonValueKind.String) continue;
+                var parts = el.GetString()!
+                    .Split(" + ", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length > 0) splits.Add(new WordSplit(rank++, parts));
+            }
+        }
+        catch (System.Text.Json.JsonException) { /* return what parsed */ }
+        return splits;
+    }
+
     public async Task<LemmaSearchResult?> ExpandAndSearchAsync(
         long lemmaId,
         bool includeFamily = false,

--- a/src/CST.Avalonia/Services/LocalApi/Lemma/LemmaApiContracts.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Lemma/LemmaApiContracts.cs
@@ -24,6 +24,18 @@ public sealed record LemmaFormsResponse(
     IReadOnlyList<LemmaFormDto> Forms, int TotalOccurrences,
     int AttestedFormCount, int CandidateFormCount, bool ExpansionCapped, string? Note);
 
+/// <summary>One ranked alternative split of a compound/sandhi word (parts in the output script).</summary>
+public sealed record WordSplitDto(int Rank, IReadOnlyList<string> Parts);
+
+/// <summary>Response for GET /v1/deconstruct/{word} — DPD's ranked candidate splits of a compound/sandhi
+/// word (rank 0 = best; splits are ALTERNATIVES, not sequential parts), plus any direct lemma(s) the whole
+/// word is itself a headword of.</summary>
+public sealed record DeconstructResponse(
+    string Word,
+    IReadOnlyList<WordSplitDto> Splits,
+    IReadOnlyList<LemmaCandidateDto> DirectLemmas,
+    string? Note);
+
 internal static class LemmaApi
 {
     // Convert a lemma citation form (IAST, may carry a trailing homonym number) to the output script.
@@ -43,6 +55,55 @@ internal static class LemmaApi
               + "for its attested paradigm with counts."
             : null;
         return new LemmaLookupResponse(form, candidates, note);
+    }
+
+    public static DeconstructResponse ToDeconstruct(string word, WordDeconstruction res, Script outputScript)
+    {
+        var splits = res.Splits
+            .Select(s => new WordSplitDto(s.Rank, s.Parts.Select(p => Script(p, outputScript)).ToList()))
+            .ToList();
+        var direct = res.DirectLemmas
+            .Select(c => new LemmaCandidateDto(c.LemmaId, Script(c.Lemma, outputScript), c.Pos, c.Gloss, ScriptOrNull(c.DerivedFrom, outputScript)))
+            .ToList();
+        // Echo the caller's word as-is (it is already in the output script), matching ToLookup — no redundant
+        // Latin-round-trip conversion. (fable review)
+        return new DeconstructResponse(word, splits, direct, DeconstructNote(splits, direct, res.Scope));
+    }
+
+    // Guidance for the NULL / not-found case (REST 404 and MCP no-result), so a missing word isn't reported as
+    // a flat "not found": point at the lemma fallback, and on a non-full asset note that full-scope coverage is
+    // needed for compounds (the mid/lean asset that dropped the split is exactly where this matters). (fable review)
+    public static string DeconstructNotFoundNote(string word, string? scope)
+    {
+        var head = $"No sandhi split recorded for '{word}'. It may be a simple word or a dictionary headword — try GET /v1/lemma/{word}.";
+        return NeedsFullHint(scope)
+            ? head + $" (This asset, scope '{scope}', records splits only for enclitic forms; install the full-scope DPD-lemma asset for full compound deconstruction.)"
+            : head;
+    }
+
+    // The scope is "" (never null) when the asset's meta omits it (DpdLemmaMeta.Scope is a non-null string), so
+    // guard on empty, not null — else an unknown-scope asset would print a bare "scope ''" hint. (fable review)
+    private static bool NeedsFullHint(string? scope) => !string.IsNullOrEmpty(scope) && scope != "full";
+
+    // Agent guidance: how to read the splits (ranked ALTERNATIVES, ambiguous, per-part homographs) and how to
+    // continue the chain (part -> /v1/lemma -> /v1/dictionary). Scope-aware: a non-full asset only records
+    // enclitic splits, so an empty result may just mean "install the full-scope asset".
+    private static string DeconstructNote(IReadOnlyList<WordSplitDto> splits, IReadOnlyList<LemmaCandidateDto> direct, string? scope)
+    {
+        if (splits.Count == 0)
+        {
+            var head = direct.Count > 0
+                ? "No sandhi split — this word is itself a dictionary headword (see directLemmas)."
+                : "No deconstruction recorded for this word.";
+            return NeedsFullHint(scope)
+                ? head + $" (asset scope '{scope}' records splits only for enclitic forms; the full-scope DPD-lemma asset covers all compounds.)"
+                : head;
+        }
+        var lead = splits.Count > 1
+            ? "This word has MULTIPLE candidate splits, ranked by DPD (rank 0 = best). They are ALTERNATIVE analyses, not sequential parts — Pāli sandhi is ambiguous, so pick the plausible one; the top rank is not guaranteed correct."
+            : "Each entry in a split's `parts` is a surface form.";
+        return lead + " Resolve a part with GET /v1/lemma/{part} for its lemma(s) (a part is often a HOMOGRAPH — don't assume one sense), then POST /v1/dictionary/lookup for glosses."
+            + (direct.Count > 0 ? " This word is ALSO a dictionary headword in its own right (see directLemmas)." : string.Empty);
     }
 
     public static LemmaFormsResponse ToForms(LemmaSearchResult res, Script outputScript)

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -513,6 +513,18 @@ namespace CST.Avalonia.Services.LocalApi
                         ? Results.NotFound(new { error = $"Unknown lemmaId {lemmaId}." })
                         : Results.Json(LemmaApi.ToForms(res, outputScript));
                 });
+
+                // Sandhi/compound deconstruction: a word -> its ranked constituent-part splits (DPD deconstructor).
+                // The word->parts primitive only; the caller composes part -> /v1/lemma -> /v1/dictionary. (#383)
+                app.MapGet(v + "/deconstruct/{word}", (string word, string? script) =>
+                {
+                    if (!lemma.IsAvailable) return LemmaUnavailable();
+                    var outputScript = ParseScript(script);
+                    var res = lemma.Deconstruct(word, outputScript);
+                    return res is null
+                        ? Results.NotFound(new { error = LemmaApi.DeconstructNotFoundNote(word, lemma.Meta?.Scope) })
+                        : Results.Json(LemmaApi.ToDeconstruct(word, res, outputScript));
+                });
             }
 
             // Lemma dossier (rendered HTML). The GUI renders it in-process; this endpoint gives agents/humans

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/LemmaMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/LemmaMcpTool.cs
@@ -60,5 +60,26 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                     Array.Empty<LemmaFormDto>(), 0, 0, 0, false, $"Unknown lemmaId {lemmaId}.")
                 : LemmaApi.ToForms(res, s);
         }
+
+        [McpServerTool(Name = "sandhi_split")]
+        [Description("Deconstruct a Pali COMPOUND or SANDHI word into its constituent parts, using the Digital "
+            + "Pali Dictionary's deconstructor. Returns DPD's RANKED alternative splits (rank 0 = best; the "
+            + "splits are ALTERNATIVE analyses, NOT sequential pieces — Pali sandhi is ambiguous and the top "
+            + "rank is not guaranteed correct), plus any direct lemma(s) if the whole word is itself a headword "
+            + "(e.g. sammāsambuddho). This is the word->parts step only: each part is a surface form, so resolve "
+            + "it with 'lemma_lookup' (a part is often a HOMOGRAPH — don't assume one sense) and look up its "
+            + "gloss. `script` is BOTH the input and output script (default Latin).")]
+        public static DeconstructResponse SandhiSplit(
+            ILemmaSearchService lemma,
+            [Description("The compound/sandhi word to deconstruct, written in `script`.")] string word,
+            [Description("Script for the input word and the output (default Latin).")] Script script = Script.Latin)
+        {
+            var s = Safe(script);
+            var res = lemma.Deconstruct(word, s);
+            return res is null
+                ? new DeconstructResponse(word, Array.Empty<WordSplitDto>(), Array.Empty<LemmaCandidateDto>(),
+                    LemmaApi.DeconstructNotFoundNote(word, lemma.Meta?.Scope))
+                : LemmaApi.ToDeconstruct(word, res, s);
+        }
     }
 }

--- a/src/CST.Lemma/ILemmaProvider.cs
+++ b/src/CST.Lemma/ILemmaProvider.cs
@@ -22,6 +22,12 @@ public interface ILemmaProvider : IDisposable
     /// <summary>Forward expansion: a lemma id → its attested surface forms (+ derived_from family when asked). Null if the id is unknown.</summary>
     LemmaExpansion? ExpandLemma(long lemmaId, bool includeFamily = false);
 
+    /// <summary>Sandhi/compound deconstruction: a surface form (IAST) → its DPD deconstructor split(s) and any
+    /// DIRECT lemma(s). Unlike <see cref="ResolveForm"/> this does NOT short-circuit when the form has no direct
+    /// lemma, so pure-sandhi words (a split with no headword) are returned. Null when the asset carries no
+    /// deconstructor column, or the form has neither a split nor a direct lemma. (sandhi decomposer, #383)</summary>
+    FormDeconstruction? Deconstruct(string form);
+
     /// <summary>A single lemma's metadata, or null if the id is unknown.</summary>
     LemmaCandidate? GetLemma(long lemmaId);
 

--- a/src/CST.Lemma/LemmaModels.cs
+++ b/src/CST.Lemma/LemmaModels.cs
@@ -20,6 +20,18 @@ public sealed record FormResolution(
     string Form, IReadOnlyList<LemmaCandidate> Candidates, string? Grammar, string? Deconstructor);
 
 /// <summary>
+/// Raw sandhi/compound deconstruction of a surface form: the DPD deconstructor JSON (a ranked array of
+/// alternative splits, each a <c>" + "</c>-joined string, e.g. <c>["sattha + kosa + karaṇatthāya", …]</c>),
+/// plus any DIRECT lemma(s) the whole word is itself a headword of. A pure sandhi word has splits and NO
+/// direct lemma; a genuine compound stored as its own headword (e.g. <c>sammāsambuddho</c>) has a direct
+/// lemma and NO split — so both fields can be empty/null independently. Parsing the JSON is the caller's job
+/// (this stays free of split policy). Distinct from <see cref="FormResolution"/>, which short-circuits to
+/// null when a form has no direct lemma — pure sandhi words would be lost that way. (sandhi decomposer, #383)
+/// </summary>
+public sealed record FormDeconstruction(
+    string Form, IReadOnlyList<LemmaCandidate> DirectLemmas, string? Deconstructor);
+
+/// <summary>
 /// Forward expansion of one lemma: its attested surface forms (IAST) and, when requested, its
 /// <c>derived_from</c> family. Occurrence counts are NOT here — the caller joins forms to the search index.
 /// </summary>

--- a/src/CST.Lemma/SqliteLemmaProvider.cs
+++ b/src/CST.Lemma/SqliteLemmaProvider.cs
@@ -94,6 +94,41 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
         return new FormResolution(form, candidates, grammar, deconstructor);
     }
 
+    public FormDeconstruction? Deconstruct(string form)
+    {
+        if (!IsAvailable || string.IsNullOrEmpty(form) || !_hasDecon) return null;
+        using var c = Open();
+
+        // Read the deconstructor DIRECTLY from forms — independent of form_lemma, so a pure-sandhi word
+        // (a split with no headword; 733k of them in DPD) is not lost the way ResolveForm would lose it.
+        string? decon = null;
+        using (var cmd = c.CreateCommand())
+        {
+            cmd.CommandText = "SELECT deconstructor FROM forms WHERE form = $f";
+            cmd.Parameters.AddWithValue("$f", form);
+            using var r = cmd.ExecuteReader();
+            if (r.Read()) decon = Str(r, 0);
+        }
+
+        // Fall-through: a compound stored as its OWN headword (e.g. sammāsambuddho) has an empty
+        // deconstructor but a direct lemma — carry those so the caller reports the headword, not "nothing".
+        var direct = new List<LemmaCandidate>();
+        using (var cmd = c.CreateCommand())
+        {
+            cmd.CommandText =
+                @"SELECT fl.lemma_id, l.lemma, l.pos, l.gloss, l.derived_from
+                  FROM form_lemma fl JOIN lemma l ON l.id = fl.lemma_id
+                  WHERE fl.form = $f ORDER BY fl.lemma_id";
+            cmd.Parameters.AddWithValue("$f", form);
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+                direct.Add(new LemmaCandidate(r.GetInt64(0), r.GetString(1), Str(r, 2), Str(r, 3), Str(r, 4)));
+        }
+
+        if (string.IsNullOrWhiteSpace(decon) && direct.Count == 0) return null;
+        return new FormDeconstruction(form, direct, decon);
+    }
+
     public LemmaExpansion? ExpandLemma(long lemmaId, bool includeFamily = false)
     {
         if (!IsAvailable) return null;


### PR DESCRIPTION
Closes the API-first slice of #383. Exposes DPD's sandhi/compound deconstruction (word → constituent parts) through the loopback REST + MCP surfaces only; the GUI is a deferred follow-up (Frank's lane).

## Scope (as agreed)
`deconstruct` is the **word→parts primitive** — the only step the API was missing. `part → lemma` is already `GET /v1/lemma`, `lemma → gloss` is already `/v1/dictionary`, so an agent composes the full "compound → words → glosses" chain from existing endpoints. Resolution-inlining (`?resolve=lemmas`) stays a **later opt-in option on this same endpoint**, not v1.

## What's here
- **`ILemmaProvider.Deconstruct`** — reads `forms.deconstructor` **directly** (not gated on `form_lemma`), so pure-sandhi words (a split with no headword — ~733k rows in DPD) aren't lost the way `ResolveForm`'s zero-candidate short-circuit would lose them. Falls through to the direct lemma when a compound is stored as its own headword (`sammāsambuddho`).
- **`LemmaSearchService.Deconstruct`** — script-normalizes input → IAST, parses the ranked alternative-split JSON, keeps parts IAST for the DTO to convert (IPE never leaks).
- **`GET /v1/deconstruct/{word}?script=`** + **MCP `sandhi_split`** — cloned from the lemma endpoint/tool. Splits are DPD's **ranked ALTERNATIVES** (rank 0 = best, *not* authoritative); response notes warn ambiguity + per-part homography and point at the resolve chain.
- **llms.txt** — documents the endpoint in the dictionary doc region.

## Correctness notes (fable adversarial review applied)
Review found no crashes / injection / IPE-leaks. Fixed the surviving guidance/degradation gaps:
- The scope-upgrade hint now reaches the case it was written for — a missing compound on a **mid** asset returns a scope-aware 404/MCP note (points at `/v1/lemma` + "install the full-scope asset"), not a flat "not found".
- Empty-scope guard (`scope` is `""`, never `null`) so an asset lacking the meta row doesn't print a bare `scope ''`.
- Echo the raw word (dropped a redundant Latin round-trip; consistent with `ToLookup`).

## Asset dependency
Non-enclitic compounds need the **full-scope** `dpd-lemma.db` (mid splits only enclitics); degrades to a scope-aware "unavailable" otherwise, same absent-asset → off contract as the lemma feature. **Shipping the full-scope asset (+25 MB zst) is a CI/build-flag decision left for you** — the code is scope-agnostic.

## Validation
- 10 unit tests (pure sandhi / enclitic / compound-as-lemma fall-through / plain-word / unknown / unavailable / scope-aware notes). Full lemma+LocalApi suite: 91 pass.
- Live against the real full-scope asset: `satthakosakaraṇatthāya` → 3 ranked splits (0 direct), `pajānātīti` → enclitic split + direct, `sammāsambuddho` → fall-through to direct lemma (no split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig