### PR TITLE
#458: dispose-before-move on cross-window drags — fix the CEF re-parent SIGSEGV

### DIFF
--- a/docs/architecture/DOCK_SUBSYSTEM.md
+++ b/docs/architecture/DOCK_SUBSYSTEM.md
@@ -36,7 +36,7 @@ Root (RootDock, Id="Root")
   is removed (failure mode #4) and the View-menu can't bring the panels back. The overhaul should make
   the dock layer handle empty/missing docks correctly (recreate structure on demand) so such keep-alive
   workarounds aren't needed — at which point the welcome page could itself become closeable.
-- Floating windows are `CstHostWindow`s tracked in `CstDockFactory.HostWindows`; each has its own `Layout` (an independent dock tree with its own `DocumentDock`). A floating window can hold **multiple books** — dragging one floated window's tab onto another combines them into one window (an **intended grouping feature to preserve**). Like all window-change drags, the combine *does* go through the View's detach→reattach dispose+recreate (§4) — but that recreate fires on **re-attach, after** the framework has already moved the View (the drag-time "hide" only sets `IsVisible=false`, it does not dispose the browser). So it's cleanup after the risky moment, not prevention — which is the suspected reason drags are intermittently crash-prone and the button path (dispose **before** move) is not. Exact NativeControlHost timing during the drop is not yet confirmed.
+- Floating windows are `CstHostWindow`s tracked in `CstDockFactory.HostWindows`; each has its own `Layout` (an independent dock tree with its own `DocumentDock`). A floating window can hold **multiple books** — dragging one floated window's tab onto another combines them into one window (an **intended grouping feature to preserve**). **CORRECTION (#458): the combine did NOT go through any dispose+recreate.** The earlier claim here was false — the recreate branch in `BookDisplayView.OnAttachedToVisualTree` is dead code (`OnDetachedFromVisualTree` nulls `_currentWindow`, so every re-attach takes the "first time" path; zero "WINDOW CONTEXT CHANGED" log lines ever). The cross-window drag path (`MoveDockable`/`SwapDockable` 4-arg overloads, `SplitToDock` across windows) carried the **live** browser into the new window, and the crash is **deterministic**, not intermittent: it fires on the first re-attach after the browser's birth window is destroyed (e.g. the emptied source float auto-closes). **Fixed (#458):** `CstDockFactory` now overrides those cross-dock overloads and calls `DisposeAndEvictRecycledView` **before** the move for a book/PDF crossing windows — the same dispose-before-move the buttons use — so a fresh browser is built at the destination. `BookDisplayView` carries a `_browserBirthWindow` invariant check that logs an Error if a live browser ever re-attaches to a different window.
 
 ---
 
@@ -127,14 +127,17 @@ remove this cost entirely by keeping the live browser; the free middle path cann
   only sets `IsVisible=false` — it does **not** dispose the browser, so a live CEF surface still exists
   through the drop.
 
-**Why buttons are safe and drags crash:** the button path tears down and rebuilds the browser in a
-**controlled, sequenced** way *before/after* the dock move (`PrepareForFloat`→dispose, move,
-`RestoreAfterFloat`→recreate) — no live browser exists during the move. A **drag** instead lets the
-framework move the View while the browser is still alive (only hidden); the dispose+recreate fires on
-**re-attach, *after* the move** (`OnAttachedToVisualTree` window-change branch). So for drags the
-recreate is *cleanup after* the risky moment, not *prevention* of it — the suspected crash window. The
-dividing line is **dispose-before-move (buttons) vs dispose-after-move (drags)**. *(Exact
-NativeControlHost timing during the drop is not yet confirmed — the overhaul should pin it down.)*
+**Why buttons are safe and drags crashed:** the button path tears down and rebuilds the browser in a
+**controlled, sequenced** way *before* the dock move (dispose+evict, move, fresh browser at the
+destination) — no live browser exists during the move. A **cross-window drag** instead let the framework
+move the live View across windows; the `OnAttachedToVisualTree` window-change "recreate" branch that was
+supposed to catch this is **dead code** (see the #458 correction under Floating windows above), so nothing
+disposed the browser. The dividing line was **dispose-before-move (buttons) vs carry-live-browser
+(drags)**. **Fixed (#458):** `CstDockFactory` now overrides the cross-dock `MoveDockable`/`SwapDockable`
+overloads and cross-window `SplitToDock` to dispose-before-move for books/PDFs, so the drag paths match the
+buttons. The crash was **deterministic** (fires on the first re-attach after the browser's birth window is
+destroyed), not a timing race — it only looked intermittent because many different drag sequences were
+being exercised.
 
 **Pre-move hooks available** (for a dispose-*before*-move on drags): Avalonia has **no** pre-detach
 event (only `DetachedFromVisualTree`, post). Dock's factory events are all post (`DockableMoved`/

--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryCrossWindowTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryCrossWindowTests.cs
@@ -1,0 +1,97 @@
+using CST.Avalonia.Services;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// #458: cross-window drag of a book/PDF must dispose its live CEF browser before the re-parent, or the
+/// SIGSEGV returns. The dispose itself needs a live View (GUI-only), but the classification it hinges on —
+/// "is this move crossing into another window's layout?" — is <see cref="CstDockFactory.GetRootOwner"/>,
+/// a pure ownership walk that these tests pin down.
+/// </summary>
+public class CstDockFactoryCrossWindowTests
+{
+    private sealed class TestDocument : Document { }
+
+    // A document nested: root → documentDock → doc. Returns (root, doc).
+    private static (RootDock Root, DocumentDock Dock, TestDocument Doc) BuildWindowLayout(string id)
+    {
+        var doc = new TestDocument { Id = id + "-doc", Title = id };
+        var dock = new DocumentDock
+        {
+            Id = "MainDocumentDock",
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { doc }
+        };
+        var root = new RootDock
+        {
+            Id = id + "-root",
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { dock }
+        };
+        // Owner links are what GetRootOwner walks; the framework sets these on real adds.
+        dock.Owner = root;
+        doc.Owner = dock;
+        return (root, dock, doc);
+    }
+
+    [Fact]
+    public void GetRootOwner_ResolvesToTheDocumentsOwnWindowRoot()
+    {
+        var (root, _, doc) = BuildWindowLayout("A");
+        Assert.Same(root, CstDockFactory.GetRootOwner(doc));
+    }
+
+    [Fact]
+    public void GetRootOwner_FromADock_ResolvesToItsRoot()
+    {
+        var (root, dock, _) = BuildWindowLayout("A");
+        Assert.Same(root, CstDockFactory.GetRootOwner(dock));
+    }
+
+    [Fact]
+    public void GetRootOwner_TwoWindows_AreDistinct_SoAMoveBetweenThemIsCrossWindow()
+    {
+        var (rootA, _, docA) = BuildWindowLayout("A");
+        var (rootB, _, docB) = BuildWindowLayout("B");
+
+        var ownerA = CstDockFactory.GetRootOwner(docA);
+        var ownerB = CstDockFactory.GetRootOwner(docB);
+
+        Assert.NotSame(ownerA, ownerB);          // different windows → cross-window
+        Assert.Same(rootA, ownerA);
+        Assert.Same(rootB, ownerB);
+    }
+
+    [Fact]
+    public void GetRootOwner_TwoDocksInTheSameWindow_ShareARoot_SoAMoveBetweenThemIsNotCrossWindow()
+    {
+        // A split within one window: two document docks under the same root.
+        var (root, dockLeft, _) = BuildWindowLayout("A");
+        var docRight = new TestDocument { Id = "A-doc2", Title = "A2" };
+        var dockRight = new DocumentDock
+        {
+            Id = "MainDocumentDock",
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { docRight }
+        };
+        root.VisibleDockables!.Add(dockRight);
+        dockRight.Owner = root;
+        docRight.Owner = dockRight;
+
+        Assert.Same(CstDockFactory.GetRootOwner(dockLeft), CstDockFactory.GetRootOwner(dockRight));
+    }
+
+    [Fact]
+    public void GetRootOwner_ARootItself_ReturnsItself()
+    {
+        var (root, _, _) = BuildWindowLayout("A");
+        Assert.Same(root, CstDockFactory.GetRootOwner(root));
+    }
+
+    [Fact]
+    public void GetRootOwner_NullOrOwnerless_ReturnsNull()
+    {
+        Assert.Null(CstDockFactory.GetRootOwner(null));
+        Assert.Null(CstDockFactory.GetRootOwner(new TestDocument { Id = "orphan" }));  // no Owner chain
+    }
+}

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -952,7 +952,14 @@ namespace CST.Avalonia.Services
             }
             
             Log.Debug("*** Using framework default split behavior ***");
-            
+
+            // Defensive only: on the STANDARD edge-split path Dock re-parents the book via the 4-arg
+            // MoveDockable before this runs, and here `dockable` is the intermediate dock (not the book), so
+            // the type filter skips it. This call covers any non-standard split that hands us the book
+            // directly; the actual same/cross-window split protection lives in PrepareCrossWindowMove's
+            // unresolved-target default. (#458)
+            PrepareCrossWindowMove(dockable, dock);
+
             // Let the framework handle the split
             if (dock != null && dockable != null)
             {
@@ -1947,10 +1954,81 @@ namespace CST.Avalonia.Services
                 return;
             }
             Log.Debug("*** MoveDockable completed ***");
-            
+
             // Trigger cleanup after move operations as they can leave empty structures
             Log.Debug("*** Post-move cleanup - checking for empty splits ***");
             CleanupEmptySplits();
+        }
+
+        // The CROSS-DOCK move overload — the drag path that merges a tab into ANOTHER window's dock. This was
+        // NOT overridden before, so it skipped the dispose-before-move discipline the float/unfloat buttons
+        // follow: a book/PDF dragged into another window kept the same View with its LIVE CEF browser, and a
+        // browser cannot survive its birth window being destroyed — the next re-attach faults in
+        // AvnNativeControlHostTopLevelAttachment::InitializeWithChildHandle (SIGSEGV). Dispose + evict first so
+        // the destination rebuilds a fresh browser. (#458)
+        public override void MoveDockable(IDock sourceDock, IDock targetDock, IDockable sourceDockable, IDockable targetDockable)
+        {
+            PrepareCrossWindowMove(sourceDockable, targetDock);
+            base.MoveDockable(sourceDock, targetDock, sourceDockable, targetDockable);
+            CleanupEmptySplits();
+        }
+
+        // Cross-dock swap: both dockables change docks, so either could be a book/PDF crossing windows.
+        public override void SwapDockable(IDock sourceDock, IDock targetDock, IDockable sourceDockable, IDockable targetDockable)
+        {
+            PrepareCrossWindowMove(sourceDockable, targetDock);
+            PrepareCrossWindowMove(targetDockable, sourceDock);
+            base.SwapDockable(sourceDock, targetDock, sourceDockable, targetDockable);
+            CleanupEmptySplits();
+        }
+
+        // When a book/PDF is about to move into a dock in a DIFFERENT window, shut down and evict its recycled
+        // View so no live CEF browser crosses the re-parent (see the cross-dock MoveDockable note). Same-window
+        // *tab* moves (Fill drops) resolve both roots to the same window and are skipped — the recycled View
+        // stays for instant tab switching.
+        //
+        // NOTE: an edge-SPLIT is different. Dock builds a brand-new, still-ownerless DocumentDock and moves the
+        // book into it BEFORE attaching it to a window, so GetRootOwner(target) is null here even for a
+        // same-window split. That falls into the "can't confirm same window → dispose" default below, so a
+        // same-window split DOES rebuild the browser (a brief flicker + a position-preserving reload). That is
+        // deliberate and must stay: the unresolved-target dispose is the ONLY thing protecting a cross-window
+        // split (the SplitToDock guard never sees the book — its dockable is the intermediate dock). Erring
+        // toward disposing when the window can't be confirmed is the safe side: a needless rebuild only
+        // flickers, whereas carrying a live browser crashes. (#458)
+        private void PrepareCrossWindowMove(IDockable? dockable, IDock? targetDock)
+        {
+            if (dockable is not (BookDisplayViewModel or PdfDisplayViewModel)) return;
+            if (targetDock == null) return;
+
+            var sourceRoot = GetRootOwner(dockable);
+            var targetRoot = GetRootOwner(targetDock);
+
+            // Skip ONLY when both roots resolve and are the same window.
+            if (sourceRoot != null && targetRoot != null && ReferenceEquals(sourceRoot, targetRoot))
+                return;
+
+            // Preserve reading position across the rebuild: queue the last-known token so the fresh
+            // destination View restores it, exactly as the float/unfloat paths seed initialPositionToken. (#434)
+            if (dockable is BookDisplayViewModel bookVm && bookVm.LastPositionToken is { } token)
+                bookVm.QueuePositionRestore(token);
+
+            Log.Information("#458: cross-window move of {Id} — disposing live WebView before re-parent", dockable.Id);
+            DisposeAndEvictRecycledView(dockable);
+        }
+
+        // The IRootDock at the top of a dockable's ownership chain — its window's layout root. Two dockables
+        // are in the same window iff this returns the same instance (each HostWindow.Layout is its own
+        // RootDock). Returns the NEAREST root ancestor so a floating window resolves to its own root, not the
+        // main one. (#458)
+        internal static IRootDock? GetRootOwner(IDockable? dockable)
+        {
+            var current = dockable;
+            for (int i = 0; current != null && i < 64; i++)
+            {
+                if (current is IRootDock root) return root;
+                current = current.Owner;
+            }
+            return null;
         }
         
         // Override AddDockable to trigger cleanup 

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -517,6 +517,11 @@ namespace CST.Avalonia.ViewModels
             return token;
         }
 
+        // Queue a reading-position token to restore when the View next becomes available. Used when a
+        // cross-window drag rebuilds this book's View with a fresh browser (#458): the VM instance is
+        // preserved, so seeding the pending token lands the fresh View where the user was reading. (#434)
+        internal void QueuePositionRestore(ReadingPositionToken token) => _pendingPositionToken = token;
+
         internal int? TakePendingHitNavigation()
         {
             var hit = _pendingHitNavigation;

--- a/src/CST.Avalonia/ViewModels/WelcomeViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/WelcomeViewModel.cs
@@ -55,6 +55,11 @@ namespace CST.Avalonia.ViewModels
             Title = "Welcome";
             CanClose = false;   // Prevent closing the welcome tab
             CanFloat = false;   // Prevent floating the welcome tab
+            // Welcome hosts its own CEF WebView. CanFloat=false blocks new-window creation but NOT dragging
+            // the tab INTO an existing floating window — which would carry a live browser across windows and
+            // hit the #458 SIGSEGV (the dispose-before-move guard covers only Book/PDF). It's a fixed tab
+            // anyway, so make it non-draggable outright. (#458)
+            CanDrag = false;
             CanPin = false;     // Prevent pinning
 
             // Set current app version from assembly

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -99,6 +99,12 @@ public partial class BookDisplayView : UserControl
 
     // Window context tracking for CEF handle invalidation detection
     private Window? _currentWindow = null;
+    // The window this View's CEF browser was created in. Unlike _currentWindow (nulled on every detach so
+    // window-change is re-evaluated), this persists across detach/reattach so we can assert the invariant a
+    // live browser must never re-attach to a different window — that is the #458 SIGSEGV. Purely diagnostic;
+    // the fix is dispose-before-move in CstDockFactory. If this ever logs, a re-parent path is carrying a
+    // live browser and needs the same guard.
+    private Window? _browserBirthWindow = null;
 
     public BookDisplayView()
     {
@@ -347,6 +353,17 @@ public partial class BookDisplayView : UserControl
         // Get the new window this view is attached to
         var newWindow = this.GetVisualRoot() as Window;
 
+        // #458 invariant check: a LIVE browser must never re-attach to a window other than the one it was
+        // born in — that is the crash. With dispose-before-move in place this can't happen; if it ever does,
+        // this Error is the early warning that a re-parent path is missing the guard (better a log than a
+        // SIGSEGV). _webView != null means the browser is still live (not disposed for a rebuild).
+        if (newWindow != null && _webView != null && _browserBirthWindow != null &&
+            !ReferenceEquals(_browserBirthWindow, newWindow))
+        {
+            _logger.Error("*** #458 VIOLATION: live WebView re-attaching to a different window — Book: {BookFile}, born in {OldHash}, now {NewHash}. A re-parent path is carrying a live browser (crash risk). ***",
+                _viewModel?.Book?.FileName ?? "null", _browserBirthWindow.GetHashCode(), newWindow.GetHashCode());
+        }
+
         if (newWindow != null)
         {
             // Compare by reference equality, not by title
@@ -370,6 +387,7 @@ public partial class BookDisplayView : UserControl
 
                 // Recreate WebView with fresh native handle for new window
                 TryCreateWebView();
+                _browserBirthWindow = newWindow;  // fresh browser born here (#458)
 
                 // Reload content if ViewModel has HTML
                 if (_viewModel != null && !string.IsNullOrEmpty(_viewModel.HtmlContent))
@@ -382,6 +400,9 @@ public partial class BookDisplayView : UserControl
             {
                 // First attachment - just track the window
                 _currentWindow = newWindow;
+                // The browser (built in the ctor's TryCreateWebView) binds to the window it first renders in —
+                // here. Recording it lets the invariant check above catch any later live cross-window attach. (#458)
+                _browserBirthWindow ??= newWindow;
                 _logger.Information("*** 🆕 BookDisplayView attached to window for FIRST TIME ***");
                 _logger.Information("    Window: {WindowTitle} (Hash: {Hash})",
                     newWindow.Title ?? "null", newWindow.GetHashCode());


### PR DESCRIPTION
Closes #458.

Dragging a book/PDF tab into **another floating window** carried the same View with its **live** CEF browser across windows. A browser can't survive its birth window being destroyed (the emptied source float auto-closes), so the next re-attach faulted in `AvnNativeControlHostTopLevelAttachment::InitializeWithChildHandle` (`SIGSEGV @ 0x0`). **Deterministic** given the operation sequence — it only looked intermittent because many drag sequences were being exercised (see the issue thread).

## Root cause

The float/unfloat **buttons** obey dispose-before-move (dispose + evict the recycled View → fresh browser at the destination). The **drag** paths did not: `CstDockFactory` overrode only the 3-arg *same-dock* `MoveDockable`/`SwapDockable`, not the 4-arg *cross-dock* overloads — and the "recreate on window change" branch in `BookDisplayView.OnAttachedToVisualTree` meant to catch this is **dead code** (detach nulls `_currentWindow`, so every re-attach takes the "first time" path; zero "WINDOW CONTEXT CHANGED" log lines in a full day).

## Fix — bring the drag paths up to the buttons' discipline

- Override the **4-arg** `MoveDockable` and `SwapDockable`; guard `SplitToDock`. Before a book/PDF crosses into another window's dock, `DisposeAndEvictRecycledView` so the destination builds a fresh browser. Same-window tab moves are skipped.
- Classify via `GetRootOwner` (nearest `IRootDock` up the `Owner` chain). When the target window can't be resolved — the ownerless intermediate dock a split creates — err toward disposing: a needless rebuild only flickers, carrying a live browser crashes. This is what protects cross-window splits.
- Preserve reading position across the rebuild (`QueuePositionRestore` seeds the #434 token).
- Include `PdfDisplayViewModel` from the start (same crash; de-risks #419).
- **Welcome tab:** it hosts a CEF browser too and was `CanDrag=true`; `CanFloat=false` doesn't block dragging it *into* a float, so it hit the identical crash. It's a fixed tab → `CanDrag=false`. (Found by Fable.)
- Diagnostic `_browserBirthWindow` in `BookDisplayView` logs an Error if a live browser ever re-attaches to a different window — a log instead of a SIGSEGV if any future path breaks the discipline.
- Corrected `DOCK_SUBSYSTEM.md` (the drag-combine never went through dispose+recreate).

## Behavior note

A same-window **edge-split** now rebuilds the browser (it can't be classified as same- vs cross-window, so it disposes to stay safe; position preserved). In practice the drag-time WebView white-out **hides this entirely** — no visible flicker (confirmed in testing). Same-window tab *reordering* is unaffected.

## Review

Fable: **SHIP-WITH-NITS**, verified via decompile that every cross-window drag route now disposes-before-move, no float path is reintroduced, and the button/close/same-window-reorder paths are untouched. Both its findings (Welcome tab; same-window-split rebuild + misleading comments) are addressed. Minor nits left as-is: a benign dead-view shell per cross-window drag (browser is freed), position restore uses the ≤200ms rolling token vs a live query, and a PDF loses its current page on a cross-window move — none are crashes.

## Verification

Manual on macOS — all previously-crashing sequences now clean, no regressions: the original multi-book-float-close repro (both close routes, both drag directions), tab-switch-back after merge (the root-cause validator), cross-window drags both ways, Welcome now non-draggable, float/unfloat buttons, same-window reorder, script change, relaunch restore. 6 new `GetRootOwner` unit tests. Full suite: **898 passed, 0 failed**.

## Related

Fixes the cross-window subset of **#39** — keep it open to retest same-window drag-to-split. Makes **#419** (PDF float) strictly safer.
