### PR TITLE
#434 (PR-B): position-token consumers — script-change, #31 reattach, cross-run, float/unfloat (Fable steps 1-3 + float)

### DIFF
--- a/src/CST.Avalonia.Tests/Models/BookWindowStateSerializationTests.cs
+++ b/src/CST.Avalonia.Tests/Models/BookWindowStateSerializationTests.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CST.Avalonia.Models;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Models;
+
+/// <summary>
+/// #434: BookWindowState.ReadingPosition (the reading-position token) must round-trip through JSON under the
+/// app's serializer options so a saved reading position restores exactly on next launch. Also verifies the
+/// absent-token case (old file / never captured) deserializes to null and falls back to CurrentAnchor.
+/// </summary>
+public class BookWindowStateSerializationTests
+{
+    // Mirror the options used by ApplicationStateService.
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private static BookWindowState RoundTrip(BookWindowState s) =>
+        JsonSerializer.Deserialize<BookWindowState>(JsonSerializer.Serialize(s, Options), Options)!;
+
+    [Fact]
+    public void ReadingPosition_token_survives_round_trip()
+    {
+        var s = new BookWindowState
+        {
+            BookFileName = "s0101m.mul.xml",
+            CurrentAnchor = "V1.0023",
+            ReadingPosition = new ReadingPositionToken { Above = "V1.0023", Below = "para145", Fraction = 0.42 }
+        };
+
+        var r = RoundTrip(s);
+
+        Assert.NotNull(r.ReadingPosition);
+        Assert.Equal("V1.0023", r.ReadingPosition!.Above);
+        Assert.Equal("para145", r.ReadingPosition.Below);
+        Assert.Equal(0.42, r.ReadingPosition.Fraction, 6);
+        Assert.Equal("V1.0023", r.CurrentAnchor); // coarse fallback preserved alongside
+    }
+
+    [Fact]
+    public void Document_start_token_survives_round_trip()
+    {
+        // Above=null with a Below is the genuine document-start token; null must survive (not become "").
+        var s = new BookWindowState
+        {
+            BookFileName = "s0101m.mul.xml",
+            ReadingPosition = new ReadingPositionToken { Above = null, Below = "V1.0001", Fraction = 0.0 }
+        };
+
+        var r = RoundTrip(s);
+
+        Assert.NotNull(r.ReadingPosition);
+        Assert.Null(r.ReadingPosition!.Above);
+        Assert.Equal("V1.0001", r.ReadingPosition.Below);
+    }
+
+    [Fact]
+    public void Absent_token_deserializes_null()
+    {
+        // An old/never-captured state has no reading position → null → restore falls back to CurrentAnchor.
+        var r = RoundTrip(new BookWindowState { BookFileName = "s0101m.mul.xml", CurrentAnchor = "para5" });
+        Assert.Null(r.ReadingPosition);
+        Assert.Equal("para5", r.CurrentAnchor);
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -716,7 +716,8 @@ public partial class App : Application
                                         bookWindowState.CurrentAnchor ?? "null");
                                     mainWindow.OpenBook(book, bookWindowState.SearchTerms, bookWindowState.BookScript, bookWindowState.WindowId,
                                         bookWindowState.DocId, bookWindowState.SearchPositions, bookWindowState.CurrentAnchor,
-                                        bookWindowState.CurrentHitIndex, bookWindowState.ShowFootnotes, bookWindowState.ShowSearchTerms);
+                                        bookWindowState.CurrentHitIndex, bookWindowState.ShowFootnotes, bookWindowState.ShowSearchTerms,
+                                        bookWindowState.ReadingPosition);
                                     Log.Debug("Book restored: {BookFile} with script: {Script}, anchor: {Anchor}",
                                         book.FileName, bookWindowState.BookScript, bookWindowState.CurrentAnchor ?? "null");
                                 }

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -207,6 +207,13 @@ public class BookWindowState
     public string? CurrentAnchor { get; set; }
 
     /// <summary>
+    /// Canonical reading-position token (#434) — the exact reading position (bracketing anchors + fraction),
+    /// preferred over the coarse <see cref="CurrentAnchor"/> on restore. No migration is needed: beta-5 testers
+    /// clean-start the app-data dir, so an old file simply has this null and falls back to CurrentAnchor.
+    /// </summary>
+    public ReadingPositionToken? ReadingPosition { get; set; }
+
+    /// <summary>
     /// Which search hit the user was viewing (1-based), restored so navigation
     /// resumes at "N of Total" instead of resetting to "1 of Total".
     /// </summary>

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1433,6 +1433,11 @@ namespace CST.Avalonia.Services
                 base.FloatDockable(newVm);
                 newVm.CanFloat = false;  // Restore to prevent drag-to-float
 
+                // A programmatic (button) float has no pointer position, so Dock lands the host window at the
+                // monitor boundary — which can be a different, possibly powered-off monitor (it landed at the
+                // left edge of the secondary screen). Reposition it onto the main window's screen. (#float-disappear)
+                PlaceAndRevealFloatingWindow(newVm);
+
                 Log.Information("Float operation completed - new instance in floating window");
             }
             catch (Exception ex)
@@ -1441,6 +1446,61 @@ namespace CST.Avalonia.Services
             }
 
             Log.Information("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        }
+
+        // Place a just-button-floated host window near the main window, CLAMPED to the main window's screen, so
+        // it never lands on another (possibly powered-off) monitor. A programmatic (button) float gives Dock no
+        // pointer position, so it defaults to a monitor boundary — on a multi-monitor setup that can be a second
+        // screen. This only repositions the already-shown window (no WebView is moved → the re-parent hard rule
+        // is unaffected) and brings it to front. The drag-to-float path is unaffected (Dock places it at the
+        // drop point). (#float-disappear)
+        private void PlaceAndRevealFloatingWindow(BookDisplayViewModel floatedVm)
+        {
+            try
+            {
+                var floatDock = floatedVm.Owner as IDock;
+                if (floatDock == null) return; // no owning dock (shouldn't happen post-float) → don't risk a null==null host match (fable)
+                CstHostWindow? host = null;
+                int hostCount = 0;
+                foreach (var hw in HostWindows)
+                {
+                    if (hw is CstHostWindow chw)
+                    {
+                        hostCount++;
+                        if (host == null && FindDocumentDockInLayout(chw.Layout) == floatDock) host = chw;
+                    }
+                }
+                if (host == null) return;
+
+                var main = CST.Avalonia.App.MainWindow;
+                if (main == null) { host.Activate(); return; }
+
+                // The screen the MAIN window is on (proven #430 pattern: WorkingArea contains the main position).
+                global::Avalonia.Platform.Screen? screen = null;
+                var all = host.Screens?.All;
+                if (all != null)
+                    foreach (var s in all)
+                        if (s.WorkingArea.Contains(main.Position)) { screen = s; break; }
+                screen ??= host.Screens?.Primary;
+
+                // Cascade near the main window; clamp inside that screen's work area.
+                int cascade = 30 * Math.Max(0, hostCount - 1);
+                int x = main.Position.X + 40 + cascade;
+                int y = main.Position.Y + 40 + cascade;
+                if (screen != null)
+                {
+                    var wa = screen.WorkingArea;                 // device px
+                    double scale = screen.Scaling <= 0 ? 1.0 : screen.Scaling;
+                    int w = (int)(host.Width * scale);           // Width/Height are logical
+                    int h = (int)(host.Height * scale);
+                    x = Math.Max(wa.X, Math.Min(x, wa.X + wa.Width - w));
+                    y = Math.Max(wa.Y, Math.Min(y, wa.Y + wa.Height - h));
+                }
+                host.Position = new PixelPoint(x, y);
+                host.Activate();
+                Log.Information("Placed floating window on the main window's screen at {Pos}", host.Position);
+            }
+            catch (Exception ex) { Log.Warning(ex, "Failed to place/reveal new floating window"); }
         }
 
         /// <summary>

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1329,16 +1329,19 @@ namespace CST.Avalonia.Services
             {
                 // Step 1: Query WebView for actual current scroll position
                 string? currentAnchor = null;
+                ReadingPositionToken? positionToken = null;   // #434: exact reading position across the re-parent
                 if (oldVm.BookDisplayControl != null)
                 {
                     Log.Information("Querying WebView for current scroll position...");
                     currentAnchor = await oldVm.BookDisplayControl.GetCurrentParagraphAnchorAsync();
+                    positionToken = await oldVm.BookDisplayControl.GetCurrentPositionTokenAsync();
                     Log.Information("Current scroll position anchor: {Anchor}", currentAnchor ?? "none");
                 }
                 else
                 {
-                    // Fallback to last known VRI anchor if WebView not available
+                    // Fallback to last known VRI anchor / rolling token if the WebView isn't available.
                     currentAnchor = oldVm.CurrentVriAnchor;
+                    positionToken = oldVm.LastPositionToken;
                     Log.Warning("BookDisplayControl not available, using fallback VRI anchor: {Anchor}", currentAnchor ?? "none");
                 }
 
@@ -1394,7 +1397,8 @@ namespace CST.Avalonia.Services
                     searchPositions: searchPositions,
                     windowId: null,  // CRITICAL: null = generates fresh GUID
                     dockFactory: this,
-                    initialBookScript: bookScript  // seed so the set below is a no-op (BOOK-3)
+                    initialBookScript: bookScript,  // seed so the set below is a no-op (BOOK-3)
+                    initialPositionToken: positionToken  // #434: restore the exact reading position across float/unfloat
                 );
 
                 // Restore additional state (BookScript set is a no-op given the seed; kept as a safety net)
@@ -1462,16 +1466,19 @@ namespace CST.Avalonia.Services
 
                 // Step 1: Query WebView for actual current scroll position
                 string? currentAnchor = null;
+                ReadingPositionToken? positionToken = null;   // #434: exact reading position across the re-parent
                 if (oldVm.BookDisplayControl != null)
                 {
                     Log.Information("Querying WebView for current scroll position...");
                     currentAnchor = await oldVm.BookDisplayControl.GetCurrentParagraphAnchorAsync();
+                    positionToken = await oldVm.BookDisplayControl.GetCurrentPositionTokenAsync();
                     Log.Information("Current scroll position anchor: {Anchor}", currentAnchor ?? "none");
                 }
                 else
                 {
-                    // Fallback to last known VRI anchor if WebView not available
+                    // Fallback to last known VRI anchor / rolling token if the WebView isn't available.
                     currentAnchor = oldVm.CurrentVriAnchor;
+                    positionToken = oldVm.LastPositionToken;
                     Log.Warning("BookDisplayControl not available, using fallback VRI anchor: {Anchor}", currentAnchor ?? "none");
                 }
 
@@ -1535,7 +1542,8 @@ namespace CST.Avalonia.Services
                     searchPositions: searchPositions,
                     windowId: null,  // CRITICAL: null = generates fresh GUID
                     dockFactory: this,
-                    initialBookScript: bookScript  // seed so the set below is a no-op (BOOK-3)
+                    initialBookScript: bookScript,  // seed so the set below is a no-op (BOOK-3)
+                    initialPositionToken: positionToken  // #434: restore the exact reading position across float/unfloat
                 );
 
                 // Restore additional state (BookScript set is a no-op given the seed; kept as a safety net)

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -474,7 +474,8 @@ namespace CST.Avalonia.Services
         
         public void OpenBook(CST.Book book, string? anchor, Script? bookScript, string? windowId,
             List<string>? searchTerms = null, int? docId = null, List<TermPosition>? searchPositions = null,
-            int? initialCurrentHitIndex = null, bool showFootnotes = true, bool showSearchTerms = true)
+            int? initialCurrentHitIndex = null, bool showFootnotes = true, bool showSearchTerms = true,
+            ReadingPositionToken? initialPositionToken = null)
         {
             _logger.Information("Opening book: {BookFile} with anchor: {Anchor}, SearchTerms: {TermCount}, Positions: {PosCount}",
                 book.FileName, anchor ?? "null", searchTerms?.Count ?? 0, searchPositions?.Count ?? 0);
@@ -514,7 +515,7 @@ namespace CST.Avalonia.Services
             Script targetScript = bookScript ?? scriptService?.CurrentScript ?? Script.Devanagari;
 
             // Pass search data if available (for state restoration with highlighting)
-            var bookDisplayViewModel = new BookDisplayViewModel(book, searchTerms, anchor, chapterListsService, settingsService, fontService, docId, searchPositions, null, this, initialCurrentHitIndex, targetScript);
+            var bookDisplayViewModel = new BookDisplayViewModel(book, searchTerms, anchor, chapterListsService, settingsService, fontService, docId, searchPositions, null, this, initialCurrentHitIndex, targetScript, initialPositionToken);
 
             // No-op given the seed above (avoids the second full pipeline run); kept as a safety net.
             bookDisplayViewModel.BookScript = targetScript;
@@ -669,7 +670,8 @@ namespace CST.Avalonia.Services
                     SearchTerms = bookDisplayViewModel.SearchTerms ?? new List<string>(),
                     DocId = bookDisplayViewModel.DocId,
                     SearchPositions = bookDisplayViewModel.SearchPositions ?? new List<TermPosition>(),
-                    CurrentAnchor = currentAnchor, // Save scroll position for restoration
+                    CurrentAnchor = currentAnchor, // Save scroll position for restoration (coarse fallback)
+                    ReadingPosition = bookDisplayViewModel.LastPositionToken, // #434 exact reading position (preferred)
                     CurrentHitIndex = bookDisplayViewModel.CurrentHitIndex, // Save which search hit was active
                     TotalHits = bookDisplayViewModel.TotalHits,
                     TabIndex = 0, // TODO: Get actual tab index from dock

--- a/src/CST.Avalonia/Services/CstHostWindow.cs
+++ b/src/CST.Avalonia/Services/CstHostWindow.cs
@@ -114,6 +114,9 @@ namespace CST.Avalonia.Services
 
         public void SetPosition(double x, double y)
         {
+            // Guard NaN like the stock Dock.Avalonia HostWindow does — a NaN from Dock's tracking must not
+            // become a garbage PixelPoint. (#float-disappear defensive)
+            if (double.IsNaN(x) || double.IsNaN(y)) return;
             Position = new PixelPoint((int)x, (int)y);
             X = x;
             Y = y;
@@ -127,8 +130,9 @@ namespace CST.Avalonia.Services
 
         public void SetSize(double width, double height)
         {
-            Width = width;
-            Height = height;
+            // Guard NaN per-dimension like the stock HostWindow. (#float-disappear defensive)
+            if (!double.IsNaN(width)) Width = width;
+            if (!double.IsNaN(height)) Height = height;
         }
 
         public void GetSize(out double width, out double height)

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -108,6 +108,7 @@ namespace CST.Avalonia.ViewModels
         private readonly CstDockFactory? _dockFactory; // Factory for float/unfloat operations
         private string? _lastCapturedAnchor = null; // Cached anchor for scroll position restoration (persists across float/unfloat)
         private string? _pendingAnchorNavigation = null; // Anchor to navigate to when View becomes available
+        private ReadingPositionToken? _pendingPositionToken = null; // #434 reading-position token to restore when the View becomes available (preferred over the coarse string anchor)
         private int? _pendingHitNavigation = null; // Search hit to scroll to when View becomes available
 
         public BookDisplayViewModel(Book book, List<string>? searchTerms = null, string? initialAnchor = null, ChapterListsService? chapterListsService = null, ISettingsService? settingsService = null, IFontService? fontService = null, int? docId = null, List<TermPosition>? searchPositions = null, string? windowId = null, CstDockFactory? dockFactory = null, int? initialCurrentHitIndex = null, Script? initialBookScript = null)
@@ -231,19 +232,18 @@ namespace CST.Avalonia.ViewModels
                         this.RaisePropertyChanged(nameof(CurrentScriptFontFamily));
                         this.RaisePropertyChanged(nameof(CurrentScriptFontSize));
 
-                        // Save current page anchor for position preservation
-                        string savedPageAnchor = "";
+                        // Capture the exact reading position (#434 token) BEFORE the reload, while the current
+                        // script's DOM is still rendered. The token interpolates between the anchors bracketing
+                        // the viewport top, so restore lands on the same reading position rather than a page
+                        // marker's top edge (the pre-#434 GetCurrentPageAnchor -> ScrollToPageAnchor drift).
+                        ReadingPositionToken? savedToken = null;
                         if (BookDisplayControl != null)
                         {
-                            savedPageAnchor = BookDisplayControl.GetCurrentPageAnchor();
-                            if (!string.IsNullOrEmpty(savedPageAnchor))
-                            {
-                                _logger.Debug("Saved page anchor: {Anchor}", savedPageAnchor);
-                            }
+                            savedToken = await BookDisplayControl.GetCurrentPositionTokenAsync();
+                            if (savedToken != null)
+                                _logger.Debug("Captured reading-position token: above={Above} below={Below} frac={Frac}", savedToken.Above, savedToken.Below, savedToken.Fraction);
                             else
-                            {
-                                _logger.Warning("No page anchor available, won't restore position");
-                            }
+                                _logger.Warning("No reading-position token available, won't restore position");
                         }
 
                         // Ensure property updates happen on UI thread
@@ -286,10 +286,10 @@ namespace CST.Avalonia.ViewModels
                         // Queue the position restore BEFORE reloading: the View executes it from
                         // OnNavigationCompleted when the re-rendered document is actually ready, instead
                         // of a 1000ms delay-then-hope timer racing the load. (BOOK-7)
-                        if (!string.IsNullOrEmpty(savedPageAnchor))
+                        if (savedToken != null)
                         {
-                            _pendingAnchorNavigation = savedPageAnchor;
-                            _logger.Debug("Queued position restore to page anchor: {Anchor}", savedPageAnchor);
+                            _pendingPositionToken = savedToken;
+                            _logger.Debug("Queued reading-position token restore");
                         }
                         await LoadBookContentAsync();
                     }
@@ -484,6 +484,16 @@ namespace CST.Avalonia.ViewModels
             var anchor = _pendingAnchorNavigation;
             _pendingAnchorNavigation = null;
             return anchor;
+        }
+
+        // Take (and clear) the queued #434 reading-position token. Preferred over the string anchor when both
+        // are queued — it interpolates between two anchors, so it restores the exact reading position rather
+        // than an anchor's top edge. (#434)
+        internal ReadingPositionToken? TakePendingPositionToken()
+        {
+            var token = _pendingPositionToken;
+            _pendingPositionToken = null;
+            return token;
         }
 
         internal int? TakePendingHitNavigation()

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -541,6 +541,16 @@ namespace CST.Avalonia.ViewModels
                         _lastCapturedAnchor = anchor;
                         _logger.Information("Captured final position before shutdown: {Anchor}", anchor);
                     }
+
+                    // Also refresh the #434 token — it is PREFERRED over _lastCapturedAnchor on restore, so a
+                    // scroll in the final sub-tick window must update the token too, or the fresh anchor above
+                    // would be ignored in favour of an up-to-one-tick-staler token. (Fable cross-run review §2)
+                    var token = await BookDisplayControl.GetCurrentPositionTokenAsync();
+                    if (token != null)
+                    {
+                        _lastPositionToken = token;
+                        _logger.Debug("Captured final reading-position token before shutdown");
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -464,11 +464,21 @@ namespace CST.Avalonia.ViewModels
             // timer keeps ticking against the old document, and an unconditional clear here would
             // cancel the queued restore before the new document's OnNavigationCompleted could
             // execute it. (BOOK-7)
-            if (_pendingAnchorNavigation != null && previous != null && anchor != previous)
+            if (previous != null && anchor != previous)
             {
-                _logger.Debug("Clearing pending anchor navigation {PendingAnchor} - user has scrolled to {CurrentAnchor}",
-                    _pendingAnchorNavigation, anchor);
-                _pendingAnchorNavigation = null;
+                if (_pendingAnchorNavigation != null)
+                {
+                    _logger.Debug("Clearing pending anchor navigation {PendingAnchor} - user has scrolled to {CurrentAnchor}",
+                        _pendingAnchorNavigation, anchor);
+                    _pendingAnchorNavigation = null;
+                }
+                // Same yield-to-the-user rule for the #434 token: a real scroll on the still-live old document
+                // cancels the queued position restore. (Fable PR-B review §4)
+                if (_pendingPositionToken != null)
+                {
+                    _logger.Debug("Clearing pending reading-position token - user has scrolled to {CurrentAnchor}", anchor);
+                    _pendingPositionToken = null;
+                }
             }
         }
 

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -47,6 +47,7 @@ namespace CST.Avalonia.ViewModels
         private readonly List<string>? _searchTerms;
         private readonly List<TermPosition>? _searchPositions;  // NEW: Store positions with IsFirstTerm flags
         private readonly string? _initialAnchor;
+        private readonly ReadingPositionToken? _initialPositionToken; // #434 cross-run restore token (preferred over _initialAnchor)
         private readonly int? _initialCurrentHitIndex; // saved search hit to restore (null = fresh open)
         private readonly int? _docId;
 
@@ -111,7 +112,7 @@ namespace CST.Avalonia.ViewModels
         private ReadingPositionToken? _pendingPositionToken = null; // #434 reading-position token to restore when the View becomes available (preferred over the coarse string anchor)
         private int? _pendingHitNavigation = null; // Search hit to scroll to when View becomes available
 
