### PR TITLE
#468 (app-side): manifest-driven multi-asset dictionary delivery

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using CST.Avalonia.Services;
@@ -9,8 +10,9 @@ using Xunit;
 
 namespace CST.Avalonia.Tests.Services;
 
-// Unit tests for DpdUpdateService's testable core (#390): manifest parsing, the two-axis version comparison,
-// the installed-meta read, and the verify→decompress→atomic-install with preservation of a good existing asset.
+// Unit tests for DpdUpdateService's testable core (#390/#468): CATALOG manifest parsing, the two-axis version
+// comparison, the per-asset version reads (a DPD lemma db vs a lexicon), and the verify→decompress→probe→atomic
+// install with preservation of a good existing asset.
 public sealed class DpdUpdateServiceTests : IDisposable
 {
     private readonly string _dir;
@@ -30,79 +32,104 @@ public sealed class DpdUpdateServiceTests : IDisposable
 
     private static string Sha(byte[] b) => Convert.ToHexString(SHA256.HashData(b)).ToLowerInvariant();
 
-    private static byte[] Manifest(string file, string dpd, string conv, string sha) =>
+    // A catalog with a single dpd entry.
+    private static byte[] Catalog(string id, string file, string src, string conv, string sha) =>
         Encoding.UTF8.GetBytes(
-            $$"""{"file":"{{file}}","dpdVersion":"{{dpd}}","converterVersion":"{{conv}}","schemaVersion":"2","scope":"full","sha256":"{{sha}}","compressedBytes":10,"rawBytes":20}""");
+            "{\"schemaVersion\":1,\"dictionaries\":[{\"id\":\"" + id + "\",\"file\":\"" + file +
+            "\",\"sourceVersion\":\"" + src + "\",\"converterVersion\":\"" + conv +
+            "\",\"sha256\":\"" + sha + "\",\"compressedBytes\":10,\"rawBytes\":20}]}");
 
-    // ---- ParseManifest ----
+    private static DpdUpdateService.ManifestEntry Entry(string id, string file, string src, string conv, string sha)
+        => DpdUpdateService.ParseCatalog(Catalog(id, file, src, conv, sha))!.Single();
+
+    // ---- ParseCatalog ----
 
     [Fact]
-    public void ParseManifest_reads_a_valid_manifest()
+    public void ParseCatalog_reads_valid_entries()
     {
-        var m = DpdUpdateService.ParseManifest(Manifest("dpd-cst-subset.db.gz", "v0.4.20260531", "3", "abc123"));
-        Assert.NotNull(m);
-        Assert.Equal("dpd-cst-subset.db.gz", m!.File);
-        Assert.Equal("v0.4.20260531", m.DpdVersion);
-        Assert.Equal("3", m.ConverterVersion);
-        Assert.Equal("abc123", m.Sha256);
-        Assert.Equal("full", m.Scope);
+        var json = Encoding.UTF8.GetBytes("""
+            {"schemaVersion":1,"dictionaries":[
+                {"id":"dpd","file":"dpd-cst-subset.db.gz","sourceVersion":"v0.4.20260531","converterVersion":"3","sha256":"abc","compressedBytes":10,"rawBytes":20},
+                {"id":"dppn","file":"dppn.db.gz","sourceVersion":"2025-08","converterVersion":"1","sha256":"def","compressedBytes":30,"rawBytes":40}
+            ]}
+            """);
+        var c = DpdUpdateService.ParseCatalog(json);
+        Assert.NotNull(c);
+        Assert.Equal(2, c!.Count);
+        var dpd = c.Single(e => e.Id == "dpd");
+        Assert.Equal("dpd-cst-subset.db.gz", dpd.File);
+        Assert.Equal("v0.4.20260531", dpd.SourceVersion);
+        Assert.Equal("3", dpd.ConverterVersion);
+        Assert.Equal("abc", dpd.Sha256);
+        Assert.Equal(20, dpd.RawBytes);
+    }
+
+    [Fact]
+    public void ParseCatalog_skips_incomplete_entries_but_keeps_good_ones()
+    {
+        var json = Encoding.UTF8.GetBytes("""
+            {"dictionaries":[
+                {"id":"dpd","sourceVersion":"v1","converterVersion":"3","sha256":"a"},
+                {"id":"dppn","file":"dppn.db.gz","sourceVersion":"2025-08","converterVersion":"1","sha256":"def"}
+            ]}
+            """);
+        var c = DpdUpdateService.ParseCatalog(json);
+        Assert.NotNull(c);
+        Assert.Single(c!);                         // the dpd entry (missing file) dropped
+        Assert.Equal("dppn", c!.Single().Id);
     }
 
     [Theory]
-    [InlineData("""{"dpdVersion":"v1","converterVersion":"3","sha256":"a"}""")]        // no file
-    [InlineData("""{"file":"x.gz","converterVersion":"3","sha256":"a"}""")]            // no dpdVersion
-    [InlineData("""{"file":"x.gz","dpdVersion":"v1","sha256":"a"}""")]                 // no converterVersion
-    [InlineData("""{"file":"x.gz","dpdVersion":"v1","converterVersion":"3"}""")]        // no sha256
     [InlineData("not json")]
-    [InlineData("[1,2,3]")]                                                             // not an object
-    public void ParseManifest_rejects_incomplete_or_malformed(string json)
-        => Assert.Null(DpdUpdateService.ParseManifest(Encoding.UTF8.GetBytes(json)));
+    [InlineData("[1,2,3]")]                                              // not an object
+    [InlineData("""{"schemaVersion":1}""")]                             // no dictionaries array
+    [InlineData("""{"dictionaries":{}}""")]                             // dictionaries not an array
+    public void ParseCatalog_rejects_malformed(string json)
+        => Assert.Null(DpdUpdateService.ParseCatalog(Encoding.UTF8.GetBytes(json)));
+
+    [Fact]
+    public void ParseCatalog_empty_array_is_an_empty_list_not_null()
+    {
+        var c = DpdUpdateService.ParseCatalog(Encoding.UTF8.GetBytes("""{"dictionaries":[]}"""));
+        Assert.NotNull(c);
+        Assert.Empty(c!);
+    }
 
     // ---- NeedsUpdate (two version axes) ----
 
     [Fact]
     public void NeedsUpdate_true_when_asset_absent()
-    {
-        var m = DpdUpdateService.ParseManifest(Manifest("x.gz", "v1", "3", "a"))!;
-        Assert.True(DpdUpdateService.NeedsUpdate(null, m));
-    }
+        => Assert.True(DpdUpdateService.NeedsUpdate(null, Entry("dpd", "x.gz", "v1", "3", "a")));
 
     [Fact]
     public void NeedsUpdate_false_when_both_axes_match()
-    {
-        var m = DpdUpdateService.ParseManifest(Manifest("x.gz", "v1", "3", "a"))!;
-        Assert.False(DpdUpdateService.NeedsUpdate(new DpdUpdateService.InstalledMeta("v1", "3"), m));
-    }
+        => Assert.False(DpdUpdateService.NeedsUpdate(
+            new DpdUpdateService.InstalledVersion("v1", "3"), Entry("dpd", "x.gz", "v1", "3", "a")));
 
     [Fact]
-    public void NeedsUpdate_true_on_a_new_dpd_version()
-    {
-        var m = DpdUpdateService.ParseManifest(Manifest("x.gz", "v2", "3", "a"))!;
-        Assert.True(DpdUpdateService.NeedsUpdate(new DpdUpdateService.InstalledMeta("v1", "3"), m));
-    }
+    public void NeedsUpdate_true_on_a_new_source_version()
+        => Assert.True(DpdUpdateService.NeedsUpdate(
+            new DpdUpdateService.InstalledVersion("v1", "3"), Entry("dpd", "x.gz", "v2", "3", "a")));
 
     [Fact]
-    public void NeedsUpdate_true_on_a_converter_bump_even_with_same_dpd()
-    {
-        // The second axis: our converter changed (e.g. the meaning_2 coalesce) with DPD unchanged.
-        var m = DpdUpdateService.ParseManifest(Manifest("x.gz", "v1", "4", "a"))!;
-        Assert.True(DpdUpdateService.NeedsUpdate(new DpdUpdateService.InstalledMeta("v1", "3"), m));
-    }
+    public void NeedsUpdate_true_on_a_converter_bump_even_with_same_source()
+        // The second axis: our converter changed with the source unchanged.
+        => Assert.True(DpdUpdateService.NeedsUpdate(
+            new DpdUpdateService.InstalledVersion("v1", "3"), Entry("dpd", "x.gz", "v1", "4", "a")));
 
-    // ---- InstallFromGzip: verify + decompress + atomic install + preservation ----
+    // ---- InstallFromGzip: verify + decompress + probe + atomic install + preservation ----
 
     [Fact]
     public void InstallFromGzip_verifies_decompresses_and_installs()
     {
-        // A REAL (tiny) valid asset db as the payload — InstallFromGzip now probes that the decompressed file is a
-        // usable asset before installing.
+        // A REAL (tiny) valid asset db as the payload — InstallFromGzip probes usability before installing.
         var gz = Gzip(BuildAssetDbBytes(dpd: "v1", conv: "3"));
         var final = Path.Combine(_dir, "sub", "dpd-cst-subset.db");   // note: a not-yet-existing subdir
 
-        DpdUpdateService.InstallFromGzip(gz, Sha(gz), final);
+        DpdUpdateService.InstallFromGzip(gz, Sha(gz), final, DpdUpdateService.ProbeDpdUsable);
 
         Assert.True(File.Exists(final));
-        Assert.Equal("v1", DpdUpdateService.ReadInstalledMeta(final)!.DpdVersion);  // installed + readable
+        Assert.Equal("v1", DpdUpdateService.ReadDpdVersion(final)!.SourceVersion);   // installed + readable
         Assert.False(File.Exists(final + ".new"));                    // temp cleaned up
     }
 
@@ -113,7 +140,8 @@ public sealed class DpdUpdateServiceTests : IDisposable
         File.WriteAllText(final, "GOOD-OLD-ASSET");
         var gz = Gzip(BuildAssetDbBytes("v1", "3"));
 
-        Assert.Throws<InvalidDataException>(() => DpdUpdateService.InstallFromGzip(gz, "deadbeef", final));
+        Assert.Throws<InvalidDataException>(() =>
+            DpdUpdateService.InstallFromGzip(gz, "deadbeef", final, DpdUpdateService.ProbeDpdUsable));
 
         Assert.Equal("GOOD-OLD-ASSET", File.ReadAllText(final));      // untouched
         Assert.False(File.Exists(final + ".new"));                    // temp cleaned up
@@ -122,15 +150,49 @@ public sealed class DpdUpdateServiceTests : IDisposable
     [Fact]
     public void InstallFromGzip_rejects_a_valid_gzip_that_is_not_a_usable_asset_and_preserves_existing()
     {
-        // Transport is fine (SHA matches its own bytes) but the decompressed content is NOT a usable dpd-cst-subset
-        // db — a bad PUBLISH must not clobber a good install. (fable review — preservation gap)
+        // Transport is fine (SHA matches its own bytes) but the decompressed content is NOT a usable asset — a bad
+        // PUBLISH must not clobber a good install. (fable review — preservation gap)
         var final = Path.Combine(_dir, "dpd-cst-subset.db");
         File.WriteAllText(final, "GOOD-OLD-ASSET");
         var gz = Gzip(Encoding.UTF8.GetBytes("decompresses fine but is not a sqlite asset"));
 
-        Assert.Throws<InvalidDataException>(() => DpdUpdateService.InstallFromGzip(gz, Sha(gz), final));
+        Assert.Throws<InvalidDataException>(() =>
+            DpdUpdateService.InstallFromGzip(gz, Sha(gz), final, DpdUpdateService.ProbeDpdUsable));
 
         Assert.Equal("GOOD-OLD-ASSET", File.ReadAllText(final));      // preserved despite a matching SHA
+        Assert.False(File.Exists(final + ".new"));
+    }
+
+    [Fact]
+    public void InstallFromGzip_installs_a_lexicon_asset_probed_by_the_lexicon_reader()
+    {
+        // The dppn path: a lexicon db installs when it probes usable via the lexicon reader.
+        var gz = Gzip(BuildLexiconDbBytes(src: "2025-08", conv: "1"));
+        var final = Path.Combine(_dir, "dppn", "dppn.db");
+
+        DpdUpdateService.InstallFromGzip(gz, Sha(gz), final, DpdUpdateService.ProbeLexiconUsable);
+
+        Assert.True(File.Exists(final));
+        var v = DpdUpdateService.ReadLexiconVersion(final);
+        Assert.Equal("2025-08", v!.SourceVersion);
+        Assert.Equal("1", v.ConverterVersion);
+    }
+
+    [Fact]
+    public void InstallFromGzip_rejects_a_lexicon_with_meta_but_no_entry_table_and_preserves_existing()
+    {
+        // A converter bug could publish a lexicon whose `meta` is well-stamped (OpenMeta passes) but whose `entry`
+        // table is missing — unusable at runtime. The probe uses full Open (not OpenMeta), so it must reject this
+        // and NOT clobber the good installed asset. (fable MED-2)
+        var final = Path.Combine(_dir, "dppn", "dppn.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(final)!);
+        File.WriteAllText(final, "GOOD-OLD-DPPN");
+        var gz = Gzip(BuildMetaOnlyLexiconDbBytes(src: "2025-08", conv: "1"));
+
+        Assert.Throws<InvalidDataException>(() =>
+            DpdUpdateService.InstallFromGzip(gz, Sha(gz), final, DpdUpdateService.ProbeLexiconUsable));
+
+        Assert.Equal("GOOD-OLD-DPPN", File.ReadAllText(final));   // preserved despite a matching SHA + valid meta
         Assert.False(File.Exists(final + ".new"));
     }
 
@@ -172,33 +234,44 @@ public sealed class DpdUpdateServiceTests : IDisposable
 
         using (var hold = new FileStream(final, FileMode.Open, FileAccess.Read, FileShare.None))   // live provider
         {
-            DpdUpdateService.InstallFromGzip(gz, Sha(gz), final);            // must NOT throw
+            DpdUpdateService.InstallFromGzip(gz, Sha(gz), final, DpdUpdateService.ProbeDpdUsable);   // must NOT throw
             Assert.True(File.Exists(final + ".pending"), "new asset staged for next launch");
             Assert.False(File.Exists(final + ".new"), "temp cleaned up");
         }
 
         // Lock released → applying the staged swap activates the new asset.
         Assert.True(DpdUpdateService.ApplyPendingInstall(final));
-        Assert.Equal("v1", DpdUpdateService.ReadInstalledMeta(final)!.DpdVersion);
+        Assert.Equal("v1", DpdUpdateService.ReadDpdVersion(final)!.SourceVersion);
         Assert.False(File.Exists(final + ".pending"));
     }
 
-    // ---- ReadInstalledMeta ----
+    // ---- per-asset version reads ----
 
     [Fact]
-    public void ReadInstalledMeta_reads_versions_from_a_real_asset()
+    public void ReadDpdVersion_reads_versions_from_a_real_asset()
     {
         var db = Path.Combine(_dir, "installed.db");
         BuildMetaFixture(db, dpd: "v0.4.20260531", conv: "3");
-        var m = DpdUpdateService.ReadInstalledMeta(db);
+        var m = DpdUpdateService.ReadDpdVersion(db);
         Assert.NotNull(m);
-        Assert.Equal("v0.4.20260531", m!.DpdVersion);
+        Assert.Equal("v0.4.20260531", m!.SourceVersion);
         Assert.Equal("3", m.ConverterVersion);
     }
 
     [Fact]
-    public void ReadInstalledMeta_null_when_absent() =>
-        Assert.Null(DpdUpdateService.ReadInstalledMeta(Path.Combine(_dir, "nope.db")));
+    public void ReadDpdVersion_null_when_absent() =>
+        Assert.Null(DpdUpdateService.ReadDpdVersion(Path.Combine(_dir, "nope.db")));
+
+    [Fact]
+    public void ReadLexiconVersion_reads_versions_from_a_real_lexicon() =>
+        Assert.Equal("2025-08", DpdUpdateService.ReadLexiconVersion(
+            BuildLexiconDb(Path.Combine(_dir, "lex.db"), src: "2025-08", conv: "1"))!.SourceVersion);
+
+    [Fact]
+    public void ReadLexiconVersion_null_when_absent() =>
+        Assert.Null(DpdUpdateService.ReadLexiconVersion(Path.Combine(_dir, "nope.db")));
+
+    // ---- fixtures ----
 
     private void BuildMetaFixture(string path, string dpd, string conv)
     {
@@ -216,12 +289,63 @@ public sealed class DpdUpdateServiceTests : IDisposable
         SqliteConnection.ClearAllPools();   // release the file handle so callers can read its bytes
     }
 
-    // A minimal but VALID dpd-cst-subset asset (has lemma + form_lemma + meta so SqliteLemmaProvider.IsAvailable),
-    // returned as the raw db bytes for use as a download payload.
+    // A minimal but VALID dpd-cst-subset asset (lemma + form_lemma + meta so SqliteLemmaProvider.IsAvailable),
+    // returned as raw db bytes for use as a download payload.
     private byte[] BuildAssetDbBytes(string dpd, string conv)
     {
         var p = Path.Combine(_dir, $"payload-{Guid.NewGuid():N}.db");
         BuildMetaFixture(p, dpd, conv);
+        var bytes = File.ReadAllBytes(p);
+        File.Delete(p);
+        return bytes;
+    }
+
+    // A minimal but VALID canonical lexicon (meta with schema/source/converter version + an entry) at `path`.
+    private string BuildLexiconDb(string path, string src, string conv)
+    {
+        using (var c = new SqliteConnection($"Data Source={path}"))
+        {
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = @"
+                CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+                CREATE TABLE entry (id INTEGER PRIMARY KEY, headword TEXT NOT NULL, body_html TEXT);
+                INSERT INTO meta VALUES
+                    ('schema_version','1'),('source_id','dppn'),('display_name','DPPN'),
+                    ('definition_language','en'),('source_version','" + src + @"'),
+                    ('converter_version','" + conv + @"');
+                INSERT INTO entry (headword, body_html) VALUES ('Nāgita','<p>a monk</p>');";
+            cmd.ExecuteNonQuery();
+        }
+        SqliteConnection.ClearAllPools();
+        return path;
+    }
+
+    private byte[] BuildLexiconDbBytes(string src, string conv)
+    {
+        var p = BuildLexiconDb(Path.Combine(_dir, $"lex-{Guid.NewGuid():N}.db"), src, conv);
+        var bytes = File.ReadAllBytes(p);
+        File.Delete(p);
+        return bytes;
+    }
+
+    // A lexicon with a valid, stamped `meta` but NO `entry` table — OpenMeta succeeds, Open fails.
+    private byte[] BuildMetaOnlyLexiconDbBytes(string src, string conv)
+    {
+        var p = Path.Combine(_dir, $"lexmeta-{Guid.NewGuid():N}.db");
+        using (var c = new SqliteConnection($"Data Source={p}"))
+        {
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = @"
+                CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+                INSERT INTO meta VALUES
+                    ('schema_version','1'),('source_id','dppn'),('display_name','DPPN'),
+                    ('definition_language','en'),('source_version','" + src + @"'),
+                    ('converter_version','" + conv + @"');";
+            cmd.ExecuteNonQuery();
+        }
+        SqliteConnection.ClearAllPools();
         var bytes = File.ReadAllBytes(p);
         File.Delete(p);
         return bytes;

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -154,12 +154,12 @@ public partial class App : Application
         ConfigureServices(services);
         ServiceProvider = services.BuildServiceProvider();
 
-        // Apply any staged dpd-cst-subset update BEFORE anything opens the asset db. On Windows a running-app
-        // install can't replace the open db, so it stages a ".pending" swap that we apply here on the next launch.
-        // Unconditional (not tied to whether/when the lemma provider is resolved) and a no-op when nothing is
-        // staged / on macOS/Linux. (#394)
+        // Apply any staged dictionary-asset updates (dpd-cst-subset, dppn, …) BEFORE anything opens those dbs. On
+        // Windows a running-app install can't replace an open db, so it stages a ".pending" swap that we apply here
+        // on the next launch. Covers ALL known asset paths; unconditional (not tied to whether/when a provider is
+        // resolved) and a no-op when nothing is staged / on macOS/Linux. (#394/#468)
         if (DpdUpdateService.ApplyPendingInstall())
-            Log.Information("Applied a staged dpd-cst-subset update on launch.");
+            Log.Information("Applied one or more staged dictionary-asset updates on launch.");
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
@@ -1057,9 +1057,7 @@ public partial class App : Application
         // reading/search feature; availability is driven by FILE PRESENCE alone (no setting), degrading to "off"
         // when absent. Seeded/downloaded to <app-support>/CSTReader/dpd-cst-subset/. (Opened once at startup, so a
         // manually dropped-in file activates on the next launch.)
-        var dpdCstSubsetPath = System.IO.Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            AppConstants.AppDataDirectoryName, "dpd-cst-subset", "dpd-cst-subset.db");
+        var dpdCstSubsetPath = Services.DpdUpdateService.DpdSubsetPath;
         services.AddSingleton<CST.Lemma.ILemmaProvider>(_ => new CST.Lemma.SqliteLemmaProvider(dpdCstSubsetPath));
         services.AddSingleton<ILemmaSearchService, LemmaSearchService>();
         services.AddSingleton<ILemmaReportService, LemmaReportService>();
@@ -1073,9 +1071,7 @@ public partial class App : Application
         // NOTE: the source set is fixed when the registry is first resolved. A DERIVED asset (dpd-cst-subset,
         // dppn.db) installed mid-session still flips available (its source checks the file live); a flat-file
         // language dir ADDED mid-session only becomes a source on the next launch. (fable LOW-2)
-        var dppnPath = System.IO.Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            AppConstants.AppDataDirectoryName, "dppn", "dppn.db");
+        var dppnPath = Services.DpdUpdateService.DppnLexiconPath;
         services.AddSingleton(sp => Services.Dictionaries.DictionarySourceFactory.Build(
             sp.GetRequiredService<IDictionaryService>(),
             sp.GetRequiredService<CST.Lemma.ILemmaProvider>(),

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -104,7 +104,7 @@ namespace CST.Avalonia.Models
     {
         public bool EnablePolling { get; set; } = true;
         public string RepositoryOwner { get; set; } = "fsnow";
-        public string RepositoryName { get; set; } = "dpd-cst-subset";
+        public string RepositoryName { get; set; } = "cst-dictionaries";
     }
     
     public class FontSettings

--- a/src/CST.Avalonia/Services/DpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/DpdUpdateService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -10,26 +11,33 @@ using System.Threading.Tasks;
 using CST.Avalonia.Constants;
 using CST.Avalonia.Models;
 using CST.Lemma;
+using CST.Lexicon;
 using Microsoft.Extensions.Logging;
 using Octokit;
 
 namespace CST.Avalonia.Services;
 
 /// <summary>
-/// Downloads / updates the derived <c>dpd-cst-subset</c> asset from the derived-asset repo's GitHub Releases,
-/// parallel to <see cref="XmlUpdateService"/>. Reads <c>releases/latest</c> (Octokit — the same client the XML
-/// path uses), compares the release manifest's version stamps to the installed asset, and downloads + verifies
-/// (SHA-256) + decompresses (gzip, built-in) + atomically installs when newer or absent. Preservation store:
-/// the existing asset is replaced only after a new one is fully verified. (#390)
+/// Keeps the derived dictionary assets up to date from the cst-dictionaries GitHub Releases, parallel to
+/// <see cref="XmlUpdateService"/> for the corpus XML. Reads a single CATALOG manifest listing every dictionary
+/// (dpd-cst-subset, dppn, …); for each, compares the release's version stamps to the installed asset and
+/// downloads + verifies (SHA-256) + decompresses (gzip) + atomically installs when newer or absent. Serving a new
+/// dictionary needs a manifest entry + asset AND a matching <see cref="AssetDescriptor"/> here (install path,
+/// version reader, usability probe). Preservation store: an existing asset is replaced only after a new one is
+/// fully verified. (#390/#468)
 /// </summary>
 public sealed class DpdUpdateService : IDpdUpdateService
 {
-    private const string ManifestAssetName = "dpd-cst-subset.manifest.json";
-    private const string AssetDirName = "dpd-cst-subset";
-    private const string AssetFileName = "dpd-cst-subset.db";
+    private const string ManifestAssetName = "dictionaries.manifest.json";
     // A verified install staged for next launch when the target db can't be replaced in place (Windows: the live
     // provider holds it open). Applied by ApplyPendingInstall() before the db is opened at startup. (#394)
     private const string PendingSuffix = ".pending";
+
+    // The installed asset paths (must match the DI wiring in App.axaml.cs).
+    public static string DpdSubsetPath =>
+        Path.Combine(AppConstants.DataDirectory, "dpd-cst-subset", "dpd-cst-subset.db");
+    public static string DppnLexiconPath =>
+        Path.Combine(AppConstants.DataDirectory, "dppn", "dppn.db");
 
     private readonly ILogger<DpdUpdateService> _logger;
     private readonly ISettingsService _settings;
@@ -50,40 +58,40 @@ public sealed class DpdUpdateService : IDpdUpdateService
         _http.DefaultRequestHeaders.Add("User-Agent", AppConstants.UserAgent);
     }
 
-    // The installed asset path: <app-support>/CSTReader/dpd-cst-subset/dpd-cst-subset.db (matches App.axaml.cs).
-    private static string AssetPath =>
-        Path.Combine(AppConstants.DataDirectory, AssetDirName, AssetFileName);
+    // The dictionaries this build knows how to install: id (matches a manifest entry), install path, how to read
+    // the installed version stamps, and how to probe that a decompressed file is a usable asset (not just valid
+    // gzip). Reading the version differs per asset (DPD's lemma db vs a lexicon), which is why it's a descriptor.
+    private static IReadOnlyList<AssetDescriptor> Descriptors => new[]
+    {
+        new AssetDescriptor("dpd", DpdSubsetPath, ReadDpdVersion, ProbeDpdUsable),
+        new AssetDescriptor("dppn", DppnLexiconPath, ReadLexiconVersion, ProbeLexiconUsable),
+    };
 
     public async Task CheckAndUpdateAsync(CancellationToken ct = default)
     {
         if (Interlocked.CompareExchange(ref _busy, 1, 0) != 0) return; // already running
         try
         {
-            // Read config INSIDE the try so a null/garbage DpdUpdateSettings (e.g. an edited settings.json) is
-            // swallowed like any other failure, not thrown out of the fire-and-forget task. (fable review)
             var cfg = _settings.Settings.DpdUpdateSettings ?? new DpdUpdateSettings();
             if (!cfg.EnablePolling)
             {
-                _logger.LogInformation("dpd-cst-subset polling disabled; skipping update check (a present file still works).");
+                _logger.LogInformation("dictionary-asset polling disabled; skipping update check (present files still work).");
                 return;
             }
-            // Hard bound on the WHOLE check+download: HttpClient.Timeout doesn't cover a streamed body read, and the
-            // startup caller passes no token — without this a stalled connection hangs the background task forever
-            // and pins _busy for the session. (fable review)
+            // Hard bound on the WHOLE check+download (HttpClient.Timeout doesn't cover a streamed body). (fable)
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromMinutes(10));
             await RunAsync(cfg, cts.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
-            _logger.LogInformation("dpd-cst-subset update check canceled/timed out (non-fatal).");
+            _logger.LogInformation("dictionary-asset update check canceled/timed out (non-fatal).");
             StatusChanged?.Invoke("Update check timed out.");
         }
         catch (Exception ex)
         {
-            // Every expected failure (offline, timeout, no release, corrupt download, bad settings) is non-fatal —
-            // the app just keeps whatever asset it has (or none). Never let this crash startup.
-            _logger.LogWarning(ex, "dpd-cst-subset update check failed (non-fatal; feature degrades to asset-absent).");
+            // Every expected failure (offline, timeout, no release, corrupt download, bad settings) is non-fatal.
+            _logger.LogWarning(ex, "dictionary-asset update check failed (non-fatal; features degrade to asset-absent).");
             StatusChanged?.Invoke("Could not check for dictionary data updates.");
         }
         finally { Volatile.Write(ref _busy, 0); }
@@ -102,60 +110,104 @@ public sealed class DpdUpdateService : IDpdUpdateService
             string.Equals(a.Name, ManifestAssetName, StringComparison.OrdinalIgnoreCase));
         if (manifestAsset is null)
         {
-            _logger.LogWarning("Latest dpd-cst-subset release {Tag} has no {Manifest}.", release.TagName, ManifestAssetName);
+            _logger.LogWarning("Latest release {Tag} has no {Manifest}.", release.TagName, ManifestAssetName);
             return;
         }
 
         var manifestBytes = await _http.GetByteArrayAsync(manifestAsset.BrowserDownloadUrl, ct).ConfigureAwait(false);
-        var manifest = ParseManifest(manifestBytes);
-        if (manifest is null)
+        var catalog = ParseCatalog(manifestBytes);
+        if (catalog is null)
         {
             _logger.LogWarning("Could not parse {Manifest} from release {Tag}.", ManifestAssetName, release.TagName);
             return;
         }
 
-        var installed = ReadInstalledMeta(AssetPath);
-        if (!NeedsUpdate(installed, manifest))
+        bool anyInstalled = false, anyFailed = false;
+        // Each dictionary is independent: a failed/absent one never blocks the others.
+        foreach (var desc in Descriptors)
         {
-            _logger.LogInformation("dpd-cst-subset up to date (DPD {Dpd}, converter {Conv}).",
-                manifest.DpdVersion, manifest.ConverterVersion);
-            StatusChanged?.Invoke("Dictionary data is up to date.");
-            return;
+            ct.ThrowIfCancellationRequested();
+            var entry = catalog.FirstOrDefault(e => string.Equals(e.Id, desc.Id, StringComparison.OrdinalIgnoreCase));
+            if (entry is null) continue;   // this build knows a dictionary the release doesn't offer (yet)
+
+            try
+            {
+                if (await UpdateOneAsync(desc, entry, release, ct).ConfigureAwait(false))
+                    anyInstalled = true;
+            }
+            // Only a REAL cancellation (our 10-min CTS or the caller's token) aborts the whole run. An
+            // HttpClient inactivity timeout also surfaces as an OCE but with the token NOT signalled — treat that
+            // as this asset's failure so the others still run. (fable MED-1)
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+            catch (Exception ex)
+            {
+                anyFailed = true;
+                _logger.LogWarning(ex, "Update of dictionary '{Id}' failed (non-fatal; others continue).", desc.Id);
+            }
+        }
+
+        StatusChanged?.Invoke(
+            anyInstalled ? "Dictionary data installed (active after restart)."
+            : anyFailed  ? "Could not update some dictionary data."
+            : "Dictionary data is up to date.");
+    }
+
+    private async Task<bool> UpdateOneAsync(AssetDescriptor desc, ManifestEntry entry, Release release, CancellationToken ct)
+    {
+        var installed = desc.ReadInstalledVersion(desc.InstallPath);
+        if (!NeedsUpdate(installed, entry))
+        {
+            _logger.LogInformation("{Id} up to date (source {Src}, converter {Conv}).",
+                desc.Id, entry.SourceVersion, entry.ConverterVersion);
+            return false;
         }
 
         var archiveAsset = release.Assets.FirstOrDefault(a =>
-            string.Equals(a.Name, manifest.File, StringComparison.OrdinalIgnoreCase));
+            string.Equals(a.Name, entry.File, StringComparison.OrdinalIgnoreCase));
         if (archiveAsset is null)
         {
-            _logger.LogWarning("Release {Tag} manifest names '{File}' but that asset is missing.", release.TagName, manifest.File);
-            return;
+            _logger.LogWarning("Release {Tag} manifest names '{File}' for '{Id}' but that asset is missing.",
+                release.TagName, entry.File, desc.Id);
+            return false;
         }
 
         StatusChanged?.Invoke(installed is null ? "Downloading dictionary data..." : "Downloading updated dictionary data...");
-        var archiveBytes = await DownloadWithProgressAsync(archiveAsset.BrowserDownloadUrl, ct).ConfigureAwait(false);
+        var archiveBytes = await DownloadWithProgressAsync(archiveAsset.BrowserDownloadUrl, entry.CompressedBytes, ct).ConfigureAwait(false);
 
         StatusChanged?.Invoke("Installing dictionary data...");
-        InstallFromGzip(archiveBytes, manifest.Sha256, AssetPath);
+        InstallFromGzip(archiveBytes, entry.Sha256, desc.InstallPath, desc.ProbeUsable);
 
-        _logger.LogInformation("Installed dpd-cst-subset (DPD {Dpd}, converter {Conv}, ~{Mb} MB). Active on next launch.",
-            manifest.DpdVersion, manifest.ConverterVersion, manifest.RawBytes / 1024 / 1024);
-        StatusChanged?.Invoke("Dictionary data installed (active after restart).");
+        _logger.LogInformation("Installed {Id} (source {Src}, converter {Conv}, ~{Mb} MB). Active on next launch.",
+            desc.Id, entry.SourceVersion, entry.ConverterVersion, entry.RawBytes / 1024 / 1024);
+        return true;
     }
 
-    // Buffer the archive in memory (a modest tens-of-MB, infrequent). Streams headers-first so progress fires.
-    private async Task<byte[]> DownloadWithProgressAsync(string url, CancellationToken ct)
+    // Buffer the archive in memory (tens of MB, infrequent). Streams headers-first so progress fires.
+    // <paramref name="expectedBytes"/> is the manifest's compressed size; a body far exceeding it (bogus/hostile
+    // Content-Length or a mis-published multi-GB asset) is rejected early rather than allocated. (fable LOW-4)
+    private async Task<byte[]> DownloadWithProgressAsync(string url, long expectedBytes, CancellationToken ct)
     {
+        // Cap = 2× the manifest size + 32 MB slack, floored at 512 MB when the manifest gave no size. Bounds both
+        // the pre-allocation and the accepted body without tripping on normal gzip/size variance.
+        long cap = expectedBytes > 0 ? expectedBytes * 2 + 32L * 1024 * 1024 : 512L * 1024 * 1024;
+
         using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
         resp.EnsureSuccessStatusCode();
         long total = resp.Content.Headers.ContentLength ?? 0;
+        if (total > cap)
+            throw new InvalidDataException(
+                $"asset body ({total} bytes) far exceeds the manifest's {expectedBytes} — refusing to download.");
         using var stream = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-        using var mem = new MemoryStream(total > 0 ? (int)Math.Min(total, int.MaxValue) : 0);
+        int initial = total > 0 ? (int)Math.Min(total, cap) : 0;
+        using var mem = new MemoryStream(initial);
         var buf = new byte[81920];
         long read = 0; int n;
         while ((n = await stream.ReadAsync(buf.AsMemory(), ct).ConfigureAwait(false)) > 0)
         {
-            mem.Write(buf, 0, n);
             read += n;
+            if (read > cap)
+                throw new InvalidDataException($"asset body exceeded {cap} bytes mid-stream — refusing (likely mis-published).");
+            mem.Write(buf, 0, n);
             DownloadProgressChanged?.Invoke(read, total);
         }
         return mem.ToArray();
@@ -166,10 +218,8 @@ public sealed class DpdUpdateService : IDpdUpdateService
         var done = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
         if (done != task)
         {
-            // Observe the abandoned task if it later faults (e.g. NotFoundException when the repo has no release
-            // yet), so it doesn't surface as an UnobservedTaskException. (fable review)
-            _ = task.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
-            _logger.LogWarning("dpd-cst-subset {What} timed out after {Sec}s.", what, timeout.TotalSeconds);
+            _ = task.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);  // observe if it later faults
+            _logger.LogWarning("dictionary-asset {What} timed out after {Sec}s.", what, timeout.TotalSeconds);
             StatusChanged?.Invoke("Update check timed out.");
             return null;
         }
@@ -178,38 +228,57 @@ public sealed class DpdUpdateService : IDpdUpdateService
 
     // ---- testable core (InternalsVisibleTo CST.Avalonia.Tests) ----
 
-    internal sealed record DpdManifest(string File, string DpdVersion, string ConverterVersion,
-        string? SchemaVersion, string? Scope, string Sha256, long CompressedBytes, long RawBytes);
+    // One dictionary in the catalog manifest.
+    internal sealed record ManifestEntry(string Id, string File, string SourceVersion, string ConverterVersion,
+        string Sha256, long CompressedBytes, long RawBytes);
 
-    internal sealed record InstalledMeta(string DpdVersion, string ConverterVersion);
+    internal sealed record InstalledVersion(string SourceVersion, string ConverterVersion);
 
-    internal static DpdManifest? ParseManifest(byte[] json)
+    // A dictionary this build can install: id, where it goes, how to read its installed version, how to probe usability.
+    internal sealed record AssetDescriptor(
+        string Id, string InstallPath,
+        Func<string, InstalledVersion?> ReadInstalledVersion,
+        Func<string, bool> ProbeUsable);
+
+    // Parse { schemaVersion, dictionaries:[ { id, file, sourceVersion, converterVersion, sha256, compressedBytes,
+    // rawBytes } ] }. Skips entries missing a required field rather than failing the whole catalog. Null only for
+    // malformed JSON / wrong shape.
+    internal static IReadOnlyList<ManifestEntry>? ParseCatalog(byte[] json)
     {
         try
         {
             using var doc = JsonDocument.Parse(json);
-            var r = doc.RootElement;
-            if (r.ValueKind != JsonValueKind.Object) return null;
-            string S(string k) => r.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString()! : "";
-            long L(string k) => r.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var n) ? n : 0;
-            var file = S("file"); var sha = S("sha256");
-            var dpd = S("dpdVersion"); var conv = S("converterVersion");
-            // file, sha256, and both version axes are required — without them we can't safely download/compare.
-            if (file.Length == 0 || sha.Length == 0 || dpd.Length == 0 || conv.Length == 0) return null;
-            return new DpdManifest(file, dpd, conv, S("schemaVersion"), S("scope"), sha, L("compressedBytes"), L("rawBytes"));
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return null;
+            if (!root.TryGetProperty("dictionaries", out var arr) || arr.ValueKind != JsonValueKind.Array) return null;
+
+            var list = new List<ManifestEntry>();
+            foreach (var e in arr.EnumerateArray())
+            {
+                if (e.ValueKind != JsonValueKind.Object) continue;
+                string S(string k) => e.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString()! : "";
+                long L(string k) => e.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var n) ? n : 0;
+                var id = S("id"); var file = S("file"); var sha = S("sha256");
+                var src = S("sourceVersion"); var conv = S("converterVersion");
+                // id, file, sha256, and both version axes are required — without them we can't safely download/compare.
+                if (id.Length == 0 || file.Length == 0 || sha.Length == 0 || src.Length == 0 || conv.Length == 0) continue;
+                list.Add(new ManifestEntry(id, file, src, conv, sha, L("compressedBytes"), L("rawBytes")));
+            }
+            return list;
         }
         catch (JsonException) { return null; }
     }
 
-    // Update when the asset is ABSENT/unreadable, or EITHER version axis differs (DPD release OR our converter).
-    internal static bool NeedsUpdate(InstalledMeta? installed, DpdManifest latest)
+    // Update when the asset is ABSENT/unreadable, or EITHER version axis differs (source release OR our converter).
+    internal static bool NeedsUpdate(InstalledVersion? installed, ManifestEntry latest)
         => installed is null
-           || !string.Equals(installed.DpdVersion, latest.DpdVersion, StringComparison.Ordinal)
+           || !string.Equals(installed.SourceVersion, latest.SourceVersion, StringComparison.Ordinal)
            || !string.Equals(installed.ConverterVersion, latest.ConverterVersion, StringComparison.Ordinal);
 
