### PR TITLE
Correct the false "paragraph numbers are unique" claim in NavigationResolver

### DIFF
--- a/src/CST.Avalonia.Tests/Navigation/NavigationResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Navigation/NavigationResolverTests.cs
@@ -261,6 +261,10 @@ namespace CST.Avalonia.Tests.Navigation
                 b.FileName, new NavigationReference.Paragraph(5, "an5")));
             Assert.Equal(NavigationStatus.InvalidReference, r.Status);
             Assert.Contains("not a multi-book volume", r.Message);
+            // The message must NOT claim paragraph numbers are unique in a non-Multi book — they repeat in 95
+            // of them, because the printed numbering restarts per section. The refusal stands (a book code is
+            // not what would disambiguate), but the reason given has to be true. (#447)
+            Assert.DoesNotContain("unique within it", r.Message);
         }
 
         [Fact]

--- a/src/CST.Core/Navigation/NavigationResolver.cs
+++ b/src/CST.Core/Navigation/NavigationResolver.cs
@@ -68,15 +68,23 @@ namespace CST.Navigation
             bool isMulti = book.BookType == BookType.Multi;
             string? bookCode = p.BookCode;
 
-            // A book code on a single-book volume is meaningless. Silently ignoring it produced a
-            // wrong-but-plausible navigation (the caller believed it had disambiguated); say so instead. (#314)
+            // A book code addresses a sub-book of a Multi volume, so it cannot address anything here. Silently
+            // ignoring it produced a wrong-but-plausible navigation (the caller believed it had disambiguated);
+            // say so instead. (#314)
+            //
+            // Two things the wording must NOT claim. A non-Multi book CAN carry a book-div id (s0101m.mul has
+            // "dn1", and the XSL does emit para5_dn1), so "that code doesn't exist" would be false. And
+            // paragraph numbers are NOT unique here either — they repeat in 95 non-Multi books, because the
+            // printed numbering restarts per section. The honest reason to refuse is narrower: a book code is
+            // not the thing that would disambiguate them. Where a number does repeat, the repeats sit WITHIN a
+            // single book div, so (number, bookCode) is exactly as ambiguous as the bare number and the anchor
+            // resolves to the first occurrence. Qualifying by the deepest enclosing div would fix ~97% of that;
+            // tracked in #447. (fable LOW-6, corrected)
             if (!isMulti && bookCode is not null)
-                // Careful with the wording: a non-Multi book CAN carry a book-div id (s0101m.mul has "dn1", and
-                // the XSL does emit para5_dn1), so "that code doesn't exist" would be false. The reason to refuse
-                // is that paragraph numbers don't need disambiguating here. (fable LOW-6)
                 return NavigationResult.InvalidReference(
-                    $"'{book.FileName}' is not a multi-book volume, so paragraph numbers are unique within it; " +
-                    $"omit the book code '{bookCode}'.");
+                    $"'{book.FileName}' is not a multi-book volume, so a book code cannot address a paragraph " +
+                    $"in it; omit '{bookCode}'. (Paragraph numbers are not necessarily unique in this book " +
+                    "either, but a book code is not what would disambiguate them — see #447.)");
 
             if (isMulti)
             {


### PR DESCRIPTION
Follow-up to #445, from the corpus measurement in #447.

`ResolveParagraph` refuses a book code on a non-Multi book. The refusal is right; its stated reason was not:

> '{book}' is not a multi-book volume, so **paragraph numbers are unique within it**; omit the book code

Paragraph numbers are **not** unique in a non-Multi book. The same number occurs more than once in **95** of them, because the printed numbering restarts per section — Frank generated these `@n` values from the printed numbers, and the printed numbers are not always unambiguous references within a book.

## What the message says now

A book code addresses a sub-book of a Multi volume, so it cannot address a paragraph in a non-Multi book — that is the true, narrower reason to refuse. The message adds that paragraph numbers are not necessarily unique here either, but that a book code is not what would disambiguate them, and points at #447.

That last part is measured: where numbers repeat, the repeats sit *within* a single book div, so `(number, bookCode)` is exactly as ambiguous as the bare number (s0510m1: 519 repeats either way, every paragraph coded). Qualifying by the deepest enclosing div instead would resolve ~97%.

## Note on how this got in

The wording came out of the #445 review — it was proposed to replace an earlier message that was wrong in a different way, and I took it. It reads plausibly, and neither of us checked whether paragraph numbers actually repeat. A test now pins the corrected claim.

Full suite 852/852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)