### PR TITLE
Expose dictionary data updates as a settings preference (#468)

### DIFF
--- a/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
+++ b/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
@@ -363,6 +363,26 @@ public class StateValidationTests
     }
 
     [Fact]
+    public void Settings_Sanitize_repairs_a_null_DpdUpdateSettings_and_blank_repo_fields()
+    {
+        // #468: a hand-edited "dpdUpdateSettings": null would NRE DpdUpdateSettingsViewModel's ctor and brick the
+        // Settings window (the #319 A7-2 failure mode) — repair like every other section, plus blank repo fields.
+        var s1 = new Settings();
+        s1.DpdUpdateSettings = null!;
+        var fixes1 = SettingsValidator.Sanitize(s1);
+        Assert.NotNull(s1.DpdUpdateSettings);
+        Assert.False(string.IsNullOrWhiteSpace(s1.DpdUpdateSettings.RepositoryOwner));
+        Assert.False(string.IsNullOrWhiteSpace(s1.DpdUpdateSettings.RepositoryName));
+
+        var s2 = new Settings();
+        s2.DpdUpdateSettings.RepositoryOwner = "";
+        s2.DpdUpdateSettings.RepositoryName = "   ";
+        SettingsValidator.Sanitize(s2);
+        Assert.False(string.IsNullOrWhiteSpace(s2.DpdUpdateSettings.RepositoryOwner));
+        Assert.False(string.IsNullOrWhiteSpace(s2.DpdUpdateSettings.RepositoryName));
+    }
+
+    [Fact]
     public void Settings_Sanitize_ClampsNonPositiveFontSizes()
     {
         var s = new Settings();

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -95,14 +95,15 @@ namespace CST.Avalonia.Models
     }
 
     /// <summary>
-    /// Update settings for the derived <c>dpd-cst-subset</c> asset (lemma / dictionary / sandhi). <see cref="EnablePolling"/>
-    /// is the ONLY DPD-related setting — it toggles the background check-for-a-newer-release, NOT whether the
-    /// features work: availability is driven purely by the asset FILE being present, so a manually dropped-in
-    /// file works regardless of this flag. Points at the derived-asset repo's releases. (#390)
+    /// Update settings for the derived dictionary assets (dpd-cst-subset, dppn, …). <see cref="EnableAutomaticUpdates"/>
+    /// (named to match <see cref="XmlUpdateSettings.EnableAutomaticUpdates"/>) toggles the background
+    /// check-for-a-newer-release, NOT whether the features work: availability is driven purely by each asset FILE
+    /// being present, so a manually dropped-in file works regardless of this flag. Points at the cst-dictionaries
+    /// repo's releases. (#390/#468)
     /// </summary>
     public class DpdUpdateSettings
     {
-        public bool EnablePolling { get; set; } = true;
+        public bool EnableAutomaticUpdates { get; set; } = true;
         public string RepositoryOwner { get; set; } = "fsnow";
         public string RepositoryName { get; set; } = "cst-dictionaries";
     }

--- a/src/CST.Avalonia/Models/SettingsValidator.cs
+++ b/src/CST.Avalonia/Models/SettingsValidator.cs
@@ -102,6 +102,14 @@ public static class SettingsValidator
         if (string.IsNullOrWhiteSpace(xml.XmlRepositoryName)) { xml.XmlRepositoryName = "tipitaka-xml"; fixes.Add("xml repo name -> tipitaka-xml"); }
         if (string.IsNullOrWhiteSpace(xml.XmlRepositoryBranch)) { xml.XmlRepositoryBranch = "main"; fixes.Add("xml repo branch -> main"); }
 
+        // Dictionary-asset update repository fields — same null/blank repair as XML, so a hand-edited
+        // "dpdUpdateSettings": null can't NRE DpdUpdateSettingsViewModel's ctor and lock the Settings window
+        // shut (the #319 A7-2 failure mode), and a blanked owner/name can't dead-end the background check. (#468)
+        var dpd = settings.DpdUpdateSettings ??= new DpdUpdateSettings();
+        var dpdDefaults = new DpdUpdateSettings();
+        if (string.IsNullOrWhiteSpace(dpd.RepositoryOwner)) { dpd.RepositoryOwner = dpdDefaults.RepositoryOwner; fixes.Add($"dictionary repo owner -> {dpdDefaults.RepositoryOwner}"); }
+        if (string.IsNullOrWhiteSpace(dpd.RepositoryName)) { dpd.RepositoryName = dpdDefaults.RepositoryName; fixes.Add($"dictionary repo name -> {dpdDefaults.RepositoryName}"); }
+
         // Fonts
         var fonts = settings.FontSettings ??= new FontSettings();
         if (fonts.LocalizationFontSize <= 0) { fonts.LocalizationFontSize = 12; fixes.Add("localization font size -> 12"); }

--- a/src/CST.Avalonia/Services/DpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/DpdUpdateService.cs
@@ -73,9 +73,9 @@ public sealed class DpdUpdateService : IDpdUpdateService
         try
         {
             var cfg = _settings.Settings.DpdUpdateSettings ?? new DpdUpdateSettings();
-            if (!cfg.EnablePolling)
+            if (!cfg.EnableAutomaticUpdates)
             {
-                _logger.LogInformation("dictionary-asset polling disabled; skipping update check (present files still work).");
+                _logger.LogInformation("dictionary-asset automatic updates disabled; skipping update check (present files still work).");
                 return;
             }
             // Hard bound on the WHOLE check+download (HttpClient.Timeout doesn't cover a streamed body). (fable)

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -844,7 +844,7 @@ namespace CST.Avalonia.ViewModels
         }
 
         // Reset the repository fields to the known-good defaults; leaves the "Enable automatic updates"
-        // checkbox alone (it's a preference, not part of the source). Mirrors the XML category. (#100)
+        // checkbox alone (it's a preference, not part of the source). Mirrors the XML category. (#468)
         public ReactiveCommand<Unit, Unit> RestoreDefaultsCommand { get; }
 
         private void RestoreDefaults()

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -38,6 +38,7 @@ namespace CST.Avalonia.ViewModels
             var fontSettings = new AppearanceSettingsViewModel(_settingsService);
             var configurationSettings = new ConfigurationSettingsViewModel(_settingsService);
             var xmlUpdateSettings = new XmlUpdateSettingsViewModel(_settingsService);
+            var dpdUpdateSettings = new DpdUpdateSettingsViewModel(_settingsService);
             var aiSettings = new AiSettingsViewModel(_settingsService);
             var loggingSettings = new DeveloperSettingsViewModel(_settingsService) { Parent = this };
 
@@ -47,6 +48,7 @@ namespace CST.Avalonia.ViewModels
                 new SettingsCategoryViewModel("Pali Script Fonts", fontSettings),
                 new SettingsCategoryViewModel("Logging", loggingSettings),
                 new SettingsCategoryViewModel("XML Data Updates", xmlUpdateSettings),
+                new SettingsCategoryViewModel("Dictionary Data Updates", dpdUpdateSettings),
                 new SettingsCategoryViewModel("AI", aiSettings),
                 new SettingsCategoryViewModel("Directories", directoriesSettings),
                 new SettingsCategoryViewModel("Configuration", configurationSettings)
@@ -816,6 +818,71 @@ namespace CST.Avalonia.ViewModels
             {
                 this.RaiseAndSetIfChanged(ref _xmlRepositoryBranch, value);
                 _settingsService.Settings.XmlUpdateSettings.XmlRepositoryBranch = value;
+                _settingsService.RequestSave();
+            }
+        }
+    }
+
+    // Dictionary Data Updates category — parallels XmlUpdateSettingsViewModel, for the derived dictionary assets
+    // (dpd-cst-subset, dppn, …) delivered from the cst-dictionaries repo's releases. (#468)
+    public class DpdUpdateSettingsViewModel : ViewModelBase
+    {
+        private readonly ISettingsService _settingsService;
+        private bool _enableAutomaticUpdates;
+        private string _repositoryOwner;
+        private string _repositoryName;
+
+        public DpdUpdateSettingsViewModel(ISettingsService settingsService)
+        {
+            _settingsService = settingsService;
+            var s = _settingsService.Settings.DpdUpdateSettings;
+            _enableAutomaticUpdates = s.EnableAutomaticUpdates;
+            _repositoryOwner = s.RepositoryOwner;
+            _repositoryName = s.RepositoryName;
+
+            RestoreDefaultsCommand = ReactiveCommand.Create(RestoreDefaults);
+        }
+
+        // Reset the repository fields to the known-good defaults; leaves the "Enable automatic updates"
+        // checkbox alone (it's a preference, not part of the source). Mirrors the XML category. (#100)
+        public ReactiveCommand<Unit, Unit> RestoreDefaultsCommand { get; }
+
+        private void RestoreDefaults()
+        {
+            var defaults = new DpdUpdateSettings();
+            RepositoryOwner = defaults.RepositoryOwner;
+            RepositoryName = defaults.RepositoryName;
+        }
+
+        public bool EnableAutomaticUpdates
+        {
+            get => _enableAutomaticUpdates;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _enableAutomaticUpdates, value);
+                _settingsService.Settings.DpdUpdateSettings.EnableAutomaticUpdates = value;
+                _settingsService.RequestSave();
+            }
+        }
+
+        public string RepositoryOwner
+        {
+            get => _repositoryOwner;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _repositoryOwner, value);
+                _settingsService.Settings.DpdUpdateSettings.RepositoryOwner = value;
+                _settingsService.RequestSave();
+            }
+        }
+
+        public string RepositoryName
+        {
+            get => _repositoryName;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _repositoryName, value);
+                _settingsService.Settings.DpdUpdateSettings.RepositoryName = value;
                 _settingsService.RequestSave();
             }
         }

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -317,6 +317,44 @@
                             </StackPanel>
                         </DataTemplate>
 
+                        <!-- Dictionary Data Updates Template (#468) -->
+                        <DataTemplate DataType="vm:DpdUpdateSettingsViewModel">
+                            <StackPanel>
+                                <Border Classes="SettingGroup">
+                                    <StackPanel>
+                                        <TextBlock Text="Dictionary Data Updates" Classes="SettingLabel"/>
+                                        <TextBlock Text="Configure automatic updates for the downloadable dictionary data (DPD, DPPN) from GitHub. Installed dictionaries keep working with this off."
+                                                  Classes="SettingDescription"/>
+
+                                        <CheckBox IsChecked="{Binding EnableAutomaticUpdates}"
+                                                 Content="Enable automatic updates"
+                                                 Margin="0,10,0,15"/>
+
+                                        <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto">
+                                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Repository Owner:"
+                                                      VerticalAlignment="Center" Margin="0,0,10,10"/>
+                                            <TextBox Grid.Row="0" Grid.Column="1"
+                                                    Text="{Binding RepositoryOwner}"
+                                                    Watermark="e.g., fsnow"
+                                                    Margin="0,0,0,10"/>
+
+                                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Repository Name:"
+                                                      VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                            <TextBox Grid.Row="1" Grid.Column="1"
+                                                    Text="{Binding RepositoryName}"
+                                                    Watermark="e.g., cst-dictionaries"/>
+                                        </Grid>
+
+                                        <Button Content="Restore Defaults"
+                                               Command="{Binding RestoreDefaultsCommand}"
+                                               Margin="0,15,0,0"
+                                               HorizontalAlignment="Left"
+                                               ToolTip.Tip="Reset the repository fields to their known-good defaults"/>
+                                    </StackPanel>
+                                </Border>
+                            </StackPanel>
+                        </DataTemplate>
+
                         <!-- AI Settings Template (#186) -->
                         <DataTemplate DataType="vm:AiSettingsViewModel">
                             <StackPanel>


### PR DESCRIPTION
Makes DPD/DPPN auto-updates a first-class **settings preference**, consistent with the existing "XML Data Updates" category. Previously the toggle existed only as a backend field with no settings-UI presence.

## Changes
- Rename `DpdUpdateSettings.EnablePolling` → `EnableAutomaticUpdates` to match `XmlUpdateSettings` (pre-beta-5; no migration).
- Add **`DpdUpdateSettingsViewModel`** mirroring `XmlUpdateSettingsViewModel` (enable toggle + repo owner/name + Restore Defaults), and register a **"Dictionary Data Updates"** settings category next to "XML Data Updates".
- Add the matching `DataTemplate` in `SettingsWindow.axaml`.
- `DpdUpdateService` reads `EnableAutomaticUpdates`. Availability is still driven purely by asset presence; this only gates the background check.

Behavior matches the XML category exactly (checked once at startup; a toggle takes effect next launch).

## Fable review — fixes applied
- **MED**: `SettingsValidator.Sanitize` now null-repairs `DpdUpdateSettings` (every other VM-backed section already was) — a hand-edited `"dpdUpdateSettings": null` would otherwise NRE the new VM ctor and silently brick the Settings window (the #319 A7-2 failure mode). Plus blank repo-field repair, mirroring XML.
- **Nit**: corrected the RestoreDefaults comment's issue ref.

## Tests
New validator coverage (null section + blank repo fields repaired). Full suite green: 926/926.

Note: the settings XAML mirrors the XML template exactly; @kestrelUser can adjust wording/placement if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)