### PR TITLE
#187: validate page anchors on navigate, and land on the page the caller meant

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/NavigateEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/NavigateEndpointTests.cs
@@ -313,6 +313,121 @@ namespace CST.Avalonia.Tests.Integration
             Assert.IsType<PresentationTarget.Hit>(_reader.Last!.Target);
         }
 
+        // ---- page-anchor validation (#187) ----
+        // The fixture books carry a single VRI page break, <pb ed="V" n="1.0001"/>, so V1.0001 exists and
+        // anything else does not.
+
+        [Fact]
+        public async Task A_real_page_anchor_is_accepted_and_carries_no_caveat()
+        {
+            var (status, body) = await PostAsync(new { bookId = _api.MulaBook, anchor = "V1.0001" });
+
+            Assert.Equal(HttpStatusCode.OK, status);
+            Assert.True(body!.Presented);
+            Assert.Null(body.Note);      // verified, so nothing to warn about
+            var target = Assert.IsType<PresentationTarget.Anchor>(_reader.Last!.Target);
+            Assert.Equal("V1.0001", target.Name);
+        }
+
+        [Fact]
+        public async Task A_page_anchor_the_book_does_not_have_is_refused()
+        {
+            // The point of the feature: "presented: true" must not be possible for a page that isn't there.
+            var (status, body) = await PostAsync(new { bookId = _api.MulaBook, anchor = "V9.9999" });
+
+            Assert.Equal(HttpStatusCode.BadRequest, status);
+            Assert.False(body!.Presented);
+            Assert.Contains("V9.9999", body.Error);
+            Assert.Empty(_reader.Requests);   // the reader was never driven
+        }
+
+        [Fact]
+        public async Task An_edition_the_book_does_not_carry_says_which_it_has()
+        {
+            // Not every text was printed in every edition, so the useful answer is "this book has no PTS
+            // numbering; it carries: Vri" rather than "page missing".
+            var (status, body) = await PostAsync(new { bookId = _api.MulaBook, anchor = "P1.0001" });
+
+            Assert.Equal(HttpStatusCode.BadRequest, status);
+            Assert.Contains("Pts", body!.Error);
+            Assert.Contains("Vri", body.Error);
+        }
+
+        [Fact]
+        public async Task A_non_page_anchor_is_still_accepted_but_flagged_as_unverified()
+        {
+            // Paragraph/chapter anchors have nothing trustworthy to check against yet (#447), so they must be
+            // reported as unchecked rather than silently implying the same guarantee as a page anchor.
+            var (status, body) = await PostAsync(new { bookId = _api.MulaBook, anchor = "para1" });
+
+            Assert.Equal(HttpStatusCode.OK, status);
+            Assert.True(body!.Presented);
+            Assert.Contains("not verified", body.Note);
+        }
+
+        [Fact]
+        public async Task A_hit_target_is_unaffected_by_page_validation()
+        {
+            var (status, body) = await PostAsync(
+                new { bookId = _api.MulaBook, terms = "dhamma", hit = 1, anchor = "V9.9999" });
+
+            // hit wins over anchor, so the bogus page anchor is never used and must not refuse the request.
+            Assert.Equal(HttpStatusCode.OK, status);
+            Assert.True(body!.Presented);
+            Assert.IsType<PresentationTarget.Hit>(_reader.Last!.Target);
+        }
+
+        [Fact]
+        public async Task An_unpadded_page_anchor_is_rewritten_to_the_documents_own_spelling()
+        {
+            // The HTML anchor is `ed + @n` matched EXACTLY, so "V1.1" and "V1.0001" name the same page but only
+            // the document's spelling resolves. An agent composing a reference from refs/pages — which serialize
+            // as bare ints — naturally writes the unpadded form. Validating already found the real spelling, so
+            // navigate with it instead of blessing an anchor that would silently miss. (fable HIGH-1)
+            var (status, body) = await PostAsync(new { bookId = _api.MulaBook, anchor = "V1.1" });
+
+            Assert.Equal(HttpStatusCode.OK, status);
+            Assert.True(body!.Presented);
+            var target = Assert.IsType<PresentationTarget.Anchor>(_reader.Last!.Target);
+            Assert.Equal("V1.0001", target.Name);
+        }
+
+        [Fact]
+        public async Task Surrounding_whitespace_does_not_defeat_validation()
+        {
+            // Validating the trimmed string while navigating with the untrimmed one is the same class of bug.
+            var (status, _) = await PostAsync(new { bookId = _api.MulaBook, anchor = "  V1.0001  " });
+
+            Assert.Equal(HttpStatusCode.OK, status);
+            var target = Assert.IsType<PresentationTarget.Anchor>(_reader.Last!.Target);
+            Assert.Equal("V1.0001", target.Name);
+        }
+
+        [Fact]
+        public async Task An_out_of_range_page_coordinate_is_refused_not_silently_blessed()
+        {
+            // Too large to parse as an int. Nothing in the book can match it, so it is a definite miss rather
+            // than an unverifiable one. (fable MED-3)
+            var (status, body) = await PostAsync(new { bookId = _api.MulaBook, anchor = "V1.99999999999" });
+
+            Assert.Equal(HttpStatusCode.BadRequest, status);
+            Assert.Empty(_reader.Requests);
+            Assert.Contains("out of range", body!.Error);
+        }
+
+        [Fact]
+        public async Task Both_a_highlight_note_and_an_anchor_caveat_survive_together()
+        {
+            // Each note is independently load-bearing and llms.txt promises both, so first-wins would silently
+            // drop the caveat that the anchor was never checked. (fable MED-2)
+            var (status, body) = await PostAsync(
+                new { bookId = _api.MulaBook, terms = "nibbana", anchor = "para1" });
+
+            Assert.Equal(HttpStatusCode.OK, status);
+            Assert.Contains("No occurrences", body!.Note);
+            Assert.Contains("not verified", body.Note);
+        }
+
         // ---- MCP surface ----
         // The REST route and the MCP tool share NavigateService; these assert that the sharing is real, so the
         // two surfaces cannot drift in consent or behaviour. (fable: "one implementation" was untested)

--- a/src/CST.Avalonia.Tests/Services/NavigateDegradeTests.cs
+++ b/src/CST.Avalonia.Tests/Services/NavigateDegradeTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CST.Avalonia.Services.LocalApi;
+using CST.Avalonia.Tests.TestSupport;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services
+{
+    /// <summary>
+    /// The one page-anchor path that must NEVER refuse: being unable to verify an anchor is not the same as
+    /// knowing it is wrong. If a missing corpus directory or an unreadable book could block navigation, this
+    /// feature would be worse than the gap it closes — a user would be denied a perfectly good reference
+    /// because of a configuration problem. Exercised directly against NavigateService (no HTTP), because the
+    /// integration harness always supplies a corpus directory. (#187, fable LOW-4)
+    /// </summary>
+    public class NavigateDegradeTests
+    {
+        private static string AnyBook() =>
+            CST.Books.Inst.First(b => b.FileName.EndsWith(".mul.xml", StringComparison.Ordinal)).FileName;
+
+        private static NavigateService Service(string? xmlDir, RecordingPresentationService reader) =>
+            new(reader, search: null, isRemoteControlAllowed: () => true, xmlBooksDirectory: xmlDir);
+
+        [Fact]
+        public async Task An_unconfigured_corpus_directory_still_navigates_and_says_it_could_not_verify()
+        {
+            var reader = new RecordingPresentationService();
+            var svc = Service(null, reader);
+
+            var (outcome, response) = await svc.NavigateAsync(new NavigateRequest(AnyBook(), Anchor: "V1.0023"));
+
+            Assert.Equal(NavigateOutcome.Presented, outcome);
+            Assert.True(response.Presented);
+            Assert.Contains("not verified", response.Note);
+            Assert.Single(reader.Requests);   // the reader WAS driven — an unverifiable anchor is not a refusal
+        }
+
+        [Fact]
+        public async Task A_missing_book_file_still_navigates_and_says_it_could_not_verify()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cst-degrade-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);   // exists, but contains no book files
+            try
+            {
+                var reader = new RecordingPresentationService();
+                var svc = Service(dir, reader);
+
+                var (outcome, response) = await svc.NavigateAsync(new NavigateRequest(AnyBook(), Anchor: "V1.0023"));
+
+                Assert.Equal(NavigateOutcome.Presented, outcome);
+                Assert.True(response.Presented);
+                Assert.Contains("not verified", response.Note);
+                Assert.Single(reader.Requests);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { /* best-effort */ }
+            }
+        }
+
+        [Fact]
+        public async Task A_corrupt_corpus_path_does_not_escape_as_an_unhandled_error()
+        {
+            // A settings value with invalid path characters throws ArgumentException rather than IOException.
+            // The contract is that ANY inability to check degrades, so this must not surface as a 500.
+            var reader = new RecordingPresentationService();
+            var svc = Service("\0not-a-real-path", reader);
+
+            var (outcome, response) = await svc.NavigateAsync(new NavigateRequest(AnyBook(), Anchor: "V1.0023"));
+
+            Assert.Equal(NavigateOutcome.Presented, outcome);
+            Assert.Contains("not verified", response.Note);
+        }
+
+        [Fact]
+        public async Task An_unverifiable_anchor_is_passed_through_unchanged()
+        {
+            // No canonical spelling is known when verification could not run, so the caller's anchor must reach
+            // the reader as given rather than being silently altered.
+            var reader = new RecordingPresentationService();
+            var svc = Service(null, reader);
+
+            await svc.NavigateAsync(new NavigateRequest(AnyBook(), Anchor: "V1.23"));
+
+            var target = Assert.IsType<CST.Avalonia.Services.Presentation.PresentationTarget.Anchor>(
+                reader.Last!.Target);
+            Assert.Equal("V1.23", target.Name);
+        }
+    }
+}

--- a/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
+++ b/src/CST.Avalonia.Tests/TestSupport/LocalApiTestServer.cs
@@ -137,6 +137,9 @@ namespace CST.Avalonia.Tests.TestSupport
             var server = new LocalApiServer("test", handshakeDir, Serilog.Log.Logger,
                 searchTool, dictionary: null, passage: passageTool, script: scriptTool,
                 lemma: lemmaSearch, lemmaReport: lemmaReport,
+                // The corpus dir is what lets navigate VALIDATE a page anchor against the book's real page
+                // breaks (#187) — without it validation degrades to "could not verify".
+                xmlBooksDirectory: xmlDir,
                 presentation: presentation, searchService: searchService,
                 isRemoteControlAllowed: isRemoteControlAllowed);
             await server.StartAsync();

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -218,6 +218,15 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   chapter id also work, but paragraph numbers repeat in many books (see the reading section), so a page anchor
   is far more likely to land where you meant. Use an edition the book actually has - take it from an
   `occurrences` hit's `refs` or a `/v1/passage` window's `pages`; not every text was printed in every edition.
+  PAGE ANCHORS ARE VERIFIED: a page anchor the book does not contain is REFUSED with a 400 naming the editions
+  the book does carry, so a verified navigate cannot land you somewhere that isn't the page you asked for.
+  You also do not have to match the document's zero-padding - send `V1.23` or `V1.0023` and either resolves,
+  because the anchor is rewritten to the book's own spelling once it is found. If verification cannot RUN at
+  all (e.g. the corpus files are unavailable) the navigate still proceeds and says so in `note` - being unable
+  to check is not the same as knowing the reference is wrong - but the anchor is then used EXACTLY as you sent
+  it, so prefer the document's own spelling (`V1.0023`) when you have it. Other anchor forms (paragraph, chapter) are NOT
+  verified - paragraph numbers are not unique corpus-wide - so those come back with a `note` saying the anchor
+  was unchecked, and a wrong one opens the book at its start.
   `terms` is a query (same syntax as `/v1/search`) whose matches are HIGHLIGHTED in the opened book; `hit` is a
   1-based match to land on and REQUIRES `terms`. Omit `outputScript` to keep the reader's current script.
   Returns `{ presented, error, bookId, highlights, note }` - on every outcome this endpoint produces, including

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -94,7 +94,8 @@ namespace CST.Avalonia.Services.LocalApi
             // grant an agent control of the user's window. (#187)
             _navigate = presentation is null
                 ? null
-                : new NavigateService(presentation, searchService, isRemoteControlAllowed ?? (() => false));
+                : new NavigateService(presentation, searchService, isRemoteControlAllowed ?? (() => false),
+                                      xmlBooksDirectory);
             _appVersion = appVersion;
             _handshakeDirectory = handshakeDirectory;
             _logger = logger.ForContext<LocalApiServer>();

--- a/src/CST.Avalonia/Services/LocalApi/NavigateService.cs
+++ b/src/CST.Avalonia/Services/LocalApi/NavigateService.cs
@@ -1,11 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models;
 using CST.Avalonia.Services.Presentation;
+using CST.Avalonia.Services.Tools;
+using CST.Navigation;
+using CST.Search;
+using Serilog;
 using TermPosition = CST.Avalonia.Models.TermPosition;
 using SearchMode = CST.Avalonia.Models.SearchMode;
 
@@ -40,12 +45,15 @@ namespace CST.Avalonia.Services.LocalApi
         private readonly IPresentationService _presentation;
         private readonly ISearchService? _search;
         private readonly Func<bool> _isRemoteControlAllowed;
+        private readonly string? _xmlBooksDirectory;
+        private readonly ILogger _logger = Log.ForContext<NavigateService>();
 
         public NavigateService(IPresentationService presentation, ISearchService? search,
-            Func<bool> isRemoteControlAllowed)
+            Func<bool> isRemoteControlAllowed, string? xmlBooksDirectory = null)
         {
             _presentation = presentation;
             _search = search;
+            _xmlBooksDirectory = xmlBooksDirectory;
             // A PREDICATE, not a captured bool: the user can revoke remote control in Settings while the server
             // is running, and that must take effect on the very next call.
             _isRemoteControlAllowed = isRemoteControlAllowed;
@@ -57,6 +65,14 @@ namespace CST.Avalonia.Services.LocalApi
             "Remote control is disabled. The user must enable Settings → AI → \"Allow agents to drive the " +
             "reader (navigate and highlight)\" before an agent can navigate; this is the user's decision, " +
             "not something to work around.";
+
+        // Both notes can be true at once (e.g. a query with no matches AND an unverifiable anchor), and each is
+        // load-bearing, so first-wins would silently drop a caveat the docs promise. (fable MED-2)
+        private static string? Combine(string? a, string? b) =>
+            a is null ? b : b is null ? a : a + " " + b;
+
+        // The page-anchor form the XSL emits and the reader looks up: edition letter, volume, '.', page.
+        private static readonly Regex PageAnchorRx = new(@"^([VMPTO])(\d+)\.(\d+)$", RegexOptions.Compiled);
 
         public async Task<(NavigateOutcome Outcome, NavigateResponse Response)> NavigateAsync(
             NavigateRequest req, CancellationToken ct = default)
@@ -107,9 +123,40 @@ namespace CST.Avalonia.Services.LocalApi
                     Failed($"The {req.Mode ?? SearchMode.Exact} pattern '{req.Terms}' is not valid: {ex.Message}"));
             }
 
+            // Validate a PAGE anchor before navigating. Page references are the corpus's reliable addressing
+            // scheme and the one we steer agents towards (#449), so "presented: true" must not be possible for a
+            // page the book does not have. Other anchor forms stay unvalidated — paragraph numbers are not
+            // unique corpus-wide and a chapter id needs structure many books lack (#447), so there is nothing
+            // trustworthy to check them against yet. (#187)
+            // Trim once and navigate with the SAME string that was validated — validating one spelling and
+            // navigating with another is exactly how a "verified" anchor still misses. (fable HIGH-1)
+            string? anchor = string.IsNullOrWhiteSpace(req.Anchor) ? null : req.Anchor!.Trim();
+
+            if (req.Hit is null && anchor is not null)
+            {
+                if (PageAnchorRx.Match(anchor) is { Success: true } pm)
+                {
+                    var check = await CheckPageAnchorAsync(book.FileName, pm, ct);
+                    if (check.Refused is { } refusal)
+                        return (NavigateOutcome.InvalidRequest, Failed(refusal, note));
+                    // Rewrite to the document's own spelling. The HTML anchor is `ed + @n` matched exactly, so
+                    // "V1.23" and "V1.0023" name the same page but only one resolves — and an agent composing a
+                    // reference from refs/pages (which serialize as bare ints) naturally writes the former.
+                    // Validating already found the real spelling, so use it. (fable HIGH-1)
+                    if (check.Canonical is { } canonical) anchor = canonical;
+                    note = Combine(note, check.Note);
+                }
+                else
+                {
+                    note = Combine(note,
+                        "The anchor was not verified — only page anchors (e.g. \"V1.0023\") are checked. " +
+                        "If it does not exist the book opens at its start.");
+                }
+            }
+
             PresentationTarget? target =
                 req.Hit is int hit ? new PresentationTarget.Hit(hit)
-                : !string.IsNullOrWhiteSpace(req.Anchor) ? new PresentationTarget.Anchor(req.Anchor!)
+                : anchor is not null ? new PresentationTarget.Anchor(anchor)
                 : null;
 
             var request = new PresentationRequest
@@ -134,6 +181,64 @@ namespace CST.Avalonia.Services.LocalApi
 
             return (NavigateOutcome.Presented,
                 new NavigateResponse(true, null, book.FileName, positions.Count, note));
+        }
+
+
+        /// <summary>
+        /// Confirm a page anchor exists in the book, using the same parsed marker index the passage and
+        /// occurrence paths use (so there is no second parser and no extra read on a warm cache).
+        /// Returns a refusal message when the page is definitively absent; a note when validation could not be
+        /// performed at all. Being unable to check must never block navigation — only a definite miss refuses.
+        /// </summary>
+        private async Task<(string? Refused, string? Note, string? Canonical)> CheckPageAnchorAsync(
+            string bookFileName, Match m, CancellationToken ct)
+        {
+            // Checked FIRST: an out-of-range coordinate is a definite miss whether or not the corpus is
+            // readable (BookMarkers only stores int-parseable pages), so refuse it uniformly rather than
+            // degrading, and skip a pointless file read. (fable MED-3 + nit)
+            if (!int.TryParse(m.Groups[2].Value, out int volume) || !int.TryParse(m.Groups[3].Value, out int page))
+                return ($"No page anchor '{m.Value}' in '{bookFileName}' — the volume or page number is out of range.",
+                        null, null);
+
+            if (string.IsNullOrWhiteSpace(_xmlBooksDirectory))
+                return (null, "The page anchor was not verified (the corpus directory is not configured).", null);
+
+            var path = Path.Combine(_xmlBooksDirectory!, bookFileName);
+            BookMarkers markers;
+            try
+            {
+                markers = (await BookTextCache.GetAsync(path, ct)).Markers;
+            }
+            // Being unable to check must NEVER block navigation, so this catches broadly: a corrupt corpus path
+            // (ArgumentException) or anything unexpected out of the parser would otherwise escape as a bodyless
+            // 500 — the one outcome this path is contracted not to produce. Cancellation still propagates.
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.Warning(ex, "Could not verify page anchor for {Book}", bookFileName);
+                return (null, "The page anchor was not verified (the book's text could not be read).", null);
+            }
+
+            var edition = m.Groups[1].Value switch
+            {
+                "V" => PageEdition.Vri,
+                "M" => PageEdition.Myanmar,
+                "P" => PageEdition.Pts,
+                "T" => PageEdition.Thai,
+                _ => PageEdition.Other
+            };
+            if (markers.TryGetPageAnchor(edition, volume, page, out var rawN))
+                return (null, null, m.Groups[1].Value + rawN);
+
+            // Report which editions the book actually carries. Not every text was printed in every edition, so
+            // the useful answer is usually "that edition isn't in this book" rather than "that page is missing".
+            var have = markers.Editions();
+            string hint = have.Count == 0
+                ? "This book has no page breaks at all."
+                : have.Contains(edition)
+                    ? $"This book carries {edition} pages, but not {volume}.{page}."
+                    : $"This book has no {edition} page numbering; it carries: {string.Join(", ", have)}.";
+            return ($"No page anchor '{m.Value}' in '{bookFileName}'. {hint} " +
+                    "Take a page reference from an occurrence's refs or a passage window's pages.", null, null);
         }
 
         /// <summary>

--- a/src/CST.Core/Search/BookMarkers.cs
+++ b/src/CST.Core/Search/BookMarkers.cs
@@ -17,7 +17,9 @@ namespace CST.Search
 
         // Ascending-by-position lists.
         private readonly List<(int Pos, int Number, string? BookCode)> _paras = new();
-        private readonly Dictionary<PageEdition, List<(int Pos, int Volume, int Number)>> _pages = new();
+        // Raw is the VERBATIM @n ("1.0023"). The HTML anchor is ed + that exact string and the reader looks it
+        // up case/character-exactly, so the raw spelling — not the parsed ints — is what can be navigated to.
+        private readonly Dictionary<PageEdition, List<(int Pos, int Volume, int Number, string Raw)>> _pages = new();
 
         private BookMarkers() { }
 
@@ -45,7 +47,7 @@ namespace CST.Search
                         {
                             if (!m._pages.TryGetValue(edition, out var list))
                                 m._pages[edition] = list = new();
-                            list.Add((tag.Index, vol, num));
+                            list.Add((tag.Index, vol, num, pn));
                         }
                         break;
 
@@ -82,6 +84,33 @@ namespace CST.Search
             }
             pages.Sort((a, b) => a.Edition.CompareTo(b.Edition));
             return (number, code, pages);
+        }
+
+        /// <summary>
+        /// Look up a page break by its parsed coordinates and return the VERBATIM <c>@n</c> that the document
+        /// actually carries (e.g. "1.0023"). Callers must navigate with this spelling rather than one they
+        /// composed: the HTML anchor is <c>ed + @n</c> matched exactly, so "V1.23" and "V1.0023" address the
+        /// same page but only one of them resolves. (#187)
+        /// </summary>
+        public bool TryGetPageAnchor(PageEdition edition, int volume, int number, out string rawN)
+        {
+            if (_pages.TryGetValue(edition, out var list))
+                foreach (var p in list)
+                    if (p.Volume == volume && p.Number == number) { rawN = p.Raw; return true; }
+            rawN = string.Empty;
+            return false;
+        }
+
+        /// <summary>
+        /// The page editions this book carries, in a stable order. Not every text was printed in every edition —
+        /// the VRI set is 140 volumes and many texts were never published outside Myanmar — so this reports what
+        /// is actually present rather than what a caller hoped for. (#187)
+        /// </summary>
+        public IReadOnlyList<PageEdition> Editions()
+        {
+            var eds = new List<PageEdition>(_pages.Keys);
+            eds.Sort();
+            return eds;
         }
 
         /// <summary>The distinct sub-book codes in this book, in first-appearance order (empty for a non-Multi


### PR DESCRIPTION
`POST /v1/navigate` accepted any anchor unchecked — a nonexistent one opened the book at its start and still reported `presented: true`, documented in llms.txt as a known limitation. Per your decision this closes it for **page anchors only**: page numbers are the corpus's reliable addressing scheme and the one we now steer agents toward (#449), while paragraph numbers are ambiguous in 102 of 217 books (#447) and chapter ids need structure many books lack — there is nothing trustworthy to check those against yet.

## What it does

A page anchor is checked against the book's real `<pb>` markers, reusing the `BookMarkers` already parsed by `BookTextCache` — the same index `/v1/passage` and `/v1/occurrences` use, so no second parser and no extra read on a warm cache.

A definite miss returns **400** and never touches the reader, naming the editions the book *does* carry. Not every text was printed in every edition, so "this book has no Pts numbering; it carries: Vri" is the useful answer rather than "page missing".

## Validation also normalizes — the better half of the change

The HTML anchor is `ed + @n` matched **exactly**, so `V1.23` and `V1.0023` name the same page but only the document's spelling resolves. An agent composing a reference from `refs`/`pages` — which serialize as bare ints — naturally writes the unpadded form. Since validation has already found the real spelling, the anchor is rewritten to it.

So the most likely caller mistake now **lands on the right page** instead of silently missing, and the one corpus anomaly (`M0.01645` in `e0801n.nrf`, #453) — unreachable under any padding rule — becomes addressable.

## Being unable to check never blocks

An unset corpus directory, an unreadable book, or a corrupt path degrades to a `note` and proceeds. Not knowing a reference is wrong is not the same as knowing it is; refusing on uncertainty would make this worse than the gap it closes. Only a definite miss refuses. Non-page anchors still work, flagged as unverified rather than silently implying the same guarantee.

## Review

Fable reviewed twice, and the first pass earned its keep: validating parsed ints while navigating with the caller's string left **exactly the hole this change claims to close** — a "verified" `V1.23` would still open at the book's start, while llms.txt now promised it couldn't. Its canonical-rewrite suggestion is what turned that into the normalization above. It also caught first-wins note handling dropping caveats the docs promise, an out-of-range coordinate being blessed rather than refused, and that the never-block path had no tests at all. Round two verified the grammar against all 217 corpus files and confirmed no (edition, volume, page) has two spellings.

## Testing

37 navigate + degrade tests. The padding test pins the rewrite — verified load-bearing by reverting that single line and watching it fail — and four new tests cover the degrade path, which previously had none. Full suite **865/865**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)