### PR TITLE
#355: stop a hit inside a <note> leaking the note's post-hit apparatus tail as base text

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiExtractionHardeningTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiExtractionHardeningTests.cs
@@ -72,5 +72,41 @@ namespace CST.Avalonia.Tests.Search
             Assert.Contains("alpha", w.Text);
             Assert.Contains("epsilon", w.Text);
         }
+
+        [Fact]
+        public void Snippet_hit_inside_a_note_does_not_leak_the_notes_post_hit_tail()
+        {
+            // #355: the hit ("TARGET") is itself footnote text; with IncludeFootnotes=false the note's PRE-hit
+            // content is stripped, but its POST-hit tail ("variant reading sii syaa") used to leak as base text
+            // because the suffix Clean started mid-note. The base text after the note must still be preserved (#310).
+            const string xml = "<p>base one two <note>TARGET variant reading sii syaa</note> three four five।</p>";
+            var markers = BookMarkers.Build(xml);
+            int hit = xml.IndexOf("TARGET", StringComparison.Ordinal);
+
+            var r = TeiSnippetExtractor.Extract(xml, hit, "TARGET".Length, markers, Deva(1, 400));
+
+            Assert.Contains("base one two", r.Snippet);          // pre-note base text
+            Assert.Contains("TARGET", r.Snippet);                // the hit (note text) still renders
+            Assert.Contains("three four five", r.Snippet);       // post-note base text preserved (#310)
+            Assert.DoesNotContain("variant reading", r.Snippet); // the leaked note tail — gone (#355)
+            Assert.DoesNotContain("syaa", r.Snippet);
+        }
+
+        [Fact]
+        public void Snippet_hit_inside_a_note_still_shows_the_note_as_apparatus_when_footnotes_included()
+        {
+            // With footnotes ON the note is rendered as braced apparatus, so its tail is DELIMITED (not leaked as
+            // base text) — the #355 clip only applies when braces are off. This pins that the fix is one-sided.
+            const string xml = "<p>base one two <note>TARGET variant reading</note> three four five।</p>";
+            var markers = BookMarkers.Build(xml);
+            int hit = xml.IndexOf("TARGET", StringComparison.Ordinal);
+            var opts = new SnippetOptions(Script.Devanagari, IncludeFootnotes: true, MinChars: 1, MaxChars: 400);
+
+            var r = TeiSnippetExtractor.Extract(xml, hit, "TARGET".Length, markers, opts);
+
+            Assert.Contains("TARGET", r.Snippet);
+            Assert.Contains("three four five", r.Snippet);
+            Assert.Contains("variant reading", r.Snippet);       // present, but as apparatus (braces)
+        }
     }
 }

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -177,7 +177,13 @@ namespace CST.Search
             var notes = TeiText.NoteRegions(xml, from, start);
             for (int j = from; j < start; j++)
                 if (TeiText.IsBoundary(xml[j]) && !TeiText.InNote(j, notes)) return j + 1;   // sentence start (note-aware, #310)
-            return Math.Max(i + 1, limit);
+            // No boundary found: the raw fallback can land mid-note, so the previous page would render that note's
+            // tail as base text (and Clean from mid-note emits an unbalanced brace). Snap out to the enclosing note's
+            // start so the cursor sits on a clean (base-text) boundary. (#355)
+            int fallback = Math.Max(i + 1, limit);
+            foreach (var (s, e) in notes)
+                if (fallback > s && fallback < e) { fallback = Math.Max(s, limit); break; }
+            return fallback;
         }
     }
 

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -101,8 +101,18 @@ namespace CST.Search
                 }
             }
 
+            // #355: if the LAST mark is itself INSIDE a note (the hit is footnote text) and we're NOT rendering the
+            // note as braced apparatus, the note's post-hit tail (variant reading + sigla, e.g. "(sī. syā.)") would
+            // leak as undelimited base text — the suffix Clean starts mid-note and never sees the opening <note> to
+            // strip it (</note> is zero-width after the #310 close-tag fix). Start the suffix at the enclosing note's
+            // END so that tail is stripped, matching the already-correct pre-hit side. (renderBraces keeps braces
+            // balanced across the segments, so leave that path untouched.)
+            int suffixStart = ms[ms.Count - 1].End;
+            if (!renderBraces)
+                foreach (var (ns, ne) in winNotes)
+                    if (suffixStart >= ns && suffixStart < ne) { suffixStart = Math.Min(ne, winEnd); break; }
             sb.Append(TeiText.Collapse(TeiText.Convert(
-                TeiText.Clean(xml, ms[ms.Count - 1].End, winEnd, renderBraces), opts.OutputScript)).TrimEnd());
+                TeiText.Clean(xml, suffixStart, winEnd, renderBraces), opts.OutputScript)).TrimEnd());
             sb.Append(ellipsisEnd ? " ..." : "");
 
             var (num, code, pages) = markers.RefsAt(anchor.Start);


### PR DESCRIPTION
Closes #355 (LOW; a #310 residual surfaced by the Fable re-review, area A4).

## The leak
When the search hit is **itself inside a `<note>`** (note text is indexed) and `IncludeFootnotes=false`, the snippet suffix `Clean(mark.End, winEnd)` starts mid-note. The #310 close-tag fix preserves the base text *after* the note, but the note's **post-hit remainder** — the variant reading tail + sigla, e.g. `(sī. syā.)` — rendered as **undelimited base text** up to the now-zero-width `</note>`. Pre-hit note content was already stripped, so the leak was one-sided.

Impact is LOW: what leaked is digitized print **apparatus** (variant readings + sigla), not private data, and only when the hit is literally inside a footnote — no dropped base text, no crash.

## Fix
- **`TeiSnippetExtractor`** — when the last mark is inside a note and we're not rendering braced apparatus, start the suffix at the enclosing note's **end**, so the tail is stripped like the already-correct pre-hit side. The braces path (`IncludeFootnotes`/`StructuredNotes`) is untouched — braces stay balanced across segments there.
- **`TeiPassageReader.WalkBackward`** — the same-class smaller case: the no-boundary fallback (`Math.Max(i+1, limit)`) could place a prev-page cursor mid-note (rendering that note's tail, and `Clean` from mid-note emits an unbalanced `}`). Snap it out to the enclosing note's start.

## Tests
- New regression test **verified to fail without the fix** (leaked `variant reading sii syaa`) and pass with it.
- A companion test pins the one-sidedness: with footnotes **on**, the note still shows as delimited apparatus.
- Full extraction / passage / search suite: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig