### PR TITLE
#479 (stage 4): dictionary source enable/order preference + folded Settings

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionarySourcePreferenceServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionarySourcePreferenceServiceTests.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Dictionaries;
+using CST.Tools;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// The dictionary source enable/order preference service (#479): the picker shows only enabled sources in the
+/// user's order, a fresh install is appended enabled, and edits persist to <see cref="DictionaryDialogState"/>.
+/// </summary>
+public sealed class DictionarySourcePreferenceServiceTests
+{
+    // A stand-in installed source. IsAvailable is settable so "uninstalled" can be simulated.
+    private sealed class FakeSource : IDictionarySource
+    {
+        public string Id { get; }
+        public string DisplayName { get; }
+        public string DefinitionLanguage => "en";
+        public DictionarySourceKind Kind => DictionarySourceKind.General;
+        public bool IsAvailable { get; set; } = true;
+        public DictionarySourceInfo? Attribution => null;
+        public FakeSource(string id, string? displayName = null) { Id = id; DisplayName = displayName ?? id.ToUpperInvariant(); }
+        public Task<IReadOnlyList<DictionaryEntry>> LookupAsync(DictionaryRequest request, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<DictionaryEntry>>(new List<DictionaryEntry>());
+    }
+
+    // Registry over the given sources, plus a state-backed preference service. The Mock state exposes a real
+    // ApplicationState so SourceOrder round-trips, and records MarkDirty calls.
+    private static (DictionarySourcePreferenceService svc, ApplicationState state, Mock<IApplicationStateService> stateMock)
+        Build(params IDictionarySource[] sources)
+    {
+        var registry = new DictionarySourceRegistry(sources);
+        var state = new ApplicationState();
+        var mock = new Mock<IApplicationStateService>();
+        mock.SetupGet(s => s.Current).Returns(state);
+        var svc = new DictionarySourcePreferenceService(registry, mock.Object);
+        return (svc, state, mock);
+    }
+
+    [Fact]
+    public void With_no_stored_preference_all_available_sources_are_enabled_in_registry_order()
+    {
+        var (svc, _, _) = Build(new FakeSource("en"), new FakeSource("hi"), new FakeSource("dpd"));
+
+        var rows = svc.GetRows();
+        Assert.Equal(new[] { "en", "hi", "dpd" }, rows.Select(r => r.Source.Id));
+        Assert.All(rows, r => Assert.True(r.Enabled));
+        Assert.Equal(new[] { "en", "hi", "dpd" }, svc.GetEffectiveSources().Select(s => s.Id));
+    }
+
+    [Fact]
+    public void Disabling_a_source_removes_it_from_the_effective_picker_list_but_keeps_it_in_rows()
+    {
+        var (svc, state, _) = Build(new FakeSource("en"), new FakeSource("hi"), new FakeSource("dpd"));
+
+        svc.SetEnabled("hi", false);
+
+        Assert.Equal(new[] { "en", "dpd" }, svc.GetEffectiveSources().Select(s => s.Id));
+        // Still shown (disabled) in the editor rows so it can be re-enabled.
+        var hi = svc.GetRows().Single(r => r.Source.Id == "hi");
+        Assert.False(hi.Enabled);
+        // Persisted with an explicit entry for every source.
+        Assert.Contains(state.DictionaryDialog.SourceOrder, p => p.Id == "hi" && !p.Enabled);
+    }
+
+    [Fact]
+    public void Cannot_disable_the_last_enabled_source()
+    {
+        var (svc, _, _) = Build(new FakeSource("en"), new FakeSource("hi"));
+
+        svc.SetEnabled("hi", false);
+        svc.SetEnabled("en", false);   // would empty the picker — rejected
+
+        Assert.Equal(new[] { "en" }, svc.GetEffectiveSources().Select(s => s.Id));
+    }
+
+    [Fact]
+    public void The_last_enabled_guard_ignores_a_retained_but_uninstalled_enabled_source()
+    {
+        // en + dppn both enabled, dppn then uninstalled (its enabled pref is retained). Disabling en would
+        // leave only the uninstalled dppn "enabled" — which draws nothing — so it must be rejected. (Fable MEDIUM-3)
+        var en = new FakeSource("en");
+        var dppn = new FakeSource("dppn");
+        var (svc, _, _) = Build(en, dppn);
+        svc.Move("dppn", -1);       // establish a stored pref that lists dppn, enabled
+        dppn.IsAvailable = false;   // uninstalled
+
+        svc.SetEnabled("en", false);
+
+        Assert.Equal(new[] { "en" }, svc.GetEffectiveSources().Select(s => s.Id));   // still non-empty
+    }
+
+    [Fact]
+    public void Disabled_state_survives_a_serialization_round_trip()
+    {
+        // The state writer uses WhenWritingDefault, which would omit Enabled==false (a bool default) unless
+        // the property forces serialization. Round-trip through the EXACT writer options. (Fable DO-NOT-SHIP-1)
+        var (svc, state, _) = Build(new FakeSource("en"), new FakeSource("hi"));
+        svc.SetEnabled("hi", false);
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        var json = JsonSerializer.Serialize(state.DictionaryDialog, options);
+        var restored = JsonSerializer.Deserialize<DictionaryDialogState>(json, options)!;
+
+        var hi = Assert.Single(restored.SourceOrder, p => p.Id == "hi");
+        Assert.False(hi.Enabled);   // regression guard: must NOT silently re-enable on reload
+    }
+
+    [Fact]
+    public void Move_reorders_the_effective_list_and_first_enabled_is_the_default()
+    {
+        var (svc, _, _) = Build(new FakeSource("en"), new FakeSource("hi"), new FakeSource("dpd"));
+
+        svc.Move("dpd", -1);   // dpd up one → en, dpd, hi
+        Assert.Equal(new[] { "en", "dpd", "hi" }, svc.GetEffectiveSources().Select(s => s.Id));
+
+        svc.Move("dpd", -1);   // dpd up again → dpd, en, hi (dpd now the default)
+        Assert.Equal(new[] { "dpd", "en", "hi" }, svc.GetEffectiveSources().Select(s => s.Id));
+
+        svc.Move("dpd", -1);   // already first → no-op
+        Assert.Equal(new[] { "dpd", "en", "hi" }, svc.GetEffectiveSources().Select(s => s.Id));
+    }
+
+    [Fact]
+    public void A_newly_installed_source_is_appended_enabled_after_the_stored_order()
+    {
+        var en = new FakeSource("en");
+        var hi = new FakeSource("hi");
+        var (svc, state, _) = Build(en, hi);
+
+        // Establish a custom order/enable so a stored preference exists.
+        svc.Move("hi", -1);            // hi, en
+        svc.SetEnabled("en", false);   // hi enabled, en disabled
+
+        // Simulate a fresh DPD install by rebuilding the service over an expanded registry, reusing state.
+        var registry = new DictionarySourceRegistry(new IDictionarySource[] { en, hi, new FakeSource("dpd") });
+        var mock = new Mock<IApplicationStateService>();
+        mock.SetupGet(s => s.Current).Returns(state);
+        var svc2 = new DictionarySourcePreferenceService(registry, mock.Object);
+
+        // Stored order preserved (hi, en) with en still disabled; dpd appended enabled.
+        Assert.Equal(new[] { "hi", "en", "dpd" }, svc2.GetRows().Select(r => r.Source.Id));
+        Assert.Equal(new[] { "hi", "dpd" }, svc2.GetEffectiveSources().Select(s => s.Id));
+    }
+
+    [Fact]
+    public void An_uninstalled_source_is_hidden_but_its_preference_is_retained()
+    {
+        var en = new FakeSource("en");
+        var dppn = new FakeSource("dppn");
+        var (svc, state, _) = Build(en, dppn);
+
+        svc.Move("dppn", -1);   // dppn, en — establish a stored order that mentions dppn
+
+        dppn.IsAvailable = false;   // uninstalled
+
+        Assert.Equal(new[] { "en" }, svc.GetRows().Select(r => r.Source.Id));
+        Assert.Equal(new[] { "en" }, svc.GetEffectiveSources().Select(s => s.Id));
+        // The dppn preference survives in state for a later re-install.
+        Assert.Contains(state.DictionaryDialog.SourceOrder, p => p.Id == "dppn");
+    }
+
+    [Fact]
+    public void Every_edit_marks_state_dirty_and_raises_Changed()
+    {
+        var (svc, _, mock) = Build(new FakeSource("en"), new FakeSource("hi"));
+        var changed = 0;
+        svc.Changed += (_, _) => changed++;
+
+        svc.SetEnabled("hi", false);
+        svc.Move("hi", -1);
+
+        Assert.Equal(2, changed);
+        mock.Verify(s => s.MarkDirty(), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void A_no_op_edit_does_not_mark_dirty_or_raise_Changed()
+    {
+        var (svc, _, mock) = Build(new FakeSource("en"), new FakeSource("hi"));
+        var changed = 0;
+        svc.Changed += (_, _) => changed++;
+
+        svc.SetEnabled("en", true);   // already enabled
+        svc.Move("en", -1);           // already first
+        svc.Move("hi", +1);           // already last
+
+        Assert.Equal(0, changed);
+        mock.Verify(s => s.MarkDirty(), Times.Never);
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -606,6 +606,15 @@ public partial class App : Application
             var searchViewModel = ServiceProvider?.GetService<SearchViewModel>();
             searchViewModel?.ApplyState(searchState);
         });
+
+        // Same story for the Dictionary panel: its VM singleton is built during the dock layout build, before
+        // this load completes, so it reads registry order + no saved source. Reapply the persisted source
+        // enable/order preference and selection now that state is available. (#479)
+        Dispatcher.UIThread.Post(() =>
+        {
+            var dictionaryViewModel = ServiceProvider?.GetService<DictionaryViewModel>();
+            dictionaryViewModel?.ApplyState();
+        });
         
         // Restore main window state (dimensions, position, etc.) - MUST be on UI thread
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop &&
@@ -1079,6 +1088,10 @@ public partial class App : Application
         services.AddSingleton<CST.Tools.IDictionaryTool>(sp =>
             new Services.Dictionaries.RegistryDictionaryTool(
                 sp.GetRequiredService<Services.Dictionaries.DictionarySourceRegistry>()));
+        // The user's enable/order preference for the sources (#479). Shared by the Settings editor (mutates)
+        // and the dictionary panel VM (consumes + rebuilds its picker). Applied only here, never in the
+        // registry/API path — an agent still sees every installed source.
+        services.AddSingleton<Services.Dictionaries.DictionarySourcePreferenceService>();
         services.AddSingleton<CST.Tools.IPassageTool, Services.Tools.PassageTool>();
         services.AddSingleton<CST.Tools.IScriptTool, Services.Tools.ScriptTool>();
         services.AddTransient<TreeStateService>();
@@ -1458,7 +1471,8 @@ public partial class App : Application
             var settingsService = ServiceProvider?.GetRequiredService<ISettingsService>();
             if (settingsService != null && MainWindow != null)
             {
-                var settingsViewModel = new SettingsViewModel(settingsService);
+                var sourcePrefs = ServiceProvider!.GetRequiredService<Services.Dictionaries.DictionarySourcePreferenceService>();
+                var settingsViewModel = new SettingsViewModel(settingsService, sourcePrefs);
                 var settingsWindow = new SettingsWindow
                 {
                     DataContext = settingsViewModel

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -141,6 +141,26 @@ public class DictionaryDialogState
     /// A source identity, not a language — two sources can share a language. Empty until first set;
     /// migrated from <see cref="Language"/> on load.</summary>
     public string SourceId { get; set; } = string.Empty;
+
+    /// <summary>User-managed enable/order preference for the dictionary sources (#479). The picker shows
+    /// only enabled sources, in this order; disabled ones are hidden but retained here so they can be
+    /// re-enabled. A source not listed here (a fresh install) is treated as enabled and appended. Empty
+    /// until the user first customizes it — until then every installed source shows, in registry order.</summary>
+    public List<DictionarySourcePreference> SourceOrder { get; set; } = new();
+}
+
+/// <summary>One row of the dictionary source enable/order preference (#479): a source id and whether it
+/// appears in the picker. List position carries the order.</summary>
+public class DictionarySourcePreference
+{
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Whether this source shows in the picker. Always serialized — the state writer's global
+    /// <c>WhenWritingDefault</c> would otherwise omit <c>Enabled == false</c> (a bool's default), so a
+    /// disabled source would silently re-enable on the next launch. <see cref="JsonIgnoreCondition.Never"/>
+    /// overrides that per-property. (#479)</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    public bool Enabled { get; set; } = true;
 }
 
 /// <summary>

--- a/src/CST.Avalonia/Services/Dictionaries/DictionarySourcePreferenceService.cs
+++ b/src/CST.Avalonia/Services/Dictionaries/DictionarySourcePreferenceService.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+
+namespace CST.Avalonia.Services.Dictionaries;
+
+/// <summary>
+/// The user-managed enable/order preference for the dictionary sources (#479). The dictionary panel's
+/// picker shows only the ENABLED sources, in this order; a fresh install (a source with no stored
+/// preference) is appended ENABLED so it appears without a settings hunt. First enabled = the default.
+///
+/// The preference is applied HERE (and consumed by <see cref="ViewModels.DictionaryViewModel"/>), never in
+/// the registry or the /v1 API path — an agent still enumerates every installed source. Persisted in
+/// <see cref="DictionaryDialogState.SourceOrder"/>, alongside the last-selected <c>SourceId</c>.
+///
+/// A single instance is shared by the Settings editor (which mutates it) and the panel VM (which consumes
+/// it and rebuilds its picker on <see cref="Changed"/>).
+/// </summary>
+public sealed class DictionarySourcePreferenceService
+{
+    private readonly DictionarySourceRegistry _registry;
+    private readonly IApplicationStateService _state;
+
+    /// <summary>Raised after the enable/order preference changes so the live panel can rebuild its picker.</summary>
+    public event EventHandler? Changed;
+
+    public DictionarySourcePreferenceService(DictionarySourceRegistry registry, IApplicationStateService state)
+    {
+        _registry = registry;
+        _state = state;
+    }
+
+    private List<DictionarySourcePreference> Stored => _state.Current.DictionaryDialog.SourceOrder;
+
+    /// <summary>One editable row: an available source and whether it is enabled in the picker.</summary>
+    public sealed record SourceRow(IDictionarySource Source, bool Enabled);
+
+    /// <summary>
+    /// Every AVAILABLE source paired with its enabled flag, in preference order: stored order first (by id),
+    /// then any newly-installed source appended enabled. DISABLED sources are included — the Settings editor
+    /// needs them so they can be re-enabled. Sources in the stored list that are no longer installed are
+    /// skipped (their preference is retained in state for a later re-install, just not shown).
+    /// </summary>
+    public IReadOnlyList<SourceRow> GetRows()
+    {
+        var available = _registry.Available;
+        var byId = available.ToDictionary(s => s.Id, StringComparer.OrdinalIgnoreCase);
+        var rows = new List<SourceRow>();
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pref in Stored)
+            if (byId.TryGetValue(pref.Id, out var src) && used.Add(src.Id))
+                rows.Add(new SourceRow(src, pref.Enabled));
+        foreach (var src in available)
+            if (used.Add(src.Id))
+                rows.Add(new SourceRow(src, true));   // newly installed → enabled, appended (#479)
+        return rows;
+    }
+
+    /// <summary>The picker list: enabled available sources in preference order. First = the default source.</summary>
+    public IReadOnlyList<IDictionarySource> GetEffectiveSources() =>
+        GetRows().Where(r => r.Enabled).Select(r => r.Source).ToList();
+
+    /// <summary>Enable or disable a source. Ignored if it would leave no enabled source (the picker must
+    /// never be empty) or if the value is unchanged.</summary>
+    public void SetEnabled(string id, bool enabled)
+    {
+        var list = Reconcile();
+        var entry = list.FirstOrDefault(p => string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase));
+        if (entry == null || entry.Enabled == enabled)
+            return;
+        if (!enabled && !AnyOtherAvailableEnabled(list, id))
+            return;   // keep at least one enabled AND installed source — the picker must never be empty
+        entry.Enabled = enabled;
+        Commit(list);
+    }
+
+    /// <summary>Move a source up (delta &lt; 0) or down (delta &gt; 0) among the shown (available) rows.</summary>
+    public void Move(string id, int delta)
+    {
+        if (delta == 0)
+            return;
+        var list = Reconcile();
+        // Reorder among the AVAILABLE (shown) entries only, stepping over any retained-but-uninstalled
+        // placeholders so the visible order matches what the user sees.
+        var availableIds = _registry.Available.Select(s => s.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var shown = list.Select((p, i) => (pref: p, index: i))
+                        .Where(t => availableIds.Contains(t.pref.Id))
+                        .ToList();
+        var pos = shown.FindIndex(t => string.Equals(t.pref.Id, id, StringComparison.OrdinalIgnoreCase));
+        if (pos < 0)
+            return;
+        var targetPos = pos + Math.Sign(delta);
+        if (targetPos < 0 || targetPos >= shown.Count)
+            return;
+        // Remove-and-reinsert next to the target (rather than swapping absolute slots), so a retained
+        // placeholder for an uninstalled source keeps its anchor relative to its neighbours. (#479, Fable LOW-5)
+        var fromIndex = shown[pos].index;
+        var toIndex = shown[targetPos].index;
+        var entry = list[fromIndex];
+        list.RemoveAt(fromIndex);
+        var targetAdjusted = toIndex > fromIndex ? toIndex - 1 : toIndex;   // target's index after removal
+        var insertAt = delta > 0 ? targetAdjusted + 1 : targetAdjusted;
+        list.Insert(insertAt, entry);
+        Commit(list);
+    }
+
+    // True iff some source OTHER than exceptId is both enabled and currently installed — the picker draws
+    // only from installed sources, so a retained-but-uninstalled enabled placeholder must not count. (Fable MEDIUM-3)
+    private bool AnyOtherAvailableEnabled(List<DictionarySourcePreference> list, string exceptId)
+    {
+        var availableIds = _registry.Available.Select(s => s.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return list.Any(p => p.Enabled
+                             && availableIds.Contains(p.Id)
+                             && !string.Equals(p.Id, exceptId, StringComparison.OrdinalIgnoreCase));
+    }
+
+    // Materialize the persisted order to hold an explicit entry for every available source (preserving the
+    // stored entries and any uninstalled placeholders), so an edit captures a stable order + enable state
+    // even the first time the user touches an all-defaults list.
+    private List<DictionarySourcePreference> Reconcile()
+    {
+        var list = Stored.Select(p => new DictionarySourcePreference { Id = p.Id, Enabled = p.Enabled }).ToList();
+        var have = new HashSet<string>(list.Select(p => p.Id), StringComparer.OrdinalIgnoreCase);
+        foreach (var src in _registry.Available)
+            if (have.Add(src.Id))
+                list.Add(new DictionarySourcePreference { Id = src.Id, Enabled = true });
+        return list;
+    }
+
+    private void Commit(List<DictionarySourcePreference> list)
+    {
+        _state.Current.DictionaryDialog.SourceOrder = list;
+        _state.MarkDirty();   // persist via the state timer/shutdown save (STATE-2), like SourceId
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -27,6 +27,7 @@ namespace CST.Avalonia.ViewModels;
 public class DictionaryViewModel : ReactiveTool, IDisposable
 {
     private readonly DictionarySourceRegistry _registry;
+    private readonly DictionarySourcePreferenceService _sourcePrefs;
     private readonly IScriptService _scriptService;
     private readonly IFontService _fontService;
     private readonly IApplicationStateService _stateService;
@@ -36,12 +37,16 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
     // Live script/font-change handlers, so the panel re-renders in the new script/font (DICT-2).
     private Action<Script>? _scriptChangedHandler;
     private EventHandler? _fontChangedHandler;
+    // Live enable/order-preference handler, so the picker rebuilds when Settings changes the sources (#479).
+    private EventHandler? _sourcePrefsChangedHandler;
 
     // <see>-link navigation history (manual typing does NOT push history; only followed links do).
     private readonly Stack<string> _backStack = new();
     private readonly Stack<string> _forwardStack = new();
 
     private string _searchText = "";
+    private IReadOnlyList<IDictionarySource> _sources = Array.Empty<IDictionarySource>();
+    private string _longestSourceName = "";
     private IDictionarySource? _selectedSource;
     private DictionaryEntryViewModel? _selectedWord;
     private string _meaningDocumentHtml = "";
@@ -51,12 +56,14 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
 
     public DictionaryViewModel(
         DictionarySourceRegistry registry,
+        DictionarySourcePreferenceService sourcePrefs,
         IScriptService scriptService,
         IFontService fontService,
         IApplicationStateService stateService,
         ILogger<DictionaryViewModel> logger)
     {
         _registry = registry;
+        _sourcePrefs = sourcePrefs;
         _scriptService = scriptService;
         _fontService = fontService;
         _stateService = stateService;
@@ -69,19 +76,17 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         CanFloat = true;    // floatable/moveable like the other tools
         CanDrag = true;
 
-        // The picker lists the installed SOURCES from the shared registry, shown by DisplayName. Only
-        // installed sources appear; a fresh install with no derived asset degrades cleanly to en/hi.
-        Sources = _registry.Available;
-        LongestSourceName = Sources.Select(s => s.DisplayName)
-            .OrderByDescending(n => n?.Length ?? 0)
-            .FirstOrDefault() ?? "";
-        // Restore the preferred SOURCE by id (#466), migrating from the older Language key; fall back to
-        // en, then the first available.
+        // The picker lists the ENABLED installed sources in the user's preferred order (#479), shown by
+        // DisplayName. Only installed sources appear; a fresh install with no derived asset degrades cleanly
+        // to en/hi. The preference is applied by the shared service — never in the registry/API path.
+        RebuildSources();
+        // Restore the preferred SOURCE by id (#466), migrating from the older Language key; fall back to the
+        // first enabled source (the #479 default). If the saved source is disabled/uninstalled, its id is
+        // no longer in the list and the first enabled wins.
         var savedId = _stateService.Current.DictionaryDialog.SourceId;
         if (string.IsNullOrEmpty(savedId))
             savedId = _stateService.Current.DictionaryDialog.Language;   // migrate #25 → #466
         _selectedSource = Sources.FirstOrDefault(s => string.Equals(s.Id, savedId, StringComparison.OrdinalIgnoreCase))
-            ?? Sources.FirstOrDefault(s => string.Equals(s.Id, "en", StringComparison.OrdinalIgnoreCase))
             ?? Sources.FirstOrDefault();
 
         Words = new ObservableCollection<DictionaryEntryViewModel>();
@@ -138,15 +143,80 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
             UpdateMeaning();   // re-render the meaning document at the new font (#466)
         });
         _fontService.FontSettingsChanged += _fontChangedHandler;
+
+        // Rebuild the picker live when the enable/order preference changes in Settings (#479). A settings
+        // edit re-defaults the selection to the first enabled source (the user's rule). Unsubscribed in
+        // Dispose. Marshalled to the UI thread — the preference service raises on the caller's thread.
+        _sourcePrefsChangedHandler = (_, _) => Dispatcher.UIThread.Post(() => RebuildSources(preferFirstEnabled: true));
+        _sourcePrefs.Changed += _sourcePrefsChangedHandler;
     }
 
-    /// <summary>The installed dictionary sources for the picker (shown by <c>DisplayName</c>). (#466)</summary>
-    public IReadOnlyList<IDictionarySource> Sources { get; }
+    /// <summary>Recompute <see cref="Sources"/> (and the picker-width measurer) from the enable/order
+    /// preference. If the current selection is no longer enabled/available, fall back to the first enabled
+    /// source (the #479 default); a null selection is left alone until the user picks one. (#479)</summary>
+    private void RebuildSources(bool preferFirstEnabled = false)
+    {
+        var newSources = _sourcePrefs.GetEffectiveSources();
+        // Decide the selection BEFORE swapping the list. Assigning Sources revalidates the bound ComboBox,
+        // which pushes SelectedSource back to null when the old selection is absent from the new list — so a
+        // post-hoc "if null" guard would already have lost _selectedSource. Capture the intended selection
+        // first, then re-assert it unconditionally after (a still-valid selection re-set is a no-op). (#479, Fable HIGH-2)
+        // After a preference EDIT (preferFirstEnabled), the first enabled source becomes the default — the
+        // user's rule "first in the list is the default after a settings change". Otherwise keep the current
+        // selection if it survives, falling back to the first enabled.
+        IDictionarySource? desired;
+        if (preferFirstEnabled)
+            desired = newSources.FirstOrDefault();
+        else
+        {
+            var keep = _selectedSource != null
+                ? newSources.FirstOrDefault(s => string.Equals(s.Id, _selectedSource.Id, StringComparison.OrdinalIgnoreCase))
+                : null;
+            desired = keep ?? newSources.FirstOrDefault();
+        }
+
+        Sources = newSources;
+        LongestSourceName = newSources.Select(s => s.DisplayName)
+            .OrderByDescending(n => n?.Length ?? 0)
+            .FirstOrDefault() ?? "";
+        SelectedSource = desired;
+    }
+
+    /// <summary>
+    /// Re-read the source enable/order preference and the saved selection after the app state has loaded from
+    /// disk. The VM singleton is built during the dock layout build (<c>CstDockFactory.CreateLayout</c>),
+    /// BEFORE <c>LoadStateAsync</c> completes — so its constructor sees an empty <c>SourceOrder</c> (registry
+    /// order) and no saved <c>SourceId</c>. This reapplies both once state is available, mirroring
+    /// <c>SearchViewModel.ApplyState</c>. Must run on the UI thread (it updates bound properties). (#479)
+    /// </summary>
+    public void ApplyState()
+    {
+        RebuildSources();   // now sees the persisted SourceOrder → the user's order, not registry order
+        var savedId = _stateService.Current.DictionaryDialog.SourceId;
+        if (string.IsNullOrEmpty(savedId))
+            savedId = _stateService.Current.DictionaryDialog.Language;
+        var restored = Sources.FirstOrDefault(s => string.Equals(s.Id, savedId, StringComparison.OrdinalIgnoreCase))
+            ?? Sources.FirstOrDefault();
+        if (restored != null)
+            SelectedSource = restored;
+    }
+
+    /// <summary>The enabled dictionary sources for the picker (shown by <c>DisplayName</c>), in the user's
+    /// preferred order. Rebuilt live when the enable/order preference changes. (#466/#479)</summary>
+    public IReadOnlyList<IDictionarySource> Sources
+    {
+        get => _sources;
+        private set => this.RaiseAndSetIfChanged(ref _sources, value);
+    }
 
     /// <summary>The longest source <c>DisplayName</c> — a hidden measurer renders it to pin the picker
     /// column to a fixed width (the longest name), so the box + dropdown don't resize as you switch
     /// sources. (#466)</summary>
-    public string LongestSourceName { get; }
+    public string LongestSourceName
+    {
+        get => _longestSourceName;
+        private set => this.RaiseAndSetIfChanged(ref _longestSourceName, value);
+    }
 
     public IDictionarySource? SelectedSource
     {
@@ -310,6 +380,8 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
             _scriptService.ScriptChanged -= _scriptChangedHandler;
         if (_fontChangedHandler != null)
             _fontService.FontSettingsChanged -= _fontChangedHandler;
+        if (_sourcePrefsChangedHandler != null)
+            _sourcePrefs.Changed -= _sourcePrefsChangedHandler;
         _disposables.Dispose();
     }
 }

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -22,13 +22,15 @@ namespace CST.Avalonia.ViewModels
     public class SettingsViewModel : ViewModelBase
     {
         private readonly ISettingsService _settingsService;
+        private readonly Services.Dictionaries.DictionarySourcePreferenceService _sourcePrefs;
         private readonly ILogger _logger;
         private SettingsCategoryViewModel? _selectedCategory;
         private bool _hasUnsavedChanges;
 
-        public SettingsViewModel(ISettingsService settingsService)
+        public SettingsViewModel(ISettingsService settingsService, Services.Dictionaries.DictionarySourcePreferenceService sourcePrefs)
         {
             _settingsService = settingsService;
+            _sourcePrefs = sourcePrefs;
             _logger = Log.ForContext<SettingsViewModel>();
 
 
@@ -39,6 +41,10 @@ namespace CST.Avalonia.ViewModels
             var configurationSettings = new ConfigurationSettingsViewModel(_settingsService);
             var xmlUpdateSettings = new XmlUpdateSettingsViewModel(_settingsService);
             var dpdUpdateSettings = new DpdUpdateSettingsViewModel(_settingsService);
+            // One "Dictionary" category (#479) folds the source enable/order preference together with the
+            // existing update settings — two groups under a single nav entry, not two "Dictionary…" entries.
+            var dictionarySettings = new DictionaryCategoryViewModel(
+                new DictionarySourceSettingsViewModel(_sourcePrefs), dpdUpdateSettings);
             var aiSettings = new AiSettingsViewModel(_settingsService);
             var loggingSettings = new DeveloperSettingsViewModel(_settingsService) { Parent = this };
 
@@ -48,7 +54,7 @@ namespace CST.Avalonia.ViewModels
                 new SettingsCategoryViewModel("Pali Script Fonts", fontSettings),
                 new SettingsCategoryViewModel("Logging", loggingSettings),
                 new SettingsCategoryViewModel("Tipitaka Updates", xmlUpdateSettings),
-                new SettingsCategoryViewModel("Dictionary Updates", dpdUpdateSettings),
+                new SettingsCategoryViewModel("Dictionary", dictionarySettings),
                 new SettingsCategoryViewModel("AI", aiSettings),
                 new SettingsCategoryViewModel("Directories", directoriesSettings),
                 new SettingsCategoryViewModel("Configuration", configurationSettings)
@@ -884,6 +890,110 @@ namespace CST.Avalonia.ViewModels
                 this.RaiseAndSetIfChanged(ref _repositoryName, value);
                 _settingsService.Settings.DpdUpdateSettings.RepositoryName = value;
                 _settingsService.RequestSave();
+            }
+        }
+    }
+
+    /// <summary>The "Dictionary" settings category (#479): two groups under one nav entry — the source
+    /// enable/order preference (<see cref="Sources"/>) and the existing update settings (<see cref="Updates"/>).</summary>
+    public class DictionaryCategoryViewModel : ViewModelBase
+    {
+        public DictionarySourceSettingsViewModel Sources { get; }
+        public DpdUpdateSettingsViewModel Updates { get; }
+
+        public DictionaryCategoryViewModel(DictionarySourceSettingsViewModel sources, DpdUpdateSettingsViewModel updates)
+        {
+            Sources = sources;
+            Updates = updates;
+        }
+    }
+
+    /// <summary>Editor for the dictionary source enable/order preference (#479): a row per installed source
+    /// with an enable checkbox and up/down reorder. Edits go straight to the shared preference service, which
+    /// the live dictionary panel observes to rebuild its picker.</summary>
+    public class DictionarySourceSettingsViewModel : ViewModelBase
+    {
+        private readonly Services.Dictionaries.DictionarySourcePreferenceService _prefs;
+        private bool _rebuilding;
+
+        public ObservableCollection<DictionarySourceRowViewModel> Rows { get; } = new();
+
+        public DictionarySourceSettingsViewModel(Services.Dictionaries.DictionarySourcePreferenceService prefs)
+        {
+            _prefs = prefs;
+            RebuildRows();
+        }
+
+        private void RebuildRows()
+        {
+            _rebuilding = true;
+            Rows.Clear();
+            var rows = _prefs.GetRows();
+            var enabledCount = rows.Count(r => r.Enabled);
+            for (var i = 0; i < rows.Count; i++)
+            {
+                var r = rows[i];
+                Rows.Add(new DictionarySourceRowViewModel(this, r.Source.Id, r.Source.DisplayName, r.Enabled)
+                {
+                    // The last remaining enabled source can't be unchecked — the picker must never be empty.
+                    CanDisable = !(r.Enabled && enabledCount <= 1),
+                    CanMoveUp = i > 0,
+                    CanMoveDown = i < rows.Count - 1,
+                });
+            }
+            _rebuilding = false;
+        }
+
+        internal void OnRowEnabledChanged(DictionarySourceRowViewModel row, bool enabled)
+        {
+            if (_rebuilding) return;
+            _prefs.SetEnabled(row.Id, enabled);
+            // Defer the row rebuild off the checkbox's own binding-write callback — mutating the bound
+            // ItemsSource from inside the originating write is the kind of re-entrancy Avalonia tolerates
+            // unreliably. The next dispatcher turn refreshes the last-enabled guard on every row. (Fable LOW-6)
+            Dispatcher.UIThread.Post(RebuildRows);
+        }
+
+        internal void MoveRow(DictionarySourceRowViewModel row, int delta)
+        {
+            _prefs.Move(row.Id, delta);
+            RebuildRows();
+        }
+    }
+
+    /// <summary>One source row in the Dictionary → Sources editor (#479).</summary>
+    public class DictionarySourceRowViewModel : ViewModelBase
+    {
+        private readonly DictionarySourceSettingsViewModel _parent;
+        private bool _enabled;
+
+        public string Id { get; }
+        public string DisplayName { get; }
+        public bool CanDisable { get; init; } = true;
+        public bool CanMoveUp { get; init; }
+        public bool CanMoveDown { get; init; }
+
+        public ReactiveCommand<Unit, Unit> MoveUpCommand { get; }
+        public ReactiveCommand<Unit, Unit> MoveDownCommand { get; }
+
+        public DictionarySourceRowViewModel(DictionarySourceSettingsViewModel parent, string id, string displayName, bool enabled)
+        {
+            _parent = parent;
+            Id = id;
+            DisplayName = displayName;
+            _enabled = enabled;   // set the field directly so rebuilding rows never re-enters SetEnabled
+            MoveUpCommand = ReactiveCommand.Create(() => _parent.MoveRow(this, -1));
+            MoveDownCommand = ReactiveCommand.Create(() => _parent.MoveRow(this, +1));
+        }
+
+        public bool Enabled
+        {
+            get => _enabled;
+            set
+            {
+                if (_enabled == value) return;
+                this.RaiseAndSetIfChanged(ref _enabled, value);
+                _parent.OnRowEnabledChanged(this, value);
             }
         }
     }

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -355,6 +355,47 @@
                             </StackPanel>
                         </DataTemplate>
 
+                        <!-- Dictionary Template (#479): Sources (enable/order) + Updates, folded into one category -->
+                        <DataTemplate DataType="vm:DictionaryCategoryViewModel">
+                            <StackPanel>
+                                <!-- Sources group: which dictionaries show in the panel picker, and their order -->
+                                <Border Classes="SettingGroup">
+                                    <StackPanel DataContext="{Binding Sources}">
+                                        <TextBlock Text="Sources" Classes="SettingLabel"/>
+                                        <TextBlock Text="Choose which dictionaries appear in the dictionary panel and their order. The first enabled source is the default. Uncheck a source to hide it; use the arrows to reorder."
+                                                  Classes="SettingDescription"/>
+
+                                        <ItemsControl ItemsSource="{Binding Rows}" Margin="0,10,0,0">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto" Margin="0,3">
+                                                        <CheckBox Grid.Column="0"
+                                                                 IsChecked="{Binding Enabled}"
+                                                                 IsEnabled="{Binding CanDisable}"
+                                                                 Content="{Binding DisplayName}"
+                                                                 VerticalAlignment="Center"/>
+                                                        <Button Grid.Column="2" Content="&#x25B2;"
+                                                               Command="{Binding MoveUpCommand}"
+                                                               IsEnabled="{Binding CanMoveUp}"
+                                                               Padding="8,2" Margin="0,0,4,0"
+                                                               ToolTip.Tip="Move up"/>
+                                                        <Button Grid.Column="3" Content="&#x25BC;"
+                                                               Command="{Binding MoveDownCommand}"
+                                                               IsEnabled="{Binding CanMoveDown}"
+                                                               Padding="8,2"
+                                                               ToolTip.Tip="Move down"/>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </Border>
+
+                                <!-- Updates group: reuse the DpdUpdateSettingsViewModel template as-is -->
+                                <ContentControl Content="{Binding Updates}"/>
+                            </StackPanel>
+                        </DataTemplate>
+
                         <!-- AI Settings Template (#186) -->
                         <DataTemplate DataType="vm:AiSettingsViewModel">
                             <StackPanel>


### PR DESCRIPTION
Completes the dictionary-panel work from #466 by letting the user choose **which** dictionary sources appear in the panel picker and **in what order** (the deferred item 4 of #466). Builds on the registry-backed panel shipped in #482.

## What changed
- **New `DictionarySourcePreferenceService`** (shared singleton): the effective picker list = *enabled available sources in stored order*; a newly-installed source is appended **enabled**; **first enabled = default**. Applied only in this service + the panel VM — never in the registry/`/v1` path, so an agent still enumerates every installed source. Persists to `DictionaryDialogState.SourceOrder`.
- **Settings folded into one "Dictionary" category** (chosen over a second "Dictionary…" entry) with two groups: **Sources** (enable checkbox + ▲/▼ reorder) on top, the existing **Updates** settings below (reused as-is via a `ContentControl`).
- **`DictionaryViewModel`** consumes the preference: `Sources`/`LongestSourceName` rebuild **live** on the service's `Changed` event; a settings change re-defaults the selection to the first enabled source. `ApplyState()` re-reads the preference after `LoadStateAsync` (the VM is constructed during layout build, *before* state loads) — mirrors `SearchViewModel`, and fixes the saved order not appearing on launch.
- `DictionarySourcePreference.Enabled` is force-serialized (`[JsonIgnore(Condition = Never)]`) so a **disabled** source survives restart despite the state writer's global `WhenWritingDefault`.

## Testing
- 10 new `DictionarySourcePreferenceService` tests (ordering, newly-installed append, uninstalled-source retention, last-enabled-available guard, serialization round-trip).
- Full suite: **943 passed, 0 failed.**
- Fable review completed; all findings addressed (DO-NOT-SHIP disabled-persistence bug, selection-clearing on live disable, available-aware last-enabled guard, placeholder-preserving reorder).
- Manually verified: live reorder/enable updates the picker; order + selection persist across restart.

## Known limitations (non-blocking)
- Sources rows don't refresh if a dictionary is *installed* while Settings is open (reopening Settings picks it up — same next-launch semantics as the rest of the registry).
- The sole-enabled row greys its whole checkbox label.

## Deferred
- #479's optional **`LemmaId` → lemma-report link** (`cst-lemma:{id}`, ties to #368) — separable follow-up, not in this PR.

Base: #466 / #482.
