### PR TITLE
#247: POST /v1/forms + MCP lemma_forms_union — de-duplicated union count of a lemma set

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -343,6 +343,37 @@ namespace CST.Avalonia.Tests.Integration
         }
 
         [Fact]
+        public async Task Forms_union_post_returns_a_deduplicated_union_of_several_lemmas()
+        {
+            // POST /v1/forms unions the two homograph lemmas' forms into one de-duplicated count. (#247)
+            using var http = _api.Http();
+            using var doc = await PostDoc(http, "/v1/forms", "{\"lemmaIds\":[100,101]}");
+            var root = doc.RootElement;
+            Assert.Equal(2, root.GetProperty("lemmaIds").GetArrayLength());
+            var forms = root.GetProperty("forms").EnumerateArray()
+                .Select(f => f.GetProperty("form").GetString()).ToHashSet();
+            Assert.Contains("dhamma", forms);                                    // shared by both lemmas — counted ONCE
+            Assert.True(root.GetProperty("totalOccurrences").GetInt32() > 0);
+            Assert.Contains("UNION", root.GetProperty("note").GetString());
+        }
+
+        [Fact]
+        public async Task Forms_union_post_empty_lemmaIds_is_400()
+        {
+            using var http = _api.Http();
+            var resp = await http.PostAsync("/v1/forms", Json("{\"lemmaIds\":[]}"));
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Forms_union_post_all_unknown_ids_is_404()
+        {
+            using var http = _api.Http();
+            var resp = await http.PostAsync("/v1/forms", Json("{\"lemmaIds\":[99999998,99999999]}"));
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, resp.StatusCode);
+        }
+
+        [Fact]
         public async Task Lemma_report_renders_the_dossier_html()
         {
             using var http = _api.Http();

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -246,9 +246,17 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   DIFFERENT words (a verb's family includes its deverbal NOUNS). For "how often does the verb X occur", use
   `family:false` - e.g. the verb `pajānāti` is ~4,195 occurrences with `family:false`, but ~17,000 with
   `family:true` (which sweeps in the noun `paññā` and its whole declension): a ~4x difference, so picking the
-  wrong flag is a gross error, not a rounding one. To count "just the verb" INCLUDING its negated/sandhi
-  sibling (e.g. `nappajānāti` = na+), union that specific sibling's forms yourself rather than taking the
-  whole family; filter by `pos` when you need to scope a family to one grammatical class.
+  wrong flag is a gross error, not a rounding one. THE MIDDLE GROUND between `family:false` and `family:true` is
+  `relatedLemmas` (returned above) + `POST /v1/forms` (below): filter `relatedLemmas` by `pos` to the class you
+  want, then count that exact set as one number.
+- `POST /v1/forms` - `{ lemmaIds:[…], script? }` -> the DE-DUPLICATED UNION of those lemmas' attested forms with a
+  combined `totalOccurrences` (each surface token counted ONCE across the set). Returns
+  `{ lemmaIds, forms:[{ form, count, bookCount }], totalOccurrences, attestedFormCount, candidateFormCount,
+  expansionCapped, note }`. This is how to COUNT a scoped set - most usefully a whole CONJUGATION: `GET
+  /v1/forms/{lemmaId}` on the verb, take the VERBAL-pos entries of its `relatedLemmas` (`pr`/`aor`/`fut`/`opt`/
+  `imp`/`cond`/`prp`/`app`/`abs`/`ger`/`inf`/`pp`/`ptp`/`fpp`/`caus`/`pass`/`denom`), and POST that lemma + those
+  ids here for the verb's conjugation count WITHOUT the deverbal-noun over-shoot of `family:true`. Do NOT sum the
+  per-lemma `totalOccurrences` yourself (shared tokens double-count) - this endpoint de-dups for you.
 - `GET  /v1/deconstruct/{word}?script=` - SANDHI/COMPOUND deconstruction: a word -> its constituent PARTS
   (DPD deconstructor). Returns `{ word, splits:[{ rank, parts:[…] }], directLemmas:[…], note }`. `splits` are
   DPD's RANKED ALTERNATIVE analyses (rank 0 = best), NOT sequential pieces - Pāli sandhi is ambiguous, so the

--- a/src/CST.Avalonia/Services/LocalApi/Lemma/LemmaApiContracts.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Lemma/LemmaApiContracts.cs
@@ -25,6 +25,16 @@ public sealed record LemmaFormsResponse(
     int AttestedFormCount, int CandidateFormCount, bool ExpansionCapped,
     IReadOnlyList<LemmaCandidateDto> RelatedLemmas, string? Note);
 
+/// <summary>Request for POST /v1/forms — count a SET of lemmas as one de-duplicated union of their forms.</summary>
+public sealed record LemmaFormsUnionRequest(long[]? LemmaIds, string? Script);
+
+/// <summary>Response for POST /v1/forms — the DE-DUPLICATED union of several lemmas' attested forms with a
+/// combined corpus total (each surface token counted once across the set). Used to count a scoped group such as
+/// a whole CONJUGATION (the verbal-pos relatedLemmas of a verb). (#247)</summary>
+public sealed record LemmaFormsUnionResponse(
+    IReadOnlyList<long> LemmaIds, IReadOnlyList<LemmaFormDto> Forms, int TotalOccurrences,
+    int AttestedFormCount, int CandidateFormCount, bool ExpansionCapped, string? Note);
+
 /// <summary>One ranked alternative split of a compound/sandhi word (parts in the output script).</summary>
 public sealed record WordSplitDto(int Rank, IReadOnlyList<string> Parts);
 
@@ -39,6 +49,10 @@ public sealed record DeconstructResponse(
 
 internal static class LemmaApi
 {
+    /// <summary>Cap on the lemmaIds a POST /v1/forms (and MCP lemma_forms_union) may expand — shared by the REST
+    /// endpoint and the MCP tool so they can't drift. (#247)</summary>
+    internal const int MaxUnionLemmas = 500;
+
     // Convert a lemma citation form (IAST, may carry a trailing homonym number) to the output script.
     private static string Script(string lemma, Script outputScript)
         => outputScript == CST.Conversion.Script.Latin ? lemma : ScriptConverter.Convert(lemma, CST.Conversion.Script.Latin, outputScript);
@@ -123,14 +137,30 @@ internal static class LemmaApi
             // family:true response the forms above ALREADY union the whole family, so re-fetching would duplicate.
             + (related.Count > 0 && !familyUnion
                 ? " relatedLemmas = the OTHER lemmas of this word-family, each with its pos — a verb's participles / "
-                  + "absolutive / infinitive are SEPARATE lemmaIds and are NOT in the forms above. To assemble a whole "
-                  + "CONJUGATION, GET /v1/forms/{lemmaId} for the VERBAL-pos relatedLemmas and union their forms "
-                  + "(family:true instead unions the ENTIRE family — including deverbal NOUNS — which is broader). Do NOT "
-                  + "sum totalOccurrences across relatedLemmas; they can share surface tokens (double-count)."
+                  + "absolutive / infinitive are SEPARATE lemmaIds and are NOT in the forms above. To COUNT a whole "
+                  + "CONJUGATION as ONE number, POST /v1/forms with { lemmaIds:[…] } = the VERBAL-pos relatedLemmas "
+                  + "(this lemma + its verbal siblings): it returns the DE-DUPLICATED union. (family:true instead unions "
+                  + "the ENTIRE family — including deverbal NOUNS — which is broader.) Do NOT sum totalOccurrences across "
+                  + "relatedLemmas yourself; they can share surface tokens (double-count)."
                 : string.Empty);
         return new LemmaFormsResponse(
             res.Lemma.LemmaId, Script(res.Lemma.Lemma, outputScript), res.Lemma.Pos, res.Lemma.Gloss,
             ScriptOrNull(res.Lemma.DerivedFrom, outputScript),
             forms, res.TotalOccurrences, res.AttestedFormCount, res.CandidateFormCount, res.ExpansionCapped, related, note);
+    }
+
+    // The forms in `res` are ALREADY in the requested output script (SearchFormsAsync converted them); this just
+    // projects them and writes the union note. Used by POST /v1/forms + MCP lemma_forms_union. (#247)
+    public static LemmaFormsUnionResponse ToFormsUnion(LemmaSearchResult res, IReadOnlyList<long> lemmaIds)
+    {
+        var forms = res.AttestedForms.Select(f => new LemmaFormDto(f.Form, f.Count, f.BookCount)).ToList();
+        string note = $"De-duplicated UNION over the {lemmaIds.Count} lemmaIds (any UNKNOWN ones are skipped) — each "
+            + "surface token counted ONCE across them (NOT the sum of per-lemma totals, which double-counts shared tokens). "
+            + $"{res.AttestedFormCount} of {res.CandidateFormCount} candidate forms occur; totalOccurrences is the "
+            + "combined corpus total. This is how to count a scoped SET such as a CONJUGATION: pass the VERBAL-pos "
+            + "relatedLemmas of a verb (from GET /v1/forms/{lemmaId})."
+            + (res.ExpansionCapped ? " NOTE: the form set was capped — narrow the set." : string.Empty);
+        return new LemmaFormsUnionResponse(
+            lemmaIds, forms, res.TotalOccurrences, res.AttestedFormCount, res.CandidateFormCount, res.ExpansionCapped, note);
     }
 }

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -522,6 +522,19 @@ namespace CST.Avalonia.Services.LocalApi
                         : Results.Json(LemmaApi.ToForms(res, outputScript, family ?? false));
                 });
 
