### PR TITLE
#44: Recent Books (MRU) — File → Open Recent menu + open/close tracking

### DIFF
--- a/src/CST.Avalonia.Tests/Services/RecentBooksServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/RecentBooksServiceTests.cs
@@ -1,0 +1,166 @@
+using System.Linq;
+using CST;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Conversion;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// The recently-opened-books (MRU) list (#44): promote-on-open (de-duplicated), cap by MaxRecentBooks
+/// (0 = disabled), clear, and trim-on-shrink. Backed by ApplicationState.Preferences.RecentBooks.
+/// </summary>
+public sealed class RecentBooksServiceTests
+{
+    private static Book Bk(int index, string file, string nav = "") =>
+        new() { Index = index, FileName = file, LongNavPath = nav };
+
+    private static (RecentBooksService svc, ApplicationState state) Build(int max = 10)
+    {
+        var state = new ApplicationState();
+        state.Preferences.MaxRecentBooks = max;
+        var mock = new Mock<IApplicationStateService>();
+        mock.SetupGet(s => s.Current).Returns(state);
+        return (new RecentBooksService(mock.Object), state);
+    }
+
+    [Fact]
+    public void Record_puts_the_newest_book_first()
+    {
+        var (svc, _) = Build();
+        svc.Record(Bk(1, "a.xml"));
+        svc.Record(Bk(2, "b.xml"));
+        svc.Record(Bk(3, "c.xml"));
+
+        Assert.Equal(new[] { 3, 2, 1 }, svc.Items.Select(i => i.BookIndex));
+    }
+
+    [Fact]
+    public void Re_opening_a_book_promotes_it_without_duplicating()
+    {
+        var (svc, _) = Build();
+        svc.Record(Bk(1, "a.xml"));
+        svc.Record(Bk(2, "b.xml"));
+        svc.Record(Bk(1, "a.xml"));   // re-open the first
+
+        Assert.Equal(new[] { 1, 2 }, svc.Items.Select(i => i.BookIndex));
+        Assert.Single(svc.Items, i => i.BookIndex == 1);
+    }
+
+    [Fact]
+    public void The_list_is_capped_at_MaxRecentBooks()
+    {
+        var (svc, _) = Build(max: 3);
+        for (int i = 1; i <= 5; i++)
+            svc.Record(Bk(i, $"{i}.xml"));
+
+        Assert.Equal(new[] { 5, 4, 3 }, svc.Items.Select(i => i.BookIndex));
+    }
+
+    [Fact]
+    public void Max_of_zero_disables_the_list()
+    {
+        var (svc, _) = Build(max: 0);
+        svc.Record(Bk(1, "a.xml"));
+        svc.Record(Bk(2, "b.xml"));
+
+        Assert.Empty(svc.Items);
+    }
+
+    [Fact]
+    public void Setting_max_to_zero_clears_a_pre_existing_list_on_the_next_record()
+    {
+        var (svc, state) = Build(max: 10);
+        svc.Record(Bk(1, "a.xml"));
+        svc.Record(Bk(2, "b.xml"));
+
+        state.Preferences.MaxRecentBooks = 0;   // disabled after the fact
+        svc.Record(Bk(3, "c.xml"));
+
+        Assert.Empty(svc.Items);
+    }
+
+    [Fact]
+    public void Record_null_is_a_safe_no_op()
+    {
+        var (svc, _) = Build();
+        svc.Record(null!);
+        Assert.Empty(svc.Items);
+    }
+
+    [Fact]
+    public void Re_opening_a_book_whose_index_shifted_promotes_by_filename_without_duplicating()
+    {
+        // A persisted entry from an older corpus (index 1, a.xml); the same file now has a different index.
+        var (svc, _) = Build();
+        svc.Record(Bk(1, "a.xml"));
+        svc.Record(Bk(7, "a.xml"));   // same file, new index
+
+        Assert.Single(svc.Items, i => i.BookFileName == "a.xml");
+        Assert.Equal(7, svc.Items[0].BookIndex);
+    }
+
+    [Fact]
+    public void Clear_empties_the_list_and_raises_Changed_once()
+    {
+        var (svc, _) = Build();
+        svc.Record(Bk(1, "a.xml"));
+        var changed = 0;
+        svc.Changed += (_, _) => changed++;
+
+        svc.Clear();
+        Assert.Empty(svc.Items);
+        Assert.Equal(1, changed);
+
+        svc.Clear();                 // already empty — no-op
+        Assert.Equal(1, changed);
+    }
+
+    [Fact]
+    public void TrimToMax_shrinks_the_list_when_the_cap_is_lowered()
+    {
+        var (svc, state) = Build(max: 10);
+        for (int i = 1; i <= 5; i++)
+            svc.Record(Bk(i, $"{i}.xml"));
+
+        state.Preferences.MaxRecentBooks = 2;   // user lowers the cap in Settings
+        svc.TrimToMax();
+
+        Assert.Equal(new[] { 5, 4 }, svc.Items.Select(i => i.BookIndex));
+    }
+
+    [Fact]
+    public void Record_marks_state_dirty()
+    {
+        var state = new ApplicationState();
+        var mock = new Mock<IApplicationStateService>();
+        mock.SetupGet(s => s.Current).Returns(state);
+        var svc = new RecentBooksService(mock.Object);
+
+        svc.Record(Bk(1, "a.xml"));
+
+        mock.Verify(s => s.MarkDirty(), Times.Once);
+    }
+
+    [Fact]
+    public void DisplayName_uses_the_last_nav_segment_converted_to_the_target_script()
+    {
+        // LongNavPath is stored in Devanagari; the label converts to the requested script (capitalized),
+        // matching a book tab's title.
+        var deva = ScriptConverter.Convert("dīghanikāyo", Script.Latin, Script.Devanagari);
+        var book = Bk(1, "s0101m.mul.xml", nav: "Something/" + deva);
+
+        var latn = RecentBooksService.DisplayName(book, Script.Latin);
+
+        Assert.Equal("Dīghanikāyo", latn);
+    }
+
+    [Fact]
+    public void DisplayName_falls_back_to_the_filename_when_no_nav_path()
+    {
+        var book = Bk(1, "s0101m.mul.xml");
+        Assert.Equal("s0101m.mul", RecentBooksService.DisplayName(book, Script.Latin));
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -69,6 +69,9 @@ public partial class App : Application
     // change title, or change activation. macOS shows the menu bar of the active window, so every window
     // carries its own copy of the (identical) list.
     private readonly Dictionary<Window, NativeMenu> _windowMenus = new();
+    // #44: each window's File → "Open Recent" submenu, repopulated from the MRU list on any change.
+    private readonly Dictionary<Window, NativeMenu> _recentMenus = new();
+    private bool _recentBooksSubscribed;
 
     public override void Initialize()
     {
@@ -615,6 +618,10 @@ public partial class App : Application
             var dictionaryViewModel = ServiceProvider?.GetService<DictionaryViewModel>();
             dictionaryViewModel?.ApplyState();
         });
+
+        // #44: the recent-books menu reads the (now-loaded) persisted MRU list; refresh it so the saved list
+        // shows on launch even if the window's menu was registered before this load finished.
+        Dispatcher.UIThread.Post(RebuildRecentMenus);
         
         // Restore main window state (dimensions, position, etc.) - MUST be on UI thread
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop &&
@@ -1056,6 +1063,8 @@ public partial class App : Application
         services.AddSingleton<IFontService, FontService>();
         services.AddSingleton<IApplicationStateService, ApplicationStateService>();
         services.AddSingleton<ChapterListsService>();
+        // Recently-opened-books (MRU) list backing the File → Open Recent menu (#44).
+        services.AddSingleton<RecentBooksService>();
         // services.AddSingleton<IBookService, BookService>();
         services.AddSingleton<ISearchService, SearchService>();
         // The single "present the reader in context" command shared by every surface (#187).
@@ -1203,6 +1212,9 @@ public partial class App : Application
             // #284: register the main window's "Window" submenu (declared empty in XAML) and fill the list.
             RegisterWindowMenu(MainWindow);
             RebuildWindowMenus();
+            // #44: register the main window's "Open Recent" submenu and fill it from the MRU list.
+            RegisterRecentMenu(MainWindow);
+            RebuildRecentMenus();
         }
     }
 
@@ -1335,6 +1347,8 @@ public partial class App : Application
 
             var fileMenu = new NativeMenu();
             fileMenu.Add(selectBookMenuItem);
+            // #44: this window's "Open Recent" submenu (populated by RebuildRecentMenus below).
+            fileMenu.Add(new NativeMenuItem { Header = "Open Recent", Menu = new NativeMenu() });
             fileMenu.Add(new NativeMenuItemSeparator());
             fileMenu.Add(closeTabItem);
 
@@ -1349,6 +1363,9 @@ public partial class App : Application
             // Register + populate the Window list (this new window now also appears in every window's list).
             RegisterWindowMenu(window);
             RebuildWindowMenus();
+            // #44: register + populate this window's Open Recent submenu.
+            RegisterRecentMenu(window);
+            RebuildRecentMenus();
 
             Log.Information("Floating window menu built - tracked toggle items: {SelectBookCount} select-book, {SearchCount} search",
                 _selectBookMenuItems.Count, _searchMenuItems.Count);
@@ -1461,6 +1478,135 @@ public partial class App : Application
         catch (Exception ex)
         {
             Log.Warning(ex, "Failed to activate window from Window menu");
+        }
+    }
+
+    // ===== #44: File → "Open Recent" menu (recently-opened-books MRU) =====
+    // Each window carries an "Open Recent" submenu under File (macOS shows the active window's menu bar).
+    // It is repopulated from the shared RecentBooksService whenever the MRU list changes, or the display
+    // script changes (labels are script-aware, like book tabs).
+
+    // Locate a window's "Open Recent" submenu (nested under File), register it for population, and drop it
+    // when the window closes. Subscribes once to the list/script change signals.
+    private void RegisterRecentMenu(Window owner)
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+        var menu = NativeMenu.GetMenu(owner);
+        var fileItem = menu?.OfType<NativeMenuItem>().FirstOrDefault(i => (i.Header as string) == "File");
+        var recentItem = (fileItem?.Menu)?.OfType<NativeMenuItem>().FirstOrDefault(i => (i.Header as string) == "Open Recent");
+        if (recentItem?.Menu is not NativeMenu submenu) return;
+
+        _recentMenus[owner] = submenu;
+        owner.Closed += (_, _) => _recentMenus.Remove(owner);
+
+        if (!_recentBooksSubscribed)
+        {
+            var recent = ServiceProvider?.GetService<RecentBooksService>();
+            if (recent != null)
+            {
+                // Latch only after a successful subscribe, so an (unexpected) early null resolution doesn't
+                // permanently wedge the menus to window-create-only refreshes. (Fable LOW-2)
+                _recentBooksSubscribed = true;
+                recent.Changed += (_, _) => Dispatcher.UIThread.Post(RebuildRecentMenus);
+                var scriptService = ServiceProvider?.GetService<IScriptService>();
+                if (scriptService != null)
+                    scriptService.ScriptChanged += _ => Dispatcher.UIThread.Post(RebuildRecentMenus);
+            }
+        }
+    }
+
+    // Repopulate every registered "Open Recent" submenu from the current MRU list. Called on list/script
+    // change, window-create, and once after state has loaded.
+    private void RebuildRecentMenus()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+        try
+        {
+            var recent = ServiceProvider?.GetService<RecentBooksService>();
+            if (recent == null) return;
+            var script = ServiceProvider?.GetService<IScriptService>()?.CurrentScript ?? Script.Latin;
+            var items = recent.Items.ToList();
+            foreach (var submenu in _recentMenus.Values.ToList())
+                PopulateRecentMenu(submenu, items, script);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to rebuild Open Recent menus");
+        }
+    }
+
+    private void PopulateRecentMenu(NativeMenu submenu, List<RecentBookItem> items, Script script)
+    {
+        submenu.Items.Clear();
+
+        if (items.Count == 0)
+        {
+            submenu.Add(new NativeMenuItem { Header = "No Recent Books", IsEnabled = false });
+            return;
+        }
+
+        foreach (var item in items)
+        {
+            var menuItem = new NativeMenuItem { Header = RecentLabel(item, script) };
+            menuItem.Click += (_, _) => OpenRecentBook(item);   // per-iteration capture (C# 5+)
+            submenu.Add(menuItem);
+        }
+
+        submenu.Add(new NativeMenuItemSeparator());
+        var clear = new NativeMenuItem { Header = "Clear Menu" };
+        clear.Click += (_, _) => ServiceProvider?.GetService<RecentBooksService>()?.Clear();
+        submenu.Add(clear);
+    }
+
+    // A live, current-script label from the resolved book (matching its tab title); falls back to the label
+    // stored when it was recorded, then the filename.
+    private static string RecentLabel(RecentBookItem item, Script script)
+    {
+        try
+        {
+            if (item.BookIndex >= 0 && item.BookIndex < Books.Inst.Count)
+            {
+                var book = Books.Inst[item.BookIndex];
+                if (book.FileName == item.BookFileName)
+                    return RecentBooksService.DisplayName(book, script);
+            }
+        }
+        catch { /* fall through to the stored name */ }
+        return string.IsNullOrEmpty(item.DisplayName) ? item.BookFileName : item.DisplayName;
+    }
+
+    // Open a recent book in the main window. Resolves by index (validated against filename) then by filename,
+    // so a stale entry from a changed corpus is skipped rather than opening the wrong text.
+    private void OpenRecentBook(RecentBookItem item)
+    {
+        try
+        {
+            Book? book = null;
+            if (item.BookIndex >= 0 && item.BookIndex < Books.Inst.Count)
+            {
+                var candidate = Books.Inst[item.BookIndex];
+                if (candidate.FileName == item.BookFileName)
+                    book = candidate;
+            }
+            if (book == null && !string.IsNullOrEmpty(item.BookFileName))
+            {
+                try { book = Books.Inst[item.BookFileName]; } catch { book = null; }
+            }
+            if (book == null)
+            {
+                Log.Warning("Recent book no longer resolvable: {BookFile} (index {Index})", item.BookFileName, item.BookIndex);
+                return;
+            }
+
+            if (MainWindow?.DataContext is LayoutViewModel layoutViewModel)
+            {
+                ActivateWindow(MainWindow);
+                layoutViewModel.OpenBook(book);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to open recent book {BookFile}", item.BookFileName);
         }
     }
 

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -351,6 +351,21 @@ namespace CST.Avalonia.Services
         
         // Returns TRUE when the book was actually opened, FALSE when the duplicate-suppression window
         // swallowed it — so a non-UI caller (the #187 present-tool) can't report a false success.
+        // Record a genuine (user-initiated) book open into the recent-books MRU list (#44). Best-effort:
+        // a failure here must never break opening a book. Session-RESTORE opens are excluded by the caller
+        // (OpenBook only records when windowId == null, i.e. a fresh open, not a restored one).
+        private static void TryRecordRecent(CST.Book book)
+        {
+            try
+            {
+                App.ServiceProvider?.GetService<RecentBooksService>()?.Record(book);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to record recent book {BookFile}", book?.FileName);
+            }
+        }
+
         public bool OpenBookInNewTab(CST.Book book, List<string> searchTerms, List<TermPosition> positions)
         {
             _logger.Information("Opening book from search: {BookFile} with {SearchTermCount} search terms and {PositionCount} positions",
@@ -372,6 +387,8 @@ namespace CST.Avalonia.Services
                 _lastSearchOpenTime = now;
                 _lastSearchOpenedBook = book.FileName;
             }
+
+            TryRecordRecent(book);   // a search-result open is a genuine user open (#44)
 
             // Get required services from DI container
             var scriptService = App.ServiceProvider?.GetRequiredService<IScriptService>();
@@ -493,8 +510,13 @@ namespace CST.Avalonia.Services
                     _lastRegularOpenTime = now;
                     _lastRegularOpenedBook = book.FileName;
                 }
+
+                // Record only fresh opens (windowId == null) — session RESTORE passes a windowId and must not
+                // reshuffle the MRU on every launch. Inside this block so a duplicate open (returned above)
+                // isn't recorded. (#44)
+                TryRecordRecent(book);
             }
-            
+
             // Allow multiple copies of the same book to be opened
             // This is useful for comparing the same text in different scripts
             
@@ -1547,6 +1569,11 @@ namespace CST.Avalonia.Services
                 // close path, not the recycled detach/reorder path.)
                 if (dockable is BookDisplayViewModel closedBookVm)
                 {
+                    // Closing a book you were reading is a strong "recent" signal — promote it to the top of
+                    // the MRU (Record de-dupes, so it just moves up). This is the real close path (not the
+                    // recycled tab-switch/float-detach path), so it won't fire spuriously. (#44)
+                    TryRecordRecent(closedBookVm.Book);
+
                     _goToSubscribedBooks.Remove(closedBookVm.Id);
                     // Release the recycled View's CEF WebView and drop the cache entry, or the closed
                     // tab leaks a live browser + its rendered DOM + HtmlContent for the session. (BOOK-1)

--- a/src/CST.Avalonia/Services/RecentBooksService.cs
+++ b/src/CST.Avalonia/Services/RecentBooksService.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Conversion;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// The recently-opened-books (MRU) list (#44). Backs the File → "Open Recent" menu. A single shared
+/// instance records each user-opened book and exposes the list; the menu rebuilds on <see cref="Changed"/>.
+///
+/// The list lives in <see cref="ApplicationPreferences.RecentBooks"/> (persisted with the rest of app state);
+/// <see cref="ApplicationPreferences.MaxRecentBooks"/> caps it, and a value of 0 disables the list entirely.
+/// </summary>
+public sealed class RecentBooksService
+{
+    private readonly IApplicationStateService _state;
+
+    /// <summary>Raised after the MRU list changes, so the (per-window) native menus can rebuild.</summary>
+    public event EventHandler? Changed;
+
+    public RecentBooksService(IApplicationStateService state) => _state = state;
+
+    private ApplicationPreferences Prefs => _state.Current.Preferences;
+
+    /// <summary>The MRU list, most-recent first.</summary>
+    public IReadOnlyList<RecentBookItem> Items => Prefs.RecentBooks;
+
+    /// <summary>
+    /// Record a book as just-opened: move it to the front (de-duplicating by book index), stamp the time,
+    /// and trim to <see cref="ApplicationPreferences.MaxRecentBooks"/>. When the cap is 0 the feature is
+    /// disabled — the list is cleared and stays empty.
+    /// </summary>
+    public void Record(CST.Book book)
+    {
+        if (book == null)
+            return;
+
+        var list = Prefs.RecentBooks;
+        // Promote, not duplicate. Match by index OR filename so a corpus reindex (indices shift between
+        // releases) can't leave a stale twin of the same file. (Fable LOW-3)
+        list.RemoveAll(r => r != null
+            && (r.BookIndex == book.Index
+                || (!string.IsNullOrEmpty(book.FileName) && r.BookFileName == book.FileName)));
+
+        var max = Prefs.MaxRecentBooks;
+        if (max <= 0)
+        {
+            // Disabled: don't grow the list. Clear only if it held stale entries (avoids a spurious Changed).
+            if (list.Count > 0) { list.Clear(); MarkChanged(); }
+            return;
+        }
+
+        list.Insert(0, new RecentBookItem
+        {
+            BookIndex = book.Index,
+            BookFileName = book.FileName ?? string.Empty,
+            DisplayName = DisplayName(book),
+            LastOpened = DateTime.UtcNow
+        });
+        if (list.Count > max)
+            list.RemoveRange(max, list.Count - max);
+
+        MarkChanged();
+    }
+
+    /// <summary>Empty the MRU list (the menu's "Clear Menu" item).</summary>
+    public void Clear()
+    {
+        if (Prefs.RecentBooks.Count == 0)
+            return;
+        Prefs.RecentBooks.Clear();
+        MarkChanged();
+    }
+
+    /// <summary>Trim the list to the current cap (e.g. after the user lowers MaxRecentBooks in Settings).
+    /// A cap of 0 clears it. Raises <see cref="Changed"/> only if something was removed.</summary>
+    public void TrimToMax()
+    {
+        var list = Prefs.RecentBooks;
+        var max = Math.Max(0, Prefs.MaxRecentBooks);
+        if (list.Count <= max)
+            return;
+        list.RemoveRange(max, list.Count - max);
+        MarkChanged();
+    }
+
+    private void MarkChanged()
+    {
+        _state.MarkDirty();   // persist via the state timer/shutdown save (STATE-2), like the other prefs
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// The menu label for a book, matching a book tab's title: the last segment of <c>LongNavPath</c>
+    /// converted from Devanagari to <paramref name="script"/> (capitalized), falling back to the filename.
+    /// (Kept in sync with BookDisplayViewModel.GetBookDisplayName.)
+    /// </summary>
+    public static string DisplayName(CST.Book book, Script script = Script.Latin)
+    {
+        if (book == null)
+            return string.Empty;
+        if (!string.IsNullOrEmpty(book.LongNavPath))
+        {
+            var parts = book.LongNavPath.Split('/');
+            var name = parts[^1];
+            return script != Script.Devanagari
+                ? ScriptConverter.Convert(name, Script.Devanagari, script, true)
+                : name;
+        }
+        return !string.IsNullOrEmpty(book.FileName)
+            ? Path.GetFileNameWithoutExtension(book.FileName)
+            : "Unknown Book";
+    }
+}

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -679,7 +679,10 @@ namespace CST.Avalonia.ViewModels
     {
         private readonly ILogger _logger;
         private readonly ISettingsService _settingsService;
+        private readonly IApplicationStateService? _stateService;
+        private readonly Services.RecentBooksService? _recentBooks;
         private bool _useHardwareAcceleration;
+        private int _maxRecentBooks;
 
         public ConfigurationSettingsViewModel(ISettingsService settingsService)
         {
@@ -688,7 +691,38 @@ namespace CST.Avalonia.ViewModels
             _useHardwareAcceleration = settingsService.Settings.UseHardwareAcceleration;
             SettingsFilePath = settingsService.GetSettingsFilePath();
             OpenSettingsFileCommand = ReactiveCommand.Create(OpenSettingsFile);
+
+            // Recent-books (MRU) size + clear (#44). MaxRecentBooks lives in ApplicationState.Preferences, not
+            // the settings file, so resolve those services from the container (this VM is constructed directly).
+            _stateService = App.ServiceProvider?.GetService<IApplicationStateService>();
+            _recentBooks = App.ServiceProvider?.GetService<Services.RecentBooksService>();
+            _maxRecentBooks = _stateService?.Current.Preferences.MaxRecentBooks ?? 10;
+            ClearRecentBooksCommand = ReactiveCommand.Create(() => _recentBooks?.Clear());
         }
+
+        /// <summary>How many recently-opened books the File → Open Recent menu remembers (#44). 0 disables the
+        /// list. Persists to ApplicationState.Preferences and trims the current list immediately.</summary>
+        public int MaxRecentBooks
+        {
+            get => _maxRecentBooks;
+            set
+            {
+                var clamped = Math.Max(0, value);
+                if (clamped == _maxRecentBooks)
+                    return;   // no spurious dirty-mark on an unchanged value (Fable NIT-8)
+                this.RaiseAndSetIfChanged(ref _maxRecentBooks, clamped);
+                if (_stateService != null)
+                {
+                    _stateService.Current.Preferences.MaxRecentBooks = clamped;
+                    _stateService.MarkDirty();
+                    // The new cap is enforced as books are opened (and by the state validator on load). We do
+                    // NOT trim the stored list here: nudging the number down then back up while experimenting
+                    // must not irreversibly delete history. (Fable MEDIUM-1)
+                }
+            }
+        }
+
+        public ReactiveCommand<Unit, Unit> ClearRecentBooksCommand { get; }
 
         // Hardware acceleration for the embedded WebView. OFF forces software compositing, avoiding the CEF
         // off-screen-rendering "black view" stall seen under some GPUs / virtualized drivers on Windows. Applied

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -243,6 +243,25 @@
                                     </StackPanel>
                                 </Border>
 
+                                <!-- Recent Books MRU (#44) -->
+                                <Border Classes="SettingGroup">
+                                    <StackPanel>
+                                        <TextBlock Text="Recent Books" Classes="SettingLabel"/>
+                                        <TextBlock Text="The File → Open Recent menu lists books you have recently opened. Set how many it remembers (0 turns the list off)."
+                                                  Classes="SettingDescription" TextWrapping="Wrap"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,10,0,0" Spacing="10">
+                                            <TextBlock Text="Books to remember:" VerticalAlignment="Center"/>
+                                            <NumericUpDown Value="{Binding MaxRecentBooks}"
+                                                          Minimum="0" Maximum="50" Increment="1"
+                                                          FormatString="0" Width="120"/>
+                                            <Button Content="Clear List"
+                                                   Command="{Binding ClearRecentBooksCommand}"
+                                                   VerticalAlignment="Center"
+                                                   ToolTip.Tip="Empty the recent-books list now"/>
+                                        </StackPanel>
+                                    </StackPanel>
+                                </Border>
+
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
                                         <TextBlock Text="Configuration" Classes="SettingLabel"/>

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -18,6 +18,10 @@
                     <!-- #111: ⌘O reveals the book tree and focuses it; it never hides the panel
                          (the View menu checkbox does that). CST4's Ctrl+O opened the book dialog. -->
                     <NativeMenuItem Header="Select a Book" Click="OnSelectBookClick" Gesture="cmd+o" />
+                    <!-- #44: populated at runtime from the recent-books MRU list by App.RebuildRecentMenus -->
+                    <NativeMenuItem Header="Open Recent">
+                        <NativeMenu />
+                    </NativeMenuItem>
                     <NativeMenuItemSeparator />
                     <NativeMenuItem Header="Close Tab" Click="OnCloseTabClick" Gesture="cmd+w" />
                 </NativeMenu>


### PR DESCRIPTION
Implements #44: a recently-opened-books (MRU) list, surfaced as a dynamic **File → Open Recent** submenu on the main window and every floating window (mirrors the existing #284 Window-menu pattern).

## What changed
- **New `RecentBooksService`** (singleton): promote-to-front, de-duped by book index **or** filename (so a corpus reindex can't leave a stale twin); capped by `MaxRecentBooks` (0 = disabled); `Clear` / `TrimToMax`. Backed by the existing `ApplicationState.Preferences.RecentBooks`, persisted via `MarkDirty`. Menu labels are **script-aware** (last nav segment converted to the current script), matching book tab titles.
- **Open-tracking** in `CstDockFactory`: a book is recorded when **opened** (search results, fresh tree / Go To / linked Aṭṭhakathā–Ṭīkā opens) and when **closed** (`CloseDockable` — the real close path, not tab-switch/float/reorder), so a book you were reading is promoted on close too. **Session-restore is excluded** (`windowId != null`), and **app-quit doesn't reshuffle** (state is saved without going through `CloseDockable`).
- **The menu**: per-window "Open Recent" submenu, rebuilt on open/clear/script-change and once after state loads; clicking an entry opens it in the main window (a stale entry is skipped, not mis-opened); ends with a separator + **Clear Menu**.
- **Setting**: Settings → Configuration → **Recent Books** — "Books to remember" (0–50, enforced as books are opened and by the load-time validator, **not** destructively on each edit) and a **Clear List** button.

## Testing
- 12 new `RecentBooksService` tests (promote/de-dup by index & filename, cap, 0-disable, clear idempotence, trim-on-shrink, dirty-marking, `Record(null)` no-op, script-aware label + filename fallback).
- Full suite: **955 passed, 0 failed.**
- Fable-reviewed: **no shippable blockers**. Addressed MEDIUM (non-destructive cap — nudging the number down then back up no longer deletes history), LOW (filename-based dedup; latch the menu subscription only after it succeeds), and NITs (guard dirty-mark on unchanged value; `RebuildRecentMenus` private; redundant capture).
- Manually verified: open/close promote to top; Clear (menu + settings); count trim; persistence across restart without restored books reshuffling; floating-window Open Recent.

## Conscious design choices (consistent with the app)
- Clicking a recent entry opens a fresh copy rather than focusing an existing tab (the app's multi-copy policy, used for script comparison).
- On non-macOS the submenu is inert (same `IsMacOS()` guard as the #284 Window menu; those platforms are untested).

Closes #44.
