### PR TITLE
Gate the DPD/lemma llms.txt docs on asset presence + asset-absent test coverage

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiAssetAbsentTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiAssetAbsentTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using System.Threading.Tasks;
+using CST.Avalonia.Tests.TestSupport;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Integration
+{
+    /// <summary>
+    /// End-to-end coverage of the asset-ABSENT path: the assembled surface-C stack with NO dpd-cst-subset asset
+    /// installed. Asserts the lemma/dictionary endpoints degrade cleanly (503, not 500/hang) and — the token-cost
+    /// point — that the DPD doc regions are GATED OUT of llms.txt so an agent never discovers functionality that
+    /// only 503s. Shares the serial "LocalApiIntegration" collection (fixture indexing mutates global Books).
+    /// </summary>
+    [Collection("LocalApiIntegration")]
+    public class LocalApiAssetAbsentTests : IAsyncLifetime
+    {
+        private LocalApiTestServer _api = null!;
+
+        public async Task InitializeAsync() => _api = await LocalApiTestServer.StartAsync(withLemmaAsset: false);
+        public async Task DisposeAsync() => await _api.DisposeAsync();
+
+        [Theory]
+        [InlineData("/v1/lemma/dhamma")]
+        [InlineData("/v1/forms/100")]
+        [InlineData("/v1/deconstruct/dhamma")]
+        [InlineData("/v1/lemma-report/100")]
+        public async Task Lemma_endpoints_return_503_when_asset_absent(string path)
+        {
+            using var http = _api.Http();
+            var resp = await http.GetAsync(path);
+            // Mapped-but-unavailable: a clear 503 (the "dataset not installed" contract), never a 500 or a hang.
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.Contains("not installed", body);
+        }
+
+        [Fact]
+        public async Task Llms_full_gates_out_the_dpd_sections_but_keeps_the_flat_dictionary()
+        {
+            using var http = _api.Http();
+            var resp = await http.GetAsync("/llms-full.txt");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            var body = await resp.Content.ReadAsStringAsync();
+
+            // DPD/lemma endpoints are gated away so an agent doesn't spend tokens on 503-only functionality.
+            Assert.DoesNotContain("/v1/deconstruct", body);
+            Assert.DoesNotContain("/v1/lemma/{form}", body);
+            Assert.DoesNotContain("/v1/forms/{lemmaId}", body);
+            Assert.DoesNotContain("language:\"dpd\"", body);
+            // The flat dictionary (en/hi) is unaffected — it works without the asset.
+            Assert.Contains("/v1/dictionary/languages", body);
+            Assert.Contains("/v1/dictionary/lookup", body);
+        }
+
+        [Fact]
+        public async Task Dictionary_doc_slice_gates_out_dpd_but_keeps_flat()
+        {
+            using var http = _api.Http();
+            var resp = await http.GetAsync("/docs/dictionary.md");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.DoesNotContain("/v1/deconstruct", body);
+            Assert.DoesNotContain("/v1/lemma/{form}", body);
+            Assert.Contains("/v1/dictionary/languages", body);
+        }
+    }
+}

--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -26,6 +26,12 @@ namespace CST.Avalonia.Tests.Integration
     /// share one server (built once) and run serially, because building the fixture index mutates global
     /// <c>Books</c> DocId state.
     /// </summary>
+    // Shared serial collection: the integration classes all build a fixture index that mutates the global Books
+    // DocId state, so they must NOT run in parallel with one another. (#355-era asset-absent coverage)
+    [CollectionDefinition("LocalApiIntegration", DisableParallelization = true)]
+    public sealed class LocalApiIntegrationCollection { }
+
+    [Collection("LocalApiIntegration")]
     public class LocalApiIntegrationTests : IAsyncLifetime
     {
         private LocalApiTestServer _api = null!;

--- a/src/CST.Avalonia.Tests/LocalApi/LayeredDocsTests.cs
+++ b/src/CST.Avalonia.Tests/LocalApi/LayeredDocsTests.cs
@@ -11,6 +11,31 @@ namespace CST.Avalonia.Tests.LocalApi
             "- `GET /v1/status` - core (unmarked)\n" +
             "<!--doc:reading-->\n- `POST /v1/passage` - read\n<!--/doc:reading-->\n";
 
+        // A doc with a DPD-gated block nested inside a topic region, plus a non-DPD sibling bullet.
+        private const string DpdSample =
+            "<!--doc:dictionary-->\n- `GET /v1/dictionary/languages` - flat dicts\n" +
+            "<!--dpd-->\n- `GET /v1/lemma/{form}` - DPD only\n<!--/dpd-->\n" +
+            "<!--/doc:dictionary-->\n";
+
+        [Fact]
+        public void GateDpd_present_strips_only_the_dpd_markers_keeps_content()
+        {
+            var s = LayeredDocs.GateDpd(DpdSample, assetAvailable: true);
+            Assert.DoesNotContain("<!--dpd-->", s);
+            Assert.DoesNotContain("<!--/dpd-->", s);
+            Assert.Contains("/v1/lemma/{form}", s);          // DPD content kept
+            Assert.Contains("/v1/dictionary/languages", s);  // flat content kept
+        }
+
+        [Fact]
+        public void GateDpd_absent_drops_the_whole_dpd_region_keeps_the_flat_sibling()
+        {
+            var s = LayeredDocs.GateDpd(DpdSample, assetAvailable: false);
+            Assert.DoesNotContain("/v1/lemma/{form}", s);     // DPD block gone
+            Assert.DoesNotContain("<!--dpd-->", s);
+            Assert.Contains("/v1/dictionary/languages", s);   // flat sibling survives
+        }
+
         [Fact]
         public void StripMarkers_removes_every_marker_but_keeps_content()
         {

--- a/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
+++ b/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
@@ -60,7 +60,11 @@ namespace CST.Avalonia.Tests.TestSupport
             return http;
         }
 
-        public static async Task<LocalApiTestServer> StartAsync()
+        /// <param name="withLemmaAsset">When false, the lemma provider points at a NONEXISTENT asset (IsAvailable
+        /// == false) so the assembled stack exercises the asset-ABSENT path: lemma endpoints 503, MCP lemma tools
+        /// unregistered, and the DPD doc regions gated out of llms.txt — the real app's behavior when the
+        /// dpd-cst-subset file isn't installed.</param>
+        public static async Task<LocalApiTestServer> StartAsync(bool withLemmaAsset = true)
         {
             var root = Path.Combine(Path.GetTempPath(), "cst-int-" + Guid.NewGuid().ToString("N"));
             var xmlDir = Path.Combine(root, "xml");
@@ -116,8 +120,10 @@ namespace CST.Avalonia.Tests.TestSupport
 
             // DPD-lemma fixture: 'dhamma' is a homograph (lemmas 100/101); lemma 100's paradigm has three
             // corpus-attested forms (dhamma, citta, kamma) + one synthetic form (dhammani, absent from the corpus).
-            string dpdLemmaPath = Path.Combine(root, "dpd-lemma.db");
-            BuildLemmaFixture(dpdLemmaPath);
+            string dpdLemmaPath = Path.Combine(root, "dpd-cst-subset.db");
+            if (withLemmaAsset) BuildLemmaFixture(dpdLemmaPath);
+            // withLemmaAsset:false -> point at a path that does NOT exist, so IsAvailable is false and the whole
+            // assembled stack takes the asset-absent path (503s / gated docs), exactly as the shipped app does.
             var lemmaProvider = new SqliteLemmaProvider(dpdLemmaPath);
             var lemmaSearch = new LemmaSearchService(lemmaProvider, searchService);
             var lemmaReport = new LemmaReportService(lemmaProvider, lemmaSearch);

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -201,13 +201,15 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - `POST /v1/dictionary/lookup` - `{ language, query, outputScript?, maxEntries? }`
   -> entries `{ headword, meaningHtml, source, lemmaId? }`, where `source` is the dictionary's title for inline
   attribution (null if unrecorded; the full citation is in `/v1/dictionary/languages`).
-  The bundled flat dictionaries (`en`, `hi`) do exact/prefix/nearest-neighbor matching. When the DPD-lemma
-  dataset is installed, `language:"dpd"` looks a word up in the **Digital Pāḷi Dictionary** — an inflected word
-  resolves through the same form->lemma index as the lemma endpoints (EXACT inflected-form match, no prefix/
-  nearest fallback), so one word can return SEVERAL entries (its candidate homograph lemmas). A DPD entry's `lemmaId` chains to `/v1/lemma-report/{lemmaId}` (full
-  dossier: etymology, root, paradigm, frequency) or `/v1/forms/{lemmaId}` (attested paradigm with counts) - the
-  dictionary meaning is deliberately COMPACT and the report is where the depth lives. `lemmaId` is null for the
-  flat dictionaries.
+  The bundled flat dictionaries (`en`, `hi`) do exact/prefix/nearest-neighbor matching.
+<!--dpd-->
+  When the dpd-cst-subset dataset is installed, `language:"dpd"` looks a word up in the **Digital Pāḷi
+  Dictionary** — an inflected word resolves through the same form->lemma index as the lemma endpoints (EXACT
+  inflected-form match, no prefix/nearest fallback), so one word can return SEVERAL entries (its candidate
+  homograph lemmas). A DPD entry's `lemmaId` chains to `/v1/lemma-report/{lemmaId}` (full dossier: etymology,
+  root, paradigm, frequency) or `/v1/forms/{lemmaId}` (attested paradigm with counts) - the dictionary meaning
+  is deliberately COMPACT and the report is where the depth lives. `lemmaId` is null for the flat dictionaries.
+<!--/dpd-->
 <!--/doc:dictionary-->
 <!--doc:scripts-->
 - `POST /v1/convert` - convert Pali text to another script. Body `{ text, outputScript }` -> `{ text, outputScript }`.