+                // UNION of several lemmas' forms as ONE de-duplicated count — a scoped set like a CONJUGATION (pass
+                // the verbal-pos relatedLemmas of a verb). Reuses the same union plumbing the report uses. (#247)
+                app.MapPost(v + "/forms", async (LemmaFormsUnionRequest req, CancellationToken ct) =>
+                {
+                    if (!lemma.IsAvailable) return LemmaUnavailable();
+                    var ids = (req.LemmaIds ?? System.Array.Empty<long>()).Distinct().Take(LemmaApi.MaxUnionLemmas).ToList();
+                    if (ids.Count == 0) return Results.BadRequest(new { error = "lemmaIds is required (a non-empty array)." });
+                    var res = await lemma.ExpandAndSearchSetAsync(ids, ParseScript(req.Script), ct);
+                    return res is null
+                        ? Results.NotFound(new { error = "None of the given lemmaIds are known." })
+                        : Results.Json(LemmaApi.ToFormsUnion(res, ids));
+                });
+
                 // Sandhi/compound deconstruction: a word -> its ranked constituent-part splits (DPD deconstructor).
                 // The word->parts primitive only; the caller composes part -> /v1/lemma -> /v1/dictionary. (#383)
                 app.MapGet(v + "/deconstruct/{word}", (string word, string? script) =>

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/LemmaMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/LemmaMcpTool.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Services;
@@ -62,6 +63,28 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                 ? new LemmaFormsResponse(lemmaId, string.Empty, null, null, null,
                     Array.Empty<LemmaFormDto>(), 0, 0, 0, false, Array.Empty<LemmaCandidateDto>(), $"Unknown lemmaId {lemmaId}.")
                 : LemmaApi.ToForms(res, s, family);
+        }
+
+        [McpServerTool(Name = "lemma_forms_union")]
+        [Description("Count a SET of lemmas as ONE de-duplicated union of their attested forms — each surface token "
+            + "counted ONCE across them (NOT the sum of per-lemma totals, which double-counts shared tokens). This is "
+            + "how you get an EXACT count for a scoped group like a whole CONJUGATION: call 'lemma_forms' on the verb, "
+            + "take the VERBAL-pos entries of its `relatedLemmas` (its participles / absolutive / infinitive — `pr`, "
+            + "`prp`, `abs`, `ger`, `pp`, `caus`, `pass`, etc.), and pass this lemma + those lemmaIds here. `script` "
+            + "sets the output script (default Latin).")]
+        public static async Task<LemmaFormsUnionResponse> LemmaFormsUnion(
+            ILemmaSearchService lemma,
+            [Description("The lemmaIds to union (e.g. a verb + its verbal-pos relatedLemmas).")] long[] lemmaIds,
+            [Description("Output script (default Latin).")] Script script = Script.Latin,
+            CancellationToken ct = default)
+        {
+            var s = Safe(script);
+            var ids = (lemmaIds ?? Array.Empty<long>()).Distinct().Take(LemmaApi.MaxUnionLemmas).ToList();
+            var res = ids.Count == 0 ? null : await lemma.ExpandAndSearchSetAsync(ids, s, ct).ConfigureAwait(false);
+            return res is null
+                ? new LemmaFormsUnionResponse(ids, Array.Empty<LemmaFormDto>(), 0, 0, 0, false,
+                    ids.Count == 0 ? "lemmaIds is required (a non-empty array)." : "None of the given lemmaIds are known.")
+                : LemmaApi.ToFormsUnion(res, ids);
         }
 
         [McpServerTool(Name = "sandhi_split")]


### PR DESCRIPTION
Follow-up surfaced by the **relatedLemmas cold-agent test**: 4/5 agents correctly scoped a conjugation via `relatedLemmas.pos`, but to **count** it they hand-unioned ~30 lemmas' forms across ~30 calls — and **haiku got the arithmetic wrong** (per-lemma totals double-count shared tokens). This exposes the de-duplicated union that already exists internally (`ExpandAndSearchSetAsync`, used for the report's homonym collapse) as a single call.

## What's added
- **`POST /v1/forms { lemmaIds:[…], script? }`** + MCP **`lemma_forms_union`** → the DE-DUPLICATED union of those lemmas' attested forms with a combined `totalOccurrences` (each surface token counted **once**). Intended use: pass a verb + its **verbal-pos `relatedLemmas`** → the conjugation count **without** `family:true`'s deverbal-noun over-shoot.
- Distinct-then-cap at `LemmaApi.MaxUnionLemmas` (500, **shared** by REST + MCP so they can't drift). `lemmaIds:[]` → 400; all-unknown → 404; unknown ids in a mixed set are skipped (the note says so).
- The `relatedLemmas` note + llms.txt now point at `POST /v1/forms` for the count — closing the loop the cold-agent test opened.

## Validation
fable-reviewed — **no bugs across all six focus areas** (cap/Distinct ordering, empty/null/all-unknown, no double script-conversion / IPE leak, bounded work, MCP branch). Its two low-severity nits fixed: the note no longer overstates "N lemmas" on partial-unknown sets, and the cap literal is shared. 3 integration tests (union / 400 / 404). Full suite **758 green**.

Advances #247 (the per-occurrence disambiguation #2/#3 and the GUI #368 stay open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYR8nPui2jgcXREYWWMWig