### PR TITLE
#109/#383: CI workflow to build & publish the DPD-lemma asset

### DIFF
--- a/.github/workflows/build-dpd-lemma-asset.yml
+++ b/.github/workflows/build-dpd-lemma-asset.yml
@@ -1,0 +1,119 @@
+# Builds the derived DPD-lemma asset (dpd-lemma.db) from a Digital Pāḷi Dictionary (DPD) release and publishes
+# it as a GitHub Release asset, so the app's (future) DpdUpdateService can download it — parallel to how the
+# corpus XML is delivered. Manual trigger: the DPD tag + scope are chosen at dispatch. (#109 / #383)
+#
+# Scope: `full` is the superset that powers EVERYTHING shipped — sandhi deconstruction (/v1/deconstruct needs
+# the non-enclitic deconstructors), the DPD dictionary source and lemma report (report-grade columns + the
+# meaning_2-coalesced gloss), and lemma search. `mid` drops the sandhi bulk (~half the size) but then
+# /v1/deconstruct only splits enclitics. Default `full`.
+#
+# Version tripwire: DpdLemmaBuilder's validation is pinned to the CURRENT DPD release (exact lemma count + a few
+# known lemma ids). A NEW DPD tag may fail those checks by design — that is a signal to re-verify the pinned
+# facts in tools/DpdLemmaBuilder/Program.cs and bump them deliberately, not a flaky build.
+
+name: Build DPD-lemma asset
+
+on:
+  workflow_dispatch:
+    inputs:
+      dpd_tag:
+        description: 'DPD dpd-db release tag to build from (e.g. v0.4.20260531)'
+        default: 'v0.4.20260531'
+        required: true
+      scope:
+        description: 'Builder scope. full = sandhi + dictionary + report + lemma; mid = no sandhi bulk'
+        default: 'full'
+        required: true
+        type: choice
+        options: [lean, mid, full]
+      publish:
+        description: 'Publish as a GitHub Release (unchecked = build + validate + upload artifact only)'
+        default: true
+        type: boolean
+
+permissions:
+  contents: write        # create/upload the release
+
+concurrency:
+  group: build-dpd-lemma-${{ inputs.scope }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install zstd
+        run: sudo apt-get update && sudo apt-get install -y zstd
+
+      - name: Download and extract DPD dpd.db
+        run: |
+          set -euo pipefail
+          url="https://github.com/digitalpalidictionary/dpd-db/releases/download/${{ inputs.dpd_tag }}/dpd.db.tar.bz2"
+          echo "Downloading $url"
+          curl -fSL "$url" -o dpd.db.tar.bz2
+          tar -xjf dpd.db.tar.bz2
+          rm -f dpd.db.tar.bz2
+          ls -la dpd.db
+
+      - name: Build dpd-lemma.db
+        run: |
+          set -euo pipefail
+          dotnet run -c Release --project tools/DpdLemmaBuilder -- \
+            dpd.db dpd-lemma.db --scope "${{ inputs.scope }}"
+          # DpdLemmaBuilder exits non-zero if any validation check fails, so a bad build fails the job here.
+
+      - name: Compress + checksum + manifest
+        run: |
+          set -euo pipefail
+          zstd -19 -T0 -f dpd-lemma.db -o dpd-lemma.db.zst
+          sha256sum dpd-lemma.db dpd-lemma.db.zst > dpd-lemma.sha256
+          raw=$(stat -c%s dpd-lemma.db)
+          zst=$(stat -c%s dpd-lemma.db.zst)
+          sha=$(sha256sum dpd-lemma.db.zst | cut -d' ' -f1)
+          cat > dpd-lemma.manifest.json <<JSON
+          {
+            "asset": "dpd-lemma",
+            "file": "dpd-lemma.db.zst",
+            "dpdTag": "${{ inputs.dpd_tag }}",
+            "scope": "${{ inputs.scope }}",
+            "rawBytes": $raw,
+            "zstBytes": $zst,
+            "sha256": "$sha"
+          }
+          JSON
+          echo "---- manifest ----"; cat dpd-lemma.manifest.json
+          echo "raw=$((raw/1024/1024))MB  zst=$((zst/1024/1024))MB"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dpd-lemma-${{ inputs.dpd_tag }}-${{ inputs.scope }}
+          path: |
+            dpd-lemma.db.zst
+            dpd-lemma.sha256
+            dpd-lemma.manifest.json
+          retention-days: 14
+
+      - name: Publish GitHub Release
+        if: ${{ inputs.publish }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="dpd-lemma-${{ inputs.dpd_tag }}-${{ inputs.scope }}"
+          files="dpd-lemma.db.zst dpd-lemma.sha256 dpd-lemma.manifest.json"
+          notes="Derived DPD-lemma asset built from DPD ${{ inputs.dpd_tag }} at scope '${{ inputs.scope }}'. Download dpd-lemma.db.zst, verify with dpd-lemma.sha256, decompress to dpd-lemma.db. See dpd-lemma.manifest.json for sizes + checksum."
+          # Idempotent per (dpd tag, scope): re-running clobbers the same release rather than erroring.
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" $files --clobber
+          else
+            gh release create "$tag" $files --title "DPD-lemma asset ($tag)" --notes "$notes"
+          fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ Lessons learned, known issues, and technical challenges:
 ### 🛠️ **development/** - Development Processes
 Guides for development workflows:
 - [Release Process](development/RELEASE_PROCESS.md) - Steps for releasing new versions
+- [DPD-lemma Asset](development/DPD_LEMMA_ASSET.md) - Building & delivering `dpd-lemma.db` (builder scopes, the CI workflow, the version tripwire)
 - [Code Review 2026-07-01](development/CODE_REVIEW_2026-07-01.md) - Multi-agent whole-codebase review (80 findings, ranked; hand-off for the fixing session)
 - [Cloud / Web Session Setup](development/CLOUD_SESSION_SETUP.md) - Provisioning a fresh remote container: XML corpus download, .NET SDK egress-policy block, CST_XML_DIR
 - [Proposed Claude Skills](development/PROPOSED_CLAUDE_SKILLS.md) - AI assistant skill definitions

--- a/docs/development/DPD_LEMMA_ASSET.md
+++ b/docs/development/DPD_LEMMA_ASSET.md
@@ -1,0 +1,47 @@
+# Building & delivering the DPD-lemma asset
+
+The lemma search, lemma report, sandhi decomposer (`/v1/deconstruct`), and the DPD dictionary source
+(`language: "dpd"`) are all powered by one derived SQLite asset, **`dpd-lemma.db`**, built from a
+[Digital Pāḷi Dictionary](https://www.dpdict.net/) (DPD) release. It is corpus-agnostic (no occurrence counts —
+those come from the app's Lucene index) and ships separately from the app binary; the app opens it read-only at
+`<app-support>/CSTReader/dpd-lemma/dpd-lemma.db` and degrades gracefully to "feature off" when it is absent.
+
+## The builder
+
+`tools/DpdLemmaBuilder` reads a full DPD `dpd.db` and emits `dpd-lemma.db`, keeping only the tables/columns the
+features need (see [../architecture/LEMMA_EXPANSION.md](../architecture/LEMMA_EXPANSION.md)). Scope tiers:
+
+| scope  | adds                                             | powers                                    | ~size (zst) |
+|--------|--------------------------------------------------|-------------------------------------------|-------------|
+| `lean` | `form_lemma` + `lemma`                            | resolver only                             | ~13 MB      |
+| `mid`  | + per-form grammar + report columns + enclitic decon | lemma search, report, dictionary; enclitic-only sandhi | ~25 MB |
+| `full` | + all sandhi deconstructors                       | **everything**, incl. compound `/v1/deconstruct` | ~51 MB |
+
+`full` is the superset that makes every shipped feature work; `mid` halves the size but limits
+`/v1/deconstruct` to enclitic splits. The builder's `gloss` column coalesces `meaning_2` when `meaning_1` is
+empty (~30% of headwords, mostly compounds — #109), so DPD dictionary definitions are never blank.
+
+```bash
+dotnet run -c Release --project tools/DpdLemmaBuilder -- <dpd.db> <out/dpd-lemma.db> --scope full
+```
+
+The builder ends with a **validation pass** (lemma count + known back-lookups/families) and exits non-zero if
+any check fails.
+
+## CI build & publish
+
+`.github/workflows/build-dpd-lemma-asset.yml` (manual `workflow_dispatch`) downloads a DPD
+`dpd.db.tar.bz2` release, runs the builder at the chosen scope, compresses with `zstd -19`, and publishes
+`dpd-lemma.db.zst` + a `.sha256` + a `dpd-lemma.manifest.json` (sizes, checksum, DPD tag, scope) as a GitHub
+Release tagged `dpd-lemma-<dpdTag>-<scope>`. Inputs: `dpd_tag` (default the last-validated release), `scope`
+(default `full`), and `publish` (uncheck to build + validate + upload an artifact only, without a release).
+
+**Version tripwire:** the builder's validation is pinned to the current DPD release (exact lemma count + a few
+known lemma ids). A *new* DPD tag can fail those checks by design — re-verify and bump the pinned facts in
+`tools/DpdLemmaBuilder/Program.cs` deliberately; it is not a flaky build.
+
+## App-side download (planned)
+
+A `DpdUpdateService` — parallel to `XmlUpdateService` for the corpus XML — will fetch the latest published
+`dpd-lemma.db.zst`, verify the checksum, and decompress it into app-support. Until then the asset is seeded
+manually. See the memory note *dpd-derived-asset-delivery* for the delivery design.


### PR DESCRIPTION
Item 1 from the Track E wrap-up: a CI pipeline that rebuilds the derived **`dpd-lemma.db`** asset so the merged sandhi (#384) and DPD-dictionary (#385) features actually ship with the data they need (converter v3 `meaning_2` coalesce; `full` scope for compound deconstruction).

## What it does
`.github/workflows/build-dpd-lemma-asset.yml` — manual `workflow_dispatch`:
1. Downloads a DPD `dpd.db.tar.bz2` release (input `dpd_tag`, default `v0.4.20260531`).
2. Runs `DpdLemmaBuilder` at `scope` (default **`full`** — the superset that powers sandhi + dictionary + report + lemma). The builder exits non-zero on any validation failure, so a bad build fails the job.
3. Compresses with `zstd -19`, writes a `.sha256` and a `dpd-lemma.manifest.json` (sizes, checksum, DPD tag, scope).
4. Uploads a workflow artifact always; if `publish` is checked, also publishes them as a GitHub Release tagged `dpd-lemma-<dpdTag>-<scope>` (idempotent per tag+scope via clobber).

## Validation
Everything locally-testable is green:
- YAML parses clean.
- `DpdLemmaBuilder` verified locally — builds the v3 asset (blank-gloss lemmas 26,782 → 0, all builder checks pass).
- `zstd -19` on the real asset: 118 MB → 25 MB (mid) / ~51 MB expected (full), matching estimates.
- The DPD download URL is confirmed live (`gh api` — `dpd.db.tar.bz2`, 177 MB, at `v0.4.20260531`).

**End-to-end CI validation is pending merge:** GitHub only allows dispatching a `workflow_dispatch` workflow once it exists on the **default branch**, so I can't run it from this PR branch. Once merged, the plan is: dispatch with **`publish: false`** first (build + validate + artifact, no release), confirm green, then a `publish: true` run to produce the shipping asset.

## Notes
- **Version tripwire:** the builder's validation is pinned to the current DPD release (exact lemma count + known ids). A *new* DPD tag can fail those checks by design — a signal to re-verify and bump the pinned facts, not a flaky build. Documented.
- Doc: `docs/development/DPD_LEMMA_ASSET.md` (builder scopes, CI flow, tripwire, the planned app-side `DpdUpdateService` download), indexed in `docs/README.md`.
- The app-side download service is a separate follow-up; this PR is the build+publish half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig