### PR TITLE
Rename the derived DPD asset: dpd-lemma.db → dpd-cst-subset.db

### DIFF
--- a/docs/architecture/LEMMA_EXPANSION.md
+++ b/docs/architecture/LEMMA_EXPANSION.md
@@ -29,7 +29,7 @@ for exactly those forms. DPD supplies the *candidate* forms; the corpus decides 
 ## 2. The DPD-lemma dataset
 
 We do not ship `dpd.db` (2.1 GB). A build tool (`DpdLemmaBuilder`) extracts a small, corpus-agnostic subset —
-**`dpd-lemma.db`** — from a given DPD release. Only the tables and columns the algorithm needs are copied:
+**`dpd-cst-subset.db`** (the derived DPD subset for CST) — from a given DPD release. Only the tables and columns the algorithm needs are copied:
 
 | Our table    | Source in `dpd.db`        | Columns kept | Role |
 |--------------|---------------------------|--------------|------|
@@ -96,7 +96,7 @@ result is flagged `ExpansionCapped` so the reader is told the count is a floor, 
 
 ### Step 4 — Attach corpus counts
 The search returns, per matched form, its **corpus occurrence count** and the number of books it appears in.
-**All counts come from the corpus index, never from `dpd-lemma.db`.** A DPD candidate form with count 0 is
+**All counts come from the corpus index, never from `dpd-cst-subset.db`.** A DPD candidate form with count 0 is
 therefore *synthetic* here — a form DPD can generate but that does not occur in this edition — and is reported as
 such (attested vs. candidate counts are shown separately).
 

--- a/docs/features/in-progress/DICTIONARIES.md
+++ b/docs/features/in-progress/DICTIONARIES.md
@@ -225,7 +225,7 @@ caller looks a word up the same way regardless of source:
   (`manifest.json` with id/headwordScript/meaningFormat/languages) is a later
   option, not required.
 - **Digital Pāḷi Dictionary (DPD)** — the reserved language code **`dpd`**, present
-  only when the DPD-lemma asset (`dpd-lemma.db`) is installed. DPD ships **no
+  only when the dpd-cst-subset asset (`dpd-cst-subset.db`) is installed. DPD ships **no
   rendered-HTML definitions**, so entries are **composed on the fly** from the
   asset's structured columns (pos + gloss + literal meaning + construction) by
   `CompositeDictionaryTool`. The word→entry key reuses the same `form_lemma`

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -996,12 +996,14 @@ public partial class App : Application
         services.AddSingleton<ISearchService, SearchService>();
         services.AddSingleton<IDictionaryService, DictionaryService>();
 
-        // Lemma search (DPD-lemma asset). NOT AI-gated — a core reading/search feature; degrades to "off"
-        // when the asset is absent. The asset is seeded/downloaded to <app-support>/CSTReader/dpd-lemma/.
-        var dpdLemmaPath = System.IO.Path.Combine(
+        // Lemma/dictionary/sandhi (dpd-cst-subset asset — our derived DPD subset for CST). NOT AI-gated — a core
+        // reading/search feature; availability is driven by FILE PRESENCE alone (no setting), degrading to "off"
+        // when absent. Seeded/downloaded to <app-support>/CSTReader/dpd-cst-subset/. (Opened once at startup, so a
+        // manually dropped-in file activates on the next launch.)
+        var dpdCstSubsetPath = System.IO.Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            AppConstants.AppDataDirectoryName, "dpd-lemma", "dpd-lemma.db");
-        services.AddSingleton<CST.Lemma.ILemmaProvider>(_ => new CST.Lemma.SqliteLemmaProvider(dpdLemmaPath));
+            AppConstants.AppDataDirectoryName, "dpd-cst-subset", "dpd-cst-subset.db");
+        services.AddSingleton<CST.Lemma.ILemmaProvider>(_ => new CST.Lemma.SqliteLemmaProvider(dpdCstSubsetPath));
         services.AddSingleton<ILemmaSearchService, LemmaSearchService>();
         services.AddSingleton<ILemmaReportService, LemmaReportService>();
 

--- a/src/CST.Lemma/ILemmaProvider.cs
+++ b/src/CST.Lemma/ILemmaProvider.cs
@@ -1,7 +1,7 @@
 namespace CST.Lemma;
 
 /// <summary>
-/// Read access to a DPD-lemma asset (dpd-lemma.db): the two hops of lemma search —
+/// Read access to the dpd-cst-subset asset (dpd-cst-subset.db, the derived DPD subset for CST): the two hops of lemma search —
 /// <see cref="ResolveForm"/> (a surface form → its candidate lemmas) and
 /// <see cref="ExpandLemma"/> (a lemma → its attested surface forms). Corpus-agnostic: no occurrence
 /// counts (those come from the search index). Forms are IAST; callers convert to IPE to search.

