### PR TITLE
chore: gitignore bin/obj for CST.Avalonia.Tests, CST.Lemma, CST.MAUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ src/CST.Avalonia/CST Reader.app/
 src/CST.Avalonia/publish/
 src/CST.Avalonia/dist/
 
+src/CST.Avalonia.Tests/bin/
 src/CST.Avalonia.Tests/obj/
 
 src/CST.CharacterAnalysis/bin/
@@ -23,8 +24,14 @@ src/CST.CharacterAnalysis/obj/
 src/CST.Core/bin/
 src/CST.Core/obj/
 
+src/CST.Lemma/bin/
+src/CST.Lemma/obj/
+
 src/CST.Lucene/bin/
 src/CST.Lucene/obj/
+
+src/CST.MAUI/bin/
+src/CST.MAUI/obj/
 
 src/CST.ScriptValidation/bin/
 src/CST.ScriptValidation/obj/
@@ -33,7 +40,9 @@ src/CST.ScriptValidation/obj/
 
 screenshots/
 
-src/CST.MAUI/obj/
+
 
 # Agent worktrees (isolated subagent workspaces) must never be committed
 .claude/worktrees/
+
+


### PR DESCRIPTION
Add missing `bin/`/`obj/` ignore entries so build output for these projects stops showing up as untracked:

- `src/CST.Avalonia.Tests/bin/`
- `src/CST.Lemma/bin/` + `src/CST.Lemma/obj/`
- `src/CST.MAUI/bin/` + `src/CST.MAUI/obj/` (consolidates the lone stray `src/CST.MAUI/obj/` entry that was sitting apart from the others)

Purely a `.gitignore` tidy-up — no source changes. Notably fixes `src/CST.Lemma/obj/` appearing as an untracked directory in `git status`.
