### PR TITLE
#423: resolve the anchor/page cache off readiness signals, not fixed delays

### DIFF
--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -368,6 +368,10 @@ public partial class BookDisplayView : UserControl
                 // no new navigation will fire); a fresh/recreated browser is handled by
                 // OnNavigationCompleted instead. (BOOK-7)
                 ExecutePendingRestoration();
+                // A recycled tab fires no navigation, so nothing else would (re)build the anchor cache —
+                // this is the path where a restored book sat at "*" until you moved the mouse. Idempotent;
+                // no-ops if the cache is already built/in-flight. (#423)
+                EnsureAnchorCacheBuilt();
             }
             else
             {
@@ -388,6 +392,10 @@ public partial class BookDisplayView : UserControl
                 // no new navigation will fire); a fresh/recreated browser is handled by
                 // OnNavigationCompleted instead. (BOOK-7)
                 ExecutePendingRestoration();
+                // A recycled tab fires no navigation, so nothing else would (re)build the anchor cache —
+                // this is the path where a restored book sat at "*" until you moved the mouse. Idempotent;
+                // no-ops if the cache is already built/in-flight. (#423)
+                EnsureAnchorCacheBuilt();
             }
         }
         _logger.Information("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
@@ -511,6 +519,9 @@ public partial class BookDisplayView : UserControl
             {
                 _logger.Debug("View became visible, starting scroll timer.");
                 _scrollTimer.Start();
+                // Becoming visible wakes an occluded renderer — dispatch the build if it hasn't happened yet
+                // (a restored/background tab whose navigation fired while hidden). Idempotent. (#423)
+                EnsureAnchorCacheBuilt();
             }
             else
             {
@@ -609,6 +620,7 @@ public partial class BookDisplayView : UserControl
                     // This prevents scroll timer from querying stale cache and overwriting
                     // ViewModel's page numbers with "*" values during tab switches
                     _anchorCacheBuilt = false;
+                    _anchorCacheBuildInFlight = false;   // new content ⇒ allow a fresh build to be dispatched (#423)
                     _logger.Debug("Invalidated anchor cache - will rebuild after navigation completes");
 
                     // Write HTML content to temporary file and load it
@@ -864,6 +876,56 @@ public partial class BookDisplayView : UserControl
     }
 
     private bool _anchorCacheBuilt = false;
+    // True from the moment a build is dispatched until CACHE_BUILT confirms it (or a new load resets it).
+    // Makes the build idempotent now that several events can trigger it (navigation, visibility, reattach)
+    // so overlapping triggers don't inject the script 2-3x and race on window.cstAnchorCache / the shared
+    // document.title channel. (#423)
+    private bool _anchorCacheBuildInFlight = false;
+
+    // Single idempotent entry point for building the anchor cache. Fired from every path that can make the
+    // renderer ready — fresh navigation, the view becoming visible, and a recycled tab reattaching with a
+    // live browser — so the cache resolves without waiting on a fixed delay AND without the old
+    // restore-until-you-move-the-mouse stall: a background/occluded CEF renderer suspends its paint loop, so
+    // the build script's requestAnimationFrame (which reads getBoundingClientRect only AFTER a paint) simply
+    // PARKS until the tab is next shown/activated and then fires — no user input needed. Runs at most once
+    // per load (guarded by _anchorCacheBuilt + _anchorCacheBuildInFlight). (#423)
+    private void EnsureAnchorCacheBuilt()
+    {
+        if (_webView == null || !_isBrowserInitialized) return;
+        if (_anchorCacheBuilt || _anchorCacheBuildInFlight) return;
+
+        _anchorCacheBuildInFlight = true;
+        _logger.Debug("EnsureAnchorCacheBuilt: dispatching anchor cache build");
+        Task.Run(BuildAnchorPositionCache);
+        StartAnchorCacheBuildWatchdog();
+    }
+
+    // Safety net: _anchorCacheBuilt now flips true ONLY when the JS CACHE_BUILT title round-trips, which is
+    // gated on a paint (fonts.ready + double-rAF). The happy path completes in a frame (~tens of ms). But if
+    // the renderer never paints this build — a genuinely stuck occluded tab, or a JS fault before build()
+    // emits the title — _anchorCacheBuildInFlight would otherwise stay true forever and suppress every C#
+    // retrigger, degrading back to the "* until you move the mouse" symptom with no recovery. So after a
+    // deadline with no CACHE_BUILT, release the guard and actively retry while visible. This only ever runs
+    // in the pathological case; the fast path clears in-flight first and makes this a no-op. (#423, fable review)
+    private void StartAnchorCacheBuildWatchdog()
+    {
+        Task.Run(async () =>
+        {
+            await Task.Delay(AnchorCacheBuildDeadlineMs);
+            if (_anchorCacheBuilt || !_anchorCacheBuildInFlight) return; // completed, or already released
+            _logger.Debug("Anchor cache build watchdog fired: no CACHE_BUILT within deadline; releasing guard");
+            _anchorCacheBuildInFlight = false;
+            // Re-dispatch only when the tab is actually visible (an awake renderer will paint → rAF fires);
+            // a hidden tab just waits for its next show to re-trigger via OnIsVisibleChanged. Marshal to the
+            // UI thread for the IsVisible / WebView reads.
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (this.IsVisible) EnsureAnchorCacheBuilt();
+            });
+        });
+    }
+
+    private const int AnchorCacheBuildDeadlineMs = 2000;
 
     private async Task BuildAnchorPositionCache()
     {
@@ -898,13 +960,10 @@ public partial class BookDisplayView : UserControl
                             this.sortedParagraphAnchors = [];
                             this.sortedChapterAnchors = [];
 
-                            // Force layout calculation for the entire document
-                            // This is a workaround to ensure getBoundingClientRect() returns correct, absolute values
-                            var allElements = document.getElementsByTagName('*');
-                            for (var i = 0; i < allElements.length; i++) {{
-                                // Accessing a property like this forces the browser to compute the layout
-                                if (allElements[i].offsetParent === null) {{ continue; }}
-                            }}
+                            // Force a full synchronous layout so getBoundingClientRect() returns correct
+                            // absolute values. One reflow computes layout for the whole document — the old
+                            // O(N) loop over every element was redundant. (#423)
+                            void document.body.offsetHeight;
 
                             // Collect page anchors with the CORRECT position calculation.
                             ['V', 'M', 'P', 'T', 'O'].forEach(function(prefix) {{
@@ -1137,9 +1196,23 @@ public partial class BookDisplayView : UserControl
                         }}
                     }};
 
