### PR TITLE
#425: unit coverage for floating-window title tracking (testability seam + #357 regression test)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryTitleTrackingTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryTitleTrackingTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using CST.Avalonia.Services;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// Unit coverage for CstDockFactory's floating-window title tracking (#284/#322/#357). Exercises the
+/// testable core (WireHostWindowTitle / ComputeFloatingWindowTitle) via the IHostWindowTitleTarget seam,
+/// so no real Avalonia Window is needed. See #425.
+/// </summary>
+public class CstDockFactoryTitleTrackingTests
+{
+    private static ObservableCollection<IDockable> List(params IDockable[] items) => new(items);
+
+    private sealed class FakeTitleTarget : IHostWindowTitleTarget
+    {
+        public IDock? Layout { get; set; }
+        public string Title { get; private set; } = "";
+        public void SetTitle(string? title) => Title = title ?? "";
+    }
+
+    // RootDock -> DocumentDock (active) holding the given leaf documents; the first is the active tab.
+    private static (RootDock root, DocumentDock docDock) BuildLayout(params Document[] docs)
+    {
+        var docDock = new DocumentDock { VisibleDockables = List(docs.Cast<IDockable>().ToArray()), ActiveDockable = docs.FirstOrDefault() };
+        var root = new RootDock { VisibleDockables = List(docDock), ActiveDockable = docDock };
+        return (root, docDock);
+    }
+
+    // ---- ComputeFloatingWindowTitle: active-leaf title, "+N" count, empty fallback ----
+
+    [Fact]
+    public void Compute_SingleLeaf_UsesItsTitle()
+    {
+        var (root, _) = BuildLayout(new Document { Title = "Dīgha 1" });
+        Assert.Equal("Dīgha 1", new CstDockFactory().ComputeFloatingWindowTitle(root));
+    }
+
+    [Fact]
+    public void Compute_MultipleLeaves_UsesActiveTitlePlusCount()
+    {
+        var a = new Document { Title = "A" };
+        var b = new Document { Title = "B" };
+        var (root, docDock) = BuildLayout(a, b);
+        docDock.ActiveDockable = b;
+        Assert.Equal("B  +1", new CstDockFactory().ComputeFloatingWindowTitle(root));
+    }
+
+    [Fact]
+    public void Compute_NoLeaves_ReturnsDefault()
+    {
+        var root = new RootDock { VisibleDockables = List(new DocumentDock { VisibleDockables = List() }) };
+        Assert.Equal("CST Reader", new CstDockFactory().ComputeFloatingWindowTitle(root));
+    }
+
+    // ---- #357 regression: a leaf dragged into an existing float gets its own Title subscription ----
+
+    [Fact]
+    public void WiredHost_ReflectsActiveLeafTitle_Initially()
+    {
+        var (root, _) = BuildLayout(new Document { Title = "A" });
+        var factory = new CstDockFactory();
+        var host = new FakeTitleTarget { Layout = root };
+
+        factory.WireHostWindowTitle(host);
+
+        Assert.Equal("A", host.Title);
+    }
+
+    // Repro of #357: float [A] -> drag B in -> close A (float now holds only B) -> retitle B (as a global
+    // script switch would). Before #424 the dragged-in leaf B had no Title subscription, so the retitle was
+    // dropped and the window title stayed "B". After the fix, re-wiring on the tab change subscribes B.
+    [Fact]
+    public void DraggedInLeaf_RetitledAfterOriginalTabClosed_UpdatesHostTitle()
+    {
+        var a = new Document { Title = "A" };
+        var b = new Document { Title = "B" };
+        var (root, docDock) = BuildLayout(a);
+        var factory = new CstDockFactory();
+        var host = new FakeTitleTarget { Layout = root };
+
+        factory.WireHostWindowTitle(host);
+        Assert.Equal("A", host.Title);
+
+        docDock.VisibleDockables!.Add(b);       // drag B in (CollectionChanged -> re-wire subscribes B)
+        docDock.ActiveDockable = b;             // B becomes the active tab
+        docDock.VisibleDockables!.Remove(a);    // close A's tab; float now holds only B
+        Assert.Equal("B", host.Title);
+
+        b.Title = "B (new script)";             // the later in-place retitle #357 dropped
+        Assert.Equal("B (new script)", host.Title);
+    }
+
+    // ---- Re-wiring on tab changes must replace, not accumulate, the subscription set ----
+
+    [Fact]
+    public void RepeatedTabChanges_DoNotAccumulateSubscriptions()
+    {
+        var a = new Document { Title = "A" };
+        var (root, docDock) = BuildLayout(a);
+        var factory = new CstDockFactory();
+        var host = new FakeTitleTarget { Layout = root };
+
+        factory.WireHostWindowTitle(host);
+        var baseline = factory._titleSubscriptions[host].Count;
+
+        for (int i = 0; i < 5; i++)
+        {
+            var tmp = new Document { Title = "tmp" };
+            docDock.VisibleDockables!.Add(tmp);     // add -> re-wire
+            docDock.VisibleDockables!.Remove(tmp);  // remove -> re-wire
+        }
+
+        // Same final layout => same subscription count. If re-wire appended instead of replacing, this grows.
+        Assert.Equal(baseline, factory._titleSubscriptions[host].Count);
+    }
+}

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -2092,7 +2092,7 @@ namespace CST.Avalonia.Services
         // #322 (#284 follow-up): the title-tracking event subscriptions per floating window, kept as
         // detach delegates so they can be removed when the window closes (no leaked handlers / rooted
         // window graph) and re-wired idempotently on a repeat SetLayout (no double-wiring).
-        private readonly Dictionary<CstHostWindow, List<Action>> _titleSubscriptions = new();
+        internal readonly Dictionary<IHostWindowTitleTarget, List<Action>> _titleSubscriptions = new();
 
         // #284: keep a floating window's title in sync with its content. Naming scheme:
         //   single item  -> that item's title (book name or tool name),
@@ -2102,34 +2102,43 @@ namespace CST.Avalonia.Services
         // "CST Reader" title.) Wired from CstHostWindow.SetLayout, once the layout exists.
         public void SetupHostWindowTitleTracking(CstHostWindow window)
         {
+            // Hook the window's close exactly once to detach + forget its subscriptions, then (re)wire.
+            if (!_titleSubscriptions.ContainsKey(window))
+            {
+                window.Closed += (_, _) =>
+                {
+                    if (_titleSubscriptions.TryGetValue(window, out var subs))
+                    {
+                        DetachTitleSubscriptions(subs);
+                        _titleSubscriptions.Remove(window);
+                    }
+                };
+            }
+            WireHostWindowTitle(window);
+        }
+
+        // Testable core (#425): (re)wire title tracking for a host and refresh its title. Idempotent —
+        // detaches any prior subscriptions first, so it's safe to call repeatedly (a SetLayout re-run, or the
+        // tab-set change handler). Has no dependency on a real Avalonia Window, so unit tests drive it with a
+        // fake IHostWindowTitleTarget.
+        internal void WireHostWindowTitle(IHostWindowTitleTarget host)
+        {
             try
             {
-                // Idempotent: drop any prior subscriptions before re-wiring (SetLayout may run again).
-                if (_titleSubscriptions.TryGetValue(window, out var existing))
+                // Idempotent: drop any prior subscriptions before re-wiring.
+                if (_titleSubscriptions.TryGetValue(host, out var existing))
                 {
                     DetachTitleSubscriptions(existing);
                 }
-                else
-                {
-                    // Hook the window's close exactly once to detach + forget its subscriptions.
-                    window.Closed += (_, _) =>
-                    {
-                        if (_titleSubscriptions.TryGetValue(window, out var subs))
-                        {
-                            DetachTitleSubscriptions(subs);
-                            _titleSubscriptions.Remove(window);
-                        }
-                    };
-                }
 
                 // Store the list BEFORE wiring so that if WireTitleUpdates throws mid-walk, the handlers it
-                // already attached are still reachable (via window.Closed / the next re-wire) and don't leak.
+                // already attached are still reachable (via close / the next re-wire) and don't leak.
                 // (Fable review of #357.)
                 var detaches = new List<Action>();
-                _titleSubscriptions[window] = detaches;
-                WireTitleUpdates(window, window.Layout, 0, detaches);
+                _titleSubscriptions[host] = detaches;
+                WireTitleUpdates(host, host.Layout, 0, detaches);
 
-                UpdateHostWindowTitle(window);
+                UpdateHostWindowTitle(host);
             }
             catch (Exception ex)
             {
@@ -2152,7 +2161,7 @@ namespace CST.Avalonia.Services
         // paired with a detach delegate collected into <paramref name="detaches"/> so it can be undone on
         // window close. Docks/leaves present at wire-up are tracked; a later tab add/remove re-runs this
         // wiring via the collection-change handler (#357), so dragged-in leaves get subscribed too.
-        private void WireTitleUpdates(CstHostWindow window, IDockable? node, int depth, List<Action> detaches)
+        private void WireTitleUpdates(IHostWindowTitleTarget host, IDockable? node, int depth, List<Action> detaches)
         {
             if (node == null || depth > 32) return;
 
@@ -2165,7 +2174,7 @@ namespace CST.Avalonia.Services
                         if (e.PropertyName == nameof(IDock.ActiveDockable) ||
                             e.PropertyName == nameof(IDock.FocusedDockable))
                         {
-                            UpdateHostWindowTitle(window);
+                            UpdateHostWindowTitle(host);
                         }
                     };
                     inpc.PropertyChanged += h;
@@ -2178,7 +2187,7 @@ namespace CST.Avalonia.Services
                     // dragged INTO an existing float also gets its own Title subscription. Without this, once
                     // the originally-wired tab is gone a later in-place retitle (global script switch) leaves
                     // this window's title bar + Window-menu entry stale. Re-wiring also refreshes the title.
-                    NotifyCollectionChangedEventHandler h = (_, _) => SetupHostWindowTitleTracking(window);
+                    NotifyCollectionChangedEventHandler h = (_, _) => WireHostWindowTitle(host);
                     incc.CollectionChanged += h;
                     detaches.Add(() => incc.CollectionChanged -= h);
                 }
@@ -2187,7 +2196,7 @@ namespace CST.Avalonia.Services
                 {
                     foreach (var child in dock.VisibleDockables)
                     {
-                        WireTitleUpdates(window, child, depth + 1, detaches);
+                        WireTitleUpdates(host, child, depth + 1, detaches);
                     }
                 }
             }
@@ -2199,7 +2208,7 @@ namespace CST.Avalonia.Services
                 {
                     if (e.PropertyName == nameof(IDockable.Title) || e.PropertyName == "DisplayTitle")
                     {
-                        UpdateHostWindowTitle(window);
+                        UpdateHostWindowTitle(host);
                     }
                 };
                 leaf.PropertyChanged += h;
@@ -2210,14 +2219,14 @@ namespace CST.Avalonia.Services
         // Compute and apply the title for a floating window from its current content. Short-circuits when
         // the computed title is unchanged, so ordinary focus flapping doesn't churn SetTitle + the native
         // Window-menu rebuild (A8-5).
-        public void UpdateHostWindowTitle(CstHostWindow window)
+        internal void UpdateHostWindowTitle(IHostWindowTitleTarget host)
         {
             try
             {
-                var newTitle = ComputeFloatingWindowTitle(window.Layout);
-                if (string.Equals(window.Title, newTitle, StringComparison.Ordinal)) return;
+                var newTitle = ComputeFloatingWindowTitle(host.Layout);
+                if (string.Equals(host.Title, newTitle, StringComparison.Ordinal)) return;
 
-                window.SetTitle(newTitle);
+                host.SetTitle(newTitle);
                 // #284: the Window menu shows this title, so refresh the lists when it actually changes.
                 (Application.Current as App)?.RebuildWindowMenus();
             }
@@ -2227,7 +2236,7 @@ namespace CST.Avalonia.Services
             }
         }
 
-        private string ComputeFloatingWindowTitle(IDock? layout)
+        internal string ComputeFloatingWindowTitle(IDock? layout)
         {
             var leaves = new List<IDockable>();
             CollectLeafDockables(layout, leaves, 0);

--- a/src/CST.Avalonia/Services/CstHostWindow.cs
+++ b/src/CST.Avalonia/Services/CstHostWindow.cs
@@ -12,9 +12,21 @@ using Microsoft.Extensions.DependencyInjection;
 namespace CST.Avalonia.Services
 {
     /// <summary>
+    /// The minimal surface CstDockFactory's floating-window title tracking needs from a host window: its
+    /// dock layout, its current title, and a way to set it. Extracted so the tracking core is unit-testable
+    /// without a real Avalonia Window (#425). <see cref="CstHostWindow"/> implements it.
+    /// </summary>
+    internal interface IHostWindowTitleTarget
+    {
+        IDock? Layout { get; }
+        string Title { get; }
+        void SetTitle(string? title);
+    }
+
+    /// <summary>
     /// Host window implementation for multi-window docking support
     /// </summary>
-    public class CstHostWindow : Window, IHostWindow
+    public class CstHostWindow : Window, IHostWindow, IHostWindowTitleTarget
     {
         public string Id { get; set; } = Guid.NewGuid().ToString();
         public object? Context { get; set; }


### PR DESCRIPTION
Fixes #425 — adds the missing unit coverage for `CstDockFactory`'s floating-window title tracking (#284/#322/#357), which had none, so both the original A8-3 bug and the #357 residual shipped uncaught.

## Testability seam (the refactor #425 anticipated)
The tracking core was coupled to `CstHostWindow` (a `Window`, uninstantiable in plain unit tests) and `App.RebuildWindowMenus`. Extracted a small internal seam so the core is drivable headlessly:

- New `internal interface IHostWindowTitleTarget { IDock? Layout; string Title; void SetTitle(string?); }`, implemented by `CstHostWindow` (members already existed).
- `SetupHostWindowTitleTracking(CstHostWindow)` stays the public entry (hooks `window.Closed` once) and delegates to a new **`internal WireHostWindowTitle(IHostWindowTitleTarget)`** core. `UpdateHostWindowTitle` / `WireTitleUpdates` now take the seam; `ComputeFloatingWindowTitle` and `_titleSubscriptions` are `internal` for assertions.
- Behavior is unchanged: `App.RebuildWindowMenus` is still called (no-ops under a null `Application.Current` in tests); the collection-change handler re-runs the core (the #357 fix); the store-before-wire leak guard is preserved.

## Tests (`CstDockFactoryTitleTrackingTests.cs`, 6)
- `ComputeFloatingWindowTitle`: single-leaf title, active-leaf + `"  +N"`, empty → `"CST Reader"`.
- Initial wire reflects the active leaf.
- **#357 regression:** float `[A]` → add `B` (drag-in) → activate `B` → remove `A` → retitle `B` ⇒ host title follows. (Pre-#424 this stayed stale.)
- Re-wiring on repeated tab add/remove **replaces** the subscription set (no accumulation).

## Verification
- New tests: 6/6 pass. Full suite: **764 passed, 0 failed**.
- App launches cleanly with the refactor (manual smoke on Kestrel) — no behavior regression.

Follow-up from the Fable review of #424. Part of epic #186.
