### PR TITLE
#55: shrink the search index ~45% by dropping term vectors + norms

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/IndexStructureTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/IndexStructureTests.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using CST.Avalonia.Services;
 using CST.Avalonia.Models;
 using CST;
+using CST.Conversion;
+using CST.Lucene;
 using Lucene.Net.Analysis;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
+using Lucene.Net.Search;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
 using Microsoft.Extensions.Logging;
@@ -45,36 +51,85 @@ namespace CST.Avalonia.Tests.Integration
                 System.IO.Directory.Delete(_testIndexDir, true);
         }
 
+        // The exact FieldType BookIndexer writes (kept in lock-step with BookIndexer.cs). Since #55 the
+        // corpus is indexed WITHOUT term vectors and WITHOUT norms — positions (proximity) and offsets
+        // (highlighting) are read straight from the postings, never from term vectors, and search never
+        // scores. Tests build docs through this so a divergence from the product config is caught here.
+        private static FieldType TextFieldType()
+        {
+            var ft = new FieldType(TextField.TYPE_NOT_STORED)
+            {
+                IsIndexed = true,
+                IsStored = false,
+                IsTokenized = true,
+                OmitNorms = true,
+                StoreTermVectors = false,
+                StoreTermVectorOffsets = false,
+                StoreTermVectorPayloads = false,
+                StoreTermVectorPositions = false,
+                IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS
+            };
+            ft.Freeze();
+            return ft;
+        }
+
         [Fact]
-        public async Task IndexStructure_SupportsPositionBasedSearches()
+        public void BookIndexer_WritesNoTermVectors_ButKeepsPostingsOffsets()
+        {
+            // Exercise the REAL BookIndexer (not the mirrored TextFieldType above) so that re-enabling term
+            // vectors — or dropping offsets — in BookIndexer.cs is caught here. That silent index-bloat
+            // regression is exactly what #55 removes; the config-mirror tests can't see BookIndexer drift.
+            var root = Path.Combine(Path.GetTempPath(), "cst55-bookindexer-" + Guid.NewGuid().ToString("N"));
+            var xmlDir = Path.Combine(root, "xml");
+            var indexDir = Path.Combine(root, "index");
+            System.IO.Directory.CreateDirectory(xmlDir);
+            System.IO.Directory.CreateDirectory(indexDir);
+            try
+            {
+                // A real catalog book so Books.Inst resolves it; synthetic Devanagari body generated from
+                // ASCII-Latin (no non-Latin literals — the tokenizer converts Devanagari -> IPE).
+                var book = Books.Inst.First(b => b.FileName.EndsWith(".mul.xml", StringComparison.Ordinal));
+                string deva = ScriptConverter.Convert("dhamma citta kamma", Script.Latin, Script.Devanagari);
+                string xml = "<body><div id=\"dn1\" type=\"book\"><pb ed=\"V\" n=\"1.0001\"/>" +
+                             "<p rend=\"bodytext\" n=\"1\">" + deva + "</p></div></body>";
+                File.WriteAllText(Path.Combine(xmlDir, book.FileName), xml, Encoding.Unicode);
+
+                new BookIndexer { XmlDirectory = xmlDir, IndexDirectory = indexDir }
+                    .IndexAll(_ => { }, new List<int> { book.Index });
+
+                using var directory = FSDirectory.Open(indexDir);
+                using var reader = DirectoryReader.Open(directory);
+                Assert.True(reader.NumDocs > 0);
+
+                // #55: the real indexer stores NO term vectors ...
+                Assert.Null(reader.GetTermVectors(0));
+
+                // ... but the postings still carry positions AND offsets (proximity + highlighting).
+                var terms = MultiFields.GetTerms(reader, "text");
+                Assert.NotNull(terms);
+                Assert.True(terms.HasPositions);
+                Assert.True(terms.HasOffsets);
+            }
+            finally
+            {
+                try { System.IO.Directory.Delete(root, true); } catch { /* best-effort temp cleanup */ }
+            }
+        }
+
+        [Fact]
+        public async Task IndexStructure_ServesPositionsAndOffsetsFromPostings_WithoutTermVectors()
         {
             // Arrange
             await _service.InitializeAsync();
-            
-            // Create a mock Lucene index with the same field configuration as BookIndexer
+
             using var directory = FSDirectory.Open(_testIndexDir);
             using var analyzer = new DevaXmlAnalyzer(LuceneVersion.LUCENE_48);
             var indexWriterConfig = new IndexWriterConfig(LuceneVersion.LUCENE_48, analyzer);
-            
+
             using (var indexWriter = new IndexWriter(directory, indexWriterConfig))
             {
-                // Create a document with the same field structure as BookIndexer
                 var doc = new Document();
-                
-                // Configure field type exactly like BookIndexer does
-                var ft = new FieldType(TextField.TYPE_NOT_STORED)
-                {
-                    IsIndexed = true,
-                    IsStored = false,
-                    IsTokenized = true,
-                    OmitNorms = false,
-                    StoreTermVectors = true,
-                    StoreTermVectorOffsets = true,
-                    StoreTermVectorPayloads = true,
-                    StoreTermVectorPositions = true,
-                    IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS
-                };
-                ft.Freeze();
+                var ft = TextFieldType();
 
                 // Add test content with various fields
                 doc.Add(new Field("text", "बुद्ध धम्म संघ tipitaka pali", ft));
@@ -82,7 +137,7 @@ namespace CST.Avalonia.Tests.Integration
                 doc.Add(new StringField("FileName", "test.xml", Field.Store.YES));
                 doc.Add(new StringField("MatnField", "Sutta", Field.Store.YES));
                 doc.Add(new StringField("PitakaField", "Tipitaka", Field.Store.YES));
-                
+
                 indexWriter.AddDocument(doc);
                 indexWriter.Commit();
             }
@@ -90,13 +145,12 @@ namespace CST.Avalonia.Tests.Integration
             // Act & Assert - Verify the index structure supports position-based operations
             using var reader = DirectoryReader.Open(directory);
             var terms = MultiFields.GetTerms(reader, "text");
-            
+
             Assert.NotNull(terms);
             Assert.True(terms.Count > 0);
-
-            // Verify we can access term vectors with positions and offsets
-            var termEnum = terms.GetEnumerator();
-            Assert.True(termEnum.MoveNext());
+            // Postings must carry both positions and offsets (what search + highlighting read).
+            Assert.True(terms.HasPositions);
+            Assert.True(terms.HasOffsets);
 
             // Get the first document
             var doc0 = reader.Document(0);
@@ -108,12 +162,25 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Equal("Sutta", doc0.Get("MatnField"));
             Assert.Equal("Tipitaka", doc0.Get("PitakaField"));
 
-            // Verify term vectors are available (required for position-based searches)
-            var termVectors = reader.GetTermVectors(0);
-            Assert.NotNull(termVectors);
-            
-            var textTerms = termVectors.GetTerms("text");
-            Assert.NotNull(textTerms);
+            // #55: term vectors are NO LONGER stored — highlighting/proximity read from the postings.
+            Assert.Null(reader.GetTermVectors(0));
+
+            // The property the (postings-based) highlight + proximity paths actually depend on: a term's
+            // positions AND character offsets come back straight from the postings, no term vectors needed.
+            // Use the first ACTUAL indexed term (the analyzer emits IPE, not ASCII) so this is encoding-agnostic.
+            var termEnum = terms.GetEnumerator();
+            Assert.True(termEnum.MoveNext());
+            var firstTerm = BytesRef.DeepCopyOf(termEnum.Term);
+
+            var liveDocs = MultiFields.GetLiveDocs(reader);
+            var dape = MultiFields.GetTermPositionsEnum(
+                reader, liveDocs, "text", firstTerm,
+                DocsAndPositionsFlags.OFFSETS);
+            Assert.NotNull(dape);
+            Assert.NotEqual(DocIdSetIterator.NO_MORE_DOCS, dape.NextDoc());
+            dape.NextPosition();
+            Assert.True(dape.StartOffset >= 0);
+            Assert.True(dape.EndOffset > dape.StartOffset);
         }
 
         [Fact]
@@ -166,18 +233,8 @@ namespace CST.Avalonia.Tests.Integration
                 for (int i = 0; i < 5; i++)
                 {
                     var doc = new Document();
-                    
-                    var ft = new FieldType(TextField.TYPE_NOT_STORED)
-                    {
-                        IsIndexed = true,
-                        IsStored = false,
-                        IsTokenized = true,
-                        StoreTermVectors = true,
-                        StoreTermVectorOffsets = true,
-                        StoreTermVectorPositions = true,
-                        IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS
-                    };
-                    ft.Freeze();
+
+                    var ft = TextFieldType();
 
                     doc.Add(new Field("text", $"Document {i} content धम्म", ft));
                     doc.Add(new StringField("id", i.ToString(), Field.Store.YES));
@@ -200,10 +257,9 @@ namespace CST.Avalonia.Tests.Integration
                 var doc = reader.Document(i);
                 Assert.Equal(i.ToString(), doc.Get("id"));
                 Assert.Equal($"doc{i}.xml", doc.Get("FileName"));
-                
-                // Verify term vectors are available for each document
-                var termVectors = reader.GetTermVectors(i);
-                Assert.NotNull(termVectors);
+
+                // #55: term vectors are no longer stored for any document.
+                Assert.Null(reader.GetTermVectors(i));
             }
         }
 

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -974,181 +974,24 @@ namespace CST.Avalonia.ViewModels
                 }
             }
 
-            if (_searchTerms == null || !_searchTerms.Any() || _docId == null)
+            if (_searchTerms == null || !_searchTerms.Any())
             {
-                Log.Debug("[BookDisplay] Skipping highlighting - no terms or no DocId");
+                Log.Debug("[BookDisplay] Skipping highlighting - no search terms");
                 return xmlContent;
             }
 
-            DirectoryReader? indexReader = null;
-            try
+            // Highlighting runs entirely off pre-computed postings offsets (_searchPositions), which
+            // every book-open path supplies (search result, state restore, float/unfloat). The former
+            // term-vector fallback here was retired with #55 when term vectors were dropped from the
+            // index; both paths read the same Lucene offset data, so the positions path is equivalent
+            // (and richer: two-color phrase/proximity). With no positions there is nothing to highlight.
+            if (_searchPositions != null && _searchPositions.Any())
             {
-                // NEW: If we have pre-computed positions (from phrase/proximity search), use them directly
-                if (_searchPositions != null && _searchPositions.Any())
-                {
-                    return ApplyHighlightingFromPositions(xmlContent);
-                }
-                // Get the IndexingService to access the Lucene index
-                var indexingService = App.ServiceProvider?.GetService<IIndexingService>();
-                if (indexingService == null)
-                {
-                    _logger.Warning("IndexingService not available for highlighting");
-                    return xmlContent;
-                }
-
-                indexReader = indexingService.GetIndexReader();
-                if (indexReader == null)
-                {
-                    _logger.Warning("Could not get index reader for highlighting");
-                    return xmlContent;
-                }
-
-                // Use the raw XML content directly (this matches what Lucene indexed)
-                var xmlString = xmlContent;
-                
-                // Get term vectors for this document
-                var termVectors = indexReader.GetTermVector(_docId.Value, "text");
-                if (termVectors == null)
-                {
-                    _logger.Warning("No term vectors found for document {DocId}", _docId.Value);
-                    return xmlContent;
-                }
-
-                // Collect all offset information for our search terms
-                var offsetList = new List<(int start, int end, string term)>();
-                
-                Log.Debug("[BookDisplay] Processing {Count} search terms for highlighting", _searchTerms.Count);
-                
-                foreach (var searchTerm in _searchTerms)
-                {
-                    if (string.IsNullOrWhiteSpace(searchTerm)) continue;
-                    
-                    Log.Debug("[BookDisplay] Looking for term: '{Term}'", searchTerm);
-                    
-                    // Get the postings for this term
-                    var termsEnum = termVectors.GetEnumerator(null);
-                    var termBytes = new BytesRef(System.Text.Encoding.UTF8.GetBytes(searchTerm));
-                    
-                    if (termsEnum.SeekExact(termBytes))
-                    {
-                        Log.Debug("[BookDisplay] Found term '{Term}' in index", searchTerm);
-                        
-                        // Get positions and offsets for this term
-                        var postingsEnum = termsEnum.DocsAndPositions(null, null, DocsAndPositionsFlags.OFFSETS);
-                        if (postingsEnum != null)
-                        {
-                            while (postingsEnum.NextDoc() != DocIdSetIterator.NO_MORE_DOCS)
-                            {
-                                var freq = postingsEnum.Freq;
-                                Log.Debug("[BookDisplay] Term '{Term}' appears {Count} times in document", searchTerm, freq);
-                                
-                                for (int i = 0; i < freq; i++)
-                                {
-                                    postingsEnum.NextPosition();
-                                    var startOffset = postingsEnum.StartOffset;
-                                    var endOffset = postingsEnum.EndOffset;
-                                    
-                                    if (startOffset >= 0 && endOffset > startOffset)
-                                    {
-                                        // Verify the offset points to the expected text
-                                        // NOTE: Lucene offsets are inclusive-exclusive, so no +1
-                                        var actualText = xmlString.Substring(startOffset, endOffset - startOffset);
-                                        offsetList.Add((startOffset, endOffset, searchTerm));
-                                        Log.Debug("[BookDisplay] Offset {Start}-{End} for '{Term}': actual text '{Text}'",
-                                            startOffset, endOffset, searchTerm, actualText);
-                                    }
-                                    else
-                                    {
-                                        Log.Warning("[BookDisplay] Invalid offset for '{Term}': {Start}-{End}", 
-                                            searchTerm, startOffset, endOffset);
-                                    }
-                                }
-                            }
-                        }
-                        else
-                        {
-                            Log.Debug("[BookDisplay] No postings enum for term '{Term}'", searchTerm);
-                        }
-                    }
-                    else
-                    {
-                        Log.Debug("[BookDisplay] Term '{Term}' not found in index", searchTerm);
-                    }
-                }
-
-                if (!offsetList.Any())
-                {
-                    Log.Debug("[BookDisplay] No offsets found for any search terms");
-                    return xmlContent;
-                }
-
-                // Sort offsets by position in REVERSE order (back to front)
-                // This is critical so that inserting tags doesn't invalidate later offsets
-                offsetList.Sort((a, b) => b.start.CompareTo(a.start));
-                
-                // Build the highlighted XML by inserting <hi> tags at the offsets
-                var sb = new StringBuilder(xmlString);
-                var hitCount = offsetList.Count;
-
-                // For single term search, use the same highlight style for all instances
-                // For multi-term search, each term would get different colors (not implemented yet)
-                var isSingleTerm = _searchTerms.Count == 1;
-                var hitIndex = hitCount - 1;
-                
-                Log.Debug("[BookDisplay] Applying {Count} highlights (single-term: {IsSingle})", hitCount, isSingleTerm);
-                
-                foreach (var (start, end, term) in offsetList)
-                {
-                    // Get the actual text at this offset
-                    var highlightedText = xmlString.Substring(start, end - start);
-                    
-                    // Create the highlight tags - always use unique IDs for navigation
-                    var openTag = $"<hi rend=\"hit\" id=\"hit{hitIndex + 1}\">";
-                    var closeTag = "</hi>";
-                    
-                    // Replace the text at this offset with highlighted version
-                    sb.Remove(start, end - start);
-                    sb.Insert(start, openTag + highlightedText + closeTag);
-                    
-                    Log.Debug("[BookDisplay] Applied highlight #{Number} at offset {Start}-{End}: '{Text}' (term: '{Term}')", 
-                        hitIndex + 1, start, end, highlightedText, term);
-                    hitIndex--;
-                }
-                
-                // Return the highlighted XML string
-                var highlightedXml = sb.ToString();
-                
-                Log.Information("[BookDisplay] Successfully applied {Count} highlights", hitCount);
-                
-                // Update hit count and status
-                var totalHits = hitCount;
-                Dispatcher.UIThread.Post(() =>
-                {
-                    TotalHits = totalHits;
-                    HasSearchHighlights = totalHits > 0;
-                    if (totalHits > 0)
-                    {
-                        // Seed only when there is no live position: this pipeline re-runs on every
-                        // re-render (script change), and resetting would clobber the hit the user
-                        // navigated to ("4 of 4" snapping back). (BOOK-7 follow-up)
-                        if (CurrentHitIndex < 1 || CurrentHitIndex > totalHits)
-                            CurrentHitIndex = 1;
-                        UpdateHitStatusText();
-                    }
-                });
-                
-                return highlightedXml;
+                return ApplyHighlightingFromPositions(xmlContent);
             }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, "Failed to apply search highlighting");
-                Log.Error(ex, "[BookDisplay] Error applying highlights");
-                return xmlContent; // Return original content on error
-            }
-            finally
-            {
-                indexReader?.DecRef(); // release the counted reference (SRCH-6, mirrors SRCH-2)
-            }
+
+            Log.Debug("[BookDisplay] No pre-computed positions - nothing to highlight");
+            return xmlContent;
         }
 
         /// <summary>

--- a/src/CST.Lucene/BookIndexer.cs
+++ b/src/CST.Lucene/BookIndexer.cs
@@ -265,11 +265,19 @@ namespace CST
             ft.IsIndexed = true;
             ft.IsStored = false;
             ft.IsTokenized = true;
-            ft.OmitNorms = false;
-            ft.StoreTermVectors = true;
-            ft.StoreTermVectorOffsets = true;
-            ft.StoreTermVectorPayloads = true;
-            ft.StoreTermVectorPositions = true;
+            // We use Lucene purely as a position/offset store read straight from the postings
+            // (MultiFields.GetTermPositionsEnum) — never via IndexSearcher scoring — so:
+            //  - Norms carry field-length normalization for scoring we never do -> omit them.
+            //  - Term vectors duplicated the postings' positions/offsets; the only reader was a
+            //    legacy highlight fallback (BookDisplayViewModel) now fully superseded by the
+            //    postings-offset path -> drop them (they were ~56 MB / ~40% of the index).
+            // Positions (proximity) and offsets (highlighting) still come from the postings, so
+            // IndexOptions keeps DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS. (#55)
+            ft.OmitNorms = true;
+            ft.StoreTermVectors = false;
+            ft.StoreTermVectorOffsets = false;
+            ft.StoreTermVectorPayloads = false;
+            ft.StoreTermVectorPositions = false;
             ft.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS;
             ft.Freeze();
 


### PR DESCRIPTION
Closes #55.

## What
The corpus is used purely as a **position/offset store read straight from the postings** (`MultiFields.GetTermPositionsEnum`) — never via `IndexSearcher` scoring. So the term vectors merely duplicated the postings' positions/offsets, and norms carried field-length normalization for scoring we never do.

- **`BookIndexer`** — `StoreTermVectors/Offsets/Payloads/Positions = false`, `OmitNorms = true`. `IndexOptions` stays `DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS` (positions for proximity, offsets for highlighting still come from the postings).
- **`BookDisplayViewModel`** — retire the legacy **term-vector highlight fallback**. Every book-open path (search result, state restore, float/unfloat) already supplies pre-computed postings offsets (`_searchPositions`); `ApplyHighlightingFromPositions` handles all highlighting and is strictly richer (two-color phrase/proximity). Both paths read the same Lucene offset data, so they're equivalent. (−160 LOC)
- **`IndexStructureTests`** — these were *duplicating* the field config inline and asserting term vectors exist **on their own docs** (they never exercised `BookIndexer`, so they gave false confidence and wouldn't catch this change). Rewritten to match the new config and assert what we now rely on: **positions + offsets served from the postings, and term vectors absent**.

## Measured (full 217-book corpus reindex)
| | Before | After |
|---|--:|--:|
| **Total index** | **136 MB** | **74 MB** (−45%) |
| term vectors (`.tv*`) | 56 MB | 0 |
| norms (`.nv*`) | ~0 | 0 |
| postings positions (`.pos`) | 30 MB | 29 MB |
| postings offsets/payloads (`.pay`) | 9.5 MB | 9.7 MB |

## Verification
- The load-bearing claim — offsets & positions readable from **postings alone** — is guarded end-to-end by `LocalApiIntegrationTests`, which builds a **real `BookIndexer` index** and runs phrase/adjacency (positions) + wildcard occurrences → snippet extraction (offsets). Green on the term-vector-free index.
- Full suite: **758 passed, 0 failed.**

## Migration
Requires a reindex to realize the savings. Per the issue, beta 5 testers clean-start their `CSTReader` directory, so no migration path is needed (a deliberate schema-version auto-rebuild trigger was prototyped and dropped as unnecessary). The local index dir has been deleted so the next launch rebuilds at 74 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)