-                    // Build the cache immediately
-                    window.cstAnchorCache.build();
-                    
+                    // Build the cache once layout has SETTLED and the renderer has PAINTED, not after a
+                    // fixed delay. Waiting on fonts.ready avoids reading positions mid-shaping; the double
+                    // requestAnimationFrame reads getBoundingClientRect only after a real paint frame — which
+                    // also means that on a background/occluded tab this simply PARKS and fires the moment the
+                    // tab is next shown, instead of stalling until a mouse move. build() emits the CACHE_BUILT
+                    // title, which is the authoritative 'cache ready' signal the C# side waits on. (#423)
+                    var cstBuildWhenReady = function() {{
+                        requestAnimationFrame(function() {{
+                            requestAnimationFrame(function() {{ window.cstAnchorCache.build(); }});
+                        }});
+                    }};
+                    if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {{
+                        document.fonts.ready.then(cstBuildWhenReady);
+                    }} else {{
+                        cstBuildWhenReady();
+                    }}
+
                     // Rebuild cache when window is resized
                     window.addEventListener('resize', function() {{
                         setTimeout(function() {{
@@ -1154,14 +1227,16 @@ public partial class BookDisplayView : UserControl
 
                 _webView.ExecuteScript(script);
 
-                // Wait for the cache to be built
-                await Task.Delay(500);
-
-                _anchorCacheBuilt = true;
-                _logger.Debug("Anchor position cache built");
+                // Do NOT set _anchorCacheBuilt here or wait a fixed delay — the build is now deferred in JS
+                // (fonts.ready + double-rAF) and completes on the next paint. _anchorCacheBuilt is set only
+                // when the script's CACHE_BUILT title arrives in OnTitleChanged, the real 'ready' signal. (#423)
+                _logger.Debug("Anchor position cache build script injected; awaiting CACHE_BUILT");
             }
             catch (Exception ex)
             {
+                // The script never posted → no CACHE_BUILT will arrive, so release the in-flight guard to let
+                // a later trigger (visibility / reattach) retry. (#423)
+                _anchorCacheBuildInFlight = false;
                 _logger.Error("Error building anchor cache | {Details}", ex.Message);
             }
             finally
@@ -1204,16 +1279,10 @@ public partial class BookDisplayView : UserControl
                 // Set up JavaScript bridge after content loads
                 SetupJavaScriptBridge();
 
-                // Build the anchor position cache in the background.
-                _logger.Debug("Starting background task to build anchor cache");
-                Task.Run(async () =>
-                {
-                    _logger.Debug("Background task started, waiting for content to settle");
-                    await Task.Delay(2000); // Wait for content to settle
-
-                    _logger.Debug("Building anchor cache");
-                    await BuildAnchorPositionCache();
-                });
+                // Build the anchor position cache. No fixed "let it settle" delay: the build itself waits for
+                // fonts.ready + a paint frame before reading positions, so this fires immediately and the
+                // heavy lifting is gated on real readiness, not a 2s guess. (#423)
+                EnsureAnchorCacheBuilt();
 
                 // The document is ready — execute any queued restoration (saved anchor or saved
                 // search hit) NOW, from the one signal that knows the DOM exists. (BOOK-7)
@@ -1412,10 +1481,12 @@ public partial class BookDisplayView : UserControl
                     }
                 }
 
-                // Handle cache built notification
+                // Handle cache built notification — the authoritative 'cache ready' signal. Clears the
+                // in-flight guard too; the next scroll-timer tick (≤200ms) surfaces the resolved page. (#423)
                 if (isCacheBuilt)
                 {
                     _anchorCacheBuilt = true;
+                    _anchorCacheBuildInFlight = false;
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #423.

## Problem
After a book loads (and on restore), there was a ~3s window where `MyanmarPage == "*"` — status readout blank, View Source gated (#54). Almost all of it was fixed `Task.Delay` guesses, and on the **restore path the cache didn't build at all until the user moved the mouse**.

## Change (all in `BookDisplayView.axaml.cs`)
- **Delete the fixed delays** — `Task.Delay(2000)` pre-build and `Task.Delay(500)` post-build.
- **Idempotent `EnsureAnchorCacheBuilt()`** fired from every path that makes the renderer ready: `OnNavigationCompleted`, `OnIsVisibleChanged`→visible, and both live-browser branches of `OnAttachedToVisualTree` (the recycled/restore tab that fires no navigation and previously had **nothing** trigger a build). Guarded by `_anchorCacheBuilt` + `_anchorCacheBuildInFlight` → builds exactly once.
- **JS defers `build()` behind `document.fonts.ready` + double-`requestAnimationFrame`** — positions are read only after layout settles *and* the renderer paints. On a background/occluded tab the rAF **parks and fires when the tab is next shown**, fixing the restore-until-you-move-the-mouse stall with no input. `build()`'s `CACHE_BUILT` title is now the sole "ready" signal.
- **Replace the O(N) `getElementsByTagName('*')` force-layout loop** with one `document.body.offsetHeight` reflow.
- **Watchdog (from Fable review)** — since `_anchorCacheBuilt` now flips true *only* via `CACHE_BUILT`, a build dispatched but never painted (stuck occluded tab / JS fault) would leave the in-flight guard set forever and suppress all retries. After a 2s deadline with no `CACHE_BUILT`, release the guard and retry while visible — restoring the old unconditional safety net without the fixed-delay stall.

## Verification
- **Headless macOS, no mouse** (the exact #423 restore case): a restored book's cache builds automatically **38 ms** after dispatch —
  ```
  Restoring book: s0101m.mul.xml ...
  EnsureAnchorCacheBuilt: dispatching anchor cache build
  Anchor position cache build script injected; awaiting CACHE_BUILT
  ...CACHE_BUILT=1026,1118,14...   (1026 page / 1118 para / 14 chapter anchors)
  ```
  This is the case that previously required a mouse move; the watchdog never fired (happy path under the 2 s deadline).
- **Reviewed by Fable** (design ×2 + implementation ×1). It confirmed idempotency is race-free (all triggers are UI-thread), `offsetHeight` forces the same reflow, `fonts.ready`+rAF doesn't reintroduce #37 (no `@font-face` in this app), and float/unfloat/tab-switch re-arm correctly. It found the missing-safety-net regression above, which the watchdog closes.
- Full test suite: **765 passed, 0 failed** (no unit coverage exists for this CEF/WebView view; logic verified by the run above).

## Manual verification still worth a visual pass on a real display (my Egret session is headless, and Accessibility isn't granted so I can't drive clicks)
- [ ] Fresh open of a large book: page readout resolves fast, no visible `*` lag.
- [ ] **Multi-book restore (3+ books)**: every restored tab resolves its page **without a mouse move**, foreground and each background tab the moment it's first shown.
- [ ] Script change (reload): page resolves; #37 paragraph readout still monotonic.
- [ ] Footnote toggle (#321) and window resize: page stays correct (still full rebuilds).
- [ ] Float/unfloat a book: page re-resolves on the recreated browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)