### PR TITLE
#496: fix ShutdownRequested re-entrancy — main-window close now quits the app

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -57,6 +57,11 @@ public partial class App : Application
     /// must be skipped. (DOCK-2)
     /// </summary>
     public static bool IsShuttingDown { get; private set; }
+    // Guards the ShutdownRequested handler against re-entrancy: desktop.Shutdown() re-raises ShutdownRequested,
+    // so without this the handler would cancel the very shutdown it just initiated (leaving the app alive with
+    // its menu bar) and re-run the save against a disposed ServiceProvider. 0 = not started, 1 = cleanup
+    // running, 2 = cleanup done (let shutdown proceed).
+    private int _shutdownState;
     private bool _hasRestoredInitialBooks = false;
 
     // Menu items for updating checkmarks across all windows
@@ -289,34 +294,58 @@ public partial class App : Application
                 desktop.TryShutdown();
             };
 
-            // Handle application shutdown to save state
+            // Handle application shutdown to save state. desktop.Shutdown() below RE-RAISES ShutdownRequested,
+            // so this handler is re-entrant and must be guarded (_shutdownState), or it cancels the very
+            // shutdown it initiated — the "close the main window and the app (menu) stays alive" regression.
             desktop.ShutdownRequested += async (sender, args) =>
             {
+                // Cleanup already finished — this is the re-raise from our own desktop.Shutdown(); let it
+                // proceed (do NOT cancel, do NOT re-save against the disposed ServiceProvider).
+                if (_shutdownState == 2)
+                {
+                    Log.Information("SHUTDOWN: cleanup already complete — allowing shutdown to proceed");
+                    return;
+                }
+
+                // Cleanup is in flight from an earlier request (e.g. a second window closing). Cancel this one;
+                // the in-flight sequence will finish and exit the app.
+                if (_shutdownState == 1)
+                {
+                    args.Cancel = true;
+                    return;
+                }
+
+                _shutdownState = 1;
                 Log.Information("SHUTDOWN: ShutdownRequested event triggered");
 
                 // From here on, window Closing events are part of shutdown, not user actions. (DOCK-2)
                 IsShuttingDown = true;
 
-                // Cancel shutdown temporarily to allow async save to complete
+                // Cancel THIS shutdown so the async save/dispose can complete before the process exits.
                 args.Cancel = true;
-                
+
+                var cleanupFailed = false;
                 try
                 {
                     await SaveApplicationStateAsync();
-                    
+
                     // Dispose ServiceProvider to trigger disposal of all singleton services
                     ServiceProvider?.Dispose();
-                    
+
                     Log.Information("SHUTDOWN: All cleanup completed, proceeding with shutdown");
-                    
-                    // Now allow shutdown to proceed
-                    desktop.Shutdown(0);
                 }
                 catch (Exception ex)
                 {
                     Log.Error(ex, "SHUTDOWN: Error during shutdown sequence");
-                    // Force shutdown even if save failed
-                    desktop.Shutdown(1);
+                    cleanupFailed = true;
+                }
+                finally
+                {
+                    // Cleanup done (or failed) — re-request shutdown; the re-raise hits the _shutdownState == 2
+                    // guard above and is allowed through, so the app actually exits exactly once. (On macOS the
+                    // OS re-raise ultimately drives exit code 0; the non-zero code still applies on Win/Linux.)
+                    _shutdownState = 2;
+                    desktop.Shutdown(cleanupFailed ? 1 : 0);
                 }
             };
         }


### PR DESCRIPTION
Fixes #496 — closing the main CST Reader window (or Quit) left the app running with its macOS menu bar.

## Root cause
`ShutdownMode` is `OnMainWindowClose`. The `desktop.ShutdownRequested` handler unconditionally set `args.Cancel = true` to run an async state save + `ServiceProvider.Dispose()`, then called `desktop.Shutdown(0)`. That shutdown **re-raises `ShutdownRequested`** — on macOS via the OS `applicationShouldTerminate` → `DoShutdown` path (hence the ~1.3 s delay seen in the logs). With **no re-entrancy guard**, the handler then:
1. cancelled the very shutdown it had just initiated (unconditional `args.Cancel`) → the process intermittently never exited; and
2. re-ran `SaveApplicationStateAsync()` against the already-disposed `ServiceProvider` → `ObjectDisposedException`.

Regression from #138 (XCUT-1), which introduced the cancel + async-save pattern (to stop racing the save against exit) without guarding the re-raise.

## Fix
A small `_shutdownState` state machine (0 = not started, 1 = cleanup running, 2 = done):
- **state 0** — run cleanup (save + dispose) exactly once; in `finally`, set state = 2 and re-request shutdown.
- **state 2** (the re-raise) — return **without** cancelling, so Avalonia proceeds to exit (its `Cancel` defaults to false); no second save against the disposed provider.
- **state 1** (a second request during the async cleanup, e.g. another window closing) — cancel it; the in-flight sequence finishes and exits.

Also preserves a non-zero exit code on cleanup failure (meaningful on Windows/Linux, where there's no OS re-raise to clobber it to 0).

## Verification
- **Manually confirmed**: red-button close of the main window **and** Cmd+Q both now quit cleanly (menu bar gone), including with a floating book window open.
- **Fable-reviewed against the actual Avalonia 11.3.6 lifetime source**: confirmed `ShutdownRequestedEventArgs.Cancel` defaults false (returning ⇒ proceed), the "re-raise" is the OS terminate path, state writes are correctly sequenced on the UI thread (`0→1` before the first `await`, `→2` before `Shutdown()`), the `ObjectDisposedException` is structurally eliminated, `IsShuttingDown`/DOCK-2 semantics are unchanged, and the guard can never block a legitimate shutdown. Verdict: safe to ship.
- Full suite: **969 passed, 0 failed** (no unit test covers window-close shutdown; this is a UI-lifecycle fix).

Out of scope (pre-existing, noted by review, not a regression from this change): the state save has no watchdog timeout, so a hung save could still stall shutdown — a separate hardening item.

Closes #496.
