### PR TITLE
#312 A4-8 pt2: skip multi-word position materialization/caching on the counts-only path

### DIFF
--- a/src/CST.Avalonia/Services/SearchService.cs
+++ b/src/CST.Avalonia/Services/SearchService.cs
@@ -486,28 +486,35 @@ public class SearchService : ISearchService
                     mt.Occurrences.Add(occ);
                 }
 
-                occ.Positions.AddRange(hit);
+                // Positions ONLY feed the UI's two-color highlighting. The counts-only path (the API when books
+                // aren't requested — SearchTool sets CountsOnly) never reads them, so skip accumulating them: for a
+                // broad multi-word query (e.g. `bhikkhu* dhamma*`) this avoids materializing — and then the
+                // BoundedCache PINNING — millions of TermPositions the caller discards. Count is tracked
+                // independently, so counts are unaffected. (#312 A4-8 pt2)
+                if (!query.CountsOnly)
+                    occ.Positions.AddRange(hit);
                 occ.Count++;
                 mt.TotalCount++;
             }
         }
         _logger.LogInformation("Multi-word: matched {BookCount} candidate books in {Elapsed}ms", candidateBooks.Count, sw.ElapsedMilliseconds);
 
-        // De-duplicate highlight positions per occurrence (a word can be shared by overlapping
-        // hits); prefer the first-term marking. Then sort for highlighting.
-        foreach (var mt in combos.Values)
-        {
-            foreach (var occ in mt.Occurrences)
+        // De-duplicate highlight positions per occurrence (a word can be shared by overlapping hits); prefer the
+        // first-term marking. Then sort for highlighting. Skipped on the counts-only path (positions are empty).
+        if (!query.CountsOnly)
+            foreach (var mt in combos.Values)
             {
-                var byOffset = new Dictionary<int, TermPosition>();
-                foreach (var tp in occ.Positions)
+                foreach (var occ in mt.Occurrences)
                 {
-                    if (!byOffset.TryGetValue(tp.StartOffset, out var existing) || (tp.IsFirstTerm && !existing.IsFirstTerm))
-                        byOffset[tp.StartOffset] = tp;
+                    var byOffset = new Dictionary<int, TermPosition>();
+                    foreach (var tp in occ.Positions)
+                    {
+                        if (!byOffset.TryGetValue(tp.StartOffset, out var existing) || (tp.IsFirstTerm && !existing.IsFirstTerm))
+                            byOffset[tp.StartOffset] = tp;
+                    }
+                    occ.Positions = byOffset.Values.OrderBy(p => p.Position).ToList();
                 }
-                occ.Positions = byOffset.Values.OrderBy(p => p.Position).ToList();
             }
-        }
 
         // Step 4: convert results. Order matching combinations alphabetically by their IPE words (word-by-word),
         // matching CST4 and the single-term path (the '~'-joined key sorts word0, then word1, ...), then apply the


### PR DESCRIPTION
Completes **#312**. The correctness halves — **A4-7** (de-dupe overlapping occurrence marks) and **A4-8 pt1** (page the multi-word search + set `HasMore`) — landed in #336. This is **pt2** (the memory half).

## The problem
The multi-word path accumulated every hit's `TermPosition`s into each occurrence and cached the lot. But positions **only** feed the UI's two-color highlighting; the **counts-only** path — the API when books aren't requested (`SearchTool` sets `CountsOnly`) — never reads them. So `bhikkhu* dhamma*` (thousands of forms) materialized **and then pinned in the `BoundedCache`** millions of `TermPosition`s the caller discards.

## The fix
Guard the position accumulation + the per-offset de-dup on `!query.CountsOnly`. `Count` is tracked independently (`occ.Count++`), so **counts are unaffected**; the UI path (`CountsOnly=false`) is unchanged and keeps positions for highlighting.

This is the safe completion — the alternative (blanket-stripping positions from the cache) would regress two-color highlighting on cache-hit re-queries, which is why pt1 stopped short. Scoping the skip to `CountsOnly` targets exactly the path the issue flagged ("only counts are used by SearchTool") with **zero UI impact**.

## Validation
Externally behavior-preserving — the API never returned positions on the counts-only path, and the UI path is untouched. Search / multi-word / integration suite **178 green** (the multi-word count tests confirm counts are unaffected).

Closes #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig