### PR TITLE
#91: restore the active left-tool tab + the dictionary's last looked-up word

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -621,6 +621,11 @@ public partial class App : Application
     
     private async Task InitializeFromLoadedState(ApplicationState state)
     {
+        // #91: capture the saved active left-tool id NOW, before the window is shown/interactive, so a user
+        // clicking a tool tab during startup can't overwrite Current.ActiveLeftToolId before we restore it
+        // (state IS Current). Applied on the UI thread after the window state restore below.
+        var savedActiveLeftToolId = state.ActiveLeftToolId;
+
         // Initialize script service with loaded script preference
         var scriptService = ServiceProvider?.GetRequiredService<IScriptService>();
         if (scriptService != null)
@@ -657,6 +662,12 @@ public partial class App : Application
             desktop.MainWindow is SimpleTabbedWindow mainWindow)
         {
             await Dispatcher.UIThread.InvokeAsync(() => mainWindow.RestoreWindowState());
+            // #91: restore which left-tool tab (Select a Book / Search / Dictionary) was active at last close.
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                if (mainWindow.DataContext is LayoutViewModel layoutViewModel)
+                    layoutViewModel.Factory.RestoreActiveLeftTool(savedActiveLeftToolId);
+            });
         }
         
         // Restore book windows if any exist

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -23,6 +23,11 @@ public class ApplicationState
     // Main Window State
     public MainWindowState MainWindow { get; set; } = new();
 
+    /// <summary>Which left-tool tab was active at last close — "OpenBookTool" / "SearchTool" / "DictionaryTool"
+    /// (a dockable Id). Restored on startup so the tool dock reopens on the tab the user left it on. Empty until
+    /// first set; empty restores the default (Select a Book). (#91)</summary>
+    public string ActiveLeftToolId { get; set; } = string.Empty;
+
     // Open Book Dialog State  
     public OpenBookDialogState OpenBookDialog { get; set; } = new();
 

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -75,6 +75,9 @@ namespace CST.Avalonia.Services
                 CanDrag = true,
                 CanDrop = true
             };
+            // #91: persist the active tool tab on switch. Attached AFTER the ActiveDockable=openBookTool
+            // initializer above, so the startup default doesn't spuriously overwrite the saved id.
+            AttachLeftToolDockMonitor(leftToolDock);
 
             // Wrap ToolDock in ProportionalDock to enable docking indicators
             var leftTools = new ProportionalDock
@@ -1370,6 +1373,45 @@ namespace CST.Avalonia.Services
         /// their windows closed (failure mode #4). This is what lets View → Show Search / Select-a-Book
         /// always bring panels back instead of no-op'ing on a corrupted layout.
         /// </summary>
+        // #91: persist which left-tool tab is active on every switch, so it can be restored next launch.
+        // Shared by CreateLayout and EnsureLeftToolDock's recreate path so persistence survives dock recreation
+        // (failure mode #4). Resolves the state service and dereferences Current at FIRE time — never captures
+        // the MainWindow/state object (they get replaced). MarkDirty routes through the timer/shutdown save.
+        private void AttachLeftToolDockMonitor(ToolDock leftToolDock)
+        {
+            if (leftToolDock is not System.ComponentModel.INotifyPropertyChanged npc) return;
+            npc.PropertyChanged += (sender, e) =>
+            {
+                if (e.PropertyName != nameof(leftToolDock.ActiveDockable)) return;
+                var id = leftToolDock.ActiveDockable?.Id;
+                if (string.IsNullOrEmpty(id)) return;
+                var stateService = App.ServiceProvider?.GetService<IApplicationStateService>();
+                if (stateService?.Current != null)
+                {
+                    stateService.Current.ActiveLeftToolId = id;
+                    stateService.MarkDirty();
+                }
+            };
+        }
+
+        // #91: restore the left-tool tab that was active at last close. Direct ActiveDockable assignment
+        // (matching the precedent elsewhere in this factory) rather than SetActiveDockable — the setter still
+        // routes focus via InitActiveDockable but skips the OnDockableActivated event, and this runs BEFORE
+        // RestoreBookWindowsAsync and the #56 startup focus-return, so a restored book document still ends up
+        // focused (with no books, the tool keeps focus — desirable). Empty/absent/unknown id → leave the
+        // default (Select a Book). Must run on the UI thread.
+        internal void RestoreActiveLeftTool(string? toolId)
+        {
+            if (string.IsNullOrEmpty(toolId)) return;
+            var dock = EnsureLeftToolDock();
+            var tool = dock?.VisibleDockables?.FirstOrDefault(d => d.Id == toolId);
+            if (tool != null)
+            {
+                dock!.ActiveDockable = tool;
+                Log.Information("[#91] Restored active left-tool tab: {ToolId}", toolId);
+            }
+        }
+
         internal ToolDock? EnsureLeftToolDock()
         {
             // Reuse an existing LeftToolDock anywhere in the main layout (it may be nested after drags).
@@ -1397,6 +1439,9 @@ namespace CST.Avalonia.Services
                 VisibleDockables = CreateList<IDockable>(),
                 Factory = this
             };
+            // #91: the recreated dock is born empty (ActiveDockable null); attach the monitor now so the tools
+            // re-added via ShowToolPanel record their active-tab switches too.
+            AttachLeftToolDockMonitor(leftToolDock);
             var leftTools = new ProportionalDock
             {
                 Id = "LeftTools",

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -126,6 +126,18 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
             })
             .DisposeWith(_disposables);
 
+        // Remember the last looked-up word across sessions (#91), so restoring the Dictionary tab also
+        // restores its content — the parallel to the Search pane (#87). Skip(1) ignores the construction-time
+        // empty value; MarkDirty defers the write to the timer/shutdown save (STATE-2).
+        this.WhenAnyValue(x => x.SearchText)
+            .Skip(1)
+            .Subscribe(text =>
+            {
+                _stateService.Current.DictionaryDialog.UserText = text ?? string.Empty;
+                _stateService.MarkDirty();
+            })
+            .DisposeWith(_disposables);
+
         // Re-render headwords + meaning when the global script or font settings change (mirrors the
         // Search tool). Unsubscribed in Dispose. (DICT-2)
         _scriptChangedHandler = script => Dispatcher.UIThread.Post(() =>
@@ -199,6 +211,12 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
             ?? Sources.FirstOrDefault();
         if (restored != null)
             SelectedSource = restored;
+
+        // #91: restore the last looked-up word too (the parallel to the Search pane's #87 term restore).
+        // Setting SearchText triggers the throttled lookup, so the last definition reappears on launch.
+        var savedText = _stateService.Current.DictionaryDialog.UserText;
+        if (!string.IsNullOrEmpty(savedText))
+            SearchText = savedText;
     }
 
     /// <summary>The enabled dictionary sources for the picker (shown by <c>DisplayName</c>), in the user's


### PR DESCRIPTION
Implements #91 — restore which left-tool tab (Select a Book / Search / Dictionary) was active at last close, plus the natural companion (raised during testing): restore the Dictionary's last looked-up word, the parallel to the Search pane's #87 term restore.

## What changed
- **Persist the active left-tool tab.** New **top-level** `ApplicationState.ActiveLeftToolId` (a peer of the dialog states, deliberately *not* in `MainWindowState` — so the frequent whole-object window-state saves can't clobber it, and there's no fragile "preserve" step to remember). A `PropertyChanged` monitor on `LeftToolDock` records the active tab id on every switch (+ `MarkDirty`); the monitor-attach is factored into a helper shared by `CreateLayout` **and** `EnsureLeftToolDock`'s recreate path, so persistence survives dock recreation (failure mode #4).
- **Restore it** in `InitializeFromLoadedState`: the saved id is captured into a local up front (so a user clicking a tool tab during startup can't clobber the loaded value before restore), then applied on the **UI thread** via a direct `ActiveDockable = tool` assignment. Empty/unknown id → the default (Select a Book).
- **Dictionary last-word persistence.** `DictionaryDialog.UserText` existed but went dead post-#466; wire it back — a `SearchText` save subscription (mirroring the `SourceId` one) + a restore in `DictionaryViewModel.ApplyState()`. Setting `SearchText` at restore re-triggers the throttled lookup, so the last definition reappears.

## Verification
- **Fable-reviewed** the plan and both diffs (dock-restore + dictionary-word). Key points confirmed: no `SaveWindowState` clobber (top-level field), the monitor dereferences `Current` at fire time (never captures a replaced object), the restore is UI-thread-marshalled and reads the startup-captured local, direct `ActiveDockable` assignment runs before the #56 focus-return so a restored **book** still gets focus, no feedback loop / double-lookup in the dictionary restore, and if Dictionary is the restored active tab the meaning-pane WebView just `LoadHtml`s the restored word (no CEF re-parent hazard).
- **User-confirmed** on macOS: Search / Dictionary / Select-a-Book tab restore, focus lands on the restored book document, and the dictionary word + its definition come back.
- Build clean; full suite **973 passed, 0 failed**.

Closes #91.
