### PR TITLE
#109 DPD as a dictionary source: language "dpd" on /v1/dictionary (API-first)

### DIFF
--- a/docs/features/in-progress/DICTIONARIES.md
+++ b/docs/features/in-progress/DICTIONARIES.md
@@ -211,6 +211,47 @@ ahead-only, tie-both-sides, and no-common-prefix → empty).
 **UI layer (owned by the app's UI work):** the results panel, WebView rendering,
 `<see>` link handling, back-stack, and per-script fonts (§6).
 
+## 8. Third-party & structured dictionaries (#109)
+
+The flat-file loader above is only one **backend**. As of #109 the dictionary
+tool (`IDictionaryTool`, surface C) unions two backends behind one contract, so a
+caller looks a word up the same way regardless of source:
+
+- **Flat-file dictionaries** — the `dictionaries/<lang>/` tree of §4. This is also
+  the **general user-import format**: drop a `<lang>/` folder with one or more
+  UTF-8 files of alternating `headword` / `definition-HTML` lines (§4 "File
+  format") plus an optional `source.json`, and it loads with no code change. A
+  Pāli↔Pāli or bilingual flat dictionary imports today; a manifest-aware v2 loader
+  (`manifest.json` with id/headwordScript/meaningFormat/languages) is a later
+  option, not required.
+- **Digital Pāḷi Dictionary (DPD)** — the reserved language code **`dpd`**, present
+  only when the DPD-lemma asset (`dpd-lemma.db`) is installed. DPD ships **no
+  rendered-HTML definitions**, so entries are **composed on the fly** from the
+  asset's structured columns (pos + gloss + literal meaning + construction) by
+  `CompositeDictionaryTool`. The word→entry key reuses the same `form_lemma`
+  index the lemma endpoints use, so an **inflected** word resolves and a homograph
+  returns several entries. Each entry carries a `lemmaId` that chains to the lemma
+  report (`/v1/lemma-report/{lemmaId}`) for the full dossier — the dictionary
+  meaning is deliberately compact; depth lives in the report.
+
+**Attribution (`source.json`, #268).** Each flat `<lang>/` dir may carry a
+`source.json` — the authoritative citation `{ title, compiler, edition, year,
+publisher, license, url }`, read **verbatim, never inferred**; a wholly-blank file
+reports `null` (unattributed), not a guess. DPD's citation is built the same shape
+from the asset's own `meta` table (so it tracks the shipped release), never
+hard-coded. `/v1/dictionary/languages` returns each dictionary's source.
+
+**The `meaning_2` coalesce (DpdLemmaBuilder, #109).** ~30% of DPD headwords
+(26,782/89,050, mostly compounds) have an empty `meaning_1` but a populated
+`meaning_2`; the builder now sets `gloss = COALESCE(NULLIF(meaning_1,''),
+meaning_2)` so the composed DPD definition is not blank for those. Requires a
+rebuilt asset (converter v3).
+
+**Deferred (UI, Frank's lane):** a dictionary/source picker (today's picker only
+chooses a *language*) and a multi-source results panel with per-source sections.
+The API-first backend above lands the "look a word up in DPD and cite it" value
+without that UI.
+
 ## Corrections vs. the previous version of this document
 
 The earlier draft (written by a much weaker model) contained errors now fixed

--- a/src/CST.Avalonia.Tests/Services/CompositeDictionaryToolTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CompositeDictionaryToolTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Services.Tools;
+using CST.Conversion;
+using CST.Lemma;
+using CST.Tools;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+// CompositeDictionaryTool (#109): DPD ("dpd") unioned with the flat-file dictionaries. Uses a real
+// report-scope SqliteLemmaProvider over a tiny fixture + a fake flat IDictionaryTool for the delegation path.
+public sealed class CompositeDictionaryToolTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public CompositeDictionaryToolTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"dpd-lemma-dict-{Guid.NewGuid():N}.db");
+        using var c = new SqliteConnection($"Data Source={_dbPath}");
+        c.Open();
+        Exec(c, @"
+            CREATE TABLE lemma (id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT,
+                root_key TEXT, construction TEXT, sanskrit TEXT, meaning_lit TEXT, pattern TEXT, ebt_count INTEGER,
+                example_source TEXT, example_sutta TEXT, example TEXT, synonym TEXT, antonym TEXT);
+            CREATE TABLE form_lemma (form TEXT NOT NULL, lemma_id INTEGER NOT NULL);
+            CREATE TABLE root (root_key TEXT PRIMARY KEY, root_sign TEXT, root_meaning TEXT, root_group INTEGER,
+                sanskrit_root TEXT, sanskrit_root_meaning TEXT, dhatupatha_pali TEXT, dhatupatha_english TEXT);
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+            INSERT INTO lemma (id,lemma,pos,gloss,derived_from,construction,meaning_lit) VALUES
+                (100,'paññā 1','fem','wisdom',NULL,'pa+√ñā','knowing'),
+                (101,'paññāya 2','fem','by wisdom',NULL,NULL,NULL);
+            INSERT INTO form_lemma VALUES
+                ('paññā',100),
+                ('paññāya',100),('paññāya',101);
+            INSERT INTO meta VALUES
+                ('scope','mid'),
+                ('source','Digital Pāḷi Dictionary (DPD)'),
+                ('author','Bodhirāsa'),
+                ('homepage','https://www.dpdict.net/'),
+                ('license','CC BY-NC-SA 4.0'),
+                ('dpd_version','v0.4.20260531');");
+    }
+
+    private static void Exec(SqliteConnection c, string sql)
+    {
+        using var cmd = c.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    private CompositeDictionaryTool NewTool(bool assetAvailable = true)
+        => new(new FakeFlat(), new SqliteLemmaProvider(assetAvailable ? _dbPath : "nope.db"));
+
+    [Fact]
+    public void Languages_unions_flat_and_dpd_with_source_from_meta()
+    {
+        var langs = NewTool().Languages;
+        Assert.Contains(langs, l => l.Language == "en");                 // flat pass-through
+        var dpd = langs.SingleOrDefault(l => l.Language == "dpd");
+        Assert.NotNull(dpd);
+        var s = dpd!.Source;
+        Assert.NotNull(s);
+        Assert.Equal("Digital Pāḷi Dictionary (DPD)", s!.Title);
+        Assert.Equal("Bodhirāsa", s.Compiler);
+        Assert.Equal("v0.4.20260531", s.Edition);
+        Assert.Equal("2026", s.Year);                                    // parsed from the YYYYMMDD in the version
+        Assert.Equal("CC BY-NC-SA 4.0", s.License);
+        Assert.Equal("https://www.dpdict.net/", s.Url);
+    }
+
+    [Fact]
+    public void Languages_omits_dpd_when_asset_absent_but_keeps_flat()
+    {
+        var langs = NewTool(assetAvailable: false).Languages;
+        Assert.Contains(langs, l => l.Language == "en");
+        Assert.DoesNotContain(langs, l => l.Language == "dpd");
+    }
+
+    [Fact]
+    public async Task Dpd_lookup_composes_entry_with_lemmaId_and_source()
+    {
+        var res = await NewTool().LookupAsync(new DictionaryRequest("dpd", "paññā", Script.Latin));
+        var e = Assert.Single(res);
+        Assert.Equal("paññā 1", e.Headword);
+        Assert.Equal(100, e.LemmaId);                                    // chains to /v1/lemma-report/100
+        Assert.Equal("Digital Pāḷi Dictionary (DPD)", e.Source);
+        Assert.Contains("wisdom", e.MeaningHtml);
+        Assert.Contains("<i>fem</i>", e.MeaningHtml);                    // pos
+        Assert.Contains("pa+√ñā", e.MeaningHtml);                        // construction
+        Assert.Contains("lit. knowing", e.MeaningHtml);                  // meaning_lit
+    }
+
+    [Fact]
+    public async Task Dpd_lookup_of_a_homograph_returns_multiple_entries()
+    {
+        // paññāya resolves to two lemmas (100, 101) → two entries.
+        var res = await NewTool().LookupAsync(new DictionaryRequest("dpd", "paññāya", Script.Latin));
+        Assert.Equal(2, res.Count);
+        Assert.Equal(new long?[] { 100, 101 }, res.Select(e => e.LemmaId).ToArray());
+    }
+
+    [Fact]
+    public async Task Dpd_lookup_is_case_insensitive_on_language_and_normalizes_input_script()
+    {
+        // "DPD" routes to DPD; a Devanagari-script query normalizes to the same IAST key as the Latin one.
+        string deva = ScriptConverter.Convert("paññā", Script.Latin, Script.Devanagari);
+        var res = await NewTool().LookupAsync(new DictionaryRequest("DPD", deva, Script.Latin));
+        var e = Assert.Single(res);
+        Assert.Equal(100, e.LemmaId);
+    }
+
+    [Fact]
+    public async Task Dpd_lookup_respects_maxEntries_clamp()
+    {
+        var res = await NewTool().LookupAsync(new DictionaryRequest("dpd", "paññāya", Script.Latin, MaxEntries: 1));
+        Assert.Single(res);
+    }
+
+    [Fact]
+    public async Task Dpd_lookup_miss_is_empty()
+    {
+        var res = await NewTool().LookupAsync(new DictionaryRequest("dpd", "nonesuch", Script.Latin));
+        Assert.Empty(res);
+    }
+
+    [Fact]
+    public async Task Dpd_lookup_when_asset_absent_is_empty()
+    {
+        var res = await NewTool(assetAvailable: false).LookupAsync(new DictionaryRequest("dpd", "paññā", Script.Latin));
+        Assert.Empty(res);
+    }
+
+    [Fact]
+    public void Dpd_is_a_reserved_code_not_double_listed_or_shadowed_by_a_flat_dpd_dir()
+    {
+        // A flat tool that (hypothetically) also exposes "dpd" must not double-list it; DPD wins.
+        var tool = new CompositeDictionaryTool(new FakeFlat(alsoExposesDpd: true), new SqliteLemmaProvider(_dbPath));
+        var dpds = tool.Languages.Where(l => l.Language == "dpd").ToList();
+        var only = Assert.Single(dpds);
+        Assert.Equal("Digital Pāḷi Dictionary (DPD)", only.Source!.Title);   // the DPD source, not the flat one
+    }
+
+    [Fact]
+    public async Task Non_dpd_language_delegates_to_flat_tool()
+    {
+        var res = await NewTool().LookupAsync(new DictionaryRequest("en", "dhamma", Script.Latin));
+        var e = Assert.Single(res);
+        Assert.Equal("FLAT:en:dhamma", e.MeaningHtml);                   // came from the fake flat tool
+        Assert.Null(e.LemmaId);
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { /* best effort */ }
+    }
+
+    // Fake flat-file tool: one language ("en"), echoes the request so the delegation path is observable.
+    private sealed class FakeFlat : IDictionaryTool
+    {
+        private readonly bool _alsoExposesDpd;
+        public FakeFlat(bool alsoExposesDpd = false) => _alsoExposesDpd = alsoExposesDpd;
+
+        public IReadOnlyList<DictionaryLanguageInfo> Languages
+        {
+            get
+            {
+                var list = new List<DictionaryLanguageInfo>
+                    { new("en", new DictionarySourceInfo("Childers", null, null, "1875", null, "Public domain", null)) };
+                if (_alsoExposesDpd)
+                    list.Add(new DictionaryLanguageInfo("dpd", new DictionarySourceInfo("Flat DPD", null, null, null, null, null, null)));
+                return list;
+            }
+        }
+
+        public Task<IReadOnlyList<DictionaryEntry>> LookupAsync(DictionaryRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<DictionaryEntry>>(
+                new[] { new DictionaryEntry(request.Query, $"FLAT:{request.Language}:{request.Query}", "Childers") });
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1007,7 +1007,12 @@ public partial class App : Application
 
         // Surface-C tool wrappers (exposed over the local API). (#186)
         services.AddSingleton<CST.Tools.ISearchTool, Services.Tools.SearchTool>();
-        services.AddSingleton<CST.Tools.IDictionaryTool, Services.Tools.DictionaryTool>();
+        // Dictionary tool = flat-file dictionaries UNIONed with DPD ("dpd" language) when the DPD-lemma asset is
+        // present; the flat tool is the fallback for every other language. (#109)
+        services.AddSingleton<Services.Tools.DictionaryTool>();
+        services.AddSingleton<CST.Tools.IDictionaryTool>(sp => new Services.Tools.CompositeDictionaryTool(
+            sp.GetRequiredService<Services.Tools.DictionaryTool>(),
+            sp.GetRequiredService<CST.Lemma.ILemmaProvider>()));
         services.AddSingleton<CST.Tools.IPassageTool, Services.Tools.PassageTool>();
         services.AddSingleton<CST.Tools.IScriptTool, Services.Tools.ScriptTool>();
         services.AddTransient<TreeStateService>();

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -199,8 +199,15 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   null) or `null` when a dictionary has NO recorded attribution. CITE this as the gloss's source; it is never
   guessed, so `source:null` means "unattributed", not "look it up yourself".
 - `POST /v1/dictionary/lookup` - `{ language, query, outputScript?, maxEntries? }`
-  -> entries `{ headword, meaningHtml, source }`, where `source` is the dictionary's title for inline
+  -> entries `{ headword, meaningHtml, source, lemmaId? }`, where `source` is the dictionary's title for inline
   attribution (null if unrecorded; the full citation is in `/v1/dictionary/languages`).
+  The bundled flat dictionaries (`en`, `hi`) do exact/prefix/nearest-neighbor matching. When the DPD-lemma
+  dataset is installed, `language:"dpd"` looks a word up in the **Digital Pāḷi Dictionary** — an inflected word
+  resolves through the same form->lemma index as the lemma endpoints (EXACT inflected-form match, no prefix/
+  nearest fallback), so one word can return SEVERAL entries (its candidate homograph lemmas). A DPD entry's `lemmaId` chains to `/v1/lemma-report/{lemmaId}` (full
+  dossier: etymology, root, paradigm, frequency) or `/v1/forms/{lemmaId}` (attested paradigm with counts) - the
+  dictionary meaning is deliberately COMPACT and the report is where the depth lives. `lemmaId` is null for the
+  flat dictionaries.
 <!--/doc:dictionary-->
 <!--doc:scripts-->
 - `POST /v1/convert` - convert Pali text to another script. Body `{ text, outputScript }` -> `{ text, outputScript }`.

--- a/src/CST.Avalonia/Services/Tools/CompositeDictionaryTool.cs
+++ b/src/CST.Avalonia/Services/Tools/CompositeDictionaryTool.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Search;
+using CST.Conversion;
+using CST.Lemma;
+using CST.Tools;
+
+namespace CST.Avalonia.Services.Tools
+{
+    /// <summary>
+    /// An <see cref="IDictionaryTool"/> that unions the flat-file dictionaries with the Digital Pāḷi Dictionary
+    /// (DPD) as the language <c>"dpd"</c>, present only when the DPD-lemma asset is installed. DPD ships no
+    /// rendered-HTML definitions, so entries are COMPOSED on the fly from the asset's structured columns; the
+    /// word→entry key reuses the same form→lemma index the lemma search uses (so an inflected word resolves).
+    /// Every language except <c>"dpd"</c> delegates unchanged to the flat-file tool, so the wire contract in
+    /// <see cref="IDictionaryTool"/> is untouched. Degrades to "flat-file only" when the asset is absent. (#109)
+    /// </summary>
+    public sealed class CompositeDictionaryTool : IDictionaryTool
+    {
+        /// <summary>The language code that routes to DPD rather than a flat-file dictionary.</summary>
+        public const string DpdLanguage = "dpd";
+
+        // Upper bound on hits per call — mirror the flat-file DictionaryTool clamp (#305).
+        private const int MaxDictEntries = 500;
+
+        private readonly IDictionaryTool _flat;
+        private readonly ILemmaProvider _lemma;
+
+        public CompositeDictionaryTool(IDictionaryTool flat, ILemmaProvider lemma)
+        {
+            _flat = flat;
+            _lemma = lemma;
+        }
+
+        public IReadOnlyList<DictionaryLanguageInfo> Languages
+        {
+            get
+            {
+                // "dpd" is a RESERVED code that always routes to the DPD path, so drop any flat-file language of
+                // that name from the union — else it would double-list and (since routing shadows it) be unreachable.
+                var list = _flat.Languages.Where(l => !IsDpd(l.Language)).ToList();
+                // Advertise DPD only when the asset is loaded; cite the shipped release from its meta (never guessed).
+                if (_lemma.IsAvailable)
+                    list.Add(new DictionaryLanguageInfo(DpdLanguage, DpdSource()));
+                return list;
+            }
+        }
+
+        public Task<IReadOnlyList<DictionaryEntry>> LookupAsync(DictionaryRequest request, CancellationToken ct = default)
+            => IsDpd(request.Language)
+                // The DPD path is blocking SQLite (a ResolveForm + up to `cap` GetDetail round-trips); offload it so
+                // it doesn't hold the Kestrel request thread the way the genuinely-async flat path doesn't. (#279)
+                ? Task.Run(() => LookupDpd(request, ct), ct)
+                : _flat.LookupAsync(request, ct);
+
+        private static bool IsDpd(string? language) => string.Equals(language, DpdLanguage, StringComparison.OrdinalIgnoreCase);
+
+        // DPD lookup: normalize the (any-script) query to the IAST key DPD stores, resolve it to candidate lemmas
+        // via the form→lemma index, and compose a compact entry per candidate from the asset's structured fields.
+        private IReadOnlyList<DictionaryEntry> LookupDpd(DictionaryRequest request, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_lemma.IsAvailable || string.IsNullOrWhiteSpace(request.Query))
+                return Array.Empty<DictionaryEntry>();
+
+            // Mirror DictionaryService's query normalization (strip zero-width joiners, lower-case, NFC), then any
+            // script → IPE (Any2Ipe does the detection the flat loader relies on) → IAST, DPD's storage script.
+            var normalized = MultiWordSearch.StripJoiners(request.Query).ToLowerInvariant().Normalize(NormalizationForm.FormC);
+            string ipe = Any2Ipe.Convert(normalized);
+            string iast = ScriptConverter.Convert(ipe, Script.Ipe, Script.Latin);
+
+            var resolution = _lemma.ResolveForm(iast);
+            if (resolution is null || resolution.Candidates.Count == 0)
+                return Array.Empty<DictionaryEntry>();
+
+            var source = DpdSource()?.Title;
+            int cap = Math.Clamp(request.MaxEntries, 0, MaxDictEntries);
+            var entries = new List<DictionaryEntry>(Math.Min(cap, resolution.Candidates.Count));
+            foreach (var cand in resolution.Candidates)
+            {
+                if (entries.Count >= cap) break;
+                ct.ThrowIfCancellationRequested();
+                var detail = _lemma.GetDetail(cand.LemmaId);
+                if (detail is null) continue;
+                entries.Add(new DictionaryEntry(
+                    Headword: ToScript(detail.Lemma, request.OutputScript),
+                    MeaningHtml: ComposeMeaning(detail),
+                    Source: source,
+                    LemmaId: detail.LemmaId));
+            }
+            return entries;
+        }
+
+        // A COMPACT entry composed from DPD's structured fields — pos, the (meaning_2-coalesced) gloss, the
+        // literal meaning, and the construction/etymology. Deliberately NOT the full dossier: an agent chains
+        // LemmaId → /v1/lemma-report/{lemmaId} for paradigm/family/root/frequency. Fields are plain text →
+        // HTML-encoded (only the composed markup is HTML).
+        private static string ComposeMeaning(LemmaDetail d)
+        {
+            var sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(d.Pos)) sb.Append("<i>").Append(Enc(d.Pos)).Append("</i> ");
+            if (!string.IsNullOrEmpty(d.Gloss)) sb.Append(Enc(d.Gloss));
+            if (!string.IsNullOrEmpty(d.MeaningLit))
+                sb.Append(" <span class=\"dpd-lit\">(lit. ").Append(Enc(d.MeaningLit)).Append(")</span>");
+            if (!string.IsNullOrEmpty(d.Construction))
+                sb.Append("<div class=\"dpd-con\">").Append(Enc(d.Construction)).Append("</div>");
+            return sb.ToString();
+        }
+
+        // Escape ONLY the HTML-significant characters, leaving Pāli diacritics (ā, ñ, √, …) as literal UTF-8 —
+        // WebUtility.HtmlEncode would mangle every non-ASCII letter into a numeric entity, which is unreadable
+        // for a Pāli dictionary. The fields are element text, so &/</> is sufficient. (& must be replaced first.)
+        private static string Enc(string s) => s
+            .Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+
+        // The lemma is stored IAST; project to the requested output script. IPE/Unknown never leaks — the stored
+        // form is IAST, and for those output scripts we return it as-is (Latin) rather than the internal encoding.
+        private static string ToScript(string iast, Script output)
+            => output is Script.Latin or Script.Ipe or Script.Unknown
+                ? iast
+                : ScriptConverter.Convert(iast, Script.Latin, output);
+
+        // Build DPD's citation from the asset's meta (written by DpdLemmaBuilder) — never hard-coded, so it tracks
+        // the shipped release. Null when the asset carries no attribution at all (mirrors the flat-file contract).
+        private DictionarySourceInfo? DpdSource()
+        {
+            var m = _lemma.Meta;
+            if (m is null) return null;
+            var info = new DictionarySourceInfo(
+                Title: NullIfBlank(m.Source),
+                Compiler: NullIfBlank(m.Author),
+                Edition: NullIfBlank(m.DpdVersion),
+                Year: YearFromVersion(m.DpdVersion),
+                Publisher: null,                       // not recorded in the asset — don't invent one
+                License: NullIfBlank(m.License),
+                Url: NullIfBlank(m.Homepage));
+            return IsUnattributed(info) ? null : info;
+        }
+
+        private static string? NullIfBlank(string? s) => string.IsNullOrWhiteSpace(s) ? null : s;
+
+        private static bool IsUnattributed(DictionarySourceInfo s) =>
+            s.Title is null && s.Compiler is null && s.Edition is null && s.Year is null &&
+            s.Publisher is null && s.License is null && s.Url is null;
+
+        // DPD versions look like "v0.4.20260531"; take the year from the first >=8-digit (YYYYMMDD) run. Null if none.
+        private static string? YearFromVersion(string? v)
+        {
+            if (string.IsNullOrEmpty(v)) return null;
+            for (int i = 0; i < v.Length;)
+            {
+                if (!char.IsDigit(v[i])) { i++; continue; }
+                int j = i;
+                while (j < v.Length && char.IsDigit(v[j])) j++;
+                if (j - i >= 8) return v.Substring(i, 4);
+                i = j;
+            }
+            return null;
+        }
+    }
+}

--- a/src/CST.Core/Tools/DictionaryToolContracts.cs
+++ b/src/CST.Core/Tools/DictionaryToolContracts.cs
@@ -50,8 +50,12 @@ namespace CST.Tools
     /// <param name="MeaningHtml">The definition as an HTML fragment (the source format).</param>
     /// <param name="Source">The dictionary's title, for inline attribution (null when unrecorded); the full
     /// citation for this language is in <see cref="IDictionaryTool.Languages"/>. (#268)</param>
+    /// <param name="LemmaId">For a structured dictionary (DPD) whose entries are DPD headwords, the DPD lemma id
+    /// — chain it to <c>/v1/lemma-report/{lemmaId}</c> for the full dossier, or <c>/v1/forms/{lemmaId}</c> for the
+    /// attested paradigm. Null for flat-file dictionaries. (#109)</param>
     public sealed record DictionaryEntry(
         string Headword,
         string MeaningHtml,
-        string? Source);
+        string? Source,
+        long? LemmaId = null);
 }

--- a/src/CST.Lemma/LemmaModels.cs
+++ b/src/CST.Lemma/LemmaModels.cs
@@ -44,14 +44,19 @@ public sealed record LemmaExpansion(
     IReadOnlyList<string> Forms,
     IReadOnlyList<LemmaCandidate>? Family);
 
-/// <summary>Provenance / version of the loaded DPD-lemma asset (from its <c>meta</c> table).</summary>
+/// <summary>Provenance / version of the loaded DPD-lemma asset (from its <c>meta</c> table). <see cref="Source"/>,
+/// <see cref="Author"/>, and <see cref="Homepage"/> are the upstream DPD citation fields, so a DPD dictionary
+/// source can cite the shipped release without hard-coding it (#109).</summary>
 public sealed record DpdLemmaMeta(
     string Scope,
     string DpdVersion,
     string ConverterVersion,
     string SchemaVersion,
     string License,
-    string Attribution);
+    string Attribution,
+    string Source,
+    string Author,
+    string Homepage);
 
 /// <summary>Root (dhātu) detail for the report's etymology band (present only in report-grade assets).</summary>
 public sealed record RootDetail(

--- a/src/CST.Lemma/SqliteLemmaProvider.cs
+++ b/src/CST.Lemma/SqliteLemmaProvider.cs
@@ -264,7 +264,8 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
         }
         string G(string k) => m.TryGetValue(k, out var v) ? v : string.Empty;
         return new DpdLemmaMeta(G("scope"), G("dpd_version"), G("converter_version"),
-                                G("schema_version"), G("license"), G("attribution"));
+                                G("schema_version"), G("license"), G("attribution"),
+                                G("source"), G("author"), G("homepage"));
     }
 
     private static bool TableExists(SqliteConnection c, string name)

