### PR TITLE
#111: ⌘O reveals the book tree; Enter opens the selected book

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1308,7 +1308,14 @@ public partial class App : Application
             // #110: File > Close Tab (⌘W) — closes the active document tab in this floating window.
             var closeTabItem = new NativeMenuItem { Header = "Close Tab", Gesture = KeyGesture.Parse("Cmd+W") };
             closeTabItem.Click += (s, e) => OnCloseTabFromFloatingWindow(window);
+            // #111: Select a Book (Cmd+O) — the tree lives in the main window, so this reveals and focuses
+            // it there, the same as the main window's File menu item.
+            var selectBookMenuItem = new NativeMenuItem { Header = "Select a Book", Gesture = KeyGesture.Parse("Cmd+O") };
+            selectBookMenuItem.Click += (s, e) => SimpleTabbedWindow.RevealSelectBookPanel();
+
             var fileMenu = new NativeMenu();
+            fileMenu.Add(selectBookMenuItem);
+            fileMenu.Add(new NativeMenuItemSeparator());
             fileMenu.Add(closeTabItem);
 
             var nativeMenu = new NativeMenu();

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml
@@ -20,10 +20,12 @@
             <Border BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="1">
                 <DockPanel>
                     <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
-                        <TreeView ItemsSource="{Binding BookTree}"
+                        <TreeView x:Name="BookTreeView"
+                                  ItemsSource="{Binding BookTree}"
                                   SelectedItem="{Binding SelectedNode}"
                                   Background="{DynamicResource SolidBackgroundFillColorBaseBrush}"
-                                  DoubleTapped="TreeView_DoubleTapped">
+                                  DoubleTapped="TreeView_DoubleTapped"
+                                  KeyDown="TreeView_KeyDown">
                             <TreeView.Styles>
                                 <!-- Style for TreeViewItem -->
                                 <Style Selector="TreeViewItem" x:DataType="vm:BookTreeNode">

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 using CST.Avalonia.ViewModels;
 using CST.Conversion;
 using Serilog;
@@ -25,6 +29,50 @@ public partial class OpenBookPanel : UserControl
         };
     }
     
+    // Put keyboard focus on the book tree, so Cmd+O lands the user somewhere they can immediately
+    // arrow around. Selects the first root node when nothing is selected yet - a TreeView with no
+    // selection swallows the first arrow key otherwise. (#111: Cmd+O)
+    public void FocusBookTree()
+    {
+        var tree = this.FindControl<TreeView>("BookTreeView");
+        if (tree == null)
+            return;
+
+        if (tree.SelectedItem == null && DataContext is OpenBookDialogViewModel { BookTree.Count: > 0 } viewModel)
+            tree.SelectedItem = viewModel.BookTree[0];
+
+        FocusSelectedTreeItem(tree, attemptsLeft: 5);
+    }
+
+    // Focus the selected node's TreeViewItem, NOT the TreeView itself: Avalonia routes arrow keys from the
+    // focused item container, so focusing the TreeView leaves the tree unnavigable. The container may not
+    // be realized yet when the panel was just created or revealed, so retry across a few dispatcher passes
+    // rather than giving up on the first miss. (#111: Cmd+O)
+    private static void FocusSelectedTreeItem(TreeView tree, int attemptsLeft)
+    {
+        var selected = tree.SelectedItem;
+        var item = tree.GetVisualDescendants().OfType<TreeViewItem>()
+            .FirstOrDefault(i => ReferenceEquals(i.DataContext, selected));
+
+        if (item != null)
+        {
+            item.BringIntoView();
+            item.Focus(NavigationMethod.Directional);
+            Log.Debug("[OpenBookPanel] Focused tree item {Node}", (selected as BookTreeNode)?.DisplayName ?? "?");
+            return;
+        }
+
+        if (attemptsLeft > 0)
+        {
+            Dispatcher.UIThread.Post(() => FocusSelectedTreeItem(tree, attemptsLeft - 1), DispatcherPriority.Background);
+            return;
+        }
+
+        // Containers never appeared (empty tree, say) — at least put focus in the panel.
+        tree.Focus();
+        Log.Debug("[OpenBookPanel] No tree item container to focus; focused the TreeView instead");
+    }
+
     public void UpdateScript(Script script)
     {
         if (DataContext is OpenBookDialogViewModel viewModel)
@@ -39,40 +87,62 @@ public partial class OpenBookPanel : UserControl
     private void TreeView_DoubleTapped(object? sender, RoutedEventArgs e)
     {
         Log.Debug("[OpenBookPanel] TreeView double-tapped");
-        
-        // Get the DataContext (OpenBookDialogViewModel)
-        if (DataContext is OpenBookDialogViewModel viewModel && viewModel.SelectedNode != null)
+        OpenSelectedBook("double-tap");
+    }
+
+    // Enter opens the selected book, as it did in CST4 — without it the tree can be reached and navigated
+    // by keyboard but not acted on, which is exactly the gap Cmd+O would otherwise leave. On a container
+    // node Enter expands/collapses instead, since there is nothing to open. (#111)
+    private void TreeView_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Enter)
+            return;
+
+        if (DataContext is not OpenBookDialogViewModel viewModel || viewModel.SelectedNode is not { } node)
+            return;
+
+        if (node.NodeType == BookTreeNodeType.Book)
         {
-            Log.Debug("[OpenBookPanel] Selected node: {NodeName} (Type: {NodeType})", 
-                viewModel.SelectedNode.DisplayName, viewModel.SelectedNode.NodeType);
-            
-            // Only open if it's a book node (leaf node)
-            if (viewModel.SelectedNode.NodeType == BookTreeNodeType.Book)
-            {
-                Log.Debug("[OpenBookPanel] Checking if command can execute for book: {FileName}", 
-                    viewModel.SelectedNode.CstBook?.FileName ?? "null");
-                
-                // Execute the open book command
-                if (viewModel.OpenBookCommand.CanExecute(viewModel.SelectedNode))
-                {
-                    Log.Information("[OpenBookPanel] Opening book from tree: {FileName}", 
-                        viewModel.SelectedNode.CstBook?.FileName ?? "null");
-                    viewModel.OpenBookCommand.Execute(viewModel.SelectedNode);
-                    Log.Debug("[OpenBookPanel] OpenBookCommand.Execute completed");
-                }
-                else
-                {
-                    Log.Debug("[OpenBookPanel] Command cannot execute");
-                }
-            }
-            else
-            {
-                Log.Debug("[OpenBookPanel] Not a book node, ignoring double-tap");
-            }
+            OpenSelectedBook("Enter");
         }
         else
         {
+            node.IsExpanded = !node.IsExpanded;
+            Log.Debug("[OpenBookPanel] Enter toggled node {NodeName} to expanded={Expanded}",
+                node.DisplayName, node.IsExpanded);
+        }
+
+        e.Handled = true;
+    }
+
+    // Shared by the double-tap and Enter paths, so the two can't diverge.
+    private void OpenSelectedBook(string source)
+    {
+        if (DataContext is not OpenBookDialogViewModel viewModel || viewModel.SelectedNode == null)
+        {
             Log.Debug("[OpenBookPanel] No valid DataContext or SelectedNode");
+            return;
+        }
+
+        var node = viewModel.SelectedNode;
+        Log.Debug("[OpenBookPanel] Selected node: {NodeName} (Type: {NodeType})", node.DisplayName, node.NodeType);
+
+        // Only open if it's a book node (leaf node)
+        if (node.NodeType != BookTreeNodeType.Book)
+        {
+            Log.Debug("[OpenBookPanel] Not a book node, ignoring {Source}", source);
+            return;
+        }
+
+        if (viewModel.OpenBookCommand.CanExecute(node))
+        {
+            Log.Information("[OpenBookPanel] Opening book from tree via {Source}: {FileName}",
+                source, node.CstBook?.FileName ?? "null");
+            viewModel.OpenBookCommand.Execute(node);
+        }
+        else
+        {
+            Log.Debug("[OpenBookPanel] Command cannot execute");
         }
     }
 }

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -15,6 +15,10 @@
             <!-- File Menu (#110): ⌘W closes the active document tab (book or PDF) in the focused window -->
             <NativeMenuItem Header="File">
                 <NativeMenu>
+                    <!-- #111: ⌘O reveals the book tree and focuses it; it never hides the panel
+                         (the View menu checkbox does that). CST4's Ctrl+O opened the book dialog. -->
+                    <NativeMenuItem Header="Select a Book" Click="OnSelectBookClick" Gesture="cmd+o" />
+                    <NativeMenuItemSeparator />
                     <NativeMenuItem Header="Close Tab" Click="OnCloseTabClick" Gesture="cmd+w" />
                 </NativeMenu>
             </NativeMenuItem>

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -733,11 +733,65 @@ public partial class SimpleTabbedWindow : Window
         }
     }
 
