### PR TITLE
#443 follow-up: forward ⌘G from JS so Go To targets the focused split's book

### DIFF
--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -3393,8 +3393,19 @@ namespace CST.Avalonia.Services
         }
 
         // Show Go To dialog for a book
+        // Guards against a second Go To dialog stacking on top of the first. Every trigger (native menu,
+        // the Avalonia tunnel handler, and the JS forward) funnels through here, so one flag covers them
+        // all - a fast double ⌘G, or a menu click while a dialog is already up, no longer stacks modals.
+        private bool _goToDialogOpen;
+
         private async System.Threading.Tasks.Task ShowGoToDialog(BookDisplayViewModel bookViewModel)
         {
+            if (_goToDialogOpen)
+            {
+                _logger.Debug("Go To dialog already open - ignoring repeat request");
+                return;
+            }
+            _goToDialogOpen = true;
             try
             {
                 _logger.Information("Showing Go To dialog for book: {BookFile}", bookViewModel.Book.FileName);
@@ -3439,6 +3450,10 @@ namespace CST.Avalonia.Services
             catch (Exception ex)
             {
                 _logger.Error(ex, "Error showing Go To dialog");
+            }
+            finally
+            {
+                _goToDialogOpen = false;
             }
         }
 

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -1995,6 +1995,27 @@ public partial class BookDisplayView : UserControl
                 _logger.Error("Error processing Close Tab request from JavaScript | {Details}", ex.Message);
             }
         }
+        // #443: Go To requested from JavaScript (⌘G while this book's WebView has focus). The message
+        // arrives on the focused book's own view, so it is inherently the right book — no layout
+        // resolution, the same reasoning as CST_CLOSE_TAB above.
+        else if (title != null && title.StartsWith("CST_GOTO:"))
+        {
+            try
+            {
+                var parts = title.Split('|');
+                var messageTabId = parts.Length > 1 && parts[1].StartsWith("TAB:") ? parts[1].Substring(4) : "";
+
+                if (messageTabId == _tabId)
+                {
+                    _logger.Debug("*** GO TO REQUESTED FROM JAVASCRIPT ***");
+                    Dispatcher.UIThread.Post(() => _viewModel?.InvokeOpenGoToDialog());
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Error processing Go To request from JavaScript | {Details}", ex.Message);
+            }
+        }
         // Check for JS log messages
         else if (title != null && title.StartsWith("CST_LOG_MSG::"))
         {
@@ -2104,6 +2125,23 @@ public partial class BookDisplayView : UserControl
                                     event.preventDefault();
                                     event.stopPropagation();
                                     document.title = 'CST_VIEW_SOURCE_1957:|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                                    return false;
+                                }
+
+                                // #443: Cmd+G / Ctrl+G (Go To) - when this WebView has focus, CEF holds the
+                                // native focus so the window's focus resolution comes back empty and the
+                                // native-menu Go To falls back to the first split's book. Forward it like
+                                // View Source / Close so it always targets THIS book.
+                                // Match 'g' AND 'G' (Caps Lock yields 'G' in Chromium); !shiftKey so ⌘⇧G
+                                // isn't caught. Without the 'G' case, ⌘G under Caps Lock would fall through
+                                // to the native menu and reopen the wrong-split bug. event.repeat is dropped
+                                // so holding ⌘G can't stack modal Go To dialogs.
+                                if ((event.key === 'g' || event.key === 'G') && !event.shiftKey && (event.metaKey || event.ctrlKey)) {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                    if (event.repeat) return false;
+                                    window.cstLogger.log('DEBUG', 'Go To shortcut detected in JavaScript');
+                                    document.title = 'CST_GOTO:|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
                                     return false;
                                 }
 


### PR DESCRIPTION
Follow-up to #461 (already merged). Completes #443 for ⌘G.

#461's focus-following resolution fixed ⌘G only when the book's **tab** had focus. With the book **body** focused, CEF holds the native keyboard focus, so `FocusManager.GetFocusedElement()` is null, `ResolveFocusedDockable` returns null, and the native-menu ⌘G falls back to the first split's book. ⌘W and ⌘E never had this because CEF eats them and the page re-emits them over the `document.title` channel with the tab id — ⌘G simply lacked that forward.

This adds the forward for ⌘G (`CST_GOTO`). The message arrives on the focused book's own view, so it needs no layout resolution — it's inherently the right book, exactly like `CST_CLOSE_TAB`.

## Fable review — SHIP-WITH-NITS, both nits fixed

- **Match `'g'` AND `'G'`.** Caps Lock yields `'G'` in Chromium; without it, ⌘G-under-Caps-Lock fell through to the menu and reopened the very wrong-split bug. `!shiftKey` keeps ⌘⇧G out.
- **Guard against stacked Go To dialogs.** Every trigger (native menu, Avalonia tunnel handler, JS forward) funnels through `ShowGoToDialog`, which had no already-open guard and ends in a modal `ShowDialog`, so a fast double-press could stack two modals. A single `_goToDialogOpen` flag there covers all paths; `event.repeat` is also dropped in JS so holding ⌘G can't queue them. (Pre-existing exposure, closed here.)

Fable confirmed no double-fire (JS forward and the Avalonia `Key.G` tunnel handler are mutually exclusive by who owns native focus), no cross-tab crosstalk (`_tabId` match, per-WebView subscription), and correct threading (`Dispatcher.UIThread.Post`, matching the sibling branches).

## Verification

Manual, in a split: ⌘G with the right split's **tab** focused and with its **book body** focused — both open Go To for the right-split book. Full suite: **884 passed, 0 failed**.
