### PR TITLE
#443: window shortcuts act on the split the user is in, not the first one

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DocumentTargetResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DocumentTargetResolverTests.cs
@@ -1,0 +1,226 @@
+using CST.Avalonia.Services;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// #443: window-level shortcuts (Cmd+W / Cmd+G / Cmd+E / Cmd+D / Cmd+F) used to act on the FIRST
+/// DocumentDock in the layout, so in a split they hit the left/top pane no matter where the user was
+/// working. Resolution now follows focus, with the old first-dock behaviour as the fallback.
+/// </summary>
+public class DocumentTargetResolverTests
+{
+    private sealed class TestDocument : Document
+    {
+    }
+
+    // root
+    //  +-- documentDockA [docA1, docA2]   <- first in tree order
+    //  +-- documentDockB [docB1]          <- the "second split"
+    private static (RootDock Root, DocumentDock A, DocumentDock B, TestDocument A1, TestDocument A2, TestDocument B1)
+        BuildSplitLayout()
+    {
+        var docA1 = new TestDocument { Id = "docA1", Title = "A1" };
+        var docA2 = new TestDocument { Id = "docA2", Title = "A2" };
+        var docB1 = new TestDocument { Id = "docB1", Title = "B1" };
+
+        var dockA = new DocumentDock
+        {
+            Id = "MainDocumentDock",
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { docA1, docA2 },
+            ActiveDockable = docA1
+        };
+
+        var dockB = new DocumentDock
+        {
+            // Real splits produce TWO docks both carrying this id - resolution must not depend on it.
+            Id = "MainDocumentDock",
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { docB1 },
+            ActiveDockable = docB1
+        };
+
+        var root = new RootDock
+        {
+            Id = "Root",
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { dockA, dockB }
+        };
+
+        return (root, dockA, dockB, docA1, docA2, docB1);
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_FocusInSecondSplit_ReturnsThatSplitsDocument()
+    {
+        var (root, _, _, _, _, docB1) = BuildSplitLayout();
+
+        root.FocusedDockable = docB1;
+
+        // The bug: this returned docA1, the first dock's active tab.
+        Assert.Same(docB1, DocumentTargetResolver.ResolveActiveDocument(root));
+    }
+
+    // The `preferred` argument is what production actually passes: real Avalonia keyboard focus, since
+    // Dock never populates RootDock.FocusedDockable in this app. These are the #443 bug as the app runs it.
+
+    [Fact]
+    public void ResolveActiveDocument_PreferredDocumentInSecondSplit_ReturnsIt()
+    {
+        var (root, _, _, _, _, docB1) = BuildSplitLayout();
+
+        // Focus resolved from the visual tree: the user clicked the second split's tab or its book body.
+        Assert.Same(docB1, DocumentTargetResolver.ResolveActiveDocument(root, docB1));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_PreferredIsADocumentDock_ReturnsThatDocksActiveTab()
+    {
+        var (root, _, dockB, _, _, docB1) = BuildSplitLayout();
+
+        // Focus landed on the pane itself (tab-strip background) rather than on a tab.
+        Assert.Same(docB1, DocumentTargetResolver.ResolveActiveDocument(root, dockB));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_PreferredNotInAnyDocumentDock_FallsBackToFirstDocumentDock()
+    {
+        var (root, _, _, docA1, _, _) = BuildSplitLayout();
+
+        // A tool (Search/Dictionary/book tree) has focus - no better signal, so behave as before #443.
+        var tool = new Tool { Id = "SearchTool", Title = "Search" };
+
+        Assert.Same(docA1, DocumentTargetResolver.ResolveActiveDocument(root, tool));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_PreferredFromAnotherWindowsLayout_FallsBackRatherThanActingOnIt()
+    {
+        var (root, _, _, docA1, _, _) = BuildSplitLayout();
+
+        // Avalonia's FocusManager is app-global, so a floating window's handler can be handed a dockable
+        // that lives in the MAIN window's layout. Containment is the only guard - it must hold, or a
+        // shortcut in one window would act on another window's tab.
+        var (otherRoot, _, _, _, _, foreignDoc) = BuildSplitLayout();
+        Assert.NotNull(otherRoot);
+
+        Assert.Same(docA1, DocumentTargetResolver.ResolveActiveDocument(root, foreignDoc));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_PreferredWins_EvenWhenDockFocusPointsElsewhere()
+    {
+        var (root, _, _, _, docA2, docB1) = BuildSplitLayout();
+
+        root.FocusedDockable = docA2;
+
+        // Real keyboard focus is the better signal; Dock's own value is stale-at-best here.
+        Assert.Same(docB1, DocumentTargetResolver.ResolveActiveDocument(root, docB1));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_PreferredAlreadyClosed_FallsBackToFirstDocumentDock()
+    {
+        var (root, _, dockB, docA1, _, docB1) = BuildSplitLayout();
+
+        dockB.VisibleDockables!.Remove(docB1);
+        dockB.ActiveDockable = null;
+
+        Assert.Same(docA1, DocumentTargetResolver.ResolveActiveDocument(root, docB1));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_FocusOnSecondSplitsDock_ReturnsItsActiveDocument()
+    {
+        var (root, _, dockB, _, _, docB1) = BuildSplitLayout();
+
+        // Focus can land on the dock rather than the document itself.
+        root.FocusedDockable = dockB;
+
+        Assert.Same(docB1, DocumentTargetResolver.ResolveActiveDocument(root));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_FocusOnNonActiveTab_PrefersTheFocusedDocument()
+    {
+        var (root, _, _, _, docA2, _) = BuildSplitLayout();
+
+        root.FocusedDockable = docA2;
+
+        Assert.Same(docA2, DocumentTargetResolver.ResolveActiveDocument(root));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_NoFocus_FallsBackToFirstDocumentDock()
+    {
+        var (root, _, _, docA1, _, _) = BuildSplitLayout();
+
+        root.FocusedDockable = null;
+
+        Assert.Same(docA1, DocumentTargetResolver.ResolveActiveDocument(root));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_StaleFocusOnClosedDocument_FallsBackToFirstDocumentDock()
+    {
+        var (root, _, dockB, docA1, _, docB1) = BuildSplitLayout();
+
+        // Focus names a document that has since been closed - FocusedDockable is not cleared for us.
+        root.FocusedDockable = docB1;
+        dockB.VisibleDockables!.Remove(docB1);
+        dockB.ActiveDockable = null;
+
+        Assert.Same(docA1, DocumentTargetResolver.ResolveActiveDocument(root));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_FocusOnToolOutsideAnyDocumentDock_FallsBackToFirstDocumentDock()
+    {
+        var (root, _, _, docA1, _, _) = BuildSplitLayout();
+
+        var tool = new Tool { Id = "SearchTool", Title = "Search" };
+        var toolDock = new ToolDock
+        {
+            Id = "LeftToolDock",
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { tool },
+            ActiveDockable = tool
+        };
+        root.VisibleDockables!.Insert(0, toolDock);
+        root.FocusedDockable = tool;
+
+        Assert.Same(docA1, DocumentTargetResolver.ResolveActiveDocument(root));
+    }
+
+
+    /// <summary>
+    /// Guards the assumption the resolver is built on: in Dock 11.3.6.5 the Tool class implements
+    /// IDocument as well as ITool, so a document CANNOT be identified by type - the resolver has to ask
+    /// the layout which dock holds the dockable. If a Dock upgrade ever separates these, this test fails
+    /// and the resolver could be simplified.
+    /// </summary>
+    [Fact]
+    public void DockTool_AlsoImplementsIDocument_SoTypeTestsCannotIdentifyDocuments()
+    {
+        Assert.True(new Tool() is Dock.Model.Controls.IDocument);
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_NullLayout_ReturnsNull()
+    {
+        Assert.Null(DocumentTargetResolver.ResolveActiveDocument(null));
+    }
+
+    [Fact]
+    public void FindFirstDocumentDock_NestedLayout_FindsDockBelowTheRoot()
+    {
+        var (root, dockA, _, _, _, _) = BuildSplitLayout();
+
+        var wrapper = new ProportionalDock
+        {
+            Id = "Wrapper",
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { root }
+        };
+
+        Assert.Same(dockA, DocumentTargetResolver.FindFirstDocumentDock(wrapper));
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1471,36 +1471,15 @@ public partial class App : Application
         try
         {
             Log.Information("Go To menu item clicked from floating window: {WindowTitle}", floatingWindow.Title);
-            Log.Information("Window type: {Type}", floatingWindow.GetType().Name);
 
-            // Floating windows are CstHostWindow instances with Layout property
-            if (floatingWindow is CstHostWindow hostWindow)
+            // Resolve the document the user is in - follows focus, so a split inside the floating window
+            // resolves to the pane they are actually working in rather than always the first. (#443)
+            if (FindActiveBookInFloatingWindow(floatingWindow) is { } bookViewModel)
             {
-                Log.Information("Found CstHostWindow");
-                Log.Information("HostWindow.Layout type: {Type}", hostWindow.Layout?.GetType().Name ?? "null");
-
-                if (hostWindow.Layout != null)
-                {
-                    // Find DocumentDock in the host window's layout
-                    var documentDock = FindDocumentDockInLayout(hostWindow.Layout) as Dock.Model.Mvvm.Controls.DocumentDock;
-                    Log.Information("DocumentDock found: {Found}", documentDock != null);
-
-                    if (documentDock != null)
-                    {
-                        Log.Information("DocumentDock.ActiveDockable type: {Type}", documentDock.ActiveDockable?.GetType().Name ?? "null");
-
-                        if (documentDock.ActiveDockable is BookDisplayViewModel bookViewModel)
-                        {
-                            Log.Information("Triggering Go To dialog for active book in floating window: {BookFile}", bookViewModel.Book.FileName);
-                            bookViewModel.InvokeOpenGoToDialog();
-                            return;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                Log.Warning("Window is not a CstHostWindow, type: {Type}", floatingWindow.GetType().Name);
+                Log.Information("Triggering Go To dialog for active book in floating window: {BookFile}",
+                    bookViewModel.Book.FileName);
+                bookViewModel.InvokeOpenGoToDialog();
+                return;
             }
 
             Log.Warning("Could not find active book document in floating window for Go To command");
@@ -1522,8 +1501,8 @@ public partial class App : Application
         if (floatingWindow is not CstHostWindow hostWindow || hostWindow.Layout == null)
             return null;
 
-        var documentDock = FindDocumentDockInLayout(hostWindow.Layout) as Dock.Model.Mvvm.Controls.DocumentDock;
-        return documentDock?.ActiveDockable as BookDisplayViewModel;
+        return DocumentTargetResolver.ResolveActiveDocument(
+            hostWindow.Layout, SimpleTabbedWindow.ResolveFocusedDockable(hostWindow)) as BookDisplayViewModel;
     }
 
     private void OnCloseTabFromFloatingWindow(Window floatingWindow)
@@ -1532,8 +1511,8 @@ public partial class App : Application
         {
             if (floatingWindow is CstHostWindow hostWindow && hostWindow.Layout != null)
             {
-                var documentDock = FindDocumentDockInLayout(hostWindow.Layout) as Dock.Model.Mvvm.Controls.DocumentDock;
-                SimpleTabbedWindow.CloseDockableIfClosable(documentDock?.ActiveDockable);
+                SimpleTabbedWindow.CloseDockableIfClosable(DocumentTargetResolver.ResolveActiveDocument(
+                    hostWindow.Layout, SimpleTabbedWindow.ResolveFocusedDockable(hostWindow)));
             }
         }
         catch (Exception ex)
@@ -1548,8 +1527,8 @@ public partial class App : Application
         {
             if (floatingWindow is CstHostWindow hostWindow && hostWindow.Layout != null)
             {
-                var documentDock = FindDocumentDockInLayout(hostWindow.Layout) as Dock.Model.Mvvm.Controls.DocumentDock;
-                if (documentDock?.ActiveDockable is BookDisplayViewModel bookViewModel)
+                if (DocumentTargetResolver.ResolveActiveDocument(
+                        hostWindow.Layout, SimpleTabbedWindow.ResolveFocusedDockable(hostWindow)) is BookDisplayViewModel bookViewModel)
                 {
                     Log.Information("View Source ({Edition}) via floating-window menu for book: {BookFile}",
                         source2010 ? "2010" : "1957", bookViewModel.Book.FileName);

--- a/src/CST.Avalonia/Services/DocumentTargetResolver.cs
+++ b/src/CST.Avalonia/Services/DocumentTargetResolver.cs
@@ -1,0 +1,123 @@
+using System.Linq;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Works out which document a window-level command (Cmd+W, Cmd+G, Cmd+E, Cmd+D, Cmd+F) should act on.
+///
+/// The handlers used to walk the layout and take the FIRST DocumentDock they found, then its
+/// ActiveDockable. In a split layout that is simply the left/top pane regardless of where the user is
+/// working, so a shortcut pressed in the second split acted on the first split's tab - closing the wrong
+/// book, or opening Go To for it. (#443)
+///
+/// Resolution now follows focus, which is what the user means by "this book", and falls back to the old
+/// first-dock behaviour when nothing usable is focused (a fresh layout, or focus sitting on a tool).
+/// </summary>
+public static class DocumentTargetResolver
+{
+    /// <summary>
+    /// The document the user is working in: the focused document, else the active document of the dock
+    /// that holds focus, else the active document of the first document dock in the layout.
+    /// </summary>
+    /// <param name="preferred">
+    /// A dockable the caller believes the user is working in - normally derived from real Avalonia keyboard
+    /// focus (see SimpleTabbedWindow.ResolveFocusedDockable). Used when it sits inside a document dock.
+    /// Dock's own <c>RootDock.FocusedDockable</c> is never populated in this app - it is null even right
+    /// after clicking a tab - so it cannot be the source of truth on its own.
+    /// </param>
+    public static IDockable? ResolveActiveDocument(IDock? layout, IDockable? preferred = null)
+    {
+        if (layout == null)
+            return null;
+
+        if (preferred != null && FindDocumentDockContaining(layout, preferred) is { } preferredDock)
+            return preferred is IDock ? preferredDock.ActiveDockable : preferred;
+
+        var focused = layout.FocusedDockable;
+
+        // What makes something a document here is WHERE it lives, not what it implements: in Dock 11.3.6.5
+        // the Tool class implements IDocument as well as ITool, so `focused is IDocument` matches the
+        // Search and Dictionary tools too (DocumentTargetResolverTests guards this). Ask the layout instead
+        // - find the document dock whose subtree holds the focused dockable.
+        //
+        // This also handles stale focus for free: FocusedDockable is not cleared when a tab closes, and a
+        // dockable that is no longer in the layout is contained by nothing, so it falls through.
+        if (focused != null)
+        {
+            var owningDock = FindDocumentDockContaining(layout, focused);
+            if (owningDock != null)
+            {
+                // Focus on the dock itself (rather than on one of its tabs) means "its current tab".
+                return focused is IDock ? owningDock.ActiveDockable : focused;
+            }
+        }
+
+        return FindFirstDocumentDock(layout)?.ActiveDockable;
+    }
+
+    /// <summary>
+    /// The first document dock in the layout, in tree order. This is the pre-#443 resolution and remains
+    /// the fallback; prefer <see cref="ResolveActiveDocument"/> for anything the user aims at.
+    /// </summary>
+    public static IDock? FindFirstDocumentDock(IDock? dock)
+    {
+        if (dock == null)
+            return null;
+
+        if (dock.Id == "MainDocumentDock" || dock is IDocumentDock)
+            return dock;
+
+        if (dock.VisibleDockables == null)
+            return null;
+
+        foreach (var child in dock.VisibleDockables.OfType<IDock>())
+        {
+            var result = FindFirstDocumentDock(child);
+            if (result != null)
+                return result;
+        }
+
+        return null;
+    }
+
+    // The document dock whose subtree contains the target (the target may be the dock itself).
+    private static IDock? FindDocumentDockContaining(IDock dock, IDockable target)
+    {
+        var isDocumentDock = dock.Id == "MainDocumentDock" || dock is IDocumentDock;
+        if (isDocumentDock && Contains(dock, target))
+            return dock;
+
+        if (dock.VisibleDockables == null)
+            return null;
+
+        foreach (var child in dock.VisibleDockables.OfType<IDock>())
+        {
+            var result = FindDocumentDockContaining(child, target);
+            if (result != null)
+                return result;
+        }
+
+        return null;
+    }
+
+    private static bool Contains(IDock dock, IDockable target)
+    {
+        if (ReferenceEquals(dock, target))
+            return true;
+
+        if (dock.VisibleDockables == null)
+            return false;
+
+        foreach (var dockable in dock.VisibleDockables)
+        {
+            if (ReferenceEquals(dockable, target))
+                return true;
+            if (dockable is IDock childDock && Contains(childDock, target))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -659,11 +659,12 @@ public partial class SimpleTabbedWindow : Window
         {
             _logger.Information("Found LayoutViewModel in current window's DockControl");
 
-            // Get the active document from this window's layout
+            // Get the document the user is working in - follows focus, so a split layout resolves to
+            // the pane they are actually in rather than always the first one. (#443)
             if (layoutViewModel.Layout is RootDock rootDock)
             {
-                var documentDock = FindDocumentDockInLayout(rootDock);
-                if (documentDock?.ActiveDockable is BookDisplayViewModel bookViewModel)
+                var active = DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this));
+                if (active is BookDisplayViewModel bookViewModel)
                 {
                     _logger.Information("Triggering Go To dialog for active book: {BookFile}", bookViewModel.Book.FileName);
                     bookViewModel.InvokeOpenGoToDialog();
@@ -671,8 +672,8 @@ public partial class SimpleTabbedWindow : Window
                 }
                 else
                 {
-                    _logger.Warning("No active book in this window's document dock. ActiveDockable type: {Type}",
-                        documentDock?.ActiveDockable?.GetType().Name ?? "null");
+                    _logger.Warning("No active book in this window. Resolved dockable type: {Type}",
+                        active?.GetType().Name ?? "null");
                 }
             }
         }
@@ -838,7 +839,7 @@ public partial class SimpleTabbedWindow : Window
             layoutViewModel.Layout is not RootDock rootDock)
             return null;
 
-        return FindDocumentDockInLayout(rootDock)?.ActiveDockable as BookDisplayViewModel;
+        return DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this)) as BookDisplayViewModel;
     }
 
     // Reduce a selection to a single lookup word: first whitespace-delimited token, minus surrounding
@@ -876,13 +877,38 @@ public partial class SimpleTabbedWindow : Window
                 layoutViewModel.Layout is not RootDock rootDock)
                 return;
 
-            var documentDock = FindDocumentDockInLayout(rootDock);
-            CloseDockableIfClosable(documentDock?.ActiveDockable);
+            CloseDockableIfClosable(DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this)));
         }
         catch (Exception ex)
         {
             _logger.Error(ex, "Close Tab (⌘W) failed");
         }
+    }
+
+    // Which dockable does the user actually have focus in? Dock's own RootDock.FocusedDockable is never
+    // populated in this app (it reads null even immediately after clicking a tab), so ask Avalonia for the
+    // focused element and walk up the visual tree to the first control bound to a dockable. Clicking a tab
+    // focuses the tab item, whose DataContext IS the dockable; clicking into a book focuses the WebView,
+    // whose DataContext is the book's ViewModel. Both give the right answer. (#443)
+    //
+    // NOTE: the window argument does NOT scope this - Avalonia's FocusManager is app-global, so a floating
+    // window's handler can be handed a dockable that lives in the main window's layout. What keeps that
+    // safe is the containment check in DocumentTargetResolver: a dockable outside this window's layout is
+    // contained by none of its document docks, so resolution falls back instead of reaching across windows.
+    // A test covers this; do not drop the containment check.
+    internal static IDockable? ResolveFocusedDockable(Window? window)
+    {
+        var element = window?.FocusManager?.GetFocusedElement() as Visual;
+
+        while (element != null)
+        {
+            if (element is StyledElement { DataContext: IDockable dockable })
+                return dockable;
+
+            element = element.GetVisualParent();
+        }
+
+        return null;
     }
 
     // Close a dockable via its own factory if it exists and permits closing (Welcome opts out via
@@ -902,7 +928,17 @@ public partial class SimpleTabbedWindow : Window
             return;
         }
 
+        var owner = active.Owner as IDock;
         factory.CloseDockable(active);
+
+        // Closing removes the focused tab's control, so Avalonia focus lands nowhere useful and the NEXT
+        // Cmd+W would resolve through the fallback - i.e. the first split's tab, the very #443 bug, one
+        // press later. Point Dock's own focus at the pane's new active tab; the resolver consults it after
+        // real keyboard focus, so repeated Cmd+W keeps closing tabs in the pane the user is working in.
+        if (owner?.ActiveDockable is { } nextActive)
+        {
+            factory.SetFocusedDockable(owner, nextActive);
+        }
     }
 
     private void TriggerViewSource(bool source2010)
@@ -915,8 +951,7 @@ public partial class SimpleTabbedWindow : Window
                 layoutViewModel.Layout is not RootDock rootDock)
                 return;
 
-            var documentDock = FindDocumentDockInLayout(rootDock);
-            if (documentDock?.ActiveDockable is not BookDisplayViewModel bookViewModel)
+            if (DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this)) is not BookDisplayViewModel bookViewModel)
                 return;
 
             _logger.Information("View Source ({Edition}) via menu/shortcut for book: {BookFile}",
@@ -981,24 +1016,4 @@ public partial class SimpleTabbedWindow : Window
         return s.Contains(' ') ? $"\"{s}\"" : s;
     }
 
-    private DocumentDock? FindDocumentDockInLayout(IDock dock)
-    {
-        if (dock is DocumentDock documentDock)
-            return documentDock;
-
-        if (dock.VisibleDockables != null)
-        {
-            foreach (var dockable in dock.VisibleDockables)
-            {
-                if (dockable is IDock childDock)
-                {
-                    var result = FindDocumentDockInLayout(childDock);
-                    if (result != null)
-                        return result;
-                }
-            }
-        }
-
-        return null;
-    }
 }


### PR DESCRIPTION
Closes #443.

⌘W, ⌘G, ⌘E/⇧⌘E, ⌘D and ⌘F resolved their target by walking the layout and taking the **first** `DocumentDock`, then its `ActiveDockable`. In a split that's always the left/top pane, so a shortcut pressed while working in the second split acted on the first split's tab — ⌘W closed the wrong book. Floating windows can be split too, and had the same bug.

Resolution now follows focus, via a new pure `DocumentTargetResolver` shared by both window types, with the old first-dock behaviour as the fallback.

## Two things had to be established the hard way

**Dock's `RootDock.FocusedDockable` is never populated in this app.** Logging showed it null *even immediately after clicking a tab*, so a first attempt built on it changed nothing. Real Avalonia keyboard focus is the usable signal: `ResolveFocusedDockable` walks up from `FocusManager.GetFocusedElement()` to the first control bound to a dockable. Clicking a tab focuses the tab item, whose `DataContext` **is** the dockable; clicking into a book focuses the WebView, whose `DataContext` is the book's ViewModel. Both give the right answer, and the body-click case no longer depends on the JS-forward path being correct.

**In Dock 11.3.6.5, `Tool` implements `IDocument` as well as `ITool`.** So a document cannot be identified by type test — with the Search panel focused, `is IDocument` would have matched the tool and ⌘W would have tried to close it. A unit test caught this before it shipped. Documents are identified by *which dock's subtree contains them*, and a test now asserts the `Tool is IDocument` quirk so a Dock upgrade that separates the interfaces tells us.

## Cross-window safety

Avalonia's `FocusManager` is app-global — the `window` argument scopes nothing — so a floating window's handler can be handed a dockable that lives in the main window's layout. The containment check is the only thing preventing a shortcut in one window from acting on another window's tab. That's now stated in the comment and covered by a test, because it's load-bearing and easy to "simplify" away.

## Repeat ⌘W

Closing a tab removes the focused control, so the *next* ⌘W would have resolved through the fallback — the same bug one press later. The close path now points Dock's focus at the pane's new active tab.

## Review

Fable reviewed: **SHIP-WITH-NITS**, no correctness defect, every surprising input degrades to pre-#443 behaviour rather than a wrong or crashing action. Its fix-first item was that the tests exercised only the dead `FocusedDockable` path and not the `preferred` path production actually uses — six tests were added for exactly that, including the foreign-dockable fallback and the `preferred is IDock` branch. Its dead-code nit (`FindDocumentDockInLayout`) is removed.

## Verification

Manual, in a split: clicking the right split's tab **or** its book body, then ⌘W, closes the correct book. Full suite: **880 passed, 0 failed** (15 in the new resolver tests).

## Related

Testing this surfaced #458 — closing a tab in a multi-book floating window can SIGSEGV re-attaching a sibling's live CEF browser. Separate, pre-existing, and reachable from the tab close button too; this PR doesn't touch that path.