+    // "Select a Book" (Cmd+O): reveal the book tree and put keyboard focus in it. Deliberately never
+    // hides the panel — Cmd+O means "I want to open a book", so closing the tree on a second press
+    // would be the opposite of the intent. The View menu checkbox is still how you hide it. (#111)
+    private void OnSelectBookClick(object? sender, EventArgs e) => RevealSelectBookPanel();
+
+    internal static void RevealSelectBookPanel()
+    {
+        try
+        {
+            if (App.MainWindow?.DataContext is not LayoutViewModel layoutViewModel)
+                return;
+
+            if (App.ServiceProvider?.GetService(typeof(OpenBookDialogViewModel)) is not OpenBookDialogViewModel openBook)
+                return;
+
+            // Recreates the panel if it was closed, same recreate-on-demand path as Cmd+D / Cmd+F.
+            layoutViewModel.ShowSelectBookPanel();
+            layoutViewModel.Factory?.SetActiveDockable(openBook);
+
+            var host = RevealWindowHosting(openBook, layoutViewModel);
+
+            // Focus after the layout settles: when the panel was just recreated, its view doesn't exist
+            // yet at this point, so focusing now would find nothing to focus.
+            Dispatcher.UIThread.Post(() =>
+            {
+                // A focused CEF WebView (a book, or the Welcome page) holds the platform keyboard focus,
+                // and focusing an Avalonia control does not take it back — keystrokes keep going to the
+                // page, so the tree looked focused but arrow keys went nowhere. Release it first.
+                ReleaseWebViewKeyboardFocus(host);
+                host?.FindDescendantOfType<OpenBookPanel>()?.FocusBookTree();
+            }, DispatcherPriority.Loaded);
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Select a Book (Cmd+O) failed");
+        }
+    }
+
+    // Ask the top level to drop whatever holds focus before the tree takes it. This is enough when focus
+    // sits on an Avalonia control; it is NOT enough when a CEF WebView (a book, or the Welcome page) holds
+    // the platform keyboard focus, which is the known limitation on #111 — the panel still reveals, but
+    // arrow keys keep going to the page until you click the tree.
+    private static void ReleaseWebViewKeyboardFocus(Window? host)
+    {
+        try
+        {
+            host?.FocusManager?.ClearFocus();
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Debug(ex, "Could not clear focus before focusing the book tree");
+        }
+    }
+
     // Bring the window that actually holds a tool to the front. The tool is usually docked in the main
     // window, but it can be floated into its own window — and then activating the main window would bury
     // the very pane the shortcut just revealed. Activating the main window when it already is the host is
     // a harmless no-op. (#448 follow-up)
-    private static void RevealWindowHosting(IDockable tool, LayoutViewModel layoutViewModel)
+    private static Window? RevealWindowHosting(IDockable tool, LayoutViewModel layoutViewModel)
     {
         var hostWindows = layoutViewModel.Factory?.HostWindows;
         if (hostWindows != null)
@@ -748,12 +802,13 @@ public partial class SimpleTabbedWindow : Window
                     LayoutContains(hostWindow.Layout, tool))
                 {
                     hostWindow.Activate();
-                    return;
+                    return hostWindow;
                 }
             }
         }
 
         App.MainWindow?.Activate();
+        return App.MainWindow;
     }
 
     private static bool LayoutContains(IDock dock, IDockable target)


### PR DESCRIPTION
Part of #111 (keyboard shortcuts umbrella). Does not close it.

## ⌘O — Select a Book

`File > Select a Book` (⌘O) on the main window and on floating windows, above Close Tab so File reads Open / Close. CST4 had Ctrl+O for this; the View menu item existed here but carried no gesture.

**⌘O reveals, it never hides.** Pressing it means "I want to open a book", so toggling the panel shut on a second press would be the opposite of the intent — the View menu checkbox stays the way to hide it. It reuses the recreate-on-demand path (so it reopens a closed panel) and the host-window reveal from #448 (so a book tree floated into its own window is raised, not buried).

## Enter opens the selected book

As in CST4. Shares one code path with the existing double-tap handler, so the mouse and keyboard routes can't drift. On a category node Enter expands/collapses instead, since there's nothing to open.

## Known limitation — deliberately shipped this way

⌘O tries to focus the selected node's `TreeViewItem` (Avalonia routes arrow keys from the item container, not from the `TreeView`), retrying across dispatcher passes because the container isn't realized when the panel has just been created. That works from an ordinary Avalonia control, but **not when a CEF WebView — a book, or the Welcome page — holds the platform keyboard focus**: the tree is focused as far as Avalonia is concerned while arrow keys still reach the page. Clearing top-level focus first isn't enough.

So: the panel reveal is reliable, and opening a book may still need the mouse. That's worth shipping on its own, and the residual focus problem is recorded on #111 along with what was tried. It's the same class as the `cstKeyboardCapture` JS relay (CEF swallowing keys before Avalonia sees them), catalogued in `docs/architecture/DOCK_WEBVIEW_WORKAROUNDS.md` section G. The likely next move is a filter/search box atop the tree, which takes focus cleanly where a TreeView contending with CEF doesn't — and would be useful in its own right.

An earlier attempt that hid the focused WebView for a dispatcher pass (the move the drag path uses) was **removed before this PR**: unverified, and it risks visible flicker for a focus fix that isn't proven.

## Verification

Manual: ⌘O with the panel hidden, visible, and from a floating book window. Full suite: **852 passed, 0 failed**.
