### PR TITLE
#112: book printing — Print (⌘P) + Print Selection (⇧⌘P)

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1374,10 +1374,20 @@ public partial class App : Application
             var selectBookMenuItem = new NativeMenuItem { Header = "Select a Book", Gesture = KeyGesture.Parse("Cmd+O") };
             selectBookMenuItem.Click += (s, e) => SimpleTabbedWindow.RevealSelectBookPanel();
 
+            // #112: Print (Cmd+P) and Print Selection (Shift+Cmd+P) the floated book — same native
+            // window.print() path as the main window.
+            var printItem = new NativeMenuItem { Header = "Print…", Gesture = KeyGesture.Parse("Cmd+P") };
+            printItem.Click += (s, e) => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.Print();
+            var printSelectionItem = new NativeMenuItem { Header = "Print Selection…", Gesture = KeyGesture.Parse("Cmd+Shift+P") };
+            printSelectionItem.Click += (s, e) => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.PrintSelection();
+
             var fileMenu = new NativeMenu();
             fileMenu.Add(selectBookMenuItem);
             // #44: this window's "Open Recent" submenu (populated by RebuildRecentMenus below).
             fileMenu.Add(new NativeMenuItem { Header = "Open Recent", Menu = new NativeMenu() });
+            fileMenu.Add(new NativeMenuItemSeparator());
+            fileMenu.Add(printItem);
+            fileMenu.Add(printSelectionItem);
             fileMenu.Add(new NativeMenuItemSeparator());
             fileMenu.Add(closeTabItem);
 

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -2530,6 +2530,98 @@ public partial class BookDisplayView : UserControl
         }
     }
 
+    /// <summary>
+    /// #112 native-print probe: open the platform print dialog for the whole book via window.print(). Uses
+    /// ExecuteScript (fire-and-forget) — EvaluateScript returns null in this CEF build, and printing needs no
+    /// return value, so this rides the same JS path the rest of the view uses. On macOS this routes into
+    /// Chromium's platform print; whether that dialog is usable in this CEF-120 build is exactly what this
+    /// probe validates. If inadequate, the fallback is CefBrowserHost.PrintToPdf (#112).
+    /// </summary>
+    public void Print()
+    {
+        if (_webView == null) return;
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(Print);
+            return;
+        }
+        try
+        {
+            _logger.Information("Print (Cmd+P): invoking window.print() on the book WebView");
+            // Defensively drop any stranded print-selection isolation (if a prior selection print's afterprint
+            // cleanup never fired) so a whole-book print can't silently print only the old selection. (#112, Fable)
+            _webView.ExecuteScript("document.body.classList.remove('cst-printing-selection'); window.print();");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Print failed | {Details}", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// #112 print selection: print only the current selection. Selection-isolation pre-step (dialog-agnostic,
+    /// works with the native window.print() route): clone the selection into a dedicated print container, add
+    /// a body class that an <c>@media print</c> rule uses to hide everything else, print, then clean up on
+    /// afterprint. Falls back to whole-book print when there is no selection. (Egret addendum)
+    /// </summary>
+    public void PrintSelection()
+    {
+        if (_webView == null) return;
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(PrintSelection);
+            return;
+        }
+        try
+        {
+            _logger.Information("Print Selection (Shift+Cmd+P): isolating the selection and invoking window.print()");
+            _webView.ExecuteScript(PrintSelectionScript);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("PrintSelection failed | {Details}", ex.Message);
+        }
+    }
+
+    // Isolates the current selection for printing: no/empty selection falls back to a whole-book print;
+    // otherwise clone the selected range(s) into #cst-print-selection and let the injected @media print rule
+    // hide every other direct child of body. Cleaned up on afterprint so the on-screen view is untouched.
+    private const string PrintSelectionScript = @"
+        (function() {
+            // Start from a clean slate in case a prior run's afterprint cleanup never fired.
+            document.body.classList.remove('cst-printing-selection');
+            var sel = window.getSelection();
+            if (!sel || sel.rangeCount === 0 || sel.isCollapsed) { window.print(); return; }
+            if (!document.getElementById('cst-print-selection-style')) {
+                var style = document.createElement('style');
+                style.id = 'cst-print-selection-style';
+                style.textContent =
+                    // Hidden on screen at all times (so the cloned selection never shows as a duplicate in the
+                    // live view, even if afterprint cleanup never fires); shown, and everything else hidden,
+                    // only in print media.
+                    '#cst-print-selection{display:none;}'
+                    + ' @media print { body.cst-printing-selection > *:not(#cst-print-selection){display:none !important;}'
+                    + ' #cst-print-selection{display:block !important;} }';
+                document.head.appendChild(style);
+            }
+            var container = document.getElementById('cst-print-selection');
+            if (!container) {
+                container = document.createElement('div');
+                container.id = 'cst-print-selection';
+                document.body.appendChild(container);
+            }
+            container.innerHTML = '';
+            for (var i = 0; i < sel.rangeCount; i++) { container.appendChild(sel.getRangeAt(i).cloneContents()); }
+            document.body.classList.add('cst-printing-selection');
+            var cleanup = function() {
+                document.body.classList.remove('cst-printing-selection');
+                if (container && container.parentNode) { container.parentNode.removeChild(container); }
+                window.removeEventListener('afterprint', cleanup);
+            };
+            window.addEventListener('afterprint', cleanup);
+            window.print();
+        })();";
+
     // #224: apply the per-book search-term highlight toggle. Routed through cstSearchHighlights because it
     // owns the inline blue/red colors on the .hit spans (which override the CSS rule). ON re-applies the
     // blue/red styling; OFF clears it so matched words show as normal text (CST4's "remove highlight, keep

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -23,6 +23,10 @@
                         <NativeMenu />
                     </NativeMenuItem>
                     <NativeMenuItemSeparator />
+                    <!-- #112: print the active book via the platform print dialog (window.print()) -->
+                    <NativeMenuItem Header="Print…" Click="OnPrintClick" Gesture="cmd+p" />
+                    <NativeMenuItem Header="Print Selection…" Click="OnPrintSelectionClick" Gesture="cmd+shift+p" />
+                    <NativeMenuItemSeparator />
                     <NativeMenuItem Header="Close Tab" Click="OnCloseTabClick" Gesture="cmd+w" />
                 </NativeMenu>
             </NativeMenuItem>

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -683,6 +683,32 @@ public partial class SimpleTabbedWindow : Window
 
     // "Look Up in Dictionary" (Cmd+D): take the word selected in the active book's WebView, drop it into
     // the Dictionary tool's search box, and bring the Dictionary tab forward. (#25)
+    // #112: print the active book. Native probe — routes to window.print() on the book's WebView.
+    private void OnPrintClick(object? sender, EventArgs e)
+    {
+        _logger.Information("Print (Cmd+P) from window: {WindowTitle}", this.Title);
+        var book = FindActiveBookInThisWindow();
+        if (book?.BookDisplayControl == null)
+        {
+            _logger.Information("Print: no active book to print");
+            return;
+        }
+        book.BookDisplayControl.Print();
+    }
+
+    // #112: print the current selection in the active book (falls back to whole-book when nothing is selected).
+    private void OnPrintSelectionClick(object? sender, EventArgs e)
+    {
+        _logger.Information("Print Selection (Shift+Cmd+P) from window: {WindowTitle}", this.Title);
+        var book = FindActiveBookInThisWindow();
+        if (book?.BookDisplayControl == null)
+        {
+            _logger.Information("Print Selection: no active book");
+            return;
+        }
+        book.BookDisplayControl.PrintSelection();
+    }
+
     private async void OnLookUpInDictionaryClick(object? sender, EventArgs e)
     {
         _logger.Information("Look Up in Dictionary (Cmd+D) from window: {WindowTitle}", this.Title);


### PR DESCRIPTION
Implements #112 — book printing, which CST4 got for free from the WinForms/IE `WebBrowser` control but the CEF WebView does not surface.

## What ships
- **Print (⌘P)** — whole book. `BookDisplayView.Print()` invokes `window.print()` on the book's WebView via `ExecuteScript` (fire-and-forget — `EvaluateScript` returns null in this CEF build and print needs no return value, so it rides the view's proven JS path). This started as a **native-print probe** and was **manually confirmed working on macOS / CEF-120** in both the main and floated book windows — so no `CefBrowserHost` / `PrintToPdf` reflection is needed for the native path.
- **Print Selection (⇧⌘P)** — a **dialog-independent selection-isolation pre-step** (Egret's design): clone the current selection into a `#cst-print-selection` container and let an injected `@media print` rule hide everything else, then `window.print()`, cleaning up on `afterprint`. Chosen over the native dialog's built-in "Selection" radio, which rides the historically-flaky macOS-CEF path. The container is **hidden on screen at all times** (so the clone never appears in the live view even if `afterprint` never fires), and both print paths **defensively clear any stranded isolation class** so a later whole-book print can never silently print only an old selection. No selection → whole-book fallback.
- **Menu + shortcuts**: File → **Print…** / **Print Selection…** on the main window and each floating book window (same resolver pattern as the #448 ⌘D/⌘F items).

## Verification
- **Manually confirmed** on a macOS display: whole-book and selection printing both work, in main and floated windows.
- **Fable-reviewed**: the selection CSS is correct against the XSL's direct-`<body>`-child output; the on-screen-container-visibility bug and the stranded-`cst-printing-selection`-class bug were caught and fixed; wiring/idempotency/timing/gesture-collision all clear.
- Build clean; full suite **969 passed, 0 failed** (this is menu wiring + a view method + injected JS — no unit-testable surface).

## Deferred to follow-ups
- **#499** — offer the native print-dialog "Selection" scope as an additive nicety.
- **#500** — `@media print` color reset so search-hit highlights (white-on-blue/red) print legibly rather than white-on-white; includes a dark-mode print check.

Closes #112.