--- a/tools/DpdLemmaBuilder/Program.cs
+++ b/tools/DpdLemmaBuilder/Program.cs
@@ -3,11 +3,11 @@ using System.Text.Json;
 using Microsoft.Data.Sqlite;
 
 // =====================================================================================================
-// DPD-lemma generator
-// Builds the trimmed, CORPUS-AGNOSTIC form->lemma asset (dpd-lemma.db) from a full DPD dpd.db release.
+// dpd-cst-subset generator (the derived DPD subset for CST — form->lemma + report + optional sandhi)
+// Builds the trimmed, CORPUS-AGNOSTIC asset (dpd-cst-subset.db) from a full DPD dpd.db release.
 //
 //   Inputs : a full DPD `dpd.db` (from digitalpalidictionary/dpd-db releases; has the `lookup` table).
-//   Output : `dpd-lemma.db` — form->lemma resolution + lemma metadata, stripped of everything else.
+//   Output : `dpd-cst-subset.db` — form->lemma resolution + lemma metadata, stripped of everything else.
 //
 // Keeps (Layer A only): form -> lemma resolution, lemma metadata (lemma/pos/gloss/derived_from), and
 // (mid/full) per-form grammar. DROPS: occurrence counts (Layer B = the app's Lucene index), roots,
@@ -19,7 +19,7 @@ using Microsoft.Data.Sqlite;
 //   mid  : + per-form grammar        (resolvable forms only; powers disambig UI)  ~20 MB zst   <-- v1
 //   full : + sandhi deconstructions  (861k splits; for a future sandhi feature)   ~46 MB zst
 //
-// Usage: DpdLemmaBuilder [<dpd.db path> [<output dpd-lemma.db path>]] [--scope lean|mid|full]
+// Usage: DpdLemmaBuilder [<dpd.db path> [<output dpd-cst-subset.db path>]] [--scope lean|mid|full]
 // =====================================================================================================
 
 const string ConverterVersion = "3";   // v3: gloss coalesces meaning_2 (blank-compound fix, #109)
@@ -41,7 +41,7 @@ if (scope is not ("lean" or "mid" or "full"))
     return 2;
 }
 string srcPath = positional.Count > 0 ? positional[0] : "/Users/fsnow/dpd-poc/dpd.db";
-string outPath = positional.Count > 1 ? positional[1] : "/Users/fsnow/dpd-poc/dpd-lemma.db";
+string outPath = positional.Count > 1 ? positional[1] : "/Users/fsnow/dpd-poc/dpd-cst-subset.db";
 
 bool includeForms = scope != "lean";      // the forms (grammar) table
 bool includeDecon = scope == "full";      // the FULL sandhi deconstructor (every decomposable form)
@@ -313,7 +313,7 @@ void Meta(string k, string v)
     c.Parameters.AddWithValue("$v", v);
     c.ExecuteNonQuery();
 }
-Meta("asset", "dpd-lemma");
+Meta("asset", "dpd-cst-subset");
 Meta("scope", scope);
 Meta("dpd_version", dpdVersion);
 Meta("converter_version", ConverterVersion);


### PR DESCRIPTION
Per the naming decision: the derived asset now carries more than the lemma index (sandhi deconstructions, report columns, and it backs the DPD dictionary), so **`dpd-lemma`** undersold it. New name **`dpd-cst-subset`** reads as *"the DPD subset for CST"* — deliberately keeping **"subset"** so it can't be misread as CST branding on DPD; it's *our derived subset of* DPD.

## Scope — public artifact only
- App-support path → `<app-support>/CSTReader/dpd-cst-subset/dpd-cst-subset.db` (`App.axaml.cs`) — the one functional change.
- `DpdLemmaBuilder` default output path + `meta.asset` value + header comments.
- Doc/summary references (`DICTIONARIES.md`, `LEMMA_EXPANSION.md`, `ILemmaProvider`).

**Internal code kept as-is** — `CST.Lemma`, `SqliteLemmaProvider`, `ILemmaProvider`, `DpdLemma*`, `LemmaSearchService`. The form→lemma index is the backbone everything keys off; renaming those namespaces is high-churn/low-value.

## Notes
- Asset is **unreleased (zero users)** → no migration. Your local install will need the file moved to the new `dpd-cst-subset/` dir (restart to activate, which you confirmed is fine).
- Feature availability stays **file-presence driven** (no enable-setting).
- Full lemma / dictionary / LocalApi suite green (134).

Follow-ups (separate PRs, per your last message): gate the llms.txt DPD sections on asset presence (don't waste agent tokens when absent) + close the asset-absent integration test gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig