### PR TITLE
#390: DpdUpdateService — download/poll the dpd-cst-subset asset from GitHub Releases

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using CST.Avalonia.Services;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+// Unit tests for DpdUpdateService's testable core (#390): manifest parsing, the two-axis version comparison,
+// the installed-meta read, and the verify→decompress→atomic-install with preservation of a good existing asset.
+public sealed class DpdUpdateServiceTests : IDisposable
+{
+    private readonly string _dir;
+
+    public DpdUpdateServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"dpd-upd-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    private static byte[] Gzip(byte[] data)
+    {
+        using var ms = new MemoryStream();
+        using (var gz = new GZipStream(ms, CompressionMode.Compress)) gz.Write(data, 0, data.Length);
+        return ms.ToArray();
+    }
+
+    private static string Sha(byte[] b) => Convert.ToHexString(SHA256.HashData(b)).ToLowerInvariant();
+
+    private static byte[] Manifest(string file, string dpd, string conv, string sha) =>
+        Encoding.UTF8.GetBytes(
+            $$"""{"file":"{{file}}","dpdVersion":"{{dpd}}","converterVersion":"{{conv}}","schemaVersion":"2","scope":"full","sha256":"{{sha}}","compressedBytes":10,"rawBytes":20}""");
+
+    // ---- ParseManifest ----
+
+    [Fact]
+    public void ParseManifest_reads_a_valid_manifest()
+    {
+        var m = DpdUpdateService.ParseManifest(Manifest("dpd-cst-subset.db.gz", "v0.4.20260531", "3", "abc123"));
+        Assert.NotNull(m);
+        Assert.Equal("dpd-cst-subset.db.gz", m!.File);
+        Assert.Equal("v0.4.20260531", m.DpdVersion);
+        Assert.Equal("3", m.ConverterVersion);
+        Assert.Equal("abc123", m.Sha256);
+        Assert.Equal("full", m.Scope);
+    }
+
+    [Theory]
+    [InlineData("""{"dpdVersion":"v1","converterVersion":"3","sha256":"a"}""")]        // no file
+    [InlineData("""{"file":"x.gz","converterVersion":"3","sha256":"a"}""")]            // no dpdVersion
+    [InlineData("""{"file":"x.gz","dpdVersion":"v1","sha256":"a"}""")]                 // no converterVersion
+    [InlineData("""{"file":"x.gz","dpdVersion":"v1","converterVersion":"3"}""")]        // no sha256
+    [InlineData("not json")]
+    [InlineData("[1,2,3]")]                                                             // not an object
+    public void ParseManifest_rejects_incomplete_or_malformed(string json)
+        => Assert.Null(DpdUpdateService.ParseManifest(Encoding.UTF8.GetBytes(json)));
+
+    // ---- NeedsUpdate (two version axes) ----
+
+    [Fact]
+    public void NeedsUpdate_true_when_asset_absent()
+    {
+        var m = DpdUpdateService.ParseManifest(Manifest("x.gz", "v1", "3", "a"))!;
+        Assert.True(DpdUpdateService.NeedsUpdate(null, m));
+    }
+
+    [Fact]
+    public void NeedsUpdate_false_when_both_axes_match()
+    {
+        var m = DpdUpdateService.ParseManifest(Manifest("x.gz", "v1", "3", "a"))!;
+        Assert.False(DpdUpdateService.NeedsUpdate(new DpdUpdateService.InstalledMeta("v1", "3"), m));
+    }
+
+    [Fact]
+    public void NeedsUpdate_true_on_a_new_dpd_version()
+    {
+        var m = DpdUpdateService.ParseManifest(Manifest("x.gz", "v2", "3", "a"))!;
+        Assert.True(DpdUpdateService.NeedsUpdate(new DpdUpdateService.InstalledMeta("v1", "3"), m));
+    }
+
+    [Fact]
+    public void NeedsUpdate_true_on_a_converter_bump_even_with_same_dpd()
+    {
+        // The second axis: our converter changed (e.g. the meaning_2 coalesce) with DPD unchanged.
+        var m = DpdUpdateService.ParseManifest(Manifest("x.gz", "v1", "4", "a"))!;
+        Assert.True(DpdUpdateService.NeedsUpdate(new DpdUpdateService.InstalledMeta("v1", "3"), m));
+    }
+
+    // ---- InstallFromGzip: verify + decompress + atomic install + preservation ----
+
+    [Fact]
+    public void InstallFromGzip_verifies_decompresses_and_installs()
+    {
+        // A REAL (tiny) valid asset db as the payload — InstallFromGzip now probes that the decompressed file is a
+        // usable asset before installing.
+        var gz = Gzip(BuildAssetDbBytes(dpd: "v1", conv: "3"));
+        var final = Path.Combine(_dir, "sub", "dpd-cst-subset.db");   // note: a not-yet-existing subdir
+
+        DpdUpdateService.InstallFromGzip(gz, Sha(gz), final);
+
+        Assert.True(File.Exists(final));
+        Assert.Equal("v1", DpdUpdateService.ReadInstalledMeta(final)!.DpdVersion);  // installed + readable
+        Assert.False(File.Exists(final + ".new"));                    // temp cleaned up
+    }
+
+    [Fact]
+    public void InstallFromGzip_rejects_a_sha_mismatch_and_preserves_the_existing_asset()
+    {
+        var final = Path.Combine(_dir, "dpd-cst-subset.db");
+        File.WriteAllText(final, "GOOD-OLD-ASSET");
+        var gz = Gzip(BuildAssetDbBytes("v1", "3"));
+
+        Assert.Throws<InvalidDataException>(() => DpdUpdateService.InstallFromGzip(gz, "deadbeef", final));
+
+        Assert.Equal("GOOD-OLD-ASSET", File.ReadAllText(final));      // untouched
+        Assert.False(File.Exists(final + ".new"));                    // temp cleaned up
+    }
+
+    [Fact]
+    public void InstallFromGzip_rejects_a_valid_gzip_that_is_not_a_usable_asset_and_preserves_existing()
+    {
+        // Transport is fine (SHA matches its own bytes) but the decompressed content is NOT a usable dpd-cst-subset
+        // db — a bad PUBLISH must not clobber a good install. (fable review — preservation gap)
+        var final = Path.Combine(_dir, "dpd-cst-subset.db");
+        File.WriteAllText(final, "GOOD-OLD-ASSET");
+        var gz = Gzip(Encoding.UTF8.GetBytes("decompresses fine but is not a sqlite asset"));
+
+        Assert.Throws<InvalidDataException>(() => DpdUpdateService.InstallFromGzip(gz, Sha(gz), final));
+
+        Assert.Equal("GOOD-OLD-ASSET", File.ReadAllText(final));      // preserved despite a matching SHA
+        Assert.False(File.Exists(final + ".new"));
+    }
+
+    // ---- ReadInstalledMeta ----
+
+    [Fact]
+    public void ReadInstalledMeta_reads_versions_from_a_real_asset()
+    {
+        var db = Path.Combine(_dir, "installed.db");
+        BuildMetaFixture(db, dpd: "v0.4.20260531", conv: "3");
+        var m = DpdUpdateService.ReadInstalledMeta(db);
+        Assert.NotNull(m);
+        Assert.Equal("v0.4.20260531", m!.DpdVersion);
+        Assert.Equal("3", m.ConverterVersion);
+    }
+
+    [Fact]
+    public void ReadInstalledMeta_null_when_absent() =>
+        Assert.Null(DpdUpdateService.ReadInstalledMeta(Path.Combine(_dir, "nope.db")));
+
+    private void BuildMetaFixture(string path, string dpd, string conv)
+    {
+        using (var c = new SqliteConnection($"Data Source={path}"))
+        {
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = @"
+                CREATE TABLE lemma (id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT);
+                CREATE TABLE form_lemma (form TEXT NOT NULL, lemma_id INTEGER NOT NULL);
+                CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+                INSERT INTO meta VALUES ('dpd_version','" + dpd + @"'),('converter_version','" + conv + @"');";
+            cmd.ExecuteNonQuery();
+        }
+        SqliteConnection.ClearAllPools();   // release the file handle so callers can read its bytes
+    }
+
+    // A minimal but VALID dpd-cst-subset asset (has lemma + form_lemma + meta so SqliteLemmaProvider.IsAvailable),
+    // returned as the raw db bytes for use as a download payload.
+    private byte[] BuildAssetDbBytes(string dpd, string conv)
+    {
+        var p = Path.Combine(_dir, $"payload-{Guid.NewGuid():N}.db");
+        BuildMetaFixture(p, dpd, conv);
+        var bytes = File.ReadAllBytes(p);
+        File.Delete(p);
+        return bytes;
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -514,6 +514,16 @@ public partial class App : Application
             await xmlUpdateService.CheckForUpdatesAsync();
 
             Log.Information("CheckForXmlUpdatesAsync() completed");
+
+            // dpd-cst-subset asset (lemma / dictionary / sandhi): check + download in the BACKGROUND
+            // (fire-and-forget) so a ~60 MB download never delays startup. Availability is driven by file
+            // presence, so a freshly downloaded asset simply activates on the NEXT launch. (#390)
+            var dpdUpdateService = ServiceProvider?.GetService<IDpdUpdateService>();
+            if (dpdUpdateService != null)
+            {
+                dpdUpdateService.StatusChanged += message => Log.Information("DPD Asset Status: {Message}", message);
+                _ = Task.Run(() => dpdUpdateService.CheckAndUpdateAsync());
+            }
         }
         catch (Exception ex)
         {
@@ -1025,6 +1035,7 @@ public partial class App : Application
         
         // XML Update service
         services.AddSingleton<IXmlUpdateService, XmlUpdateService>();
+        services.AddSingleton<IDpdUpdateService, DpdUpdateService>();
 
         // SharePoint service for PDF downloads
         services.AddSingleton<ISharePointService, SharePointService>();

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -16,6 +16,7 @@ namespace CST.Avalonia.Models
         public FontSettings FontSettings { get; set; } = new();
         public DeveloperSettings DeveloperSettings { get; set; } = new();
         public XmlUpdateSettings XmlUpdateSettings { get; set; } = new();
+        public DpdUpdateSettings DpdUpdateSettings { get; set; } = new();
         public AiSettings Ai { get; set; } = new();
     }
 
@@ -86,6 +87,19 @@ namespace CST.Avalonia.Models
         public string XmlRepositoryName { get; set; } = "tipitaka-xml";
         public string XmlRepositoryPath { get; set; } = "deva master";
         public string XmlRepositoryBranch { get; set; } = "main";
+    }
+
+    /// <summary>
+    /// Update settings for the derived <c>dpd-cst-subset</c> asset (lemma / dictionary / sandhi). <see cref="EnablePolling"/>
+    /// is the ONLY DPD-related setting — it toggles the background check-for-a-newer-release, NOT whether the
+    /// features work: availability is driven purely by the asset FILE being present, so a manually dropped-in
+    /// file works regardless of this flag. Points at the derived-asset repo's releases. (#390)
+    /// </summary>
+    public class DpdUpdateSettings
+    {
+        public bool EnablePolling { get; set; } = true;
+        public string RepositoryOwner { get; set; } = "fsnow";
+        public string RepositoryName { get; set; } = "dpd-cst-subset";
     }
     
     public class FontSettings

--- a/src/CST.Avalonia/Services/DpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/DpdUpdateService.cs
@@ -1,0 +1,261 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Constants;
+using CST.Avalonia.Models;
+using CST.Lemma;
+using Microsoft.Extensions.Logging;
+using Octokit;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Downloads / updates the derived <c>dpd-cst-subset</c> asset from the derived-asset repo's GitHub Releases,
+/// parallel to <see cref="XmlUpdateService"/>. Reads <c>releases/latest</c> (Octokit — the same client the XML
+/// path uses), compares the release manifest's version stamps to the installed asset, and downloads + verifies
+/// (SHA-256) + decompresses (gzip, built-in) + atomically installs when newer or absent. Preservation store:
+/// the existing asset is replaced only after a new one is fully verified. (#390)
+/// </summary>
+public sealed class DpdUpdateService : IDpdUpdateService
+{
+    private const string ManifestAssetName = "dpd-cst-subset.manifest.json";
+    private const string AssetDirName = "dpd-cst-subset";
+    private const string AssetFileName = "dpd-cst-subset.db";
+
+    private readonly ILogger<DpdUpdateService> _logger;
+    private readonly ISettingsService _settings;
+    private readonly GitHubClient _github;
+    private readonly HttpClient _http;
+    private int _busy;
+
+    public event Action<string>? StatusChanged;
+    public event Action<long, long>? DownloadProgressChanged;
+    public bool IsBusy => Volatile.Read(ref _busy) == 1;
+
+    public DpdUpdateService(ILogger<DpdUpdateService> logger, ISettingsService settings)
+    {
+        _logger = logger;
+        _settings = settings;
+        _github = new GitHubClient(new ProductHeaderValue(AppConstants.UserAgent));
+        _http = new HttpClient();
+        _http.DefaultRequestHeaders.Add("User-Agent", AppConstants.UserAgent);
+    }
+
+    // The installed asset path: <app-support>/CSTReader/dpd-cst-subset/dpd-cst-subset.db (matches App.axaml.cs).
+    private static string AssetPath =>
+        Path.Combine(AppConstants.DataDirectory, AssetDirName, AssetFileName);
+
+    public async Task CheckAndUpdateAsync(CancellationToken ct = default)
+    {
+        if (Interlocked.CompareExchange(ref _busy, 1, 0) != 0) return; // already running
+        try
+        {
+            // Read config INSIDE the try so a null/garbage DpdUpdateSettings (e.g. an edited settings.json) is
+            // swallowed like any other failure, not thrown out of the fire-and-forget task. (fable review)
+            var cfg = _settings.Settings.DpdUpdateSettings ?? new DpdUpdateSettings();
+            if (!cfg.EnablePolling)
+            {
+                _logger.LogInformation("dpd-cst-subset polling disabled; skipping update check (a present file still works).");
+                return;
+            }
+            // Hard bound on the WHOLE check+download: HttpClient.Timeout doesn't cover a streamed body read, and the
+            // startup caller passes no token — without this a stalled connection hangs the background task forever
+            // and pins _busy for the session. (fable review)
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(TimeSpan.FromMinutes(10));
+            await RunAsync(cfg, cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("dpd-cst-subset update check canceled/timed out (non-fatal).");
+            StatusChanged?.Invoke("Update check timed out.");
+        }
+        catch (Exception ex)
+        {
+            // Every expected failure (offline, timeout, no release, corrupt download, bad settings) is non-fatal —
+            // the app just keeps whatever asset it has (or none). Never let this crash startup.
+            _logger.LogWarning(ex, "dpd-cst-subset update check failed (non-fatal; feature degrades to asset-absent).");
+            StatusChanged?.Invoke("Could not check for dictionary data updates.");
+        }
+        finally { Volatile.Write(ref _busy, 0); }
+    }
+
+    private async Task RunAsync(DpdUpdateSettings cfg, CancellationToken ct)
+    {
+        StatusChanged?.Invoke("Checking for dictionary data updates...");
+
+        var release = await WithTimeout(
+            _github.Repository.Release.GetLatest(cfg.RepositoryOwner, cfg.RepositoryName),
+            TimeSpan.FromSeconds(15), "release lookup").ConfigureAwait(false);
+        if (release is null) return;
+
+        var manifestAsset = release.Assets.FirstOrDefault(a =>
+            string.Equals(a.Name, ManifestAssetName, StringComparison.OrdinalIgnoreCase));
+        if (manifestAsset is null)
+        {
+            _logger.LogWarning("Latest dpd-cst-subset release {Tag} has no {Manifest}.", release.TagName, ManifestAssetName);
+            return;
+        }
+
+        var manifestBytes = await _http.GetByteArrayAsync(manifestAsset.BrowserDownloadUrl, ct).ConfigureAwait(false);
+        var manifest = ParseManifest(manifestBytes);
+        if (manifest is null)
+        {
+            _logger.LogWarning("Could not parse {Manifest} from release {Tag}.", ManifestAssetName, release.TagName);
+            return;
+        }
+
+        var installed = ReadInstalledMeta(AssetPath);
+        if (!NeedsUpdate(installed, manifest))
+        {
+            _logger.LogInformation("dpd-cst-subset up to date (DPD {Dpd}, converter {Conv}).",
+                manifest.DpdVersion, manifest.ConverterVersion);
+            StatusChanged?.Invoke("Dictionary data is up to date.");
+            return;
+        }
+
+        var archiveAsset = release.Assets.FirstOrDefault(a =>
+            string.Equals(a.Name, manifest.File, StringComparison.OrdinalIgnoreCase));
+        if (archiveAsset is null)
+        {
+            _logger.LogWarning("Release {Tag} manifest names '{File}' but that asset is missing.", release.TagName, manifest.File);
+            return;
+        }
+
+        StatusChanged?.Invoke(installed is null ? "Downloading dictionary data..." : "Downloading updated dictionary data...");
+        var archiveBytes = await DownloadWithProgressAsync(archiveAsset.BrowserDownloadUrl, ct).ConfigureAwait(false);
+
+        StatusChanged?.Invoke("Installing dictionary data...");
+        InstallFromGzip(archiveBytes, manifest.Sha256, AssetPath);
+
+        _logger.LogInformation("Installed dpd-cst-subset (DPD {Dpd}, converter {Conv}, ~{Mb} MB). Active on next launch.",
+            manifest.DpdVersion, manifest.ConverterVersion, manifest.RawBytes / 1024 / 1024);
+        StatusChanged?.Invoke("Dictionary data installed (active after restart).");
+    }
+
+    // Buffer the archive in memory (a modest tens-of-MB, infrequent). Streams headers-first so progress fires.
+    private async Task<byte[]> DownloadWithProgressAsync(string url, CancellationToken ct)
+    {
+        using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+        resp.EnsureSuccessStatusCode();
+        long total = resp.Content.Headers.ContentLength ?? 0;
+        using var stream = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var mem = new MemoryStream(total > 0 ? (int)Math.Min(total, int.MaxValue) : 0);
+        var buf = new byte[81920];
+        long read = 0; int n;
+        while ((n = await stream.ReadAsync(buf.AsMemory(), ct).ConfigureAwait(false)) > 0)
+        {
+            mem.Write(buf, 0, n);
+            read += n;
+            DownloadProgressChanged?.Invoke(read, total);
+        }
+        return mem.ToArray();
+    }
+
+    private async Task<T?> WithTimeout<T>(Task<T> task, TimeSpan timeout, string what) where T : class
+    {
+        var done = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
+        if (done != task)
+        {
+            // Observe the abandoned task if it later faults (e.g. NotFoundException when the repo has no release
+            // yet), so it doesn't surface as an UnobservedTaskException. (fable review)
+            _ = task.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+            _logger.LogWarning("dpd-cst-subset {What} timed out after {Sec}s.", what, timeout.TotalSeconds);
+            StatusChanged?.Invoke("Update check timed out.");
+            return null;
+        }
+        return await task.ConfigureAwait(false);
+    }
+
+    // ---- testable core (InternalsVisibleTo CST.Avalonia.Tests) ----
+
+    internal sealed record DpdManifest(string File, string DpdVersion, string ConverterVersion,
+        string? SchemaVersion, string? Scope, string Sha256, long CompressedBytes, long RawBytes);
+
+    internal sealed record InstalledMeta(string DpdVersion, string ConverterVersion);
+
+    internal static DpdManifest? ParseManifest(byte[] json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var r = doc.RootElement;
+            if (r.ValueKind != JsonValueKind.Object) return null;
+            string S(string k) => r.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString()! : "";
+            long L(string k) => r.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var n) ? n : 0;
+            var file = S("file"); var sha = S("sha256");
+            var dpd = S("dpdVersion"); var conv = S("converterVersion");
+            // file, sha256, and both version axes are required — without them we can't safely download/compare.
+            if (file.Length == 0 || sha.Length == 0 || dpd.Length == 0 || conv.Length == 0) return null;
+            return new DpdManifest(file, dpd, conv, S("schemaVersion"), S("scope"), sha, L("compressedBytes"), L("rawBytes"));
+        }
+        catch (JsonException) { return null; }
+    }
+
+    // Update when the asset is ABSENT/unreadable, or EITHER version axis differs (DPD release OR our converter).
+    internal static bool NeedsUpdate(InstalledMeta? installed, DpdManifest latest)
+        => installed is null
+           || !string.Equals(installed.DpdVersion, latest.DpdVersion, StringComparison.Ordinal)
+           || !string.Equals(installed.ConverterVersion, latest.ConverterVersion, StringComparison.Ordinal);
+
+    // Read the installed asset's version stamps via the same provider the app uses (no new SQLite dep). Null when
+    // absent/unreadable → treated as "needs update".
+    internal static InstalledMeta? ReadInstalledMeta(string dbPath)
+    {
+        if (!File.Exists(dbPath)) return null;
+        try
+        {
+            using var p = new SqliteLemmaProvider(dbPath);
+            var m = p.Meta;
+            if (!p.IsAvailable || m is null || string.IsNullOrEmpty(m.DpdVersion) || string.IsNullOrEmpty(m.ConverterVersion))
+                return null;
+            return new InstalledMeta(m.DpdVersion, m.ConverterVersion);
+        }
+        catch { return null; }
+    }
+
+    // Verify the gzip archive's SHA-256, decompress to a temp file, then atomically move it into place. The
+    // existing asset is untouched until the move, so a failed/corrupt download never destroys a good install.
+    internal static void InstallFromGzip(byte[] archive, string expectedSha256, string finalPath)
+    {
+        string actual = Convert.ToHexString(SHA256.HashData(archive)).ToLowerInvariant();
+        if (!string.Equals(actual, expectedSha256, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidDataException(
+                $"dpd-cst-subset archive failed its SHA-256 check (expected {expectedSha256}, got {actual}) — corrupt or partial download.");
+
+        var dir = Path.GetDirectoryName(finalPath)!;
+        Directory.CreateDirectory(dir);
+        var tmp = finalPath + ".new";
+        try
+        {
+            using (var src = new MemoryStream(archive, writable: false))
+            using (var gz = new GZipStream(src, CompressionMode.Decompress))
+            using (var outFs = File.Create(tmp))
+                gz.CopyTo(outFs);
+
+            // SHA-256 only proves TRANSPORT integrity (the archive matches the manifest). It does NOT prove the
+            // publisher gzipped a USABLE db — a truncated/wrong-schema source would still verify and then clobber a
+            // good existing asset. So open the decompressed file and require it to be a usable asset BEFORE the
+            // replace; if not, throw and leave the existing install untouched. (fable review — preservation gap)
+            using (var probe = new SqliteLemmaProvider(tmp))
+                if (!probe.IsAvailable)
+                    throw new InvalidDataException(
+                        "decompressed dpd-cst-subset archive is not a usable asset (missing core tables) — not installing.");
+
+            // Atomic same-volume replace; the old file is preserved until here. (macOS keeps the old inode open for
+            // the live provider — restart-to-activate. On Windows File.Move over an open db throws; a running-app
+            // install there needs a staged-swap-on-next-launch — deferred, Windows is untested/designed-in.)
+            File.Move(tmp, finalPath, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(tmp)) { try { File.Delete(tmp); } catch { /* best effort */ } }
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/IDpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/IDpdUpdateService.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Keeps the derived <c>dpd-cst-subset</c> asset (lemma / dictionary / sandhi) up to date by polling the
+/// derived-asset repo's GitHub Releases — parallel to <see cref="IXmlUpdateService"/> for the corpus XML.
+/// It only DOWNLOADS the asset; feature availability is driven by the file's presence (the provider opens it at
+/// startup), so a freshly downloaded (or manually dropped-in) asset takes effect on the next launch. A no-op
+/// when polling is disabled or the network is unreachable — the app degrades to "asset absent". (#390)
+/// </summary>
+public interface IDpdUpdateService
+{
+    /// <summary>Human-readable progress for a status banner (same UX as the XML update).</summary>
+    event Action<string>? StatusChanged;
+
+    /// <summary>Download progress: (bytesSoFar, totalBytes). totalBytes may be 0 if the length is unknown.</summary>
+    event Action<long, long>? DownloadProgressChanged;
+
+    bool IsBusy { get; }
+
+    /// <summary>
+    /// Check the latest release's manifest and, if it is newer than the installed asset (compared on DPD version
+    /// + our converter version) or the asset is absent, download + verify + install it. Never throws for the
+    /// expected failure modes (polling off, offline, timeout, no release) — it logs and returns. The existing
+    /// asset is preserved until a new one is fully verified.
+    /// </summary>
+    Task CheckAndUpdateAsync(CancellationToken ct = default);
+}


### PR DESCRIPTION
Closes the app-side half of **#390**: an auto-downloader for the derived **`dpd-cst-subset`** asset (lemma / dictionary / sandhi), parallel to `XmlUpdateService`. Now that the [first release](https://github.com/fsnow/dpd-cst-subset/releases/tag/v0.4.20260531-conv3-full) is live, this consumes it.

## Behavior
- Reads `releases/latest` from `fsnow/dpd-cst-subset` via the **same Octokit client** the XML path uses (**no new dependency**), pulls the small `dpd-cst-subset.manifest.json`, compares its `(dpdVersion, converterVersion)` to the **installed** asset's `meta`, and if newer/absent downloads the archive → **SHA-256 verify → gunzip (built-in) → atomic install**.
- **`DpdUpdateSettings.EnablePolling` (default ON)** — the *only* DPD setting. It toggles the auto-check, **not** whether the features work: availability is driven by **file presence**, so a manually dropped-in file works regardless. **Two version axes:** update on a new DPD `dpd.db` **or** a converter bump.
- **Fire-and-forget at startup** — never blocks or crashes startup; the asset activates on the **next launch** (restart-to-activate, which you confirmed is fine).
- **Preservation store:** the existing asset is replaced only after the new one is fully verified (`<path>.new` → atomic `File.Move`).

## fable review applied
- **Bounded downloads** — a linked `CancellationTokenSource` (10 min) + threaded cancellation, since `HttpClient.Timeout` doesn't cover a streamed body; a stalled connection no longer wedges the service for the session.
- **Bad-publish preservation gap (the important one)** — SHA proves *transport*, not that the publisher gzipped a *valid* db, so the decompressed file is now validated (`SqliteLemmaProvider.IsAvailable`) **before** the atomic replace. A truncated/wrong-schema publish can no longer clobber a good install.
- Config read moved inside the `try` (a null `DpdUpdateSettings` is swallowed, non-fatal); abandoned Octokit task observed on timeout.
- **Windows caveat documented:** `File.Move` over the open db throws on Windows (macOS keeps the old inode for the live provider). A staged-swap-on-next-launch is deferred — Windows is untested/designed-in. (Follow-up issue filed.)

## Validation
- **16 unit tests** — manifest parse (incl. malformed/missing fields), two-axis version compare (incl. converter-bump-with-same-DPD), verify/decompress/atomic-install, and preservation on **both** a SHA mismatch **and** a valid-gzip-but-invalid-db.
- **Live end-to-end against the real first release** — 62 MB download → SHA verify → gunzip → installed asset resolves `dhammaṃ` (17 candidates) and deconstructs a full-scope compound.
- Full suite **749 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig