### PR TITLE
#110: ⌘W closes the active tab (book or View Source PDF) + fix null Factory on book dockables

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1292,7 +1292,14 @@ public partial class App : Application
             toolsMenu.Add(viewSource1957Item);
             toolsMenu.Add(viewSource2010Item);
 
+            // #110: File > Close Tab (⌘W) — closes the active document tab in this floating window.
+            var closeTabItem = new NativeMenuItem { Header = "Close Tab", Gesture = KeyGesture.Parse("Cmd+W") };
+            closeTabItem.Click += (s, e) => OnCloseTabFromFloatingWindow(window);
+            var fileMenu = new NativeMenu();
+            fileMenu.Add(closeTabItem);
+
             var nativeMenu = new NativeMenu();
+            nativeMenu.Add(new NativeMenuItem { Header = "File", Menu = fileMenu });
             nativeMenu.Add(new NativeMenuItem { Header = "View", Menu = viewMenu });
             nativeMenu.Add(new NativeMenuItem { Header = "Tools", Menu = toolsMenu });
             // #284: this window's "Window" submenu (populated by RebuildWindowMenus below).
@@ -1486,6 +1493,25 @@ public partial class App : Application
 
     // View Source (Cmd+E = 1957, Shift+Cmd+E = 2010) for the active book in a floating window, so the
     // shortcut works without the book's WebView having focus (previously only a JS keydown handled it).
+    // #110: ⌘W in a floating window closes its active document tab (book or PDF). Uses the same close path
+    // as the main window (SimpleTabbedWindow.CloseDockableIfClosable) — skips a non-closable tab; a float
+    // holding only that tab closes with it.
+    private void OnCloseTabFromFloatingWindow(Window floatingWindow)
+    {
+        try
+        {
+            if (floatingWindow is CstHostWindow hostWindow && hostWindow.Layout != null)
+            {
+                var documentDock = FindDocumentDockInLayout(hostWindow.Layout) as Dock.Model.Mvvm.Controls.DocumentDock;
+                SimpleTabbedWindow.CloseDockableIfClosable(documentDock?.ActiveDockable);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error handling Close Tab from floating window");
+        }
+    }
+
     private void OnViewSourceFromFloatingWindow(Window floatingWindow, bool source2010)
     {
         try

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -287,29 +287,12 @@ namespace CST.Avalonia.Services
                     }
                 }
             }
-            else if (dockable is IDockable otherDockable)
+            else
             {
-                // For tools, documents, and splitters, we might need to set factory too
-                if (otherDockable is Tool tool)
-                {
-                    tool.Factory = this;
-                }
-                else if (otherDockable is Document document)
-                {
-                    document.Factory = this;
-                }
-                else if (otherDockable is ReactiveDocument reactiveDocument)
-                {
-                    reactiveDocument.Factory = this;
-                }
-                else if (otherDockable is ReactiveTool reactiveTool)
-                {
-                    reactiveTool.Factory = this;
-                }
-                else if (otherDockable is ProportionalDockSplitter splitter)
-                {
-                    splitter.Factory = this;
-                }
+                // Every dockable carries its factory. This used to be a type-switch over Tool/Document/
+                // ReactiveDocument/ReactiveTool/Splitter, which silently missed BookDisplayViewModel — so
+                // books ran with Factory == null and any factory-routed command on them no-opped (#110).
+                dockable.Factory = this;
             }
         }
 
@@ -1976,6 +1959,10 @@ namespace CST.Avalonia.Services
             Log.Debug("*** AddDockable called - Dock: {DockId}, Dockable: {DockableId} ***", dock?.Id, dockable?.Id);
             if (dock != null && dockable != null)
             {
+                // Dockables created outside CreateLayout/SetFactory (every book opened at runtime) would
+                // otherwise never get a Factory, so stamp it here — the single funnel every add goes
+                // through. Idempotent; leaves an already-assigned factory alone. (#110)
+                dockable.Factory ??= this;
                 base.AddDockable(dock, dockable);
             }
             else
@@ -3175,18 +3162,18 @@ namespace CST.Avalonia.Services
         {
             Log.Debug("*** CloseHostWindow called for: {WindowId} ***", hostWindow.Id);
 
-            // Untrack FIRST: the rescue below empties this window's dock, and the collection-changed
+            // Untrack FIRST: the close below empties this window's dock, and the collection-changed
             // monitor reacts to that by closing any empty window it finds in HostWindows — running
             // that against a window already inside its own Closing event would re-enter Close().
             // (Idempotent: CloseEmptyHostWindow untracks before Close(), so this is often a no-op.)
             HostWindows.Remove(hostWindow);
             Log.Debug("*** Host window removed from tracking. Remaining host windows: {Count} ***", HostWindows.Count);
 
-            // The old rescue was doubly dead code: hostWindow.Layout is a RootDock (never a
-            // DocumentDock), and books are ReactiveDocument, which OfType<Document>() never matched —
-            // so closing a floating window silently dropped its books (leaked VMs, ghost tabs on next
-            // launch). Rescue them for real now. (DOCK-2)
-            RescueBooksFromClosingWindow(hostWindow);
+            // Closing a floating window closes the tabs inside it, the way a browser window does.
+            // (Originally these books were silently dropped — leaked VMs, ghost tabs next launch — DOCK-2
+            // then rescued them back into the main window; that surprised users, since the red button
+            // read as "close", so they are now really closed.)
+            CloseDockablesInClosingWindow(hostWindow);
 
             // Update panel visibility state after removing window
             // This ensures menu checkmarks update correctly when panels were in the closed window
@@ -3197,125 +3184,57 @@ namespace CST.Avalonia.Services
             }
         }
 
-        // Move any books left in a closing floating window back into the main document dock. (DOCK-2)
-        private void RescueBooksFromClosingWindow(CstHostWindow hostWindow)
+        // Close every tab in a closing floating window (books, PDFs) through the normal close path, so
+        // each one gets its persisted state removed, its CEF browser disposed and its VM disposed —
+        // the same treatment as closing the tab with the tab button or Cmd+W.
+        private void CloseDockablesInClosingWindow(CstHostWindow hostWindow)
         {
-            // During app shutdown every floating window closes as a matter of course: the books'
-            // states are already saved (they restore next launch) and ServiceProvider may already be
-            // disposed, so recreating tabs — which spins up fresh CEF browsers mid-teardown — would
-            // be wasted work at best and a crash at worst.
+            // During app shutdown every floating window closes as a matter of course: the books' states
+            // are already saved and must stay saved so they restore next launch, so nothing is closed here.
             if (App.IsShuttingDown)
             {
-                Log.Information("*** Skipping book rescue for {WindowId} - application is shutting down ***", hostWindow.Id);
+                Log.Information("*** Skipping tab close for {WindowId} - application is shutting down ***", hostWindow.Id);
                 return;
             }
 
             try
             {
                 var floatingDock = FindDocumentDockInLayout(hostWindow.Layout);
-                var mainDocDock = FindDocumentDock();
-                var booksToRescue = floatingDock?.VisibleDockables?.OfType<BookDisplayViewModel>().ToList();
-
-                if (booksToRescue == null || booksToRescue.Count == 0)
+                var toClose = floatingDock?.VisibleDockables?.ToList();
+                if (toClose == null || toClose.Count == 0)
                 {
-                    Log.Debug("*** No books to rescue - window was already empty ***");
-                    return;
-                }
-                if (mainDocDock == null)
-                {
-                    Log.Error("*** Cannot rescue {Count} book(s) from {WindowId} - main document dock not found ***",
-                        booksToRescue.Count, hostWindow.Id);
+                    Log.Debug("*** No tabs to close - window was already empty ***");
                     return;
                 }
 
-                Log.Information("*** Rescuing {Count} book(s) from closing floating window {WindowId} ***",
-                    booksToRescue.Count, hostWindow.Id);
+                Log.Information("*** Closing {Count} tab(s) with floating window {WindowId} ***", toClose.Count, hostWindow.Id);
 
-                foreach (var oldVm in booksToRescue)
+                foreach (var dockable in toClose)
                 {
                     try
                     {
-                        RescueBookToMainDock(oldVm, mainDocDock);
+                        if (dockable.CanClose)
+                        {
+                            CloseDockable(dockable);
+                        }
+                        else
+                        {
+                            // Nothing in a floating document dock opts out of closing today; if something
+                            // ever does, leave it be rather than force it - and say so.
+                            Log.Warning("*** Tab {Title} is not closable - left in the closing window {WindowId} ***",
+                                dockable.Title, hostWindow.Id);
+                        }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "*** ERROR rescuing book {BookFile} from closing window ***", oldVm.Book.FileName);
+                        Log.Error(ex, "*** ERROR closing tab {Title} with its floating window ***", dockable.Title);
                     }
                 }
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "*** ERROR rescuing books from closing window {WindowId} ***", hostWindow.Id);
+                Log.Error(ex, "*** ERROR closing tabs in closing window {WindowId} ***", hostWindow.Id);
             }
-        }
-
-        // Recreate one book from a closing floating window inside the main dock. Same discipline as
-        // UnfloatDockableWithoutRecycling: the old View's live CEF WebView must never be re-parented —
-        // capture state, shut down + evict the old View, dispose the old VM, create a fresh VM
-        // (fresh GUID => fresh View + browser). NOTE the WebView does NOT die with the closing window:
-        // WebViewControl auto-disposes only on detach with the window's PlatformImpl already null, and
-        // this runs inside Window.Closing while it is still live — the explicit
-        // DisposeAndEvictRecycledView below is what actually releases the browser (#177 reopen).
-        // The window is mid-Close, so no async WebView query is possible; CurrentVriAnchor (from the
-        // last scroll status update) is the best available scroll position. (DOCK-2)
-        private void RescueBookToMainDock(BookDisplayViewModel oldVm, DocumentDock mainDocDock)
-        {
-            var book = oldVm.Book;
-            var searchTerms = oldVm.SearchTerms?.ToList();
-            var searchPositions = oldVm.SearchPositions?.ToList();
-            var bookScript = oldVm.BookScript;
-            var docId = oldVm.DocId;
-            var currentHitIndex = oldVm.CurrentHitIndex;
-            var totalHits = oldVm.TotalHits;
-            var showFootnotes = oldVm.ShowFootnotes;       // #224: carry View toggles across float/unfloat
-            var showSearchTerms = oldVm.ShowSearchTerms;
-            var title = oldVm.Title;  // preserve the exact tab title (current script + any prefix) across recreation
-            var anchor = oldVm.CurrentVriAnchor;
-
-            // Old id's persisted state and subscriptions go away with the old VM (the collection-changed
-            // monitor also removes the state on RemoveDockable; this keeps the ordering explicit).
-            RemoveBookWindowState(oldVm.Id);
-            RemoveDockable(oldVm, false);
-            _goToSubscribedBooks.Remove(oldVm.Id);
-            DisposeAndEvictRecycledView(oldVm);
-            oldVm.Dispose();
-
-            var chapterListsService = App.ServiceProvider?.GetService<ChapterListsService>();
-            var settingsService = App.ServiceProvider?.GetService<ISettingsService>();
-            var fontService = App.ServiceProvider?.GetService<IFontService>();
-
-            var newVm = new BookDisplayViewModel(
-                book: book,
-                searchTerms: searchTerms,
-                initialAnchor: anchor,
-                chapterListsService: chapterListsService,
-                settingsService: settingsService,
-                fontService: fontService,
-                docId: docId,
-                searchPositions: searchPositions,
-                windowId: null,  // CRITICAL: null = generates fresh GUID
-                dockFactory: this,
-                initialBookScript: bookScript  // seed so the set below is a no-op (BOOK-3)
-            );
-
-            // Restore additional state (BookScript set is a no-op given the seed; kept as a safety net)
-            newVm.BookScript = bookScript;
-            newVm.CurrentHitIndex = currentHitIndex;
-            newVm.TotalHits = totalHits;
-            newVm.ShowFootnotes = showFootnotes;
-            newVm.ShowSearchTerms = showSearchTerms;
-            newVm.IsFloating = false;
-            newVm.CanFloat = false; // Restore drag-to-float block (CEF crash mitigation); matches the open + float paths
-            newVm.Title = title;
-
-            // Wire Go To / Attha-Tika / View Source for the fresh instance
-            EnsureBookEventSubscription(newVm);
-
-            AddDockable(mainDocDock, newVm);
-            SetActiveDockable(newVm);
-            SetFocusedDockable(mainDocDock, newVm);
-
-            Log.Information("*** Rescued book {BookFile} into main window as {NewId} ***", book.FileName, newVm.Id);
         }
 
         // Find which window contains a specific book instance

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -1973,6 +1973,28 @@ public partial class BookDisplayView : UserControl
                 _logger.Error("Error processing View Source 2010 request from JavaScript | {Details}", ex.Message);
             }
         }
+        // #110: Close Tab requested from JavaScript (⌘W while the book WebView has focus).
+        else if (title != null && title.StartsWith("CST_CLOSE_TAB:"))
+        {
+            try
+            {
+                var parts = title.Split('|');
+                var messageTabId = parts.Length > 1 && parts[1].StartsWith("TAB:") ? parts[1].Substring(4) : "";
+
+                if (messageTabId == _tabId)
+                {
+                    _logger.Debug("*** CLOSE TAB REQUESTED FROM JAVASCRIPT ***");
+                    // OnTitleChanged runs on the CEF thread; closing mutates the dock layout (and disposes
+                    // this very WebView), so defer to the UI thread — the current title callback returns
+                    // first, then the close runs. (BOOK-2)
+                    Dispatcher.UIThread.Post(() => SimpleTabbedWindow.CloseDockableIfClosable(_viewModel));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Error processing Close Tab request from JavaScript | {Details}", ex.Message);
+            }
+        }
         // Check for JS log messages
         else if (title != null && title.StartsWith("CST_LOG_MSG::"))
         {
@@ -2082,6 +2104,16 @@ public partial class BookDisplayView : UserControl
                                     event.preventDefault();
                                     event.stopPropagation();
                                     document.title = 'CST_VIEW_SOURCE_1957:|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                                    return false;
+                                }
+
+                                // #110: Cmd+W / Ctrl+W (Close Tab) - CEF eats the key when the book WebView
+                                // has focus, so forward it like the View Source shortcuts to close this tab.
+                                if (event.key === 'w' && (event.metaKey || event.ctrlKey)) {
+                                    window.cstLogger.log('DEBUG', 'Close Tab shortcut detected in JavaScript');
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                    document.title = 'CST_CLOSE_TAB:|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
                                     return false;
                                 }
                             }, true); // Use capture phase to intercept before other handlers

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -12,6 +12,13 @@
     <!-- Native Menu for macOS - Window level (creates top-level menus in menu bar) -->
     <NativeMenu.Menu>
         <NativeMenu>
+            <!-- File Menu (#110): ⌘W closes the active document tab (book or PDF) in the focused window -->
+            <NativeMenuItem Header="File">
+                <NativeMenu>
+                    <NativeMenuItem Header="Close Tab" Click="OnCloseTabClick" Gesture="cmd+w" />
+                </NativeMenu>
+            </NativeMenuItem>
+
             <!-- View Menu as top-level menu -->
             <NativeMenuItem Header="View">
                 <NativeMenu>

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -752,6 +752,49 @@ public partial class SimpleTabbedWindow : Window
     private void OnViewSource1957Click(object? sender, EventArgs e) => TriggerViewSource(source2010: false);
     private void OnViewSource2010Click(object? sender, EventArgs e) => TriggerViewSource(source2010: true);
 
+    // #110: ⌘W closes the active document tab in THIS window (main or floating routes here for the main
+    // window; floating windows use App.OnCloseTabFromFloatingWindow). Resolves the active dockable the same
+    // way ⌘G/⌘E do, but for ANY document type (book or View Source PDF); a non-closable tab (Welcome,
+    // CanClose=false) is skipped. A floating window with a single tab closes with its tab (framework closes
+    // the emptied window).
+    private void OnCloseTabClick(object? sender, EventArgs e)
+    {
+        try
+        {
+            var dockControl = this.FindDescendantOfType<global::Dock.Avalonia.Controls.DockControl>();
+            if (dockControl?.DataContext is not LayoutViewModel layoutViewModel ||
+                layoutViewModel.Layout is not RootDock rootDock)
+                return;
+
+            var documentDock = FindDocumentDockInLayout(rootDock);
+            CloseDockableIfClosable(documentDock?.ActiveDockable);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Close Tab (⌘W) failed");
+        }
+    }
+
+    // Close a dockable via its own factory if it exists and permits closing (Welcome opts out via
+    // CanClose=false). Shared by the ⌘W menu handler and the JS-forwarded close from a focused book WebView.
+    internal static void CloseDockableIfClosable(IDockable? active)
+    {
+        if (active is not { CanClose: true }) return;
+
+        // Belt-and-braces: CstDockFactory now stamps Factory on every added dockable, but a dockable
+        // restored from an older layout could still arrive without one — fall back to the owning dock's
+        // factory rather than silently doing nothing (the original #110 failure mode: books had a null
+        // Factory, so ⌘W closed PDFs but never a book).
+        var factory = active.Factory ?? (active.Owner as IDock)?.Factory;
+        if (factory is null)
+        {
+            Serilog.Log.Warning("Close Tab: no factory for {Dockable} - tab left open", active.GetType().Name);
+            return;
+        }
+
+        factory.CloseDockable(active);
+    }
+
     private void TriggerViewSource(bool source2010)
     {
         try


### PR DESCRIPTION
Closes #110.

## ⌘W closes the active tab

`File > Close Tab` (⌘W) on the main window and on every floating window closes the active document tab — book or View Source PDF. Three routes reach one shared close path:

- the menu item;
- the native accelerator, which fires whenever focus is outside a book WebView — including inside a View Source PDF, since PDFium lets the accelerator through (verified by hand);
- a JS keydown forward from a focused book WebView over the existing `document.title` channel, because CEF consumes the key there.

The Welcome tab opts out (`CanClose = false`) and is skipped, so ⌘W on it does nothing. A floating window holding only the closed tab goes away with it.

## The latent bug this uncovered: books had a null `IDockable.Factory`

⌘W closed PDFs but never a book, in any window. `SetFactory` was a type-switch over `Tool` / `Document` / `ReactiveDocument` / `ReactiveTool` / `ProportionalDockSplitter` that never matched `BookDisplayViewModel` — and books opened at runtime never reached it at all — so **every book dockable carried `Factory == null`**. PDFs matched a listed type, which is the whole of the difference.

This was never a ⌘W bug. It was latent in every book dockable; ⌘W is just the first feature to route through `IDockable.Factory`. Fixed at the source:

- `SetFactory` stamps any dockable instead of enumerating types;
- `AddDockable` — the single funnel every add goes through — sets `Factory ??= this`, covering runtime-created dockables;
- `CloseDockableIfClosable` falls back to the owning dock's factory and logs a warning instead of failing silently.

## Note: closing a floating window now closes its tabs

**This part is beyond #110's scope and was requested during testing.** Closing a floating window with the red button used to move its books back into the main window (the DOCK-2 rescue, which itself replaced silently dropping them). That reads wrong for a control labelled "close", so each tab now goes through the normal close path — persisted state removed, CEF browser disposed, VM disposed — matching browser-window behaviour. The ~120-line rescue-and-recreate machinery is deleted.

Shutdown is unchanged: floating windows close as part of teardown, and their books stay saved and restore on the next launch.

## Verification

Manual, on macOS: ⌘W on a book tab with and without WebView focus; on a View Source PDF with and without PDFium focus; on the Welcome tab (no-op); in a floating window; and red-button close of a float. Diagnosed with temporary INFO probes along the whole path, which pinpointed `factory=null`; the probes are removed.

Full suite: **837 passed, 0 failed**.

## Known follow-up

In a split layout, the menu path resolves the target through the first `DocumentDock` found in the layout, so ⌘W can close the active tab of the wrong split. Pre-existing in the ⌘G / ⌘E handlers this mirrors; filed separately rather than widened here.
