### PR TITLE
#403: Windows packaging - InnoSetup installer + GitHub Release + bundled-resource fix

### DIFF
--- a/src/CST.Avalonia/CST.Avalonia.iss
+++ b/src/CST.Avalonia/CST.Avalonia.iss
@@ -1,0 +1,56 @@
+; CST Reader - InnoSetup installer script (#403)
+; Built by package-windows.ps1, which passes /DAppVersion, /DPublishDir, /DOutputDir.
+; Per-user install (no admin/UAC), unsigned for beta (real code-signing cert is a pre-1.0 follow-up, #28).
+; Distributed via GitHub Releases + WinGet (fsnow.CSTReader).
+
+#ifndef AppVersion
+  #define AppVersion "5.0.0"
+#endif
+#ifndef PublishDir
+  #define PublishDir "bin\Release\net10.0\win-x64\publish"
+#endif
+#ifndef OutputDir
+  #define OutputDir "dist"
+#endif
+
+[Setup]
+; Stable AppId - do NOT change (it keys the uninstall entry / upgrade detection; WinGet ProductCode is AppId + "_is1").
+AppId={{6F3A9C2E-1D4B-4A7E-9F2C-8B5E3D1A0C74}
+AppName=CST Reader
+AppVersion={#AppVersion}
+AppVerName=CST Reader {#AppVersion}
+AppPublisher=Frank Snow
+AppPublisherURL=https://github.com/fsnow/cst
+AppSupportURL=https://github.com/fsnow/cst/issues
+DefaultDirName={autopf}\CST Reader
+DefaultGroupName=CST Reader
+UninstallDisplayName=CST Reader
+UninstallDisplayIcon={app}\CST.Avalonia.exe
+OutputDir={#OutputDir}
+OutputBaseFilename=CST-Reader-{#AppVersion}-win-x64-setup
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+; x64compatible requires Inno Setup 6.3+ (also allows install on ARM64 via x64 emulation). Built with 6.7.x.
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+; Per-user install so no UAC prompt; {autopf} resolves to %LOCALAPPDATA%\Programs under lowest privileges.
+PrivilegesRequired=lowest
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+; The self-contained publish output (app + .NET runtime + CEF + staged xsl/ + dictionaries/).
+Source: "{#PublishDir}\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs ignoreversion
+
+[Icons]
+Name: "{group}\CST Reader"; Filename: "{app}\CST.Avalonia.exe"
+Name: "{group}\Uninstall CST Reader"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\CST Reader"; Filename: "{app}\CST.Avalonia.exe"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\CST.Avalonia.exe"; Description: "{cm:LaunchProgram,CST Reader}"; Flags: nowait postinstall skipifsilent

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -104,6 +104,10 @@ public sealed class DictionaryService : IDictionaryService
         var dev = Path.Combine(asmDir, "..", "..", "..", "dictionaries");
         if (Directory.Exists(dev))
             return dev;
+        // Packaged beside the executable (Windows/Linux self-contained publish): <app>/dictionaries. (#403)
+        var beside = Path.Combine(asmDir, "dictionaries");
+        if (Directory.Exists(beside))
+            return beside;
         // Packaged .app: Contents/MacOS/ -> ../Resources/dictionaries
         var bundle = Path.Combine(asmDir, "..", "Resources", "dictionaries");
         if (Directory.Exists(bundle))

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -1403,12 +1403,21 @@ namespace CST.Avalonia.ViewModels
                 }
                 else
                 {
-                    // Try app bundle location for production (lowercase)
+                    // Packaged beside the executable (Windows/Linux self-contained publish): <app>/xsl. (#403)
+                    var besideExePath = Path.Combine(
+                        Path.GetDirectoryName(assemblyLocation) ?? "", "xsl");
+
+                    // Try app bundle location for production (macOS: Contents/MacOS -> ../Resources/xsl)
                     var bundleResourcesPath = Path.Combine(
                         Path.GetDirectoryName(assemblyLocation) ?? "",
                         "..", "Resources", "xsl");
 
-                    if (Directory.Exists(bundleResourcesPath))
+                    if (Directory.Exists(besideExePath))
+                    {
+                        sourceXslDir = besideExePath;
+                        _logger.Information("Found XSL files next to the executable: {Path}", besideExePath);
+                    }
+                    else if (Directory.Exists(bundleResourcesPath))
                     {
                         sourceXslDir = bundleResourcesPath;
                         _logger.Information("Found XSL files in app bundle: {Path}", bundleResourcesPath);

--- a/src/CST.Avalonia/package-windows.ps1
+++ b/src/CST.Avalonia/package-windows.ps1
@@ -1,0 +1,114 @@
+<#
+.SYNOPSIS
+  CST Avalonia Windows packaging script (#403).
+
+.DESCRIPTION
+  Publishes a self-contained win-x64 build, stages the bundled resources (xsl + dictionaries) beside the
+  executable so a fresh machine can seed them, then produces:
+    - a portable .zip
+    - an InnoSetup installer (setup.exe), if the InnoSetup compiler (ISCC.exe) is on PATH or installed
+  Both land in dist/. Distribution is via GitHub Releases + WinGet (fsnow.CSTReader); unsigned for beta. (#28)
+
+.PARAMETER Arch
+  Target architecture. Only x64 is supported for now (ARM64 deferred, #28).
+
+.PARAMETER NoInstaller
+  Skip the InnoSetup step (portable zip only).
+
+.EXAMPLE
+  ./package-windows.ps1
+  ./package-windows.ps1 -NoInstaller
+#>
+param(
+    [ValidateSet('x64')]
+    [string]$Arch = 'x64',
+    [switch]$NoInstaller
+)
+
+$ErrorActionPreference = 'Stop'
+$RID = "win-$Arch"
+$ProjectDir = $PSScriptRoot
+$PublishDir = Join-Path $ProjectDir "bin\Release\net10.0\$RID\publish"
+$DistDir    = Join-Path $ProjectDir "dist"
+
+Write-Host "CST Avalonia Windows Packaging" -ForegroundColor Cyan
+Write-Host "==============================" -ForegroundColor Cyan
+Write-Host "Architecture: $RID"
+
+# --- Version (from the csproj <Version>) ---
+$verMatch = Select-String -Path (Join-Path $ProjectDir 'CST.Avalonia.csproj') -Pattern '<Version>(.*?)</Version>' | Select-Object -First 1
+if (-not $verMatch) { throw "Could not read <Version> from CST.Avalonia.csproj - refusing to build a mislabeled release." }
+$Version = $verMatch.Matches[0].Groups[1].Value
+Write-Host "Version: $Version"
+
+# --- Clean + publish ---
+if (Test-Path $PublishDir) { Remove-Item $PublishDir -Recurse -Force }
+Write-Host "`nPublishing self-contained $RID build..." -ForegroundColor Yellow
+dotnet publish (Join-Path $ProjectDir 'CST.Avalonia.csproj') -c Release -r $RID --self-contained
+if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed ($LASTEXITCODE)" }
+
+# --- Stage bundled resources beside the exe (the app seeds %APPDATA%\CSTReader from here on first run) ---
+Write-Host "`nStaging bundled resources (xsl + dictionaries)..." -ForegroundColor Yellow
+foreach ($res in @('xsl','dictionaries')) {
+    $src = Join-Path $ProjectDir $res
+    $dst = Join-Path $PublishDir $res
+    if (-not (Test-Path $src)) { throw "Bundled resource source not found: $src" }
+    Copy-Item $src $dst -Recurse -Force
+    $n = (Get-ChildItem $dst -Recurse -File | Measure-Object).Count
+    Write-Host "  - $res : $n file(s)"
+}
+
+# Sanity: confirm CEF actually landed in the publish (the biggest packaging risk).
+if (-not (Test-Path (Join-Path $PublishDir 'libcef.dll'))) { throw "libcef.dll missing from publish output - CEF not packaged." }
+
+New-Item -ItemType Directory -Force -Path $DistDir | Out-Null
+
+# --- Portable zip ---
+$zip = Join-Path $DistDir "CST-Reader-$Version-$RID-portable.zip"
+if (Test-Path $zip) { Remove-Item $zip -Force }
+Write-Host "`nCreating portable zip..." -ForegroundColor Yellow
+# Build entries with forward-slash names. Under Windows PowerShell 5.1 (.NET Framework) BOTH Compress-Archive and
+# ZipFile.CreateFromDirectory write BACKSLASH separators, which mangle when extracted on macOS/Linux. Stream each
+# file so the 205 MB libcef.dll isn't buffered in memory. (fable review, #403)
+Add-Type -AssemblyName System.IO.Compression, System.IO.Compression.FileSystem
+if (Test-Path $zip) { Remove-Item $zip -Force }
+$baseLen = ((Resolve-Path $PublishDir).Path.TrimEnd('\') + '\').Length
+$fs = [System.IO.File]::Open($zip, [System.IO.FileMode]::Create)
+try {
+    $archive = New-Object System.IO.Compression.ZipArchive($fs, [System.IO.Compression.ZipArchiveMode]::Create)
+    try {
+        foreach ($file in (Get-ChildItem $PublishDir -Recurse -File)) {
+            $rel = $file.FullName.Substring($baseLen).Replace('\','/')
+            $entry = $archive.CreateEntry($rel, [System.IO.Compression.CompressionLevel]::Optimal)
+            $dst = $entry.Open()
+            $src = [System.IO.File]::OpenRead($file.FullName)
+            try { $src.CopyTo($dst) } finally { $src.Dispose(); $dst.Dispose() }
+        }
+    } finally { $archive.Dispose() }
+} finally { $fs.Dispose() }
+Write-Host "  -> $zip  ($([math]::Round((Get-Item $zip).Length/1MB)) MB)"
+
+# --- InnoSetup installer ---
+if ($NoInstaller) { Write-Host "`nSkipping installer (-NoInstaller)."; return }
+
+$iscc = (Get-Command ISCC.exe -ErrorAction SilentlyContinue).Source
+if (-not $iscc) {
+    foreach ($p in @("${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe", "$env:ProgramFiles\Inno Setup 6\ISCC.exe", "$env:LOCALAPPDATA\Programs\Inno Setup 6\ISCC.exe")) {
+        if (Test-Path $p) { $iscc = $p; break }
+    }
+}
+if (-not $iscc) {
+    Write-Warning "InnoSetup compiler (ISCC.exe) not found. Install it (winget install JRSoftware.InnoSetup) and re-run, or use -NoInstaller. Portable zip is ready."
+    return
+}
+
+Write-Host "`nBuilding InnoSetup installer with $iscc ..." -ForegroundColor Yellow
+& $iscc "/DAppVersion=$Version" "/DPublishDir=$PublishDir" "/DOutputDir=$DistDir" (Join-Path $ProjectDir 'CST.Avalonia.iss')
+if ($LASTEXITCODE -ne 0) { throw "ISCC failed ($LASTEXITCODE)" }
+
+$setup = Join-Path $DistDir "CST-Reader-$Version-$RID-setup.exe"
+if (-not (Test-Path $setup)) { throw "ISCC reported success but $setup was not produced (OutputBaseFilename drift?)." }
+$sha = (Get-FileHash $setup -Algorithm SHA256).Hash.ToLower()
+Write-Host "`nInstaller: $setup  ($([math]::Round((Get-Item $setup).Length/1MB)) MB)" -ForegroundColor Green
+Write-Host "SHA256:    $sha  (for the WinGet manifest, #410)"
+Write-Host "`nDone." -ForegroundColor Cyan


### PR DESCRIPTION
InnoSetup per-user installer + package-windows.ps1, plus a real fix: the app now finds bundled xsl/dictionaries beside the exe (fresh Windows machines rendered no books / had no dictionaries). Verified end-to-end (silent install/uninstall, resources seeded from beside-exe). Fable-reviewed. Closes #403. Refs #28.