### PR TITLE
#357: fix stale floating-window title for a dragged-in tab on script switch

### DIFF
--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -2122,9 +2122,12 @@ namespace CST.Avalonia.Services
                     };
                 }
 
+                // Store the list BEFORE wiring so that if WireTitleUpdates throws mid-walk, the handlers it
+                // already attached are still reachable (via window.Closed / the next re-wire) and don't leak.
+                // (Fable review of #357.)
                 var detaches = new List<Action>();
-                WireTitleUpdates(window, window.Layout, 0, detaches);
                 _titleSubscriptions[window] = detaches;
+                WireTitleUpdates(window, window.Layout, 0, detaches);
 
                 UpdateHostWindowTitle(window);
             }
@@ -2147,8 +2150,8 @@ namespace CST.Avalonia.Services
         // (VisibleDockables collection) and active tab (ActiveDockable/FocusedDockable), plus each LEAF
         // dockable's own Title (a book retitles on a global script switch — A8-3). Every subscription is
         // paired with a detach delegate collected into <paramref name="detaches"/> so it can be undone on
-        // window close. Only the docks/leaves present at wire-up are tracked; a later split still updates
-        // the title on the parent's collection change.
+        // window close. Docks/leaves present at wire-up are tracked; a later tab add/remove re-runs this
+        // wiring via the collection-change handler (#357), so dragged-in leaves get subscribed too.
         private void WireTitleUpdates(CstHostWindow window, IDockable? node, int depth, List<Action> detaches)
         {
             if (node == null || depth > 32) return;
@@ -2171,7 +2174,11 @@ namespace CST.Avalonia.Services
 
                 if (dock.VisibleDockables is INotifyCollectionChanged incc)
                 {
-                    NotifyCollectionChangedEventHandler h = (_, _) => UpdateHostWindowTitle(window);
+                    // #357: on any tab add/remove, re-run the whole wiring (detach + re-subscribe) so a leaf
+                    // dragged INTO an existing float also gets its own Title subscription. Without this, once
+                    // the originally-wired tab is gone a later in-place retitle (global script switch) leaves
+                    // this window's title bar + Window-menu entry stale. Re-wiring also refreshes the title.
+                    NotifyCollectionChangedEventHandler h = (_, _) => SetupHostWindowTitleTracking(window);
                     incc.CollectionChanged += h;
                     detaches.Add(() => incc.CollectionChanged -= h);
                 }


### PR DESCRIPTION
Fixes #357 — a residual of #322 (A8-3) surfaced by the Fable re-review.

## Problem
Per-window floating-title tracking subscribes each leaf dockable's `Title`/`DisplayTitle` at float-creation time. A book **dragged into an existing float later** got no leaf-title subscription, so once the originally-wired tab is gone (float holds only dragged-in tabs), a later in-place retitle — e.g. a global Pāli-script switch — left the float's **title bar + Window-menu entry stale** (the tab caption updated, the window title didn't).

## Fix (`CstDockFactory.cs`)
The float's `VisibleDockables` `CollectionChanged` handler now re-runs the full per-window wiring (`SetupHostWindowTitleTracking`) instead of only re-computing the title. `Setup` detaches the prior subscriptions and re-walks the layout, so a dragged-in leaf gets its own `Title` subscription — and removed tabs are cleaned up too. Re-wiring also refreshes the title.

Plus one hardening from the review: store the per-window detach list **before** wiring, so a throw mid-walk can't strand already-attached handlers.

## Repro (fixed)
Open A + B → float A → drag B into the float → close A's tab (float now holds only B) → switch the global script. Before: title bar/Window-menu stayed old-script. After: they follow the new script.

## Review
Reviewed by a Fable subagent — verdict **SHIP-WITH-NITS**:
- Re-entrancy safe (.NET raises over an immutable invocation-list snapshot; the handler removing itself mid-fire completes cleanly, replacement isn't double-invoked); no infinite loop (re-wire path mutates no dock collection); no leak/accumulation on the happy path; correctly subscribes the dragged-in leaf incl. nested-dock ordering cases.
- **Applied:** the exception-path leak hardening (store-list-before-wiring).
- **Deferred (theoretical):** also re-wire if `VisibleDockables` is replaced wholesale — can't happen today (Dock mutates in place).
- **Noted:** no unit coverage for title-tracking; a #357 regression + accumulation test is worth adding as a separate, UI-coupled follow-up.

LOW priority; part of epic #186.
