### PR TITLE
#448: make ⌘D and ⌘F work in floating book windows

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1287,8 +1287,21 @@ public partial class App : Application
             var viewSource2010Item = new NativeMenuItem { Header = "View Source (2010 ed.)", Gesture = KeyGesture.Parse("Cmd+Shift+E") };
             viewSource2010Item.Click += (s, e) => OnViewSourceFromFloatingWindow(window, source2010: true);
 
+            // #448: Look Up in Dictionary (Cmd+D) and Search for Selection (Cmd+F). These were declared only
+            // in the main window's Tools menu, and macOS shows the menu bar of whichever window is active —
+            // so with a floated book focused they were dead keys. Both act on the floated book's selection
+            // and reveal their tool in the main window.
+            var lookUpItem = new NativeMenuItem { Header = "Look Up in Dictionary", Gesture = KeyGesture.Parse("Cmd+D") };
+            lookUpItem.Click += async (s, e) =>
+                await SimpleTabbedWindow.LookUpInDictionaryAsync(FindActiveBookInFloatingWindow(window));
+            var searchSelectionItem = new NativeMenuItem { Header = "Search for Selection", Gesture = KeyGesture.Parse("Cmd+F") };
+            searchSelectionItem.Click += async (s, e) =>
+                await SimpleTabbedWindow.SearchForSelectionAsync(FindActiveBookInFloatingWindow(window));
+
             var toolsMenu = new NativeMenu();
             toolsMenu.Add(goToItem);
+            toolsMenu.Add(lookUpItem);
+            toolsMenu.Add(searchSelectionItem);
             toolsMenu.Add(viewSource1957Item);
             toolsMenu.Add(viewSource2010Item);
 
@@ -1496,6 +1509,16 @@ public partial class App : Application
     // #110: ⌘W in a floating window closes its active document tab (book or PDF). Uses the same close path
     // as the main window (SimpleTabbedWindow.CloseDockableIfClosable) — skips a non-closable tab; a float
     // holding only that tab closes with it.
+    // The active book in a floating window, or null if its active tab isn't a book. (#448)
+    private BookDisplayViewModel? FindActiveBookInFloatingWindow(Window floatingWindow)
+    {
+        if (floatingWindow is not CstHostWindow hostWindow || hostWindow.Layout == null)
+            return null;
+
+        var documentDock = FindDocumentDockInLayout(hostWindow.Layout) as Dock.Model.Mvvm.Controls.DocumentDock;
+        return documentDock?.ActiveDockable as BookDisplayViewModel;
+    }
+
     private void OnCloseTabFromFloatingWindow(Window floatingWindow)
     {
         try

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -685,10 +685,18 @@ public partial class SimpleTabbedWindow : Window
     private async void OnLookUpInDictionaryClick(object? sender, EventArgs e)
     {
         _logger.Information("Look Up in Dictionary (Cmd+D) from window: {WindowTitle}", this.Title);
+        await LookUpInDictionaryAsync(FindActiveBookInThisWindow());
+    }
+
+    // The Dictionary and Search tools always live in the main window, so only the book differs between the
+    // main-window and floating-window shortcuts — hence one shared implementation each, taking the active
+    // book as its parameter. Both finish by bringing the tool's own window forward, wherever it lives, so
+    // the keystroke never looks like it did nothing. (#448)
+    internal static async Task LookUpInDictionaryAsync(BookDisplayViewModel? book)
+    {
         try
         {
-            var dockControl = this.FindDescendantOfType<global::Dock.Avalonia.Controls.DockControl>();
-            if (dockControl?.DataContext is not LayoutViewModel layoutViewModel)
+            if (App.MainWindow?.DataContext is not LayoutViewModel layoutViewModel)
                 return;
 
             if (App.ServiceProvider?.GetService(typeof(DictionaryViewModel)) is not DictionaryViewModel dictionary)
@@ -700,35 +708,82 @@ public partial class SimpleTabbedWindow : Window
 
             // If a book is active AND has a selection, look that word up; otherwise we still open the pane.
             // Cmd+D (and the menu item) must reveal the Dictionary regardless of selection or book focus. (#175)
-            string? selection = null;
-            if (layoutViewModel.Layout is RootDock rootDock)
-            {
-                var documentDock = FindDocumentDockInLayout(rootDock);
-                if (documentDock?.ActiveDockable is BookDisplayViewModel bookViewModel &&
-                    bookViewModel.BookDisplayControl != null)
-                {
-                    selection = await bookViewModel.BookDisplayControl.GetWebViewSelectionAsync();
-                }
-            }
+            string? selection = book?.BookDisplayControl != null
+                ? await book.BookDisplayControl.GetWebViewSelectionAsync()
+                : null;
 
             var word = ExtractLookupWord(selection);
             if (!string.IsNullOrEmpty(word))
             {
                 dictionary.SearchText = word;
-                _logger.Information("Looked up '{Word}' in the dictionary", word);
+                Serilog.Log.Information("Looked up '{Word}' in the dictionary", word);
             }
             else
             {
-                _logger.Debug("Look Up in Dictionary: no selection — just opening the Dictionary pane");
+                Serilog.Log.Debug("Look Up in Dictionary: no selection — just opening the Dictionary pane");
             }
 
             // Always bring the Dictionary tab forward, whether or not a word was found. (#175)
             layoutViewModel.Factory?.SetActiveDockable(dictionary);
+            RevealWindowHosting(dictionary, layoutViewModel);
         }
         catch (Exception ex)
         {
-            _logger.Error(ex, "Look Up in Dictionary failed");
+            Serilog.Log.Error(ex, "Look Up in Dictionary failed");
         }
+    }
+
+    // Bring the window that actually holds a tool to the front. The tool is usually docked in the main
+    // window, but it can be floated into its own window — and then activating the main window would bury
+    // the very pane the shortcut just revealed. Activating the main window when it already is the host is
+    // a harmless no-op. (#448 follow-up)
+    private static void RevealWindowHosting(IDockable tool, LayoutViewModel layoutViewModel)
+    {
+        var hostWindows = layoutViewModel.Factory?.HostWindows;
+        if (hostWindows != null)
+        {
+            foreach (var host in hostWindows)
+            {
+                if (host is CstHostWindow hostWindow && hostWindow.Layout != null &&
+                    LayoutContains(hostWindow.Layout, tool))
+                {
+                    hostWindow.Activate();
+                    return;
+                }
+            }
+        }
+
+        App.MainWindow?.Activate();
+    }
+
+    private static bool LayoutContains(IDock dock, IDockable target)
+    {
+        if (ReferenceEquals(dock, target))
+            return true;
+
+        if (dock.VisibleDockables == null)
+            return false;
+
+        foreach (var dockable in dock.VisibleDockables)
+        {
+            if (ReferenceEquals(dockable, target))
+                return true;
+            if (dockable is IDock childDock && LayoutContains(childDock, target))
+                return true;
+        }
+
+        return false;
+    }
+
+    // The active book in THIS window, or null if the active tab isn't a book (a PDF, Welcome, or nothing).
+    private BookDisplayViewModel? FindActiveBookInThisWindow()
+    {
+        var dockControl = this.FindDescendantOfType<global::Dock.Avalonia.Controls.DockControl>();
+        if (dockControl?.DataContext is not LayoutViewModel layoutViewModel ||
+            layoutViewModel.Layout is not RootDock rootDock)
+            return null;
+
+        return FindDocumentDockInLayout(rootDock)?.ActiveDockable as BookDisplayViewModel;
     }
 
     // Reduce a selection to a single lookup word: first whitespace-delimited token, minus surrounding
@@ -827,35 +882,37 @@ public partial class SimpleTabbedWindow : Window
     private async void OnSearchForSelectionClick(object? sender, EventArgs e)
     {
         _logger.Information("Search for Selection (Cmd+F) from window: {WindowTitle}", this.Title);
+        await SearchForSelectionAsync(FindActiveBookInThisWindow());
+    }
+
+    // Shared by both windows' Cmd+F, same as LookUpInDictionaryAsync above. (#448)
+    internal static async Task SearchForSelectionAsync(BookDisplayViewModel? book)
+    {
         try
         {
-            var dockControl = this.FindDescendantOfType<global::Dock.Avalonia.Controls.DockControl>();
-            if (dockControl?.DataContext is not LayoutViewModel layoutViewModel)
+            if (App.MainWindow?.DataContext is not LayoutViewModel layoutViewModel)
                 return;
 
-            string? selection = null;
-            if (layoutViewModel.Layout is RootDock rootDock)
-            {
-                var documentDock = FindDocumentDockInLayout(rootDock);
-                if (documentDock?.ActiveDockable is BookDisplayViewModel bookViewModel &&
-                    bookViewModel.BookDisplayControl != null)
-                {
-                    selection = await bookViewModel.BookDisplayControl.GetWebViewSelectionAsync();
-                }
-            }
+            string? selection = book?.BookDisplayControl != null
+                ? await book.BookDisplayControl.GetWebViewSelectionAsync()
+                : null;
 
             if (App.ServiceProvider?.GetService(typeof(SearchViewModel)) is not SearchViewModel search)
                 return;
+
+            // Recreate the Search pane if it was closed, for the same reason Cmd+D reopens the Dictionary.
+            layoutViewModel.ShowSearchPanel();
 
             var query = BuildSearchQuery(selection);
             if (!string.IsNullOrEmpty(query))
                 search.SearchText = query;   // the Search tool's real-time throttle runs the search
             layoutViewModel.Factory?.SetActiveDockable(search);   // reveal the Search tab
-            _logger.Information("Search for selection: '{Query}'", query);
+            RevealWindowHosting(search, layoutViewModel);
+            Serilog.Log.Information("Search for selection: '{Query}'", query);
         }
         catch (Exception ex)
         {
-            _logger.Error(ex, "Search for Selection failed");
+            Serilog.Log.Error(ex, "Search for Selection failed");
         }
     }
 


### PR DESCRIPTION
Closes #448.

⌘D (Look Up in Dictionary) and ⌘F (Search for Selection) were declared only in the main window's Tools menu. macOS shows the menu bar of whichever window is active, so with a floated book focused they were dead keys — the only book shortcuts with neither a floating-window menu item nor a JS fallback.

## Approach

The Dictionary and Search tools always live outside the book window, so the only thing that differs between the two windows is **which book supplies the selection**. Each command is now a single shared implementation — `LookUpInDictionaryAsync` / `SearchForSelectionAsync` — taking the active book as a parameter, with the main-window handlers and the new floating-window menu items as thin callers. The two paths can't drift.

## Two adjacent bugs fixed on the way

**⌘F never reopened a closed Search pane.** ⌘D has reopened the Dictionary since the #175 follow-up, but ⌘F only called `SetActiveDockable`, which no-ops when the pane isn't in the layout — so after floating and closing the Search panel, ⌘F was dead in the main window too. It now calls `ShowSearchPanel()` first, matching ⌘D.

**Revealing the tool buried it.** The reveal activated the main window unconditionally, so with the Search pane floated, ⌘F raised the main window *over* the pane it had just populated (caught in testing). `RevealWindowHosting` now finds the window whose layout actually contains the tool and activates that, falling back to the main window. It also raises the tool's window when it's merely covered by another window, and it applies from either window — so the mirror case (⌘F from the main window with a floated Search) is fixed too.

## Verification

Manual, on macOS: ⌘D and ⌘F from a floated book with the tools docked in the main window; then with the Search pane itself floated, invoked from both the floated book and the main window. Selection handling is unchanged — single words go through bare, multi-word selections search as a quoted phrase.

Full suite: **852 passed, 0 failed**.

## No JS fallback needed

Confirmed by hand that CEF does **not** swallow ⌘D/⌘F when the book text has focus — unlike ⌘W, which is why that one carries a JS keydown forward. The native menu accelerator reaches us in every focus state, so `d`/`f` do not need adding to the injected handler alongside `c`/`a`/`e`/`w`.
