### PR TITLE
Add DisplayName field for the dictionary source picker (#466)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionaryServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryServiceTests.cs
@@ -72,6 +72,21 @@ public class DictionaryServiceTests : IDisposable
     }
 
     [Fact]
+    public void SourceFor_surfaces_a_displayName_only_source()
+    {
+        // A source.json with ONLY a display name (hi's real case: "VRI Pāli-Hindi Dictionary" with no citation
+        // yet) must NOT collapse to null — else the picker falls back to the bare language code. (#466)
+        WriteLang("hi", "vri-pali-hindi-dictionary.txt", "buddha", "<p>bauddha</p>");
+        File.WriteAllText(Path.Combine(_root, "hi", "source.json"),
+            "{ \"displayName\": \"VRI Pāli-Hindi Dictionary\", \"title\": \"\", \"url\": \"\" }");
+
+        var hi = Service().SourceFor("hi");
+        Assert.NotNull(hi);
+        Assert.Equal("VRI Pāli-Hindi Dictionary", hi!.DisplayName);
+        Assert.True(string.IsNullOrEmpty(hi.Title));   // no citation title yet
+    }
+
+    [Fact]
     public void SourceFor_is_null_when_no_source_file()
     {
         WriteLang("en", "vri-pali-english-dictionary.txt", "buddha", "<p>awakened</p>");

--- a/src/CST.Avalonia.Tests/Services/FlatFileDictionarySourceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/FlatFileDictionarySourceTests.cs
@@ -40,6 +40,20 @@ namespace CST.Avalonia.Tests.Services
         }
 
         [Fact]
+        public void DisplayName_prefers_the_displayName_field_over_the_citation_title()
+        {
+            // en's real case: a short picker label distinct from the full citation title.
+            var mock = new Mock<IDictionaryService>();
+            mock.Setup(d => d.SourceFor("en")).Returns(new DictionarySourceInfo(
+                "A Dictionary of the Pali Language", "Childers", null, "1875", null, null, null,
+                DisplayName: "Childers' Dictionary of the Pali Language"));
+
+            var en = new FlatFileDictionarySource(mock.Object, "en");
+            Assert.Equal("Childers' Dictionary of the Pali Language", en.DisplayName);   // displayName wins
+            Assert.Equal("A Dictionary of the Pali Language", en.Attribution?.Title);    // citation unchanged
+        }
+
+        [Fact]
         public async Task LookupAsync_attaches_the_source_title_to_each_entry()
         {
             var mock = new Mock<IDictionaryService>();

--- a/src/CST.Avalonia/Services/Dictionaries/DpdDictionarySource.cs
+++ b/src/CST.Avalonia/Services/Dictionaries/DpdDictionarySource.cs
@@ -26,7 +26,7 @@ namespace CST.Avalonia.Services.Dictionaries
         public DpdDictionarySource(ILemmaProvider lemma) => _lemma = lemma;
 
         public string Id => SourceId;
-        public string DisplayName => "DPD";
+        public string DisplayName => "Digital Pāḷi Dictionary";
         public string DefinitionLanguage => "en";
         public DictionarySourceKind Kind => DictionarySourceKind.General;
         public bool IsAvailable => _lemma.IsAvailable;

--- a/src/CST.Avalonia/Services/Dictionaries/FlatFileDictionarySource.cs
+++ b/src/CST.Avalonia/Services/Dictionaries/FlatFileDictionarySource.cs
@@ -26,8 +26,11 @@ namespace CST.Avalonia.Services.Dictionaries
         }
 
         public string Id { get; }
-        // The source.json title is the friendly name; fall back to the language code.
-        public string DisplayName => Attribution?.Title ?? Id;
+        // The picker label: the source.json displayName if set, else the citation Title, else the language code.
+        public string DisplayName =>
+            !string.IsNullOrWhiteSpace(Attribution?.DisplayName) ? Attribution!.DisplayName!
+            : !string.IsNullOrWhiteSpace(Attribution?.Title) ? Attribution!.Title!
+            : Id;
         public string DefinitionLanguage => Id;
         public DictionarySourceKind Kind => DictionarySourceKind.General;
         public bool IsAvailable => _dictionary.AvailableLanguages.Contains(Id, StringComparer.OrdinalIgnoreCase);
