### PR TITLE
#494: close-by-id now reaches a book in a floating window

### DIFF
--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryCloseBookTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryCloseBookTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CST.Avalonia.Services;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+// #494: close-by-id (CstDockFactory.CloseBook) must reach a book that lives in a FLOATING window, not just the
+// main window — the old path searched/removed main-window-only. A real CstHostWindow needs an Avalonia platform
+// the headless test host lacks, so we inject handcrafted floating layouts via the GetFloatingLayouts seam and
+// seed the main tree via _context. Uses plain Dock Documents (BookDisplayViewModel needs live services); the
+// book-specific CEF branches in CloseDockable are guarded and skipped for a plain Document.
+public class CstDockFactoryCloseBookTests
+{
+    private sealed class TestDockFactory : CstDockFactory
+    {
+        private readonly List<IDock> _floating = new();
+        public void SetFloatingLayouts(params IDock[] layouts) { _floating.Clear(); _floating.AddRange(layouts); }
+        internal override IEnumerable<IDock> GetFloatingLayouts() => _floating;
+    }
+
+    // A DocumentDock holding the given documents, with Owner wired (CloseDockable removes by Owner).
+    private static (RootDock root, DocumentDock dock) Window(string dockId, params Document[] docs)
+    {
+        var dock = new DocumentDock { Id = dockId, VisibleDockables = new ObservableCollection<IDockable>(docs) };
+        foreach (var d in docs) d.Owner = dock;
+        dock.ActiveDockable = docs.LastOrDefault();
+        var root = new RootDock { Id = dockId + "Root", VisibleDockables = new ObservableCollection<IDockable> { dock } };
+        dock.Owner = root;
+        return (root, dock);
+    }
+
+    private static Document Doc(string id, bool canClose = true) => new() { Id = id, CanClose = canClose };
+
+    [Fact]
+    public void CloseBook_removes_a_book_in_a_floating_window()
+    {
+        var f = new TestDockFactory();
+        var a = Doc("floatBook"); var b = Doc("otherBook");
+        var (floatRoot, floatDock) = Window("FloatDock", a, b);
+        floatDock.ActiveDockable = a;   // close the ACTIVE doc, so the neighbor-reactivation branch actually runs
+        f._context = new RootDock { Id = "MainRoot", VisibleDockables = new ObservableCollection<IDockable>() };  // main has no such book
+        f.SetFloatingLayouts(floatRoot);
+
+        f.CloseBook("floatBook");
+
+        Assert.DoesNotContain(a, floatDock.VisibleDockables);          // removed from the FLOATING dock
+        Assert.Contains(b, floatDock.VisibleDockables);                // sibling untouched
+        Assert.Equal(b, floatDock.ActiveDockable);                     // sibling activated after the active doc closed
+    }
+
+    [Fact]
+    public void CloseBook_removes_a_book_in_the_main_window()
+    {
+        var f = new TestDockFactory();
+        var a = Doc("mainBook"); var b = Doc("otherBook");
+        var (mainRoot, mainDock) = Window("MainDock", a, b);
+        f._context = mainRoot;
+
+        f.CloseBook("mainBook");
+
+        Assert.DoesNotContain(a, mainDock.VisibleDockables);
+        Assert.Contains(b, mainDock.VisibleDockables);
+    }
+
+    [Fact]
+    public void CloseBook_is_a_no_op_for_an_unknown_id()
+    {
+        var f = new TestDockFactory();
+        var (mainRoot, mainDock) = Window("MainDock", Doc("book1"));
+        f._context = mainRoot;
+
+        f.CloseBook("does-not-exist");   // must not throw
+
+        Assert.Single(mainDock.VisibleDockables);
+    }
+
+    [Fact]
+    public void CloseBook_refuses_a_non_closable_dockable()
+    {
+        // CanClose=false (e.g. the Welcome tab) must survive — the old raw-remove path would have ripped it out.
+        var f = new TestDockFactory();
+        var welcome = Doc("WelcomeDocument", canClose: false);
+        var (mainRoot, mainDock) = Window("MainDock", welcome, Doc("book1"));
+        f._context = mainRoot;
+
+        f.CloseBook("WelcomeDocument");
+
+        Assert.Contains(welcome, mainDock.VisibleDockables);   // still present
+    }
+}

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -28,7 +28,7 @@ namespace CST.Avalonia.Services
 {
     public class CstDockFactory : Factory
     {
-        private object? _context;
+        internal object? _context;   // the root layout; internal so tests can seed a handcrafted main tree (#494)
         private readonly ILogger _logger;
 
         // Store the user's desired main dock proportions (LeftTools / MainDocumentDock)
@@ -761,14 +761,22 @@ namespace CST.Avalonia.Services
         public void CloseBook(string bookId)
         {
             var dockable = FindDockable(bookId);
-            if (dockable != null)
+            if (dockable == null)
             {
-                // Remove book window state before removing the document
-                RemoveBookWindowState(dockable.Id);
-
-                RemoveDocumentFromLayout(dockable);
-                _logger.Debug("Closed book: {BookId}", bookId);
+                _logger.Debug("CloseBook: no dockable found for {BookId}", bookId);
+                return;
             }
+            // Route through the real close path. CloseDockable removes by Owner (works whether the book is in the
+            // main OR a floating window), disposes the CEF View before its window closes, clears the book window
+            // state, and funnels the emptied-floating-window cleanup — none of which the old raw-remove path did.
+            // NOTE for a future caller (an API/MCP "close book"): this mutates the dock model, so it must run on
+            // the UI thread (which also makes the deferred empty-window close land after this returns). (#494)
+            CloseDockable(dockable);
+            if (FindDockable(bookId) != null)
+                // Tripwire: base.CloseDockable declined the removal (e.g. CanClose=false, or a null Owner). (#494)
+                _logger.Debug("CloseBook: {BookId} still present after CloseDockable (close declined)", bookId);
+            else
+                _logger.Debug("Closed book: {BookId}", bookId);
         }
 
         public WelcomeViewModel? GetWelcomeViewModel()
@@ -780,16 +788,13 @@ namespace CST.Avalonia.Services
 
         public void ShowWelcomeScreen()
         {
-            // Show the Welcome document tab as active
+            // Activate the Welcome doc within the dock that actually owns it, rather than assuming the main
+            // document dock — so it can never set ActiveDockable on a dock that doesn't contain it. (#494)
             var welcomeDoc = FindDockable("WelcomeDocument");
-            if (welcomeDoc != null)
+            if (welcomeDoc?.Owner is IDock ownerDock)
             {
-                var documentDock = FindDocumentDock();
-                if (documentDock != null)
-                {
-                    documentDock.ActiveDockable = welcomeDoc;
-                    _logger.Debug("Welcome screen activated");
-                }
+                ownerDock.ActiveDockable = welcomeDoc;
+                _logger.Debug("Welcome screen activated");
             }
         }
 
@@ -801,11 +806,17 @@ namespace CST.Avalonia.Services
         }
 
         // Generic dockable finder - works for ReactiveDocument/ReactiveTool as well as Document/Tool
+        // Search the main window's dock tree, then each floating window's — so close-by-id and lookups reach a
+        // book that has been floated out, not just the main window. Mirrors FindParentDock(IDock). (#494)
         private IDockable? FindDockable(string id)
         {
-            if (_context is RootDock rootDock && rootDock.VisibleDockables != null)
+            var roots = _context is IDock main
+                ? new[] { main }.Concat(GetFloatingLayouts())
+                : GetFloatingLayouts();
+            foreach (var root in roots)
             {
-                foreach (var dockable in rootDock.VisibleDockables)
+                if (root.VisibleDockables == null) continue;
+                foreach (var dockable in root.VisibleDockables)
                 {
                     var found = FindDockableRecursive(dockable, id);
                     if (found != null) return found;
@@ -813,6 +824,11 @@ namespace CST.Avalonia.Services
             }
             return null;
         }
+
+        // The floating windows' dock layouts. Overridable so tests can inject handcrafted layouts without a
+        // real CstHostWindow (which needs an Avalonia platform the headless test host lacks). (#494)
+        internal virtual IEnumerable<IDock> GetFloatingLayouts() =>
+            HostWindows.OfType<CstHostWindow>().Select(w => w.Layout).OfType<IDock>();
 
         private IDockable? FindDockableRecursive(IDockable dockable, string id)
         {
@@ -882,28 +898,6 @@ namespace CST.Avalonia.Services
             Log.Warning("*** WARNING: Could not find document dock to add book ***");
             _logger.Warning("Could not find document dock to add book");
             return false;
-        }
-        
-        private void RemoveDocumentFromLayout(IDockable dockable)
-        {
-            var documentDock = FindDocumentDock();
-            if (documentDock != null && documentDock.VisibleDockables != null)
-            {
-                Log.Debug("*** REMOVING DOCUMENT FROM LAYOUT: {DocumentId} ***", dockable.Id);
-                var countBefore = documentDock.VisibleDockables.Count;
-                documentDock.VisibleDockables.Remove(dockable);
-                var countAfter = documentDock.VisibleDockables.Count;
-                Log.Debug("*** DOCUMENT REMOVAL: Before={CountBefore}, After={CountAfter} ***", countBefore, countAfter);
-
-                // If this was the active document, activate another one
-                if (documentDock.ActiveDockable == dockable)
-                {
-                    // Find the Welcome document first, then fall back to last document
-                    var welcomeDoc = documentDock.VisibleDockables.FirstOrDefault(d => d.Id == "WelcomeDocument");
-                    documentDock.ActiveDockable = welcomeDoc ?? documentDock.VisibleDockables.LastOrDefault();
-                    Log.Debug("*** ACTIVATED NEW DOCUMENT: {NewActiveDocument} ***", documentDock.ActiveDockable?.Id ?? "null");
-                }
-            }
         }
         
         private DocumentDock? FindDocumentDock()


### PR DESCRIPTION
`CstDockFactory.CloseBook(id)` silently no-op'd for a book in a **floating** window — `FindDockable` and the old `RemoveDocumentFromLayout`/`FindDocumentDock` were all main-window-only. And the old removal did a *raw* `VisibleDockables.Remove` that never disposed the book's CEF View, stranding a live browser (the BOOK-1 leak) and poisoning the recycling cache.

Fable-planned → implemented → Fable re-reviewed (faithful, no confirmed defects).

## Fix
- **`FindDockable`** now searches the main window **and** each floating window, via an overridable `GetFloatingLayouts()` seam — mirrors `FindParentDock(IDock)`.
- **`CloseBook`** routes through the real **`CloseDockable`** override instead of raw removal: owner-based removal (window-agnostic), **CEF dispose-before-window-close**, `RemoveBookWindowState`, and the deferred empty-floating-window cleanup — the proven tab-close path. Bonus: the `CanClose` gate now refuses `CloseBook("WelcomeDocument")` instead of ripping the tab out.
- **Deleted** the dead, main-only, leak-prone `RemoveDocumentFromLayout`.
- **`ShowWelcomeScreen`** activates via the doc's `Owner`, not the main document dock.

## Why it's safe
`CloseBook` is **latent** (only caller `LayoutViewModel.CloseBook`, itself uncalled) — no production regression; this is correctness for the eventual close-by-id surface (e.g. an MCP `close_book`). Fable traced the **CEF ordering** through the decompiled Dock 11.3.6.5 source: the floating `DocumentDock`'s `IsCollapsable=false` makes `CollapseDock`'s synchronous `RemoveWindow` branch **unreachable**, so disposal is synchronous and the window-close is deferred — the #458/#39 SIGSEGV class can't occur.

## Tests
4 new via a `TestDockFactory` injecting handcrafted floating layouts: floated-book removal **+ neighbor reactivation of the active tab**, main-window removal, unknown-id no-op, `CanClose=false` refused. Full suite **973/973**. (Last-doc-in-float → deferred window closure needs real `CstHostWindow`s + a pumping dispatcher — honestly untestable headless; verified safe from code instead.)

Closes #494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)