### PR TITLE
#280 (backend) + #440: split the MCP settings surface from REST and fix the remote-control gate

### DIFF
--- a/src/CST.Avalonia.Tests/Models/AiSettingsTests.cs
+++ b/src/CST.Avalonia.Tests/Models/AiSettingsTests.cs
@@ -21,8 +21,8 @@ namespace CST.Avalonia.Tests.Models
             Assert.True(ai.LocalApi.Enabled);         // sub-permissions ON...
             Assert.True(ai.LocalApi.EnableMcpServer);
             Assert.True(ai.LocalApi.AllowRemoteControl);
-            Assert.Equal(0, ai.LocalApi.Port);        // ephemeral by default (#278 Phase 4 reverted the fixed port)
-            Assert.Null(ai.LocalApi.Token);           // per-session token minted at start; not persisted
+            // Port/Token are no longer settings fields (#280): the loopback port is ephemeral and the token
+            // per-session, both held only in local-api.json.
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
@@ -1,0 +1,80 @@
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.ViewModels;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels
+{
+    /// <summary>
+    /// The AI settings view-model gating, focused on the case that had no coverage and a latent bug: an
+    /// MCP-only configuration. navigate is offered over BOTH the REST and MCP surfaces, so "allow remote
+    /// control" must be reachable whenever EITHER runs — keying it to the REST flag alone would grey it out for
+    /// an MCP-only user whose navigate works fine, telling them to enable a box already ticked. (#280, #440)
+    /// </summary>
+    public class AiSettingsViewModelTests
+    {
+        private static (AiSettingsViewModel Vm, Settings Settings) Make()
+        {
+            var settings = new Settings();
+            var svc = new Mock<ISettingsService>();
+            svc.SetupGet(s => s.Settings).Returns(settings);
+            return (new AiSettingsViewModel(svc.Object), settings);
+        }
+
+        [Fact]
+        public void The_two_server_surfaces_are_independent()
+        {
+            var (vm, settings) = Make();
+
+            vm.LocalApiEnabled = false;
+            vm.McpEnabled = true;
+
+            // Turning off REST must NOT turn off MCP — the #318 workaround that coupled them is gone.
+            Assert.False(settings.Ai.LocalApi.Enabled);
+            Assert.True(settings.Ai.LocalApi.EnableMcpServer);
+        }
+
+        [Fact]
+        public void Remote_control_is_reachable_with_only_the_MCP_surface_on()
+        {
+            var (vm, _) = Make();
+            vm.AiEnabled = true;
+
+            vm.LocalApiEnabled = false;
+            vm.McpEnabled = false;
+            Assert.False(vm.RemoteControlEnabled);   // no surface running → not reachable
+
+            vm.McpEnabled = true;
+            Assert.True(vm.RemoteControlEnabled);    // MCP alone is enough (#440)
+        }
+
+        [Fact]
+        public void Remote_control_needs_the_master_switch_regardless_of_surface()
+        {
+            var (vm, _) = Make();
+            vm.LocalApiEnabled = true;
+            vm.McpEnabled = true;
+
+            vm.AiEnabled = false;
+            Assert.False(vm.RemoteControlEnabled);   // master off overrides everything
+        }
+
+        [Fact]
+        public void Toggling_either_surface_updates_remote_control_reachability()
+        {
+            var (vm, _) = Make();
+            vm.AiEnabled = true;
+            vm.McpEnabled = false;
+
+            bool raised = false;
+            vm.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(AiSettingsViewModel.RemoteControlEnabled)) raised = true;
+            };
+
+            vm.LocalApiEnabled = true;
+            Assert.True(raised);   // the REST toggle must re-notify the remote-control gate, not just the MCP one
+        }
+    }
+}

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -31,8 +31,9 @@ namespace CST.Avalonia.Models
     /// The "AI" settings area. <see cref="Enabled"/> is the master "Enable AI Features" switch (default OFF);
     /// the sub-permissions default ON, so enabling the master turns everything on and the user can then pare
     /// back. Effective state is always master AND the specific permission, so unchecking the master disables
