### PR TITLE
#408: fix 3 Windows-only test failures (test hygiene)

### DIFF
--- a/src/CST.Avalonia.Tests/BugFix/DefaultIndexDirectorySettingTest.cs
+++ b/src/CST.Avalonia.Tests/BugFix/DefaultIndexDirectorySettingTest.cs
@@ -62,7 +62,7 @@ namespace CST.Avalonia.Tests.BugFix
         public async Task DefaultIndexDirectory_GetsSavedToSettings_OnFirstRun()
         {
             // Arrange
-            var indexingService = new IndexingService(_mockLogger.Object, _mockSettingsService.Object, _mockXmlFileDatesService.Object);
+            var indexingService = new IndexingService(_mockLogger.Object, _mockSettingsService.Object, _mockXmlFileDatesService.Object, _testAppDataDir);
 
             // Verify initial state - IndexDirectory should be empty
             Assert.Empty(_testSettings.IndexDirectory);
@@ -93,7 +93,7 @@ namespace CST.Avalonia.Tests.BugFix
             var configuredPath = Path.Combine(_testAppDataDir, "CustomIndex");
             _testSettings.IndexDirectory = configuredPath;
             
-            var indexingService = new IndexingService(_mockLogger.Object, _mockSettingsService.Object, _mockXmlFileDatesService.Object);
+            var indexingService = new IndexingService(_mockLogger.Object, _mockSettingsService.Object, _mockXmlFileDatesService.Object, _testAppDataDir);
 
             _output.WriteLine($"Configured IndexDirectory: '{_testSettings.IndexDirectory}'");
 
@@ -115,35 +115,44 @@ namespace CST.Avalonia.Tests.BugFix
         public async Task DefaultIndexDirectory_IsValidPath()
         {
             // Arrange
-            var indexingService = new IndexingService(_mockLogger.Object, _mockSettingsService.Object, _mockXmlFileDatesService.Object);
+            var indexingService = new IndexingService(_mockLogger.Object, _mockSettingsService.Object, _mockXmlFileDatesService.Object, _testAppDataDir);
 
             // Act
             await indexingService.InitializeAsync();
 
             // Assert
             var savedPath = _testSettings.IndexDirectory;
-            
-            // Path should be absolute
-            Assert.True(Path.IsPathRooted(savedPath), $"Path should be absolute: {savedPath}");
-            
-            // Path should be valid for directory creation
-            Assert.True(Directory.Exists(savedPath), $"Directory should exist after initialization: {savedPath}");
-            
-            // Path should be platform-appropriate
-            if (OperatingSystem.IsWindows())
-            {
-                Assert.Contains("AppData", savedPath);
-            }
-            else if (OperatingSystem.IsMacOS())
-            {
-                Assert.Contains("Library/Application Support", savedPath);
-            }
-            else // Linux
-            {
-                Assert.Contains(".config", savedPath);
-            }
 
-            _output.WriteLine($"✅ Default path is valid and platform-appropriate: {savedPath}");
+            // Path should be absolute and created — but under the temp override, so no real profile is touched.
+            Assert.True(Path.IsPathRooted(savedPath), $"Path should be absolute: {savedPath}");
+            Assert.True(Directory.Exists(savedPath), $"Directory should exist after initialization: {savedPath}");
+            Assert.StartsWith(_testAppDataDir, savedPath);
+            Assert.Contains("CSTReader", savedPath);
+            Assert.EndsWith("index", savedPath);
+
+            _output.WriteLine($"✅ Default path is valid and under the test base: {savedPath}");
+        }
+
+        [Fact]
+        public void GetDefaultIndexDirectory_IsPlatformAppropriate()
+        {
+            // No override → the real per-OS computation. GetDefaultIndexDirectory() does NOT create the
+            // directory, so this verifies the platform-appropriate shape without touching the filesystem
+            // (the reason the old approach polluted the real %APPDATA%\CSTReader profile).
+            var indexingService = new IndexingService(
+                _mockLogger.Object, _mockSettingsService.Object, _mockXmlFileDatesService.Object);
+
+            var path = indexingService.GetDefaultIndexDirectory();
+
+            Assert.True(Path.IsPathRooted(path), $"Path should be absolute: {path}");
+            Assert.Contains("CSTReader", path);
+            Assert.EndsWith("index", path);
+            if (OperatingSystem.IsWindows())
+                Assert.Contains("AppData", path);
+            else if (OperatingSystem.IsMacOS())
+                Assert.Contains("Library/Application Support", path);
+            else // Linux
+                Assert.Contains(".config", path);
         }
     }
 }

