### PR TITLE
#434 (PR-A): reading-position token model + pure fidelity math

### DIFF
--- a/src/CST.Avalonia.Tests/Models/ReadingPositionMathTests.cs
+++ b/src/CST.Avalonia.Tests/Models/ReadingPositionMathTests.cs
@@ -1,0 +1,187 @@
+using CST.Avalonia.Models;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Models
+{
+    /// <summary>
+    /// Fidelity math for the #434 reading-position token: capture a bracket + fraction from live positions,
+    /// restore it against the anchors' current positions. Covers the degenerate guards from the Fable review
+    /// (§3: zero/inverted bracket, out-of-range clamps; §5: an anchor vanishing on reload).
+    /// </summary>
+    public class ReadingPositionMathTests
+    {
+        // ---- Capture ----
+
+        [Fact]
+        public void Capture_bracketed_computes_fraction()
+        {
+            // scrollTop 130 sits 30 of 100 px from A(100) toward B(200) → 0.3
+            var t = ReadingPositionMath.Capture("A", 100, "B", 200, 130);
+            Assert.Equal("A", t.Above);
+            Assert.Equal("B", t.Below);
+            Assert.Equal(0.3, t.Fraction, 6);
+        }
+
+        [Theory]
+        [InlineData(90, 0.0)]    // above the upper anchor → clamped to 0
+        [InlineData(100, 0.0)]   // exactly on A
+        [InlineData(150, 0.5)]
+        [InlineData(200, 1.0)]   // exactly on B
+        [InlineData(260, 1.0)]   // below the lower anchor → clamped to 1
+        public void Capture_fraction_is_clamped_0_1(double scrollTop, double expected)
+        {
+            var t = ReadingPositionMath.Capture("A", 100, "B", 200, scrollTop);
+            Assert.Equal(expected, t.Fraction, 6);
+        }
+
+        [Fact]
+        public void Capture_coincident_bracket_pins_to_upper_no_nan()
+        {
+            // A and B on the same line (page + paragraph anchor) → denominator ~0 → fraction 0, not NaN.
+            var t = ReadingPositionMath.Capture("A", 500, "B", 500, 500);
+            Assert.Equal(0.0, t.Fraction, 6);
+            Assert.False(double.IsNaN(t.Fraction));
+        }
+
+        [Fact]
+        public void Capture_inverted_bracket_pins_to_upper_no_nan()
+        {
+            // JS handed an inverted bracket (belowPos < abovePos). Capture's SIGNED epsilon guard catches it
+            // (negative denom <= 0.5) → fraction pinned to 0, not a negative/garbage value. (guards the
+            // signed-vs-abs asymmetry between Capture and ResolveTarget)
+            var t = ReadingPositionMath.Capture("A", 200, "B", 100, 150);
+            Assert.Equal(0.0, t.Fraction, 6);
+            Assert.False(double.IsNaN(t.Fraction));
+        }
+
+        [Fact]
+        public void Capture_document_start_when_no_anchor_above()
+        {
+            var t = ReadingPositionMath.Capture(null, 0, "B", 200, 40);
+            Assert.Null(t.Above);
+            Assert.Equal("B", t.Below);
+            Assert.Equal(0.0, t.Fraction, 6);
+        }
+
+        [Fact]
+        public void Capture_past_last_anchor_when_no_anchor_below()
+        {
+            var t = ReadingPositionMath.Capture("Z", 9000, null, 0, 9500);
+            Assert.Equal("Z", t.Above);
+            Assert.Null(t.Below);
+            Assert.Equal(0.0, t.Fraction, 6);
+        }
+
+        // ---- ResolveTarget ----
+
+        [Fact]
+        public void Resolve_bracketed_interpolates_current_positions()
+        {
+            var t = new ReadingPositionToken { Above = "A", Below = "B", Fraction = 0.3 };
+            // After reflow A is at 300, B at 500 → 300 + 0.3*200 = 360
+            Assert.Equal(360.0, ReadingPositionMath.ResolveTarget(t, 300, 500));
+        }
+
+        [Fact]
+        public void Resolve_document_start_needs_no_positions()
+        {
+            var t = new ReadingPositionToken { Above = null, Below = "B", Fraction = 0.0 };
+            Assert.Equal(0.0, ReadingPositionMath.ResolveTarget(t, null, null));
+        }
+
+        [Fact]
+        public void Resolve_both_ends_null_returns_null_not_top()
+        {
+            // No-anchors / empty-cache token → unresolvable → caller fuzzy-fallbacks (must NOT silently scroll
+            // to 0). Distinguishes it from a genuine document-start token, which names a real Below anchor.
+            var t = new ReadingPositionToken { Above = null, Below = null, Fraction = 0.0 };
+            Assert.Null(ReadingPositionMath.ResolveTarget(t, null, null));
+        }
+
+        [Fact]
+        public void Resolve_default_or_malformed_token_returns_null_not_top()
+        {
+            // A default-constructed token (e.g. a truncated {} deserialization) is all-null → unresolvable,
+            // NOT document-start. (Fable review §1)
+            Assert.Null(ReadingPositionMath.ResolveTarget(new ReadingPositionToken(), 100, 200));
+        }
+
+        [Fact]
+        public void Resolve_nan_fraction_stays_finite_in_bracket()
+        {
+            // A NaN Fraction (hand-built / malformed persisted) must not slip through the range clamp.
+            var t = new ReadingPositionToken { Above = "A", Below = "B", Fraction = double.NaN };
+            var target = ReadingPositionMath.ResolveTarget(t, 300, 500);
+            Assert.NotNull(target);
+            Assert.False(double.IsNaN(target!.Value));
+            Assert.InRange(target.Value, 300, 500);
+        }
+
+        [Fact]
+        public void Resolve_past_last_returns_upper_position()
+        {
+            var t = new ReadingPositionToken { Above = "Z", Below = null, Fraction = 0.0 };
+            Assert.Equal(9000.0, ReadingPositionMath.ResolveTarget(t, 9000, null));
+        }
+
+        [Fact]
+        public void Resolve_past_last_upper_missing_returns_null_for_fallback()
+        {
+            var t = new ReadingPositionToken { Above = "Z", Below = null, Fraction = 0.0 };
+            Assert.Null(ReadingPositionMath.ResolveTarget(t, null, null));
+        }
+
+        [Fact]
+        public void Resolve_clamps_target_into_the_bracket_on_inverted_reflow()
+        {
+            // Pathological: after reflow A(500) is BELOW B(400). Target must stay within [400, 500].
+            var t = new ReadingPositionToken { Above = "A", Below = "B", Fraction = 0.9 };
+            var target = ReadingPositionMath.ResolveTarget(t, 500, 400);
+            Assert.NotNull(target);
+            Assert.InRange(target!.Value, 400, 500);
+        }
+
+        [Fact]
+        public void Resolve_coincident_current_positions_no_nan()
+        {
+            var t = new ReadingPositionToken { Above = "A", Below = "B", Fraction = 0.7 };
+            var target = ReadingPositionMath.ResolveTarget(t, 500, 500);
+            Assert.Equal(500.0, target);
+        }
+
+        [Fact]
+        public void Resolve_above_vanished_falls_back_to_lower_edge()
+        {
+            var t = new ReadingPositionToken { Above = "A", Below = "B", Fraction = 0.5 };
+            Assert.Equal(700.0, ReadingPositionMath.ResolveTarget(t, null, 700));
+        }
+
+        [Fact]
+        public void Resolve_below_vanished_falls_back_to_upper_edge()
+        {
+            var t = new ReadingPositionToken { Above = "A", Below = "B", Fraction = 0.5 };
+            Assert.Equal(300.0, ReadingPositionMath.ResolveTarget(t, 300, null));
+        }
+
+        [Fact]
+        public void Resolve_both_vanished_returns_null_for_fuzzy_fallback()
+        {
+            var t = new ReadingPositionToken { Above = "A", Below = "B", Fraction = 0.5 };
+            Assert.Null(ReadingPositionMath.ResolveTarget(t, null, null));
+        }
+
+        // ---- Round trip: capture then restore at the SAME positions lands back on scrollTop ----
+
+        [Theory]
+        [InlineData(130)]
+        [InlineData(100)]
+        [InlineData(199)]
+        public void Roundtrip_same_positions_returns_scrolltop(double scrollTop)
+        {
+            var t = ReadingPositionMath.Capture("A", 100, "B", 200, scrollTop);
+            var restored = ReadingPositionMath.ResolveTarget(t, 100, 200);
+            Assert.NotNull(restored);
+            Assert.Equal(scrollTop, restored!.Value, 6);
+        }
+    }
+}

--- a/src/CST.Avalonia/Models/ReadingPositionMath.cs
+++ b/src/CST.Avalonia/Models/ReadingPositionMath.cs
@@ -1,0 +1,95 @@
+using System;
+
+namespace CST.Avalonia.Models;
+
+/// <summary>
+/// Pure, DOM-free fidelity math for the reading-position token (#434), kept out of the WebView JS so it is
+/// directly unit-testable. The JS side does only the cheap DOM work — find the anchors bracketing the
+/// viewport top, read their live <c>getBoundingClientRect</c> positions, and <c>scrollTo</c> — and feeds
+/// those raw numbers here; this class owns the fraction, the interpolation, and every degenerate-case guard
+/// (Fable review §3).
+///
+/// All positions are absolute document offsets in pixels (a live <c>scrollTop</c>-space value), NOT the
+/// cached <c>build()</c>-time snapshots — capture reads live rects so the fraction can't be skewed by a
+/// reflow since the last cache build (Fable review §1).
+/// </summary>
+public static class ReadingPositionMath
+{
+    // Positions within this many pixels are treated as coincident (page + paragraph anchor on one line), which
+    // would otherwise make the bracket a zero/near-zero interval and the fraction meaningless.
+    private const double CoincidentEpsilon = 0.5;
+
+    /// <summary>
+    /// Build a token from the bracketing anchors the JS side found for the current viewport top.
+    /// </summary>
+    /// <param name="above">Name of the nearest anchor at/above the viewport top, or null if none (document start).</param>
+    /// <param name="abovePos">Live position of <paramref name="above"/> (ignored when it is null).</param>
+    /// <param name="below">Name of the nearest anchor below the viewport top, or null if none (past last anchor).</param>
+    /// <param name="belowPos">Live position of <paramref name="below"/> (ignored when it is null).</param>
+    /// <param name="scrollTop">The current viewport-top offset (raw scrollTop; no display fudge factors — Fable §7).</param>
+    public static ReadingPositionToken Capture(string? above, double abovePos, string? below, double belowPos, double scrollTop)
+    {
+        // Both ends present → real interpolation between them.
+        if (above != null && below != null)
+        {
+            var denom = belowPos - abovePos;
+            double fraction = denom <= CoincidentEpsilon
+                ? 0.0                                   // coincident/inverted bracket → pin to the upper anchor
+                : Clamp01((scrollTop - abovePos) / denom);
+            return new ReadingPositionToken { Above = above, Below = below, Fraction = fraction };
+        }
+
+        // Past the last anchor → clamp to it. At/before the first anchor, or no anchors at all → document start.
+        return new ReadingPositionToken { Above = above, Below = below, Fraction = 0.0 };
+    }
+
+    /// <summary>
+    /// Resolve a token to a target scrollTop using the anchors' CURRENT (post-reload / post-reflow) positions,
+    /// as re-read by the JS side at restore time. Returns null only when the token names an anchor bracket but
+    /// NEITHER end still exists — the caller then applies its own fuzzy fallback (e.g. nearest-paragraph). A
+    /// document-start token (<see cref="ReadingPositionToken.Above"/> == null) resolves to 0 without needing any
+    /// position, so restore never has to wait on the anchor cache (Fable §2).
+    /// </summary>
+    /// <param name="token">The saved token.</param>
+    /// <param name="abovePos">Current position of <see cref="ReadingPositionToken.Above"/>, or null if it no longer exists.</param>
+    /// <param name="belowPos">Current position of <see cref="ReadingPositionToken.Below"/>, or null if it no longer exists.</param>
+    public static double? ResolveTarget(ReadingPositionToken token, double? abovePos, double? belowPos)
+    {
+        if (token == null) return null;
+
+        if (token.Above == null)
+        {
+            // A GENUINE document-start token always names the first anchor as its lower end (there IS an anchor
+            // below the top), so Above==null WITH a Below resolves to 0 with no positions needed (Fable §2). But
+            // a token with BOTH ends null is the "no anchors / empty cache" case — and also what a default-
+            // constructed or malformed-deserialized token looks like — so return null for the caller's fuzzy
+            // fallback rather than silently scrolling to the top (Fable review §1).
+            return token.Below != null ? 0.0 : (double?)null;
+        }
+
+        // Past the last anchor when captured → land on the upper anchor's current position.
+        if (token.Below == null)
+            return abovePos; // null if the anchor vanished → caller fuzzy-fallbacks
+
+        // Full bracket. Interpolate when both ends survive; degrade to whichever end remains (Fable §5).
+        if (abovePos is double a && belowPos is double b)
+        {
+            var denom = b - a;
+            // Defend against a NaN/out-of-range Fraction from a hand-built or malformed-persisted token — a NaN
+            // would slip through the range clamp below (NaN compares false both ways) and yield scrollTo(NaN).
+            var fraction = double.IsNaN(token.Fraction) ? 0.0 : Clamp01(token.Fraction);
+            double target = Math.Abs(denom) <= CoincidentEpsilon
+                ? a                                     // coincident/inverted → the upper anchor's top edge
+                : a + fraction * denom;
+            // Never scroll outside the bracket even if reflow inverted or squeezed it (Fable §3).
+            return Clamp(target, Math.Min(a, b), Math.Max(a, b));
+        }
+        if (abovePos is double aOnly) return aOnly;     // below vanished → upper anchor top edge
+        if (belowPos is double bOnly) return bOnly;     // above vanished → lower anchor top edge
+        return null;                                    // both vanished → caller's fuzzy fallback
+    }
+
+    private static double Clamp01(double v) => v < 0 ? 0 : (v > 1 ? 1 : v);
+
+    private static double Clamp(double v, double lo, double hi) => v < lo ? lo : (v > hi ? hi : v);
+}

--- a/src/CST.Avalonia/Models/ReadingPositionToken.cs
+++ b/src/CST.Avalonia/Models/ReadingPositionToken.cs
@@ -1,0 +1,36 @@
+namespace CST.Avalonia.Models;
+
+/// <summary>
+/// Canonical reading-position representation (#434): the two nearest anchors that bracket the viewport top,
+/// plus the fraction of the way from the upper anchor to the lower one.
+///
+/// It stores a RELATIVE position between two stable anchor NAMES, not an absolute pixel offset, so it is
+/// robust to reflow and to different window sizes — restoring interpolates between the anchors' CURRENT
+/// positions, so the reading position is preserved even when the content between them re-lays-out. Anchor
+/// names (page V/M/P/T/O, paragraph, chapter) derive from the source XML rather than the rendered script, so
+/// the token also survives a script-change reload by construction.
+///
+/// Semantics of the two ends:
+/// <list type="bullet">
+///   <item><see cref="Above"/> = null, <see cref="Below"/> set → the position is at the document start
+///     (above the first anchor); it resolves to scrollTop 0.</item>
+///   <item><see cref="Below"/> = null, <see cref="Above"/> set → the position is past the last anchor
+///     (clamped to it).</item>
+///   <item><b>Both</b> null → no anchors / empty cache — and also what a default-constructed or malformed
+///     token looks like — so it is treated as UNRESOLVABLE (the caller applies its own fuzzy fallback),
+///     NOT as document start. A genuine document-start token always names a real first anchor as its
+///     <see cref="Below"/>.</item>
+/// </list>
+/// </summary>
+public sealed class ReadingPositionToken
+{
+    /// <summary>Name of the nearest anchor at or ABOVE the viewport top; null means "at document start".</summary>
+    public string? Above { get; set; }
+
+    /// <summary>Name of the nearest anchor BELOW the viewport top; null means "past the last anchor".</summary>
+    public string? Below { get; set; }
+
+    /// <summary>How far the viewport top sits from <see cref="Above"/> (0) toward <see cref="Below"/> (1).
+    /// Always in [0, 1] (clamped at capture).</summary>
+    public double Fraction { get; set; }
+}


