### PR TITLE
#351: pair the handshake pid with a stable start token so a recycled pid can't pass as live

### DIFF
--- a/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
+++ b/src/CST.Avalonia.Tests/Services/StableApiConfigTests.cs
@@ -113,12 +113,82 @@ namespace CST.Avalonia.Tests.Services
                 new LocalApiInfo(51515, "TOK", 2_000_000_000).Write(dir);   // pid far above OS max = not running
                 Assert.Null(McpBridge.ReadLiveHandshake(dir));
 
-                new LocalApiInfo(51515, "TOK", Environment.ProcessId).Write(dir);   // a live pid
+                // A live pid with no recorded start time (0) → pid-only fallback, treated as live. This keeps a
+                // handshake written before #351 (or by a build that couldn't read its own start time) usable.
+                new LocalApiInfo(51515, "TOK", Environment.ProcessId).Write(dir);
                 var info = McpBridge.ReadLiveHandshake(dir);
                 Assert.NotNull(info);
                 Assert.Equal(Environment.ProcessId, info!.Pid);
+
+                // A live pid whose recorded start time is ours → verified live.
+                new LocalApiInfo(51515, "TOK", Environment.ProcessId,
+                    CST.Avalonia.Services.LocalApi.ProcessIdentity.CurrentStartToken()).Write(dir);
+                Assert.NotNull(McpBridge.ReadLiveHandshake(dir));
+
+                // #351: a live pid whose recorded start time is NOT ours = a recycled pid from a crashed
+                // instance. Must be treated as stale (null) so attach falls through to launch, rather than
+                // attaching to a dead loopback port.
+                long impostorStart = CST.Avalonia.Services.LocalApi.ProcessIdentity.CurrentStartToken()
+                                     - System.TimeSpan.FromHours(1).Ticks;
+                new LocalApiInfo(51515, "TOK", Environment.ProcessId, impostorStart).Write(dir);
+                Assert.Null(McpBridge.ReadLiveHandshake(dir));
             }
             finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+        }
+
+        [Fact]
+        public void LocalApiInfo_round_trips_the_start_time()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cst-hsrt-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                new LocalApiInfo(52344, "tok", 4242, StartToken: 638_000_000_000_000_000L).Write(dir);
+                var back = LocalApiInfo.Read(dir);
+                Assert.NotNull(back);
+                Assert.Equal(638_000_000_000_000_000L, back!.StartToken);
+
+                // Absent from the JSON (a pre-#351 file) deserializes to 0, the pid-only sentinel.
+                File.WriteAllText(LocalApiInfo.PathIn(dir), "{\"port\":1,\"token\":\"t\",\"pid\":2}");
+                Assert.Equal(0, LocalApiInfo.Read(dir)!.StartToken);
+            }
+            finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+        }
+
+        [Fact]
+        public async Task Liveness_watcher_with_no_recorded_token_falls_back_to_pid_only_and_stays_quiet()
+        {
+            // A live pid + startToken 0 (a pre-#351 handshake) must degrade to the old pid-only check, not trip.
+            using var onGone = new CancellationTokenSource();
+            var watch = McpBridge.WatchProcessLivenessAsync(
+                System.Environment.ProcessId, startToken: 0, onGone, pollMs: 20, onGone.Token);
+
+            await Task.Delay(300);
+            Assert.False(onGone.IsCancellationRequested);
+
+            onGone.Cancel();
+            await watch;
+        }
+
+        [Theory]
+        // field 22 (starttime jiffies) is the value; comm may contain spaces and parentheses, which is the trap.
+        // Tail after the last ')' starts at field 3 (state); starttime is field 22 = tail[19]. So 19 filler
+        // tokens (fields 3–21) then the value, then any trailing fields.
+        [InlineData("1234 (cst) S 1 1 1 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 987654 0 0", 987654L)]
+        [InlineData("42 (weird )name( x) R 1 1 1 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 555 0 0", 555L)]
+        public void Linux_proc_stat_start_jiffies_is_parsed_past_a_tricky_comm(string stat, long expected)
+        {
+            Assert.True(CST.Avalonia.Services.LocalApi.ProcessIdentity.TryParseLinuxStartJiffies(stat, out var j));
+            Assert.Equal(expected, j);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("no closing paren here")]
+        [InlineData("1 (short) S 1 2 3")]   // too few fields to reach field 22
+        public void Linux_proc_stat_parse_rejects_malformed_input(string stat)
+        {
+            Assert.False(CST.Avalonia.Services.LocalApi.ProcessIdentity.TryParseLinuxStartJiffies(stat, out _));
         }
 
         [Fact]
@@ -128,7 +198,7 @@ namespace CST.Avalonia.Tests.Services
             // exits (one -> zero, never a lone bridge). A pid far above the OS max is guaranteed not running. (#278)
             const int deadPid = 2_000_000_000;
             using var onGone = new CancellationTokenSource();
-            var watch = McpBridge.WatchProcessLivenessAsync(deadPid, onGone, pollMs: 20, onGone.Token);
+            var watch = McpBridge.WatchProcessLivenessAsync(deadPid, startToken: 0, onGone, pollMs: 20, onGone.Token);
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
             while (!onGone.IsCancellationRequested && sw.Elapsed < System.TimeSpan.FromSeconds(2))
@@ -141,15 +211,36 @@ namespace CST.Avalonia.Tests.Services
         [Fact]
         public async Task Liveness_watcher_stays_quiet_while_the_process_is_alive()
         {
-            // Our own process is alive -> the watcher must NOT trip. (#278)
+            // Our own process is alive AND its recorded start time matches -> the watcher must NOT trip. (#278)
             using var onGone = new CancellationTokenSource();
             var watch = McpBridge.WatchProcessLivenessAsync(
-                System.Environment.ProcessId, onGone, pollMs: 20, onGone.Token);
+                System.Environment.ProcessId,
+                CST.Avalonia.Services.LocalApi.ProcessIdentity.CurrentStartToken(),
+                onGone, pollMs: 20, onGone.Token);
 
             await Task.Delay(300);
             Assert.False(onGone.IsCancellationRequested);
 
             onGone.Cancel();   // stop the watcher
+            await watch;
+        }
+
+        [Fact]
+        public async Task Liveness_watcher_trips_when_a_live_pid_is_a_recycled_impostor()
+        {
+            // #351: the crash-recovery hazard. The recorded pid is LIVE (our own process), but the recorded
+            // start time is NOT ours — as if the OS recycled a crashed instance's pid onto an unrelated process.
+            // Identity, not bare pid liveness, must detect the mismatch and tear the bridge down.
+            using var onGone = new CancellationTokenSource();
+            long notOurStart = CST.Avalonia.Services.LocalApi.ProcessIdentity.CurrentStartToken() - System.TimeSpan.FromHours(1).Ticks;
+            var watch = McpBridge.WatchProcessLivenessAsync(
+                System.Environment.ProcessId, notOurStart, onGone, pollMs: 20, onGone.Token);
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            while (!onGone.IsCancellationRequested && sw.Elapsed < System.TimeSpan.FromSeconds(2))
+                await Task.Delay(20);
+
+            Assert.True(onGone.IsCancellationRequested);
             await watch;
         }
 

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
@@ -11,14 +11,22 @@ namespace CST.Avalonia.Services.LocalApi
     /// The discovery/handshake file for the local API (AI_INTEGRATION.md §6). Written to
     /// <c>…/CSTReader/local-api.json</c> when the server starts so a client (the MCP adapter, a coding agent)
     /// can find the ephemeral <see cref="Port"/> and present the per-session bearer <see cref="Token"/>. The
-    /// <see cref="Pid"/> lets a client detect a stale file after a crash. Written owner-only where the OS
-    /// supports it; never contains anything but this handshake (the token is a session secret, not persisted
-    /// to settings).
+    /// <see cref="Pid"/> plus <see cref="StartToken"/> let a client detect a stale file after a crash: a bare
+    /// pid can be recycled by the OS onto an unrelated process, so the pid is paired with a stable start token to
+    /// form a durable identity (#351). Written owner-only where the OS supports it; never contains anything but
+    /// this handshake (the token is a session secret, not persisted to settings).
     /// </summary>
+    /// <param name="StartToken">An opaque, stable identity token for the publishing process — its start time,
+    /// in whatever clock-immune form the platform provides (see <c>ProcessIdentity</c>). 0 = not recorded, in
+    /// which case a reader falls back to a pid-only liveness check. Compared only for equality, never interpreted.
+    /// On macOS/Windows this exceeds 2^53, so a consumer that round-trips this file through IEEE doubles (e.g. a
+    /// naive JS reader) would corrupt it — the only in-process reader is the C# bridge, which keeps it a
+    /// <c>long</c>, and external readers need just port/token; revisit as a string if that ever changes.</param>
     public sealed record LocalApiInfo(
         [property: JsonPropertyName("port")] int Port,
         [property: JsonPropertyName("token")] string Token,
-        [property: JsonPropertyName("pid")] int Pid)
+        [property: JsonPropertyName("pid")] int Pid,
+        [property: JsonPropertyName("startToken")] long StartToken = 0)
     {
         public const string FileName = "local-api.json";
 

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -313,7 +313,10 @@ namespace CST.Avalonia.Services.LocalApi
             Token = token;
             BaseUrl = $"http://127.0.0.1:{port}";
 
-            new LocalApiInfo(port, token, Environment.ProcessId).Write(_handshakeDirectory);
+            // Record start time alongside the pid so a crashed instance's recycled pid can't be mistaken for a
+            // live one (#351).
+            new LocalApiInfo(port, token, Environment.ProcessId, ProcessIdentity.CurrentStartToken())
+                .Write(_handshakeDirectory);
             _logger.Information("Local API listening on {BaseUrl} (rest={Rest}, mcp={Mcp})",
                 BaseUrl, _restApiEnabled, _mcpEnabled);
             }

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
@@ -92,7 +92,7 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         {
             using var appGoneCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             var watcher = info.Pid > 0
-                ? WatchProcessLivenessAsync(info.Pid, appGoneCts, AppLivenessPollMs, appGoneCts.Token)
+                ? WatchProcessLivenessAsync(info.Pid, info.StartToken, appGoneCts, AppLivenessPollMs, appGoneCts.Token)
                 : Task.CompletedTask;
             try
             {
@@ -107,19 +107,24 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         }
 
         /// <summary>
-        /// Poll <paramref name="pid"/> (the attached CST Reader GUI, from <c>local-api.json</c>); when it is no
-        /// longer running, cancel <paramref name="onGone"/> so the relay unwinds and the bridge process exits.
-        /// Deliberately does NOT relaunch the app — a user closing it is authoritative. Checking the pid (not the
-        /// handshake file) catches every death: clean quit, crash, and <c>kill -9</c> (which leaves the file stale).
+        /// Poll the attached CST Reader GUI (<paramref name="pid"/> + <paramref name="startToken"/> from
+        /// <c>local-api.json</c>); when it is no longer the same running process, cancel <paramref name="onGone"/>
+        /// so the relay unwinds and the bridge process exits. Deliberately does NOT relaunch the app — a user
+        /// closing it is authoritative. Identity (pid + start token), not bare pid liveness, catches the deaths a
+        /// pid alone can — clean quit, crash, <c>kill -9</c> (which leaves the file stale) — plus a crash whose
+        /// pid is recycled onto another SAME-USER process (#351). On the TEARDOWN path the safe default under a
+        /// transient error is to assume the app is still alive — tearing down a working session over a glitch is
+        /// worse than polling a moment longer — so a pid recycled onto ANOTHER user's process (start time
+        /// unreadable) is not guaranteed to be caught here; the attach path catches that one. (#307 A2-6, #351)
         /// </summary>
         internal static async Task WatchProcessLivenessAsync(
-            int pid, CancellationTokenSource onGone, int pollMs, CancellationToken ct)
+            int pid, long startToken, CancellationTokenSource onGone, int pollMs, CancellationToken ct)
         {
             try
             {
                 while (!ct.IsCancellationRequested)
                 {
-                    if (!IsProcessAlive(pid))
+                    if (!ProcessIdentity.IsSameProcess(pid, startToken, assumeOnError: true))
                     {
                         Log.Information("--mcp-bridge: CST Reader (pid {Pid}) is gone; shutting the bridge down.", pid);
                         onGone.Cancel();
@@ -129,21 +134,6 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                 }
             }
             catch (OperationCanceledException) { }
-        }
-
-        /// <summary>True while a process with <paramref name="pid"/> exists. <see cref="Process.GetProcessById(int)"/>
-        /// throws <see cref="ArgumentException"/> when it doesn't — the canonical cross-platform liveness check.</summary>
-        private static bool IsProcessAlive(int pid)
-        {
-            try { using var _ = Process.GetProcessById(pid); return true; }
-            catch (ArgumentException) { return false; }   // definitively not running
-            catch (Exception ex)
-            {
-                // Any other failure (transient/platform quirk) must NOT fault the watcher task — that would
-                // silently lose liveness protection for the bridge's whole life. Assume alive and keep polling. (#307 A2-6)
-                Log.Warning(ex, "--mcp-bridge: liveness check for pid {Pid} failed; assuming alive.", pid);
-                return true;
-            }
         }
 
         /// <summary>
@@ -266,7 +256,12 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         internal static LocalApiInfo? ReadLiveHandshake(string dir)
         {
             var info = LocalApiInfo.Read(dir);
-            if (info is not null && info.Pid > 0 && !IsProcessAlive(info.Pid)) return null;
+            // Identity, not bare liveness: a recycled pid must not read as a live instance (#351). On the ATTACH
+            // path, an alive-but-unverifiable pid is treated as stale — falling through to launch is cheap
+            // (LaunchServices single-instances) and is the safe response to "can't confirm this is our app".
+            if (info is not null && info.Pid > 0
+                && !ProcessIdentity.IsSameProcess(info.Pid, info.StartToken, assumeOnError: false))
+                return null;
             return info;
         }
 

--- a/src/CST.Avalonia/Services/LocalApi/ProcessIdentity.cs
+++ b/src/CST.Avalonia/Services/LocalApi/ProcessIdentity.cs
@@ -1,0 +1,118 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using Serilog;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>
+    /// Durable process identity for the handshake liveness check. A bare pid is NOT a stable identity: after the
+    /// app crashes (leaving <c>local-api.json</c> behind) the OS can recycle its pid onto an unrelated live
+    /// process, and a pid-only check then passes for a dead loopback port. Pairing the pid with a stable
+    /// START TOKEN closes that — a recycled pid necessarily belongs to a process that started later. (#351)
+    /// </summary>
+    internal static class ProcessIdentity
+    {
+        private enum Lookup { Ok, NotRunning, AccessDenied, Unknown }
+
+        /// <summary>
+        /// Start token of the CURRENT process, to record in the handshake. Returns 0 if it cannot be read — the
+        /// file then carries no identity beyond the pid and callers fall back to the pid-only check.
+        /// </summary>
+        public static long CurrentStartToken()
+        {
+            using var self = Process.GetCurrentProcess();
+            return TryGetStartToken(Environment.ProcessId, self, out long token) == Lookup.Ok ? token : 0;
+        }
+
+        /// <summary>
+        /// Whether the process at <paramref name="pid"/> is the same instance that wrote <paramref name="recordedToken"/>.
+        /// Comparison is EXACT: the token is a stable, clock-immune per-platform value, and a self-query and an
+        /// other-process query of the same live pid yield the identical value on all three platforms (Linux uses
+        /// the boot-relative jiffy start time from <c>/proc</c>; macOS/Windows an absolute creation timestamp), so
+        /// no tolerance is needed and none is wanted — slack only widens the window for a false match.
+        /// <para>
+        /// A dead pid is a definite "no". A zero <paramref name="recordedToken"/> means the handshake carried no
+        /// token, so this degrades to a pid-only liveness check (pre-#351 behaviour). A live pid whose token
+        /// cannot be read because access is DENIED is treated as "not us" regardless of
+        /// <paramref name="assumeOnError"/> — the app always runs as the invoking user, and a same-user process's
+        /// start time is always readable, so access-denied means the pid was recycled onto another user's process.
+        /// Only a genuinely indeterminate failure defers to <paramref name="assumeOnError"/>, whose safe default
+        /// differs between the two call sites.
+        /// </para>
+        /// </summary>
+        public static bool IsSameProcess(int pid, long recordedToken, bool assumeOnError)
+        {
+            if (pid <= 0) return false;
+
+            Process p;
+            try { p = Process.GetProcessById(pid); }
+            catch (ArgumentException) { return false; }          // definitively not running
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Liveness check for pid {Pid} failed; assuming {Assume}.", pid, assumeOnError);
+                return assumeOnError;
+            }
+
+            using (p)
+            {
+                if (recordedToken == 0) return true;             // no identity recorded → pid-only fallback
+
+                return TryGetStartToken(pid, p, out long live) switch
+                {
+                    Lookup.Ok => live == recordedToken,
+                    Lookup.NotRunning => false,                  // exited during the race → gone
+                    Lookup.AccessDenied => false,                // recycled onto another user's process → not us
+                    _ => assumeOnError                           // genuinely indeterminate
+                };
+            }
+        }
+
+        // Linux Process.StartTime is recomputed each query as (wall clock) - (elapsed since boot) + (start
+        // jiffies), so a clock step (NTP, VM resume) shifts the SAME process's reported start time — unusable as
+        // an identity. The raw jiffy field is boot-relative and clock-immune, so read it directly instead. (#351,
+        // fable) macOS/Windows expose an absolute creation timestamp, which is stable, so Process.StartTime is
+        // fine there.
+        private static Lookup TryGetStartToken(int pid, Process p, out long token)
+        {
+            token = 0;
+            if (OperatingSystem.IsLinux())
+            {
+                string stat;
+                try { stat = File.ReadAllText($"/proc/{pid}/stat"); }
+                catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+                {
+                    return Lookup.NotRunning;
+                }
+                catch (UnauthorizedAccessException) { return Lookup.AccessDenied; }
+                catch (Exception ex) { Log.Warning(ex, "Could not read /proc/{Pid}/stat.", pid); return Lookup.Unknown; }
+
+                return TryParseLinuxStartJiffies(stat, out token) ? Lookup.Ok : Lookup.Unknown;
+            }
+
+            try { token = p.StartTime.ToUniversalTime().Ticks; return Lookup.Ok; }
+            catch (InvalidOperationException) { return Lookup.NotRunning; }      // exited between calls
+            catch (Win32Exception) { return Lookup.AccessDenied; }              // another user's process
+            catch (Exception ex) { Log.Warning(ex, "Could not read start time of pid {Pid}.", pid); return Lookup.Unknown; }
+        }
+
+        /// <summary>
+        /// Parse the start-time jiffy count (field 22) from a Linux <c>/proc/&lt;pid&gt;/stat</c> line. Field 2
+        /// (comm) is wrapped in parentheses and may itself contain spaces and parentheses, so anchor on the LAST
+        /// ')': everything after it is a clean space-separated list starting at field 3 (state), making start
+        /// time index 19 in that tail. Internal + testable because the comm-quoting is the easy thing to get
+        /// wrong.
+        /// </summary>
+        internal static bool TryParseLinuxStartJiffies(string stat, out long jiffies)
+        {
+            jiffies = 0;
+            if (string.IsNullOrEmpty(stat)) return false;
+            int close = stat.LastIndexOf(')');
+            if (close < 0 || close + 2 >= stat.Length) return false;
+            var tail = stat.Substring(close + 2).Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            // tail[0] = state (field 3), so field 22 = tail[19].
+            return tail.Length > 19 && long.TryParse(tail[19], out jiffies);
+        }
+    }
+}


### PR DESCRIPTION
The MCP bridge decided a running CST Reader existed by checking whether the pid in `local-api.json` was alive. A pid is not durable identity: after a crash (which leaves the handshake file behind) the OS can recycle the pid onto an unrelated process, and the check passes — the bridge attaches to a dead loopback port, or the liveness watcher never tears down.

## Fix

The handshake now carries the publishing process's **start token** beside the pid, and both check sites — `ReadLiveHandshake` (attach) and `WatchProcessLivenessAsync` (teardown) — require identity, not bare liveness. A recycled pid necessarily belongs to a process that started later, so its token differs.

## Why the token isn't just `Process.StartTime`

This is the crux, and it's what Fable's first review caught. On **Linux**, `Process.StartTime` is recomputed at every query as *(wall clock − elapsed-since-boot + start jiffies)*. Any wall-clock **step** — NTP correction, a VM resume, a manual clock set — shifts the *same* process's reported start time. A tick comparison would then judge a healthy app an impostor: tearing down a live MCP session, or on the attach path refusing to reconnect **permanently** (auto-launch is macOS-only). That is worse than the LOW bug being fixed.

So on Linux the token is the boot-relative **start-jiffy field (field 22) read directly from `/proc/<pid>/stat`**, which is clock-immune. macOS/Windows keep `Process.StartTime` — an absolute creation timestamp, stable there. Because the token is now identical between a self-query and an other-query on every platform, comparison is **exact**; the interim 3-second tolerance is gone (it only papered over the Linux instability and widened the false-match window).

## Access-denied is definitive, not transient

Reading a live pid's start time and getting *access denied* is treated as "not us": the app always runs as the invoking user, so a same-user start time is always readable — denial means the pid was recycled onto another user's process. `assumeOnError` now covers only genuinely indeterminate failures, and its two call sites keep opposite safe defaults (attach → stale, cheap relaunch; teardown → alive, don't kill a session over a glitch).

## Compatibility

`StartToken` (JSON `startToken`) replaces the interim `StartTimeTicks` name, since on Linux it's jiffies not ticks — free rename, the field never shipped (beta-5 clean-start). A missing token (pre-change file) deserializes to 0 and takes the pid-only path.

## Testing

892/892. The recycled-pid scenario is modelled faithfully — our own live pid recorded with a deliberately wrong token — on **both** the attach and teardown paths, and I verified both fail when the comparison is neutered. The `/proc` `comm`-quoting parser (spaces *and* parens in the process name) is extracted to `TryParseLinuxStartJiffies` and unit-tested directly, so the trickiest logic has coverage on any platform.

**Linux bring-up note:** the `/proc` read + exception-mapping branch can't run on the macOS test machine. The platform-agnostic tests (token round-trip, both impostor cases, the pid-only fallbacks) exercise the real path automatically when the suite runs on Linux — do one `dotnet test` run in a Linux container before Linux ships.

Reviewed adversarially by Fable across two passes. Closes #351. Part of epic #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)