### PR TITLE
#109: derive lexicon keys at read time (self-contained converters, no key-parity risk)

### DIFF
--- a/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
+++ b/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
@@ -92,6 +92,8 @@ namespace CST.Avalonia.Tests.Lexicon
             Assert.Equal(("Nāgita", 1), LexiconKey.SplitHomonym("Nāgita 1"));
             Assert.Equal(("Sāvatthī", 0), LexiconKey.SplitHomonym("Sāvatthī"));
             Assert.Equal(("Migāra", 12), LexiconKey.SplitHomonym("Migāra 12"));   // base has the number stripped
+            Assert.Equal(("Piyasutta", 5), LexiconKey.SplitHomonym("Piyasutta 5-6"));   // range → first number
+            Assert.Equal(("dhamma 1.01", 0), LexiconKey.SplitHomonym("dhamma 1.01"));    // dotted → not split
             // A name that legitimately ends in a word, or has an interior number, is left whole.
             Assert.Equal(("Vessantara Jātaka", 0), LexiconKey.SplitHomonym("Vessantara Jātaka"));
         }

--- a/src/CST.Lexicon/LexiconBuilder.cs
+++ b/src/CST.Lexicon/LexiconBuilder.cs
@@ -68,25 +68,19 @@ namespace CST.Lexicon
 
                 using (var insert = conn.CreateCommand())
                 {
-                    insert.CommandText =
-                        "INSERT INTO entry(ipe_key, headword, homonym, body_html) VALUES ($k, $h, $n, $b)";
-                    var pk = insert.CreateParameter(); pk.ParameterName = "$k"; insert.Parameters.Add(pk);
+                    insert.CommandText = "INSERT INTO entry(headword, body_html) VALUES ($h, $b)";
                     var ph = insert.CreateParameter(); ph.ParameterName = "$h"; insert.Parameters.Add(ph);
-                    var pn = insert.CreateParameter(); pn.ParameterName = "$n"; insert.Parameters.Add(pn);
                     var pb = insert.CreateParameter(); pb.ParameterName = "$b"; insert.Parameters.Add(pb);
 
                     foreach (var raw in entries)
                     {
+                        // Store the clean PUBLISHED headword (HTML stripped, homonym number kept, e.g. "Nāgita 1").
+                        // The key and homonym are derived at READ time — the builder does no IPE work, so a
+                        // producer needs no CST.Core, and there is no build-vs-read key to keep in lockstep.
                         string stripped = LexiconKey.StripHtml(raw.Headword ?? string.Empty);
-                        if (string.IsNullOrWhiteSpace(stripped)) continue;   // nothing to key on
+                        if (string.IsNullOrWhiteSpace(stripped)) continue;   // nothing to index
 
-                        var (headBase, homonym) = LexiconKey.SplitHomonym(stripped);
-                        string key = LexiconKey.DeriveKey(headBase);
-                        if (string.IsNullOrEmpty(key)) continue;
-
-                        pk.Value = key;
-                        ph.Value = stripped;                 // verbatim published form (homonym number kept)
-                        pn.Value = homonym;
+                        ph.Value = stripped;
                         pb.Value = raw.BodyHtml ?? string.Empty;
                         insert.ExecuteNonQuery();
                         written++;

--- a/src/CST.Lexicon/LexiconKey.cs
+++ b/src/CST.Lexicon/LexiconKey.cs
@@ -34,25 +34,29 @@ namespace CST.Lexicon
 
         /// <summary>
         /// Split a trailing homonym number off a headword: <c>"Nāgita 1"</c> → (<c>"Nāgita"</c>, 1);
-        /// <c>"Sāvatthī"</c> → (<c>"Sāvatthī"</c>, 0). A homonym marker is a final space-separated token of
-        /// digits ONLY. Not split: an interior number, a token with non-digits, or a DOTTED sub-homonym like
-        /// DPD's <c>"dhamma 1.01"</c> — this deliberately differs from <c>SqliteLemmaProvider.StripHomonym</c>
-        /// (which allows dots) because the proper-name/import sources this serves publish plain integer markers;
-        /// a dotted DPD-shaped source would keep its whole headword (harmless — still findable by prefix).
+        /// <c>"Sāvatthī"</c> → (<c>"Sāvatthī"</c>, 0). A homonym marker is a final space-separated token that is a
+        /// bare integer, or a hyphenated integer RANGE (<c>"Piyasutta 5-6"</c>, one entry covering homonyms 5–6,
+        /// as DPPN publishes) — the first number is the sort homonym. NOT split: an interior number, a token with
+        /// other non-digits, or a DOTTED sub-homonym like DPD's <c>"dhamma 1.01"</c> — this deliberately differs
+        /// from <c>SqliteLemmaProvider.StripHomonym</c> (which allows dots) because the proper-name/import sources
+        /// this serves publish plain integer markers; a dotted DPD-shaped source keeps its whole headword
+        /// (harmless — still findable by prefix).
         /// </summary>
         public static (string Base, int Homonym) SplitHomonym(string headword)
         {
             if (string.IsNullOrEmpty(headword)) return (headword, 0);
             int sp = headword.LastIndexOf(' ');
             if (sp <= 0 || sp + 1 >= headword.Length) return (headword, 0);
-            for (int i = sp + 1; i < headword.Length; i++)
-                if (!char.IsDigit(headword[i])) return (headword, 0);
+            var m = HomonymTail.Match(headword[(sp + 1)..]);
             // TryParse, not Parse: an absurdly long all-digit run overflows int and falls back to (whole, 0).
-            var tail = headword[(sp + 1)..];
-            return int.TryParse(tail, NumberStyles.None, CultureInfo.InvariantCulture, out int n)
+            return m.Success && int.TryParse(m.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out int n)
                 ? (headword[..sp].TrimEnd(), n)
                 : (headword, 0);
         }
+
+        // A final token that is a bare integer or a hyphenated integer range ("5" / "5-6"). The first number is
+        // the sort homonym. A dotted token ("1.01") is not matched (see the doc above).
+        private static readonly Regex HomonymTail = new(@"^(\d+)(?:-\d+)?$", RegexOptions.Compiled);
 
         /// <summary>
         /// The IPE lookup key for a headword base (homonym + HTML already removed). Mirrors the runtime query

--- a/src/CST.Lexicon/LexiconModels.cs
+++ b/src/CST.Lexicon/LexiconModels.cs
@@ -45,10 +45,11 @@ namespace CST.Lexicon
     /// </summary>
     public sealed record RawEntry(string Headword, string BodyHtml);
 
-    /// <summary>A stored/looked-up lexicon entry.</summary>
-    /// <param name="IpeKey">The IPE lookup/sort key (homonym + HTML removed).</param>
+    /// <summary>A looked-up lexicon entry. Only <see cref="Headword"/> and <see cref="BodyHtml"/> are stored;
+    /// <see cref="IpeKey"/> and <see cref="Homonym"/> are DERIVED from the headword at load.</summary>
+    /// <param name="IpeKey">The IPE lookup/sort key (homonym + HTML removed), derived at read time.</param>
     /// <param name="Headword">The published headword, HTML stripped, homonym number kept (e.g. "Nāgita 1").</param>
-    /// <param name="Homonym">The parsed homonym number, or 0.</param>
+    /// <param name="Homonym">The homonym number parsed from the headword, or 0.</param>
     /// <param name="BodyHtml">The definition HTML fragment.</param>
     public sealed record LexiconEntry(string IpeKey, string Headword, int Homonym, string BodyHtml);
 }

--- a/src/CST.Lexicon/LexiconReader.cs
+++ b/src/CST.Lexicon/LexiconReader.cs
@@ -42,15 +42,20 @@ namespace CST.Lexicon
             var list = new List<LexiconEntry>();
             using (var cmd = conn.CreateCommand())
             {
-                cmd.CommandText = "SELECT ipe_key, headword, homonym, body_html FROM entry";
+                cmd.CommandText = "SELECT headword, body_html FROM entry";
                 using var r = cmd.ExecuteReader();
                 while (r.Read())
-                    list.Add(new LexiconEntry(r.GetString(0), r.GetString(1), r.GetInt32(2), r.GetString(3)));
+                {
+                    string headword = r.GetString(0);
+                    // Derive the lookup key + homonym HERE, from the stored headword — the single derivation
+                    // path (LexiconKey) also serves typed queries, so keys and queries can't drift.
+                    var (headBase, homonym) = LexiconKey.SplitHomonym(headword);
+                    string key = LexiconKey.DeriveKey(headBase);
+                    list.Add(new LexiconEntry(key, headword, homonym, r.GetString(1)));
+                }
             }
 
-            // Sort in-memory with the SAME ordinal (UTF-16 code-unit) comparison the binary search uses, rather
-            // than trusting SQL's BINARY (UTF-8 byte) ORDER BY — they agree for all-BMP strings (IPE tops out at
-            // U+1E6D) but making the collation invariant local removes the cross-system assumption. (fable LOW-4)
+            // Sort by the derived key with the SAME ordinal (UTF-16 code-unit) comparison the binary search uses.
             var arr = list.ToArray();
             Array.Sort(arr, (a, b) =>
             {

--- a/src/CST.Lexicon/LexiconSchema.cs
+++ b/src/CST.Lexicon/LexiconSchema.cs
@@ -2,9 +2,12 @@ namespace CST.Lexicon
 {
     /// <summary>
     /// The canonical lexicon SQLite schema — one place so the builder and reader can't drift. A lexicon is two
-    /// tables: <c>meta</c> (source id + attribution + version stamps, key/value) and <c>entry</c>
-    /// (IPE-keyed, homonym-aware, HTML-definition rows). Bumping <see cref="SchemaVersion"/> means an older
-    /// reader should refuse a newer file (the delivery layer gates on it).
+    /// tables: <c>meta</c> (source id + attribution + version stamps, key/value) and <c>entry</c>, which stores
+    /// just the published <c>headword</c> and its HTML <c>body</c>. The IPE lookup key and homonym number are
+    /// NOT stored — <see cref="LexiconReader"/> derives them at load from the headword, so a producer (a
+    /// build-time converter, or the in-app import) needs no knowledge of IPE and there is no build-vs-read key
+    /// to keep in lockstep: one derivation path serves both stored headwords and typed queries. Bumping
+    /// <see cref="SchemaVersion"/> means an older reader should refuse a newer file (the delivery layer gates on it).
     /// </summary>
     public static class LexiconSchema
     {
@@ -30,11 +33,8 @@ namespace CST.Lexicon
 CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT);
 CREATE TABLE entry(
     id         INTEGER PRIMARY KEY,
-    ipe_key    TEXT NOT NULL,
     headword   TEXT NOT NULL,
-    homonym    INTEGER NOT NULL DEFAULT 0,
     body_html  TEXT NOT NULL
-);
-CREATE INDEX ix_entry_key ON entry(ipe_key);";
+);";
     }
 }


### PR DESCRIPTION
Reworks the lexicon format from #470 so a stored entry is just `(headword, body_html)`; `LexiconReader` derives the IPE key and homonym from the headword at load.

## Why

Two goals, one change:

1. **Self-contained converters.** With the key derived at read time, a producer writes only `(headword, body)` — needing just `Microsoft.Data.Sqlite`, no `CST.Lexicon`/`CST.Core`. That's what lets the DPPN converter live in the `cst-dictionaries` repo beside `DpdLemmaBuilder`, self-contained (Frank's call).
2. **No key-parity risk.** #470 derived a key at build AND at query time — a hand-maintained parity. Now the reader's single derivation serves both stored headwords and typed queries, so they can't drift by construction. (This was a risk I'd flagged in the #470 review.)

Cost: deriving ~13k keys on load (ms via `Any2Ipe`), the same thing `SqliteLemmaProvider` already does for DPD forms.

## Scope

- `entry` table: dropped `ipe_key` + `homonym` columns and the key index; now `(id, headword, body_html)`.
- `LexiconBuilder`: stores the HTML-stripped headword + body; no IPE work.
- `LexiconReader`: derives `(base, homonym)` + key from each headword at load, sorts by the derived key.
- Ported the homonym-range fix (`5-6`) into `SplitHomonym` so it survives the converter's relocation.

Behaviour-preserving: all 18 lexicon tests pass unchanged (build → read → lookup is identical). Full suite **916/916**.

## Follow-ups
- The DPPN converter moves to `cst-dictionaries` as a self-contained tool writing this two-column format directly; **#471 (converter in the CST repo) is superseded** and will be closed once the relocation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)