### PR TITLE
#187 (Phase 1): extract the shared present-in-context command (IPresentationService)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/PresentationPlannerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/PresentationPlannerTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services.Presentation;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services
+{
+    /// <summary>
+    /// #187: the pure mapping from a presentation request to the dock open-path parameters. Guards the target
+    /// precedence (explicit hit/anchor outranks a restored reading position) and the choice between the
+    /// search-tab path (multiple instances + highlight plumbing) and the general path (carries a landing target).
+    /// </summary>
+    public class PresentationPlannerTests
+    {
+        private static readonly global::CST.Book AnyBook = global::CST.Books.Inst[0];
+
+        private static PresentationRequest Req(
+            PresentationTarget? target = null,
+            bool withHighlights = false) => new()
+        {
+            Book = AnyBook,
+            Target = target,
+            SearchTerms = withHighlights ? new List<string> { "dhamma" } : null,
+            Positions = withHighlights ? new List<TermPosition> { new() { Position = 1, StartOffset = 10, EndOffset = 16 } } : null,
+        };
+
+        [Fact]
+        public void No_target_no_highlights_uses_general_path_with_no_landing()
+        {
+            var p = PresentationPlanner.Plan(Req());
+            Assert.False(p.UseSearchTab);
+            Assert.Null(p.Anchor);
+            Assert.Null(p.HitIndex);
+            Assert.Null(p.PositionToken);
+        }
+
+        [Fact]
+        public void Highlights_without_a_target_use_the_search_tab_path()
+        {
+            var p = PresentationPlanner.Plan(Req(withHighlights: true));
+            Assert.True(p.UseSearchTab);
+        }
+
+        [Fact]
+        public void Explicit_hit_wins_and_forces_the_general_path_even_with_highlights()
+        {
+            // An explicit landing target must be carried by the general path — the search tab lands on its own.
+            var p = PresentationPlanner.Plan(Req(new PresentationTarget.Hit(3), withHighlights: true));
+            Assert.False(p.UseSearchTab);
+            Assert.Equal(3, p.HitIndex);
+            Assert.Null(p.Anchor);
+            Assert.Null(p.PositionToken);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-5)]
+        public void Hit_index_below_one_is_clamped(int given)
+        {
+            var p = PresentationPlanner.Plan(Req(new PresentationTarget.Hit(given)));
+            Assert.Equal(1, p.HitIndex);
+        }
+
+        [Fact]
+        public void Anchor_target_maps_to_the_anchor_parameter()
+        {
+            var p = PresentationPlanner.Plan(Req(new PresentationTarget.Anchor("V1.0023")));
+            Assert.Equal("V1.0023", p.Anchor);
+            Assert.Null(p.HitIndex);
+            Assert.Null(p.PositionToken);
+            Assert.False(p.UseSearchTab);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Blank_anchor_is_ignored(string name)
+        {
+            var p = PresentationPlanner.Plan(Req(new PresentationTarget.Anchor(name)));
+            Assert.Null(p.Anchor);
+        }
+
+        [Fact]
+        public void Position_token_target_maps_to_the_token_parameter()
+        {
+            var token = new ReadingPositionToken { Above = "para5", Below = "para6", Fraction = 0.4 };
+            var p = PresentationPlanner.Plan(Req(new PresentationTarget.Position(token)));
+            Assert.Same(token, p.PositionToken);
+            Assert.Null(p.Anchor);
+            Assert.Null(p.HitIndex);
+            Assert.False(p.UseSearchTab);
+        }
+
+        [Fact]
+        public void Position_token_with_highlights_still_uses_the_general_path()
+        {
+            // A restored reading position is a landing target too — it must not be swallowed by the search tab.
+            var token = new ReadingPositionToken { Above = "para5", Below = "para6", Fraction = 0.4 };
+            var p = PresentationPlanner.Plan(Req(new PresentationTarget.Position(token), withHighlights: true));
+            Assert.False(p.UseSearchTab);
+            Assert.Same(token, p.PositionToken);
+        }
+
+        [Fact]
+        public void Terms_without_positions_do_not_trigger_the_search_tab()
+        {
+            // The search tab exists for real hit highlighting; terms alone have nothing to land on.
+            var r = new PresentationRequest { Book = AnyBook, SearchTerms = new List<string> { "dhamma" } };
+            Assert.False(PresentationPlanner.Plan(r).UseSearchTab);
+        }
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/PresentationPlannerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/PresentationPlannerTests.cs
@@ -108,5 +108,62 @@ namespace CST.Avalonia.Tests.Services
             var r = new PresentationRequest { Book = AnyBook, SearchTerms = new List<string> { "dhamma" } };
             Assert.False(PresentationPlanner.Plan(r).UseSearchTab);
         }
+
+        // ---- Validation: never report success for a request that could only be a silent no-op ----
+
+        [Fact]
+        public void Hit_target_without_search_context_is_rejected()
+        {
+            var err = PresentationPlanner.Validate(Req(new PresentationTarget.Hit(3)));
+            Assert.NotNull(err);
+            Assert.Contains("Hit target", err);
+        }
+
+        [Fact]
+        public void Hit_target_with_search_context_is_valid()
+        {
+            Assert.Null(PresentationPlanner.Validate(Req(new PresentationTarget.Hit(3), withHighlights: true)));
+        }
+
+        [Fact]
+        public void Plain_and_anchor_and_position_requests_are_valid()
+        {
+            Assert.Null(PresentationPlanner.Validate(Req()));
+            Assert.Null(PresentationPlanner.Validate(Req(new PresentationTarget.Anchor("V1.0023"))));
+            Assert.Null(PresentationPlanner.Validate(Req(new PresentationTarget.Position(
+                new ReadingPositionToken { Above = "para5", Below = "para6", Fraction = 0.4 }))));
+        }
+
+        // ---- Option-aware routing: the search tab can't carry these, so they force the general path ----
+
+        [Fact]
+        public void Explicit_script_forces_the_general_path()
+        {
+            var r = Req(withHighlights: true) with { Script = global::CST.Conversion.Script.Thai };
+            Assert.False(PresentationPlanner.Plan(r).UseSearchTab);
+        }
+
+        [Fact]
+        public void Explicit_docid_forces_the_general_path()
+        {
+            var r = Req(withHighlights: true) with { DocId = 42 };
+            Assert.False(PresentationPlanner.Plan(r).UseSearchTab);
+        }
+
+        [Theory]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        public void Non_default_view_toggles_force_the_general_path(bool footnotes, bool searchTerms)
+        {
+            var r = Req(withHighlights: true) with { ShowFootnotes = footnotes, ShowSearchTerms = searchTerms };
+            Assert.False(PresentationPlanner.Plan(r).UseSearchTab);
+        }
+
+        [Fact]
+        public void Default_toggles_still_use_the_search_tab()
+        {
+            // Guards the refactor: today's search UI sets none of these, so it must keep the search-tab path.
+            Assert.True(PresentationPlanner.Plan(Req(withHighlights: true)).UseSearchTab);
+        }
     }
 }

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1049,6 +1049,8 @@ public partial class App : Application
         services.AddSingleton<ChapterListsService>();
         // services.AddSingleton<IBookService, BookService>();
         services.AddSingleton<ISearchService, SearchService>();
