### PR TITLE
#54 follow-up: queue View Source when the page isn't resolved (no silent no-op mid-recalc)

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1492,10 +1492,11 @@ public partial class App : Application
                 var documentDock = FindDocumentDockInLayout(hostWindow.Layout) as Dock.Model.Mvvm.Controls.DocumentDock;
                 if (documentDock?.ActiveDockable is BookDisplayViewModel bookViewModel)
                 {
-                    var command = source2010 ? bookViewModel.ShowSource2010Command : bookViewModel.ShowSource1957Command;
                     Log.Information("View Source ({Edition}) via floating-window menu for book: {BookFile}",
                         source2010 ? "2010" : "1957", bookViewModel.Book.FileName);
-                    command.Execute().Subscribe(_ => { }, ex => Log.Debug(ex, "View Source command not available"));
+                    // Queue-intent (see BookDisplayViewModel.RequestShowSource): fire now if the Myanmar page
+                    // is resolved, else once it resolves, so a mid-recalc shortcut isn't a silent no-op.
+                    bookViewModel.RequestShowSource(source2010);
                 }
             }
         }

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -1584,6 +1584,51 @@ namespace CST.Avalonia.ViewModels
         /// Show source PDF for the current book at the current Myanmar page.
         /// Downloads PDF from SharePoint and displays in a dockable tab.
         /// </summary>
+        // Queue-intent entry point for View Source (keystroke / menu / JS paths). During a fast UI sequence
+        // the target Myanmar page may not be resolved yet (MyanmarPage == "*"), which greys the ShowSource
+        // commands (#54) — so a shortcut pressed in that window silently no-ops. Instead: fire immediately if
+        // the page is known, else remember the request and fire it once MyanmarPage resolves. (The toolbar
+        // buttons stay bound to the gated commands, so they still visibly grey out as before.)
+        // Distinct editions requested while the page was unresolved (deduped, request order preserved), plus
+        // the single wait-subscription that flushes them once MyanmarPage resolves. Both editions open if the
+        // user pressed Cmd+E and Cmd+Shift+E before resolution.
+        private readonly List<Sources.SourceType> _pendingSourceRequests = new();
+        private IDisposable? _pendingSourceSubscription;
+
+        public void RequestShowSource(bool source2010)
+        {
+            var sourceType = source2010 ? Sources.SourceType.Burmese2010 : Sources.SourceType.Burmese1957;
+            if (_myanmarPage != "*" && !string.IsNullOrEmpty(_myanmarPage))
+            {
+                ShowSource(sourceType);
+                return;
+            }
+
+            // Not resolved yet: queue this edition (deduped) and arm one wait that flushes ALL pending once
+            // the page lands, so requesting both editions before resolution opens both.
+            if (!_pendingSourceRequests.Contains(sourceType))
+                _pendingSourceRequests.Add(sourceType);
+
+            if (_pendingSourceSubscription != null) return;   // already waiting; the list above will be flushed
+
+            _pendingSourceSubscription = this.WhenAnyValue(x => x.MyanmarPage)
+                .Where(p => p != "*" && !string.IsNullOrEmpty(p))
+                .Take(1)   // auto-completes after the first resolved value
+                .Subscribe(_ =>
+                {
+                    var pending = _pendingSourceRequests.ToList();
+                    _pendingSourceRequests.Clear();
+                    _pendingSourceSubscription?.Dispose();
+                    _pendingSourceSubscription = null;
+                    // MyanmarPage may be set off the UI thread; ShowSource mutates the dock layout. (BOOK-2)
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        foreach (var t in pending) ShowSource(t);
+                    });
+                });
+            _logger.Debug("View Source queued ({Source}) until the Myanmar page resolves", sourceType);
+        }
+
         private void ShowSource(Sources.SourceType sourceType)
         {
             _logger.Information("ShowSource called - raw _myanmarPage value: '{MyanmarPage}', book: {Book}",

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -160,7 +160,7 @@ public partial class BookDisplayView : UserControl
         {
             _logger.Debug("*** VIEW SOURCE 1957 SHORTCUT DETECTED IN BookDisplayView ***");
             e.Handled = true; // Prevent further processing
-            _viewModel?.ShowSource1957Command.Execute().Subscribe();
+            _viewModel?.RequestShowSource(source2010: false);
             return;
         }
 
@@ -169,7 +169,7 @@ public partial class BookDisplayView : UserControl
         {
             _logger.Debug("*** VIEW SOURCE 2010 SHORTCUT DETECTED IN BookDisplayView ***");
             e.Handled = true; // Prevent further processing
-            _viewModel?.ShowSource2010Command.Execute().Subscribe();
+            _viewModel?.RequestShowSource(source2010: true);
             return;
         }
     }
@@ -1595,7 +1595,7 @@ public partial class BookDisplayView : UserControl
                     _logger.Debug("*** VIEW SOURCE 1957 REQUESTED FROM JAVASCRIPT ***");
                     // OnTitleChanged runs on the CEF thread; the command mutates the dock layout, so it
                     // must run on the UI thread. (BOOK-2)
-                    Dispatcher.UIThread.Post(() => _viewModel?.ShowSource1957Command.Execute().Subscribe());
+                    Dispatcher.UIThread.Post(() => _viewModel?.RequestShowSource(source2010: false));
                 }
             }
             catch (Exception ex)
@@ -1616,7 +1616,7 @@ public partial class BookDisplayView : UserControl
                     _logger.Debug("*** VIEW SOURCE 2010 REQUESTED FROM JAVASCRIPT ***");
                     // OnTitleChanged runs on the CEF thread; the command mutates the dock layout, so it
                     // must run on the UI thread. (BOOK-2)
-                    Dispatcher.UIThread.Post(() => _viewModel?.ShowSource2010Command.Execute().Subscribe());
+                    Dispatcher.UIThread.Post(() => _viewModel?.RequestShowSource(source2010: true));
                 }
             }
             catch (Exception ex)

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -737,11 +737,11 @@ public partial class SimpleTabbedWindow : Window
             if (documentDock?.ActiveDockable is not BookDisplayViewModel bookViewModel)
                 return;
 
-            var command = source2010 ? bookViewModel.ShowSource2010Command : bookViewModel.ShowSource1957Command;
             _logger.Information("View Source ({Edition}) via menu/shortcut for book: {BookFile}",
                 source2010 ? "2010" : "1957", bookViewModel.Book.FileName);
-            // Swallow the CanExecute-false case (book has no source PDF) instead of faulting.
-            command.Execute().Subscribe(_ => { }, ex => _logger.Debug(ex, "View Source command not available"));
+            // Queue-intent: fires now if the Myanmar page is resolved, else once it resolves (so a shortcut
+            // pressed mid-recalc during fast UI sequences isn't a silent no-op). (#54 follow-up)
+            bookViewModel.RequestShowSource(source2010);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
View Source (Cmd+E / Cmd+Shift+E, Tools menu) is gated on the current Myanmar page resolving (`canShowSource`, #54) — which correctly greys the toolbar buttons, but also makes the **keystroke/menu** a silent no-op if pressed while the anchor map / current page is still recalculating. That window is easy to hit during fast UI sequences, and there's no visible feedback for the shortcut (you're looking at the book, not the greyed button).

## Fix — queue the intent
New `BookDisplayViewModel.RequestShowSource(bool source2010)`:
- If the page is resolved → open the PDF immediately (unchanged).
- If not → queue the request and fire it once `MyanmarPage` resolves (single `WhenAnyValue(...).Take(1)` wait).
- **Both editions supported:** requesting 1957 *and* 2010 before resolution opens both, in press order; duplicate presses of the same edition are deduped.

The keystroke (`OnKeyDown`), JS-capture (`document.title` → C#), main-window menu (`SimpleTabbedWindow.TriggerViewSource`), and floating-window menu (`App.OnViewSourceFromFloatingWindow`) paths now route through `RequestShowSource` instead of `ShowSource{1957,2010}Command.Execute()`.

The **toolbar buttons stay bound to the gated commands**, so they still visibly grey out during recalc — that #54 "not ready" feedback is intentional and unchanged; queueing applies to the paths where the no-op was invisible.

Follow-up to #54. (Separate, noted: the recalc itself could be faster — its own issue.)

## Verify
- Build clean.
- Manual: fire Cmd+E and/or Cmd+Shift+E mid-recalc during a fast sequence → the PDF(s) open the moment the page resolves; both open if both were pressed.
