### PR TITLE
#83: remove dead duplicate FindParentDock(IDockable) overload

### DIFF
--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1200,38 +1200,7 @@ namespace CST.Avalonia.Services
                 Log.Error(ex, "*** Error in SetEqualProportions ***");
             }
         }
-        
-        /// <summary>
-        /// Find the parent dock of a given dockable
-        /// </summary>
-        private IDock? FindParentDock(IDockable target)
-        {
-            if (_context is not RootDock rootDock)
-                return null;
-                
-            return FindParentDockRecursive(rootDock, target);
-        }
-        
-        private IDock? FindParentDockRecursive(IDock dock, IDockable target)
-        {
-            if (dock.VisibleDockables?.Contains(target) == true)
-            {
-                return dock;
-            }
-            
-            if (dock.VisibleDockables != null)
-            {
-                foreach (var child in dock.VisibleDockables.OfType<IDock>())
-                {
-                    var found = FindParentDockRecursive(child, target);
-                    if (found != null)
-                        return found;
-                }
-            }
-            
-            return null;
-        }
-        
+
         /// <summary>
         /// Replace a child dockable in a parent dock
         /// </summary>


### PR DESCRIPTION
Resolves #83 after re-evaluating its three claims against the current code (Fable-confirmed).

## Disposition of the three claims
- **Item 3 (fragile `Task.Delay` float/unfloat, "6-step") — stale.** #476 (drag-to-float) deleted the `FloatDockableWithoutRecycling`/`UnfloatDockableWithoutRecycling` methods + the buttons; float is now the `SplitToWindow` override + dispose-before-move. The current `FloatDockable` just calls `base` + `CleanupEmptySplits`; no delays. (The lone `Task.Delay(50)` is an unrelated defensive tool-misdrop handler.)
- **Item 1 (10-iteration cleanup cap) — benign, kept.** `CleanupEmptySplits` exits on `count == 0`; the cap only fires on non-progress, which is provably excluded (spine/LeftTools are filtered before flagging; removal is deepest-first with parent chains intact). It's a correct never-fires backstop.
- **Item 2 (uncached O(n·h) parent-dock search) — the real content was a dead duplicate, now removed.** Two overloads existed: the complete `FindParentDock(IDock)` (main + floating) and a dead `FindParentDock(IDockable)` (main-only). Both live callers pass `IDock` → bind to the complete one. This PR deletes the dead `(IDockable)` overload + its recursive helper. The surviving search runs on discrete user actions over a tiny dock tree, so **caching is unwarranted** (would add a cache-invalidation hazard for no measurable gain).

## Change
Pure deletion of the dead pair (−31 lines). Compile-proven dead (both `private`, zero references). Full suite **969/969**.

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)