--- a/tools/DpdLemmaBuilder/Program.cs
+++ b/tools/DpdLemmaBuilder/Program.cs
@@ -22,7 +22,7 @@ using Microsoft.Data.Sqlite;
 // Usage: DpdLemmaBuilder [<dpd.db path> [<output dpd-lemma.db path>]] [--scope lean|mid|full]
 // =====================================================================================================
 
-const string ConverterVersion = "2";   // v2: report-grade per-lemma columns + root table
+const string ConverterVersion = "3";   // v3: gloss coalesces meaning_2 (blank-compound fix, #109)
 const string SchemaVersion = "2";
 
 // ---- args ----
@@ -135,13 +135,16 @@ using (var tx = outDb.BeginTransaction())
             (id,lemma,pos,gloss,derived_from,root_key,construction,sanskrit,meaning_lit,pattern,ebt_count,
              example_source,example_sutta,example,synonym,antonym)
             VALUES ($id,$lemma,$pos,$gloss,$df,$rk,$con,$skt,$lit,$pat,$ebt,$exs,$exu,$ex,$syn,$ant)";
-        read.CommandText = @"SELECT id,lemma_1,pos,meaning_1,derived_from,root_key,construction,sanskrit,
+        // gloss = COALESCE(meaning_1, meaning_2): ~30% of DPD headwords (26,782/89,050, mostly compounds) have
+        // an EMPTY meaning_1 but a populated meaning_2, so a gloss keyed on meaning_1 alone would blank them —
+        // which surfaces as blank dictionary definitions (#109). meaning_2 is the fallback, ~0.7 MB total. (#109)
+        read.CommandText = @"SELECT id,lemma_1,pos,COALESCE(NULLIF(meaning_1,''),meaning_2),derived_from,root_key,construction,sanskrit,
             meaning_lit,pattern,ebt_count,source_1,sutta_1,example_1,synonym,antonym FROM dpd_headwords";
     }
     else
     {
         ins.CommandText = "INSERT INTO lemma(id,lemma,pos,gloss,derived_from) VALUES($id,$lemma,$pos,$gloss,$df)";
-        read.CommandText = "SELECT id, lemma_1, pos, meaning_1, derived_from FROM dpd_headwords";
+        read.CommandText = "SELECT id, lemma_1, pos, COALESCE(NULLIF(meaning_1,''),meaning_2), derived_from FROM dpd_headwords";
     }
     var pId = ins.Parameters.Add("$id", SqliteType.Integer);
     var pLemma = ins.Parameters.Add("$lemma", SqliteType.Text);