--- a/src/CST.Avalonia.Tests/Services/IndexingServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/IndexingServiceTests.cs
@@ -118,7 +118,11 @@ namespace CST.Avalonia.Tests.Services
         {
             CreateMinimalIndex(1);
             await _service.InitializeAsync();
-            Assert.NotNull(_service.GetIndexReader());
+            var reader = _service.GetIndexReader();
+            Assert.NotNull(reader);
+            reader!.DecRef();   // release the caller's counted ref (GetIndexReader IncRef's) so Dispose can fully
+                                // close the reader — otherwise the FSDirectory handle stays open and the Windows
+                                // Directory.Delete below fails (macOS masks this: POSIX deletes open files). (#408)
 
             _service.Dispose();
 

--- a/src/CST.Avalonia.Tests/Services/PhraseProximityPOCTests.cs
+++ b/src/CST.Avalonia.Tests/Services/PhraseProximityPOCTests.cs
@@ -42,7 +42,18 @@ public class Tests_PhraseProximityPOC : IDisposable
             return;
         }
 
-        _indexReader = DirectoryReader.Open(FSDirectory.Open(_indexDirectory));
+        // The directory can exist but hold no index (e.g. created empty by another test / a partial run); opening
+        // a reader there throws IndexNotFoundException in the ctor and fails all tests. Guard on IndexExists so
+        // _indexReader stays null and each test early-returns (skips) instead. (#408)
+        var fsDir = FSDirectory.Open(_indexDirectory);
+        if (!DirectoryReader.IndexExists(fsDir))
+        {
+            fsDir.Dispose();
+            _output.WriteLine($"POC tests skipped: directory exists but holds no Lucene index at {_indexDirectory}.");
+            return;
+        }
+
+        _indexReader = DirectoryReader.Open(fsDir);   // reader now owns fsDir; disposed with _indexReader
         _output.WriteLine($"Opened index with {_indexReader.NumDocs} documents");
     }
 

--- a/src/CST.Avalonia/Services/IndexingService.cs
+++ b/src/CST.Avalonia/Services/IndexingService.cs
@@ -15,6 +15,7 @@ namespace CST.Avalonia.Services
         private readonly ILogger<IndexingService> _logger;
         private readonly ISettingsService _settingsService;
         private readonly IXmlFileDatesService _xmlFileDatesService;
+        private readonly string? _appDataDirOverride;
         private BookIndexerAsync? _bookIndexer;
         private string _indexDirectory = string.Empty;
         private DirectoryReader? _indexReader;
@@ -24,14 +25,20 @@ namespace CST.Avalonia.Services
 
         public string IndexDirectory => _indexDirectory;
 
+        /// <param name="appDataDirOverride">Test/portability hook: when set, the default index directory is
+        /// computed under this base (<c>&lt;override&gt;/CSTReader/index</c>) instead of the real per-user
+        /// app-data location. Lets tests exercise the "empty setting → default path" flow without creating
+        /// or touching the real user profile. Null in production (the default).</param>
         public IndexingService(
             ILogger<IndexingService> logger,
             ISettingsService settingsService,
-            IXmlFileDatesService xmlFileDatesService)
+            IXmlFileDatesService xmlFileDatesService,
+            string? appDataDirOverride = null)
         {
             _logger = logger;
             _settingsService = settingsService;
             _xmlFileDatesService = xmlFileDatesService;
+            _appDataDirOverride = appDataDirOverride;
         }
 
         public async Task InitializeAsync()
@@ -230,8 +237,15 @@ namespace CST.Avalonia.Services
             });
         }
 
-        private string GetDefaultIndexDirectory()
+        internal string GetDefaultIndexDirectory()
         {
+            // Test/portability hook: override the app-data base so tests never create/touch the real user
+            // profile. Keeps the AppDataDirectoryName + "index" shape so the "default path" contract holds.
+            if (!string.IsNullOrEmpty(_appDataDirOverride))
+            {
+                return Path.Combine(_appDataDirOverride, AppConstants.AppDataDirectoryName, "index");
+            }
+
             string indexPath;
 
             if (OperatingSystem.IsWindows())


### PR DESCRIPTION
Fixes the 3 test-only failures that fail on Windows (macOS masks them). See commit for details. Verified green on Placid (28 tests in the affected classes); Fable-reviewed. Closes #408. Refs #28.