-    /// everything at once. Secrets (the local-API port + bearer token) are never stored here — they are
-    /// written to <c>local-api.json</c> at runtime.
+    /// everything at once. No secrets are stored here: the loopback port is ephemeral and the bearer token is
+    /// minted per session, both written only to <c>local-api.json</c> at runtime. (True again since #280 removed
+    /// the interim persisted port/token fields.)
     /// </summary>
     public class AiSettings
     {
@@ -77,13 +78,6 @@ namespace CST.Avalonia.Models
         /// <summary>Let agents drive the reader (navigate/highlight) vs. read-only. On by default under the master.</summary>
         public bool AllowRemoteControl { get; set; } = true;
 
-        // Deprecated (#278 Phase 4): the API reverted to an EPHEMERAL loopback port + a PER-SESSION token — no
-        // stable secret is stored, and an MCP client no longer needs one (the app's --mcp-bridge relay reads the
-        // current local-api.json each spawn). The runtime ignores these; they remain only so the pre-#280 Settings
-        // UI keeps compiling and #280 removes them.
-        public int Port { get; set; } = 0;                 // 0 => ephemeral (OS-assigned)
-        public const int DefaultPort = 8765;               // legacy fixed default (#276), retained for the UI only
-        public string? Token { get; set; }                 // no longer persisted; per-session token minted at start
     }
     
     public class DeveloperSettings

--- a/src/CST.Avalonia/Models/SettingsValidator.cs
+++ b/src/CST.Avalonia/Models/SettingsValidator.cs
@@ -92,19 +92,9 @@ public static class SettingsValidator
         if (settings.Ai == null) { settings.Ai = new AiSettings(); fixes.Add("ai settings were null; reset to default"); }
         if (settings.Ai.LocalApi == null) { settings.Ai.LocalApi = new LocalApiSettings(); fixes.Add("ai.localApi settings were null; reset to default"); }
 
-        // #320 (A7-3): the local-API port + bearer token are per-session at runtime (ephemeral port; token
-        // minted at start) and runtime-ignored since #278 Phase 4. Clear any historical persisted values on
-        // load so a plaintext token can't linger in settings.json and a stale fixed port can't be reused.
-        if (!string.IsNullOrEmpty(settings.Ai.LocalApi.Token))
-        {
-            settings.Ai.LocalApi.Token = null;
-            fixes.Add("cleared persisted ai.localApi.token (runtime mints a per-session token)");
-        }
-        if (settings.Ai.LocalApi.Port != 0)
-        {
-            settings.Ai.LocalApi.Port = 0;
-            fixes.Add("reset ai.localApi.port to ephemeral (runtime ignores a fixed port)");
-        }
+        // (The historical local-API Port/Token scrub is gone with those fields, removed in #280: the port is
+        // ephemeral and the token per-session, both held only in local-api.json. A stale value left in an old
+        // settings.json is now an unknown property the deserializer ignores.)
 
         // XML update repository fields
         var xml = settings.XmlUpdateSettings ??= new XmlUpdateSettings();

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -827,9 +827,8 @@ namespace CST.Avalonia.ViewModels
         private readonly ISettingsService _settingsService;
         private bool _aiEnabled;
         private bool _localApiEnabled;
+        private bool _mcpEnabled;
         private bool _allowRemoteControl;
-        private int _port;
-        private string _token = string.Empty;
 
         public AiSettingsViewModel(ISettingsService settingsService)
         {
@@ -838,24 +837,8 @@ namespace CST.Avalonia.ViewModels
             var ai = _settingsService.Settings.Ai;
             _aiEnabled = ai.Enabled;
             _localApiEnabled = ai.LocalApi.Enabled;
+            _mcpEnabled = ai.LocalApi.EnableMcpServer;
             _allowRemoteControl = ai.LocalApi.AllowRemoteControl;
-            _port = ai.LocalApi.Port;
-            _token = ai.LocalApi.Token ?? string.Empty;
-
-            // Rotate icons (password-generator style); both apply on the next API (re)start. (#275)
-            // #320 (A7-5): PickAvailable() runs TcpListener probes whose non-SocketException failures (e.g. a
-            // sandbox/entitlement SecurityException) would otherwise escape a ReactiveCommand with no
-            // ThrownExceptions subscriber and crash via RxApp's default handler. Contain them here.
-            RotatePortCommand = ReactiveCommand.Create(() =>
-            {
-                try { Port = CST.Avalonia.Services.LocalApi.PortAvailability.PickAvailable(); }
-                catch (Exception ex) { Log.Warning(ex, "Rotate port failed"); }
-            });
-            RotateTokenCommand = ReactiveCommand.Create(() =>
-            {
-                try { Token = CST.Avalonia.Services.LocalApi.ApiToken.Generate(); }
-                catch (Exception ex) { Log.Warning(ex, "Rotate token failed"); }
-            });
         }
 
         /// <summary>Master switch — "Enable AI Features". Everything AI-related is gated behind this (default OFF).</summary>
@@ -873,7 +856,8 @@ namespace CST.Avalonia.ViewModels
             }
         }
 
-        /// <summary>Run the loopback corpus-API server. Effective only while the master is also on.</summary>
+        /// <summary>Expose the /v1 REST surface (corpus data for code agents). Effective only while the master
+        /// is also on. Independent of <see cref="McpEnabled"/> — the two surfaces run separately. (#280)</summary>
         public bool LocalApiEnabled
         {
             get => _localApiEnabled;
@@ -881,13 +865,24 @@ namespace CST.Avalonia.ViewModels
             {
                 this.RaiseAndSetIfChanged(ref _localApiEnabled, value);
                 _settingsService.Settings.Ai.LocalApi.Enabled = value;
-                // #318 (A7-1): this single "Run the local API server" checkbox controls the WHOLE loopback
-                // server (both /v1 REST and /mcp), matching its label. EnableMcpServer has no separate UI yet
-                // (that lands in the #280 rework), so gate it here too — otherwise unchecking this leaves /mcp
-                // running (ServerShouldRun = LocalApiEnabled || McpEnabled) and silently ignores the opt-out.
+                _settingsService.RequestSave();
+                // Remote control follows "a server surface is running", not the REST flag specifically. (#440)
+                this.RaisePropertyChanged(nameof(RemoteControlEnabled));
+            }
+        }
+
+        /// <summary>Expose the /mcp surface (for chat clients like Claude Desktop, via the app's --mcp-bridge
+        /// relay). Effective only while the master is also on. Independent of <see cref="LocalApiEnabled"/>. The
+        /// #318 workaround that forced this to track the REST flag is gone now that it has its own toggle. (#280)</summary>
+        public bool McpEnabled
+        {
+            get => _mcpEnabled;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _mcpEnabled, value);
                 _settingsService.Settings.Ai.LocalApi.EnableMcpServer = value;
                 _settingsService.RequestSave();
-                // Remote control is only reachable when the local API is on.
+                // navigate is offered over BOTH surfaces, so remote control is reachable whenever EITHER runs. (#440)
                 this.RaisePropertyChanged(nameof(RemoteControlEnabled));
             }
         }
@@ -904,40 +899,6 @@ namespace CST.Avalonia.ViewModels
             }
         }
 
-        /// <summary>Loopback port. A FIXED default so a BYO-MCP config stays valid across restarts; 0 = ephemeral.
-        /// Applies on the next API (re)start.</summary>
-        public int Port
-        {
-            get => _port;
-            set
-            {
-                this.RaiseAndSetIfChanged(ref _port, value);
-                _settingsService.Settings.Ai.LocalApi.Port = value;
-                _settingsService.RequestSave();
-                this.RaisePropertyChanged(nameof(McpClientConfigJson));
-            }
-        }
-
-        /// <summary>The persisted bearer token, reused across launches. Surfaced so it can be copied into an MCP
-        /// client config; rotate to invalidate the old one. Applies on the next API (re)start. (#275)</summary>
-        public string Token
-        {
-            get => _token;
-            set
-            {
-                this.RaiseAndSetIfChanged(ref _token, value);
-                _settingsService.Settings.Ai.LocalApi.Token = value;
-                _settingsService.RequestSave();
-                this.RaisePropertyChanged(nameof(McpClientConfigJson));
-            }
-        }
-
-        /// <summary>Rotate to a fresh AVAILABLE loopback port (rotate icon). (#275)</summary>
-        public ReactiveCommand<Unit, Unit> RotatePortCommand { get; }
-
-        /// <summary>Rotate (regenerate) the bearer token (rotate icon). (#275)</summary>
-        public ReactiveCommand<Unit, Unit> RotateTokenCommand { get; }
-
         /// <summary>Pre-populated Claude Desktop MCP config for the "Copy MCP configuration" button. Emits the
         /// #278 bridge config (spawn this app with --mcp-bridge); carries no port/token. (#280 reworks the UI.)</summary>
         public string McpClientConfigJson => CST.Avalonia.Services.LocalApi.McpClientConfig.ClaudeDesktop(
@@ -946,8 +907,10 @@ namespace CST.Avalonia.ViewModels
         /// <summary>The local-API sub-permissions are editable only when the master switch is on.</summary>
         public bool SubPermissionsEnabled => AiEnabled;
 
-        /// <summary>"Allow remote control" is editable only when the master AND the local API are both on.</summary>
-        public bool RemoteControlEnabled => AiEnabled && LocalApiEnabled;
+        /// <summary>"Allow remote control" is editable whenever the master is on and a server surface (REST OR
+        /// MCP) is running — because navigate is offered over both. Keying it to the REST flag alone would grey
+        /// it out for an MCP-only user whose navigate works fine, telling them to enable a box already ticked. (#440)</summary>
+        public bool RemoteControlEnabled => AiEnabled && (LocalApiEnabled || McpEnabled);
     }
 
     public class DeveloperSettingsViewModel : ViewModelBase

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -352,59 +352,17 @@
                                         <TextBlock Text="When off, agents can read the corpus but cannot control the reader window."
                                                   Classes="SettingDescription"/>
 
-                                        <!-- Port: plain numeric entry (spinner arrows removed, #277); the ⟳ button
-                                             picks a fresh AVAILABLE port. Fixed by default so a copied client config
-                                             stays valid across restarts. -->
-                                        <Grid ColumnDefinitions="120,Auto,Auto" RowDefinitions="Auto" Margin="0,12,0,0">
-                                            <TextBlock Grid.Column="0" Text="Port:"
-                                                      VerticalAlignment="Center" Margin="0,0,10,0"/>
-                                            <NumericUpDown Grid.Column="1"
-                                                          Value="{Binding Port}"
-                                                          IsEnabled="{Binding SubPermissionsEnabled}"
-                                                          Minimum="0" Maximum="65535" Increment="1"
-                                                          ShowButtonSpinner="False"
-                                                          FormatString="0"
-                                                          Width="120"/>
-                                            <Button Grid.Column="2"
-                                                    Command="{Binding RotatePortCommand}"
-                                                    IsEnabled="{Binding SubPermissionsEnabled}"
-                                                    ToolTip.Tip="Pick a fresh available port"
-                                                    Margin="6,0,0,0" Padding="8,4" VerticalAlignment="Center">
-                                                <TextBlock Text="⟳" FontSize="14"/>
-                                            </Button>
-                                        </Grid>
-                                        <TextBlock Text="Loopback port; 0 = automatic (ephemeral). The MCP config launches the app's --mcp-bridge relay, which reads the live port at spawn, so it needn't match. Applies on the next start of the API server."
-                                                  Classes="SettingDescription" Margin="0,4,0,0"/>
-
-                                        <!-- Token: the persisted bearer secret. Masked by default; the 👁 toggle reveals it
-                                             for reading/copying, the ⟳ button regenerates it (invalidating the old one). -->
-                                        <Grid ColumnDefinitions="120,*,Auto,Auto" RowDefinitions="Auto" Margin="0,8,0,0">
-                                            <TextBlock Grid.Column="0" Text="Token:"
-                                                      VerticalAlignment="Center" Margin="0,0,10,0"/>
-                                            <TextBox Grid.Column="1"
-                                                    Text="{Binding Token}"
-                                                    IsReadOnly="True"
-                                                    IsEnabled="{Binding SubPermissionsEnabled}"
-                                                    PasswordChar="●"
-                                                    RevealPassword="{Binding #RevealToken.IsChecked, FallbackValue=False}"
-                                                    FontFamily="Consolas,Menlo,Courier New,monospace"
-                                                    VerticalAlignment="Center"/>
-                                            <ToggleButton Grid.Column="2" x:Name="RevealToken"
-                                                          IsEnabled="{Binding SubPermissionsEnabled}"
-                                                          ToolTip.Tip="Show / hide the token"
-                                                          Margin="6,0,0,0" Padding="8,4" VerticalAlignment="Center">
-                                                <TextBlock Text="👁" FontSize="14"/>
-                                            </ToggleButton>
-                                            <Button Grid.Column="3"
-                                                    Command="{Binding RotateTokenCommand}"
-                                                    IsEnabled="{Binding SubPermissionsEnabled}"
-                                                    ToolTip.Tip="Generate a new token (invalidates the old one)"
-                                                    Margin="6,0,0,0" Padding="8,4" VerticalAlignment="Center">
-                                                <TextBlock Text="⟳" FontSize="14"/>
-                                            </Button>
-                                        </Grid>
-                                        <TextBlock Text="Bearer token agents authenticate with. Applies on the next start of the API server."
-                                                  Classes="SettingDescription" Margin="0,4,0,0"/>
+                                        <!-- #280 UI (Kestrel): the port + token controls were removed here — the API is now
+                                             ephemeral (OS-assigned port) with a per-session token, both in local-api.json, so
+                                             there is nothing to configure or copy. The ViewModel now exposes `McpEnabled`
+                                             (bound to LocalApi.EnableMcpServer, independent of the REST toggle above). ADD the
+                                             MCP sub-permission checkbox here, e.g.:
+                                               <CheckBox IsChecked="{Binding McpEnabled}"
+                                                         IsEnabled="{Binding SubPermissionsEnabled}"
+                                                         Content="Enable MCP access (Claude Desktop &amp; other chat clients)"
+                                                         Margin="0,10,0,0"/>
+                                             plus the top-of-panel one-line mention of the two access modes. The Copy-config
+                                             block below is already correct (bridge config, no port/token). -->
 
                                         <!-- Copy the ready-made Claude Desktop MCP config: it launches CST Reader's
                                              mcp-bridge relay and carries no port/token. Clipboard is done in


### PR DESCRIPTION
The non-view half of #280, plus #440 which lands with it. Kestrel keeps the additive Settings UI — the branch hands it a compiling state with the right ViewModel surface to bind.

## Decoupling the two surfaces

The Path B backend (#278 Phase 4) made `/v1` (REST) and `/mcp` independent, but the Settings *view* still coupled them: the "Run the local API server" setter force-wrote `EnableMcpServer = value` (the #318 A7-1 workaround), because there was no MCP toggle and otherwise unchecking REST left `/mcp` running. That workaround is gone — `AiSettingsViewModel` now exposes **`McpEnabled`** as its own property, independent of `LocalApiEnabled`.

## #440 — the remote-control gate

`RemoteControlEnabled` was `AiEnabled && LocalApiEnabled`, keyed to the REST flag. Navigate is offered over **both** surfaces (the runtime predicate became `ServerShouldRun && AllowRemoteControl` back in #439), so an MCP-only user would have found "Allow agents to drive the reader" greyed out while navigate worked fine over MCP — told to enable a box already ticked. Now `AiEnabled && (LocalApiEnabled || McpEnabled)`, with both setters re-notifying it.

This was **latent until the toggles split**, which they now do, so the fix belongs in the same change.

## Dead plumbing removed

`LocalApi.Port` / `Token` / `DefaultPort` are gone from `Settings` — the API has been ephemeral + per-session since #278 Phase 4, both values living only in `local-api.json`. With them go the VM's `Port`/`Token` properties, `RotatePortCommand`/`RotateTokenCommand`, and the `SettingsValidator` scrub that reset them (a stale value in an old `settings.json` is now an unknown property the deserializer ignores; beta-5 testers wipe the dir, so no migration). The `AiSettings` "no secrets are stored here" doc is true again and says so.

## XAML

The now-dead Port/Token controls + rotate/reveal buttons are removed so the branch compiles. A comment marks where the **MCP checkbox** and the top-of-panel two-access-modes mention go — the additive UI is yours, and now has a real `McpEnabled` property and an honest `RemoteControlEnabled` to bind against. The Copy-config block was already correct (bridge config, no port/token) and is untouched.

## Tests

New `AiSettingsViewModelTests` cover the MCP-only gate — the #440 case, which had no coverage — and surface independence. `AiSettingsTests` drops the removed Port/Token assertions. Full suite **884/884**.

Closes #440. Advances #280 (leaves the view rework). Part of epic #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)