### PR TITLE
#280: AI Settings View — MCP toggle + two-access-mode framing (Path B)

### DIFF
--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -329,40 +329,37 @@
                                         <CheckBox IsChecked="{Binding AiEnabled}"
                                                  Content="Enable AI Features"
                                                  Margin="0,10,0,0"/>
-                                        <TextBlock Text="Master switch. When off, nothing AI-related runs."
+                                        <TextBlock Text="Master switch. When off, nothing AI-related runs. Two access modes are available below: a local API for code agents, and MCP for chat clients like Claude Desktop."
                                                   Classes="SettingDescription"/>
                                     </StackPanel>
                                 </Border>
 
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
-                                        <TextBlock Text="Local API Server" Classes="SettingLabel"/>
-                                        <TextBlock Text="A loopback-only HTTP server that exposes read access to the corpus (search, dictionary, passages) to local agents."
+                                        <TextBlock Text="Access for AI Clients" Classes="SettingLabel"/>
+                                        <TextBlock Text="A loopback-only server that exposes read access to the corpus (search, dictionary, passages). Two surfaces run on it independently — enable either or both."
                                                   Classes="SettingDescription"/>
 
+                                        <!-- REST surface (/v1): for code agents. -->
                                         <CheckBox IsChecked="{Binding LocalApiEnabled}"
                                                  IsEnabled="{Binding SubPermissionsEnabled}"
-                                                 Content="Run the local API server"
+                                                 Content="Run the local API server (for code agents)"
                                                  Margin="0,10,0,0"/>
 
+                                        <!-- MCP surface (/mcp): for chat clients, reached via the app's mcp-bridge relay. #280 -->
+                                        <CheckBox IsChecked="{Binding McpEnabled}"
+                                                 IsEnabled="{Binding SubPermissionsEnabled}"
+                                                 Content="Enable MCP access (Claude Desktop &amp; other chat clients)"
+                                                 Margin="0,5,0,0"/>
+
+                                        <!-- Cross-cutting capability: navigate/highlight is offered over BOTH surfaces, so this
+                                             is enabled whenever either one is on (RemoteControlEnabled). #440 -->
                                         <CheckBox IsChecked="{Binding AllowRemoteControl}"
                                                  IsEnabled="{Binding RemoteControlEnabled}"
                                                  Content="Allow agents to drive the reader (navigate and highlight)"
                                                  Margin="0,5,0,0"/>
                                         <TextBlock Text="When off, agents can read the corpus but cannot control the reader window."
                                                   Classes="SettingDescription"/>
-
-                                        <!-- #280 UI (Kestrel): the port + token controls were removed here — the API is now
-                                             ephemeral (OS-assigned port) with a per-session token, both in local-api.json, so
-                                             there is nothing to configure or copy. The ViewModel now exposes `McpEnabled`
-                                             (bound to LocalApi.EnableMcpServer, independent of the REST toggle above). ADD the
-                                             MCP sub-permission checkbox here, e.g.:
-                                               <CheckBox IsChecked="{Binding McpEnabled}"
-                                                         IsEnabled="{Binding SubPermissionsEnabled}"
-                                                         Content="Enable MCP access (Claude Desktop &amp; other chat clients)"
-                                                         Margin="0,10,0,0"/>
-                                             plus the top-of-panel one-line mention of the two access modes. The Copy-config
-                                             block below is already correct (bridge config, no port/token). -->
 
                                         <!-- Copy the ready-made Claude Desktop MCP config: it launches CST Reader's
                                              mcp-bridge relay and carries no port/token. Clipboard is done in
@@ -376,7 +373,7 @@
                                                       Foreground="{DynamicResource DockApplicationAccentBrushLow}"
                                                       VerticalAlignment="Center" Margin="10,0,0,0" IsVisible="False"/>
                                         </StackPanel>
-                                        <TextBlock Text="Paste into the Claude Desktop config (~/Library/Application Support/Claude/claude_desktop_config.json) under &quot;mcpServers&quot;. It launches CST Reader's --mcp-bridge relay and embeds no port or token — copy it once (no Node, and no re-copy after rotating)."
+                                        <TextBlock Text="Paste into the Claude Desktop config (~/Library/Application Support/Claude/claude_desktop_config.json) under &quot;mcpServers&quot;. It launches CST Reader's --mcp-bridge relay and embeds no port or token, so you copy it just once — no Node.js needed. Enable MCP access above; CST Reader must be running, and can auto-launch when a client connects."
                                                   Classes="SettingDescription" Margin="0,4,0,0"/>
 
                                         <Expander Header="Show configuration" Margin="0,4,0,0">


### PR DESCRIPTION
Closes #280.

The additive Settings **View** half of #280 — the backend and ViewModel surface landed in #462 (which also removed the port/token/rotate controls and the port-in-use popup that Path A assumed). No `SettingsViewModel` or model changes here; this is XAML only.

## Changes

- **Add the MCP toggle** — "Enable MCP access (Claude Desktop & other chat clients)", bound to `McpEnabled` (`LocalApi.EnableMcpServer`), independent of the REST toggle. Gated on the master via `SubPermissionsEnabled`.
- **Rename the group** "Local API Server" → **"Access for AI Clients"**. Under Path B it hosts two independent surfaces — REST `/v1` for code agents, MCP `/mcp` for chat clients — on the one loopback server, and its description now says so. The REST checkbox reads "Run the local API server (for code agents)" so the two are a matched pair.
- **Order:** the two surface toggles together, then "Allow agents to drive the reader" — the cross-cutting capability, offered over both surfaces, which enables whenever either is on (`RemoteControlEnabled`, per #440).
- **Top-of-panel mention** under the master switch naming both access modes.
- **De-stale the Copy-config caption:** drop "re-copy after rotating" (no rotation under Path B), and note MCP must be enabled and that CST Reader can auto-launch when a client connects. The emitted config was already correct (bridge config, no port/token).

## Also cleared by #462 (verified, nothing left here)

No port/token/rotate controls or port-in-use references remain in `SettingsWindow.axaml`; the only "port/token" strings are prose stating the config carries none.

## Review

Fable: **SHIP**, no defects. It verified every binding maps to a notifying property, the full `RaisePropertyChanged` chain (master toggle greys all three sub-checkboxes; the **MCP-only** case live-enables "Allow agents to drive the reader"), and that each caption claim matches the Path B backend (`ServerShouldRun`, the bridge auto-launch, no Node). Its one nit — that auto-launch is macOS-only — is defensible since the caption is already macOS-framed with the `~/Library/...` path.

## Verification

Built clean; manually confirmed in Settings → AI: checkbox order and wrapping, master-off greys all three, and MCP-only enabling "Allow agents to drive the reader". Part of epic #186; supersedes the Path A UI (#277).