-    // Read the installed asset's version stamps via the same provider the app uses (no new SQLite dep). Null when
-    // absent/unreadable → treated as "needs update".
-    internal static InstalledMeta? ReadInstalledMeta(string dbPath)
+    // ---- per-asset version readers + usability probes ----
+
+    // DPD's dpd-cst-subset: version stamps via the same provider the app uses (no new SQLite dep).
+    internal static InstalledVersion? ReadDpdVersion(string dbPath)
     {
         if (!File.Exists(dbPath)) return null;
         try
@@ -218,19 +287,48 @@ public sealed class DpdUpdateService : IDpdUpdateService
             var m = p.Meta;
             if (!p.IsAvailable || m is null || string.IsNullOrEmpty(m.DpdVersion) || string.IsNullOrEmpty(m.ConverterVersion))
                 return null;
-            return new InstalledMeta(m.DpdVersion, m.ConverterVersion);
+            return new InstalledVersion(m.DpdVersion, m.ConverterVersion);
         }
         catch { return null; }
     }
 
-    // Verify the gzip archive's SHA-256, decompress to a temp file, then atomically move it into place. The
-    // existing asset is untouched until the move, so a failed/corrupt download never destroys a good install.
-    internal static void InstallFromGzip(byte[] archive, string expectedSha256, string finalPath)
+    internal static bool ProbeDpdUsable(string dbPath)
+    {
+        try { using var p = new SqliteLemmaProvider(dbPath); return p.IsAvailable; }
+        catch { return false; }
+    }
+
+    // A lexicon asset (dppn): version stamps from its meta (source_version + converter_version).
+    internal static InstalledVersion? ReadLexiconVersion(string dbPath)
+    {
+        if (!File.Exists(dbPath)) return null;
+        try
+        {
+            var m = LexiconReader.OpenMeta(dbPath);
+            if (string.IsNullOrEmpty(m.SourceVersion)) return null;
+            return new InstalledVersion(m.SourceVersion!, m.ConverterVersion.ToString());
+        }
+        catch { return null; }
+    }
+
+    // Full Open (not OpenMeta): a usable lexicon needs the `entry` table too, not just a well-stamped `meta`.
+    // Probing meta-only would let a converter bug that drops `entry` verify and then clobber a good install.
+    // The entry set is small (tens of thousands) — loaded once here and discarded. (fable MED-2)
+    internal static bool ProbeLexiconUsable(string dbPath)
+    {
+        try { LexiconReader.Open(dbPath); return true; }
+        catch { return false; }
+    }
+
+    // Verify the gzip archive's SHA-256, decompress to a temp file, probe it is a USABLE asset, then atomically
+    // install (or stage for next launch on Windows). The existing asset is untouched until then, so a
+    // failed/corrupt/wrong-schema download never destroys a good install. (fable — preservation)
+    internal static void InstallFromGzip(byte[] archive, string expectedSha256, string finalPath, Func<string, bool> probeUsable)
     {
         string actual = Convert.ToHexString(SHA256.HashData(archive)).ToLowerInvariant();
         if (!string.Equals(actual, expectedSha256, StringComparison.OrdinalIgnoreCase))
             throw new InvalidDataException(
-                $"dpd-cst-subset archive failed its SHA-256 check (expected {expectedSha256}, got {actual}) — corrupt or partial download.");
+                $"asset archive failed its SHA-256 check (expected {expectedSha256}, got {actual}) — corrupt or partial download.");
 
         var dir = Path.GetDirectoryName(finalPath)!;
         Directory.CreateDirectory(dir);
@@ -242,32 +340,33 @@ public sealed class DpdUpdateService : IDpdUpdateService
             using (var outFs = File.Create(tmp))
                 gz.CopyTo(outFs);
 
-            // SHA-256 only proves TRANSPORT integrity (the archive matches the manifest). It does NOT prove the
-            // publisher gzipped a USABLE db — a truncated/wrong-schema source would still verify and then clobber a
-            // good existing asset. So open the decompressed file and require it to be a usable asset BEFORE the
-            // replace; if not, throw and leave the existing install untouched. (fable review — preservation gap)
-            using (var probe = new SqliteLemmaProvider(tmp))
-                if (!probe.IsAvailable)
-                    throw new InvalidDataException(
-                        "decompressed dpd-cst-subset archive is not a usable asset (missing core tables) — not installing.");
+            // SHA-256 proves only TRANSPORT integrity. Require the decompressed file to be a USABLE asset before
+            // the replace, so a truncated/wrong-schema source can't verify and then clobber a good asset. (fable)
+            if (!probeUsable(tmp))
+                throw new InvalidDataException(
+                    "decompressed asset is not usable (missing/invalid tables) — not installing.");
 
-            // Replace the installed asset with the freshly verified file. The old file is preserved until here.
-            //  - macOS/Linux: File.Move succeeds even while the live provider holds the old db open (POSIX unlinks
-            //    the old inode); the running provider keeps reading the old one until restart-to-activate.
-            //  - Windows: File.Move over an OPEN db throws a sharing violation. Rather than fail the install, stage
-            //    the verified file beside the target and swap it in on the next launch — before the provider opens
-            //    it — via ApplyPendingInstall(). Same user-visible outcome either way: active after restart. (#394)
             try
             {
                 File.Move(tmp, finalPath, overwrite: true);
-                // This direct install supersedes any earlier staged one — drop a leftover .pending so a stale,
-                // older staged file can't later regress the asset on a future launch. (fable review — #394)
+                // Supersede any earlier staged install so a stale one can't later regress the asset. (fable, #394)
+                // Log a failed delete: if it lingers, ApplyPendingInstall would move the OLDER file back over this
+                // fresh one on next launch (self-heals on the next update check, but worth surfacing). (fable LOW-1)
                 var superseded = finalPath + PendingSuffix;
-                if (File.Exists(superseded)) { try { File.Delete(superseded); } catch { /* best effort */ } }
+                if (File.Exists(superseded))
+                {
+                    try { File.Delete(superseded); }
+                    catch (Exception ex)
+                    {
+                        Serilog.Log.Warning(ex,
+                            "Could not remove a superseded staged install at {Path}; a stale swap may be re-applied next launch.",
+                            superseded);
+                    }
+                }
             }
             catch (Exception ex) when ((ex is IOException || ex is UnauthorizedAccessException) && File.Exists(finalPath))
             {
-                // The existing asset is still in place (untouched), so preservation holds — stage for next launch.
+                // Windows: the live db is open → stage beside it and swap on next launch (existing asset intact). (#394)
                 File.Move(tmp, finalPath + PendingSuffix, overwrite: true);
             }
         }
@@ -278,34 +377,32 @@ public sealed class DpdUpdateService : IDpdUpdateService
     }
 
     /// <summary>
-    /// Applies a staged install (see <see cref="InstallFromGzip"/>) on the next launch — call this BEFORE the
-    /// asset db is opened. No-op when nothing is staged (the common case, and always on macOS/Linux). Best-effort:
-    /// any failure leaves the staged file for a later attempt and must never block startup. Returns true when a
-    /// staged install was applied. (#394)
+    /// Apply a staged install for <paramref name="finalPath"/> on the next launch — call BEFORE the db is opened.
+    /// No-op when nothing is staged (the common case, always on macOS/Linux). Best-effort; never blocks startup.
+    /// Returns true when a staged install was applied. (#394)
     /// </summary>
     internal static bool ApplyPendingInstall(string finalPath)
     {
         var pending = finalPath + PendingSuffix;
         if (!File.Exists(pending)) return false;
-        try
-        {
-            File.Move(pending, finalPath, overwrite: true);
-            return true;
-        }
+        try { File.Move(pending, finalPath, overwrite: true); return true; }
         catch (Exception ex)
         {
-            // Leave the staged file for the next launch rather than crash startup — but log it: a persistent
-            // failure here means the update never activates and CheckAndUpdate keeps re-downloading it. (#394)
             Serilog.Log.Warning(ex,
-                "Failed to apply a staged dpd-cst-subset update at {Pending}; will retry on next launch.", pending);
+                "Failed to apply a staged update at {Pending}; will retry on next launch.", pending);
             return false;
         }
     }
 
     /// <summary>
-    /// Applies a staged install for the standard asset path (<see cref="AssetPath"/>). Call this once, early at
-    /// startup — before anything opens the db — so a Windows staged swap activates regardless of whether/when the
-    /// lemma provider gets resolved. No-op when nothing is staged. (#394)
+    /// Apply any staged installs for ALL known asset paths. Call once, early at startup — before anything opens a
+    /// db. No-op when nothing is staged. Returns true when at least one staged install was applied. (#394/#468)
     /// </summary>
-    internal static bool ApplyPendingInstall() => ApplyPendingInstall(AssetPath);
+    public static bool ApplyPendingInstall()
+    {
+        bool any = false;
+        foreach (var desc in Descriptors)
+            any |= ApplyPendingInstall(desc.InstallPath);
+        return any;
+    }
 }

--- a/src/CST.Avalonia/Services/IDpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/IDpdUpdateService.cs
@@ -5,11 +5,12 @@ using System.Threading.Tasks;
 namespace CST.Avalonia.Services;
 
 /// <summary>
-/// Keeps the derived <c>dpd-cst-subset</c> asset (lemma / dictionary / sandhi) up to date by polling the
-/// derived-asset repo's GitHub Releases — parallel to <see cref="IXmlUpdateService"/> for the corpus XML.
-/// It only DOWNLOADS the asset; feature availability is driven by the file's presence (the provider opens it at
+/// Keeps the derived dictionary assets (<c>dpd-cst-subset</c>, <c>dppn</c>, …) up to date by polling the
+/// cst-dictionaries repo's GitHub Releases — parallel to <see cref="IXmlUpdateService"/> for the corpus XML. A
+/// single CATALOG manifest lists every dictionary; each is downloaded/verified/installed independently. It only
+/// DOWNLOADS the assets; feature availability is driven by each file's presence (the provider/reader opens it at
 /// startup), so a freshly downloaded (or manually dropped-in) asset takes effect on the next launch. A no-op
-/// when polling is disabled or the network is unreachable — the app degrades to "asset absent". (#390)
+/// when polling is disabled or the network is unreachable — the app degrades to "asset absent". (#390/#468)
 /// </summary>
 public interface IDpdUpdateService
 {
@@ -22,10 +23,11 @@ public interface IDpdUpdateService
     bool IsBusy { get; }
 
     /// <summary>
-    /// Check the latest release's manifest and, if it is newer than the installed asset (compared on DPD version
-    /// + our converter version) or the asset is absent, download + verify + install it. Never throws for the
-    /// expected failure modes (polling off, offline, timeout, no release) — it logs and returns. The existing
-    /// asset is preserved until a new one is fully verified.
+    /// Check the latest release's catalog manifest and, for each dictionary that is newer than its installed
+    /// asset (compared on source version + our converter version) or absent, download + verify + install it. Each
+    /// dictionary is independent — a failed/absent one never blocks the others. Never throws for the expected
+    /// failure modes (polling off, offline, timeout, no release) — it logs and returns. Every existing asset is
+    /// preserved until its replacement is fully verified.
     /// </summary>
     Task CheckAndUpdateAsync(CancellationToken ct = default);
 }


### PR DESCRIPTION
Generalizes `DpdUpdateService` from the single `dpd-cst-subset` asset to a **catalog manifest** (`dictionaries.manifest.json`) that lists every derived dictionary. This is the app-side half of #468; the paired ops step (publishing the catalog + gzipped releases from `cst-dictionaries`) follows separately.

## What changes
- **Catalog-driven.** One manifest lists all dictionaries (`dpd` = dpd-cst-subset lemma db, `dppn` = a CST.Lexicon proper-names db). Each is downloaded / SHA-256-verified / gzip-decompressed / usability-probed / atomically installed **independently** — a failed or absent one never blocks the others.
- **Per-asset descriptor.** `AssetDescriptor` = install path + version reader + usability probe. `dpd` reads its version via `SqliteLemmaProvider`; `dppn` via `LexiconReader` (`source_version`/`converter_version`). Two-axis compare (source version AND our converter version) unchanged.
- **Preservation store intact.** An existing good asset is replaced only after its replacement is fully verified and probed usable. Windows staging (`.pending`) + `ApplyPendingInstall()` now cover **all** known asset paths at startup.
- **Single source of truth for paths.** `DpdUpdateService.DpdSubsetPath` / `DppnLexiconPath` are shared by the descriptors and the `App.axaml.cs` DI wiring (no drift).
- **Settings:** `DpdUpdateSettings.RepositoryName` → `cst-dictionaries`.

## Fable review (adversarial) — fixes applied
- **MED-1:** only a real cancellation (our 10-min CTS or the caller's token) aborts the whole run; an HttpClient inactivity timeout (an OCE with the token *not* signalled) is now treated as that asset's failure so the rest still run.
- **MED-2:** probe a lexicon via full `Open` (not `OpenMeta`) — a published db with a valid `meta` but a missing `entry` table can no longer verify-then-clobber a good install. New test covers it.
- **LOW-1/2/4:** log a superseded-`.pending` delete failure; report "could not update" instead of "up to date" when every asset failed; cap the download against the manifest's compressed size.

## Tests
23 unit tests: catalog parse (valid/partial/malformed/empty), two-axis needs-update, both version-read paths, preservation (SHA mismatch, unusable gzip, **meta-only lexicon**), staged swap. Full suite green apart from one pre-existing flaky MCP-handshake integration test (passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)