@@ -171,7 +174,9 @@ using (var tx = outDb.BeginTransaction())
         pId.Value = r.GetInt64(0);
         pLemma.Value = r.GetString(1);
         pPos.Value = NullIfEmpty(r.GetString(2));
-        pGloss.Value = NullIfEmpty(r.GetString(3));
+        // gloss is now a COALESCE(NULLIF(meaning_1,''),meaning_2) expression — NULL-capable if BOTH are empty
+        // (never happens in DPD, meaning_2 is NOT NULL, but guard so GetString can't throw on a future release).
+        pGloss.Value = r.IsDBNull(3) ? DBNull.Value : NullIfEmpty(r.GetString(3));
         pDf.Value = NullIfEmpty(r.GetString(4));
         if (includeReport)
         {


### PR DESCRIPTION
First API-first slice of #109. Exposes the **Digital Pāḷi Dictionary (DPD)** through the existing `/v1/dictionary` surface as `language: "dpd"`, reusing the attribution contract from #268. The dictionary/source-picker UX + multi-source results panel remain the deferred UI half (Frank's lane).

## Key finding (from the research pass)
DPD ships **no rendered-HTML definitions** — the DB carries only structured fields — and the `dpd-lemma.db` we already build already holds those fields **plus** the word→lemma index (`form_lemma`). So "DPD as a dictionary" is a **thin read path over the asset we already ship**, not a new 2 GB dependency and not a new asset.

## What's here
- **`CompositeDictionaryTool`** — unions the flat-file dictionaries with DPD, routing the reserved code `"dpd"` to a composed-entry path and delegating every other language unchanged to the flat tool. The `IDictionaryTool` wire contract is untouched.
- **Word→entry** reuses `ILemmaProvider.ResolveForm` (the same form→lemma index as the lemma endpoints), so an inflected word resolves and a **homograph returns several entries** (`dhammaṃ` → 17). Query normalized exactly like the flat loader (`StripJoiners → lower → NFC → Any2Ipe → IAST`); **IPE never leaks**.
- **Compact `meaningHtml`** = pos + gloss + literal + construction. Escapes only `& < >` — `WebUtility.HtmlEncode` would entity-mangle Pāli diacritics into `&#257;` etc.
- **`DictionaryEntry` gains `LemmaId`** → chains to `/v1/lemma-report/{lemmaId}` (full dossier) or `/v1/forms/{lemmaId}`. Depth stays in the report; the dictionary meaning is deliberately compact. `LemmaId` is null for flat dictionaries.
- **DPD `DictionarySourceInfo` from the asset's `meta`** (title/author/version/license/homepage; year parsed from the version date) — never hard-coded, tracks the shipped release; null when wholly unattributed.

## Mandatory builder fix — the blank-definition trap
**30% of DPD headwords (26,782/89,050, mostly compounds) have an empty `meaning_1` but a populated `meaning_2`.** The builder set `gloss = meaning_1` only, so a naïve DPD dictionary would render **blank definitions for ~30% of entries**. Fixed: `gloss = COALESCE(NULLIF(meaning_1,''), meaning_2)` (~0.7 MB). **Verified: blank-gloss lemmas 26,782 → 0.** `ConverterVersion` bumped 2→3.

## fable adversarial review applied
No high-severity bugs; escaping/IPE-leak/clamp/YearFromVersion/COALESCE/culture explicitly cleared. Fixed the four low-severity items:
- Offload the blocking DPD SQLite to the thread pool so it doesn't hold the Kestrel request thread (#279).
- Reserve `"dpd"` so a hypothetical flat `dpd/` dir can't double-list or be shadowed.
- `IsDBNull` guard on the now-NULL-capable COALESCE read (latent, defensive).
- llms.txt states DPD is **exact inflected-form match** (no prefix/nearest fallback), unlike the flat dicts.

## Asset dependency
The coalesce needs the shipped `dpd-lemma.db` **rebuilt** (a CI/asset-delivery step, like the sandhi full-scope flip). Until then DPD lookups work but re-blank the 30% compounds. Degrades to flat-file-only when the asset is absent.

## Validation
- Live against a freshly built v3 mid asset: source metadata correct (Bodhirāsa / v0.4.20260531 / 2026 / CC BY-NC-SA / dpdict.net), `dhammaṃ`→17, `paññāya`→12, `gacchati`→2, diacritics literal.
- 10 unit tests (routing, composition, source-from-meta, homographs, script normalization, reserved-word dedup, degradation). Full suite: **723 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig