### PR TITLE
Windows support: WebView (CEF) package refs + in-window menu bar

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -162,13 +162,12 @@ public partial class App : Application
             // Close application when main window is closed
             desktop.ShutdownMode = ShutdownMode.OnMainWindowClose;
 
-            // Set up window-level native menu events (View menu) on macOS
-            if (OperatingSystem.IsMacOS())
-            {
-                SetupWindowMenuEvents();
-                // Update panel visibility to sync initial checkmark state
-                layoutViewModel.UpdatePanelVisibility();
-            }
+            // Set up window-level menu events (View toggles + checkmarks). On macOS these back the system
+            // menu bar; on Windows/Linux they back the in-window <NativeMenuBar/>. SetupWindowMenuEvents is
+            // platform-agnostic; the macOS-only #284 Window-list helpers it calls simply no-op off macOS.
+            SetupWindowMenuEvents();
+            // Update panel visibility to sync initial checkmark state
+            layoutViewModel.UpdatePanelVisibility();
 
             // Get the WelcomeViewModel to update startup status
             var welcomeViewModel = layoutViewModel.GetWelcomeViewModel();

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -82,8 +82,14 @@
     <!-- WebView packages for different architectures -->
     <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'" />
     <PackageReference Include="WebViewControl-Avalonia" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == 'osx-x64'" />
-    <!-- Fallback for development (when RuntimeIdentifier is not set) -->
-    <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == ''" />
+    <!-- Windows (#20/#28): the plain WebViewControl-Avalonia package carries the Windows (win-x64 / win-arm64) CEF natives. -->
+    <PackageReference Include="WebViewControl-Avalonia" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == 'win-x64'" />
+    <PackageReference Include="WebViewControl-Avalonia" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == 'win-arm64'" />
+    <!-- Fallback for development when RuntimeIdentifier is not set (plain `dotnet run`): pick by host OS so
+         `dotnet run` works everywhere without an explicit -r. Windows host -> plain (Windows) package;
+         everything else keeps the macOS/Linux ARM64 package (the Apple-Silicon dev default). -->
+    <PackageReference Include="WebViewControl-Avalonia" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == '' and '$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == '' and '$(OS)' != 'Windows_NT'" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="ReactiveUI" Version="23.2.28" />
     <!-- MCP surface (#191): Streamable HTTP transport mounted in-process at /mcp on the loopback API server. -->

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -41,6 +41,10 @@
 
     <!-- Main Layout with Toolbar and DockControl -->
     <DockPanel>
+        <!-- In-window menu bar for Windows/Linux; on macOS this renders nothing (the NativeMenu.Menu
+             above is exported to the system menu bar instead), so it is safe to include unconditionally. -->
+        <NativeMenuBar DockPanel.Dock="Top" />
+
         <!-- Top Toolbar -->
         <Border Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
                 BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"


### PR DESCRIPTION
First working Windows build. Verified end-to-end on Placid (Windows 10 x64, .NET 10.0.302): launch → CEF init → Welcome page → download the 217-book corpus → build the Lucene index → install the DPD asset → open/read books, search + highlighted-result navigation, dictionary, book linking, Attha/Tika, and dock float/unfloat/split all working.

## Changes

**1. WebView/CEF packaging (`CST.Avalonia.csproj`)** — the real launch blocker.
The WebView package refs were macOS-only, and the empty-`RuntimeIdentifier` dev fallback pulled the macOS-ARM64 package, so Windows never restored win-x64 CEF and the app died at startup with `Could not load file or assembly 'WebViewControl.Avalonia'`. Adds `win-x64` / `win-arm64` conditions on the plain `WebViewControl-Avalonia` package (which carries the Windows CEF natives, per #20) and makes the empty-RID fallback host-aware via `$(OS)` so `dotnet run` works on both Windows and macOS with no explicit `-r`. macOS conditions untouched; pinned to the existing `3.120.9`.

**2. In-window menu (`SimpleTabbedWindow.axaml`, `App.axaml.cs`).**
On Windows/Linux a `NativeMenu.Menu` doesn't render without a `NativeMenuBar` control, and the View-toggle wiring was macOS-gated. Adds `<NativeMenuBar/>` (a no-op on macOS, which keeps using the system menu bar) and un-gates `SetupWindowMenuEvents` so the View menu toggles panels on all platforms. Tools items are already `Click`-wired. **macOS behavior is unchanged** (that method already ran there; the macOS-only #284 Window-list helpers it calls no-op off macOS).

## Not included (follow-ups)
- **Keyboard shortcuts** are still `cmd+…` (won't bind on Windows) — `cmd→ctrl` conversion pending, and unverifiable under Parallels anyway.
- **Black-window OSR stall under a virtualized GPU** — confirmed via a `--disable-gpu` diagnostic; will be handled as a hardware-acceleration preference (tracked separately).

Closes #20. Refs #28.
