### PR TITLE
#401: hardware-acceleration preference (Windows black-view mitigation)

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -128,6 +128,19 @@ public partial class App : Application
             }
         }
 
+        // Hardware-acceleration preference (#401). CEF renders off-screen (OSR) and composites onto the Avalonia
+        // surface; under some GPUs/drivers (notably virtualized GPUs) that path stalls and the view goes black
+        // until an input event. When the user turns hardware acceleration OFF we disable the GPU so CEF composites
+        // in software. Windows-gated (the black-out class we've seen is Windows/virtual-GPU); macOS/Linux keep the
+        // GPU. This switch must be set before the first WebView initializes CEF, so read the setting from disk here
+        // (the same early-read approach as ReadSavedLogLevel; SettingsService isn't built yet).
+        if (OperatingSystem.IsWindows() && !ReadSavedUseHardwareAcceleration())
+        {
+            WebView.Settings.AddCommandLineSwitch("disable-gpu", "");
+            WebView.Settings.AddCommandLineSwitch("disable-gpu-compositing", "");
+            Log.Information("Hardware acceleration disabled by preference; forcing software compositing for the WebView.");
+        }
+
         // Disable persistent cache to use in-memory storage only
         // We still need to provide a path (WebViewLoader expects it), but PersistCache=false ensures it's temporary
         WebView.Settings.PersistCache = false;
@@ -956,6 +969,31 @@ public partial class App : Application
         catch
         {
             return null;
+        }
+    }
+
+    // Peek the persisted hardware-acceleration preference straight from settings.json, before DI is built (the
+    // CEF disable-gpu switch must be set before the first WebView initializes CEF). Same rationale/caveats as
+    // ReadSavedLogLevel. Defaults to true (accelerated) when unset or unreadable. (#401)
+    private static bool ReadSavedUseHardwareAcceleration()
+    {
+        try
+        {
+            var settingsPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                AppConstants.AppDataDirectoryName,
+                "settings.json");
+            if (!File.Exists(settingsPath))
+                return true;
+
+            var json = File.ReadAllText(settingsPath);
+            var settings = JsonSerializer.Deserialize<Settings>(json,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return settings?.UseHardwareAcceleration ?? true;
+        }
+        catch
+        {
+            return true;
         }
     }
 

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -18,6 +18,13 @@ namespace CST.Avalonia.Models
         public XmlUpdateSettings XmlUpdateSettings { get; set; } = new();
         public DpdUpdateSettings DpdUpdateSettings { get; set; } = new();
         public AiSettings Ai { get; set; } = new();
+
+        /// <summary>
+        /// When false, hardware acceleration is disabled for the embedded WebView (forces software compositing).
+        /// Mitigates the CEF off-screen-rendering "black view" stall seen under some GPUs / virtualized drivers on
+        /// Windows (#401). Default true (accelerated). Takes effect on next launch (applied before CEF initializes).
+        /// </summary>
+        public bool UseHardwareAcceleration { get; set; } = true;
     }
 
     /// <summary>

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -670,13 +670,35 @@ namespace CST.Avalonia.ViewModels
     public class ConfigurationSettingsViewModel : ViewModelBase
     {
         private readonly ILogger _logger;
+        private readonly ISettingsService _settingsService;
+        private bool _useHardwareAcceleration;
 
         public ConfigurationSettingsViewModel(ISettingsService settingsService)
         {
             _logger = Log.ForContext<ConfigurationSettingsViewModel>();
+            _settingsService = settingsService;
+            _useHardwareAcceleration = settingsService.Settings.UseHardwareAcceleration;
             SettingsFilePath = settingsService.GetSettingsFilePath();
             OpenSettingsFileCommand = ReactiveCommand.Create(OpenSettingsFile);
         }
+
+        // Hardware acceleration for the embedded WebView. OFF forces software compositing, avoiding the CEF
+        // off-screen-rendering "black view" stall seen under some GPUs / virtualized drivers on Windows. Applied
+        // on the next launch (the CEF switch is set before the browser initializes). (#401)
+        public bool UseHardwareAcceleration
+        {
+            get => _useHardwareAcceleration;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _useHardwareAcceleration, value);
+                _settingsService.Settings.UseHardwareAcceleration = value;
+                _settingsService.RequestSave();
+            }
+        }
+
+        // The mitigation only takes effect on Windows (the black-view stall is Windows / virtual-GPU specific;
+        // macOS/Linux keep the GPU), so the Graphics group is hidden off-Windows rather than shown as a no-op. (#401)
+        public bool IsWindows => OperatingSystem.IsWindows();
 
         public string SettingsFilePath { get; }
 

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -232,6 +232,17 @@
                         <!-- Configuration Settings Template -->
                         <DataTemplate DataType="vm:ConfigurationSettingsViewModel">
                             <StackPanel>
+                                <Border Classes="SettingGroup" IsVisible="{Binding IsWindows}">
+                                    <StackPanel>
+                                        <TextBlock Text="Graphics" Classes="SettingLabel"/>
+                                        <TextBlock Text="Hardware acceleration for the reader view. If book pages occasionally go blank until you click or select text (seen with some GPUs and in virtual machines), turn this off to use software rendering."
+                                                  Classes="SettingDescription" TextWrapping="Wrap"/>
+                                        <CheckBox IsChecked="{Binding UseHardwareAcceleration}"
+                                                 Content="Use hardware acceleration (requires restart)"
+                                                 Margin="0,10,0,0"/>
+                                    </StackPanel>
+                                </Border>
+
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
                                         <TextBlock Text="Configuration" Classes="SettingLabel"/>


### PR DESCRIPTION
Adds Settings.UseHardwareAcceleration (default true) + a Windows-only Settings checkbox; when off, disables CEF GPU at startup to force software compositing (mitigates the virtualized-GPU black-view stall). Replaces the temp diagnostic. Verified (setting=false disables GPU before CEF init). Fable-reviewed. Default (on/off) provisional pending bare-metal #404. Closes #401. Refs #28, #404.