### PR TITLE
#466: multi-source dictionary UI — registry-backed panel, source picker, WebView meaning pane

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionaryHtmlRendererTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryHtmlRendererTests.cs
@@ -1,0 +1,77 @@
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>#466: the dictionary meaning WebView host-document builder.</summary>
+public class DictionaryHtmlRendererTests
+{
+    private const string Sep = "<hr/>";   // DictionaryService.MeaningSeparator
+    private static string Id(string s) => s; // identity link-display
+
+    [Fact]
+    public void Render_WrapsFragmentInCspHostDocument()
+    {
+        var html = DictionaryHtmlRenderer.Render("a town", Id, Sep, "Arial", 11);
+
+        Assert.Contains("<!doctype html>", html);
+        // Strict CSP: nothing loads, no scripts.
+        Assert.Contains("default-src 'none'", html);
+        Assert.DoesNotContain("script-src", html);
+        Assert.Contains("a town", html);
+    }
+
+    [Fact]
+    public void Render_UsesPointUnitsForFontSize_NotPx()
+    {
+        var html = DictionaryHtmlRenderer.Render("x", Id, Sep, "Arial", 11);
+        Assert.Contains("font-size: 11pt", html);
+        Assert.DoesNotContain("font-size: 11px", html);
+    }
+
+    [Fact]
+    public void Render_TransformsSeeTagIntoCstSeeLink()
+    {
+        var html = DictionaryHtmlRenderer.Render("see <see>nagara</see> here", Id, Sep, "Arial", 11);
+
+        Assert.Contains($"href=\"{DictionaryHtmlRenderer.SeeScheme}nagara\"", html);
+        Assert.Contains("class=\"see\"", html);
+        Assert.DoesNotContain("<see>", html);
+    }
+
+    [Fact]
+    public void Render_SeeLinkText_UsesTheDisplayMapping()
+    {
+        // linkDisplay converts the Latin target to a display form; the link TEXT shows that, the HREF keeps
+        // the original target for lookup.
+        var html = DictionaryHtmlRenderer.Render("<see>nagara</see>", t => t.ToUpperInvariant(), Sep, "Arial", 11);
+
+        Assert.Contains(">NAGARA</a>", html);                                   // display text
+        Assert.Contains($"href=\"{DictionaryHtmlRenderer.SeeScheme}nagara\"", html); // original target
+    }
+
+    [Fact]
+    public void Render_SplitsMergedDefinitionsOnSeparatorIntoRules()
+    {
+        var html = DictionaryHtmlRenderer.Render($"first{Sep}second", Id, Sep, "Arial", 11);
+
+        Assert.Contains("first", html);
+        Assert.Contains("second", html);
+        Assert.Contains("class=\"def-sep\"", html);   // a rule between the two definitions
+    }
+
+    [Fact]
+    public void Render_NullOrEmpty_ProducesEmptyBodyButValidDocument()
+    {
+        var html = DictionaryHtmlRenderer.Render(null, Id, Sep, "Arial", 11);
+        Assert.Contains("<body></body>", html);
+    }
+
+    [Fact]
+    public void Render_EscapesTheFontFamily()
+    {
+        var html = DictionaryHtmlRenderer.Render("x", Id, Sep, "Weird\"Font", 11);
+        Assert.DoesNotContain("Weird\"Font", html);   // the raw quote must be encoded
+        Assert.Contains("Weird&quot;Font", html);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/DictionaryHtmlRendererTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryHtmlRendererTests.cs
@@ -6,13 +6,12 @@ namespace CST.Avalonia.Tests.Services;
 /// <summary>#466: the dictionary meaning WebView host-document builder.</summary>
 public class DictionaryHtmlRendererTests
 {
-    private const string Sep = "<hr/>";   // DictionaryService.MeaningSeparator
     private static string Id(string s) => s; // identity link-display
 
     [Fact]
     public void Render_WrapsFragmentInCspHostDocument()
     {
-        var html = DictionaryHtmlRenderer.Render("a town", Id, Sep, "Arial", 11);
+        var html = DictionaryHtmlRenderer.Render("a town", Id, "Arial", 11);
 
         Assert.Contains("<!doctype html>", html);
         // Strict CSP: nothing loads, no scripts.
@@ -24,7 +23,7 @@ public class DictionaryHtmlRendererTests
     [Fact]
     public void Render_UsesPointUnitsForFontSize_NotPx()
     {
-        var html = DictionaryHtmlRenderer.Render("x", Id, Sep, "Arial", 11);
+        var html = DictionaryHtmlRenderer.Render("x", Id, "Arial", 11);
         Assert.Contains("font-size: 11pt", html);
         Assert.DoesNotContain("font-size: 11px", html);
     }
@@ -32,7 +31,7 @@ public class DictionaryHtmlRendererTests
     [Fact]
     public void Render_TransformsSeeTagIntoCstSeeLink()
     {
-        var html = DictionaryHtmlRenderer.Render("see <see>nagara</see> here", Id, Sep, "Arial", 11);
+        var html = DictionaryHtmlRenderer.Render("see <see>nagara</see> here", Id, "Arial", 11);
 
         Assert.Contains($"href=\"{DictionaryHtmlRenderer.SeeScheme}nagara\"", html);
         Assert.Contains("class=\"see\"", html);
@@ -44,33 +43,34 @@ public class DictionaryHtmlRendererTests
     {
         // linkDisplay converts the Latin target to a display form; the link TEXT shows that, the HREF keeps
         // the original target for lookup.
-        var html = DictionaryHtmlRenderer.Render("<see>nagara</see>", t => t.ToUpperInvariant(), Sep, "Arial", 11);
+        var html = DictionaryHtmlRenderer.Render("<see>nagara</see>", t => t.ToUpperInvariant(), "Arial", 11);
 
         Assert.Contains(">NAGARA</a>", html);                                   // display text
         Assert.Contains($"href=\"{DictionaryHtmlRenderer.SeeScheme}nagara\"", html); // original target
     }
 
     [Fact]
-    public void Render_SplitsMergedDefinitionsOnSeparatorIntoRules()
+    public void Render_PassesHrThrough_DoesNotSplitContent()
     {
-        var html = DictionaryHtmlRenderer.Render($"first{Sep}second", Id, Sep, "Arial", 11);
+        // <hr/> is the flat-file merge sentinel AND real content in some HTML sources (DPPN). It must render
+        // as-is (a rule), never trigger a special split that could mangle HTML fragments. (#466 Fable)
+        var html = DictionaryHtmlRenderer.Render("first<hr/>second", Id, "Arial", 11);
 
-        Assert.Contains("first", html);
-        Assert.Contains("second", html);
-        Assert.Contains("class=\"def-sep\"", html);   // a rule between the two definitions
+        Assert.Contains("first<hr/>second", html);        // fragment passed through unchanged
+        Assert.DoesNotContain("def-sep", html);           // no synthetic split marker
     }
 
     [Fact]
     public void Render_NullOrEmpty_ProducesEmptyBodyButValidDocument()
     {
-        var html = DictionaryHtmlRenderer.Render(null, Id, Sep, "Arial", 11);
+        var html = DictionaryHtmlRenderer.Render(null, Id, "Arial", 11);
         Assert.Contains("<body></body>", html);
     }
 
     [Fact]
     public void Render_EscapesTheFontFamily()
     {
-        var html = DictionaryHtmlRenderer.Render("x", Id, Sep, "Weird\"Font", 11);
+        var html = DictionaryHtmlRenderer.Render("x", Id, "Weird\"Font", 11);
         Assert.DoesNotContain("Weird\"Font", html);   // the raw quote must be encoded
         Assert.Contains("Weird&quot;Font", html);
     }

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -133,8 +133,14 @@ public class DictionaryDialogState
     public int LanguageIndex { get; set; }
 
     /// <summary>Preferred definition-language code ("en"/"hi"); remembered across sessions (#25).
-    /// A robust code rather than an index, so it survives changes to the available-language order.</summary>
+    /// A robust code rather than an index, so it survives changes to the available-language order.
+    /// Superseded by <see cref="SourceId"/> (#466); kept for migration from older state.</summary>
     public string Language { get; set; } = "en";
+
+    /// <summary>Preferred dictionary SOURCE id ("en"/"hi"/"dpd"/"dppn"), remembered across sessions (#466).
+    /// A source identity, not a language — two sources can share a language. Empty until first set;
+    /// migrated from <see cref="Language"/> on load.</summary>
+    public string SourceId { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1469,7 +1469,7 @@ namespace CST.Avalonia.Services
         // detach and must be torn down explicitly on close, or the closed tab strands a browser +
         // renderer for the session. (BookDisplayViewModel also exposes a live-view backref as a
         // cache-miss fallback; PdfDisplayViewModel has none, so it relies on the cache lookup.)
-        private void DisposeAndEvictRecycledView(IDockable dockable)
+        internal void DisposeAndEvictRecycledView(IDockable dockable)
         {
             var recycling = GetControlRecycling();
 
@@ -3000,12 +3000,42 @@ namespace CST.Avalonia.Services
             // read as "close", so they are now really closed.)
             CloseDockablesInClosingWindow(hostWindow);
 
+            // A CEF-hosting TOOL (the dictionary, #466) floated into this window is NOT covered above:
+            // CloseDockablesInClosingWindow only walks DocumentDocks, and the tool is CanClose=false anyway.
+            // Left alone, its live WebView stays in the recycling cache (keyed by the singleton VM); the next
+            // View → Dictionary re-attaches that dead-window browser → SIGSEGV (#458). Dispose + evict it so a
+            // fresh panel with a fresh browser is built when it's next shown. (#466, Fable)
+            DisposeCefToolsInClosingWindow(hostWindow);
+
             // Update panel visibility state after removing window
             // This ensures menu checkmarks update correctly when panels were in the closed window
             if (App.MainWindow?.DataContext is LayoutViewModel layoutViewModel)
             {
                 layoutViewModel.UpdatePanelVisibility();
                 Log.Debug("*** Panel visibility updated after window close ***");
+            }
+        }
+
+        // Dispose + evict the recycled View of any CEF-hosting TOOL (the dictionary) in a closing floating
+        // window, so its live browser can't be re-attached from a destroyed window later. The tool's
+        // singleton VM survives; only its View/browser is released, and a fresh one is built when the tool is
+        // next shown. Skipped during shutdown (the whole app is going away). (#466)
+        private void DisposeCefToolsInClosingWindow(CstHostWindow hostWindow)
+        {
+            if (App.IsShuttingDown) return;
+            try
+            {
+                var leaves = new List<IDockable>();
+                CollectLeafDockables(hostWindow.Layout, leaves, 0);
+                foreach (var tool in leaves.OfType<DictionaryViewModel>())
+                {
+                    Log.Information("#466: disposing dictionary WebView with its closing floating window {WindowId}", hostWindow.Id);
+                    DisposeAndEvictRecycledView(tool);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "#466: error disposing CEF tool(s) in closing window {WindowId}", hostWindow.Id);
             }
         }
 

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1486,6 +1486,7 @@ namespace CST.Avalonia.Services
                 {
                     case BookDisplayView bookView: bookView.Shutdown(); break;  // release the CEF WebView — the actual leak
                     case PdfDisplayView pdfView: pdfView.Shutdown(); break;
+                    case DictionaryPanel dictView: dictView.Shutdown(); break;  // #466: the dictionary tool's meaning WebView
                 }
 
                 if (recycling == null)
@@ -1658,7 +1659,9 @@ namespace CST.Avalonia.Services
         // `CanFloat = true` on books safe. (#39)
         public override void SplitToWindow(IDock dock, IDockable dockable, double x, double y, double width, double height)
         {
-            if (dockable is BookDisplayViewModel or PdfDisplayViewModel)
+            // DictionaryViewModel is a CEF-hosting TOOL (#466) — same re-parent hazard as the book/PDF
+            // documents, so it gets the same dispose-before-move.
+            if (dockable is BookDisplayViewModel or PdfDisplayViewModel or DictionaryViewModel)
             {
                 if (dockable is BookDisplayViewModel bookVm && bookVm.LastPositionToken is { } token)
                     bookVm.QueuePositionRestore(token);
@@ -1693,7 +1696,8 @@ namespace CST.Avalonia.Services
         // flickers, whereas carrying a live browser crashes. (#458)
         private void PrepareCrossWindowMove(IDockable? dockable, IDock? targetDock)
         {
-            if (dockable is not (BookDisplayViewModel or PdfDisplayViewModel)) return;
+            // Books, PDFs, and the CEF-hosting Dictionary tool (#466) — everything that carries a live browser.
+            if (dockable is not (BookDisplayViewModel or PdfDisplayViewModel or DictionaryViewModel)) return;
             if (targetDock == null) return;
 
             var sourceRoot = GetRootOwner(dockable);

--- a/src/CST.Avalonia/Services/DictionaryHtmlRenderer.cs
+++ b/src/CST.Avalonia/Services/DictionaryHtmlRenderer.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Builds the self-contained HTML document the dictionary meaning pane renders in its WebView (#466).
+///
+/// Every source now returns its definition as an HTML fragment (<c>MeaningHtml</c>): the flat-file
+/// dictionaries emit plain text + <c>&lt;see&gt;word&lt;/see&gt;</c> cross-references (joined by a merge
+/// separator when a headword has several definitions); DPD/DPPN emit richer structured HTML, already
+/// reduced to a safe tag allowlist when the asset was built. This wraps that fragment in a host page that:
+///   - carries a strict CSP (no network, no script) — so the pane can never fetch or execute anything;
+///   - transforms <c>&lt;see&gt;</c> tags into <c>&lt;a href="cst-see:…"&gt;</c> links (display text in the
+///     current script) that the view intercepts via BeforeNavigate — no JavaScript needed;
+///   - styles Pāli text in the reader's current script font.
+/// Pure/string-only so it is unit-testable without a WebView.
+/// </summary>
+public static class DictionaryHtmlRenderer
+{
+    private static readonly Regex SeeTag =
+        new(@"<see>(.*?)</see>", RegexOptions.Compiled | RegexOptions.Singleline);
+
+    /// <summary>The custom scheme a <c>&lt;see&gt;</c> cross-reference navigates to; the view cancels the
+    /// navigation and looks the word up instead.</summary>
+    public const string SeeScheme = "cst-see:";
+
+    /// <summary>
+    /// Render <paramref name="meaningHtml"/> (one entry's definition, possibly multi-definition) into a full
+    /// host document. <paramref name="linkDisplay"/> maps a <c>&lt;see&gt;</c> target (stored in Latin) to
+    /// its current-script display form; <paramref name="separator"/> is the merge sentinel between a merged
+    /// headword's definitions.
+    /// </summary>
+    public static string Render(
+        string? meaningHtml,
+        Func<string, string> linkDisplay,
+        string separator,
+        string fontFamily,
+        double fontSizePt)
+    {
+        var body = BuildBody(meaningHtml, linkDisplay, separator);
+        var family = WebUtility.HtmlEncode(fontFamily);
+        // POINTS, not px, to match the book pages (tipitaka-*.xsl size body text in pt). The WebView renders
+        // px smaller than the app's font setting implies; pt keeps the meaning in scale with the reader,
+        // without a zoom hack (the book pipeline uses none either). (#466)
+        var size = fontSizePt.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        // CSP: nothing loads (default-src 'none'); only inline styles are allowed, no scripts, no network.
+        return $$"""
+            <!doctype html>
+            <html>
+            <head>
+            <meta charset="utf-8">
+            <meta http-equiv="Content-Security-Policy"
+                  content="default-src 'none'; style-src 'unsafe-inline'; img-src data:;">
+            <style>
+              html, body { margin: 0; padding: 0; background: transparent; }
+              body {
+                font-family: '{{family}}', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+                font-size: {{size}}pt;
+                line-height: 1.5;
+                padding: 8px;
+                color: #202020;
+                word-wrap: break-word;
+              }
+              a.see { color: #0b5cad; text-decoration: underline; cursor: pointer; }
+              hr.def-sep { border: none; border-top: 1px solid #d0d0d0; margin: 10px 0; }
+              @media (prefers-color-scheme: dark) {
+                body { color: #e0e0e0; }
+                a.see { color: #6db3f2; }
+                hr.def-sep { border-top-color: #444; }
+              }
+            </style>
+            </head>
+            <body>{{body}}</body>
+            </html>
+            """;
+    }
+
+    private static string BuildBody(string? meaningHtml, Func<string, string> linkDisplay, string separator)
+    {
+        if (string.IsNullOrEmpty(meaningHtml))
+            return string.Empty;
+
+        // A merged headword's definitions are joined by the separator sentinel; render each with a rule
+        // between, so the boundary reads as a divider rather than the raw marker. (DICT-1, now in HTML)
+        var definitions = meaningHtml.Split(new[] { separator }, StringSplitOptions.None);
+        var sb = new StringBuilder();
+        for (int i = 0; i < definitions.Length; i++)
+        {
+            if (i > 0)
+                sb.Append("<hr class=\"def-sep\">");
+            sb.Append("<div class=\"def\">")
+              .Append(TransformSeeTags(definitions[i].Trim(), linkDisplay))
+              .Append("</div>");
+        }
+        return sb.ToString();
+    }
+
+    // Replace <see>word</see> with an anchor to the cst-see scheme; the link text is the word in the
+    // current display script, the href carries the original (Latin) target for lookup.
+    private static string TransformSeeTags(string html, Func<string, string> linkDisplay) =>
+        SeeTag.Replace(html, m =>
+        {
+            var target = m.Groups[1].Value.Trim();
+            var display = WebUtility.HtmlEncode(linkDisplay(target));
+            var href = WebUtility.HtmlEncode(SeeScheme + target);
+            return $"<a class=\"see\" href=\"{href}\">{display}</a>";
+        });
+}

--- a/src/CST.Avalonia/Services/DictionaryHtmlRenderer.cs
+++ b/src/CST.Avalonia/Services/DictionaryHtmlRenderer.cs
@@ -28,19 +28,21 @@ public static class DictionaryHtmlRenderer
     public const string SeeScheme = "cst-see:";
 
     /// <summary>
-    /// Render <paramref name="meaningHtml"/> (one entry's definition, possibly multi-definition) into a full
-    /// host document. <paramref name="linkDisplay"/> maps a <c>&lt;see&gt;</c> target (stored in Latin) to
-    /// its current-script display form; <paramref name="separator"/> is the merge sentinel between a merged
-    /// headword's definitions.
+    /// Render <paramref name="meaningHtml"/> (one entry's definition) into a full host document.
+    /// <paramref name="linkDisplay"/> maps a <c>&lt;see&gt;</c> target (stored in Latin) to its current-script
+    /// display form.
     /// </summary>
     public static string Render(
         string? meaningHtml,
         Func<string, string> linkDisplay,
-        string separator,
         string fontFamily,
         double fontSizePt)
     {
-        var body = BuildBody(meaningHtml, linkDisplay, separator);
+        // The fragment is rendered as-is (with <see> turned into links). We do NOT split on the flat-file
+        // merge sentinel <hr/>: it also occurs as real content in some HTML sources (e.g. DPPN entries), and
+        // a plain <hr/> already renders as the divider a merged flat-file headword wants — so passing it
+        // through is both correct for HTML sources and visually right for flat-file. (#466, Fable)
+        var body = string.IsNullOrEmpty(meaningHtml) ? "" : TransformSeeTags(meaningHtml, linkDisplay);
         var family = WebUtility.HtmlEncode(fontFamily);
         // POINTS, not px, to match the book pages (tipitaka-*.xsl size body text in pt). The WebView renders
         // px smaller than the app's font setting implies; pt keeps the meaning in scale with the reader,
@@ -66,37 +68,17 @@ public static class DictionaryHtmlRenderer
                 word-wrap: break-word;
               }
               a.see { color: #0b5cad; text-decoration: underline; cursor: pointer; }
-              hr.def-sep { border: none; border-top: 1px solid #d0d0d0; margin: 10px 0; }
+              hr { border: none; border-top: 1px solid #d0d0d0; margin: 10px 0; }
               @media (prefers-color-scheme: dark) {
                 body { color: #e0e0e0; }
                 a.see { color: #6db3f2; }
-                hr.def-sep { border-top-color: #444; }
+                hr { border-top-color: #444; }
               }
             </style>
             </head>
             <body>{{body}}</body>
             </html>
             """;
-    }
-
-    private static string BuildBody(string? meaningHtml, Func<string, string> linkDisplay, string separator)
-    {
-        if (string.IsNullOrEmpty(meaningHtml))
-            return string.Empty;
-
-        // A merged headword's definitions are joined by the separator sentinel; render each with a rule
-        // between, so the boundary reads as a divider rather than the raw marker. (DICT-1, now in HTML)
-        var definitions = meaningHtml.Split(new[] { separator }, StringSplitOptions.None);
-        var sb = new StringBuilder();
-        for (int i = 0; i < definitions.Length; i++)
-        {
-            if (i > 0)
-                sb.Append("<hr class=\"def-sep\">");
-            sb.Append("<div class=\"def\">")
-              .Append(TransformSeeTags(definitions[i].Trim(), linkDisplay))
-              .Append("</div>");
-        }
-        return sb.ToString();
     }
 
     // Replace <see>word</see> with an anchor to the cst-see scheme; the link text is the word in the

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -9,22 +9,24 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CST.Avalonia.Services;
+using CST.Avalonia.Services.Dictionaries;
 using CST.Avalonia.ViewModels.Dock;
 using CST.Conversion;
+using CST.Tools;
 using Microsoft.Extensions.Logging;
 using ReactiveUI;
 
 namespace CST.Avalonia.ViewModels;
 
 /// <summary>
-/// The Pāli dictionary tool (#25). A dockable left-tool panel: pick a language, type a headword in
-/// any script (IPE-normalized by the service), pick from the matching Words, and read the definition.
-/// Definitions render natively (the data is plain text + <c>&lt;see&gt;</c> cross-references only, so no
-/// WebView is needed); <c>&lt;see&gt;</c> links look up the referenced word, with back/forward history.
+/// The Pāli dictionary tool (#25, #466). A dockable left-tool panel: pick a SOURCE (a specific dictionary —
+/// Childers, DPD, Pāli–Hindi, DPPN — not a language, since sources can share one), type a headword in any
+/// script, pick from the matching Words, and read the definition. Sources come from the shared
+/// <see cref="DictionarySourceRegistry"/>, the same set the /v1 API serves, so UI and API can't drift.
 /// </summary>
 public class DictionaryViewModel : ReactiveTool, IDisposable
 {
-    private readonly IDictionaryService _dictionaryService;
+    private readonly DictionarySourceRegistry _registry;
     private readonly IScriptService _scriptService;
     private readonly IFontService _fontService;
     private readonly IApplicationStateService _stateService;
@@ -47,13 +49,13 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
     private bool _canGoForward;
 
     public DictionaryViewModel(
-        IDictionaryService dictionaryService,
+        DictionarySourceRegistry registry,
         IScriptService scriptService,
         IFontService fontService,
         IApplicationStateService stateService,
         ILogger<DictionaryViewModel> logger)
     {
-        _dictionaryService = dictionaryService;
+        _registry = registry;
         _scriptService = scriptService;
         _fontService = fontService;
         _stateService = stateService;
@@ -66,12 +68,16 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         CanFloat = true;    // floatable/moveable like the other tools
         CanDrag = true;
 
-        AvailableLanguages = _dictionaryService.AvailableLanguages.Count > 0
-            ? _dictionaryService.AvailableLanguages
-            : new[] { "en" };
-        // Restore the preferred definition language (#25); fall back to en, then whatever's available.
-        var savedLanguage = _stateService.Current.DictionaryDialog.Language;
-        _selectedLanguage = AvailableLanguages.Contains(savedLanguage) ? savedLanguage
+        // The picker's items are SOURCE ids from the shared registry (Stage 2 will show DisplayName instead).
+        // Only installed sources appear; a fresh install with no derived asset degrades cleanly to en/hi.
+        var available = _registry.Available.Select(s => s.Id).ToList();
+        AvailableLanguages = available.Count > 0 ? available : new[] { "en" };
+        // Restore the preferred SOURCE (#466), migrating from the older Language key; fall back to en, then
+        // whatever's available.
+        var savedSource = _stateService.Current.DictionaryDialog.SourceId;
+        if (string.IsNullOrEmpty(savedSource))
+            savedSource = _stateService.Current.DictionaryDialog.Language;   // migrate #25 → #466
+        _selectedLanguage = AvailableLanguages.Contains(savedSource) ? savedSource
             : AvailableLanguages.Contains("en") ? "en"
             : AvailableLanguages[0];
 
@@ -97,9 +103,9 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         // set above so construction doesn't write state. (#25)
         this.WhenAnyValue(x => x.SelectedLanguage)
             .Skip(1)
-            .Subscribe(lang =>
+            .Subscribe(sourceId =>
             {
-                _stateService.Current.DictionaryDialog.Language = lang;
+                _stateService.Current.DictionaryDialog.SourceId = sourceId;
                 _stateService.MarkDirty();   // persist via the timer/shutdown save, not a full off-thread save per change (STATE-2)
             })
             .DisposeWith(_disposables);
@@ -173,21 +179,27 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
 
     private async Task LookupAsync(string query)
     {
-        var lang = SelectedLanguage;   // capture: results are only valid if these still hold on completion
+        var sourceId = SelectedLanguage;   // capture: results are only valid if these still hold on completion
         try
         {
-            var results = await _dictionaryService.LookupAsync(lang, query ?? "");
+            var source = _registry.ById(sourceId);
+            IReadOnlyList<DictionaryEntry> results = source == null
+                ? Array.Empty<DictionaryEntry>()
+                // The source returns Headword already in the requested output script and the definition as
+                // MeaningHtml (for flat-file, the same <see>-tagged text the native renderer handles). (#466)
+                : await source.LookupAsync(new DictionaryRequest(sourceId, query ?? "", _scriptService.CurrentScript, 500));
+
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                // Ignore a stale completion: a newer query/language has superseded this lookup, so its
-                // results must not clobber the current ones (e.g. a slow first-time Hindi load finishing
-                // after a fast cached English lookup). (DICT-3)
-                if (query != SearchText || lang != SelectedLanguage)
+                // Ignore a stale completion: a newer query/source has superseded this lookup, so its results
+                // must not clobber the current ones (e.g. a slow first-time load finishing after a fast
+                // cached lookup). (DICT-3)
+                if (query != SearchText || sourceId != SelectedLanguage)
                     return;
 
                 Words.Clear();
-                foreach (var w in results)
-                    Words.Add(new DictionaryEntryViewModel(w, IpeToDisplay(w.Word)));
+                foreach (var e in results)
+                    Words.Add(new DictionaryEntryViewModel(e));
 
                 // Auto-select the best (first) match so the definition shows immediately, like CST4.
                 SelectedWord = Words.FirstOrDefault();
@@ -195,20 +207,13 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Dictionary lookup failed for '{Query}' ({Lang})", query, lang);
+            _logger.LogWarning(ex, "Dictionary lookup failed for '{Query}' ({Source})", query, sourceId);
         }
     }
 
     private void UpdateMeaning()
     {
-        MeaningSegments = MeaningParser.Parse(SelectedWord?.Source.Meaning, PaliToDisplay);
-    }
-
-    // A stored IPE headword -> the user's current display script.
-    private string IpeToDisplay(string ipe)
-    {
-        try { return ScriptConverter.Convert(ipe, Script.Ipe, _scriptService.CurrentScript); }
-        catch { return ipe; }
+        MeaningSegments = MeaningParser.Parse(SelectedWord?.Source.MeaningHtml, PaliToDisplay);
     }
 
     // A cross-reference word from a <see> tag (stored in Latin) -> current display script.
@@ -263,16 +268,17 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
     }
 }
 
-/// <summary>A row in the Words list: the source entry plus its headword rendered in the display script.</summary>
+/// <summary>A row in the Words list: the source entry, whose Headword is already in the display script
+/// (the source converts it — no IPE reconstruction needed, which was lossy for proper names). (#466)</summary>
 public sealed class DictionaryEntryViewModel
 {
-    public DictionaryEntryViewModel(CST.Avalonia.Models.DictionaryWord source, string displayWord)
+    public DictionaryEntryViewModel(DictionaryEntry source)
     {
         Source = source;
-        DisplayWord = displayWord;
+        DisplayWord = source.Headword;
     }
 
-    public CST.Avalonia.Models.DictionaryWord Source { get; }
+    public DictionaryEntry Source { get; }
     public string DisplayWord { get; }
 }
 

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -44,7 +44,8 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
     private string _searchText = "";
     private IDictionarySource? _selectedSource;
     private DictionaryEntryViewModel? _selectedWord;
-    private IReadOnlyList<MeaningSegment> _meaningSegments = Array.Empty<MeaningSegment>();
+    private string _meaningDocumentHtml = "";
+    private string _attribution = "";
     private bool _canGoBack;
     private bool _canGoForward;
 
@@ -101,6 +102,11 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
             .Subscribe(_ => UpdateMeaning())
             .DisposeWith(_disposables);
 
+        // Per-source attribution line, refreshed when the source changes (initial value included — no Skip).
+        this.WhenAnyValue(x => x.SelectedSource)
+            .Subscribe(source => Attribution = FormatAttribution(source?.Attribution))
+            .DisposeWith(_disposables);
+
         // Remember the preferred source across sessions. Skip(1) ignores the initial value set above so
         // construction doesn't write state. (#466)
         this.WhenAnyValue(x => x.SelectedSource)
@@ -129,6 +135,7 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         {
             this.RaisePropertyChanged(nameof(CurrentScriptFontFamily));
             this.RaisePropertyChanged(nameof(CurrentScriptFontSize));
+            UpdateMeaning();   // re-render the meaning document at the new font (#466)
         });
         _fontService.FontSettingsChanged += _fontChangedHandler;
     }
@@ -161,11 +168,34 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         set => this.RaiseAndSetIfChanged(ref _selectedWord, value);
     }
 
-    /// <summary>The selected definition, split into plain-text and clickable link segments.</summary>
-    public IReadOnlyList<MeaningSegment> MeaningSegments
+    /// <summary>The selected definition as a full HTML document for the meaning WebView — the source's
+    /// MeaningHtml wrapped in a CSP host page, with &lt;see&gt; cross-references turned into links. (#466)</summary>
+    public string MeaningDocumentHtml
     {
-        get => _meaningSegments;
-        private set => this.RaiseAndSetIfChanged(ref _meaningSegments, value);
+        get => _meaningDocumentHtml;
+        private set => this.RaiseAndSetIfChanged(ref _meaningDocumentHtml, value);
+    }
+
+    /// <summary>A one-line citation for the selected source, shown under the meaning (never hard-coded — it
+    /// comes from the source's recorded attribution; blank when unrecorded). (#466, #268)</summary>
+    public string Attribution
+    {
+        get => _attribution;
+        private set => this.RaiseAndSetIfChanged(ref _attribution, value);
+    }
+
+    // Compose the recorded attribution fields into a compact one-liner, skipping any that are unset.
+    private static string FormatAttribution(CST.Tools.DictionarySourceInfo? a)
+    {
+        if (a == null) return "";
+        var parts = new System.Collections.Generic.List<string>();
+        void Add(string? s) { if (!string.IsNullOrWhiteSpace(s)) parts.Add(s.Trim()); }
+        Add(a.Title);
+        Add(a.Compiler);
+        Add(a.Edition);
+        Add(a.Year);
+        Add(a.Publisher);
+        return string.Join(" · ", parts);
     }
 
     public bool CanGoBack
@@ -223,7 +253,14 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
 
     private void UpdateMeaning()
     {
-        MeaningSegments = MeaningParser.Parse(SelectedWord?.Source.MeaningHtml, PaliToDisplay);
+        // Definitions are prose (mostly English/Hindi with Pāli terms); render just under the headword
+        // size — the current script font size minus one — as a comfortable reading size. (#466)
+        MeaningDocumentHtml = DictionaryHtmlRenderer.Render(
+            SelectedWord?.Source.MeaningHtml,
+            PaliToDisplay,
+            DictionaryService.MeaningSeparator,
+            CurrentScriptFontFamily,
+            Math.Max(1, CurrentScriptFontSize - 1));
     }
 
     // A cross-reference word from a <see> tag (stored in Latin) -> current display script.

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -42,7 +42,7 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
     private readonly Stack<string> _forwardStack = new();
 
     private string _searchText = "";
-    private string _selectedLanguage = "en";
+    private IDictionarySource? _selectedSource;
     private DictionaryEntryViewModel? _selectedWord;
     private IReadOnlyList<MeaningSegment> _meaningSegments = Array.Empty<MeaningSegment>();
     private bool _canGoBack;
@@ -68,18 +68,20 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         CanFloat = true;    // floatable/moveable like the other tools
         CanDrag = true;
 
-        // The picker's items are SOURCE ids from the shared registry (Stage 2 will show DisplayName instead).
-        // Only installed sources appear; a fresh install with no derived asset degrades cleanly to en/hi.
-        var available = _registry.Available.Select(s => s.Id).ToList();
-        AvailableLanguages = available.Count > 0 ? available : new[] { "en" };
-        // Restore the preferred SOURCE (#466), migrating from the older Language key; fall back to en, then
-        // whatever's available.
-        var savedSource = _stateService.Current.DictionaryDialog.SourceId;
-        if (string.IsNullOrEmpty(savedSource))
-            savedSource = _stateService.Current.DictionaryDialog.Language;   // migrate #25 → #466
-        _selectedLanguage = AvailableLanguages.Contains(savedSource) ? savedSource
-            : AvailableLanguages.Contains("en") ? "en"
-            : AvailableLanguages[0];
+        // The picker lists the installed SOURCES from the shared registry, shown by DisplayName. Only
+        // installed sources appear; a fresh install with no derived asset degrades cleanly to en/hi.
+        Sources = _registry.Available;
+        LongestSourceName = Sources.Select(s => s.DisplayName)
+            .OrderByDescending(n => n?.Length ?? 0)
+            .FirstOrDefault() ?? "";
+        // Restore the preferred SOURCE by id (#466), migrating from the older Language key; fall back to
+        // en, then the first available.
+        var savedId = _stateService.Current.DictionaryDialog.SourceId;
+        if (string.IsNullOrEmpty(savedId))
+            savedId = _stateService.Current.DictionaryDialog.Language;   // migrate #25 → #466
+        _selectedSource = Sources.FirstOrDefault(s => string.Equals(s.Id, savedId, StringComparison.OrdinalIgnoreCase))
+            ?? Sources.FirstOrDefault(s => string.Equals(s.Id, "en", StringComparison.OrdinalIgnoreCase))
+            ?? Sources.FirstOrDefault();
 
         Words = new ObservableCollection<DictionaryEntryViewModel>();
 
@@ -87,11 +89,11 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         ForwardCommand = ReactiveCommand.Create(GoForward, this.WhenAnyValue(x => x.CanGoForward));
         NavigateToWordCommand = ReactiveCommand.Create<string>(NavigateToWord);
 
-        // Real-time lookup as the query or language changes (throttled, like the Search tool). The
+        // Real-time lookup as the query or source changes (throttled, like the Search tool). The
         // throttle fires off the UI thread; LookupAsync marshals its collection updates back.
-        this.WhenAnyValue(x => x.SearchText, x => x.SelectedLanguage)
+        this.WhenAnyValue(x => x.SearchText, x => x.SelectedSource)
             .Throttle(TimeSpan.FromMilliseconds(300))
-            .Subscribe(pair => { _ = LookupAsync(SearchText); })
+            .Subscribe(change => { _ = LookupAsync(SearchText); })
             .DisposeWith(_disposables);
 
         // Rebuild the meaning display whenever the selected headword changes.
@@ -99,14 +101,17 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
             .Subscribe(_ => UpdateMeaning())
             .DisposeWith(_disposables);
 
-        // Remember the preferred definition language across sessions. Skip(1) ignores the initial value
-        // set above so construction doesn't write state. (#25)
-        this.WhenAnyValue(x => x.SelectedLanguage)
+        // Remember the preferred source across sessions. Skip(1) ignores the initial value set above so
+        // construction doesn't write state. (#466)
+        this.WhenAnyValue(x => x.SelectedSource)
             .Skip(1)
-            .Subscribe(sourceId =>
+            .Subscribe(source =>
             {
-                _stateService.Current.DictionaryDialog.SourceId = sourceId;
-                _stateService.MarkDirty();   // persist via the timer/shutdown save, not a full off-thread save per change (STATE-2)
+                if (source != null)
+                {
+                    _stateService.Current.DictionaryDialog.SourceId = source.Id;
+                    _stateService.MarkDirty();   // persist via the timer/shutdown save, not a full off-thread save per change (STATE-2)
+                }
             })
             .DisposeWith(_disposables);
 
@@ -128,12 +133,18 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         _fontService.FontSettingsChanged += _fontChangedHandler;
     }
 
-    public IReadOnlyList<string> AvailableLanguages { get; }
+    /// <summary>The installed dictionary sources for the picker (shown by <c>DisplayName</c>). (#466)</summary>
+    public IReadOnlyList<IDictionarySource> Sources { get; }
 
-    public string SelectedLanguage
+    /// <summary>The longest source <c>DisplayName</c> — a hidden measurer renders it to pin the picker
+    /// column to a fixed width (the longest name), so the box + dropdown don't resize as you switch
+    /// sources. (#466)</summary>
+    public string LongestSourceName { get; }
+
+    public IDictionarySource? SelectedSource
     {
-        get => _selectedLanguage;
-        set => this.RaiseAndSetIfChanged(ref _selectedLanguage, value);
+        get => _selectedSource;
+        set => this.RaiseAndSetIfChanged(ref _selectedSource, value);
     }
 
     public string SearchText
@@ -179,22 +190,21 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
 
     private async Task LookupAsync(string query)
     {
-        var sourceId = SelectedLanguage;   // capture: results are only valid if these still hold on completion
+        var source = SelectedSource;   // capture: results are only valid if these still hold on completion
         try
         {
-            var source = _registry.ById(sourceId);
             IReadOnlyList<DictionaryEntry> results = source == null
                 ? Array.Empty<DictionaryEntry>()
                 // The source returns Headword already in the requested output script and the definition as
                 // MeaningHtml (for flat-file, the same <see>-tagged text the native renderer handles). (#466)
-                : await source.LookupAsync(new DictionaryRequest(sourceId, query ?? "", _scriptService.CurrentScript, 500));
+                : await source.LookupAsync(new DictionaryRequest(source.Id, query ?? "", _scriptService.CurrentScript, 500));
 
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
                 // Ignore a stale completion: a newer query/source has superseded this lookup, so its results
                 // must not clobber the current ones (e.g. a slow first-time load finishing after a fast
                 // cached lookup). (DICT-3)
-                if (query != SearchText || sourceId != SelectedLanguage)
+                if (query != SearchText || !ReferenceEquals(source, SelectedSource))
                     return;
 
                 Words.Clear();
@@ -207,7 +217,7 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Dictionary lookup failed for '{Query}' ({Source})", query, sourceId);
+            _logger.LogWarning(ex, "Dictionary lookup failed for '{Query}' ({Source})", query, source?.Id);
         }
     }
 

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -258,7 +258,6 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         MeaningDocumentHtml = DictionaryHtmlRenderer.Render(
             SelectedWord?.Source.MeaningHtml,
             PaliToDisplay,
-            DictionaryService.MeaningSeparator,
             CurrentScriptFontFamily,
             Math.Max(1, CurrentScriptFontSize - 1));
     }

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -379,6 +379,14 @@ namespace CST.Avalonia.ViewModels
 
             if (parentDock?.VisibleDockables != null)
             {
+                // #466: hiding a CEF-hosting tool (the dictionary) that lives in a FLOATING window is about to
+                // close that window; release its WebView first, or its browser (born in the closing window)
+                // lingers in the recycling cache and the next re-show re-attaches it to a destroyed window →
+                // SIGSEGV (#458). A docked hide re-shows into the same main window, so no dispose is needed
+                // there. (Fable)
+                if (sourceHostWindow != null && tool is DictionaryViewModel && _factory is CstDockFactory cefFactory)
+                    cefFactory.DisposeAndEvictRecycledView(tool);
+
                 parentDock.VisibleDockables.Remove(tool);
                 Log.Information("[Layout] Removed tool {ToolId} from parent dock {ParentId}",
                     tool.Id, parentDock.Id);

--- a/src/CST.Avalonia/Views/DictionaryPanel.axaml
+++ b/src/CST.Avalonia/Views/DictionaryPanel.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:CST.Avalonia.ViewModels"
+             xmlns:dict="using:CST.Avalonia.Services.Dictionaries"
              xmlns:converters="using:CST.Avalonia.Converters"
              x:Class="CST.Avalonia.Views.DictionaryPanel"
              x:DataType="vm:DictionaryViewModel">
@@ -26,17 +27,36 @@
 
     <Grid RowDefinitions="Auto,Auto,2*,Auto,3*">
 
-        <!-- Search box + compact language picker -->
-        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="8,8,8,4">
-            <TextBox Grid.Column="0"
+        <!-- Search box stacked above the source picker, both in one Auto-width column so the column sizes
+             to its widest child (the dropdown, which fits the longest DisplayName) and both STRETCH to that
+             same width. Left-aligned so the block hugs its content instead of filling the panel. -->
+        <Grid Grid.Row="0" RowDefinitions="Auto,Auto" ColumnDefinitions="Auto"
+              HorizontalAlignment="Left" Margin="8,8,8,4">
+            <TextBox Grid.Row="0"
                      Text="{Binding SearchText}"
-                     Watermark="Look up a word…"/>
-            <ComboBox Grid.Column="1"
-                      Margin="6,0,0,0"
-                      MinWidth="64"
-                      ItemsSource="{Binding AvailableLanguages}"
-                      SelectedItem="{Binding SelectedLanguage}"
-                      ToolTip.Tip="Definition language"/>
+                     Watermark="Look up a word…"
+                     HorizontalAlignment="Stretch"
+                     Margin="0,0,0,4"/>
+            <!-- Hidden measurer: renders the longest DisplayName (plus room for the dropdown arrow) so the
+                 Auto column stays fixed at that width regardless of which — possibly short — source is
+                 selected. Opacity 0 + not hit-testable; shares the ComboBox's cell so it adds no height. -->
+            <TextBlock Grid.Row="1"
+                       Text="{Binding LongestSourceName}"
+                       Padding="12,0,34,0"
+                       Opacity="0"
+                       IsHitTestVisible="False"
+                       VerticalAlignment="Center"/>
+            <ComboBox Grid.Row="1"
+                      HorizontalAlignment="Stretch"
+                      ItemsSource="{Binding Sources}"
+                      SelectedItem="{Binding SelectedSource}"
+                      ToolTip.Tip="Dictionary source">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate x:DataType="dict:IDictionarySource">
+                        <TextBlock Text="{Binding DisplayName}"/>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
         </Grid>
 
         <!-- Words -->

--- a/src/CST.Avalonia/Views/DictionaryPanel.axaml
+++ b/src/CST.Avalonia/Views/DictionaryPanel.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:CST.Avalonia.ViewModels"
              xmlns:dict="using:CST.Avalonia.Services.Dictionaries"
+             xmlns:wv="using:WebViewControl"
              xmlns:converters="using:CST.Avalonia.Converters"
              x:Class="CST.Avalonia.Views.DictionaryPanel"
              x:DataType="vm:DictionaryViewModel">
@@ -86,8 +87,8 @@
                       ResizeDirection="Rows"
                       Background="{DynamicResource CardStrokeColorDefaultBrush}"/>
 
-        <!-- Meaning block: header + back/forward + definition together, so it's one resizable row. -->
-        <Grid Grid.Row="4" RowDefinitions="Auto,*">
+        <!-- Meaning block: header + back/forward + definition + attribution together, one resizable row. -->
+        <Grid Grid.Row="4" RowDefinitions="Auto,*,Auto">
             <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto" Margin="8,4,8,2">
                 <TextBlock Grid.Column="0" Classes="pane-label" Text="Meaning"/>
                 <Button Grid.Column="1" Classes="nav"
@@ -100,15 +101,24 @@
                         ToolTip.Tip="Forward"/>
             </Grid>
 
-            <!-- Definition (native text; <see> links built in code-behind) -->
+            <!-- Definition: rendered as an HTML document in a WebView (#466). The source's MeaningHtml is
+                 wrapped in a CSP host page by DictionaryHtmlRenderer; <see>/lemma links are intercepted in
+                 code-behind via BeforeNavigate (no script). -->
             <Border Grid.Row="1" Margin="8,0,8,8"
                     BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     Background="{DynamicResource CardBackgroundFillColorDefaultBrush}">
-                <ScrollViewer Padding="8" VerticalScrollBarVisibility="Auto">
-                    <TextBlock x:Name="MeaningText" TextWrapping="Wrap"/>
-                </ScrollViewer>
+                <wv:WebView x:Name="MeaningWebView"/>
             </Border>
+
+            <!-- Per-source attribution (from the source's recorded citation; hidden when blank). -->
+            <TextBlock Grid.Row="2"
+                       Text="{Binding Attribution}"
+                       IsVisible="{Binding Attribution, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                       FontSize="10"
+                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                       TextWrapping="Wrap"
+                       Margin="8,4,8,6"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/CST.Avalonia/Views/DictionaryPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/DictionaryPanel.axaml.cs
@@ -1,18 +1,21 @@
 using System;
-using System.Collections.Generic;
 using System.Reactive.Linq;
 using Avalonia.Controls;
-using Avalonia.Controls.Documents;
 using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using CST.Avalonia.Services;
 using CST.Avalonia.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using ReactiveUI;
+using WebViewControl;
 
 namespace CST.Avalonia.Views;
 
 public partial class DictionaryPanel : UserControl
 {
     private IDisposable? _meaningSub;
+    private WebView? _meaningWebView;
+    private DictionaryViewModel? _vm;
 
     public DictionaryPanel()
     {
@@ -41,48 +44,85 @@ public partial class DictionaryPanel : UserControl
 
     private void OnDataContextChanged(object? sender, EventArgs e) => WireMeaning();
 
+    /// <summary>
+    /// Release the meaning WebView's live CEF browser before this panel is moved across windows. Called by
+    /// CstDockFactory.DisposeAndEvictRecycledView on a cross-window drag/float of the dictionary tool: the
+    /// panel now hosts a CEF browser, so — exactly like the book/PDF views — it must be disposed-before-move
+    /// or the re-parent SIGSEGVs on macOS. The evicted panel is discarded; a fresh one is built (with a fresh
+    /// browser) at the destination and re-binds to the singleton VM. (#466 / #458 discipline)
+    /// </summary>
+    public void Shutdown()
+    {
+        _meaningSub?.Dispose();
+        _meaningSub = null;
+        try
+        {
+            if (_meaningWebView != null)
+            {
+                _meaningWebView.BeforeNavigate -= OnBeforeNavigate;
+                _meaningWebView.Dispose();
+            }
+        }
+        catch (Exception)
+        {
+            // Already torn down / mid-reparent — nothing more to release.
+        }
+        _meaningWebView = null;
+    }
+
     private void WireMeaning()
     {
         _meaningSub?.Dispose();
         _meaningSub = null;
+
+        _meaningWebView ??= this.FindControl<WebView>("MeaningWebView");
+        if (_meaningWebView != null)
+        {
+            // Intercept <see>/lemma link clicks (cst-see: … ) — the CSP host page runs no script, so
+            // navigation is the channel. Cancel the navigation and look the referenced word up instead;
+            // real content is loaded via LoadHtml (about:blank), never navigated to. (#466)
+            _meaningWebView.BeforeNavigate -= OnBeforeNavigate;
+            _meaningWebView.BeforeNavigate += OnBeforeNavigate;
+        }
+
         if (DataContext is DictionaryViewModel vm)
         {
-            // Definitions are rendered as native inlines (plain text + clickable <see> links); the
-            // Inlines collection can't be bound, so we rebuild it whenever the selection changes.
-            // MeaningSegments changes on the UI thread (SelectedWord is set inside a UI-thread dispatch).
-            _meaningSub = vm.WhenAnyValue(x => x.MeaningSegments)
-                .Subscribe(segments => BuildMeaning(vm, segments));
+            _vm = vm;
+            // Re-render the meaning WebView whenever the selected definition's document HTML changes
+            // (selection, script, or font). A short throttle coalesces the rapid pair a query change emits —
+            // Words.Clear() momentarily nulls the selection (an empty document) before the first result is
+            // reselected — so only the FINAL document loads. Two LoadHtml calls ~1ms apart otherwise race
+            // and the stale/empty one can win, leaving the pane blank. (#466)
+            _meaningSub = vm.WhenAnyValue(x => x.MeaningDocumentHtml)
+                .Throttle(TimeSpan.FromMilliseconds(60))
+                .Subscribe(html => Dispatcher.UIThread.Post(() => LoadMeaning(html)));
         }
     }
 
-    private void BuildMeaning(DictionaryViewModel vm, IReadOnlyList<MeaningSegment> segments)
+    private void LoadMeaning(string? html)
     {
-        var text = this.FindControl<TextBlock>("MeaningText");
-        if (text?.Inlines == null)
+        if (_meaningWebView == null)
             return;
-
-        text.Inlines.Clear();
-        foreach (var seg in segments)
+        try
         {
-            if (seg.IsSeparator)
-            {
-                // Break between the definitions of a merged (duplicate) headword: a blank line, so the
-                // separator reads as a boundary instead of showing the raw sentinel (DICT-1).
-                text.Inlines.Add(new LineBreak());
-                text.Inlines.Add(new LineBreak());
-            }
-            else if (seg.IsLink)
-            {
-                var link = new TextBlock { Text = seg.Text };
-                link.Classes.Add("dict-link");
-                var target = seg.Target ?? seg.Text;
-                link.PointerPressed += (_, _) => vm.NavigateToWordCommand.Execute(target).Subscribe();
-                text.Inlines.Add(new InlineUIContainer(link));
-            }
-            else
-            {
-                text.Inlines.Add(new Run(seg.Text));
-            }
+            _meaningWebView.LoadHtml(string.IsNullOrEmpty(html) ? "<html><body></body></html>" : html);
+        }
+        catch (Exception)
+        {
+            // The WebView may not be ready during teardown/re-parent; the next selection re-renders.
+        }
+    }
+
+    private void OnBeforeNavigate(WebViewControl.Request request)
+    {
+        var url = request.Url ?? string.Empty;
+        if (url.StartsWith(DictionaryHtmlRenderer.SeeScheme, StringComparison.OrdinalIgnoreCase))
+        {
+            request.Cancel();
+            var target = Uri.UnescapeDataString(url.Substring(DictionaryHtmlRenderer.SeeScheme.Length));
+            var vm = _vm;
+            if (vm != null && !string.IsNullOrWhiteSpace(target))
+                Dispatcher.UIThread.Post(() => vm.NavigateToWordCommand.Execute(target).Subscribe());
         }
     }
 }

--- a/src/CST.Avalonia/Views/DictionaryPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/DictionaryPanel.axaml.cs
@@ -60,6 +60,7 @@ public partial class DictionaryPanel : UserControl
             if (_meaningWebView != null)
             {
                 _meaningWebView.BeforeNavigate -= OnBeforeNavigate;
+                _meaningWebView.PopupOpening -= OnPopupOpening;
                 _meaningWebView.Dispose();
             }
         }
@@ -78,11 +79,15 @@ public partial class DictionaryPanel : UserControl
         _meaningWebView ??= this.FindControl<WebView>("MeaningWebView");
         if (_meaningWebView != null)
         {
-            // Intercept <see>/lemma link clicks (cst-see: … ) — the CSP host page runs no script, so
-            // navigation is the channel. Cancel the navigation and look the referenced word up instead;
-            // real content is loaded via LoadHtml (about:blank), never navigated to. (#466)
+            // Intercept navigations. The content is rendered via LoadHtml (an internal URL that never
+            // reaches BeforeNavigate), so ANYTHING that does reach here is a link the user (or a future
+            // asset's <a>/meta-refresh) tried to follow. Handle our own cst-see: cross-references, and
+            // CANCEL everything else — the meaning pane must never navigate away or hit the network. A
+            // no-op popup handler blocks target="_blank" from spawning an external browser. (#466, Fable)
             _meaningWebView.BeforeNavigate -= OnBeforeNavigate;
             _meaningWebView.BeforeNavigate += OnBeforeNavigate;
+            _meaningWebView.PopupOpening -= OnPopupOpening;
+            _meaningWebView.PopupOpening += OnPopupOpening;
         }
 
         if (DataContext is DictionaryViewModel vm)
@@ -113,9 +118,16 @@ public partial class DictionaryPanel : UserControl
         }
     }
 
+    // Real external schemes the meaning pane must never navigate to or fetch. The content itself loads over
+    // WebViewControl's internal scheme (not in this list), so cancelling these can't break rendering.
+    private static readonly string[] ExternalSchemes =
+        { "http:", "https:", "file:", "ftp:", "mailto:", "javascript:" };
+
     private void OnBeforeNavigate(WebViewControl.Request request)
     {
         var url = request.Url ?? string.Empty;
+
+        // Our own cross-reference links: cancel the navigation and look the word up instead.
         if (url.StartsWith(DictionaryHtmlRenderer.SeeScheme, StringComparison.OrdinalIgnoreCase))
         {
             request.Cancel();
@@ -123,6 +135,21 @@ public partial class DictionaryPanel : UserControl
             var vm = _vm;
             if (vm != null && !string.IsNullOrWhiteSpace(target))
                 Dispatcher.UIThread.Post(() => vm.NavigateToWordCommand.Execute(target).Subscribe());
+            return;
         }
+
+        // Block any real link-out (a future asset's <a href>/meta-refresh) — the pane must never leave its
+        // rendered content or hit the network. The internal content load uses a custom scheme not listed
+        // here, so it is allowed through and renders. (#466, Fable)
+        foreach (var scheme in ExternalSchemes)
+            if (url.StartsWith(scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                request.Cancel();
+                return;
+            }
     }
+
+    // Never spawn a popup/external browser from the meaning pane (a target="_blank" would otherwise reach
+    // the system browser). Handling the event with no action suppresses it.
+    private void OnPopupOpening(string url) { }
 }


### PR DESCRIPTION
Implements #466 Stages 1–3 — surface every installed dictionary source (flat-file en/hi, DPD, DPPN) in the reader's dictionary panel, rendering definitions as HTML, on top of Egret's source-registry backend (#474/#478/#480). GUI-verified on macOS; full suite **933 passed**. Stage 4 (source enable/order preference + LemmaId lemma-report link) is deferred to **#479**.

## What changed

**1. Route the panel through the shared registry.** `DictionaryViewModel` now injects `DictionarySourceRegistry` (the same set `/v1/dictionary` serves, so UI and API can't drift) instead of the flat-file `IDictionaryService`. Lookups call the selected `IDictionarySource.LookupAsync` → unified `DictionaryEntry` (`Headword` already script-converted, `MeaningHtml`, `Source`, `LemmaId`). Retired `IpeToDisplay` — the source returns the published headword form (the old IPE reconstruction was lossy for proper names). Degrades cleanly to en/hi when no derived asset is installed.

**2. Source picker (not a language toggle).** The dropdown binds `Sources`/`SelectedSource` and shows each source's `DisplayName` ("DPD", "DPPN", the Childers title, …). Two English sources (Childers + DPD) are why it must be a *source* picker. The word box is stacked above the dropdown, both fixed to the longest name's width (a hidden measurer) so nothing resizes as you switch sources. Preferred source persisted as `DictionaryDialog.SourceId` (migrated from the old `.Language`).

**3. WebView meaning pane.** New `DictionaryHtmlRenderer` wraps a source's `MeaningHtml` in a host document with a strict CSP (`default-src 'none'`; no scripts, no network), transforms `<see>word</see>` cross-references into `cst-see:` links (text in the current script), and sizes text in **pt** to match the book pages (`tipitaka-*.xsl`; px rendered too small). The meaning `TextBlock` becomes a `WebView`; code-behind `LoadHtml`s the document, intercepts `cst-see:` via `BeforeNavigate` (no script) to look the word up, and cancels external navigations. A 60ms throttle coalesces the rapid empty→real document pair a single-result lookup emits (which otherwise raced two `LoadHtml` calls and left the pane blank). Per-source **attribution** shows in a muted line under the meaning.

**4. Dock discipline for a CEF-hosting tool.** The dictionary is `CanFloat=true` and now hosts a live CEF browser, so floating/dragging/closing it must observe the #458 dispose-before-move rule like books. `DictionaryViewModel` is added to the `SplitToWindow` and `PrepareCrossWindowMove` guards; `DisposeAndEvictRecycledView` shuts down the panel's WebView; and — the one thing Fable's review caught as a hard crash — closing a *floated* dictionary window (or hiding it via the View menu while floated) now disposes its WebView too (`DisposeCefToolsInClosingWindow` / `RemoveToolFromLayout`), so a later re-show can't re-attach a dead-window browser. GUI-verified crash-proof.

## Review

Fable reviewed the branch: **DO-NOT-SHIP → fixed**. It caught the float-window-close crash above (verified by decompiling the recycling + WebView internals), a real content bug (the `<hr/>` merge sentinel collided with DPPN entries that contain literal `<hr/>` — now the fragment renders as-is, no split), and hardened `OnBeforeNavigate`. It confirmed by reading/decompile: the CSP blocks script/network, the `<see>` transform encodes href+text (no attribute breakout), the singleton-tool dispose/rebuild holds, and no subscription/WebView leaks. Two nits noted for follow-up: dead `MeaningParser`/`MeaningSegment` (retired native renderer), and `Sources` frozen at VM construction (mid-session installs need a relaunch — same as the registry's own "activate next launch" model).

## Verification

Manual on macOS: en/DPD/DPPN render; `<see>` links navigate with Back/Forward (e.g. `akatvā` → *karoti*); source switching + persistence; fixed-width picker; pt font size; attribution; script/font re-render; and the crash paths — float→close-window→re-show, float→hide→re-show, float/drag round-trips — all crash-free. 7 `DictionaryHtmlRenderer` unit tests; full suite **933 passed**.

## Coordination
- Source **DisplayName** normalization landed separately (Egret, #478); this UI just renders `DisplayName`.
- Dictionary-file **update logic** is Egret's (#481, already on main).
- Follow-up: **#479** (source enable/order preference + LemmaId link).

Closes #466 (Stages 1–3). Base: #25/#109. Backend: #474/#478/#480/#468.
