### PR TITLE
#467: DPPN converter — DPPN.json → canonical lexicon (CST.LexiconTools)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ src/CST.Lemma/obj/
 src/CST.Lexicon/bin/
 src/CST.Lexicon/obj/
 
+src/CST.LexiconTools/bin/
+src/CST.LexiconTools/obj/
+
 src/CST.Lucene/bin/
 src/CST.Lucene/obj/
 

--- a/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
+++ b/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
@@ -41,6 +41,7 @@
     <ProjectReference Include="..\CST.Lucene\CST.Lucene.csproj" />
     <ProjectReference Include="..\CST.Lemma\CST.Lemma.csproj" />
     <ProjectReference Include="..\CST.Lexicon\CST.Lexicon.csproj" />
+    <ProjectReference Include="..\CST.LexiconTools\CST.LexiconTools.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/CST.Avalonia.Tests/Lexicon/DppnConverterTests.cs
+++ b/src/CST.Avalonia.Tests/Lexicon/DppnConverterTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using System.Linq;
+using CST.Lexicon;
+using CST.LexiconTools;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Lexicon
+{
+    /// <summary>
+    /// The DPPN converter (#467). The `name` field is a malformed formatted heading (lemma in the first
+    /// &lt;b&gt;, an optional bare homonym number after it, citations in &lt;abbr&gt;), so these fixtures use the
+    /// REAL shapes seen in DPPN.json, not tidied ones. The body filter must reduce definitions to the closed
+    /// allowlist with no attributes surviving.
+    /// </summary>
+    public class DppnConverterTests : IDisposable
+    {
+        private readonly string _dir;
+        public DppnConverterTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "cst-dppn-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+        public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+        // ---- headword extraction ----
+
+        [Fact]
+        public void The_first_bold_run_is_the_headword()
+        {
+            Assert.Equal("A-An",
+                DppnConverter.ParseHeadword("<p class=\"Heading3\"><b>A-An</b>. </span>"));
+        }
+
+        [Fact]
+        public void A_citation_after_the_lemma_is_excluded_from_the_headword()
+        {
+            // The (Ja 90) abbr citation is heading chrome, not part of the name.
+            Assert.Equal("Akataññujātaka",
+                DppnConverter.ParseHeadword(
+                    "<p><span class=\"Head\"><b>Akataññujātaka</b> (<abbr title=\"Added\">Ja 90</abbr>). </span>"));
+        }
+
+        [Fact]
+        public void A_bare_number_after_the_lemma_is_a_homonym_normalized_and_folded_into_the_headword()
+        {
+            // "01." -> homonym 1, folded to "… 1" so the lexicon builder splits it uniformly.
+            Assert.Equal("Akatuññatāsutta 1",
+                DppnConverter.ParseHeadword("<b>Akatuññatāsutta</b> 01. </span>"));
+            Assert.Equal("Akatuññatāsutta 2",
+                DppnConverter.ParseHeadword("<b>Akatuññatāsutta</b> 02. </span>"));
+        }
+
+        [Fact]
+        public void A_multi_word_name_is_kept_whole()
+        {
+            Assert.Equal("Akaniṭṭhā Devā",
+                DppnConverter.ParseHeadword("<span class=\"Head\"><b>Akaniṭṭhā Devā</b>. </span>"));
+        }
+
+        [Fact]
+        public void A_name_with_no_bold_lemma_yields_nothing()
+        {
+            Assert.Equal("", DppnConverter.ParseHeadword("<p>just prose, no lemma</p>"));
+            Assert.Equal("", DppnConverter.ParseHeadword(""));
+        }
+
+        // ---- body filtering ----
+
+        [Fact]
+        public void The_body_keeps_allowed_tags_and_drops_the_rest_with_no_attributes()
+        {
+            string cleaned = DppnConverter.CleanBody(
+                "<p>A <b>Deva</b> in the <span class=\"ref\">highest</span> heaven. " +
+                "<abbr title=\"Anguttara\">AN.ii.226</abbr>.</p>");
+            // span dropped (text kept); class/title attributes gone; p/b/abbr kept as bare tags.
+            Assert.Contains("<b>Deva</b>", cleaned);
+            Assert.Contains("highest", cleaned);
+            Assert.DoesNotContain("<span", cleaned);
+            Assert.DoesNotContain("class=", cleaned);
+            Assert.DoesNotContain("title=", cleaned);
+            Assert.Contains("<abbr>AN.ii.226</abbr>", cleaned);
+        }
+
+        [Fact]
+        public void No_disallowed_tag_survives_the_body_filter()
+        {
+            string cleaned = DppnConverter.CleanBody(
+                "<script>x</script><style>y</style><a href=\"http://evil\">z</a><img src=\"q\"><b>ok</b>");
+            foreach (var bad in new[] { "<script", "<style", "<a ", "<a>", "href=", "<img" })
+                Assert.DoesNotContain(bad, cleaned);
+            Assert.Contains("<b>ok</b>", cleaned);
+            // The disallowed tags' text content is preserved (dropped tag, kept text).
+            Assert.Contains("z", cleaned);
+        }
+
+        // ---- end to end ----
+
+        [Fact]
+        public void ToEntries_skips_header_stubs_and_maps_records()
+        {
+            // Record 1 is a section header (A-An) whose entry is effectively empty -> skipped.
+            string json = "[" +
+                "{\"name\":\"<p class=\\\"Heading3\\\"><b>A-An</b>. </span>\",\"entry\":\" </p>\"}," +
+                "{\"name\":\"<b>Sāvatthī</b>. </span>\",\"entry\":\"<p>A city of <b>Kosala</b>.</p>\"}," +
+                "{\"name\":\"<b>Jetavana</b> 01. </span>\",\"entry\":\"<p>A grove.</p>\"}" +
+            "]";
+            var entries = DppnConverter.ToEntries(json).ToList();
+            Assert.Equal(2, entries.Count);                          // header stub skipped
+            Assert.Equal("Sāvatthī", entries[0].Headword);
+            Assert.Equal("Jetavana 1", entries[1].Headword);        // homonym folded
+        }
+
+        [Fact]
+        public void Built_dppn_lexicon_is_looked_up_by_name_with_homonyms()
+        {
+            string json = "[" +
+                "{\"name\":\"<b>Jetavana</b> 01. </span>\",\"entry\":\"<p>A grove near Sāvatthī.</p>\"}," +
+                "{\"name\":\"<b>Jetavana</b> 02. </span>\",\"entry\":\"<p>Another Jetavana.</p>\"}," +
+                "{\"name\":\"<span class=\\\"Head\\\"><b>Sāvatthī</b>. </span>\",\"entry\":\"<p>Capital of Kosala.</p>\"}" +
+            "]";
+            string dppnJsonFile = Path.Combine(_dir, "DPPN.json");
+            File.WriteAllText(dppnJsonFile, json);
+            string db = Path.Combine(_dir, "dppn.db");
+            int n = DppnConverter.BuildLexicon(dppnJsonFile, db, "test");
+            Assert.Equal(3, n);
+
+            var lex = LexiconReader.Open(db);
+            Assert.Equal(LexiconKind.ProperNames, lex.Meta.Kind);
+            Assert.Equal("G. P. Malalasekera", lex.Meta.Author);
+
+            var jeta = lex.Lookup("jetavana");
+            Assert.Equal(new[] { "Jetavana 1", "Jetavana 2" }, jeta.Select(h => h.Headword));
+            Assert.Single(lex.Lookup("sāvatthī"));
+        }
+    }
+}

--- a/src/CST.Avalonia.Tests/Lexicon/DppnConverterTests.cs
+++ b/src/CST.Avalonia.Tests/Lexicon/DppnConverterTests.cs
@@ -65,6 +65,24 @@ namespace CST.Avalonia.Tests.Lexicon
             Assert.Equal("", DppnConverter.ParseHeadword(""));
         }
 
+        [Fact]
+        public void Alternative_title_homonyms_take_the_first_bold_and_the_trailing_number()
+        {
+            // The only multi-bold+number headings in DPPN are "X or Y NN" alternatives; the first bold is the
+            // indexed lemma and the trailing number after the LATER </b> is its real homonym. (fable L1)
+            Assert.Equal("Uttiyasutta 2",
+                DppnConverter.ParseHeadword("<b>Uttiyasutta</b> or <b>Uttikasutta</b> 02. </span>"));
+        }
+
+        [Fact]
+        public void A_homonym_range_keeps_both_numbers_in_the_headword()
+        {
+            // DPPN's sole ranged heading: one entry covering homonyms 5–6. Display both; the key derives from the
+            // lemma alone (homonym split takes 5 as the sort number). (fable L2)
+            Assert.Equal("Piyasutta 5-6",
+                DppnConverter.ParseHeadword("<b>Piyasutta</b> 05-06. </span>"));
+        }
+
         // ---- body filtering ----
 
         [Fact]
@@ -92,6 +110,36 @@ namespace CST.Avalonia.Tests.Lexicon
             Assert.Contains("<b>ok</b>", cleaned);
             // The disallowed tags' text content is preserved (dropped tag, kept text).
             Assert.Contains("z", cleaned);
+            Assert.True(DppnConverter.IsClosedAllowlist(cleaned));
+        }
+
+        [Fact]
+        public void A_bare_angle_bracket_in_prose_is_not_read_as_a_tag()
+        {
+            // fable M1: "< b" (space after '<') is text, not a <b> tag, and the surrounding prose must survive.
+            string cleaned = DppnConverter.CleanBody("a < b and c > d");
+            Assert.Equal("a &lt; b and c &gt; d", cleaned);
+            Assert.True(DppnConverter.IsClosedAllowlist(cleaned));
+        }
+
+        [Fact]
+        public void Split_tags_and_comments_cannot_reassemble_into_live_markup()
+        {
+            // fable M2: the safety property is now intrinsic — stray angle brackets in text are escaped, so no
+            // dropped-tag remnant, split tag, comment, or dangling partial tag can form live markup.
+            foreach (var input in new[]
+            {
+                "<<script>script>alert(1)<</script>/script>",   // split-tag reassembly
+                "x <!-- <script>y</script> --> z",              // HTML comment
+                "trailing partial <b",                          // dangling open at end
+                "an entity &lt;script&gt; stays text",          // pre-escaped payload
+            })
+            {
+                string cleaned = DppnConverter.CleanBody(input);
+                Assert.True(DppnConverter.IsClosedAllowlist(cleaned), $"unsafe: {cleaned}");
+                Assert.DoesNotContain("<script", cleaned);
+                Assert.DoesNotContain("<!--", cleaned);
+            }
         }
 
         // ---- end to end ----

--- a/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
+++ b/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
@@ -92,6 +92,10 @@ namespace CST.Avalonia.Tests.Lexicon
             Assert.Equal(("Nāgita", 1), LexiconKey.SplitHomonym("Nāgita 1"));
             Assert.Equal(("Sāvatthī", 0), LexiconKey.SplitHomonym("Sāvatthī"));
             Assert.Equal(("Migāra", 12), LexiconKey.SplitHomonym("Migāra 12"));   // base has the number stripped
+            // A hyphenated range is a homonym marker too (DPPN "Piyasutta 5-6"): first number is the sort key.
+            Assert.Equal(("Piyasutta", 5), LexiconKey.SplitHomonym("Piyasutta 5-6"));
+            // A dotted DPD-style token is NOT split (kept whole).
+            Assert.Equal(("dhamma 1.01", 0), LexiconKey.SplitHomonym("dhamma 1.01"));
             // A name that legitimately ends in a word, or has an interior number, is left whole.
             Assert.Equal(("Vessantara Jātaka", 0), LexiconKey.SplitHomonym("Vessantara Jātaka"));
         }

--- a/src/CST.Lexicon/LexiconKey.cs
+++ b/src/CST.Lexicon/LexiconKey.cs
@@ -40,16 +40,19 @@ namespace CST.Lexicon
         /// (which allows dots) because the proper-name/import sources this serves publish plain integer markers;
         /// a dotted DPD-shaped source would keep its whole headword (harmless — still findable by prefix).
         /// </summary>
+        // A final space-separated token that is a bare integer, or a hyphenated integer RANGE ("5-6", a single
+        // entry covering homonyms 5–6, as DPPN's "Piyasutta 05-06" publishes). The first number is the sort
+        // homonym. A DOTTED token ("1.01", DPD) is deliberately NOT matched (see the doc above).
+        private static readonly Regex HomonymTail = new(@"^(\d+)(?:-\d+)?$", RegexOptions.Compiled);
+
         public static (string Base, int Homonym) SplitHomonym(string headword)
         {
             if (string.IsNullOrEmpty(headword)) return (headword, 0);
             int sp = headword.LastIndexOf(' ');
             if (sp <= 0 || sp + 1 >= headword.Length) return (headword, 0);
-            for (int i = sp + 1; i < headword.Length; i++)
-                if (!char.IsDigit(headword[i])) return (headword, 0);
+            var m = HomonymTail.Match(headword[(sp + 1)..]);
             // TryParse, not Parse: an absurdly long all-digit run overflows int and falls back to (whole, 0).
-            var tail = headword[(sp + 1)..];
-            return int.TryParse(tail, NumberStyles.None, CultureInfo.InvariantCulture, out int n)
+            return m.Success && int.TryParse(m.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out int n)
                 ? (headword[..sp].TrimEnd(), n)
                 : (headword, 0);
         }

--- a/src/CST.LexiconTools/CST.LexiconTools.csproj
+++ b/src/CST.LexiconTools/CST.LexiconTools.csproj
@@ -3,13 +3,14 @@
   <!--
     CST.LexiconTools — BUILD-TIME converters that turn an upstream dictionary source into a canonical
     CST.Lexicon asset (#109). Run locally to produce the .db files the app downloads; NOT referenced by
-    the app, so its HTML dependencies (AngleSharp / Ganss.Xss) never ship in CST Reader. The app reads a
-    lexicon through CST.Lexicon.LexiconReader and trusts it was sanitized here.
+    the app, so nothing it does can ship in CST Reader. The app reads a lexicon through
+    CST.Lexicon.LexiconReader and trusts it was reduced to the closed tag set here.
 
     First converter: DPPN (Dictionary of Pāli Proper Names). Its source is a TRUSTED, fixed, public-domain
     file whose definitions use a tiny known tag set (b i p abbr li ul ol hr). So the body is reduced to our
-    closed allowlist by a small build-time filter (validated against the full corpus), and the bold headword
-    is extracted by regex — no XSS-sanitizer dependency, which belongs on the UNTRUSTED in-app import path
+    closed allowlist by a small build-time filter that is safe by construction (stray angle brackets in text
+    are escaped) and post-condition-checked, and the bold headword is extracted by regex. This tool therefore
+    pulls NO third-party HTML dependency; a vetted XSS sanitizer belongs on the UNTRUSTED in-app import path
     (a later change), not on a one-time conversion of data we control.
   -->
 
@@ -24,10 +25,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CST.Lexicon\CST.Lexicon.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <InternalsVisibleTo Include="CST.Avalonia.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/CST.LexiconTools/CST.LexiconTools.csproj
+++ b/src/CST.LexiconTools/CST.LexiconTools.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    CST.LexiconTools — BUILD-TIME converters that turn an upstream dictionary source into a canonical
+    CST.Lexicon asset (#109). Run locally to produce the .db files the app downloads; NOT referenced by
+    the app, so its HTML dependencies (AngleSharp / Ganss.Xss) never ship in CST Reader. The app reads a
+    lexicon through CST.Lexicon.LexiconReader and trusts it was sanitized here.
+
+    First converter: DPPN (Dictionary of Pāli Proper Names). Its source is a TRUSTED, fixed, public-domain
+    file whose definitions use a tiny known tag set (b i p abbr li ul ol hr). So the body is reduced to our
+    closed allowlist by a small build-time filter (validated against the full corpus), and the bold headword
+    is extracted by regex — no XSS-sanitizer dependency, which belongs on the UNTRUSTED in-app import path
+    (a later change), not on a one-time conversion of data we control.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>CST.LexiconTools</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>cst-lexicon-tools</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CST.Lexicon\CST.Lexicon.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="CST.Avalonia.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/CST.LexiconTools/DppnConverter.cs
+++ b/src/CST.LexiconTools/DppnConverter.cs
@@ -23,8 +23,13 @@ namespace CST.LexiconTools
     {
         // The lemma is the FIRST <b>…</b> run; verified across all 13,642 records to be the headword.
         private static readonly Regex FirstBold = new("<b>(.*?)</b>", RegexOptions.Singleline | RegexOptions.Compiled);
-        // A bare integer immediately after that first </b> is the homonym marker ("…</b> 01.").
-        private static readonly Regex HomonymAfterBold = new("</b>\\s*0*(\\d+)", RegexOptions.Compiled);
+        // A bare integer after a </b> in the heading is the homonym marker ("…</b> 01."), optionally a RANGE
+        // ("…</b> 05-06." — one entry covering homonyms 5–6). NOTE this matches a number after ANY </b>, not
+        // only the first: the sole multi-bold+number headings in DPPN are alternative-title homonyms
+        // ("<b>Uttiyasutta</b> or <b>Uttikasutta</b> 02."), where the trailing number is the real homonym and
+        // matching the later </b> is correct. (fable L1)
+        private static readonly Regex HomonymAfterBold =
+            new("</b>\\s*0*(\\d+)(?:-0*(\\d+))?", RegexOptions.Compiled);
         private static readonly Regex AnyTag = new("<[^>]*>", RegexOptions.Compiled);
 
         /// <summary>
@@ -43,12 +48,16 @@ namespace CST.LexiconTools
             string lemma = WebUtility.HtmlDecode(AnyTag.Replace(m.Value, string.Empty)).Trim();
             if (lemma.Length == 0) return string.Empty;
 
-            // Look for a homonym number in the tail AFTER the first </b> only (not inside a later bold run).
+            // A homonym number (or range) after the lemma's </b>. Search from the first </b> onward.
             string tail = nameHtml[(m.Index + m.Length)..];
-            var h = HomonymAfterBold.Match("</b>" + tail);   // re-anchor so the pattern's </b> matches
-            return h.Success && int.TryParse(h.Groups[1].Value, out int n) && n > 0
-                ? $"{lemma} {n}"
-                : lemma;
+            var h = HomonymAfterBold.Match("</b>" + tail);
+            if (!h.Success || !int.TryParse(h.Groups[1].Value, out int n) || n <= 0)
+                return lemma;
+            // A range ("05-06") keeps both numbers in the display; the lexicon builder's homonym split takes the
+            // first as the sort number and derives the key from the lemma alone. (fable L2)
+            return h.Groups[2].Success && int.TryParse(h.Groups[2].Value, out int m2)
+                ? $"{lemma} {n}-{m2}"
+                : $"{lemma} {n}";
         }
 
         /// <summary>The tags a definition body may keep — DPPN uses only these; everything else is dropped
@@ -56,13 +65,19 @@ namespace CST.LexiconTools
         private static readonly HashSet<string> AllowedTags = new(StringComparer.OrdinalIgnoreCase)
         { "p", "br", "i", "b", "em", "strong", "ul", "ol", "li", "hr", "abbr" };
 
-        private static readonly Regex TagToken = new("<(/?)\\s*([a-zA-Z0-9]+)[^>]*?(/?)>", RegexOptions.Compiled);
+        // No "\s*" after "<": per the HTML spec a "<" followed by whitespace is TEXT, not a tag-open, so
+        // "a < b" must not be read as a "<b>" tag. (fable M1)
+        private static readonly Regex TagToken = new("<(/?)([a-zA-Z0-9]+)[^>]*?(/?)>", RegexOptions.Compiled);
 
         /// <summary>
-        /// Reduce a definition body to the closed allowlist: keep an allowed tag as its bare form (no
-        /// attributes — so no href/style/on*/class/title survives), drop any other tag while keeping the text
-        /// between tags. Malformed input is handled token-by-token (each tag stands alone). Trusted build-time
-        /// input, so this is a normalize-to-our-tag-set filter, not an adversarial sanitizer.
+        /// Reduce a definition body to the closed allowlist, SAFE BY CONSTRUCTION: an allowed tag is emitted as
+        /// its bare form (no attributes — so no href/style/on*/class/title survives), any other tag is dropped,
+        /// and every character of the text BETWEEN tags has its stray <c>&lt;</c>/<c>&gt;</c> escaped. That last
+        /// step is what makes the guarantee a property of the code rather than of the corpus: after cleaning,
+        /// the ONLY <c>&lt;</c>/<c>&gt;</c> in the output are the bare allowed tags this method wrote, so no
+        /// dropped-tag remnant, HTML comment, dangling partial tag, or split-tag reassembly can form live markup
+        /// in the WebView. Trusted build-time input, so this is a normalize-to-our-tag-set filter, not an
+        /// adversarial sanitizer — but it is now demonstrably closed. (fable M2)
         /// </summary>
         public static string CleanBody(string html)
         {
@@ -71,10 +86,10 @@ namespace CST.LexiconTools
             int pos = 0;
             foreach (Match t in TagToken.Matches(html))
             {
-                sb.Append(html, pos, t.Index - pos);          // text before this tag, verbatim
+                AppendEscaped(sb, html, pos, t.Index);        // text before this tag, with stray <> escaped
                 pos = t.Index + t.Length;
                 string name = t.Groups[2].Value;
-                if (!AllowedTags.Contains(name)) continue;    // drop the tag, keep surrounding text
+                if (!AllowedTags.Contains(name)) continue;    // drop the tag, keep surrounding (escaped) text
                 bool closing = t.Groups[1].Value == "/";
                 bool selfClose = t.Groups[3].Value == "/" || name.Equals("br", StringComparison.OrdinalIgnoreCase)
                                  || name.Equals("hr", StringComparison.OrdinalIgnoreCase);
@@ -82,9 +97,34 @@ namespace CST.LexiconTools
                         : selfClose ? $"<{name.ToLowerInvariant()}/>"
                         : $"<{name.ToLowerInvariant()}>");
             }
-            sb.Append(html, pos, html.Length - pos);          // trailing text
+            AppendEscaped(sb, html, pos, html.Length);        // trailing text
             return sb.ToString().Trim();
         }
+
+        // Append html[start..end], turning a stray '<' or '>' into an entity so text can never form or complete
+        // a tag. Existing entities (&lt; etc.) contain no '<'/'>' char, so they pass through untouched.
+        private static void AppendEscaped(StringBuilder sb, string html, int start, int end)
+        {
+            for (int i = start; i < end; i++)
+            {
+                char ch = html[i];
+                sb.Append(ch == '<' ? "&lt;" : ch == '>' ? "&gt;" : ch.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Build-time post-condition: a cleaned body must contain no markup outside the bare allowlist. Stripping
+        /// the allowed bare tags must leave zero <c>&lt;</c>/<c>&gt;</c>. Throws otherwise, so a future CleanBody
+        /// regression fails the build rather than shipping unsafe HTML. (fable M2)
+        /// </summary>
+        public static bool IsClosedAllowlist(string cleanedBody)
+        {
+            string stripped = AllowedBareTag.Replace(cleanedBody, string.Empty);
+            return !stripped.Contains('<') && !stripped.Contains('>');
+        }
+
+        private static readonly Regex AllowedBareTag =
+            new("</?(?:p|br|i|b|em|strong|ul|ol|li|hr|abbr)/?>", RegexOptions.Compiled);
 
         /// <summary>
         /// Map the DPPN source JSON to canonical raw entries. Skips records with no bold lemma or an effectively
@@ -102,8 +142,14 @@ namespace CST.LexiconTools
                 if (headword.Length == 0) continue;
 
                 string body = CleanBody(entry);
-                // A body that is empty once tags are stripped is a header stub, not a definition.
-                if (AnyTag.Replace(body, string.Empty).Trim().Length == 0) continue;
+                // A body that is empty once tags AND entities are removed is a header stub, not a definition
+                // (decode so "&nbsp;</p>" also counts as empty). (fable L3)
+                if (WebUtility.HtmlDecode(AnyTag.Replace(body, string.Empty)).Trim().Length == 0) continue;
+
+                // Safety post-condition: never emit a body with markup outside the closed allowlist. (fable M2)
+                if (!IsClosedAllowlist(body))
+                    throw new InvalidOperationException(
+                        $"CleanBody produced non-allowlisted markup for '{headword}': {body}");
 
                 yield return new RawEntry(headword, body);
             }

--- a/src/CST.LexiconTools/DppnConverter.cs
+++ b/src/CST.LexiconTools/DppnConverter.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using CST.Lexicon;
+
+namespace CST.LexiconTools
+{
+    /// <summary>
+    /// Converts the Dictionary of Pāli Proper Names (DPPN, Malalasekera / rev. Ānandajoti 2025) source
+    /// <c>DPPN.json</c> into a canonical <see cref="CST.Lexicon"/> asset.
+    ///
+    /// <para>The source is a JSON array of <c>{ "name", "entry" }</c> where <c>name</c> is a formatted heading
+    /// (the lemma in the first <c>&lt;b&gt;</c>, an optional bare homonym number after it, citations in
+    /// <c>&lt;abbr&gt;</c>, all in malformed markup) and <c>entry</c> is the definition HTML. Trusted, fixed,
+    /// public-domain input, so the body is reduced to a closed allowlist by a build-time filter rather than a
+    /// full XSS sanitizer.</para>
+    /// </summary>
+    public static class DppnConverter
+    {
+        // The lemma is the FIRST <b>…</b> run; verified across all 13,642 records to be the headword.
+        private static readonly Regex FirstBold = new("<b>(.*?)</b>", RegexOptions.Singleline | RegexOptions.Compiled);
+        // A bare integer immediately after that first </b> is the homonym marker ("…</b> 01.").
+        private static readonly Regex HomonymAfterBold = new("</b>\\s*0*(\\d+)", RegexOptions.Compiled);
+        private static readonly Regex AnyTag = new("<[^>]*>", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Extract the published headword and homonym number from a DPPN <c>name</c> heading. The homonym (if
+        /// any) is folded back into the returned headword as " N" so the lexicon builder splits it the same way
+        /// it does for every other source. Returns an empty headword when there is no bold lemma.
+        /// </summary>
+        public static string ParseHeadword(string nameHtml)
+        {
+            if (string.IsNullOrEmpty(nameHtml)) return string.Empty;
+
+            var m = FirstBold.Match(nameHtml);
+            if (!m.Success) return string.Empty;
+
+            // The bold content itself can carry inner markup/entities — reduce to plain text.
+            string lemma = WebUtility.HtmlDecode(AnyTag.Replace(m.Value, string.Empty)).Trim();
+            if (lemma.Length == 0) return string.Empty;
+
+            // Look for a homonym number in the tail AFTER the first </b> only (not inside a later bold run).
+            string tail = nameHtml[(m.Index + m.Length)..];
+            var h = HomonymAfterBold.Match("</b>" + tail);   // re-anchor so the pattern's </b> matches
+            return h.Success && int.TryParse(h.Groups[1].Value, out int n) && n > 0
+                ? $"{lemma} {n}"
+                : lemma;
+        }
+
+        /// <summary>The tags a definition body may keep — DPPN uses only these; everything else is dropped
+        /// (its text content preserved). No attributes survive, so nothing external, scripted, or styled can.</summary>
+        private static readonly HashSet<string> AllowedTags = new(StringComparer.OrdinalIgnoreCase)
+        { "p", "br", "i", "b", "em", "strong", "ul", "ol", "li", "hr", "abbr" };
+
+        private static readonly Regex TagToken = new("<(/?)\\s*([a-zA-Z0-9]+)[^>]*?(/?)>", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Reduce a definition body to the closed allowlist: keep an allowed tag as its bare form (no
+        /// attributes — so no href/style/on*/class/title survives), drop any other tag while keeping the text
+        /// between tags. Malformed input is handled token-by-token (each tag stands alone). Trusted build-time
+        /// input, so this is a normalize-to-our-tag-set filter, not an adversarial sanitizer.
+        /// </summary>
+        public static string CleanBody(string html)
+        {
+            if (string.IsNullOrEmpty(html)) return string.Empty;
+            var sb = new StringBuilder(html.Length);
+            int pos = 0;
+            foreach (Match t in TagToken.Matches(html))
+            {
+                sb.Append(html, pos, t.Index - pos);          // text before this tag, verbatim
+                pos = t.Index + t.Length;
+                string name = t.Groups[2].Value;
+                if (!AllowedTags.Contains(name)) continue;    // drop the tag, keep surrounding text
+                bool closing = t.Groups[1].Value == "/";
+                bool selfClose = t.Groups[3].Value == "/" || name.Equals("br", StringComparison.OrdinalIgnoreCase)
+                                 || name.Equals("hr", StringComparison.OrdinalIgnoreCase);
+                sb.Append(closing ? $"</{name.ToLowerInvariant()}>"
+                        : selfClose ? $"<{name.ToLowerInvariant()}/>"
+                        : $"<{name.ToLowerInvariant()}>");
+            }
+            sb.Append(html, pos, html.Length - pos);          // trailing text
+            return sb.ToString().Trim();
+        }
+
+        /// <summary>
+        /// Map the DPPN source JSON to canonical raw entries. Skips records with no bold lemma or an effectively
+        /// empty body (DPPN's section headers, e.g. "A-An" whose entry is just "&lt;/p&gt;").
+        /// </summary>
+        public static IEnumerable<RawEntry> ToEntries(string dppnJson)
+        {
+            using var doc = JsonDocument.Parse(dppnJson);
+            foreach (var rec in doc.RootElement.EnumerateArray())
+            {
+                string name = rec.TryGetProperty("name", out var n) ? n.GetString() ?? string.Empty : string.Empty;
+                string entry = rec.TryGetProperty("entry", out var e) ? e.GetString() ?? string.Empty : string.Empty;
+
+                string headword = ParseHeadword(name);
+                if (headword.Length == 0) continue;
+
+                string body = CleanBody(entry);
+                // A body that is empty once tags are stripped is a header stub, not a definition.
+                if (AnyTag.Replace(body, string.Empty).Trim().Length == 0) continue;
+
+                yield return new RawEntry(headword, body);
+            }
+        }
+
+        /// <summary>The DPPN source metadata (attribution + version stamps) for the built lexicon.</summary>
+        public static LexiconMeta Meta(string sourceVersion) => new(
+            SourceId: "dppn",
+            DisplayName: "DPPN",
+            DefinitionLanguage: "en",
+            Kind: LexiconKind.ProperNames,
+            Title: "Dictionary of Pāli Proper Names",
+            Author: "G. P. Malalasekera",
+            Reviser: "Ānandajoti Bhikkhu",
+            Year: "2025",
+            Publisher: null,
+            License: "public-domain",
+            Url: "https://ancient-buddhist-texts.net/Textual-Studies/DPPN/index.htm",
+            SourceVersion: sourceVersion,
+            ConverterVersion: 1);
+
+        /// <summary>Read <paramref name="jsonPath"/>, build a lexicon at <paramref name="dbPath"/>, return the
+        /// entry count.</summary>
+        public static int BuildLexicon(string jsonPath, string dbPath, string sourceVersion)
+        {
+            string json = System.IO.File.ReadAllText(jsonPath);
+            var entries = ToEntries(json).ToList();
+            return LexiconBuilder.Build(dbPath, Meta(sourceVersion), entries);
+        }
+    }
+}

--- a/src/CST.LexiconTools/Program.cs
+++ b/src/CST.LexiconTools/Program.cs
@@ -1,0 +1,20 @@
+using System;
+using CST.LexiconTools;
+
+// Build-time CLI. Usage:
+//   cst-lexicon-tools dppn <DPPN.json> <out.db> [sourceVersion]
+if (args.Length >= 1 && args[0].Equals("dppn", StringComparison.OrdinalIgnoreCase))
+{
+    if (args.Length < 3)
+    {
+        Console.Error.WriteLine("usage: cst-lexicon-tools dppn <DPPN.json> <out.db> [sourceVersion]");
+        return 2;
+    }
+    string json = args[1], db = args[2], ver = args.Length >= 4 ? args[3] : "unknown";
+    int n = DppnConverter.BuildLexicon(json, db, ver);
+    Console.WriteLine($"DPPN → {db}: {n} entries (source {ver}).");
+    return 0;
+}
+
+Console.Error.WriteLine("usage: cst-lexicon-tools dppn <DPPN.json> <out.db> [sourceVersion]");
+return 2;

--- a/src/CST.LexiconTools/Program.cs
+++ b/src/CST.LexiconTools/Program.cs
@@ -11,9 +11,17 @@ if (args.Length >= 1 && args[0].Equals("dppn", StringComparison.OrdinalIgnoreCas
         return 2;
     }
     string json = args[1], db = args[2], ver = args.Length >= 4 ? args[3] : "unknown";
-    int n = DppnConverter.BuildLexicon(json, db, ver);
-    Console.WriteLine($"DPPN → {db}: {n} entries (source {ver}).");
-    return 0;
+    try
+    {
+        int n = DppnConverter.BuildLexicon(json, db, ver);
+        Console.WriteLine($"DPPN → {db}: {n} entries (source {ver}).");
+        return 0;
+    }
+    catch (Exception ex) when (ex is System.IO.IOException or System.Text.Json.JsonException or InvalidOperationException)
+    {
+        Console.Error.WriteLine($"DPPN conversion failed: {ex.Message}");
+        return 1;
+    }
 }
 
 Console.Error.WriteLine("usage: cst-lexicon-tools dppn <DPPN.json> <out.db> [sourceVersion]");

--- a/src/CST.sln
+++ b/src/CST.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CST.Lexicon", "CST.Lexicon\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CST.Core", "CST.Core\CST.Core.csproj", "{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CST.LexiconTools", "CST.LexiconTools\CST.LexiconTools.csproj", "{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -119,6 +121,22 @@ Global
 		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|x86.Build.0 = Release|Any CPU
 		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|x64.ActiveCfg = Release|Any CPU
 		{308EA01B-F1F3-4ADC-AD51-F822E84FEA90}.Release|x64.Build.0 = Release|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Debug|x86.Build.0 = Debug|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Debug|x64.Build.0 = Debug|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Release|x86.ActiveCfg = Release|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Release|x86.Build.0 = Release|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Release|x64.ActiveCfg = Release|Any CPU
+		{C7A4E994-C31D-4CE2-AA5F-2CC2A9E0C64A}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Second implementation PR of the multi-source dictionary work (#467), on the just-merged `CST.Lexicon` format. Adds `CST.LexiconTools` — a **build-time console tool, not referenced by the app** — whose first converter turns the Dictionary of Pāli Proper Names source `DPPN.json` into a canonical lexicon asset.

## Real data drove the design

I fetched and analysed the actual 13,642-record `DPPN.json`, which overturned my synthetic assumptions. The `name` field is a malformed formatted **heading**, not a clean headword: the lemma is the first `<b>` run, an optional bare homonym number follows (`<b>Akatuññatāsutta</b> 01.`), citations sit in `<abbr>`, and the markup is unbalanced. So the converter:

- **`ParseHeadword`** takes the first bold run, folds a trailing homonym number/range back in, and excludes citation chrome.
- **`CleanBody`** reduces a definition to the closed allowlist (`p br i b em strong ul ol li hr abbr`), dropping every other tag and **all** attributes.

DPPN is trusted, fixed, public-domain input with a tiny known tag set, so this is build-time *normalization to our tag set*, not an adversarial sanitizer — hence **no third-party HTML dependency**. A vetted sanitizer belongs on the later untrusted in-app import path.

## Validated end-to-end on the real file

13,642 records → **13,594 entries** (48 section-header stubs skipped), **5,053 homonyms**, and — checked across the whole corpus — zero disallowed tags/attributes survive any body. Lookups round-trip: `jetavana` → 3 homonyms, `anāthapiṇḍika` → its 2 homonyms then the deeper prefix run.

## Fable review — two MEDIUM, real-data defects, all fixed

Fable replicated the regex over the full corpus:
- **M1**: `<` + whitespace (`a < b`) was read as a `<b>` tag, corrupting prose. Fixed to match the HTML spec.
- **M2**: the "no unsafe HTML reaches the WebView" guarantee was a property of the *data*, not the *code* (split-tag reassembly, comments, dangling tags could pass). `CleanBody` now **escapes stray `<`/`>` in every text run**, so the only markup in the output is the bare allowed tags it wrote — safe by construction — plus a build-time post-condition assert. Verified across all 13,594 bodies.
- **L1**: documented + tested the (correct) alternative-title homonym behavior (`Uttiyasutta`), which was untested and comment-contradicted.
- **L2**: `Piyasutta 05-06` (the one ranged heading) stored as `Piyasutta 5`, falsely implying a `Piyasutta 6`; now `Piyasutta 5-6`, with `LexiconKey.SplitHomonym` learning a hyphenated range.
- L3 + nits: entity-decode the stub check; csproj comment; drop unneeded `InternalsVisibleTo`; `Program.cs` error handling.

## Testing

13 converter + 20 lexicon tests, using the **real** malformed shapes; the M2 tests pin the safety property against split-tag/comment/partial-tag inputs. Full suite **929/929**.

## Not in this PR
The built `dppn.db` (13,594 entries) exists locally as a byproduct; it's *delivered* by the manifest work (#468). The runtime `SqliteDictionarySource` + registry (#466 spine) exposes it. #466's UI stays with the Kestrel session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