+        // The single "present the reader in context" command shared by every surface (#187).
+        services.AddSingleton<Services.Presentation.IPresentationService, Services.Presentation.PresentationService>();
         services.AddSingleton<IDictionaryService, DictionaryService>();
 
         // Lemma/dictionary/sandhi (dpd-cst-subset asset — our derived DPD subset for CST). NOT AI-gated — a core

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -452,7 +452,14 @@ namespace CST.Avalonia.Services
                 // Capture current proportions before adding document (preserves user adjustments)
                 CaptureMainDockProportions();
 
-                documentDock.VisibleDockables?.Add(bookDisplayViewModel);
+                // A null collection would make the ?.Add a silent no-op and leave us reporting success with
+                // no tab; treat it as the broken-layout failure it is. (fable)
+                if (documentDock.VisibleDockables is not { } searchDockables)
+                {
+                    Log.Error("*** Document dock has no VisibleDockables collection - cannot add search document ***");
+                    return false;
+                }
+                searchDockables.Add(bookDisplayViewModel);
                 documentDock.ActiveDockable = bookDisplayViewModel;
                 SetFactory(bookDisplayViewModel);
                 Log.Information("*** SEARCH DOCUMENT ADDED SUCCESSFULLY. Total documents: {DocumentCount} ***", documentDock.VisibleDockables?.Count ?? 0);
@@ -854,7 +861,13 @@ namespace CST.Avalonia.Services
                     _logger.Error("Document with ID {DocumentId} already exists {Count} times", dockable.Id, existingWithSameId.Count);
                 }
 
-                documentDock.VisibleDockables?.Add(dockable);
+                // Same guard: a null collection must not be reported as a successful add. (fable)
+                if (documentDock.VisibleDockables is not { } dockables)
+                {
+                    Log.Error("*** Document dock has no VisibleDockables collection - cannot add document ***");
+                    return false;
+                }
+                dockables.Add(dockable);
                 documentDock.ActiveDockable = dockable;
                 SetFactory(dockable); // Ensure the document has the factory reference
                 Log.Information("*** DOCUMENT ADDED SUCCESSFULLY. Total documents: {DocumentCount} ***", documentDock.VisibleDockables?.Count ?? 0);

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -366,7 +366,9 @@ namespace CST.Avalonia.Services
         private static DateTime _lastSearchOpenTime = DateTime.MinValue;
         private static string? _lastSearchOpenedBook = null;
         
-        public void OpenBookInNewTab(CST.Book book, List<string> searchTerms, List<TermPosition> positions)
+        // Returns TRUE when the book was actually opened, FALSE when the duplicate-suppression window
+        // swallowed it — so a non-UI caller (the #187 present-tool) can't report a false success.
+        public bool OpenBookInNewTab(CST.Book book, List<string> searchTerms, List<TermPosition> positions)
         {
             _logger.Information("Opening book from search: {BookFile} with {SearchTermCount} search terms and {PositionCount} positions",
                 book.FileName, searchTerms.Count, positions.Count);
@@ -381,7 +383,7 @@ namespace CST.Avalonia.Services
                 if (book.FileName == _lastSearchOpenedBook && timeSinceLastSearchOpen.TotalMilliseconds < 2000)
                 {
                     _logger.Debug("Duplicate search book open prevented: {BookFile} (opened {TimeAgo}ms ago)", book.FileName, timeSinceLastSearchOpen.TotalMilliseconds);
-                    return;
+                    return false;
                 }
 
                 _lastSearchOpenTime = now;
@@ -466,13 +468,16 @@ namespace CST.Avalonia.Services
             }
             
             _logger.Debug("Search book opening completed");
+            return true;
         }
         
         private static readonly object _regularOpenLock = new object();
         private static DateTime _lastRegularOpenTime = DateTime.MinValue;
         private static string? _lastRegularOpenedBook = null;
         
-        public void OpenBook(CST.Book book, string? anchor, Script? bookScript, string? windowId,
+        // Returns TRUE when the book was actually opened, FALSE when the duplicate-suppression window
+        // swallowed it — so a non-UI caller (the #187 present-tool) can't report a false success.
+        public bool OpenBook(CST.Book book, string? anchor, Script? bookScript, string? windowId,
             List<string>? searchTerms = null, int? docId = null, List<TermPosition>? searchPositions = null,
             int? initialCurrentHitIndex = null, bool showFootnotes = true, bool showSearchTerms = true,
             ReadingPositionToken? initialPositionToken = null)
@@ -493,7 +498,7 @@ namespace CST.Avalonia.Services
                     if (book.FileName == _lastRegularOpenedBook && timeSinceLastOpen.TotalMilliseconds < 1000)
                     {
                         _logger.Debug("Duplicate book open prevented: {BookFile} (opened {TimeAgo}ms ago)", book.FileName, timeSinceLastOpen.TotalMilliseconds);
-                        return;
+                        return false;
                     }
                     
                     _lastRegularOpenTime = now;
@@ -546,6 +551,7 @@ namespace CST.Avalonia.Services
             // Don't save state immediately - let tab changes trigger state saving
 
             _logger.Debug("Book document created: {DocumentId} with title: {Title}", bookDisplayViewModel.Id, bookDisplayViewModel.Title);
+            return true;
         }
 
         /// <summary>

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -465,6 +465,7 @@ namespace CST.Avalonia.Services
             {
                 Log.Error("*** NO DOCUMENT DOCK FOUND - Cannot add search document ***");
                 _logger.Error("No document dock found for search document");
+                return false;   // nothing was opened — don't let the caller report success (fable)
             }
             
             _logger.Debug("Search book opening completed");
@@ -546,12 +547,12 @@ namespace CST.Avalonia.Services
             EnsureBookEventSubscription(bookDisplayViewModel);
 
             // Add to the document dock
-            AddDocumentToLayout(bookDisplayViewModel);
+            var added = AddDocumentToLayout(bookDisplayViewModel);
 
             // Don't save state immediately - let tab changes trigger state saving
 
             _logger.Debug("Book document created: {DocumentId} with title: {Title}", bookDisplayViewModel.Id, bookDisplayViewModel.Title);
-            return true;
+            return added;   // no dock => nothing opened; don't report success (fable)
         }
 
         /// <summary>