-        public BookDisplayViewModel(Book book, List<string>? searchTerms = null, string? initialAnchor = null, ChapterListsService? chapterListsService = null, ISettingsService? settingsService = null, IFontService? fontService = null, int? docId = null, List<TermPosition>? searchPositions = null, string? windowId = null, CstDockFactory? dockFactory = null, int? initialCurrentHitIndex = null, Script? initialBookScript = null)
+        public BookDisplayViewModel(Book book, List<string>? searchTerms = null, string? initialAnchor = null, ChapterListsService? chapterListsService = null, ISettingsService? settingsService = null, IFontService? fontService = null, int? docId = null, List<TermPosition>? searchPositions = null, string? windowId = null, CstDockFactory? dockFactory = null, int? initialCurrentHitIndex = null, Script? initialBookScript = null, ReadingPositionToken? initialPositionToken = null)
         {
             _logger = Log.ForContext<BookDisplayViewModel>();
             _chapterListsService = chapterListsService;
@@ -122,6 +123,7 @@ namespace CST.Avalonia.ViewModels
             _searchTerms = searchTerms;
             _searchPositions = searchPositions;  // NEW: Store positions for two-color highlighting
             _initialAnchor = initialAnchor;
+            _initialPositionToken = initialPositionToken;
             _initialCurrentHitIndex = initialCurrentHitIndex;
             _docId = docId;
             // Seed the per-tab script to the target the factory will use, so its post-construction
@@ -448,6 +450,15 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public string? LastCapturedAnchor => _lastCapturedAnchor;
 
+        // Latest rolling reading-position token, pushed from the View's status tick; persisted on shutdown for
+        // cross-run restore (#434). Preferred over LastCapturedAnchor when present.
+        private ReadingPositionToken? _lastPositionToken = null;
+        public ReadingPositionToken? LastPositionToken => _lastPositionToken;
+        public void UpdateLastPositionToken(ReadingPositionToken? token)
+        {
+            if (token != null) _lastPositionToken = token;
+        }
+
         /// <summary>
         /// Updates the cached anchor for scroll position restoration.
         /// Called by BookDisplayView scroll timer every 200ms.
@@ -727,7 +738,14 @@ namespace CST.Avalonia.ViewModels
                 // the exact hit over the anchor, which only lands at the paragraph start and can leave
                 // the highlighted term off-screen in a long paragraph. (#36)
                 bool restoreSearchHit = _searchTerms?.Any() == true && _initialCurrentHitIndex.HasValue;
-                if (!string.IsNullOrEmpty(_initialAnchor) && !restoreSearchHit)
+                if (_initialPositionToken != null && !restoreSearchHit)
+                {
+                    // #434 cross-run restore: prefer the exact reading-position token over the coarse anchor.
+                    _pendingPositionToken = _initialPositionToken;
+                    _logger.Debug("Queued initial reading-position token restore (above={Above}, below={Below})",
+                        _initialPositionToken.Above, _initialPositionToken.Below);
+                }
+                else if (!string.IsNullOrEmpty(_initialAnchor) && !restoreSearchHit)
                 {
                     _pendingAnchorNavigation = _initialAnchor;
                     _logger.Debug("Queued initial anchor navigation: {Anchor}", _initialAnchor);

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -86,9 +86,10 @@ namespace CST.Avalonia.ViewModels
 
         public void OpenBook(CST.Book book, List<string>? searchTerms = null, Script? bookScript = null, string? windowId = null,
             int? docId = null, List<TermPosition>? searchPositions = null, string? initialAnchor = null,
-            int? initialCurrentHitIndex = null, bool showFootnotes = true, bool showSearchTerms = true)
+            int? initialCurrentHitIndex = null, bool showFootnotes = true, bool showSearchTerms = true,
+            ReadingPositionToken? initialPositionToken = null)
         {
-            _factory.OpenBook(book, initialAnchor, bookScript, windowId, searchTerms, docId, searchPositions, initialCurrentHitIndex, showFootnotes, showSearchTerms);
+            _factory.OpenBook(book, initialAnchor, bookScript, windowId, searchTerms, docId, searchPositions, initialCurrentHitIndex, showFootnotes, showSearchTerms, initialPositionToken);
         }
 
         public void CloseBook(string bookId)

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -45,6 +45,7 @@ public partial class BookDisplayView : UserControl
     // computed C#-side by ReadingPositionMath so it stays unit-tested.
     private TaskCompletionSource<string?>? _posTokenTcs = null;
     private int _posTokenReq = 0; // monotonic capture request id; a late title with a stale id is ignored (#434)
+    private ReadingPositionToken? _lastPositionToken = null; // #434 rolling-captured reading position (from the status tick); restored on tab reattach (#31)
     private readonly string _tabId = $"tab_{DateTime.Now.Ticks}_{Guid.NewGuid().ToString("N")[..8]}";
     private string? _tempHtmlFilePath;   // the temp HTML file this View last loaded from; deleted on dispose (BOOK-8)
 
@@ -875,8 +876,29 @@ public partial class BookDisplayView : UserControl
                     }} catch(anchorError) {{
                     }}
 
+                    // #434 rolling reading-position bracket, piggybacked on this same tick (no extra round-trip)
+                    // so the View always has a fresh token to restore on tab reattach (#31). Isolated in its own
+                    // try so a bracket glitch can never disturb the status readout above.
+                    var ptA = '', ptAP = '', ptB = '', ptBP = '';
+                    try {{
+                        var ptc = window.cstAnchorCache;
+                        if (ptc && ptc.isBuilt && ptc.sortedAllAnchors && ptc.sortedAllAnchors.length > 0) {{
+                            var ptl = ptc.sortedAllAnchors;
+                            var ptIdx = -1;
+                            for (var pi = 0; pi < ptl.length; pi++) {{ if (ptl[pi].position <= scrollY) ptIdx = pi; else break; }}
+                            ptA = ptIdx >= 0 ? ptl[ptIdx].name : '';
+                            ptB = (ptIdx + 1 < ptl.length) ? ptl[ptIdx + 1].name : '';
+                            var ptLive = function(nm) {{
+                                if (!nm) return '';
+                                var el = document.querySelector('a[name=' + JSON.stringify(nm) + ']') || document.getElementById(nm);
+                                return el ? Math.round(el.getBoundingClientRect().top + window.pageYOffset) : '';
+                            }};
+                            ptAP = ptLive(ptA); ptBP = ptLive(ptB);
+                        }}
+                    }} catch(ptErr) {{ }}
+
                     // ATOMIC UPDATE: Send all status info in one message with tab ID including chapter and best anchor
-                    document.title = 'CST_STATUS_UPDATE:VRI=' + vri + '|MYANMAR=' + myanmar + '|PTS=' + pts + '|THAI=' + thai + '|OTHER=' + other + '|PARA=' + para + '|CHAPTER=' + currentChapter + '|ANCHOR=' + bestAnchor + '|SCROLL=' + scrollY + '|TAB:__TAB_ID_PLACEHOLDER__';
+                    document.title = 'CST_STATUS_UPDATE:VRI=' + vri + '|MYANMAR=' + myanmar + '|PTS=' + pts + '|THAI=' + thai + '|OTHER=' + other + '|PARA=' + para + '|CHAPTER=' + currentChapter + '|ANCHOR=' + bestAnchor + '|SCROLL=' + scrollY + '|PTA=' + ptA + '|PTAP=' + ptAP + '|PTB=' + ptB + '|PTBP=' + ptBP + '|TAB:__TAB_ID_PLACEHOLDER__';
                 }} catch(e) {{
                     // Emit nothing on error — an all-'*' title would clobber a good readout (#432
                     // constraint). The next scroll tick retries. (#423)
@@ -1482,6 +1504,15 @@ public partial class BookDisplayView : UserControl
             _logger.Debug("Navigating to current search hit: {HitIndex}", _viewModel.CurrentHitIndex);
             NavigateToHighlight(_viewModel.CurrentHitIndex);
         }
+        // #31: a NON-search book reattaching a recycled tab has no hit/anchor/token intent, but CEF can reset
+        // the live browser's scroll on reattach — so restore the rolling-captured reading position. Lowest
+        // precedence (search-hit wins, Fable §6); cache-free, so it's safe before the deferred cache rebuild.
+        else if (_lastPositionToken != null)
+        {
+            _logger.Debug("Restoring rolling reading-position token on reattach (#31): above={Above}, below={Below}, frac={Frac}",
+                _lastPositionToken.Above, _lastPositionToken.Below, _lastPositionToken.Fraction);
+            ScrollToPositionToken(_lastPositionToken);
+        }
     }
 
 
@@ -1545,6 +1576,7 @@ public partial class BookDisplayView : UserControl
 
                 // Parse message components
                 string vri = "*", myanmar = "*", pts = "*", thai = "*", other = "*", para = "*", chapter = "*", anchor = "*";
+                string ptA = "", ptAP = "", ptB = "", ptBP = "";   // #434 rolling reading-position bracket
                 int scrollY = 0;
                 bool isCacheBuilt = false;
 
@@ -1558,6 +1590,10 @@ public partial class BookDisplayView : UserControl
                     else if (part.StartsWith("PARA=")) para = part.Substring(5);
                     else if (part.StartsWith("CHAPTER=")) chapter = part.Substring(8);
                     else if (part.StartsWith("ANCHOR=")) anchor = part.Substring(7);
+                    else if (part.StartsWith("PTAP=")) ptAP = part.Substring(5);
+                    else if (part.StartsWith("PTA=")) ptA = part.Substring(4);
+                    else if (part.StartsWith("PTBP=")) ptBP = part.Substring(5);
+                    else if (part.StartsWith("PTB=")) ptB = part.Substring(4);
                     else if (part.StartsWith("SCROLL=")) int.TryParse(part.Substring(7), out scrollY);
                     else if (part.StartsWith("CACHE_BUILT="))
                     {
@@ -1602,6 +1638,22 @@ public partial class BookDisplayView : UserControl
 
                     // Update scroll position
                     if (scrollY > 0) _lastKnownScrollY = scrollY;
+
+                    // #434 rolling capture: keep the freshest reading-position token so a tab reattach can
+                    // restore the exact position (#31). Computed via the unit-tested ReadingPositionMath. Only
+                    // overwrite when the bracket is present (cache built + a real position), so a transient
+                    // empty tick can't wipe a good token.
+                    {
+                        string? above = ptA.Length == 0 ? null : ptA;
+                        string? below = ptB.Length == 0 ? null : ptB;
+                        if (above != null || below != null)
+                        {
+                            var inv = System.Globalization.CultureInfo.InvariantCulture;
+                            double.TryParse(ptAP, System.Globalization.NumberStyles.Any, inv, out var aP);
+                            double.TryParse(ptBP, System.Globalization.NumberStyles.Any, inv, out var bP);
+                            _lastPositionToken = ReadingPositionMath.Capture(above, aP, below, bP, scrollY);
+                        }
+                    }
 
                     // Store last known values
                     if (vri != "*") _lastKnownVri = vri;

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -44,6 +44,7 @@ public partial class BookDisplayView : UserControl
     // capture (#434). Carries the raw "above,abovePos,below,belowPos,scrollTop" string; the fraction math is
     // computed C#-side by ReadingPositionMath so it stays unit-tested.
     private TaskCompletionSource<string?>? _posTokenTcs = null;
+    private int _posTokenReq = 0; // monotonic capture request id; a late title with a stale id is ignored (#434)
     private readonly string _tabId = $"tab_{DateTime.Now.Ticks}_{Guid.NewGuid().ToString("N")[..8]}";
     private string? _tempHtmlFilePath;   // the temp HTML file this View last loaded from; deleted on dispose (BOOK-8)
 
@@ -1675,8 +1676,16 @@ public partial class BookDisplayView : UserControl
             {
                 var parts = title.Split('|');
                 var raw = parts[0].Substring("CST_POSTOKEN:".Length);
-                var messageTabId = parts.Length > 1 && parts[1].StartsWith("TAB:") ? parts[1].Substring(4) : "";
-                if (messageTabId == _tabId)
+                var messageTabId = "";
+                int reqId = -1;
+                foreach (var p in parts)
+                {
+                    if (p.StartsWith("TAB:")) messageTabId = p.Substring(4);
+                    else if (p.StartsWith("REQ:")) int.TryParse(p.Substring(4), out reqId);
+                }
+                // Only accept the title for THIS tab and THIS request — a late result from a timed-out capture
+                // (stale reqId) must not complete a newer capture with the wrong payload. (Fable PR-B review §3)
+                if (messageTabId == _tabId && reqId == _posTokenReq)
                     _posTokenTcs?.TrySetResult(raw);
             }
             catch (Exception ex)
@@ -2587,7 +2596,7 @@ public partial class BookDisplayView : UserControl
     /// cache staleness); the fraction is computed C#-side by <see cref="ReadingPositionMath"/> so it stays
     /// unit-tested. Returns null when the cache isn't built yet (nothing meaningful to capture).
     /// </summary>
-    public async Task<ReadingPositionToken?> GetCurrentPositionTokenAsync()
+    public async Task<ReadingPositionToken?> GetCurrentPositionTokenAsync(int attempt = 0)
     {
         if (_webView == null || !_isBrowserInitialized) return null;
 
@@ -2595,6 +2604,9 @@ public partial class BookDisplayView : UserControl
         {
             try
             {
+                // Tag this request so a LATE title from a previous (timed-out) capture can't complete THIS one
+                // with stale data — OnTitleChanged only accepts the matching REQ. (Fable PR-B review §3)
+                var reqId = ++_posTokenReq;
                 _posTokenTcs?.TrySetCanceled();
                 _posTokenTcs = new TaskCompletionSource<string?>();
 
@@ -2618,12 +2630,12 @@ public partial class BookDisplayView : UserControl
                             };
                             out = aName + ',' + livePos(aName) + ',' + bName + ',' + livePos(bName) + ',' + Math.round(scrollY);
                         }
-                        document.title = 'CST_POSTOKEN:' + out + '|TAB:{_tabId}' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                        document.title = 'CST_POSTOKEN:' + out + '|TAB:{_tabId}' + '|REQ:{_reqId}' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
                     } catch (e) {
-                        document.title = 'CST_POSTOKEN:err|TAB:{_tabId}' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                        document.title = 'CST_POSTOKEN:err|TAB:{_tabId}' + '|REQ:{_reqId}' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
                     }
                 })();";
-                script = script.Replace("{_tabId}", _tabId);
+                script = script.Replace("{_tabId}", _tabId).Replace("{_reqId}", reqId.ToString());
                 _webView.ExecuteScript(script);
 
                 var completed = await Task.WhenAny(_posTokenTcs.Task, Task.Delay(1000));
@@ -2638,8 +2650,11 @@ public partial class BookDisplayView : UserControl
             finally { _jsExecutionLock.Release(); }
         }
 
+        // Bounded lock-contention retry — a wedged lock must degrade to "no token" (no restore), NOT hang the
+        // synchronous script-change reload that awaits this. ~1s worth of attempts, then give up. (Fable §3)
+        if (attempt >= 10) { _logger.Warning("GetCurrentPositionTokenAsync gave up after {N} lock-contention retries", attempt); return null; }
         await Task.Delay(100);
-        return await GetCurrentPositionTokenAsync();
+        return await GetCurrentPositionTokenAsync(attempt + 1);
     }
 
     // Parse the raw "above,abovePos,below,belowPos,scrollTop" payload into a token via the unit-tested math.
@@ -2677,28 +2692,35 @@ public partial class BookDisplayView : UserControl
         // Past the last anchor → land on the upper anchor (reuse the existing anchor scroll + fuzzy fallback).
         if (token.Below == null) { ScrollToPageAnchor(token.Above); return; }
 
-        // Full bracket: resolve both live and interpolate. The JS mirrors ReadingPositionMath.ResolveTarget's
-        // clamp(a + f*(b-a)) and degrades to whichever anchor survives; if BOTH are gone it leaves the position
-        // (the nearest-paragraph fuzzy fallback for a corpus-update rename belongs to the cross-run PR).
+        // Full bracket. Restore RELATIVELY — scrollIntoView(above) then scrollBy(fraction * gap) — rather than
+        // computing an ABSOLUTE window.scrollTo(target). The final scrollTop is the same as
+        // ReadingPositionMath.ResolveTarget (above + fraction*(below-above)), but this is robust to an early /
+        // pre-reflow rect read: if the gap is misread small (or 0), it simply lands at the above anchor's top
+        // edge — i.e. no worse than ScrollToPageAnchor — instead of an absolute scrollTo(0) jump-to-top (the
+        // #423 failure mode a raw getBoundingClientRect().top could trigger). (Fable PR-B review §1/§2)
         var aboveJson = System.Text.Json.JsonSerializer.Serialize(token.Above);
         var belowJson = System.Text.Json.JsonSerializer.Serialize(token.Below);
-        var fraction = token.Fraction.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        // Clamp the fraction defensively (matches ResolveTarget's guard) for hand-built / persisted tokens.
+        var f = double.IsNaN(token.Fraction) ? 0.0 : Math.Max(0.0, Math.Min(1.0, token.Fraction));
+        var fraction = f.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var script = $@"
             (function() {{
-                var livePos = function(name) {{
-                    var el = document.querySelector('a[name=' + JSON.stringify(name) + ']') || document.getElementById(name);
-                    return el ? (el.getBoundingClientRect().top + window.pageYOffset) : null;
+                var find = function(name) {{
+                    return document.querySelector('a[name=' + JSON.stringify(name) + ']') || document.getElementById(name);
                 }};
-                var a = livePos({aboveJson}), b = livePos({belowJson});
-                var target = null;
-                if (a !== null && b !== null) {{
-                    var denom = b - a;
-                    target = (Math.abs(denom) <= 0.5) ? a : (a + {fraction} * denom);
-                    var lo = Math.min(a, b), hi = Math.max(a, b);
-                    target = Math.max(lo, Math.min(hi, target));
-                }} else if (a !== null) {{ target = a; }}
-                else if (b !== null) {{ target = b; }}
-                if (target !== null) {{ window.scrollTo({{ top: target, behavior: 'instant' }}); }}
+                var aEl = find({aboveJson}), bEl = find({belowJson});
+                if (aEl) {{
+                    aEl.scrollIntoView({{ behavior: 'instant', block: 'start' }});
+                    if (bEl) {{
+                        // With aEl now at the viewport top, bEl's rect.top IS the live gap to the next anchor.
+                        var gap = bEl.getBoundingClientRect().top;
+                        if (gap > 0) {{ window.scrollBy(0, {fraction} * gap); }}
+                    }}
+                }} else if (bEl) {{
+                    bEl.scrollIntoView({{ behavior: 'instant', block: 'start' }});
+                }}
+                // Both anchors gone (a corpus-update rename) → leave the position; the nearest-paragraph fuzzy
+                // fallback belongs to the cross-run PR.
             }})();";
         RunScrollScript(script);
     }

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -17,6 +17,7 @@ using Avalonia.VisualTree;
 using WebViewControl;
 using CST.Avalonia.ViewModels;
 using CST.Avalonia.Services;
+using CST.Avalonia.Models;
 using Serilog;
 
 namespace CST.Avalonia.Views;
@@ -39,6 +40,10 @@ public partial class BookDisplayView : UserControl
     private int _lastScrollPosition = 0;
     private bool _isBrowserInitialized = false;
     private TaskCompletionSource<string?>? _paraAnchorTcs = null;
+    // Completes when OnTitleChanged receives the CST_POSTOKEN raw bracket payload for a reading-position
+    // capture (#434). Carries the raw "above,abovePos,below,belowPos,scrollTop" string; the fraction math is
+    // computed C#-side by ReadingPositionMath so it stays unit-tested.
+    private TaskCompletionSource<string?>? _posTokenTcs = null;
     private readonly string _tabId = $"tab_{DateTime.Now.Ticks}_{Guid.NewGuid().ToString("N")[..8]}";
     private string? _tempHtmlFilePath;   // the temp HTML file this View last loaded from; deleted on dispose (BOOK-8)
 
@@ -975,6 +980,7 @@ public partial class BookDisplayView : UserControl
                         sortedPageAnchors: {{ V: [], M: [], P: [], T: [], O: [] }},
                         sortedParagraphAnchors: [],
                         sortedChapterAnchors: [],
+                        sortedAllAnchors: [],   // merged page+para+chapter, position-sorted (#434 token bracket lookup)
                         // False until build() has actually populated the anchors. The status-update
                         // script gates on this so a defined-but-empty cache (script injected, build
                         // still deferred behind a paint) can never emit an all-'*' readout that
@@ -988,6 +994,7 @@ public partial class BookDisplayView : UserControl
                             this.sortedPageAnchors = {{ V: [], M: [], P: [], T: [], O: [] }};
                             this.sortedParagraphAnchors = [];
                             this.sortedChapterAnchors = [];
+                            this.sortedAllAnchors = [];
 
                             // Force a full synchronous layout so getBoundingClientRect() returns correct
                             // absolute values. One reflow computes layout for the whole document — the old
@@ -1052,6 +1059,18 @@ public partial class BookDisplayView : UserControl
                                 this.sortedChapterAnchors.push({{ name: name, position: this.chapterAnchors[name] }});
                             }}
                             this.sortedChapterAnchors.sort(function(a, b) {{ return a.position - b.position; }});
+
+                            // Merged, position-sorted list of ALL anchor types (page V/M/P/T/O + paragraph +
+                            // chapter) so the reading-position token (#434) can find the anchors bracketing the
+                            // viewport top in one lookup. The A->B gap across all types is typically well under a
+                            // screenful, so interpolating between them is a faithful proxy for the reading
+                            // position even across reflow/script change. Names only need to be UNIQUE and STABLE
+                            // across a script change, which they are (derived from the source XML).
+                            this.sortedAllAnchors = [];
+                            for (var pn in this.pageAnchors) this.sortedAllAnchors.push({{ name: pn, position: this.pageAnchors[pn] }});
+                            for (var qn in this.paragraphAnchors) this.sortedAllAnchors.push({{ name: qn, position: this.paragraphAnchors[qn] }});
+                            for (var cn in this.chapterAnchors) this.sortedAllAnchors.push({{ name: cn, position: this.chapterAnchors[cn] }});
+                            this.sortedAllAnchors.sort(function(a, b) {{ return a.position - b.position; }});
 
                             // Populated — status queries may now trust this cache. Set BEFORE the title
                             // signal so the C# side can never observe CACHE_BUILT ahead of the data. (#423)
@@ -1404,6 +1423,7 @@ public partial class BookDisplayView : UserControl
         ApplySearchTermsVisibility(_viewModel.ShowSearchTerms);
 
         var pendingHit = _viewModel.TakePendingHitNavigation();
+        var pendingToken = _viewModel.TakePendingPositionToken();
         var pendingAnchor = _viewModel.TakePendingAnchorNavigation();
 
         if (pendingHit is int savedHit && savedHit >= 1)
@@ -1417,6 +1437,22 @@ public partial class BookDisplayView : UserControl
             var target = total > 0 ? Math.Min(savedHit, total) : savedHit;
             _logger.Information("Restoring scroll to saved search hit {Hit}", target);
             NavigateToHighlight(target);
+            return;
+        }
+
+        // #434 reading-position token — preferred over the coarse string anchor (it interpolates to the exact
+        // reading position). Search-hit restore still wins (Fable §6 / #36). ScrollToPositionToken is cache-free
+        // (live querySelector), so it works here even before the deferred cache rebuild (Fable §2).
+        if (pendingToken != null)
+        {
+            _logger.Information("Restoring reading position from #434 token (above={Above}, below={Below}, frac={Frac})",
+                pendingToken.Above, pendingToken.Below, pendingToken.Fraction);
+            ScrollToPositionToken(pendingToken);
+
+            // As in the anchor branch: the token owns the scroll position, so re-mark the CURRENT hit (red)
+            // WITHOUT scrolling to keep the highlight matching the "N of M" counter after a reload.
+            if (_viewModel.HasSearchHighlights && _viewModel.CurrentHitIndex > 0)
+                SyncCurrentHitStyle(_viewModel.CurrentHitIndex);
             return;
         }
 
@@ -1630,6 +1666,23 @@ public partial class BookDisplayView : UserControl
             {
                 _logger.Error("Error parsing GetPara result | {Details}", ex.Message);
                 _paraAnchorTcs?.TrySetException(ex);
+            }
+        }
+        // Reading-position token capture result (#434) — hand the raw bracket payload to the awaiting capture.
+        else if (title != null && title.StartsWith("CST_POSTOKEN:"))
+        {
+            try
+            {
+                var parts = title.Split('|');
+                var raw = parts[0].Substring("CST_POSTOKEN:".Length);
+                var messageTabId = parts.Length > 1 && parts[1].StartsWith("TAB:") ? parts[1].Substring(4) : "";
+                if (messageTabId == _tabId)
+                    _posTokenTcs?.TrySetResult(raw);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Error parsing reading-position token result | {Details}", ex.Message);
+                _posTokenTcs?.TrySetException(ex);
             }
         }
         // Check for copy operation results
@@ -2524,6 +2577,145 @@ public partial class BookDisplayView : UserControl
             _logger.Debug("GetCurrentParagraphAnchorAsync failed to acquire JS lock - retrying after delay");
             await Task.Delay(100);
             return await GetCurrentParagraphAnchorAsync();
+        }
+    }
+
+    /// <summary>
+    /// Capture the current reading position as a #434 token — the anchors bracketing the viewport top plus the
+    /// fraction between them. The JS uses the cache only to SELECT the bracketing names (sorted lookup over
+    /// sortedAllAnchors), then reads LIVE getBoundingClientRect on just those two elements (Fable §1: immune to
+    /// cache staleness); the fraction is computed C#-side by <see cref="ReadingPositionMath"/> so it stays
+    /// unit-tested. Returns null when the cache isn't built yet (nothing meaningful to capture).
+    /// </summary>
+    public async Task<ReadingPositionToken?> GetCurrentPositionTokenAsync()
+    {
+        if (_webView == null || !_isBrowserInitialized) return null;
+
+        if (await _jsExecutionLock.WaitAsync(10))
+        {
+            try
+            {
+                _posTokenTcs?.TrySetCanceled();
+                _posTokenTcs = new TaskCompletionSource<string?>();
+
+                var script = @"
+                (function() {
+                    try {
+                        var scrollY = window.pageYOffset || document.documentElement.scrollTop || 0;
+                        var out = 'null';
+                        var c = window.cstAnchorCache;
+                        if (c && c.isBuilt && c.sortedAllAnchors && c.sortedAllAnchors.length > 0) {
+                            var list = c.sortedAllAnchors;
+                            // Cache SELECTS the bracket (last <= scrollY, first > scrollY); live rects MEASURE it.
+                            var aIdx = -1;
+                            for (var i = 0; i < list.length; i++) { if (list[i].position <= scrollY) aIdx = i; else break; }
+                            var aName = aIdx >= 0 ? list[aIdx].name : '';
+                            var bName = (aIdx + 1 < list.length) ? list[aIdx + 1].name : '';
+                            var livePos = function(name) {
+                                if (!name) return '';
+                                var el = document.querySelector('a[name=' + JSON.stringify(name) + ']') || document.getElementById(name);
+                                return el ? Math.round(el.getBoundingClientRect().top + window.pageYOffset) : '';
+                            };
+                            out = aName + ',' + livePos(aName) + ',' + bName + ',' + livePos(bName) + ',' + Math.round(scrollY);
+                        }
+                        document.title = 'CST_POSTOKEN:' + out + '|TAB:{_tabId}' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                    } catch (e) {
+                        document.title = 'CST_POSTOKEN:err|TAB:{_tabId}' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                    }
+                })();";
+                script = script.Replace("{_tabId}", _tabId);
+                _webView.ExecuteScript(script);
+
+                var completed = await Task.WhenAny(_posTokenTcs.Task, Task.Delay(1000));
+                if (completed != _posTokenTcs.Task) { _posTokenTcs.TrySetCanceled(); return null; }
+                return ParsePositionToken(await _posTokenTcs.Task);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Error capturing reading-position token | {Details}", ex.Message);
+                return null;
+            }
+            finally { _jsExecutionLock.Release(); }
+        }
+
+        await Task.Delay(100);
+        return await GetCurrentPositionTokenAsync();
+    }
+
+    // Parse the raw "above,abovePos,below,belowPos,scrollTop" payload into a token via the unit-tested math.
+    private static ReadingPositionToken? ParsePositionToken(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw) || raw == "null" || raw == "err") return null;
+        var f = raw.Split(',');
+        if (f.Length != 5) return null;
+        var inv = System.Globalization.CultureInfo.InvariantCulture;
+        string? above = f[0].Length == 0 ? null : f[0];
+        string? below = f[2].Length == 0 ? null : f[2];
+        double.TryParse(f[1], System.Globalization.NumberStyles.Any, inv, out var aPos);
+        double.TryParse(f[3], System.Globalization.NumberStyles.Any, inv, out var bPos);
+        double.TryParse(f[4], System.Globalization.NumberStyles.Any, inv, out var scrollTop);
+        if (above == null && below == null) return null; // no anchors → nothing to capture
+        return ReadingPositionMath.Capture(above, aPos, below, bPos, scrollTop);
+    }
+
+    /// <summary>
+    /// Restore a reading-position token (#434). CACHE-FREE (Fable §2): resolves the bracketing anchors by name
+    /// with live querySelector and interpolates, so it works even before the (deferred) cache rebuild and slots
+    /// into the existing ExecutePendingRestoration timing. Non-bracket cases are handled C#-side without JS.
+    /// </summary>
+    public void ScrollToPositionToken(ReadingPositionToken token)
+    {
+        if (_webView == null || !_isBrowserInitialized || token == null) return;
+        if (!Dispatcher.UIThread.CheckAccess()) { Dispatcher.UIThread.Post(() => ScrollToPositionToken(token)); return; }
+
+        // Empty / unresolvable (no anchors, or a malformed token) → leave the position untouched.
+        if (token.Above == null && token.Below == null) return;
+
+        // Document start → top, no anchor lookup needed.
+        if (token.Above == null) { RunScrollScript("window.scrollTo({ top: 0, behavior: 'instant' });"); return; }
+
+        // Past the last anchor → land on the upper anchor (reuse the existing anchor scroll + fuzzy fallback).
+        if (token.Below == null) { ScrollToPageAnchor(token.Above); return; }
+
+        // Full bracket: resolve both live and interpolate. The JS mirrors ReadingPositionMath.ResolveTarget's
+        // clamp(a + f*(b-a)) and degrades to whichever anchor survives; if BOTH are gone it leaves the position
+        // (the nearest-paragraph fuzzy fallback for a corpus-update rename belongs to the cross-run PR).
+        var aboveJson = System.Text.Json.JsonSerializer.Serialize(token.Above);
+        var belowJson = System.Text.Json.JsonSerializer.Serialize(token.Below);
+        var fraction = token.Fraction.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var script = $@"
+            (function() {{
+                var livePos = function(name) {{
+                    var el = document.querySelector('a[name=' + JSON.stringify(name) + ']') || document.getElementById(name);
+                    return el ? (el.getBoundingClientRect().top + window.pageYOffset) : null;
+                }};
+                var a = livePos({aboveJson}), b = livePos({belowJson});
+                var target = null;
+                if (a !== null && b !== null) {{
+                    var denom = b - a;
+                    target = (Math.abs(denom) <= 0.5) ? a : (a + {fraction} * denom);
+                    var lo = Math.min(a, b), hi = Math.max(a, b);
+                    target = Math.max(lo, Math.min(hi, target));
+                }} else if (a !== null) {{ target = a; }}
+                else if (b !== null) {{ target = b; }}
+                if (target !== null) {{ window.scrollTo({{ top: target, behavior: 'instant' }}); }}
+            }})();";
+        RunScrollScript(script);
+    }
+
+    // Run a scroll script under the JS lock, mirroring ScrollToPageAnchor's lock discipline + retry.
+    private void RunScrollScript(string script)
+    {
+        if (_webView == null) return;
+        if (_jsExecutionLock.Wait(0))
+        {
+            try { _webView.ExecuteScript(script); }
+            catch (Exception ex) { _logger.Error("Reading-position scroll failed | {Details}", ex.Message); }
+            finally { _jsExecutionLock.Release(); }
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(async () => { await Task.Delay(100); RunScrollScript(script); }, DispatcherPriority.Background);
         }
     }
 

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -2772,9 +2772,24 @@ public partial class BookDisplayView : UserControl
                     }}
                 }} else if (bEl) {{
                     bEl.scrollIntoView({{ behavior: 'instant', block: 'start' }});
+                }} else {{
+                    // BOTH bracket anchors gone (a corpus-update rename between runs) — restore the fuzzy
+                    // nearest-paragraph fallback the coarse ScrollToPageAnchor had, so cross-run restore doesn't
+                    // regress to top-of-doc. Use whichever bracket end is a paragraph anchor. (Fable cross-run §1)
+                    var fuzzyPara = function(name) {{
+                        if (!name || name.indexOf('para') !== 0) return false;
+                        var tgt = parseInt(name.substring(4).split('-')[0]);
+                        if (isNaN(tgt)) return false;
+                        var best = null, bestDiff = Infinity;
+                        document.querySelectorAll('a[name^=""para""]').forEach(function(a) {{
+                            var n = parseInt((a.name || '').substring(4).split('-')[0]);
+                            if (!isNaN(n)) {{ var d = Math.abs(n - tgt); if (d < bestDiff) {{ bestDiff = d; best = a; }} }}
+                        }});
+                        if (best) {{ best.scrollIntoView({{ behavior: 'instant', block: 'start' }}); return true; }}
+                        return false;
+                    }};
+                    fuzzyPara({aboveJson}) || fuzzyPara({belowJson});
                 }}
