### PR TITLE
#394: staged-swap dpd-cst-subset install on Windows (File.Move over open db)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
@@ -134,6 +134,55 @@ public sealed class DpdUpdateServiceTests : IDisposable
         Assert.False(File.Exists(final + ".new"));
     }
 
+    // ---- Staged-swap install on Windows (#394) ----
+
+    [Fact]
+    public void ApplyPendingInstall_swaps_a_staged_file_into_place()
+    {
+        var final = Path.Combine(_dir, "dpd-cst-subset.db");
+        File.WriteAllText(final, "OLD");
+        File.WriteAllText(final + ".pending", "NEW-STAGED");
+
+        Assert.True(DpdUpdateService.ApplyPendingInstall(final));
+        Assert.Equal("NEW-STAGED", File.ReadAllText(final));
+        Assert.False(File.Exists(final + ".pending"));   // staged file consumed
+    }
+
+    [Fact]
+    public void ApplyPendingInstall_is_noop_when_nothing_staged()
+    {
+        var final = Path.Combine(_dir, "dpd-cst-subset.db");
+        File.WriteAllText(final, "OLD");
+
+        Assert.False(DpdUpdateService.ApplyPendingInstall(final));
+        Assert.Equal("OLD", File.ReadAllText(final));    // untouched
+    }
+
+    [Fact]
+    public void InstallFromGzip_stages_when_the_target_is_locked_then_activates_on_apply()
+    {
+        // Windows-specific: File.Move over an OPEN db throws a sharing violation, so the install stages a
+        // ".pending" swap for next launch instead of failing (and never clobbers the good, open asset). POSIX
+        // allows the move, so this reproduces only on Windows. (#394)
+        if (!OperatingSystem.IsWindows()) return;
+
+        var final = Path.Combine(_dir, "dpd-cst-subset.db");
+        File.WriteAllBytes(final, BuildAssetDbBytes(dpd: "v0", conv: "3"));   // a real, openable existing asset
+        var gz = Gzip(BuildAssetDbBytes(dpd: "v1", conv: "3"));
+
+        using (var hold = new FileStream(final, FileMode.Open, FileAccess.Read, FileShare.None))   // live provider
+        {
+            DpdUpdateService.InstallFromGzip(gz, Sha(gz), final);            // must NOT throw
+            Assert.True(File.Exists(final + ".pending"), "new asset staged for next launch");
+            Assert.False(File.Exists(final + ".new"), "temp cleaned up");
+        }
+
+        // Lock released → applying the staged swap activates the new asset.
+        Assert.True(DpdUpdateService.ApplyPendingInstall(final));
+        Assert.Equal("v1", DpdUpdateService.ReadInstalledMeta(final)!.DpdVersion);
+        Assert.False(File.Exists(final + ".pending"));
+    }
+
     // ---- ReadInstalledMeta ----
 
     [Fact]

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -141,6 +141,13 @@ public partial class App : Application
         ConfigureServices(services);
         ServiceProvider = services.BuildServiceProvider();
 
+        // Apply any staged dpd-cst-subset update BEFORE anything opens the asset db. On Windows a running-app
+        // install can't replace the open db, so it stages a ".pending" swap that we apply here on the next launch.
+        // Unconditional (not tied to whether/when the lemma provider is resolved) and a no-op when nothing is
+        // staged / on macOS/Linux. (#394)
+        if (DpdUpdateService.ApplyPendingInstall())
+            Log.Information("Applied a staged dpd-cst-subset update on launch.");
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             // Avoid duplicate validations from both Avalonia and the CommunityToolkit.

--- a/src/CST.Avalonia/Services/DpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/DpdUpdateService.cs
@@ -27,6 +27,9 @@ public sealed class DpdUpdateService : IDpdUpdateService
     private const string ManifestAssetName = "dpd-cst-subset.manifest.json";
     private const string AssetDirName = "dpd-cst-subset";
     private const string AssetFileName = "dpd-cst-subset.db";
+    // A verified install staged for next launch when the target db can't be replaced in place (Windows: the live
+    // provider holds it open). Applied by ApplyPendingInstall() before the db is opened at startup. (#394)
+    private const string PendingSuffix = ".pending";
 
     private readonly ILogger<DpdUpdateService> _logger;
     private readonly ISettingsService _settings;
@@ -248,14 +251,61 @@ public sealed class DpdUpdateService : IDpdUpdateService
                     throw new InvalidDataException(
                         "decompressed dpd-cst-subset archive is not a usable asset (missing core tables) — not installing.");
 
-            // Atomic same-volume replace; the old file is preserved until here. (macOS keeps the old inode open for
-            // the live provider — restart-to-activate. On Windows File.Move over an open db throws; a running-app
-            // install there needs a staged-swap-on-next-launch — deferred, Windows is untested/designed-in.)
-            File.Move(tmp, finalPath, overwrite: true);
+            // Replace the installed asset with the freshly verified file. The old file is preserved until here.
+            //  - macOS/Linux: File.Move succeeds even while the live provider holds the old db open (POSIX unlinks
+            //    the old inode); the running provider keeps reading the old one until restart-to-activate.
+            //  - Windows: File.Move over an OPEN db throws a sharing violation. Rather than fail the install, stage
+            //    the verified file beside the target and swap it in on the next launch — before the provider opens
+            //    it — via ApplyPendingInstall(). Same user-visible outcome either way: active after restart. (#394)
+            try
+            {
+                File.Move(tmp, finalPath, overwrite: true);
+                // This direct install supersedes any earlier staged one — drop a leftover .pending so a stale,
+                // older staged file can't later regress the asset on a future launch. (fable review — #394)
+                var superseded = finalPath + PendingSuffix;
+                if (File.Exists(superseded)) { try { File.Delete(superseded); } catch { /* best effort */ } }
+            }
+            catch (Exception ex) when ((ex is IOException || ex is UnauthorizedAccessException) && File.Exists(finalPath))
+            {
+                // The existing asset is still in place (untouched), so preservation holds — stage for next launch.
+                File.Move(tmp, finalPath + PendingSuffix, overwrite: true);
+            }
         }
         finally
         {
             if (File.Exists(tmp)) { try { File.Delete(tmp); } catch { /* best effort */ } }
         }
     }
+
+    /// <summary>
+    /// Applies a staged install (see <see cref="InstallFromGzip"/>) on the next launch — call this BEFORE the
+    /// asset db is opened. No-op when nothing is staged (the common case, and always on macOS/Linux). Best-effort:
+    /// any failure leaves the staged file for a later attempt and must never block startup. Returns true when a
+    /// staged install was applied. (#394)
+    /// </summary>
+    internal static bool ApplyPendingInstall(string finalPath)
+    {
+        var pending = finalPath + PendingSuffix;
+        if (!File.Exists(pending)) return false;
+        try
+        {
+            File.Move(pending, finalPath, overwrite: true);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Leave the staged file for the next launch rather than crash startup — but log it: a persistent
+            // failure here means the update never activates and CheckAndUpdate keeps re-downloading it. (#394)
+            Serilog.Log.Warning(ex,
+                "Failed to apply a staged dpd-cst-subset update at {Pending}; will retry on next launch.", pending);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Applies a staged install for the standard asset path (<see cref="AssetPath"/>). Call this once, early at
+    /// startup — before anything opens the db — so a Windows staged swap activates regardless of whether/when the
+    /// lemma provider gets resolved. No-op when nothing is staged. (#394)
+    /// </summary>
+    internal static bool ApplyPendingInstall() => ApplyPendingInstall(AssetPath);
 }


### PR DESCRIPTION
On Windows the live provider holds the asset db open, so File.Move over it throws. Now stages a .pending swap applied unconditionally at next launch (ApplyPendingInstall). Fable-reviewed (fixed a stale-pending regression + silent-redownload gap). 19 DpdUpdateService tests green on Windows. Closes #394. Refs #28.