@@ -37,7 +40,8 @@ namespace CST.Avalonia.Services.Dictionaries
         {
             ct.ThrowIfCancellationRequested();
             var words = await _dictionary.LookupAsync(Id, request.Query ?? string.Empty, ct).ConfigureAwait(false);
-            var source = Attribution?.Title;
+            // Inline attribution is the citation Title, not the picker DisplayName; blank (e.g. hi) → none.
+            var source = string.IsNullOrWhiteSpace(Attribution?.Title) ? null : Attribution!.Title;
             return words
                 .Take(Math.Clamp(request.MaxEntries, 0, MaxDictEntries))
                 .Select(w => new DictionaryEntry(

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -164,7 +164,11 @@ public sealed class DictionaryService : IDictionaryService
         return info;
     }
 
+    // A DisplayName counts as metadata worth keeping: a source.json that sets ONLY a display name (e.g. hi's
+    // "VRI Pāli-Hindi Dictionary", with no citation yet) must still surface so the picker shows the real name
+    // rather than the bare language code. (#466)
     private static bool IsUnattributed(DictionarySourceInfo s) =>
+        string.IsNullOrWhiteSpace(s.DisplayName) &&
         string.IsNullOrWhiteSpace(s.Title) && string.IsNullOrWhiteSpace(s.Compiler) &&
         string.IsNullOrWhiteSpace(s.Edition) && string.IsNullOrWhiteSpace(s.Year) &&
         string.IsNullOrWhiteSpace(s.Publisher) && string.IsNullOrWhiteSpace(s.License) &&

--- a/src/CST.Avalonia/dictionaries/en/source.json
+++ b/src/CST.Avalonia/dictionaries/en/source.json
@@ -1,4 +1,5 @@
 {
+  "displayName": "Childers' Dictionary of the Pali Language",
   "title": "A Dictionary of the Pali Language",
   "compiler": "Robert Cæsar Childers",
   "edition": "",

--- a/src/CST.Avalonia/dictionaries/hi/source.json
+++ b/src/CST.Avalonia/dictionaries/hi/source.json
@@ -1,4 +1,5 @@
 {
+  "displayName": "VRI Pāli-Hindi Dictionary",
   "title": "",
   "compiler": "",
   "edition": "",

--- a/src/CST.Core/Tools/DictionaryToolContracts.cs
+++ b/src/CST.Core/Tools/DictionaryToolContracts.cs
@@ -28,7 +28,10 @@ namespace CST.Tools
     public sealed record DictionaryLanguageInfo(string Language, DictionarySourceInfo? Source);
 
     /// <summary>Authoritative citation for a dictionary — populated verbatim from the dictionary's own
-    /// <c>source.json</c>, never inferred. Every field is optional; an unpopulated source is null. (#268)</summary>
+    /// <c>source.json</c>, never inferred. Every field is optional; an unpopulated source is null. (#268)
+    /// <para><see cref="DisplayName"/> is the short label the source picker shows (e.g. "Childers' Dictionary of
+    /// the Pali Language"), distinct from <see cref="Title"/> (the work's actual title, used in the citation
+    /// block). Mirrors the lexicon format's <c>display_name</c> meta. (#466)</para></summary>
     public sealed record DictionarySourceInfo(
         string? Title,
         string? Compiler,
@@ -36,7 +39,8 @@ namespace CST.Tools
         string? Year,
         string? Publisher,
         string? License,
-        string? Url);
+        string? Url,
+        string? DisplayName = null);
 
     /// <summary>A dictionary lookup request.</summary>
     public sealed record DictionaryRequest(


### PR DESCRIPTION
Gives every dictionary source a proper **display name** for the #466 picker, via a dedicated metadata field — replacing the inconsistent fallbacks (flat-file dicts showed their citation Title or the bare language code, while DPD/DPPN had short names).

## Changes
- **`DictionarySourceInfo`** gains an optional `DisplayName` — the short picker label, distinct from `Title` (the work's citation title). Mirrors the lexicon format's `display_name`.
- **`en`/`hi` `source.json`** get a `displayName`. `DictionaryService.SourceFor` no longer collapses a *display-name-only* source to null (so `hi`'s name surfaces even with no citation yet); `FlatFileDictionarySource` prefers `DisplayName` → `Title` → id. Inline per-entry attribution stays the citation `Title` (blank → none), not the picker label.
- **`DpdDictionarySource`**: `"DPD"` → `"Digital Pāḷi Dictionary"`.

## Final picker names — three intentional spellings of Pali, preserved verbatim
| id | display name |
|----|-------------|
| `en` | Childers' Dictionary of the Pali Language |
| `hi` | VRI Pāli-Hindi Dictionary |
| `dpd` | Digital Pāḷi Dictionary |
| `dppn` | Dictionary of Pāli Proper Names |

(`dppn`'s name is set in `DppnBuilder` — fsnow/cst-dictionaries — and lands on the next `dppn.db` rebuild.)

## Tests
New coverage: `DisplayName` prefers the `displayName` field over Title; a display-name-only `source.json` surfaces (not null). Full suite green: 923/923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)