-                // Both anchors gone (a corpus-update rename) → leave the position; the nearest-paragraph fuzzy
-                // fallback belongs to the cross-run PR.
             }})();";
         RunScrollScript(script);
     }

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -1652,6 +1652,8 @@ public partial class BookDisplayView : UserControl
                             double.TryParse(ptAP, System.Globalization.NumberStyles.Any, inv, out var aP);
                             double.TryParse(ptBP, System.Globalization.NumberStyles.Any, inv, out var bP);
                             _lastPositionToken = ReadingPositionMath.Capture(above, aP, below, bP, scrollY);
+                            // Push to the ViewModel so it can be persisted on shutdown for cross-run restore (#434).
+                            _viewModel?.UpdateLastPositionToken(_lastPositionToken);
                         }
                     }
 

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -2780,12 +2780,16 @@ public partial class BookDisplayView : UserControl
                         if (!name || name.indexOf('para') !== 0) return false;
                         var tgt = parseInt(name.substring(4).split('-')[0]);
                         if (isNaN(tgt)) return false;
+                        var paras = document.querySelectorAll('a[name^=""para""]');
                         var best = null, bestDiff = Infinity;
-                        document.querySelectorAll('a[name^=""para""]').forEach(function(a) {{
+                        paras.forEach(function(a) {{
                             var n = parseInt((a.name || '').substring(4).split('-')[0]);
                             if (!isNaN(n)) {{ var d = Math.abs(n - tgt); if (d < bestDiff) {{ bestDiff = d; best = a; }} }}
                         }});
-                        if (best) {{ best.scrollIntoView({{ behavior: 'instant', block: 'start' }}); return true; }}
+                        // Same distance cap as ScrollToPageAnchor: don't jump to a far paragraph on a drastic
+                        // renumber — leave the position instead. (Fable cross-run re-review)
+                        var maxAllowedDiff = paras.length < 300 ? 100 : 50;
+                        if (best && bestDiff <= maxAllowedDiff) {{ best.scrollIntoView({{ behavior: 'instant', block: 'start' }}); return true; }}
                         return false;
                     }};
                     fuzzyPara({aboveJson}) || fuzzyPara({belowJson});

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -218,12 +218,13 @@ public partial class SimpleTabbedWindow : Window
 
     public void OpenBook(Book book, List<string>? searchTerms = null, Script? bookScript = null, string? windowId = null,
         int? docId = null, List<TermPosition>? searchPositions = null, string? initialAnchor = null,
-        int? initialCurrentHitIndex = null, bool showFootnotes = true, bool showSearchTerms = true)
+        int? initialCurrentHitIndex = null, bool showFootnotes = true, bool showSearchTerms = true,
+        ReadingPositionToken? initialPositionToken = null)
     {
         // Delegate to LayoutViewModel if available
         if (DataContext is LayoutViewModel layoutViewModel)
         {
-            layoutViewModel.OpenBook(book, searchTerms, bookScript, windowId, docId, searchPositions, initialAnchor, initialCurrentHitIndex, showFootnotes, showSearchTerms);
+            layoutViewModel.OpenBook(book, searchTerms, bookScript, windowId, docId, searchPositions, initialAnchor, initialCurrentHitIndex, showFootnotes, showSearchTerms, initialPositionToken);
         }
         else
         {


### PR DESCRIPTION
**PR 2 of the #434 series.** Wires the token (PR-A #435) into its first and worst consumer — the **script-change reload** (which saved a *page* anchor and restored to its top edge, the biggest drift).

⚠️ **UI change — left OPEN for @fsnow's visual review** (per the overnight merge policy: only mechanical non-UI pieces auto-merge). The token math is unit-tested (PR-A); this PR is the DOM plumbing + one consumer.

## Primitive
- **`build()` → `sortedAllAnchors`**: merged, position-sorted page+paragraph+chapter list, so capture finds the bracket across all types in one lookup.
- **`GetCurrentPositionTokenAsync()`**: JS uses the cache only to *select* the bracketing names, then reads **live** `getBoundingClientRect` on just those two elements (Fable §1); the fraction is computed C#-side by the unit-tested `ReadingPositionMath`.
- **`ScrollToPositionToken()`**: **cache-free** restore (Fable §2) — resolves the two anchors by live `querySelector` and interpolates, so it works before the deferred cache rebuild and slots into the existing `ExecutePendingRestoration` timing. Document-start / past-last handled C#-side without JS.

## Consumer
- Script change captures the token **before** the reload (old script's DOM still live), queues it; `ExecutePendingRestoration` restores with precedence **search-hit > token > legacy string anchor** (Fable §6 / #36 preserved).

## Not in this PR (later, per Fable's sequence)
Tab reattach/#31, float/unfloat, cross-run serialization, resize. `GetCurrentPageAnchor` left in place until those migrate.

## Verify on a real display (my Egret session may lock; headless can't drive a script change)
- [ ] Scroll mid-paragraph, change script → the **same reading position** is restored (not the page-marker top edge; no drift up/down).
- [ ] Repeat near the very top and very bottom of a book (document-start / past-last clamps).
- [ ] A search-result book: script change keeps the **hit** (search-hit precedence), highlight still matches "N of M".
- [ ] Debug log shows `Captured reading-position token…` then `Restoring reading position from #434 token…` with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)