@@ -215,11 +217,12 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 - `GET  /v1/scripts` - the valid script names for `outputScript` and the `?script=` params.
 <!--/doc:scripts-->
 <!--doc:dictionary-->
+<!--dpd-->
 - `GET  /v1/lemma/{form}?script=` - LEMMA back-lookup: resolve a surface form to its candidate dictionary
   lemmas (DPD). Returns `{ form, candidates:[{ lemmaId, lemma, pos, gloss, derivedFrom }], note }`. A form is
   often a HOMOGRAPH (>1 candidate) - pick the intended `lemmaId`. `script` is BOTH the input form's script and
   the output. `{form}` is a PATH segment, so PERCENT-ENCODE diacritics (`pajānāti` -> `paj%C4%81n%C4%81ti`).
-  (Present only when the DPD-lemma dataset is installed; 503 if not.)
+  (Present only when the dpd-cst-subset dataset is installed; 503 if not.)
 - `GET  /v1/forms/{lemmaId}?family=&script=` - LEMMA forward-expansion: a lemma's ATTESTED paradigm WITH
   corpus counts. Returns `{ lemmaId, lemma, pos, gloss, forms:[{ form, count, bookCount }], totalOccurrences,
   attestedFormCount, candidateFormCount, expansionCapped, note }`. This answers "the whole declension/
@@ -247,8 +250,9 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   comes back with `directLemmas` and no split. This is the word->PARTS step only: each part is a surface form,
   so chain it - `GET /v1/lemma/{part}` for the part's lemma(s) (a part is often a HOMOGRAPH), then
   `/v1/dictionary/lookup` for glosses. `{word}` is a PATH segment, so PERCENT-ENCODE diacritics. `script` is
-  BOTH the input and output script. (Present only when the DPD-lemma dataset is installed; 503 if not. Full
+  BOTH the input and output script. (Present only when the dpd-cst-subset dataset is installed; 503 if not. Full
   compound coverage needs the full-scope asset; a mid-scope asset splits only enclitics like `…ti`/`…iti`.)
+<!--/dpd-->
 <!--/doc:dictionary-->
 
 <!--doc:search-->

--- a/src/CST.Avalonia/Services/LocalApi/LayeredDocs.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LayeredDocs.cs
@@ -35,6 +35,22 @@ namespace CST.Avalonia.Services.LocalApi
 
         private static readonly Regex MultiBlank = new(@"\n{3,}", RegexOptions.Compiled);
 
+        // Asset-dependent blocks: <!--dpd-->…<!--/dpd--> wraps content that only works when the dpd-cst-subset
+        // asset is installed (lemma / forms / deconstruct endpoints + the DPD dictionary source). These nest
+        // INSIDE the doc:TOPIC regions; GateDpd runs FIRST so the doc-marker processing then sees a doc that
+        // already reflects asset presence.
+        private static readonly Regex DpdMarkerLine =
+            new(@"^[ \t]*<!--/?dpd-->[ \t]*\r?\n?", RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex DpdRegion =
+            new(@"[ \t]*<!--dpd-->.*?<!--/dpd-->[ \t]*\r?\n?", RegexOptions.Singleline | RegexOptions.Compiled);
+
+        /// <summary>Gate the DPD/lemma blocks on asset presence: when the dpd-cst-subset asset is ABSENT, drop the
+        /// whole <c>&lt;!--dpd--&gt;…&lt;!--/dpd--&gt;</c> regions so agents don't discover functionality that only
+        /// 503s (matching the MCP tools, which are already unregistered when the asset is absent); when PRESENT,
+        /// just remove the marker lines and keep the content. Apply BEFORE the doc-marker processing.</summary>
+        public static string GateDpd(string raw, bool assetAvailable) =>
+            assetAvailable ? DpdMarkerLine.Replace(raw, "") : DpdRegion.Replace(raw, "");
+
         /// <summary>Remove every region marker line (for the full-document output).</summary>
         public static string StripMarkers(string raw) => MarkerLine.Replace(raw, "");
 

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -355,10 +355,16 @@ namespace CST.Avalonia.Services.LocalApi
         // The version-stamped FULL llms.txt body (markers stripped), served at GET /llms-full.txt and as the
         // MCP llms.txt resource. /llms.txt itself serves the thin index (BuildThinIndex). Single source (the
         // embedded resource), so none of the three can drift. Version-stamped per build.
+        // Whether the DPD/lemma docs should be served: the asset must be installed (same contract as the
+        // endpoints/MCP tools). Absent → GateDpd drops the <!--dpd--> regions so agents don't discover 503-only
+        // functionality. Evaluated per request (restart-to-activate: the provider opens the file once at startup).
+        private bool DpdDocsAvailable => _lemma?.IsAvailable == true;
+
         private string BuildLlmsText()
         {
             var body = ReadResource("LocalApi.llms.txt")
                 ?? "# CST Reader Local API\n\n(llms.txt resource missing)\n";
+            body = LayeredDocs.GateDpd(body, DpdDocsAvailable);
             // Strip the progressive-discovery region markers; the full document is the monolith. (#259)
             return $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + LayeredDocs.StripMarkers(body);
         }
@@ -368,6 +374,7 @@ namespace CST.Avalonia.Services.LocalApi
         {
             var body = ReadResource("LocalApi.llms.txt")
                 ?? "# CST Reader Local API\n\n(llms.txt resource missing)\n";
+            body = LayeredDocs.GateDpd(body, DpdDocsAvailable);
             return $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + LayeredDocs.ThinIndex(body);
         }
 
@@ -376,6 +383,7 @@ namespace CST.Avalonia.Services.LocalApi
         private string? BuildDocSlice(string topic)
         {
             var raw = ReadResource("LocalApi.llms.txt");
+            if (raw is not null) raw = LayeredDocs.GateDpd(raw, DpdDocsAvailable);
             var slice = raw is null ? null : LayeredDocs.Slice(raw, topic);
             return slice is null ? null : $"<!-- CST Reader {_appVersion} | API {ApiVersion} -->\n" + slice;
         }


### PR DESCRIPTION
Addresses your two points: **don't waste agent tokens on absent DPD functionality**, and **close the asset-absent test gap**.

## The problem
When the `dpd-cst-subset` asset is absent, the lemma/forms/deconstruct endpoints 503 and `language:"dpd"` is unavailable — but **llms.txt is a static resource**, so it kept advertising them. A REST agent could read the docs, call, and burn tokens on 503-only functionality. (MCP already unregisters its lemma/sandhi tools when absent; this makes the docs entry point match.)

## Gating
- **`LayeredDocs.GateDpd(raw, assetAvailable)`** — asset-dependent blocks are wrapped in `<!--dpd-->…<!--/dpd-->`. Present → strip just the marker lines (keep content); absent → drop the whole regions. Runs before the doc-marker processing, so `/llms-full.txt`, `/llms.txt`, and the `/docs/*.md` slices all reflect it.
- **llms.txt** — wrapped the DPD dictionary paragraph (split from the flat-dict sentence, which stays) and the entire lemma/forms/deconstruct block; also updated the naming to `dpd-cst-subset`.
- **`LocalApiServer`** — `BuildLlmsText` / `BuildThinIndex` / `BuildDocSlice` gate on `_lemma?.IsAvailable` (per request; restart-to-activate). The flat **en/hi** dictionary docs are untouched — they work without the asset.

## Test coverage (the gap)
- **`LocalApiAssetAbsentTests`** (new, end-to-end, no asset): `/v1/lemma`, `/v1/forms`, `/v1/deconstruct`, `/v1/lemma-report` all return **503**; `/llms-full.txt` and `/docs/dictionary.md` **omit** the DPD endpoints but **keep** `/v1/dictionary`. Shares a serial collection with the existing integration class (fixture indexing mutates global `Books`).
- **`LocalApiTestServer`** gains a `withLemmaAsset` flag (false → provider over a nonexistent path → `IsAvailable` false, the shipped app's absent-file behavior).
- **`LayeredDocsTests`** — `GateDpd` both directions (present keeps content; absent drops the region, keeps the flat sibling).

Full suite **733 green**.

Note: uses the new `dpd-cst-subset` name in llms.txt; complements the rename PR #389 (which doesn't touch llms.txt), so no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig