### PR TITLE
#247: relatedLemmas on /v1/forms — the conjugation-scoping middle ground

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
@@ -110,6 +110,39 @@ public sealed class LemmaSearchServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ExpandAndSearch_reports_relatedLemmas_even_without_family_union()
+    {
+        var fake = new FakeSearchService();
+        var svc = NewService(fake);
+
+        // Focus = the verb pajānāti (39702). Its derived_from cluster = {39702, 39994 (paññā 1, fem),
+        // 40070 (paññāya 1, ger)}. Even with family:false (forms = just the verb's own), relatedLemmas must list
+        // the SIBLINGS with their pos so a client can scope a conjugation (the verbal `ger` 40070) vs a deverbal
+        // noun (`fem` 39994) — WITHOUT unioning the whole family. (#247 relatedLemmas)
+        var result = await svc.ExpandAndSearchAsync(39702, includeFamily: false, outputScript: Script.Ipe);
+
+        Assert.NotNull(result);
+        var related = result!.RelatedLemmas.ToDictionary(r => r.LemmaId);
+        Assert.Contains(39994L, related.Keys);              // deverbal noun sibling
+        Assert.Contains(40070L, related.Keys);              // a VERBAL sibling (its own lemmaId)
+        Assert.DoesNotContain(39702L, related.Keys);        // the focus itself is excluded
+        Assert.Equal("ger", related[40070].Pos);            // pos carried so the client can scope the conjugation
+        Assert.Equal("fem", related[39994].Pos);
+        // family:false → the searched alternation is just the verb's own forms, not the siblings'
+        Assert.DoesNotContain("paññāhi", fake.LastQuery!.QueryText);
+    }
+
+    [Fact]
+    public async Task ExpandAndSearch_includeRelated_false_skips_relatedLemmas()
+    {
+        // The report's focus-count path opts out — no family query, empty relatedLemmas. (#247 perf)
+        var svc = NewService(new FakeSearchService());
+        var result = await svc.ExpandAndSearchAsync(39702, includeFamily: false, outputScript: Script.Ipe, includeRelated: false);
+        Assert.NotNull(result);
+        Assert.Empty(result!.RelatedLemmas);
+    }
+
+    [Fact]
     public async Task ExpandAndSearchSet_unions_several_lemmas_forms_in_one_query()
     {
         var fake = new FakeSearchService();

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -225,14 +225,20 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   (Present only when the dpd-cst-subset dataset is installed; 503 if not.)
 - `GET  /v1/forms/{lemmaId}?family=&script=` - LEMMA forward-expansion: a lemma's ATTESTED paradigm WITH
   corpus counts. Returns `{ lemmaId, lemma, pos, gloss, forms:[{ form, count, bookCount }], totalOccurrences,
-  attestedFormCount, candidateFormCount, expansionCapped, note }`. This answers "the whole declension/
+  attestedFormCount, candidateFormCount, expansionCapped, relatedLemmas:[{ lemmaId, lemma, pos, gloss, derivedFrom }],
+  note }`. This answers "the whole declension/
   conjugation of X and how often each form occurs" in ONE call - counts come from the corpus index, so a
   DPD form that never occurs is omitted (synthetic). `totalOccurrences` is de-duplicated within this response.
   ** For an inflectional family, PREFER this lemma path over hand-built search regexes (see `/docs/search.md`) - it handles the
   stem alternation, the homograph (you chose the lemma), and the synthetic-vs-attested split for you. **
   CROSS-LEMMA CAUTION: a word's forms are often SPLIT across SIBLING lemmas (e.g. a verb's present participle
   is its OWN lemmaId), and the SAME surface token can appear under several of them - so do NOT sum
-  `totalOccurrences` across sibling lemmaIds (that double-counts the shared tokens). `family:true` returns the
+  `totalOccurrences` across sibling lemmaIds (that double-counts the shared tokens). This is exactly what
+  `relatedLemmas` is for: it lists those OTHER family lemmas (each with its `pos`), which are NOT in `forms`
+  above. THE MIDDLE GROUND between `family:false` and `family:true`: to assemble a whole CONJUGATION, take the
+  VERBAL-pos entries of `relatedLemmas` (`pr`/`aor`/`fut`/`opt`/`imp`/`cond`/`prp`/`app`/`abs`/`ger`/`inf`/`pp`/
+  `ptp`/`fpp`/`caus`/`pass`/`denom`), `GET /v1/forms/{lemmaId}` for each, and union their forms - that gets the
+  verb + all its participles/absolutive WITHOUT the deverbal nouns that `family:true` sweeps in. `family:true` returns the
   DE-DUPLICATED UNION of the whole `derived_from` word family (the verb AND its participles, deverbal nouns,
   causative, passive - everything sharing the root-sense), each token counted ONCE, with a combined
   `totalOccurrences`. CHOOSE DELIBERATELY, the gap is large: `family:false` (the DEFAULT) = just THIS lemma's

--- a/src/CST.Avalonia/Services/ILemmaSearchService.cs
+++ b/src/CST.Avalonia/Services/ILemmaSearchService.cs
@@ -25,7 +25,8 @@ public sealed record LemmaSearchResult(
     int TotalOccurrences,
     int CandidateFormCount,
     int AttestedFormCount,
-    bool ExpansionCapped);
+    bool ExpansionCapped,
+    IReadOnlyList<LemmaCandidate> RelatedLemmas);
 
 /// <summary>One alternative sandhi/compound split of a word: its constituent parts (IAST) and DPD's rank
 /// (0 = best-ranked). The splits are ALTERNATIVES, not sequential pieces — Pāli sandhi is ambiguous, so DPD
@@ -66,13 +67,17 @@ public interface ILemmaSearchService
     /// for its lemma(s). (sandhi decomposer, #383)</summary>
     WordDeconstruction? Deconstruct(string word, Script sourceScript = Script.Ipe);
 
-    /// <summary>Forward-expand a chosen lemma (optionally its derived_from family) and search the corpus for the forms.</summary>
+    /// <summary>Forward-expand a chosen lemma (optionally its derived_from family) and search the corpus for the forms.
+    /// <paramref name="includeRelated"/> (default true) also reports the family's OTHER lemmas as
+    /// <see cref="LemmaSearchResult.RelatedLemmas"/> metadata; pass false to skip that family query when the caller
+    /// doesn't need it (e.g. the report's focus-count call). (#247 relatedLemmas)</summary>
     Task<LemmaSearchResult?> ExpandAndSearchAsync(
         long lemmaId,
         bool includeFamily = false,
         BookFilter? filter = null,
         Script outputScript = Script.Latin,
-        CancellationToken ct = default);
+        CancellationToken ct = default,
+        bool includeRelated = true);
 
     /// <summary>Expand and search the DE-DUPLICATED UNION of several lemmas' forms in ONE query — used to count
     /// a collapsed family row (the homonyms of one headword) without double-counting their shared forms. (#247)</summary>

--- a/src/CST.Avalonia/Services/LemmaReportService.cs
+++ b/src/CST.Avalonia/Services/LemmaReportService.cs
@@ -67,7 +67,7 @@ public sealed class LemmaReportService : ILemmaReportService
 
         // Focus paradigm — forms with corpus counts (in IPE). A form is a homograph only if it also belongs
         // to a lemma OUTSIDE this word-family.
-        var focus = await _search.ExpandAndSearchAsync(lemmaId, includeFamily: false, filter: null, outputScript: Script.Ipe, ct: ct)
+        var focus = await _search.ExpandAndSearchAsync(lemmaId, includeFamily: false, filter: null, outputScript: Script.Ipe, ct: ct, includeRelated: false)
             .ConfigureAwait(false);
         var forms = new List<ReportForm>();
         var homographs = new List<ReportHomograph>();

--- a/src/CST.Avalonia/Services/LemmaSearchService.cs
+++ b/src/CST.Avalonia/Services/LemmaSearchService.cs
@@ -81,20 +81,27 @@ public sealed class LemmaSearchService : ILemmaSearchService
         bool includeFamily = false,
         BookFilter? filter = null,
         Script outputScript = Script.Latin,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        bool includeRelated = true)
     {
         if (!IsAvailable) return null;
 
-        var expansion = _lemma.ExpandLemma(lemmaId, includeFamily);
+        // Fetch the family iff we need it — either to UNION its forms (family:true) or to REPORT its members as
+        // `relatedLemmas` metadata (includeRelated, the default: a verb's participles/absolutive are their OWN
+        // lemmaIds, so this is how a client discovers them and scopes "the conjugation" without over-shooting to
+        // the whole family). When neither is needed (e.g. the report's focus-count call), skip the family query. (#247)
+        bool needFamily = includeFamily || includeRelated;
+        var expansion = _lemma.ExpandLemma(lemmaId, includeFamily: needFamily);
         if (expansion is null) return null;
 
         var lemma = new LemmaCandidate(expansion.LemmaId, expansion.Lemma, expansion.Pos, expansion.Gloss, expansion.DerivedFrom);
+        var siblings = expansion.Family?.Where(m => m.LemmaId != lemmaId).ToList() ?? new List<LemmaCandidate>();
 
-        // Gather forms: the lemma's own paradigm, plus (when asked) each derived_from family member's forms.
+        // Gather forms: the lemma's own paradigm, plus — only when family:true — each family member's forms UNIONed.
         var forms = new SortedSet<string>(expansion.Forms, StringComparer.Ordinal);
-        if (includeFamily && expansion.Family is { } family)
+        if (includeFamily)
         {
-            foreach (var member in family.Where(m => m.LemmaId != lemmaId))
+            foreach (var member in siblings)
             {
                 var fe = _lemma.ExpandLemma(member.LemmaId, includeFamily: false);
                 if (fe is not null)
@@ -102,7 +109,8 @@ public sealed class LemmaSearchService : ILemmaSearchService
             }
         }
 
-        return await SearchFormsAsync(lemma, forms, filter, outputScript, ct).ConfigureAwait(false);
+        var related = includeRelated ? (IReadOnlyList<LemmaCandidate>)siblings : Array.Empty<LemmaCandidate>();
+        return await SearchFormsAsync(lemma, forms, related, filter, outputScript, ct).ConfigureAwait(false);
     }
 
     public async Task<LemmaSearchResult?> ExpandAndSearchSetAsync(
@@ -121,16 +129,17 @@ public sealed class LemmaSearchService : ILemmaSearchService
             foreach (var f in e.Forms) forms.Add(f);
         }
         return lemma is null ? null
-            : await SearchFormsAsync(lemma, forms, null, outputScript, ct).ConfigureAwait(false);
+            : await SearchFormsAsync(lemma, forms, Array.Empty<LemmaCandidate>(), null, outputScript, ct).ConfigureAwait(false);
     }
 
     // Search a de-duplicated form set as one anchored IAST alternation (converted to IPE by the search path)
-    // and project the attested terms with corpus counts.
+    // and project the attested terms with corpus counts. `relatedLemmas` is carried through as metadata.
     private async Task<LemmaSearchResult> SearchFormsAsync(
-        LemmaCandidate lemma, SortedSet<string> forms, BookFilter? filter, Script outputScript, CancellationToken ct)
+        LemmaCandidate lemma, SortedSet<string> forms, IReadOnlyList<LemmaCandidate> relatedLemmas,
+        BookFilter? filter, Script outputScript, CancellationToken ct)
     {
         if (forms.Count == 0)
-            return new LemmaSearchResult(lemma, Array.Empty<LemmaSearchForm>(), 0, 0, 0, false);
+            return new LemmaSearchResult(lemma, Array.Empty<LemmaSearchForm>(), 0, 0, 0, false, relatedLemmas);
 
         bool capped = forms.Count > MaxAlternationForms;
         var searchForms = capped ? forms.Take(MaxAlternationForms).ToList() : forms.ToList();
@@ -163,6 +172,7 @@ public sealed class LemmaSearchService : ILemmaSearchService
             sr.TotalOccurrenceCount,
             CandidateFormCount: searchForms.Count,
             AttestedFormCount: attested.Count,
-            ExpansionCapped: capped || sr.ExpansionCapped);
+            ExpansionCapped: capped || sr.ExpansionCapped,
+            RelatedLemmas: relatedLemmas);
     }
 }

--- a/src/CST.Avalonia/Services/LocalApi/Lemma/LemmaApiContracts.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Lemma/LemmaApiContracts.cs
@@ -22,7 +22,8 @@ public sealed record LemmaFormDto(string Form, int Count, int BookCount);
 public sealed record LemmaFormsResponse(
     long LemmaId, string Lemma, string? Pos, string? Gloss, string? DerivedFrom,
     IReadOnlyList<LemmaFormDto> Forms, int TotalOccurrences,
-    int AttestedFormCount, int CandidateFormCount, bool ExpansionCapped, string? Note);
+    int AttestedFormCount, int CandidateFormCount, bool ExpansionCapped,
+    IReadOnlyList<LemmaCandidateDto> RelatedLemmas, string? Note);
 
 /// <summary>One ranked alternative split of a compound/sandhi word (parts in the output script).</summary>
 public sealed record WordSplitDto(int Rank, IReadOnlyList<string> Parts);
@@ -106,17 +107,30 @@ internal static class LemmaApi
             + (direct.Count > 0 ? " This word is ALSO a dictionary headword in its own right (see directLemmas)." : string.Empty);
     }
 
-    public static LemmaFormsResponse ToForms(LemmaSearchResult res, Script outputScript)
+    public static LemmaFormsResponse ToForms(LemmaSearchResult res, Script outputScript, bool familyUnion = false)
     {
         var forms = res.AttestedForms.Select(f => new LemmaFormDto(f.Form, f.Count, f.BookCount)).ToList();
+        var related = res.RelatedLemmas
+            .Select(c => new LemmaCandidateDto(c.LemmaId, Script(c.Lemma, outputScript), c.Pos, c.Gloss, ScriptOrNull(c.DerivedFrom, outputScript)))
+            .ToList();
         int synthetic = res.CandidateFormCount - res.AttestedFormCount;
         string note = $"Counts are corpus occurrences (from the index). {res.AttestedFormCount} of "
             + $"{res.CandidateFormCount} DPD candidate forms occur; the other {synthetic} are synthetic "
-            + "(never attested). totalOccurrences is the grand total for this lemma."
-            + (res.ExpansionCapped ? " NOTE: the form set was capped — narrow the query." : string.Empty);
+            + "(never attested). totalOccurrences is the grand total for this "
+            + (familyUnion ? "whole word family (de-duplicated union)." : "lemma.")
+            + (res.ExpansionCapped ? " NOTE: the form set was capped — narrow the query." : string.Empty)
+            // The "assemble a conjugation" guidance only makes sense on the DEFAULT (family:false) response — on a
+            // family:true response the forms above ALREADY union the whole family, so re-fetching would duplicate.
+            + (related.Count > 0 && !familyUnion
+                ? " relatedLemmas = the OTHER lemmas of this word-family, each with its pos — a verb's participles / "
+                  + "absolutive / infinitive are SEPARATE lemmaIds and are NOT in the forms above. To assemble a whole "
+                  + "CONJUGATION, GET /v1/forms/{lemmaId} for the VERBAL-pos relatedLemmas and union their forms "
+                  + "(family:true instead unions the ENTIRE family — including deverbal NOUNS — which is broader). Do NOT "
+                  + "sum totalOccurrences across relatedLemmas; they can share surface tokens (double-count)."
+                : string.Empty);
         return new LemmaFormsResponse(
             res.Lemma.LemmaId, Script(res.Lemma.Lemma, outputScript), res.Lemma.Pos, res.Lemma.Gloss,
             ScriptOrNull(res.Lemma.DerivedFrom, outputScript),
-            forms, res.TotalOccurrences, res.AttestedFormCount, res.CandidateFormCount, res.ExpansionCapped, note);
+            forms, res.TotalOccurrences, res.AttestedFormCount, res.CandidateFormCount, res.ExpansionCapped, related, note);
     }
 }

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -519,7 +519,7 @@ namespace CST.Avalonia.Services.LocalApi
                     var res = await lemma.ExpandAndSearchAsync(lemmaId, family ?? false, null, outputScript, ct);
                     return res is null
                         ? Results.NotFound(new { error = $"Unknown lemmaId {lemmaId}." })
-                        : Results.Json(LemmaApi.ToForms(res, outputScript));
+                        : Results.Json(LemmaApi.ToForms(res, outputScript, family ?? false));
                 });
 
                 // Sandhi/compound deconstruction: a word -> its ranked constituent-part splits (DPD deconstructor).

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/LemmaMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/LemmaMcpTool.cs
@@ -44,8 +44,11 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             + "form that OCCURS in the corpus, each with its occurrence count and book count, plus the grand "
             + "total. Answers 'give me the whole declension/conjugation of X and how often each form occurs' in "
             + "ONE call — no wildcard/regex, no homograph confusion (the lemma was already chosen). Counts come "
-            + "from the corpus index; DPD candidate forms that never occur are omitted (synthetic). `family:true` "
-            + "widens to the whole derived_from word family. `script` sets the output script (default Latin).")]
+            + "from the corpus index; DPD candidate forms that never occur are omitted (synthetic). Also returns "
+            + "`relatedLemmas` — the OTHER lemmas of this word-family (a verb's participles/absolutive are SEPARATE "
+            + "lemmaIds, NOT in this paradigm): to build a whole CONJUGATION, call this again for the verbal-pos "
+            + "relatedLemmas and union. `family:true` instead widens to the ENTIRE derived_from word family (incl. "
+            + "deverbal nouns — broader). `script` sets the output script (default Latin).")]
         public static async Task<LemmaFormsResponse> LemmaForms(
             ILemmaSearchService lemma,
             [Description("The lemma id from 'lemma_lookup'.")] long lemmaId,
@@ -57,8 +60,8 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             var res = await lemma.ExpandAndSearchAsync(lemmaId, family, null, s, ct).ConfigureAwait(false);
             return res is null
                 ? new LemmaFormsResponse(lemmaId, string.Empty, null, null, null,
-                    Array.Empty<LemmaFormDto>(), 0, 0, 0, false, $"Unknown lemmaId {lemmaId}.")
-                : LemmaApi.ToForms(res, s);
+                    Array.Empty<LemmaFormDto>(), 0, 0, 0, false, Array.Empty<LemmaCandidateDto>(), $"Unknown lemmaId {lemmaId}.")
+                : LemmaApi.ToForms(res, s, family);
         }
 
         [McpServerTool(Name = "sandhi_split")]


### PR DESCRIPTION
Builds the *"one genuinely-missing backend capability"* from #247's backlog.

## The gap
`GET /v1/forms/{lemmaId}` returns just *that* lemma's inflected forms. But a verb's participles/absolutive are **separate lemmaIds** (its `derived_from` family), so `/v1/forms` on the finite verb omits them — and `family:true` over-shoots to the *whole* word-family (verb + participles + deverbal **nouns** → 17,143 for `pajānāti`, ~4× the verb). There was no way to say "the conjugation" — the middle ground.

## What this adds
`relatedLemmas` — the family's **other** lemmas as metadata `{ lemmaId, lemma, pos, gloss, derivedFrom }` — on `/v1/forms` and MCP `lemma_forms`. A client filters the **verbal-pos** entries, `GET /v1/forms/{lemmaId}` for each, and unions → the verb + all its participles/absolutive **without** the deverbal nouns. The response `note` + llms.txt spell out exactly that (turning the existing CROSS-LEMMA caution actionable).

## Correctness / perf
- **`family:false` forms + counts are byte-identical to before** — forms come from the lemma's own `form_lemma` rows (unchanged); only the `relatedLemmas` metadata is added. (Verified by fable across all 6 focus areas.)
- **New `includeRelated` flag** (default true) lets a caller skip the family query; `LemmaReportService`'s focus-count call opts out, so the report has **no perf regression** (fable finding A).
- The "assemble a conjugation" note is **gated to `family:false`** — on `family:true` the forms already union the family, so the guidance would be redundant (fable finding B).

## Validation
fable-reviewed (verdict: correct on every load-bearing point; both low-severity items fixed). Unit tests: `relatedLemmas` populated with pos + focus excluded on the default call, and empty on the opt-out path. Full suite **755 green**.

Advances #247 (the remaining per-occurrence disambiguation #2/#3 and the GUI #368 stay open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig