### PR TITLE
Refresh bundled source.json into app-support when it changes (#466)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionaryServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryServiceTests.cs
@@ -72,6 +72,40 @@ public class DictionaryServiceTests : IDisposable
     }
 
     [Fact]
+    public void SeedDictionaries_refreshes_a_changed_source_json_but_never_clobbers_data()
+    {
+        var src = Path.Combine(_root, "bundle");
+        var dst = Path.Combine(_root, "appsupport");
+        Directory.CreateDirectory(Path.Combine(src, "hi"));
+        Directory.CreateDirectory(Path.Combine(dst, "hi"));
+        // Bundle has the NEW metadata + a (newer) data file; app-support has the OLD blank metadata + user data.
+        File.WriteAllText(Path.Combine(src, "hi", "source.json"), "{ \"displayName\": \"VRI Pāli-Hindi Dictionary\" }");
+        File.WriteAllText(Path.Combine(src, "hi", "dict.txt"), "NEW DATA");
+        File.WriteAllText(Path.Combine(dst, "hi", "source.json"), "{ \"title\": \"\" }");           // stale metadata
+        File.WriteAllText(Path.Combine(dst, "hi", "dict.txt"), "EXISTING DATA");                     // must NOT be clobbered
+
+        DictionaryService.SeedDictionaries(src, dst);
+
+        // Metadata refreshed from the bundle...
+        Assert.Contains("VRI Pāli-Hindi Dictionary", File.ReadAllText(Path.Combine(dst, "hi", "source.json")));
+        // ...but existing dictionary data is left exactly as it was.
+        Assert.Equal("EXISTING DATA", File.ReadAllText(Path.Combine(dst, "hi", "dict.txt")));
+    }
+
+    [Fact]
+    public void SeedDictionaries_copies_missing_files_and_leaves_an_unchanged_source_json_alone()
+    {
+        var src = Path.Combine(_root, "bundle2");
+        var dst = Path.Combine(_root, "appsupport2");
+        Directory.CreateDirectory(Path.Combine(src, "en"));
+        File.WriteAllText(Path.Combine(src, "en", "source.json"), "{ \"displayName\": \"Childers\" }");
+        File.WriteAllText(Path.Combine(src, "en", "dict.txt"), "DATA");
+
+        Assert.Equal(2, DictionaryService.SeedDictionaries(src, dst));   // both copied into a fresh install
+        Assert.Equal(0, DictionaryService.SeedDictionaries(src, dst));   // second run: nothing changed -> no copies
+    }
+
+    [Fact]
     public void SourceFor_surfaces_a_displayName_only_source()
     {
         // A source.json with ONLY a display name (hi's real case: "VRI Pāli-Hindi Dictionary" with no citation

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -62,38 +62,58 @@ public sealed class DictionaryService : IDictionaryService
     {
         try
         {
-            // NOTE: we no longer early-return when already populated. The copy loop below only writes MISSING
-            // files, so it's cheap to re-check every launch — and it means a file ADDED to a bundled dictionary
-            // (e.g. a new source.json attribution, #268) reaches an existing install on its next launch, not
-            // just fresh installs. Existing dictionary data is never overwritten.
             var source = ResolveBundledDictionariesDir();
             if (source == null)
             {
                 _logger.LogWarning("No bundled dictionaries found to seed {Path}", _dictionariesDirectory);
                 return;
             }
-
-            int copied = 0;
-            foreach (var langDir in Directory.GetDirectories(source))
-            {
-                var destLangDir = Path.Combine(_dictionariesDirectory, Path.GetFileName(langDir));
-                Directory.CreateDirectory(destLangDir);
-                foreach (var file in Directory.GetFiles(langDir))
-                {
-                    var dest = Path.Combine(destLangDir, Path.GetFileName(file));
-                    if (!File.Exists(dest))
-                    {
-                        File.Copy(file, dest);
-                        copied++;
-                    }
-                }
-            }
-            _logger.LogInformation("Seeded {Count} bundled dictionary file(s) into {Path}", copied, _dictionariesDirectory);
+            int copied = SeedDictionaries(source, _dictionariesDirectory);
+            _logger.LogInformation("Seeded/refreshed {Count} bundled dictionary file(s) into {Path}", copied, _dictionariesDirectory);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to seed bundled dictionaries into {Path}", _dictionariesDirectory);
         }
+    }
+
+    // Copy bundled dictionary files into the app-support tree. Re-checked every launch (cheap).
+    //   - Dictionary DATA files are written only when MISSING — an existing install's data is never clobbered.
+    //   - source.json is app-owned METADATA (display name + attribution, #268/#466): REFRESH it whenever the
+    //     bundled copy differs, so a metadata change (e.g. a new displayName) reaches an existing install on its
+    //     next launch, not just fresh installs. (Otherwise the write-if-missing rule pins the stale copy forever.)
+    internal static int SeedDictionaries(string sourceRoot, string destRoot)
+    {
+        int copied = 0;
+        foreach (var langDir in Directory.GetDirectories(sourceRoot))
+        {
+            var destLangDir = Path.Combine(destRoot, Path.GetFileName(langDir));
+            Directory.CreateDirectory(destLangDir);
+            foreach (var file in Directory.GetFiles(langDir))
+            {
+                var dest = Path.Combine(destLangDir, Path.GetFileName(file));
+                bool isMeta = string.Equals(Path.GetFileName(file), "source.json", StringComparison.OrdinalIgnoreCase);
+                if (!File.Exists(dest))
+                {
+                    File.Copy(file, dest);
+                    copied++;
+                }
+                else if (isMeta && !FilesEqual(file, dest))
+                {
+                    File.Copy(file, dest, overwrite: true);
+                    copied++;
+                }
+            }
+        }
+        return copied;
+    }
+
+    private static bool FilesEqual(string a, string b)
+    {
+        var fa = new FileInfo(a);
+        var fb = new FileInfo(b);
+        if (!fa.Exists || !fb.Exists || fa.Length != fb.Length) return false;
+        return File.ReadAllBytes(a).AsSpan().SequenceEqual(File.ReadAllBytes(b));
     }
 
     // The bundled dictionaries live in the dev project dir, or under Resources/ in a packaged .app.


### PR DESCRIPTION
Fixes the picker still showing `hi` (and `en`'s old title) after the display-name change (#478): the dictionary **seeder** only copied *missing* files into app-support, so an updated bundled `source.json` never overwrote the copy already there. Existing installs kept reading stale metadata and fell back to the bare language code.

## Fix
`source.json` is app-owned metadata (display name + attribution), so it's now **refreshed whenever the bundled copy differs**. Dictionary `.txt` **data** stays write-if-missing — an existing install's data is never clobbered. Copy logic extracted into a testable `SeedDictionaries(source, dest)`.

## Tests
- A changed bundled `source.json` is refreshed into app-support; an existing data file is left untouched.
- Missing files are copied on a fresh install; a second run with nothing changed copies nothing.

Full suite green: 925/925. (Existing installs also self-heal on next launch; no manual step.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)