### PR DESCRIPTION
Foundation for #434 (canonical reading-position token). **PR 1 of the Fable-sequenced series** — pure model + math, no consumers wired, behavior-neutral.

## What
- **`ReadingPositionToken`** `{ Above, Below, Fraction }` — bracketing anchor names + the fraction between them. `Above=null` = document start; `Below=null` = past the last anchor. Anchor names derive from the source XML, so a token survives a script-change reload by construction.
- **`ReadingPositionMath`** (pure, DOM-free, unit-tested): `Capture(above, abovePos, below, belowPos, scrollTop) → token` and `ResolveTarget(token, abovePos?, belowPos?) → scrollTop?`. The JS side will do only the DOM work (bracket lookup, live rect reads, `scrollTo`) and feed raw numbers here, so the fidelity math stays testable and **un-duplicated**.

## Fable-review constraints already baked in
- **§1** capture uses **live** positions, not cached `build()`-time snapshots.
- **§2** a document-start token resolves to 0 with **no positions**, so restore never waits on the anchor cache (the recycled-tab race).
- **§3** degenerate guards: zero/inverted bracket → pin to upper edge (no NaN); target **clamped into the bracket**; fraction clamped `[0,1]`.
- **§5** an anchor vanishing on reload → degrade to the surviving edge; `null` only when **both** vanish (caller applies its own fuzzy fallback).
- **§7** raw `scrollTop`, no display fudge factors.

## Tests
21 unit tests: capture (bracketed/clamped/coincident/doc-start/past-last), resolve (interpolate/doc-start/past-last/inverted-clamp/edge-degrade/both-missing), and capture→restore round-trip.

## Migration
Intentionally omitted — beta-5 testers clean-start the app-data dir, so the serialization consumer (later PR) changes the schema directly. No `Migrate` step.

Next PRs (left open for visual review): JS capture/restore primitive wired into script-change + #31 reattach, then float/unfloat, cross-run serialization, resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)