### PR TITLE
#109: CST.Lexicon — the canonical multi-source dictionary asset format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ src/CST.Core/obj/
 src/CST.Lemma/bin/
 src/CST.Lemma/obj/
 
+src/CST.Lexicon/bin/
+src/CST.Lexicon/obj/
+
 src/CST.Lucene/bin/
 src/CST.Lucene/obj/
 

--- a/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
+++ b/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="..\CST.Avalonia\CST.Avalonia.csproj" />
     <ProjectReference Include="..\CST.Lucene\CST.Lucene.csproj" />
     <ProjectReference Include="..\CST.Lemma\CST.Lemma.csproj" />
+    <ProjectReference Include="..\CST.Lexicon\CST.Lexicon.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
+++ b/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.IO;
+using System.Linq;
+using CST.Conversion;
+using CST.Lexicon;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Lexicon
+{
+    /// <summary>
+    /// The canonical lexicon format (#109): build → read round-trips, and the load-bearing correctness
+    /// properties — keys are derived the SAME way a runtime query is (so lookups can't silently miss),
+    /// homonyms surface together, HTML in a headword is stripped for the key but the published form is kept,
+    /// and the exact/prefix/nearest search matches the flat-file dictionary's behaviour.
+    /// </summary>
+    public class LexiconTests : IDisposable
+    {
+        private readonly string _dir;
+
+        public LexiconTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "cst-lex-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try { SqliteConnection.ClearAllPools(); } catch { }
+            try { Directory.Delete(_dir, recursive: true); } catch { }
+        }
+
+        private LexiconReader Build(params RawEntry[] entries)
+        {
+            var meta = new LexiconMeta("dppn", "DPPN", "en", LexiconKind.ProperNames,
+                Title: "Dictionary of Pāli Proper Names", Author: "G. P. Malalasekera",
+                Reviser: "Ānandajoti Bhikkhu", Year: "2025", License: "public-domain",
+                SourceVersion: "2025-06", ConverterVersion: 1);
+            var path = Path.Combine(_dir, "dppn.db");
+            LexiconBuilder.Build(path, meta, entries);
+            return LexiconReader.Open(path);
+        }
+
+        // ---- key derivation ----
+
+        [Fact]
+        public void The_stored_key_equals_the_key_a_runtime_query_derives()
+        {
+            // This is the whole game: a headword's stored key and a user's typed query must normalize to the
+            // same IPE string, or the word is unfindable. Derive both ways and assert equality.
+            foreach (var head in new[] { "Sāvatthī", "Nāgita", "Jetavana", "Anāthapiṇḍika" })
+            {
+                var storedKey = LexiconKey.DeriveKey(head);
+                var queryKey = LexiconKey.DeriveQueryKey(head.ToUpperInvariant());   // user types any case
+                Assert.Equal(storedKey, queryKey);
+                Assert.Equal(Any2Ipe.Convert(head.ToLowerInvariant()), storedKey);   // and it IS the IPE form
+            }
+        }
+
+        [Fact]
+        public void A_headword_is_found_regardless_of_query_case_or_script()
+        {
+            var lex = Build(new RawEntry("Sāvatthī", "<p>A city.</p>"));
+            Assert.Single(lex.Lookup("sāvatthī"));
+            Assert.Single(lex.Lookup("SĀVATTHĪ"));
+            Assert.Single(lex.Lookup("Sāvatthī"));
+            // Devanagari of the same word resolves to the same IPE key.
+            var deva = ScriptConverter.Convert("sāvatthī", Script.Latin, Script.Devanagari);
+            Assert.Single(lex.Lookup(deva));
+        }
+
+        // ---- homonyms ----
+
+        [Fact]
+        public void Homonyms_share_a_key_and_all_surface_on_an_exact_lookup()
+        {
+            var lex = Build(
+                new RawEntry("Nāgita 1", "<p>An elder.</p>"),
+                new RawEntry("Nāgita 2", "<p>A brahmin.</p>"));
+
+            var hits = lex.Lookup("nāgita");
+            Assert.Equal(2, hits.Count);
+            Assert.Equal(new[] { "Nāgita 1", "Nāgita 2" }, hits.Select(h => h.Headword));
+            Assert.Equal(new[] { 1, 2 }, hits.Select(h => h.Homonym));
+            // Same key for both; the published form (with the number) is preserved separately.
+            Assert.All(hits, h => Assert.Equal(LexiconKey.DeriveKey("Nāgita"), h.IpeKey));
+        }
+
+        [Fact]
+        public void A_bare_integer_is_a_homonym_marker_but_an_interior_number_is_not()
+        {
+            Assert.Equal(("Nāgita", 1), LexiconKey.SplitHomonym("Nāgita 1"));
+            Assert.Equal(("Sāvatthī", 0), LexiconKey.SplitHomonym("Sāvatthī"));
+            Assert.Equal(("Migāra", 12), LexiconKey.SplitHomonym("Migāra 12"));   // base has the number stripped
+            // A name that legitimately ends in a word, or has an interior number, is left whole.
+            Assert.Equal(("Vessantara Jātaka", 0), LexiconKey.SplitHomonym("Vessantara Jātaka"));
+        }
+
+        // ---- HTML in the headword ----
+
+        [Fact]
+        public void Html_in_a_headword_is_stripped_for_key_and_display()
+        {
+            var lex = Build(new RawEntry("<b>Jeta</b>vana", "<p>A grove.</p>"));
+            var hit = Assert.Single(lex.Lookup("jetavana"));
+            Assert.Equal("Jetavana", hit.Headword);                 // tags gone from the published form
+            Assert.Equal(LexiconKey.DeriveKey("Jetavana"), hit.IpeKey);
+        }
+
+        [Fact]
+        public void The_body_html_is_stored_verbatim()
+        {
+            var lex = Build(new RawEntry("Sāvatthī", "<p>Capital of <i>Kosala</i>.</p>"));
+            Assert.Equal("<p>Capital of <i>Kosala</i>.</p>", lex.Lookup("sāvatthī").Single().BodyHtml);
+        }
+
+        // ---- exact / prefix / nearest ----
+
+        [Fact]
+        public void An_exact_hit_is_followed_by_the_prefix_run()
+        {
+            var lex = Build(
+                new RawEntry("Nāga", "n"),
+                new RawEntry("Nāgadatta", "n"),
+                new RawEntry("Nāgita", "n"),
+                new RawEntry("Bimbisāra", "b"));
+            var hits = lex.Lookup("nāga").Select(h => h.Headword).ToList();
+            Assert.Equal(new[] { "Nāga", "Nāgadatta" }, hits);       // "Nāgita" shares only "nāg", not "nāga"
+        }
+
+        [Fact]
+        public void A_miss_returns_the_nearest_common_prefix_run()
+        {
+            var lex = Build(
+                new RawEntry("Nāgadatta", "n"),
+                new RawEntry("Nāgita", "n"),
+                new RawEntry("Bimbisāra", "b"));
+            // No entry keyed exactly "nāg"; the two sharing that 3-char prefix come back.
+            var hits = lex.Lookup("nāg").Select(h => h.Headword).ToList();
+            Assert.Equal(new[] { "Nāgadatta", "Nāgita" }, hits);
+        }
+
+        [Fact]
+        public void No_shared_leading_character_returns_nothing()
+        {
+            var lex = Build(new RawEntry("Sāvatthī", "s"));
+            Assert.Empty(lex.Lookup("kosala"));
+        }
+
+        [Fact]
+        public void Max_bounds_the_result()
+        {
+            var lex = Build(
+                new RawEntry("Nāga 1", "n"), new RawEntry("Nāga 2", "n"), new RawEntry("Nāga 3", "n"));
+            Assert.Equal(2, lex.Lookup("nāga", max: 2).Count);
+        }
+
+        // ---- meta ----
+
+        [Fact]
+        public void Meta_round_trips()
+        {
+            var lex = Build(new RawEntry("Sāvatthī", "s"));
+            Assert.Equal("dppn", lex.Meta.SourceId);
+            Assert.Equal("DPPN", lex.Meta.DisplayName);
+            Assert.Equal("en", lex.Meta.DefinitionLanguage);
+            Assert.Equal(LexiconKind.ProperNames, lex.Meta.Kind);
+            Assert.Equal("G. P. Malalasekera", lex.Meta.Author);
+            Assert.Equal("Ānandajoti Bhikkhu", lex.Meta.Reviser);
+            Assert.Equal("public-domain", lex.Meta.License);
+            Assert.Equal("2025-06", lex.Meta.SourceVersion);
+        }
+
+        [Fact]
+        public void A_blank_headword_is_skipped()
+        {
+            var path = Path.Combine(_dir, "skip.db");
+            var meta = new LexiconMeta("x", "X", "en", LexiconKind.General);
+            int written = LexiconBuilder.Build(path, meta, new[]
+            {
+                new RawEntry("Sāvatthī", "s"),
+                new RawEntry("<i></i>", "empty after strip"),   // nothing to key on
+                new RawEntry("   ", "blank"),
+            });
+            Assert.Equal(1, written);
+        }
+
+        [Fact]
+        public void A_schema_newer_than_this_build_is_refused()
+        {
+            var path = Path.Combine(_dir, "future.db");
+            LexiconBuilder.Build(path, new LexiconMeta("x", "X", "en", LexiconKind.General),
+                new[] { new RawEntry("Sāvatthī", "s") });
+            // Forge a newer schema_version in the file.
+            var csb = new SqliteConnectionStringBuilder { DataSource = path };
+            using (var c = new SqliteConnection(csb.ToString()))
+            {
+                c.Open();
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = "UPDATE meta SET value = '999' WHERE key = 'schema_version'";
+                cmd.ExecuteNonQuery();
+            }
+            SqliteConnection.ClearAllPools();
+            Assert.Throws<NotSupportedException>(() => LexiconReader.Open(path));
+        }
+    }
+}

--- a/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
+++ b/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
@@ -186,6 +186,81 @@ namespace CST.Avalonia.Tests.Lexicon
         }
 
         [Fact]
+        public void Rebuilding_the_same_path_replaces_the_lexicon_without_loss()
+        {
+            // fable HIGH-1: with SQLite pooling on, a second Build to the same path resurrected the deleted
+            // file's handle and threw, losing the prior good lexicon. Build twice, then read.
+            var path = Path.Combine(_dir, "rebuild.db");
+            var meta = new LexiconMeta("x", "X", "en", LexiconKind.General);
+            LexiconBuilder.Build(path, meta, new[] { new RawEntry("Sāvatthī", "first") });
+            LexiconBuilder.Build(path, meta, new[] { new RawEntry("Kosala", "second") });   // must not throw
+
+            var lex = LexiconReader.Open(path);
+            Assert.Equal(1, lex.Count);
+            Assert.Empty(lex.Lookup("sāvatthī"));                 // old content gone
+            Assert.Equal("second", lex.Lookup("kosala").Single().BodyHtml);
+            Assert.False(File.Exists(path + ".tmp"));             // temp cleaned up by the rename
+        }
+
+        [Fact]
+        public void An_entity_encoded_headword_is_decoded_so_its_key_is_findable()
+        {
+            // fable MED-1: "N&#257;ga" must key/display as "Nāga", not keep the literal entity (a dead key).
+            var lex = Build(new RawEntry("N&#257;ga", "<p>A serpent-being.</p>"));
+            var hit = Assert.Single(lex.Lookup("nāga"));
+            Assert.Equal("Nāga", hit.Headword);
+            Assert.Equal(LexiconKey.DeriveKey("Nāga"), hit.IpeKey);
+            // A genuinely escaped literal is kept as the literal, not re-read as a tag.
+            Assert.Equal("a < b", LexiconKey.StripHtml("a &lt; b"));
+        }
+
+        [Fact]
+        public void Exact_homonyms_then_the_deeper_prefix_run_all_surface_together()
+        {
+            var lex = Build(
+                new RawEntry("Nāga 1", "n"),
+                new RawEntry("Nāga 2", "n"),
+                new RawEntry("Nāgadatta", "n"));
+            // Exact key "nāga" → both homonyms, then the deeper-prefix "Nāgadatta".
+            Assert.Equal(new[] { "Nāga 1", "Nāga 2", "Nāgadatta" },
+                lex.Lookup("nāga").Select(h => h.Headword));
+        }
+
+        [Fact]
+        public void A_miss_tied_on_both_sides_collects_both_runs_in_ascending_key_order()
+        {
+            var lex = Build(
+                new RawEntry("Nabhasa", "n"),      // shares "na"
+                new RawEntry("Nandā", "n"));       // shares "na"
+            // "naX" (no exact) with both neighbors sharing "na" (2) → both are returned...
+            var hits = lex.Lookup("naxyz");
+            Assert.Equal(2, hits.Count);
+            Assert.Contains(hits, h => h.Headword == "Nabhasa");
+            Assert.Contains(hits, h => h.Headword == "Nandā");
+            // ...in ascending IPE-key order (Pāli collation: dental 'n' sorts before labial 'b', so this is
+            // Nandā then Nabhasa — the point is the reader emits them sorted, whatever the collation says).
+            var keys = hits.Select(h => h.IpeKey).ToList();
+            Assert.Equal(keys.OrderBy(k => k, StringComparer.Ordinal), keys);
+        }
+
+        [Fact]
+        public void A_file_without_a_schema_version_is_refused()
+        {
+            var path = Path.Combine(_dir, "noschema.db");
+            LexiconBuilder.Build(path, new LexiconMeta("x", "X", "en", LexiconKind.General),
+                new[] { new RawEntry("Sāvatthī", "s") });
+            var csb = new SqliteConnectionStringBuilder { DataSource = path, Pooling = false };
+            using (var c = new SqliteConnection(csb.ToString()))
+            {
+                c.Open();
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = "DELETE FROM meta WHERE key = 'schema_version'";
+                cmd.ExecuteNonQuery();
+            }
+            Assert.Throws<NotSupportedException>(() => LexiconReader.Open(path));
+        }
+
+        [Fact]
         public void A_schema_newer_than_this_build_is_refused()
         {
             var path = Path.Combine(_dir, "future.db");

--- a/src/CST.Lexicon/CST.Lexicon.csproj
+++ b/src/CST.Lexicon/CST.Lexicon.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    CST.Lexicon — the canonical multi-source dictionary asset format (#109). Both our build-time
+    converters (e.g. DPPN) and the future in-app import produce a "lexicon": a small SQLite carrying
+    IPE-keyed, homonym-aware, HTML-definition entries plus source/attribution meta. One writer
+    (LexiconBuilder), one reader (LexiconReader), one key-derivation (LexiconKey) — so build-time and
+    read-time can never drift on how a headword becomes a lookup key.
+
+    Depends on CST.Core for Any2Ipe (the key derivation must match the runtime query normalization
+    exactly) + Microsoft.Data.Sqlite. No HTML sanitizer here: our downloaded assets are sanitized at
+    BUILD time by the converter; runtime sanitization only matters for the later user-import path.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>CST.Lexicon</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- Same patched-native-SQLite pin as CST.Lemma (clears advisory GHSA-2m69-gcr7-jv3q). -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CST.Core\CST.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="CST.Avalonia.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/CST.Lexicon/LexiconBuilder.cs
+++ b/src/CST.Lexicon/LexiconBuilder.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Data.Sqlite;
+
+namespace CST.Lexicon
+{
+    /// <summary>
+    /// Writes a canonical lexicon SQLite from a source's meta + raw entries. Build-time only (our local
+    /// converters, and later the in-app import). Derives each entry's IPE key, splits its homonym number, and
+    /// strips HTML from the headword — through <see cref="LexiconKey"/>, the same logic the reader's query path
+    /// uses — so a lexicon and a query can't disagree on keys.
+    ///
+    /// <para><b>Body HTML is stored verbatim.</b> The builder does NOT sanitize: sanitization is the converter's
+    /// job (done once at build time, over a source's known markup) so the app never ships an HTML sanitizer for
+    /// its own trusted downloaded assets. The in-app import path (untrusted HTML) sanitizes before calling this.</para>
+    /// </summary>
+    public static class LexiconBuilder
+    {
+        /// <summary>
+        /// Build a lexicon at <paramref name="dbPath"/> (overwriting any existing file) from
+        /// <paramref name="meta"/> and <paramref name="entries"/>. An entry whose headword is blank after HTML
+        /// stripping is skipped (counted in the return).
+        /// </summary>
+        /// <returns>The number of entries written.</returns>
+        public static int Build(string dbPath, LexiconMeta meta, IEnumerable<RawEntry> entries)
+        {
+            if (dbPath is null) throw new ArgumentNullException(nameof(dbPath));
+            if (meta is null) throw new ArgumentNullException(nameof(meta));
+            if (entries is null) throw new ArgumentNullException(nameof(entries));
+
+            // Start from a clean file so a rebuild can't leave stale rows.
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+
+            var csb = new SqliteConnectionStringBuilder { DataSource = dbPath, Mode = SqliteOpenMode.ReadWriteCreate };
+            using var conn = new SqliteConnection(csb.ToString());
+            conn.Open();
+
+            using (var pragma = conn.CreateCommand())
+            {
+                pragma.CommandText = "PRAGMA journal_mode=OFF; PRAGMA synchronous=OFF;";
+                pragma.ExecuteNonQuery();
+            }
+            using (var create = conn.CreateCommand())
+            {
+                create.CommandText = LexiconSchema.CreateSql;
+                create.ExecuteNonQuery();
+            }
+
+            using var tx = conn.BeginTransaction();
+
+            WriteMeta(conn, meta);
+
+            int written = 0;
+            using (var insert = conn.CreateCommand())
+            {
+                insert.CommandText =
+                    "INSERT INTO entry(ipe_key, headword, homonym, body_html) VALUES ($k, $h, $n, $b)";
+                var pk = insert.CreateParameter(); pk.ParameterName = "$k"; insert.Parameters.Add(pk);
+                var ph = insert.CreateParameter(); ph.ParameterName = "$h"; insert.Parameters.Add(ph);
+                var pn = insert.CreateParameter(); pn.ParameterName = "$n"; insert.Parameters.Add(pn);
+                var pb = insert.CreateParameter(); pb.ParameterName = "$b"; insert.Parameters.Add(pb);
+
+                foreach (var raw in entries)
+                {
+                    string stripped = LexiconKey.StripHtml(raw.Headword ?? string.Empty);
+                    if (string.IsNullOrWhiteSpace(stripped)) continue;   // nothing to key on
+
+                    var (headBase, homonym) = LexiconKey.SplitHomonym(stripped);
+                    string key = LexiconKey.DeriveKey(headBase);
+                    if (string.IsNullOrEmpty(key)) continue;
+
+                    pk.Value = key;
+                    ph.Value = stripped;                 // verbatim published form (homonym number kept)
+                    pn.Value = homonym;
+                    pb.Value = raw.BodyHtml ?? string.Empty;
+                    insert.ExecuteNonQuery();
+                    written++;
+                }
+            }
+
+            tx.Commit();
+            return written;
+        }
+
+        private static void WriteMeta(SqliteConnection conn, LexiconMeta m)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT OR REPLACE INTO meta(key, value) VALUES ($k, $v)";
+            var pk = cmd.CreateParameter(); pk.ParameterName = "$k"; cmd.Parameters.Add(pk);
+            var pv = cmd.CreateParameter(); pv.ParameterName = "$v"; cmd.Parameters.Add(pv);
+
+            void Put(string key, string? value)
+            {
+                if (value is null) return;
+                pk.Value = key; pv.Value = value; cmd.ExecuteNonQuery();
+            }
+
+            Put(LexiconSchema.MetaSchemaVersion, LexiconSchema.SchemaVersion.ToString());
+            Put(LexiconSchema.MetaSourceId, m.SourceId);
+            Put(LexiconSchema.MetaDisplayName, m.DisplayName);
+            Put(LexiconSchema.MetaDefinitionLanguage, m.DefinitionLanguage);
+            Put(LexiconSchema.MetaKind, m.Kind == LexiconKind.ProperNames ? "proper-names" : "general");
+            Put(LexiconSchema.MetaTitle, m.Title);
+            Put(LexiconSchema.MetaAuthor, m.Author);
+            Put(LexiconSchema.MetaReviser, m.Reviser);
+            Put(LexiconSchema.MetaYear, m.Year);
+            Put(LexiconSchema.MetaPublisher, m.Publisher);
+            Put(LexiconSchema.MetaLicense, m.License);
+            Put(LexiconSchema.MetaUrl, m.Url);
+            Put(LexiconSchema.MetaSourceVersion, m.SourceVersion);
+            Put(LexiconSchema.MetaConverterVersion, m.ConverterVersion.ToString());
+        }
+    }
+}

--- a/src/CST.Lexicon/LexiconBuilder.cs
+++ b/src/CST.Lexicon/LexiconBuilder.cs
@@ -29,57 +29,74 @@ namespace CST.Lexicon
             if (meta is null) throw new ArgumentNullException(nameof(meta));
             if (entries is null) throw new ArgumentNullException(nameof(entries));
 
-            // Start from a clean file so a rebuild can't leave stale rows.
-            if (File.Exists(dbPath)) File.Delete(dbPath);
+            // Build to a temp file and atomically rename into place, so a crash mid-build (journal_mode=OFF)
+            // can never leave a corrupt file at the real path, and an existing good lexicon is only replaced by
+            // a complete new one. (fable HIGH-1)
+            string tmp = dbPath + ".tmp";
+            if (File.Exists(tmp)) File.Delete(tmp);
 
-            var csb = new SqliteConnectionStringBuilder { DataSource = dbPath, Mode = SqliteOpenMode.ReadWriteCreate };
-            using var conn = new SqliteConnection(csb.ToString());
-            conn.Open();
-
-            using (var pragma = conn.CreateCommand())
+            // Pooling=false: these are open-once/close-once connections. With pooling on, a rebuild-at-same-path
+            // gets back a pooled handle pointing at the unlinked old inode ("table already exists" / "unable to
+            // open"), and a pooled handle also blocks File.Move/Delete on Windows. Same footgun SqliteLemmaProvider
+            // guards with ClearPool. (fable HIGH-1)
+            var csb = new SqliteConnectionStringBuilder
             {
-                pragma.CommandText = "PRAGMA journal_mode=OFF; PRAGMA synchronous=OFF;";
-                pragma.ExecuteNonQuery();
-            }
-            using (var create = conn.CreateCommand())
-            {
-                create.CommandText = LexiconSchema.CreateSql;
-                create.ExecuteNonQuery();
-            }
-
-            using var tx = conn.BeginTransaction();
-
-            WriteMeta(conn, meta);
+                DataSource = tmp,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Pooling = false
+            };
 
             int written = 0;
-            using (var insert = conn.CreateCommand())
+            using (var conn = new SqliteConnection(csb.ToString()))
             {
-                insert.CommandText =
-                    "INSERT INTO entry(ipe_key, headword, homonym, body_html) VALUES ($k, $h, $n, $b)";
-                var pk = insert.CreateParameter(); pk.ParameterName = "$k"; insert.Parameters.Add(pk);
-                var ph = insert.CreateParameter(); ph.ParameterName = "$h"; insert.Parameters.Add(ph);
-                var pn = insert.CreateParameter(); pn.ParameterName = "$n"; insert.Parameters.Add(pn);
-                var pb = insert.CreateParameter(); pb.ParameterName = "$b"; insert.Parameters.Add(pb);
+                conn.Open();
 
-                foreach (var raw in entries)
+                using (var pragma = conn.CreateCommand())
                 {
-                    string stripped = LexiconKey.StripHtml(raw.Headword ?? string.Empty);
-                    if (string.IsNullOrWhiteSpace(stripped)) continue;   // nothing to key on
-
-                    var (headBase, homonym) = LexiconKey.SplitHomonym(stripped);
-                    string key = LexiconKey.DeriveKey(headBase);
-                    if (string.IsNullOrEmpty(key)) continue;
-
-                    pk.Value = key;
-                    ph.Value = stripped;                 // verbatim published form (homonym number kept)
-                    pn.Value = homonym;
-                    pb.Value = raw.BodyHtml ?? string.Empty;
-                    insert.ExecuteNonQuery();
-                    written++;
+                    pragma.CommandText = "PRAGMA journal_mode=OFF; PRAGMA synchronous=OFF;";
+                    pragma.ExecuteNonQuery();
                 }
-            }
+                using (var create = conn.CreateCommand())
+                {
+                    create.CommandText = LexiconSchema.CreateSql;
+                    create.ExecuteNonQuery();
+                }
 
-            tx.Commit();
+                using var tx = conn.BeginTransaction();
+
+                WriteMeta(conn, meta);
+
+                using (var insert = conn.CreateCommand())
+                {
+                    insert.CommandText =
+                        "INSERT INTO entry(ipe_key, headword, homonym, body_html) VALUES ($k, $h, $n, $b)";
+                    var pk = insert.CreateParameter(); pk.ParameterName = "$k"; insert.Parameters.Add(pk);
+                    var ph = insert.CreateParameter(); ph.ParameterName = "$h"; insert.Parameters.Add(ph);
+                    var pn = insert.CreateParameter(); pn.ParameterName = "$n"; insert.Parameters.Add(pn);
+                    var pb = insert.CreateParameter(); pb.ParameterName = "$b"; insert.Parameters.Add(pb);
+
+                    foreach (var raw in entries)
+                    {
+                        string stripped = LexiconKey.StripHtml(raw.Headword ?? string.Empty);
+                        if (string.IsNullOrWhiteSpace(stripped)) continue;   // nothing to key on
+
+                        var (headBase, homonym) = LexiconKey.SplitHomonym(stripped);
+                        string key = LexiconKey.DeriveKey(headBase);
+                        if (string.IsNullOrEmpty(key)) continue;
+
+                        pk.Value = key;
+                        ph.Value = stripped;                 // verbatim published form (homonym number kept)
+                        pn.Value = homonym;
+                        pb.Value = raw.BodyHtml ?? string.Empty;
+                        insert.ExecuteNonQuery();
+                        written++;
+                    }
+                }
+
+                tx.Commit();
+            }   // connection disposed (and, with Pooling=false, its file handle released) before the rename
+
+            File.Move(tmp, dbPath, overwrite: true);
             return written;
         }
 

--- a/src/CST.Lexicon/LexiconKey.cs
+++ b/src/CST.Lexicon/LexiconKey.cs
@@ -20,16 +20,25 @@ namespace CST.Lexicon
 
         private static readonly Regex TagRx = new("<[^>]+>", RegexOptions.Compiled);
 
-        /// <summary>Remove HTML tags from a headword (some upstream sources wrap the name in markup), matching
-        /// the upstream exporters' <c>&lt;[^&gt;]+&gt;</c> strip. Leaves the text content.</summary>
+        /// <summary>
+        /// Reduce a headword to its plain text: strip HTML tags (some upstream sources wrap the name in markup),
+        /// then decode HTML entities. Decoding AFTER the tag strip is deliberate — an entity-escaped headword
+        /// like <c>N&amp;#257;ga</c> must become <c>Nāga</c> (else its key contains literal <c>&amp;#257;</c> and
+        /// the entry is permanently unfindable), while genuine escaped text (<c>a &amp;lt; b</c>) is left as the
+        /// literal it denotes rather than being re-interpreted as a tag. (fable MED-1)
+        /// </summary>
         public static string StripHtml(string headword) =>
-            string.IsNullOrEmpty(headword) ? headword : TagRx.Replace(headword, string.Empty).Trim();
+            string.IsNullOrEmpty(headword)
+                ? headword
+                : System.Net.WebUtility.HtmlDecode(TagRx.Replace(headword, string.Empty)).Trim();
 
         /// <summary>
         /// Split a trailing homonym number off a headword: <c>"Nāgita 1"</c> → (<c>"Nāgita"</c>, 1);
         /// <c>"Sāvatthī"</c> → (<c>"Sāvatthī"</c>, 0). A homonym marker is a final space-separated token of
-        /// digits only (the form the proper-name and DPD sources publish). Not stripped: an interior number, or
-        /// a token with non-digits.
+        /// digits ONLY. Not split: an interior number, a token with non-digits, or a DOTTED sub-homonym like
+        /// DPD's <c>"dhamma 1.01"</c> — this deliberately differs from <c>SqliteLemmaProvider.StripHomonym</c>
+        /// (which allows dots) because the proper-name/import sources this serves publish plain integer markers;
+        /// a dotted DPD-shaped source would keep its whole headword (harmless — still findable by prefix).
         /// </summary>
         public static (string Base, int Homonym) SplitHomonym(string headword)
         {
@@ -38,7 +47,7 @@ namespace CST.Lexicon
             if (sp <= 0 || sp + 1 >= headword.Length) return (headword, 0);
             for (int i = sp + 1; i < headword.Length; i++)
                 if (!char.IsDigit(headword[i])) return (headword, 0);
-            // int.Parse is safe: the tail is all digits. Clamp absurdly long runs to avoid overflow.
+            // TryParse, not Parse: an absurdly long all-digit run overflows int and falls back to (whole, 0).
             var tail = headword[(sp + 1)..];
             return int.TryParse(tail, NumberStyles.None, CultureInfo.InvariantCulture, out int n)
                 ? (headword[..sp].TrimEnd(), n)

--- a/src/CST.Lexicon/LexiconKey.cs
+++ b/src/CST.Lexicon/LexiconKey.cs
@@ -1,0 +1,64 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using CST.Conversion;
+
+namespace CST.Lexicon
+{
+    /// <summary>
+    /// Turns a published headword into its canonical IPE lookup key, and splits off a homonym marker — the
+    /// SINGLE place that logic lives, so a lexicon built by the converter and a query typed at runtime can
+    /// never disagree on how text becomes a key. The runtime query path (DictionaryService) does
+    /// <c>StripJoiners → ToLowerInvariant → NFC → Any2Ipe</c>; a headword does the same, after first removing
+    /// the things a query never carries (HTML tags, a trailing homonym number).
+    /// </summary>
+    public static class LexiconKey
+    {
+        // Zero-width joiner / non-joiner: Any2Ipe classifies them Unknown and passes them through, so a key or
+        // query that kept them would match nothing. Same set DictionaryService/MultiWordSearch strip. (SRCH-3)
+        private static string StripJoiners(string s) => s.Replace("\u200C", string.Empty).Replace("\u200D", string.Empty);
+
+        private static readonly Regex TagRx = new("<[^>]+>", RegexOptions.Compiled);
+
+        /// <summary>Remove HTML tags from a headword (some upstream sources wrap the name in markup), matching
+        /// the upstream exporters' <c>&lt;[^&gt;]+&gt;</c> strip. Leaves the text content.</summary>
+        public static string StripHtml(string headword) =>
+            string.IsNullOrEmpty(headword) ? headword : TagRx.Replace(headword, string.Empty).Trim();
+
+        /// <summary>
+        /// Split a trailing homonym number off a headword: <c>"Nāgita 1"</c> → (<c>"Nāgita"</c>, 1);
+        /// <c>"Sāvatthī"</c> → (<c>"Sāvatthī"</c>, 0). A homonym marker is a final space-separated token of
+        /// digits only (the form the proper-name and DPD sources publish). Not stripped: an interior number, or
+        /// a token with non-digits.
+        /// </summary>
+        public static (string Base, int Homonym) SplitHomonym(string headword)
+        {
+            if (string.IsNullOrEmpty(headword)) return (headword, 0);
+            int sp = headword.LastIndexOf(' ');
+            if (sp <= 0 || sp + 1 >= headword.Length) return (headword, 0);
+            for (int i = sp + 1; i < headword.Length; i++)
+                if (!char.IsDigit(headword[i])) return (headword, 0);
+            // int.Parse is safe: the tail is all digits. Clamp absurdly long runs to avoid overflow.
+            var tail = headword[(sp + 1)..];
+            return int.TryParse(tail, NumberStyles.None, CultureInfo.InvariantCulture, out int n)
+                ? (headword[..sp].TrimEnd(), n)
+                : (headword, 0);
+        }
+
+        /// <summary>
+        /// The IPE lookup key for a headword base (homonym + HTML already removed). Mirrors the runtime query
+        /// normalization exactly so keys and queries collate identically.
+        /// </summary>
+        public static string DeriveKey(string headwordBase) =>
+            Any2Ipe.Convert(StripJoiners(headwordBase).ToLowerInvariant().Normalize(NormalizationForm.FormC));
+
+        /// <summary>
+        /// Normalize a runtime query the same way DictionaryService does, to compare against stored keys. No
+        /// HTML/homonym stripping — a query never carries those.
+        /// </summary>
+        public static string DeriveQueryKey(string query) =>
+            string.IsNullOrEmpty(query)
+                ? string.Empty
+                : Any2Ipe.Convert(StripJoiners(query).ToLowerInvariant().Normalize(NormalizationForm.FormC));
+    }
+}

--- a/src/CST.Lexicon/LexiconModels.cs
+++ b/src/CST.Lexicon/LexiconModels.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace CST.Lexicon
+{
+    /// <summary>What kind of reference a lexicon is — a rendering/labeling hint, not a lookup change.</summary>
+    public enum LexiconKind
+    {
+        /// <summary>Word glosses (Childers, DPD).</summary>
+        General,
+        /// <summary>Entity/proper-name reference (DPPN).</summary>
+        ProperNames
+    }
+
+    /// <summary>
+    /// Source identity + attribution for a lexicon, stored in its <c>meta</c> table. Mirrors the fields the
+    /// existing dictionary surface already carries (#268) so a lexicon source slots into the same attribution
+    /// display. Every attribution field is optional; an entirely blank attribution means "unattributed".
+    /// </summary>
+    public sealed record LexiconMeta(
+        string SourceId,
+        string DisplayName,
+        string DefinitionLanguage,
+        LexiconKind Kind,
+        // attribution (all optional)
+        string? Title = null,
+        string? Author = null,
+        string? Reviser = null,
+        string? Year = null,
+        string? Publisher = null,
+        string? License = null,
+        string? Url = null,
+        // provenance / staleness stamps
+        string? SourceVersion = null,
+        int ConverterVersion = 1);
+
+    /// <summary>
+    /// A raw entry as a converter hands it in: the published headword (may contain HTML and a trailing homonym
+    /// number) and the definition as an HTML fragment. The builder derives the key, splits the homonym, and
+    /// strips HTML from the headword. <c>BodyHtml</c> is stored verbatim — the caller is responsible for having
+    /// sanitized it (our converters do so at build time; see the project notes).
+    /// </summary>
+    public sealed record RawEntry(string Headword, string BodyHtml);
+
+    /// <summary>A stored/looked-up lexicon entry.</summary>
+    /// <param name="IpeKey">The IPE lookup/sort key (homonym + HTML removed).</param>
+    /// <param name="Headword">The published headword, HTML stripped, homonym number kept (e.g. "Nāgita 1").</param>
+    /// <param name="Homonym">The parsed homonym number, or 0.</param>
+    /// <param name="BodyHtml">The definition HTML fragment.</param>
+    public sealed record LexiconEntry(string IpeKey, string Headword, int Homonym, string BodyHtml);
+}

--- a/src/CST.Lexicon/LexiconModels.cs
+++ b/src/CST.Lexicon/LexiconModels.cs
@@ -34,10 +34,14 @@ namespace CST.Lexicon
         int ConverterVersion = 1);
 
     /// <summary>
-    /// A raw entry as a converter hands it in: the published headword (may contain HTML and a trailing homonym
-    /// number) and the definition as an HTML fragment. The builder derives the key, splits the homonym, and
-    /// strips HTML from the headword. <c>BodyHtml</c> is stored verbatim — the caller is responsible for having
-    /// sanitized it (our converters do so at build time; see the project notes).
+    /// A raw entry as a converter hands it in: the published headword (may contain HTML tags and/or a trailing
+    /// homonym number) and the definition as an HTML fragment. The builder derives the key, splits the homonym,
+    /// and reduces the headword to plain text (tags stripped, entities decoded).
+    /// <para>
+    /// <b>BodyHtml is stored VERBATIM.</b> The caller must have SANITIZED it — our build-time converters do so
+    /// over a source's known markup, so the app ships no sanitizer for its own trusted downloaded assets; the
+    /// untrusted in-app import path sanitizes before calling the builder.
+    /// </para>
     /// </summary>
     public sealed record RawEntry(string Headword, string BodyHtml);
 

--- a/src/CST.Lexicon/LexiconReader.cs
+++ b/src/CST.Lexicon/LexiconReader.cs
@@ -26,7 +26,14 @@ namespace CST.Lexicon
         /// <summary>Open a lexicon file, or throw if it is missing/malformed/too new for this schema.</summary>
         public static LexiconReader Open(string dbPath)
         {
-            var csb = new SqliteConnectionStringBuilder { DataSource = dbPath, Mode = SqliteOpenMode.ReadOnly };
+            // Pooling=false: a pooled read-only handle would block the delivery layer from replacing the lexicon
+            // file (File.Move/Delete) on Windows. Open-once/close-once — pooling buys nothing. (fable HIGH-1)
+            var csb = new SqliteConnectionStringBuilder
+            {
+                DataSource = dbPath,
+                Mode = SqliteOpenMode.ReadOnly,
+                Pooling = false
+            };
             using var conn = new SqliteConnection(csb.ToString());
             conn.Open();
 
@@ -35,14 +42,23 @@ namespace CST.Lexicon
             var list = new List<LexiconEntry>();
             using (var cmd = conn.CreateCommand())
             {
-                // Sort in SQL by key then homonym then rowid so homonyms surface in published order.
-                cmd.CommandText =
-                    "SELECT ipe_key, headword, homonym, body_html FROM entry ORDER BY ipe_key, homonym, id";
+                cmd.CommandText = "SELECT ipe_key, headword, homonym, body_html FROM entry";
                 using var r = cmd.ExecuteReader();
                 while (r.Read())
                     list.Add(new LexiconEntry(r.GetString(0), r.GetString(1), r.GetInt32(2), r.GetString(3)));
             }
-            return new LexiconReader(list.ToArray(), meta);
+
+            // Sort in-memory with the SAME ordinal (UTF-16 code-unit) comparison the binary search uses, rather
+            // than trusting SQL's BINARY (UTF-8 byte) ORDER BY — they agree for all-BMP strings (IPE tops out at
+            // U+1E6D) but making the collation invariant local removes the cross-system assumption. (fable LOW-4)
+            var arr = list.ToArray();
+            Array.Sort(arr, (a, b) =>
+            {
+                int c = string.CompareOrdinal(a.IpeKey, b.IpeKey);
+                if (c != 0) return c;
+                return a.Homonym.CompareTo(b.Homonym);
+            });
+            return new LexiconReader(arr, meta);
         }
 
         /// <summary>
@@ -139,14 +155,19 @@ namespace CST.Lexicon
 
             string? Get(string k) => m.TryGetValue(k, out var v) ? v : null;
 
-            // A file whose schema is NEWER than this reader understands must be refused, not misread.
-            if (int.TryParse(Get(LexiconSchema.MetaSchemaVersion), out int sv) && sv > LexiconSchema.SchemaVersion)
+            // The version stamp must be PRESENT and parseable: an unstamped file isn't a lexicon this reader
+            // should guess at. Absent or NEWER than we understand → refuse, don't misread. (fable LOW-1)
+            if (!int.TryParse(Get(LexiconSchema.MetaSchemaVersion), out int sv))
+                throw new NotSupportedException("Not a lexicon: missing or invalid schema_version.");
+            if (sv > LexiconSchema.SchemaVersion)
                 throw new NotSupportedException(
                     $"Lexicon schema version {sv} is newer than this build supports ({LexiconSchema.SchemaVersion}).");
 
             var kind = string.Equals(Get(LexiconSchema.MetaKind), "proper-names", StringComparison.Ordinal)
                 ? LexiconKind.ProperNames : LexiconKind.General;
-            int.TryParse(Get(LexiconSchema.MetaConverterVersion), out int conv);
+            // Default to 1 when absent, symmetric with the record default (a lexicon the builder wrote always
+            // carries it). (fable LOW-5)
+            int conv = int.TryParse(Get(LexiconSchema.MetaConverterVersion), out int c) ? c : 1;
 
             return new LexiconMeta(
                 SourceId: Get(LexiconSchema.MetaSourceId) ?? string.Empty,

--- a/src/CST.Lexicon/LexiconReader.cs
+++ b/src/CST.Lexicon/LexiconReader.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.Sqlite;
+
+namespace CST.Lexicon
+{
+    /// <summary>
+    /// Reads a canonical lexicon and answers headword lookups. Loads the (small — tens of thousands of) entries
+    /// into a sorted in-memory array once at open, then serves lookups IO-free, with the exact/prefix/nearest
+    /// semantics ported from the flat-file <c>DictionaryIndex</c> (CST4's <c>FormDictionary.Search</c>), adapted
+    /// so HOMONYMS — several rows sharing one key — all surface together.
+    /// </summary>
+    public sealed class LexiconReader
+    {
+        private readonly LexiconEntry[] _entries;   // sorted by (ipe_key ordinal, homonym, rowid)
+        public LexiconMeta Meta { get; }
+
+        private LexiconReader(LexiconEntry[] entries, LexiconMeta meta)
+        {
+            _entries = entries;
+            Meta = meta;
+        }
+
+        public int Count => _entries.Length;
+
+        /// <summary>Open a lexicon file, or throw if it is missing/malformed/too new for this schema.</summary>
+        public static LexiconReader Open(string dbPath)
+        {
+            var csb = new SqliteConnectionStringBuilder { DataSource = dbPath, Mode = SqliteOpenMode.ReadOnly };
+            using var conn = new SqliteConnection(csb.ToString());
+            conn.Open();
+
+            var meta = ReadMeta(conn);
+
+            var list = new List<LexiconEntry>();
+            using (var cmd = conn.CreateCommand())
+            {
+                // Sort in SQL by key then homonym then rowid so homonyms surface in published order.
+                cmd.CommandText =
+                    "SELECT ipe_key, headword, homonym, body_html FROM entry ORDER BY ipe_key, homonym, id";
+                using var r = cmd.ExecuteReader();
+                while (r.Read())
+                    list.Add(new LexiconEntry(r.GetString(0), r.GetString(1), r.GetInt32(2), r.GetString(3)));
+            }
+            return new LexiconReader(list.ToArray(), meta);
+        }
+
+        /// <summary>
+        /// Look up an already-derived query key (see <see cref="LexiconKey.DeriveQueryKey"/>). Returns the exact
+        /// entries plus the prefix run, or on a miss the nearest-common-prefix run. <paramref name="max"/>
+        /// bounds the result (0 or negative = unbounded).
+        /// </summary>
+        public IReadOnlyList<LexiconEntry> LookupByKey(string queryKey, int max = 0)
+        {
+            var results = new List<LexiconEntry>();
+            if (string.IsNullOrEmpty(queryKey) || _entries.Length == 0)
+                return results;
+
+            int lo = LowerBound(queryKey);   // first entry with key >= queryKey
+
+            // Exact-key hit: collect the contiguous StartsWith run (homonyms sharing the key + deeper prefixes).
+            if (lo < _entries.Length && string.CompareOrdinal(_entries[lo].IpeKey, queryKey) == 0)
+            {
+                for (int i = lo; i < _entries.Length; i++)
+                {
+                    if (!_entries[i].IpeKey.StartsWith(queryKey, StringComparison.Ordinal)) break;
+                    results.Add(_entries[i]);
+                    if (Reached(results, max)) return results;
+                }
+                return results;
+            }
+
+            // Miss: pick the neighbor side (behind / ahead of the insertion point) sharing the most leading
+            // characters, and collect the consecutive run tied at that length. Ported from DictionaryIndex.
+            int commonBehind = lo - 1 >= 0 ? CommonPrefix(queryKey, _entries[lo - 1].IpeKey) : 0;
+            int commonAhead = lo < _entries.Length ? CommonPrefix(queryKey, _entries[lo].IpeKey) : 0;
+
+            if (commonBehind >= commonAhead && commonBehind > 0)
+            {
+                var stack = new Stack<LexiconEntry>();
+                for (int i = lo - 1; i >= 0; i--)
+                {
+                    if (CommonPrefix(queryKey, _entries[i].IpeKey) == commonBehind) stack.Push(_entries[i]);
+                    else break;
+                }
+                while (stack.Count > 0)
+                {
+                    results.Add(stack.Pop());
+                    if (Reached(results, max)) return results;
+                }
+            }
+
+            if (commonAhead >= commonBehind && commonAhead > 0)
+            {
+                for (int i = lo; i < _entries.Length; i++)
+                {
+                    if (CommonPrefix(queryKey, _entries[i].IpeKey) != commonAhead) break;
+                    results.Add(_entries[i]);
+                    if (Reached(results, max)) return results;
+                }
+            }
+
+            return results;
+        }
+
+        private static bool Reached(List<LexiconEntry> r, int max) => max > 0 && r.Count >= max;
+
+        // First index whose key is >= queryKey (ordinal). Standard lower-bound binary search.
+        private int LowerBound(string queryKey)
+        {
+            int lo = 0, hi = _entries.Length;
+            while (lo < hi)
+            {
+                int mid = lo + ((hi - lo) >> 1);
+                if (string.CompareOrdinal(_entries[mid].IpeKey, queryKey) < 0) lo = mid + 1;
+                else hi = mid;
+            }
+            return lo;
+        }
+
+        private static int CommonPrefix(string a, string b)
+        {
+            if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return 0;
+            int n = Math.Min(a.Length, b.Length), i = 0;
+            while (i < n && a[i] == b[i]) i++;
+            return i;
+        }
+
+        private static LexiconMeta ReadMeta(SqliteConnection conn)
+        {
+            var m = new Dictionary<string, string>(StringComparer.Ordinal);
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT key, value FROM meta";
+                using var r = cmd.ExecuteReader();
+                while (r.Read())
+                    if (!r.IsDBNull(1)) m[r.GetString(0)] = r.GetString(1);
+            }
+
+            string? Get(string k) => m.TryGetValue(k, out var v) ? v : null;
+
+            // A file whose schema is NEWER than this reader understands must be refused, not misread.
+            if (int.TryParse(Get(LexiconSchema.MetaSchemaVersion), out int sv) && sv > LexiconSchema.SchemaVersion)
+                throw new NotSupportedException(
+                    $"Lexicon schema version {sv} is newer than this build supports ({LexiconSchema.SchemaVersion}).");
+
+            var kind = string.Equals(Get(LexiconSchema.MetaKind), "proper-names", StringComparison.Ordinal)
+                ? LexiconKind.ProperNames : LexiconKind.General;
+            int.TryParse(Get(LexiconSchema.MetaConverterVersion), out int conv);
+
+            return new LexiconMeta(
+                SourceId: Get(LexiconSchema.MetaSourceId) ?? string.Empty,
+                DisplayName: Get(LexiconSchema.MetaDisplayName) ?? string.Empty,
+                DefinitionLanguage: Get(LexiconSchema.MetaDefinitionLanguage) ?? string.Empty,
+                Kind: kind,
+                Title: Get(LexiconSchema.MetaTitle),
+                Author: Get(LexiconSchema.MetaAuthor),
+                Reviser: Get(LexiconSchema.MetaReviser),
+                Year: Get(LexiconSchema.MetaYear),
+                Publisher: Get(LexiconSchema.MetaPublisher),
+                License: Get(LexiconSchema.MetaLicense),
+                Url: Get(LexiconSchema.MetaUrl),
+                SourceVersion: Get(LexiconSchema.MetaSourceVersion),
+                ConverterVersion: conv);
+        }
+
+        /// <summary>Convenience: derive the key from a raw query and look up. (The app's source adapter can call
+        /// this directly.)</summary>
+        public IReadOnlyList<LexiconEntry> Lookup(string query, int max = 0) =>
+            LookupByKey(LexiconKey.DeriveQueryKey(query), max);
+    }
+}

--- a/src/CST.Lexicon/LexiconSchema.cs
+++ b/src/CST.Lexicon/LexiconSchema.cs
@@ -1,0 +1,40 @@
+namespace CST.Lexicon
+{
+    /// <summary>
+    /// The canonical lexicon SQLite schema — one place so the builder and reader can't drift. A lexicon is two
+    /// tables: <c>meta</c> (source id + attribution + version stamps, key/value) and <c>entry</c>
+    /// (IPE-keyed, homonym-aware, HTML-definition rows). Bumping <see cref="SchemaVersion"/> means an older
+    /// reader should refuse a newer file (the delivery layer gates on it).
+    /// </summary>
+    public static class LexiconSchema
+    {
+        public const int SchemaVersion = 1;
+
+        // meta keys (mirror the LexiconMeta record + the dpd-cst-subset meta vocabulary).
+        public const string MetaSchemaVersion = "schema_version";
+        public const string MetaSourceId = "source_id";
+        public const string MetaDisplayName = "display_name";
+        public const string MetaDefinitionLanguage = "definition_language";
+        public const string MetaKind = "kind";
+        public const string MetaTitle = "title";
+        public const string MetaAuthor = "author";
+        public const string MetaReviser = "reviser";
+        public const string MetaYear = "year";
+        public const string MetaPublisher = "publisher";
+        public const string MetaLicense = "license";
+        public const string MetaUrl = "url";
+        public const string MetaSourceVersion = "source_version";
+        public const string MetaConverterVersion = "converter_version";
+
+        public const string CreateSql = @"
+CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT);
+CREATE TABLE entry(
+    id         INTEGER PRIMARY KEY,
+    ipe_key    TEXT NOT NULL,
+    headword   TEXT NOT NULL,
+    homonym    INTEGER NOT NULL DEFAULT 0,
+    body_html  TEXT NOT NULL
+);
+CREATE INDEX ix_entry_key ON entry(ipe_key);";
+    }
+}

--- a/src/CST.sln
+++ b/src/CST.sln
@@ -11,6 +11,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CST.Lucene", "CST.Lucene\CS
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CST.Lemma", "CST.Lemma\CST.Lemma.csproj", "{13DFA6E7-5C61-4A86-98BF-E9FB1A6CD483}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CST.Lexicon", "CST.Lexicon\CST.Lexicon.csproj", "{4C24F681-3301-4148-87F5-B3BD4C468D9C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CST.Core", "CST.Core\CST.Core.csproj", "{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +87,38 @@ Global
 		{13DFA6E7-5C61-4A86-98BF-E9FB1A6CD483}.Release|x86.Build.0 = Release|Any CPU
 		{13DFA6E7-5C61-4A86-98BF-E9FB1A6CD483}.Release|x64.ActiveCfg = Release|Any CPU
 		{13DFA6E7-5C61-4A86-98BF-E9FB1A6CD483}.Release|x64.Build.0 = Release|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Debug|x86.Build.0 = Debug|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Debug|x64.Build.0 = Debug|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Release|x86.ActiveCfg = Release|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Release|x86.Build.0 = Release|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Release|x64.ActiveCfg = Release|Any CPU
+		{4C24F681-3301-4148-87F5-B3BD4C468D9C}.Release|x64.Build.0 = Release|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Debug|x86.Build.0 = Debug|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Debug|x64.Build.0 = Debug|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|x86.ActiveCfg = Release|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|x86.Build.0 = Release|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|x64.ActiveCfg = Release|Any CPU
+		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
First implementation PR of the multi-source dictionary work (#109), following the Fable design consult. Introduces **`CST.Lexicon`** — the canonical dictionary-asset format every source (DPPN first, then user imports) normalizes into. This is *just* the format library + tests; no consumer is wired yet (the DPPN converter and the runtime registry adapter come next).

## What a lexicon is

A small SQLite: a `meta` table (source id + attribution + version stamps) and an `entry` table (`ipe_key`, `headword`, `homonym`, `body_html`). One writer (`LexiconBuilder`), one reader (`LexiconReader`), one key-derivation (`LexiconKey`).

## The load-bearing property: key parity

A stored entry's `ipe_key` and a runtime query must normalize to the **same** IPE string or the word is unfindable. `LexiconKey` matches `DictionaryService`'s query normalization exactly — `StripJoiners → ToLowerInvariant → NFC → Any2Ipe` — after first removing what a query never carries (HTML, a trailing homonym number). A test derives both ways and asserts equality, including cross-script (a Devanagari query finds a Latin-entered headword).

## Homonyms and display fidelity

Homonyms are **separate rows sharing a key** (retiring the flat loader's `<hr/>`-merge). The published headword (`Nāgita 1`) is stored verbatim while the key is derived from the base (`Nāgita`), so proper names keep their capitals and numbers — which reconstructing display from the lowercased key (today's UI) cannot. `LexiconReader` ports the flat dictionary's exact/prefix/nearest search, adapted so all homonyms for an exact key surface together, then the deeper prefix run.

## Fable review — one HIGH, one MEDIUM, five LOW, all fixed

- **HIGH**: rebuilding a lexicon at the same path threw *and destroyed the prior good file* — SQLite connection pooling resurrected the deleted file's handle. Fixed with `Pooling=false` on both connections + build-to-`.tmp`-then-atomic-rename. Reproduced by a new test (verified it fails with pooling on). This mattered because the import and delivery layers rebuild-in-place.
- **MEDIUM**: an entity-encoded headword (`N&#257;ga`) produced a permanently dead key. `StripHtml` now decodes entities after stripping tags.
- **LOW**: missing `schema_version` now refused; in-memory re-sort with the same ordinal comparison the search uses (invariant made local rather than trusting SQL's byte-order `ORDER BY`); symmetric `ConverterVersion` default; two stale comments corrected.

Fable verified the rest is sound: key parity byte-for-byte, the homonym/nearest adaptation, no injection surface (all parameterized), culture-correct number parsing, and — after I'd hit the rule once — **no literal zero-width characters, `\uXXXX` escapes only**.

## Testing

18 tests (13 → 18 after review): key/query parity, case & cross-script independence, homonyms, HTML-and-entity headwords, verbatim body, exact/prefix/nearest, rebuild-same-path, missing/too-new schema refusal. Full suite **916/916**. New `CST.Lexicon` project mirrors `CST.Lemma`'s csproj (Microsoft.Data.Sqlite + SQLitePCLRaw pin); `.gitignore` updated for its `bin/`/`obj/`.

## Not in this PR
The DPPN converter (#467, with build-time HTML sanitization), the runtime `SqliteDictionarySource` + registry (#466 spine), and manifest delivery (#468) build on this. #466's UI stays with the Kestrel session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
