### PR TITLE
Shorten Settings category labels (Tipitaka Updates / Dictionary Updates)

### DIFF
--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -47,8 +47,8 @@ namespace CST.Avalonia.ViewModels
             {
                 new SettingsCategoryViewModel("Pali Script Fonts", fontSettings),
                 new SettingsCategoryViewModel("Logging", loggingSettings),
-                new SettingsCategoryViewModel("XML Data Updates", xmlUpdateSettings),
-                new SettingsCategoryViewModel("Dictionary Data Updates", dpdUpdateSettings),
+                new SettingsCategoryViewModel("Tipitaka Updates", xmlUpdateSettings),
+                new SettingsCategoryViewModel("Dictionary Updates", dpdUpdateSettings),
                 new SettingsCategoryViewModel("AI", aiSettings),
                 new SettingsCategoryViewModel("Directories", directoriesSettings),
                 new SettingsCategoryViewModel("Configuration", configurationSettings)

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -270,7 +270,7 @@
                             <StackPanel>
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
-                                        <TextBlock Text="XML Data Updates" Classes="SettingLabel"/>
+                                        <TextBlock Text="Tipitaka Updates" Classes="SettingLabel"/>
                                         <TextBlock Text="Configure automatic updates for Tipitaka XML files from GitHub" 
                                                   Classes="SettingDescription"/>
                                         
@@ -322,7 +322,7 @@
                             <StackPanel>
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
-                                        <TextBlock Text="Dictionary Data Updates" Classes="SettingLabel"/>
+                                        <TextBlock Text="Dictionary Updates" Classes="SettingLabel"/>
                                         <TextBlock Text="Configure automatic updates for the downloadable dictionary data (DPD, DPPN) from GitHub. Installed dictionaries keep working with this off."
                                                   Classes="SettingDescription"/>
 


### PR DESCRIPTION
"Dictionary Data Updates" overflowed the Settings left-nav column. Shorten it to **"Dictionary Updates"**, and rename **"XML Data Updates" → "Tipitaka Updates"** to match.

Both the nav category name and the in-panel header are updated (kept in sync, as the pair already were). "Tipitaka" (plain) matches the Settings window's existing usage ("Tipitaka XML files"). Pure label strings; build green, no tests reference the old names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)