### PR TITLE
Steer agents towards page references, and correct the paragraph-number guidance

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/NavigateEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/NavigateEndpointTests.cs
@@ -366,6 +366,24 @@ namespace CST.Avalonia.Tests.Integration
 
 
         [Fact]
+        public async Task The_docs_steer_agents_towards_page_references_over_paragraph_numbers()
+        {
+            // A deliberate policy, not incidental prose: paragraph numbers are a weak addressing scheme in this
+            // corpus (repeated in 102 of 217 books, ~3,600 printed as ranges) while page numbers are strong, so
+            // the agent-facing docs must say so. Pinned because it is easy to lose in an edit. (#447, #446)
+            using var http = _api.Http();
+
+            var reading = await http.GetStringAsync("/docs/reading.md");
+            Assert.Contains("PREFER PAGE REFERENCES", reading);
+            // ...and must NOT revive the old advice that a bookCode disambiguates, which holds only for the
+            // 7 multi-book volumes — elsewhere the repeats are WITHIN one sub-book.
+            Assert.Contains("only disambiguates in the 7 multi-book volumes", reading);
+
+            var navigate = await http.GetStringAsync("/docs/navigate.md");
+            Assert.Contains("PREFER A PAGE ANCHOR", navigate);
+        }
+
+        [Fact]
         public async Task Navigate_is_documented_so_an_agent_can_tell_the_user_how_to_enable_it()
         {
             using var http = _api.Http();

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -189,17 +189,35 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   START of paragraph N but the window is bounded by `maxChars`, so a long paragraph spans several windows and
   `nextCursor` may still be INSIDE the same paragraph - keep paging until `normalizedReference` changes, or
   raise `maxChars`.
-  PARAGRAPH NUMBERS ARE NOT GLOBALLY UNIQUE: in a multi-section book they RESTART per section, so `paragraph:N`
-  can land on a DIFFERENT paragraph N than the one an `occurrences` hit reported. For exact addressing use the
-  hit's `cursor` (unique); if you must go by number, pass the `bookCode` (the sub-book, from the occurrence's
-  `refs.paragraphBookCode`) alongside `paragraph` to disambiguate.
+  PREFER PAGE REFERENCES OVER PARAGRAPH NUMBERS. Paragraph numbers are a weak addressing scheme in this
+  corpus and page numbers are a strong one - when you have a choice, cite and navigate by page.
+  Paragraph numbers have three problems, measured over the corpus: (1) they are NOT UNIQUE - in 102 of 217
+  books the same number occurs more than once, because the printed numbering restarts per section, so
+  `paragraph:N` can land on a DIFFERENT paragraph N than the one an `occurrences` hit reported; (2) ~3,600
+  paragraphs are printed as RANGES (`16-26`, or abbreviated `196-7` meaning 196-197) because a commentary
+  passage comments on a span of root-text paragraphs - an exact number inside such a span may not be
+  addressable; (3) a `bookCode` only disambiguates in the 7 multi-book volumes - elsewhere the repeats occur
+  WITHIN one sub-book, so the code does not help.
+  For exact addressing, in order of preference: the hit's `cursor` (always unique - use this when you have
+  one), then a page reference, then `paragraph`. When you report a location to a user, a page citation
+  ("VRI vol 1 p. 23") is more trustworthy than a paragraph number.
+  WHICH EDITION: do not assume a book has pages in the edition you prefer. The print editions cover DIFFERENT
+  parts of the corpus - the VRI set is 140 volumes, and many texts (particularly the `e*` Anya/other works)
+  were never published outside Myanmar, so they legitimately have no VRI or PTS numbering at all. A missing
+  edition is expected, not an error and not missing data. Always take the editions from what the book itself
+  reports - the `pages` array on an `/v1/passage` window, or `refs` on an `occurrences` hit - and cite one of
+  those, rather than constructing a page anchor in an edition the book does not use.
 <!--/doc:reading-->
 <!--doc:navigate-->
 - `POST /v1/navigate` - SHOW a passage to the user in the CST Reader window. This is the only endpoint with a
   visible side effect: it changes what the person in front of the app is looking at. Use it when the user asks
   to be SHOWN something; to read text yourself use `/v1/passage`.
   Body: `{ bookId, anchor?, terms?, hit?, mode?, proximityDistance?, outputScript? }`.
-  `anchor` is a reference to scroll to - a page anchor (`"V1.0023"`), a paragraph (`"para5"`), or a chapter id.
+  `anchor` is a reference to scroll to. PREFER A PAGE ANCHOR - `"V1.0023"` (edition letter, volume, then the
+  page zero-padded to 4 digits; `V`=VRI, `M`=Myanmar, `P`=PTS, `T`=Thai). A paragraph anchor (`"para5"`) or a
+  chapter id also work, but paragraph numbers repeat in many books (see the reading section), so a page anchor
+  is far more likely to land where you meant. Use an edition the book actually has - take it from an
+  `occurrences` hit's `refs` or a `/v1/passage` window's `pages`; not every text was printed in every edition.
   `terms` is a query (same syntax as `/v1/search`) whose matches are HIGHLIGHTED in the opened book; `hit` is a
   1-based match to land on and REQUIRES `terms`. Omit `outputScript` to keep the reader's current script.
   Returns `{ presented, error, bookId, highlights, note }` - on every outcome this endpoint produces, including

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/NavigateMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/NavigateMcpTool.cs
@@ -28,7 +28,10 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             NavigateService navigate,
             [Description("Book id (file name) from the 'books' tool or a search result, e.g. 's0101m.mul.xml'.")]
             string bookId,
-            [Description("Optional reference to scroll to: a page anchor ('V1.0023'), a paragraph ('para5'), or a chapter id.")]
+            [Description("Optional reference to scroll to. PREFER a page anchor — 'V1.0023' = edition letter "
+                + "(V=VRI, M=Myanmar, P=PTS, T=Thai), volume, then the page zero-padded to 4 digits. A paragraph "
+                + "anchor ('para5') or chapter id also work, but paragraph numbers repeat in many books, so a "
+                + "page anchor is far more likely to land where you meant.")]
             string? anchor = null,
             [Description("Optional query whose matches are highlighted in the book — same syntax as the 'search' tool.")]
             string? terms = null,

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/PassageMcpTool.cs
@@ -23,7 +23,11 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             + "the hit is read with its full governing clause, never mid-sentence. Use the returned "
             + "nextCursor/prevCursor to page. With neither paragraph nor cursor, reads from the book start. "
             + "'noteCount' is how many {…} apparatus notes fall in the window (counted regardless of "
-            + "includeFootnotes) — noteCount>0 means apparatus is present here.")]
+            + "includeFootnotes) — noteCount>0 means apparatus is present here. "
+            + "CAVEAT ON `paragraph`: paragraph numbers are NOT unique in this corpus — in 102 of 217 books the "
+            + "same number occurs more than once (the printed numbering restarts per section), and ~3,600 "
+            + "paragraphs are printed as ranges. Prefer a `cursor` when you have one, and prefer citing a PAGE "
+            + "when you report a location back to the user.")]
         public static async Task<PassageResult> PassageAsync(
             IPassageTool passage,
             [Description("The book's id (file name), e.g. from the 'books' tool or a search result.")]


### PR DESCRIPTION
Acting on the conclusion from the #447 / #446 investigation: paragraph numbers are not a good navigation system across this corpus, so the agent-facing surface should steer toward page numbers.

## Evidence

| | paragraph numbers | page numbers |
|---|---|---|
| files with ambiguity | **102 of 217** | 4–7 per edition |
| malformed values | ~3,600 ranged + 2 broken | **0** |
| ambiguous items | 12,944 | ~1,380, in 7 files |

Every `pb/@n` in the corpus is a well-formed `vol.page`. Nothing like the ranged/abbreviated/malformed spread on the paragraph side.

## Corrects advice that was wrong

The reading docs told an agent that if it must go by number, it should pass a `bookCode` alongside `paragraph` to disambiguate. That holds only for the **7 multi-book volumes**. Everywhere else the repeats occur *within* one sub-book — verified: `(paragraph, bookCode)` repeats exactly as often as the bare number (s0510m1: 519 and 519, with every paragraph coded). The advice could not have worked.

## Adds the edition caveat

This matters the moment agents are told to prefer pages, or they will construct a `V1.0023` anchor for a book VRI never printed. The print editions cover **different parts of the corpus**: the VRI set is 140 volumes, and many texts — particularly the `e*` Anya/other works — were never published outside Myanmar and so legitimately carry no VRI or PTS numbering. That is expected, not missing data.

Agents are told to take the edition from what the book itself reports — a passage window's `pages`, or an occurrence's `refs` — rather than assuming their preferred edition exists.

## Scope

`llms.txt` (reading + navigate regions) and the MCP `passage` / `navigate` tool descriptions, so it also reaches clients that never fetch `llms.txt`. Pinned by a test — this is a deliberate policy, easy to lose in an edit.

Full suite 852/852. Related: #447 (anchor granularity), #446 (ranged `@n`), #444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)