@@ -832,7 +833,9 @@ namespace CST.Avalonia.Services
             }
         }
 
-        private void AddDocumentToLayout(IDockable dockable)
+        // Returns TRUE when the document was actually added; FALSE when there is no document dock (e.g. the
+        // layout spine is still being built), so callers can report an honest failure. (fable / #187)
+        private bool AddDocumentToLayout(IDockable dockable)
         {
             var documentDock = FindDocumentDock();
             if (documentDock != null)
@@ -859,12 +862,12 @@ namespace CST.Avalonia.Services
 
                 // Restore user's proportions (framework may have recalculated them)
                 RestoreMainDockProportions();
+                return true;
             }
-            else
-            {
-                Log.Warning("*** WARNING: Could not find document dock to add book ***");
-                _logger.Warning("Could not find document dock to add book");
-            }
+
+            Log.Warning("*** WARNING: Could not find document dock to add book ***");
+            _logger.Warning("Could not find document dock to add book");
+            return false;
         }
         
         private void RemoveDocumentFromLayout(IDockable dockable)

--- a/src/CST.Avalonia/Services/Presentation/PresentationContracts.cs
+++ b/src/CST.Avalonia/Services/Presentation/PresentationContracts.cs
@@ -115,8 +115,11 @@ public static class PresentationPlanner
         // It also CANNOT carry script / docId / the per-book view toggles (it hardcodes the current script and
         // the ViewModel defaults), so any request that sets those must take the general path — otherwise those
         // fields would be silently dropped while the caller was told it succeeded. (fable §2)
+        // A DocId equal to the book's own is what the search tab would have used anyway, so it isn't a reason
+        // to give up search-tab semantics — only a DIFFERENT DocId is. (fable)
         bool hasHighlights = HasHighlights(request);
-        bool needsGeneralOnlyOptions = request.Script != null || request.DocId != null
+        bool needsGeneralOnlyOptions = request.Script != null
+                                       || (request.DocId != null && request.DocId != request.Book.DocId)
                                        || !request.ShowFootnotes || !request.ShowSearchTerms;
         bool useSearchTab = hasHighlights && anchor == null && hit == null && token == null && !needsGeneralOnlyOptions;
 

--- a/src/CST.Avalonia/Services/Presentation/PresentationContracts.cs
+++ b/src/CST.Avalonia/Services/Presentation/PresentationContracts.cs
@@ -73,6 +73,21 @@ public sealed record PresentationPlan(
 /// </summary>
 public static class PresentationPlanner
 {
+    /// <summary>
+    /// Pure precondition check. Returns null when the request is presentable, else the reason — so a caller
+    /// can't be told "presented" for a request that could only ever be a silent no-op. (fable §4)
+    /// </summary>
+    public static string? Validate(PresentationRequest request)
+    {
+        if (request?.Book == null) return "No book specified.";
+        if (request.Target is PresentationTarget.Hit && !HasHighlights(request))
+            return "A Hit target requires searchTerms and positions — there are no highlights to land on.";
+        return null;
+    }
+
+    private static bool HasHighlights(PresentationRequest r) =>
+        r.SearchTerms is { Count: > 0 } && r.Positions is { Count: > 0 };
+
     public static PresentationPlan Plan(PresentationRequest request)
     {
         string? anchor = null;
@@ -96,8 +111,14 @@ public static class PresentationPlanner
         // The search-tab path exists to allow MULTIPLE independent instances of the same book (one per result)
         // and owns the highlight plumbing. Use it when we have real highlight context AND no explicit landing
         // target; an explicit target needs the general path, which can carry an anchor/hit/token.
-        bool hasHighlights = request.SearchTerms is { Count: > 0 } && request.Positions is { Count: > 0 };
-        bool useSearchTab = hasHighlights && anchor == null && hit == null && token == null;
+        //
+        // It also CANNOT carry script / docId / the per-book view toggles (it hardcodes the current script and
+        // the ViewModel defaults), so any request that sets those must take the general path — otherwise those
+        // fields would be silently dropped while the caller was told it succeeded. (fable §2)
+        bool hasHighlights = HasHighlights(request);
+        bool needsGeneralOnlyOptions = request.Script != null || request.DocId != null
+                                       || !request.ShowFootnotes || !request.ShowSearchTerms;
+        bool useSearchTab = hasHighlights && anchor == null && hit == null && token == null && !needsGeneralOnlyOptions;
 
         return new PresentationPlan(useSearchTab, anchor, hit, token);
     }

--- a/src/CST.Avalonia/Services/Presentation/PresentationContracts.cs
+++ b/src/CST.Avalonia/Services/Presentation/PresentationContracts.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using CST.Conversion;
+// Explicit aliases: CST.Avalonia.Services has its own `Book`, which would otherwise shadow the catalog type.
+using Book = CST.Book;
+using ReadingPositionToken = CST.Avalonia.Models.ReadingPositionToken;
+using TermPosition = CST.Avalonia.Models.TermPosition;
+
+namespace CST.Avalonia.Services.Presentation;
+
+/// <summary>
+/// Where a presentation should land in the book. Exactly one of these, or none (just open the book).
+/// Precedence when a caller could supply more than one is resolved by <see cref="PresentationPlanner"/>:
+/// an explicit hit/anchor (deliberate agent or user intent) outranks a restored reading position — the same
+/// rule <c>ExecutePendingRestoration</c> enforces (#36 / #434 fable §6).
+/// </summary>
+public abstract record PresentationTarget
+{
+    private PresentationTarget() { }
+
+    /// <summary>Restore an exact reading position (#434 token) — robust to reflow and window size.</summary>
+    public sealed record Position(ReadingPositionToken Token) : PresentationTarget;
+
+    /// <summary>Go to a named anchor / reference: page ("V1.0023"), paragraph ("para5"), or chapter id.</summary>
+    public sealed record Anchor(string Name) : PresentationTarget;
+
+    /// <summary>Land on a 1-based search hit (requires the search context below to have been supplied).</summary>
+    public sealed record Hit(int Index) : PresentationTarget;
+}
+
+/// <summary>
+/// One "present the reader in context" request — the single internal command behind every surface (the
+/// search UI today; the agent present-tool, App Intents and the <c>cstreader://</c> URL next). (#187)
+/// </summary>
+public sealed record PresentationRequest
+{
+    public required global::CST.Book Book { get; init; }
+
+    /// <summary>Where to land. Null = just open the book at its natural start.</summary>
+    public PresentationTarget? Target { get; init; }
+
+    /// <summary>IPE search terms to highlight.</summary>
+    public IReadOnlyList<string>? SearchTerms { get; init; }
+
+    /// <summary>Source-offset hit positions (with IsFirstTerm flags) driving the two-colour highlighting.</summary>
+    public IReadOnlyList<TermPosition>? Positions { get; init; }
+
+    public Script? Script { get; init; }
+    public int? DocId { get; init; }
+    public bool ShowFootnotes { get; init; } = true;
+    public bool ShowSearchTerms { get; init; } = true;
+}
+
+/// <summary>Outcome of a presentation, so a non-UI caller (the agent tool) can report a clean failure.</summary>
+public sealed record PresentationResult(bool Presented, string? Error = null)
+{
+    public static PresentationResult Ok() => new(true);
+    public static PresentationResult Fail(string error) => new(false, error);
+}
+
+/// <summary>
+/// The resolved dock-call shape for a request: which open path to use and which landing parameters to pass.
+/// Kept separate from the service so the mapping + precedence are pure and unit-testable.
+/// </summary>
+public sealed record PresentationPlan(
+    bool UseSearchTab,
+    string? Anchor,
+    int? HitIndex,
+    ReadingPositionToken? PositionToken);
+
+/// <summary>
+/// Pure mapping from a <see cref="PresentationRequest"/> to the parameters the dock open paths take.
+/// No UI, no DI — directly unit-testable.
+/// </summary>
+public static class PresentationPlanner
+{
+    public static PresentationPlan Plan(PresentationRequest request)
+    {
+        string? anchor = null;
+        int? hit = null;
+        ReadingPositionToken? token = null;
+
+        switch (request.Target)
+        {
+            case PresentationTarget.Hit h:
+                // Explicit hit wins outright (deliberate intent).
+                hit = h.Index >= 1 ? h.Index : 1;
+                break;
+            case PresentationTarget.Anchor a when !string.IsNullOrWhiteSpace(a.Name):
+                anchor = a.Name;
+                break;
+            case PresentationTarget.Position p:
+                token = p.Token;
+                break;
+        }
+
+        // The search-tab path exists to allow MULTIPLE independent instances of the same book (one per result)
+        // and owns the highlight plumbing. Use it when we have real highlight context AND no explicit landing
+        // target; an explicit target needs the general path, which can carry an anchor/hit/token.
+        bool hasHighlights = request.SearchTerms is { Count: > 0 } && request.Positions is { Count: > 0 };
+        bool useSearchTab = hasHighlights && anchor == null && hit == null && token == null;
+
+        return new PresentationPlan(useSearchTab, anchor, hit, token);
+    }
+}

--- a/src/CST.Avalonia/Services/Presentation/PresentationService.cs
+++ b/src/CST.Avalonia/Services/Presentation/PresentationService.cs
@@ -21,8 +21,9 @@ public interface IPresentationService
 {
     /// <summary>
     /// Present the reader. Safe to call from any thread — marshals to the Avalonia UI thread itself.
-    /// Returns a failure result (rather than throwing) when there is no reader to drive, so a non-UI caller
-    /// can surface a clean error.
+    /// Returns a failure RESULT (rather than throwing) for every expected condition: no reader to drive, an
+    /// unpresentable request, or a duplicate open suppressed by the dock. Only cancellation throws, per the
+    /// usual CancellationToken contract.
     /// </summary>
     Task<PresentationResult> PresentAsync(PresentationRequest request, CancellationToken ct = default);
 }
@@ -33,7 +34,8 @@ public sealed class PresentationService : IPresentationService
 
     public async Task<PresentationResult> PresentAsync(PresentationRequest request, CancellationToken ct = default)
     {
-        if (request?.Book == null) return PresentationResult.Fail("No book specified.");
+        var invalid = PresentationPlanner.Validate(request);
+        if (invalid != null) return PresentationResult.Fail(invalid);
         ct.ThrowIfCancellationRequested();
 
         // Presentation mutates the dock/visual tree, so it must run on the UI thread regardless of who called
@@ -57,18 +59,19 @@ public sealed class PresentationService : IPresentationService
             var terms = request.SearchTerms?.ToList() ?? new List<string>();
             var positions = request.Positions?.ToList() ?? new List<TermPosition>();
 
+            bool opened;
             if (plan.UseSearchTab)
             {
                 // Search-result semantics: a fresh tab per result, highlight plumbing, lands on the first hit.
                 _logger.Information("Presenting {Book} in a search tab ({Terms} terms, {Positions} positions)",
                     request.Book.FileName, terms.Count, positions.Count);
-                factory.OpenBookInNewTab(request.Book, terms, positions);
+                opened = factory.OpenBookInNewTab(request.Book, terms, positions);
             }
             else
             {
                 _logger.Information("Presenting {Book} (anchor={Anchor}, hit={Hit}, token={HasToken})",
                     request.Book.FileName, plan.Anchor ?? "none", plan.HitIndex, plan.PositionToken != null);
-                factory.OpenBook(
+                opened = factory.OpenBook(
                     request.Book,
                     plan.Anchor,
                     request.Script,
@@ -80,6 +83,15 @@ public sealed class PresentationService : IPresentationService
                     request.ShowFootnotes,
                     request.ShowSearchTerms,
                     plan.PositionToken);
+            }
+
+            // The dock paths suppress a repeat open of the same book inside a short window and return silently.
+            // Report that honestly instead of claiming success a caller can't verify. (fable §1)
+            if (!opened)
+            {
+                _logger.Debug("Presentation suppressed as a duplicate open: {Book}", request.Book.FileName);
+                return PresentationResult.Fail(
+                    "Duplicate open suppressed — this book was just opened; retry in a moment.");
             }
 
             return PresentationResult.Ok();

--- a/src/CST.Avalonia/Services/Presentation/PresentationService.cs
+++ b/src/CST.Avalonia/Services/Presentation/PresentationService.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using CST.Avalonia.ViewModels;
+using Serilog;
+// Explicit alias: CST.Avalonia.Services has its own `Book`, which would otherwise shadow the catalog type.
+using TermPosition = CST.Avalonia.Models.TermPosition;
+
+namespace CST.Avalonia.Services.Presentation;
+
+/// <summary>
+/// The single internal "present the reader in context" command (#187): open the book, apply the search
+/// highlights, and land on the requested target. Every surface is a thin adapter over this — the search UI
+/// today, and next the agent present-tool (<c>POST /navigate</c>), App Intents, and the <c>cstreader://</c>
+/// URL. Keeping one command means those surfaces can't drift apart in behaviour.
+/// </summary>
+public interface IPresentationService
+{
+    /// <summary>
+    /// Present the reader. Safe to call from any thread — marshals to the Avalonia UI thread itself.
+    /// Returns a failure result (rather than throwing) when there is no reader to drive, so a non-UI caller
+    /// can surface a clean error.
+    /// </summary>
+    Task<PresentationResult> PresentAsync(PresentationRequest request, CancellationToken ct = default);
+}
+
+public sealed class PresentationService : IPresentationService
+{
+    private readonly ILogger _logger = Log.ForContext<PresentationService>();
+
+    public async Task<PresentationResult> PresentAsync(PresentationRequest request, CancellationToken ct = default)
+    {
+        if (request?.Book == null) return PresentationResult.Fail("No book specified.");
+        ct.ThrowIfCancellationRequested();
+
+        // Presentation mutates the dock/visual tree, so it must run on the UI thread regardless of who called
+        // (the agent tool will call from a Kestrel request thread).
+        return await Dispatcher.UIThread.InvokeAsync(() => Present(request));
+    }
+
+    private PresentationResult Present(PresentationRequest request)
+    {
+        try
+        {
+            // The dock factory isn't in DI — it belongs to the main window's layout, same lookup the search
+            // panel uses. Absent = there is no reader to drive (not running / still starting).
+            if ((App.MainWindow?.DataContext as LayoutViewModel)?.Factory is not CstDockFactory factory)
+            {
+                _logger.Warning("Presentation requested but no reader layout is available");
+                return PresentationResult.Fail("CST Reader is not presentable (no reader window is available).");
+            }
+
+            var plan = PresentationPlanner.Plan(request);
+            var terms = request.SearchTerms?.ToList() ?? new List<string>();
+            var positions = request.Positions?.ToList() ?? new List<TermPosition>();
+
+            if (plan.UseSearchTab)
+            {
+                // Search-result semantics: a fresh tab per result, highlight plumbing, lands on the first hit.
+                _logger.Information("Presenting {Book} in a search tab ({Terms} terms, {Positions} positions)",
+                    request.Book.FileName, terms.Count, positions.Count);
+                factory.OpenBookInNewTab(request.Book, terms, positions);
+            }
+            else
+            {
+                _logger.Information("Presenting {Book} (anchor={Anchor}, hit={Hit}, token={HasToken})",
+                    request.Book.FileName, plan.Anchor ?? "none", plan.HitIndex, plan.PositionToken != null);
+                factory.OpenBook(
+                    request.Book,
+                    plan.Anchor,
+                    request.Script,
+                    null,                       // windowId: null = fresh instance
+                    terms.Count > 0 ? terms : null,
+                    request.DocId ?? request.Book.DocId,
+                    positions.Count > 0 ? positions : null,
+                    plan.HitIndex,
+                    request.ShowFootnotes,
+                    request.ShowSearchTerms,
+                    plan.PositionToken);
+            }
+
+            return PresentationResult.Ok();
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Presentation failed for {Book}", request.Book?.FileName ?? "null");
+            return PresentationResult.Fail($"Presentation failed: {ex.Message}");
+        }
+    }
+}

--- a/src/CST.Avalonia/Views/SearchPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/SearchPanel.axaml.cs
@@ -113,12 +113,21 @@ public partial class SearchPanel : UserControl
                     var presenter = App.ServiceProvider?.GetService<Services.Presentation.IPresentationService>();
                     if (presenter != null)
                     {
-                        _ = presenter.PresentAsync(new Services.Presentation.PresentationRequest
+                        // Observe the task: PresentAsync returns failures as a result, but the task itself can
+                        // still fault (e.g. dispatcher teardown during shutdown) and a bare discard would leak
+                        // it to UnobservedTaskException.
+                        presenter.PresentAsync(new Services.Presentation.PresentationRequest
                         {
                             Book = occurrence.Book,
                             SearchTerms = searchTerms,
                             Positions = occurrence.Positions
-                        });
+                        }).ContinueWith(t =>
+                        {
+                            if (t.IsFaulted)
+                                Log.Error(t.Exception, "[SearchPanel] Presentation task faulted");
+                            else if (t.Result is { Presented: false } r)
+                                Log.Warning("[SearchPanel] Presentation did not happen: {Error}", r.Error);
+                        }, System.Threading.Tasks.TaskScheduler.Default);
                     }
                     else
                     {

--- a/src/CST.Avalonia/Views/SearchPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/SearchPanel.axaml.cs
@@ -108,10 +108,25 @@ public partial class SearchPanel : UserControl
                     Log.Information("[SearchPanel] Opening book {FileName} with {TermCount} search terms for highlighting", 
                         occurrence.Book.FileName, searchTerms.Count);
                     
-                    // Use the search-specific method to open book with highlighting
-                    layoutViewModel.Factory.OpenBookInNewTab(occurrence.Book, searchTerms, occurrence.Positions);
-                    
-                    Log.Debug("[SearchPanel] OpenBookInNewTab call completed");
+                    // Route through the shared presentation command (#187) rather than calling the dock
+                    // directly, so the search UI and the agent present-tool drive the reader identically.
+                    var presenter = App.ServiceProvider?.GetService<Services.Presentation.IPresentationService>();
+                    if (presenter != null)
+                    {
+                        _ = presenter.PresentAsync(new Services.Presentation.PresentationRequest
+                        {
+                            Book = occurrence.Book,
+                            SearchTerms = searchTerms,
+                            Positions = occurrence.Positions
+                        });
+                    }
+                    else
+                    {
+                        // Defensive: fall back to the dock call if the service isn't registered.
+                        layoutViewModel.Factory.OpenBookInNewTab(occurrence.Book, searchTerms, occurrence.Positions);
+                    }
+
+                    Log.Debug("[SearchPanel] present request dispatched");
                 }
                 else
                 {

--- a/src/CST.Avalonia/Views/SearchPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/SearchPanel.axaml.cs
@@ -123,9 +123,12 @@ public partial class SearchPanel : UserControl
                             Positions = occurrence.Positions
                         }).ContinueWith(t =>
                         {
+                            // Must check IsCompletedSuccessfully before touching t.Result: on dispatcher
+                            // teardown at shutdown the task completes CANCELED, and reading Result would throw
+                            // inside this continuation — whose own faulted task nobody observes. (fable)
                             if (t.IsFaulted)
                                 Log.Error(t.Exception, "[SearchPanel] Presentation task faulted");
-                            else if (t.Result is { Presented: false } r)
+                            else if (t.IsCompletedSuccessfully && t.Result is { Presented: false } r)
                                 Log.Warning("[SearchPanel] Presentation did not happen: {Error}", r.Error);
                         }, System.Threading.Tasks.TaskScheduler.Default);
                     }


### PR DESCRIPTION
First deliverable of #187 — one internal *"open the reader to (book, target, search-terms), highlight, scroll"* command that every surface adapts over. The search UI uses it today; Phase 2's consent-gated `POST /navigate`, App Intents and the `cstreader://` URL follow.

**Behaviour-preserving refactor — nothing user-visible.** It's a façade over the existing dock open paths rather than a rewrite, so the fragile open/float machinery is untouched.

## What's in it
- **`PresentationTarget`** — the target union #434 called for: `Position(ReadingPositionToken)` / `Anchor(name)` / `Hit(index)`.
- **`PresentationRequest` / `PresentationResult`** — the request shape, plus a result so a non-UI caller gets a clean failure instead of an exception.
- **`PresentationPlanner`** — **pure, unit-tested** `Plan` + `Validate`. Owns the precedence rule (an explicit hit/anchor outranks a restored reading position — #36 / #434 fable §6) and the routing choice.
- **`PresentationService.PresentAsync`** — marshals to the UI thread itself (Phase 2 calls from a Kestrel request thread), resolves the dock factory the same way the search panel does.
- **`SearchPanel`** now presents through the service instead of calling `Factory.OpenBookInNewTab` directly, and observes the returned task.

## Fable review — 4 rounds, 7 findings, all fixed
The valuable theme: the service would have reported **success for things that never happened** — invisible with one UI caller, real bugs once Phase 2 trusts the result.
- **Dedup-suppressed opens** → `OpenBookInNewTab`/`OpenBook` now return `bool`; the service reports `"Duplicate open suppressed"`.
- **No document dock** → both paths return `false` (`AddDocumentToLayout` became `bool`).
- **Null `VisibleDockables`** → the `?.Add` silent no-op now fails explicitly.
- **Unlandable `Hit`** (no search context) → rejected by `Validate` instead of opening at the top and claiming success.
- **Silently dropped fields** → `Script`/`DocId`/view toggles can't ride the search-tab path, so requests setting them route to the general path. Verified this causes **no** highlight/landing degradation (highlighting is applied to raw XML by source offsets *before* script conversion, so it's script-agnostic; first-hit landing is shared View code).
- Plus: doc now matches behaviour (only cancellation throws), and the task continuation guards `IsCompletedSuccessfully` so a canceled task can't throw inside an unobserved continuation.

**19 planner tests; 812 total pass.**

## Needs a click-test before merge (refactors the search-result path)
- [ ] Search → double-click a result: opens with two-colour highlights, lands on the hit.
- [ ] Double-click a second result in the same book: gets its own tab.
- [ ] Rapid double-double-click: still only one tab (dedup intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)