### PR TITLE
#397: fix Windows .new temp-file leak (pooled SQLite handle) + skip 8 macOS-only tests off macOS

### DIFF
--- a/src/CST.Avalonia.Tests/Services/PhraseProximityPOCTests.cs
+++ b/src/CST.Avalonia.Tests/Services/PhraseProximityPOCTests.cs
@@ -22,20 +22,24 @@ namespace CST.Avalonia.Tests;
 public class Tests_PhraseProximityPOC : IDisposable
 {
     private readonly ITestOutputHelper _output;
-    private readonly DirectoryReader _indexReader;
+    private readonly DirectoryReader? _indexReader;
     private readonly string _indexDirectory;
 
     public Tests_PhraseProximityPOC(ITestOutputHelper output)
     {
         _output = output;
 
-        // Use existing index from settings or environment variable
+        // POC/integration tests over a REAL pre-built Lucene index (from CST_INDEX_DIR or the app-support default,
+        // OS-appropriate). That index isn't present in CI or on a fresh machine — when absent, leave _indexReader
+        // null and each test early-returns (skips) rather than the whole class failing in the ctor. (#397)
         _indexDirectory = Environment.GetEnvironmentVariable("CST_INDEX_DIR")
-            ?? "/Users/fsnow/Library/Application Support/CSTReader/index";
+            ?? System.IO.Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "CSTReader", "index");
 
         if (!System.IO.Directory.Exists(_indexDirectory))
         {
-            throw new InvalidOperationException($"Index directory not found: {_indexDirectory}");
+            _output.WriteLine($"POC tests skipped: no Lucene index at {_indexDirectory} (set CST_INDEX_DIR to run).");
+            return;
         }
 
         _indexReader = DirectoryReader.Open(FSDirectory.Open(_indexDirectory));
@@ -49,6 +53,7 @@ public class Tests_PhraseProximityPOC : IDisposable
     [Fact]
     public void POC_01_GetTermPositions_SingleTerm()
     {
+        if (_indexReader is null) { _output.WriteLine("skipped: no index"); return; }
         // Search for a common Pali word - convert Latin to IPE
         string latinTerm = "bhikkhusatehi";  // "with five hundred monks"
         string ipeTerm = Latn2Ipe.Convert(latinTerm);
@@ -99,6 +104,7 @@ public class Tests_PhraseProximityPOC : IDisposable
     [Fact]
     public void POC_02_ProximitySearch_TwoTerms()
     {
+        if (_indexReader is null) { _output.WriteLine("skipped: no index"); return; }
         // Search for two related terms - convert Latin to IPE
         string latin1 = "rājagahaṃ";
         string latin2 = "nāḷandaṃ"; 
@@ -178,6 +184,7 @@ public class Tests_PhraseProximityPOC : IDisposable
     [Fact]
     public void POC_03_PhraseSearch_ExactOrder()
     {
+        if (_indexReader is null) { _output.WriteLine("skipped: no index"); return; }
         // Search for a common two-word phrase - "thus have I heard"
         string latin1 = "evaṃ";  // "thus"
         string latin2 = "me";  // "to me"
@@ -249,6 +256,7 @@ public class Tests_PhraseProximityPOC : IDisposable
     [Fact]
     public void POC_04_WildcardTermExpansion_WithPositions()
     {
+        if (_indexReader is null) { _output.WriteLine("skipped: no index"); return; }
         string latinPattern = "bhikkhu*";
         string ipePattern = Latn2Ipe.Convert("bhikkhu") + "*";  // Convert base then add wildcard
 
@@ -305,6 +313,7 @@ public class Tests_PhraseProximityPOC : IDisposable
     [Fact]
     public void POC_05_WildcardProximity_Combined()
     {
+        if (_indexReader is null) { _output.WriteLine("skipped: no index"); return; }
         // Search for "bhikkhu*" within 5 words of "sangha*"
         string latinPattern1 = "bhikkhu*";  // monk
         string latinPattern2 = "saṅgha*";   // community

--- a/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
+++ b/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
@@ -64,7 +64,12 @@ namespace CST.Avalonia.Tests.Services
         [InlineData("/Applications/CST Reader.app/Contents/MacOS/CST.Avalonia", "/Applications/CST Reader.app")]
         [InlineData("/Users/x/Desktop/CST Reader.app/Contents/MacOS/CST.Avalonia", "/Users/x/Desktop/CST Reader.app")]
         public void AppBundleFromExecutablePath_finds_the_enclosing_app_bundle(string exe, string expected)
-            => Assert.Equal(expected, McpBridge.AppBundleFromExecutablePath(exe));
+        {
+            // The macOS `.app` bundle concept + these Unix fixture paths are macOS-only; on Windows the Path APIs
+            // return backslashes and there is no bundle. Don't count as a failure off macOS. (#397)
+            if (!OperatingSystem.IsMacOS()) return;
+            Assert.Equal(expected, McpBridge.AppBundleFromExecutablePath(exe));
+        }
 
         [Theory]
         // Dev / non-bundle layouts (e.g. `dotnet run`) have no .app ancestor -> launch-or-attach can't auto-launch.
@@ -72,7 +77,10 @@ namespace CST.Avalonia.Tests.Services
         [InlineData("")]
         [InlineData(null)]
         public void AppBundleFromExecutablePath_is_null_outside_a_bundle(string? exe)
-            => Assert.Null(McpBridge.AppBundleFromExecutablePath(exe));
+        {
+            if (!OperatingSystem.IsMacOS()) return;   // macOS-only bundle parsing (#397)
+            Assert.Null(McpBridge.AppBundleFromExecutablePath(exe));
+        }
 
         [Fact]
         public void Write_creates_the_handshake_owner_only_and_leaves_no_temp()

--- a/src/CST.Lemma/SqliteLemmaProvider.cs
+++ b/src/CST.Lemma/SqliteLemmaProvider.cs
@@ -34,6 +34,13 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
         {
             using var c = new SqliteConnection(connString);
             c.Open();
+            // Record the connection string NOW, before the table checks — with pooling on, `using var c` returns
+            // the OS file handle to the POOL rather than closing it, and only Dispose()->ClearPool releases it. If
+            // we set _connString later (after the checks), the unusable-asset early return below leaves _connString
+            // null, Dispose() no-ops, and the pooled handle lingers — which on Windows blocks a File.Delete of the
+            // file (a leaked .new temp on a rejected DPD download). _connString is consumed only by Open() (reached
+            // only when IsAvailable) and Dispose(), so setting it on the not-available path is safe. (#397)
+            _connString = connString;
             // Minimal sanity check: the core tables must exist.
             if (!TableExists(c, "lemma") || !TableExists(c, "form_lemma"))
                 return;
@@ -41,7 +48,6 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
             _hasDecon = _hasFormsTable && ColumnExists(c, "forms", "deconstructor");
             _hasReport = TableExists(c, "root") && ColumnExists(c, "lemma", "root_key");
             Meta = LoadMeta(c);
-            _connString = connString;
             IsAvailable = true;
         }
         catch


### PR DESCRIPTION
Addresses the first Windows test run (#397): 1 real cross-platform bug + 8 macOS-assuming test failures.

## 1. Real bug — leaked pooled SQLite handle → orphaned `.new` temp on Windows
`SqliteLemmaProvider`'s ctor set `_connString` **after** the table checks. When handed a file that *opens* but isn't a usable asset (the `DpdUpdateService.InstallFromGzip` probe's rejection path), it took the early `return` with `_connString` still null → `Dispose()`→`ClearPool` never ran → the pooled OS file handle stayed open. On macOS/Unix a `File.Delete` of an open file succeeds; on **Windows it fails**, leaving a `dpd-cst-subset.db.new` orphan on a rejected download (cleanup leak; the good asset is still preserved).

**Fix (your one-liner):** record `_connString` immediately after `Open()`, before the checks — it's consumed only by `Open()` (reached only when `IsAvailable`) and `Dispose()`, so it's safe on the not-available path, and also covers the "opened, later query threw" path into the `catch`.

> The separate deferred item (the comment about `File.Move` over an open db needing a staged-swap on Windows) is #394 — untouched here.

## 2. `.app`-bundle tests (3) — macOS-only
`AppBundleFromExecutablePath_*` assert Unix paths against a macOS-only bundle concept. Guarded with `OperatingSystem.IsMacOS()` so they don't count as failures off macOS.

## 3. Phrase-proximity POC tests (5) — real-index integration tests
They need a pre-built Lucene index at a hardcoded `/Users/fsnow/...` path. Now default to the **OS-appropriate** app-support path (or `CST_INDEX_DIR`), and **skip** (each test early-returns) when the index is absent instead of throwing in the ctor.

## Validation
Full suite **749 green on macOS** — the POC tests still actually run here (the index is present), and the `SqliteLemmaProvider` change is exercised across the lemma/dictionary/update tests. On Windows/CI (no index) the POC + bundle tests now skip, so a clean Windows run should be green.

Refs #397 — to be verified on Placid (Windows), then closed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig
