### PR TITLE
#39: fix split-float tab loss, blank windows, and split-collapse data loss in dock cleanup

### DIFF
--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1921,8 +1921,10 @@ namespace CST.Avalonia.Services
             // Clean up empty splits after closing a dockable
             Log.Debug("*** Post-close cleanup - checking for empty splits ***");
             CleanupEmptySplits();
+            // (The empty-floating-window check is scheduled centrally in RemoveDockable, which base.CloseDockable
+            // routes through — see #39 note there.)
         }
-        
+
         // Override SwapDockable to debug tab operations and trigger cleanup
         public override void SwapDockable(IDock dock, IDockable sourceDockable, IDockable targetDockable)
         {
@@ -1974,6 +1976,7 @@ namespace CST.Avalonia.Services
             PrepareCrossWindowMove(sourceDockable, targetDock);
             base.MoveDockable(sourceDock, targetDock, sourceDockable, targetDockable);
             CleanupEmptySplits();
+            // Empty-floating-window check runs centrally in RemoveDockable (base.MoveDockable routes through it).
         }
 
         // Cross-dock swap: both dockables change docks, so either could be a book/PDF crossing windows.
@@ -1983,6 +1986,18 @@ namespace CST.Avalonia.Services
             PrepareCrossWindowMove(targetDockable, sourceDock);
             base.SwapDockable(sourceDock, targetDock, sourceDockable, targetDockable);
             CleanupEmptySplits();
+        }
+
+        // Close any now-empty floating window after a cross-window move, DEFERRED to the next dispatcher
+        // tick. Two reasons: (1) the per-pane collection monitor (SetupFloatingWindowMonitoring) is wired
+        // only at window creation, so emptying a pane added by a LATER split fires no handler and the empty
+        // window would otherwise linger blank — running the check here covers every drag path regardless of
+        // monitoring. (2) Deferring keeps the window Close() (native teardown, with CEF in the mix) out of
+        // the middle of base.MoveDockable's half-finished mutation; the check recomputes from live state, so
+        // one tick later is harmless. (#39 blank window)
+        private void ScheduleEmptyFloatingWindowCheck()
+        {
+            Dispatcher.UIThread.Post(CheckForEmptyFloatingWindows, DispatcherPriority.Background);
         }
 
         // When a book/PDF is about to move into a dock in a DIFFERENT window, shut down and evict its recycled
@@ -2083,9 +2098,16 @@ namespace CST.Avalonia.Services
             // Trigger cleanup after remove operations
             Log.Debug("*** Post-remove cleanup - checking for empty splits ***");
             CleanupEmptySplits();
+
+            // Every removal funnels through here — base.CloseDockable (tab close) and base.MoveDockable
+            // (drag out) both call the virtual RemoveDockable — so scheduling the empty-floating-window check
+            // HERE covers all of them in one place, regardless of whether the emptied pane was monitored (a
+            // later-split pane never is). Deferred so the native window Close() doesn't run inside a
+            // half-finished framework mutation; the check recomputes from live state. (#39 blank window)
+            ScheduleEmptyFloatingWindowCheck();
         }
-        
-        
+
+
         // Initialize host window support for floating windows
         public override void InitLayout(IDockable layout)
         {
@@ -2198,13 +2220,15 @@ namespace CST.Avalonia.Services
                             }
                         }
                         
-                        // Check for empty floating windows after any collection change
-                        Log.Debug("*** Floating window collection changed - calling CheckForEmptyFloatingWindows ***");
-                        CheckForEmptyFloatingWindows();
-                        
                         // Clean up empty splits in floating windows after any collection change
                         Log.Debug("*** Floating window collection changed - cleaning up empty splits ***");
                         CleanupEmptySplits();
+
+                        // Check for empty floating windows AFTER cleanup, deferred: this handler can fire
+                        // mid-mutation (inside base.MoveDockable), and closing a window there — native
+                        // teardown with CEF — is the risky moment the comment near the top of this file warns
+                        // about. The check recomputes from live state, so a tick later is safe. (#39)
+                        ScheduleEmptyFloatingWindowCheck();
                     };
                 }
                 
@@ -2477,30 +2501,27 @@ namespace CST.Avalonia.Services
                 {
                     Log.Debug("*** Checking host window: {WindowId} ***", hostWindow.Id);
 
-                    // Look at EVERY DocumentDock in the layout, not just the first: a split floating window
-                    // has more than one pane, and checking only the first orphaned the others' books when
-                    // that first pane emptied. The window is empty only when NO pane holds a document.
-                    // (#39 tab-loss)
-                    var documentDocks = FindAllDocumentDocksInLayout(hostWindow.Layout);
+                    // A floating window is empty when it has NO real content anywhere — no documents AND no
+                    // tools. Test the leaves of the whole layout, not a single DocumentDock:
+                    //   • split float, drag one pane's book out → the OTHER pane still holds books, so the
+                    //     window must stay (the old first-pane check closed it and orphaned them). (#39 tab-loss)
+                    //   • move the LAST books out → CleanupEmptySplits removes the emptied DocumentDock entirely,
+                    //     leaving a float with no DocumentDock at all; the old "needs a DocumentDock" gate left
+                    //     that blank "CST Reader" window open forever. (#39 blank window)
+                    // Leaf-based (not document-count) because floated TOOL panels (Search/Dictionary/Select a
+                    // Book — all CanFloat=true) are real content with zero documents; a doc-count test would
+                    // wrongly close them. Splitters are the only leaves that don't count as content.
+                    var leaves = new List<IDockable>();
+                    CollectLeafDockables(hostWindow.Layout, leaves, 0);
+                    var contentLeaves = leaves.Count(l => l is not ProportionalDockSplitter);
 
-                    if (documentDocks.Count > 0)
+                    Log.Debug("*** Host window {WindowId} - Layout: {LayoutType}, {LeafCount} leaf/leaves, {ContentCount} content (non-splitter) ***",
+                        hostWindow.Id, hostWindow.Layout?.GetType().Name ?? "null", leaves.Count, contentLeaves);
+
+                    if (contentLeaves == 0)
                     {
-                        var docCount = documentDocks.Sum(d => d.VisibleDockables?.OfType<ReactiveDocument>().Count() ?? 0);
-                        var hasDocuments = docCount > 0;
-
-                        Log.Debug("*** Host window {WindowId} - Layout: {LayoutType}, {DockCount} DocumentDock(s), ReactiveDocuments: {DocumentCount}, HasDocuments: {HasDocuments} ***",
-                            hostWindow.Id, hostWindow.Layout?.GetType().Name, documentDocks.Count, docCount, hasDocuments);
-
-                        if (!hasDocuments)
-                        {
-                            Log.Debug("*** EMPTY FLOATING WINDOW DETECTED: {WindowId} - scheduling for closure ***", hostWindow.Id);
-                            emptyWindows.Add(hostWindow);
-                        }
-                    }
-                    else
-                    {
-                        Log.Warning("*** Host window {WindowId} has layout {LayoutType} but no DocumentDock found ***",
-                            hostWindow.Id, hostWindow.Layout?.GetType().Name ?? "null");
+                        Log.Debug("*** EMPTY FLOATING WINDOW DETECTED: {WindowId} (no documents or tools) - scheduling for closure ***", hostWindow.Id);
+                        emptyWindows.Add(hostWindow);
                     }
                 }
                 
@@ -2899,13 +2920,20 @@ namespace CST.Avalonia.Services
                             if (index >= 0)
                             {
                                 parent.VisibleDockables[index] = onlyChild;
-                                
-                                // Update active dockable if needed
+
+                                // Re-home the surviving child: without this its Owner still points at the now-
+                                // detached wrapper, so a follow-up base.SplitToDock (edge-drop is a two-step
+                                // move+split) resolves `dockable.Owner` to the dead wrapper and splits inside a
+                                // tree unreachable from any window — silently losing the dragged tab. (#39 data loss)
+                                onlyChild.Owner = parent;
+
+                                // Repoint active/default away from the removed wrapper, or the floating
+                                // RootDock renders a dangling ActiveDockable → a blank window. (#39 blank window)
                                 if (parent.ActiveDockable == emptySplit)
-                                {
                                     parent.ActiveDockable = onlyChild;
-                                }
-                                
+                                if (parent.DefaultDockable == emptySplit)
+                                    parent.DefaultDockable = onlyChild;
+
                                 Log.Information("*** Successfully replaced single-child ProportionalDock with child ***");
                             }
                             else
@@ -2928,7 +2956,17 @@ namespace CST.Avalonia.Services
                         Log.Information("*** Removing empty dock completely ***");
                         parent.VisibleDockables.Remove(emptySplit);
                     }
-                    
+
+                    // A removed split must not stay referenced as the parent's active/default dockable — the
+                    // floating RootDock renders ActiveDockable, so a dangling reference is a blank window.
+                    // Repoint at a surviving non-splitter child (or null). (#39 blank window)
+                    if (ReferenceEquals(parent.ActiveDockable, emptySplit) || ReferenceEquals(parent.DefaultDockable, emptySplit))
+                    {
+                        var survivor = parent.VisibleDockables?.FirstOrDefault(d => d is not ProportionalDockSplitter);
+                        if (ReferenceEquals(parent.ActiveDockable, emptySplit)) parent.ActiveDockable = survivor;
+                        if (ReferenceEquals(parent.DefaultDockable, emptySplit)) parent.DefaultDockable = survivor;
+                    }
+
                     // If parent is also a ProportionalDock, clean up splitters
                     if (parent is ProportionalDock parentProportional)
                     {

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1578,9 +1578,11 @@ namespace CST.Avalonia.Services
                 CstHostWindow? sourceHostWindow = null;
                 if (oldVm.Owner is IDock currentDock)
                 {
-                    // Find the host window that contains this dock
+                    // Find the host window that contains this dock — match against ANY of its panes, not
+                    // just the first, or unfloating from the second pane of a split float misidentifies the
+                    // source window. (#39 tab-loss)
                     sourceHostWindow = HostWindows.OfType<CstHostWindow>()
-                        .FirstOrDefault(hw => FindDocumentDockInLayout(hw.Layout) == currentDock);
+                        .FirstOrDefault(hw => FindAllDocumentDocksInLayout(hw.Layout).Contains(currentDock));
 
                     Log.Information("Unfloating from host window: {WindowId}", sourceHostWindow?.Id ?? "unknown");
 
@@ -1643,12 +1645,13 @@ namespace CST.Avalonia.Services
                 // DO NOT check all floating windows - this was causing other floating windows to disappear
                 if (sourceHostWindow != null)
                 {
-                    var documentDock = FindDocumentDockInLayout(sourceHostWindow.Layout);
-                    if (documentDock != null)
+                    var documentDocks = FindAllDocumentDocksInLayout(sourceHostWindow.Layout);
+                    if (documentDocks.Count > 0)
                     {
-                        // Check for ReactiveDocument (BookDisplayViewModel) not just Document
-                        var hasDocuments = documentDock.VisibleDockables?.OfType<ReactiveDocument>().Any() ?? false;
-                        if (!hasDocuments)
+                        // Empty only when NO pane holds a document — else unfloating from a split float would
+                        // close a window still showing books in its other pane. (#39 tab-loss)
+                        var docCount = documentDocks.Sum(d => d.VisibleDockables?.OfType<ReactiveDocument>().Count() ?? 0);
+                        if (docCount == 0)
                         {
                             Log.Information("Source floating window {WindowId} is now empty - closing it", sourceHostWindow.Id);
                             CloseEmptyHostWindow(sourceHostWindow);
@@ -1656,7 +1659,7 @@ namespace CST.Avalonia.Services
                         else
                         {
                             Log.Information("Source floating window {WindowId} still has {Count} documents - keeping it open",
-                                sourceHostWindow.Id, documentDock.VisibleDockables?.OfType<ReactiveDocument>().Count() ?? 0);
+                                sourceHostWindow.Id, docCount);
                         }
                     }
                 }
@@ -2224,11 +2227,11 @@ namespace CST.Avalonia.Services
         private DocumentDock? FindDocumentDockInLayout(IDock? layout)
         {
             if (layout == null) return null;
-            
+
             // Direct DocumentDock
             if (layout is DocumentDock documentDock)
                 return documentDock;
-                
+
             // Search recursively in child docks
             if (layout.VisibleDockables != null)
             {
@@ -2240,6 +2243,29 @@ namespace CST.Avalonia.Services
             }
 
             return null;
+        }
+
+        // ALL DocumentDocks in a layout, not just the first. A floating window can be SPLIT (a
+        // ProportionalDock with two+ DocumentDock panes), and the single-dock FindDocumentDockInLayout above
+        // returns only the first in tree order — so "is this window empty?" and "close its tabs" both used to
+        // see only one pane. That silently orphaned the other pane's books: drag one pane's book out (or
+        // red-button-close a split float) and the survivors vanished. Enumerate every pane instead. (#39 tab-loss)
+        private void CollectDocumentDocks(IDock? layout, List<DocumentDock> result)
+        {
+            if (layout == null) return;
+            if (layout is DocumentDock documentDock) result.Add(documentDock);
+            if (layout.VisibleDockables != null)
+            {
+                foreach (var child in layout.VisibleDockables.OfType<IDock>())
+                    CollectDocumentDocks(child, result);
+            }
+        }
+
+        private List<DocumentDock> FindAllDocumentDocksInLayout(IDock? layout)
+        {
+            var docks = new List<DocumentDock>();
+            CollectDocumentDocks(layout, docks);
+            return docks;
         }
 
         // Fallback title for a floating window that momentarily has no content (empty windows are
@@ -2450,19 +2476,20 @@ namespace CST.Avalonia.Services
                 foreach (var hostWindow in HostWindows.OfType<CstHostWindow>().ToList())
                 {
                     Log.Debug("*** Checking host window: {WindowId} ***", hostWindow.Id);
-                    
-                    // Find the DocumentDock within the host window's layout hierarchy
-                    var documentDock = FindDocumentDockInLayout(hostWindow.Layout);
-                    
-                    if (documentDock != null)
-                    {
-                        var totalDockables = documentDock.VisibleDockables?.Count ?? 0;
-                        // Check for ReactiveDocument (BookDisplayViewModel) not just Document
-                        var hasDocuments = documentDock.VisibleDockables?.OfType<ReactiveDocument>().Any() ?? false;
-                        var docCount = documentDock.VisibleDockables?.OfType<ReactiveDocument>().Count() ?? 0;
 
-                        Log.Debug("*** Host window {WindowId} - Layout: {LayoutType}, DocumentDock found - Total dockables: {TotalCount}, ReactiveDocuments: {DocumentCount}, HasDocuments: {HasDocuments} ***",
-                            hostWindow.Id, hostWindow.Layout?.GetType().Name, totalDockables, docCount, hasDocuments);
+                    // Look at EVERY DocumentDock in the layout, not just the first: a split floating window
+                    // has more than one pane, and checking only the first orphaned the others' books when
+                    // that first pane emptied. The window is empty only when NO pane holds a document.
+                    // (#39 tab-loss)
+                    var documentDocks = FindAllDocumentDocksInLayout(hostWindow.Layout);
+
+                    if (documentDocks.Count > 0)
+                    {
+                        var docCount = documentDocks.Sum(d => d.VisibleDockables?.OfType<ReactiveDocument>().Count() ?? 0);
+                        var hasDocuments = docCount > 0;
+
+                        Log.Debug("*** Host window {WindowId} - Layout: {LayoutType}, {DockCount} DocumentDock(s), ReactiveDocuments: {DocumentCount}, HasDocuments: {HasDocuments} ***",
+                            hostWindow.Id, hostWindow.Layout?.GetType().Name, documentDocks.Count, docCount, hasDocuments);
 
                         if (!hasDocuments)
                         {
@@ -2472,7 +2499,7 @@ namespace CST.Avalonia.Services
                     }
                     else
                     {
-                        Log.Warning("*** Host window {WindowId} has layout {LayoutType} but no DocumentDock found ***", 
+                        Log.Warning("*** Host window {WindowId} has layout {LayoutType} but no DocumentDock found ***",
                             hostWindow.Id, hostWindow.Layout?.GetType().Name ?? "null");
                     }
                 }
@@ -3277,9 +3304,13 @@ namespace CST.Avalonia.Services
 
             try
             {
-                var floatingDock = FindDocumentDockInLayout(hostWindow.Layout);
-                var toClose = floatingDock?.VisibleDockables?.ToList();
-                if (toClose == null || toClose.Count == 0)
+                // Close tabs from EVERY pane, not just the first DocumentDock — a split floating window has
+                // more than one, and closing only the first orphaned the rest (they stayed in the destroyed
+                // window's dead layout, leaking a live browser). (#39 tab-loss)
+                var toClose = FindAllDocumentDocksInLayout(hostWindow.Layout)
+                    .SelectMany(d => d.VisibleDockables ?? Enumerable.Empty<IDockable>())
+                    .ToList();
+                if (toClose.Count == 0)
                 {
                     Log.Debug("*** No tabs to close - window was already empty ***");
                     return;


### PR DESCRIPTION
Fixes a family of **pre-existing** dock-cleanup data-loss and blank-window bugs, surfaced while building drag-to-float. All predate #458/#110 — the single-DocumentDock assumption is from the original (early) cleanup code. GUI-verified on macOS; full suite **916 passed**.

## Bugs fixed

**1. Split-float tab loss.** A floating window can be split into 2+ `DocumentDock` panes. Emptiness and tab-close both used `FindDocumentDockInLayout` (the *first* dock in tree order), so emptying the first pane — drag its book out, or red-button-close — declared the whole window empty and closed it, silently orphaning the other pane's books (leaked VM + live CEF browser; the book's persisted state survived, so it reappeared next launch). Direction-sensitive: only the original/first pane (the tab that created the window) triggered it.
→ Emptiness and close now walk **every** pane (`FindAllDocumentDocksInLayout`).

**2. Blank floating window.** Moving/closing the last book out of a *previously split* float made `CleanupEmptySplits` remove the emptied `DocumentDock` entirely, leaving a float with no `DocumentDock`; the old "needs a DocumentDock" gate then left a blank "CST Reader" window open forever. Worse, the per-pane collection monitor is wired only at window creation, so emptying a pane added by a *later* split (by drag **or** tab close) fired no handler at all.
→ Emptiness is now **leaf-based** (empty = no non-splitter leaf — no documents *and* no tools), and the empty-window check is scheduled centrally in `RemoveDockable` — the one choke point `base.CloseDockable` and `base.MoveDockable` both route through — so every path is covered regardless of monitoring. Deferred via `Dispatcher.UIThread.Post` so the native window `Close()` never runs inside a half-finished framework mutation.

**3. Regression averted.** Leaf-based (not document-count) matters because floated **tool panels** (Search / Dictionary / Select a Book are all `CanFloat=true`) have no `DocumentDock` and zero documents — a doc-count test would have wrongly closed them. Verified live: a floated tool panel stays open when book tabs elsewhere close.

**4. Split-collapse data loss + blank window (`RemoveEmptySplit`).** When a single-child `ProportionalDock` was replaced by its child, the child's `Owner` was never repointed at the new parent — so a follow-up `SplitToDock` (an edge-drop is a two-step move+split) resolved `Owner` to the detached wrapper and split into a tree unreachable from any window, losing the dragged tab. And a `ProportionalDock` left as the parent's dangling `ActiveDockable`/`DefaultDockable` renders as a blank window.
→ Re-home the surviving child (`Owner = parent`) and repoint `Active`/`DefaultDockable` off the removed split.

## Provenance & review

Root-caused and reviewed across two Fable passes (a focused root-cause + a comprehensive cleanup-subsystem sweep). Fable caught the tool-panel regression and the `RemoveEmptySplit` `Owner` gap. Its lower-priority leftovers (`FindWindowContainingBook` single-dock → Go To dialog parents to the wrong window for a 2nd-pane book, cosmetic; `RemoveDockable` purging persisted state on a *move*; dead `CleanupEmptyFloatingWindows`) are noted for a follow-up, not in this PR.

## GUI verification (macOS)

Tab-loss (drag one pane's book out, both orders); red-button close of a split float; blank-window-on-drag and blank-window-on-close repros; in-float edge-rearrange (the `Owner` repair); floated-tool-panel regression guard. No blank windows, no lost tabs, no `#458 VIOLATION` (live-browser cross-window) in any run.

Part of #39. A drag-to-float feature builds on top of this next.
