### PR TITLE
#28: Windows ARM64 build and packaging

### DIFF
--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -2,7 +2,7 @@
 
 This document describes the complete process for releasing a new version of CST Reader.
 
-**Last Updated:** June 23, 2026
+**Last Updated:** July 25, 2026
 **Current Version:** 5.0.0-beta.5
 
 > ⚠️ **Beta 5 — mandatory clean start (put at the TOP of the GitHub release notes).** The search
@@ -17,11 +17,29 @@ This document describes the complete process for releasing a new version of CST 
 ## Overview
 
 The release process consists of five main steps:
-1. **Build and notarize packages** on Caracara (macOS-specific security)
+1. **Build packages** — macOS (build + notarize on Caracara) and Windows (build on a Windows machine)
 2. **Create a git tag** for the release
 3. **Create a GitHub release** with release notes
-4. **Attach binary files** (DMG installers) to the release
+4. **Attach binary files** (DMG + Windows installers/zips) to the release
 5. **Update welcome-updates.json** to notify users
+
+### Shipping matrix
+
+Beta 5 ships **four** builds. Each is built natively on its own architecture — there is no
+cross-compilation step, so each row needs a machine (or VM) of that architecture.
+
+| Platform | Arch  | Built on            | Artifacts |
+|----------|-------|---------------------|-----------|
+| macOS    | arm64 | Caracara / Kestrel  | `CST-Reader-arm64.dmg` (notarized) |
+| macOS    | x64   | Caracara            | `CST-Reader-x64.dmg` (notarized) |
+| Windows  | x64   | Windows x64 machine | `CST-Reader-<ver>-win-x64-setup.exe`, `…-win-x64-portable.zip` |
+| Windows  | arm64 | Windows arm64 VM    | `CST-Reader-<ver>-win-arm64-setup.exe`, `…-win-arm64-portable.zip` |
+
+**The two Windows builds are not interchangeable.** `CST.Avalonia.csproj` selects a different CEF
+native package per RID — `WebViewControl-Avalonia` for `win-x64`, `WebViewControl-Avalonia-ARM64` for
+`win-arm64`. Publishing a RID without its matching package produces a build with **no `libcef.dll` at
+all** (RID-mismatched natives are silently dropped) and every book view fails at CEF init.
+`package-windows.ps1` guards against this explicitly, so let it fail rather than working around it.
 
 ---
 
@@ -37,6 +55,20 @@ dotnet --list-sdks   # expect a 10.0.x entry
 If missing, install via the official `.pkg` from https://dotnet.microsoft.com/download/dotnet/10.0
 (Apple-Silicon installer on Kestrel, Intel installer on Caracara). The CST.MAUI POC additionally needs
 `sudo dotnet workload install maui`, but it is not part of the shipping macOS app.
+
+**Windows build machines** additionally need:
+
+- **.NET 10 SDK matching the machine's architecture** — install the arm64 SDK on an arm64 machine.
+  Verify with `dotnet --info`; the `RID:` line should read `win-arm64` (or `win-x64`).
+- **Inno Setup 6.3+** for the installer step: `winget install JRSoftware.InnoSetup`. The script finds
+  `ISCC.exe` on PATH or in the standard Program Files / `%LOCALAPPDATA%\Programs` locations. Without it
+  the script warns and still produces the portable zip. 6.3+ is required for the `x64compatible` and
+  `arm64` architecture identifiers used by `CST.Avalonia.iss`.
+- **GitHub CLI** (`winget install GitHub.cli`) if you plan to create the release from Windows.
+
+Windows builds are **unsigned** for beta — there is no Windows equivalent of the notarization step, so
+users will see a SmartScreen warning ("More info" → "Run anyway"). A real code-signing certificate is a
+pre-1.0 follow-up (#28).
 
 ---
 
@@ -54,6 +86,9 @@ Before starting the release process, verify on Kestrel:
   - `Services/WelcomeUpdateService.cs` - `CurrentAppVersion` default
   - `ViewModels/WelcomeViewModel.cs` - version fallback string
   - `CLAUDE.md` - header, status, dates
+  Note: the Windows packaging path reads `<Version>` straight out of `CST.Avalonia.csproj` and passes it
+  to Inno Setup as `/DAppVersion`, so `CST.Avalonia.iss` and `package-windows.ps1` cannot drift — but the
+  `.iss` **AppId must never change** (it keys uninstall/upgrade detection and the WinGet ProductCode).
 - [ ] Build succeeds: `dotnet build`
 - [ ] Tests pass: `dotnet test` (or acceptable skip rate documented)
 - [ ] All changes committed and pushed to `main` branch
@@ -61,7 +96,7 @@ Before starting the release process, verify on Kestrel:
 
 ---
 
-## Step 1: Build, Notarize, and Staple Packages (Caracara)
+## Step 1a: Build, Notarize, and Staple macOS Packages (Caracara)
 
 **Machine:** Caracara (macOS build machine with notarization credentials)
 
@@ -138,6 +173,77 @@ open dist/CST-Reader-arm64.dmg
 - Notarization failed or wasn't stapled correctly
 - Check notarization logs: `xcrun notarytool log <submission-id>`
 - Re-run notarization script
+
+---
+
+## Step 1b: Build Windows Packages
+
+**Machine:** a Windows x64 machine for the x64 build, and a Windows arm64 machine/VM for the arm64
+build. Run the script **once per architecture, on that architecture** — see the shipping matrix above.
+
+### Pull Latest Code
+
+```powershell
+git checkout main
+git pull
+```
+
+### Build
+
+```powershell
+cd src\CST.Avalonia
+
+# On the x64 machine
+.\package-windows.ps1              # -Arch x64 is the default
+
+# On the arm64 machine
+.\package-windows.ps1 -Arch arm64
+```
+
+Add `-NoInstaller` to produce only the portable zip (useful when Inno Setup isn't installed).
+
+**What the script does:**
+1. Reads `<Version>` from `CST.Avalonia.csproj` (aborts if absent, rather than mislabeling a release)
+2. Cleans and runs `dotnet publish -c Release -r win-<arch> --self-contained`
+3. Stages `xsl/` and `dictionaries/` beside the exe (the app seeds `%APPDATA%\CSTReader` from these on first run)
+4. **Asserts `libcef.dll` is present** — this is the packaging failure that matters most; see the warning
+   in the shipping matrix above
+5. Writes a portable `.zip` (forward-slash entry names, streamed so the 178–205 MB `libcef.dll` isn't
+   buffered in memory)
+6. Runs Inno Setup to produce `setup.exe`, and prints its SHA256 for the WinGet manifest (#410)
+
+Artifacts land in `src\CST.Avalonia\dist\`:
+- `CST-Reader-<version>-win-<arch>-portable.zip` (~218 MB arm64 / ~230 MB x64)
+- `CST-Reader-<version>-win-<arch>-setup.exe`
+
+Save the printed **SHA256** of each `setup.exe` — you need both for the WinGet manifest.
+
+### Test Installation
+
+There is no notarization to verify, so the smoke test is the whole check:
+
+1. Run `setup.exe`. It is a per-user install (`PrivilegesRequired=lowest`), so there should be **no UAC
+   prompt**; it installs to `%LOCALAPPDATA%\Programs\CST Reader`.
+2. Expect a SmartScreen warning on first run — "More info" → "Run anyway". This is normal for unsigned
+   beta builds.
+3. Launch and confirm **a book actually opens**. This is the CEF check: if `libcef.dll` is missing or is
+   the wrong architecture, the app window appears but every book view fails. Watch
+   `%APPDATA%\CSTReader\logs\cst-avalonia-<date>.log` for `WebView initialized event fired`.
+4. On first launch the app downloads the 217 XML books and builds the Lucene index — allow a few minutes
+   before the app is usable.
+5. Uninstall via Settings → Apps to confirm the uninstall entry works.
+
+**ARM64 note:** the x64 installer is marked `x64compatible`, so it will also install on an ARM64 machine
+and run under emulation. Both installers share an `AppId`, so installing the native arm64 build over an
+emulated x64 install upgrades it in place.
+
+**ARM64 development note:** `dotnet build` / `dotnet run` work normally on an ARM64 Windows box — no
+`-r` needed. This is not automatic, though: `CefGlue.Common.props` hardcodes
+`CefGlueTargetPlatform=win-x64` for *any* RID-less Windows build (it only honours `Platform=ARM64`,
+which the SDK leaves at `AnyCPU`), which would wire x64 CEF paths into an arm64 process.
+`src/CST.Avalonia/Directory.Build.props` compensates by pinning `RuntimeIdentifier=win-arm64` on ARM64
+Windows hosts, early enough that CefGlue sees it. Note that dev output therefore lands in
+`bin\<Config>\net10.0\win-arm64\`. An explicit `-r` always wins, so packaging is unaffected.
 
 ---
 
@@ -241,15 +347,34 @@ This ensures accurate release notes based on actual changes, not assumptions.
 - macOS 11.0 (Big Sur) or later
 - Apple Silicon (M1/M2/M3) or Intel processor
 
-### Download
-- **Apple Silicon (M1/M2/M3):** `CST-Reader-arm64.dmg`
-- **Intel Macs:** `CST-Reader-x64.dmg`
+### Windows Requirements
+- Windows 10 1809 or later / Windows 11
+- x64 or ARM64 processor
 
-### First Launch
-After installation, if you see a security warning:
+### Download
+- **macOS, Apple Silicon (M1/M2/M3):** `CST-Reader-arm64.dmg`
+- **macOS, Intel:** `CST-Reader-x64.dmg`
+- **Windows, x64:** `CST-Reader-5.0.0-beta.X-win-x64-setup.exe`
+- **Windows, ARM64:** `CST-Reader-5.0.0-beta.X-win-arm64-setup.exe`
+
+Portable `.zip` builds are attached for both Windows architectures if you prefer no installer.
+
+Not sure which Windows build you need? Settings → System → About → "System type". The x64 installer
+also runs on ARM64 under emulation, but the ARM64 build is faster.
+
+### First Launch — macOS
+If you see a security warning:
 1. Open System Settings → Privacy & Security
 2. Scroll down and click "Open Anyway"
 3. Confirm when prompted
+
+### First Launch — Windows
+These beta builds are not code-signed, so Windows SmartScreen will warn you:
+1. Click **"More info"**
+2. Click **"Run anyway"**
+
+On first launch the app downloads the Tipiṭaka texts and builds its search index. This takes a few
+minutes — the welcome page shows progress.
 
 ## Upgrade Notes
 
@@ -268,17 +393,22 @@ Found a bug or have a suggestion?
 
 ---
 
-## Step 3: Attach Binary Files
+## Step 4: Attach Binary Files
 
-Upload the DMG installers to the release.
+Upload the macOS and Windows installers to the release. The Windows artifacts are produced on
+different machines than the DMGs, so collect them all in one place first.
 
 ### Using GitHub Web Interface
 
 1. In the draft release page, scroll to **"Attach binaries by dropping them here or selecting them"**
-2. Drag and drop or select both DMG files:
-   - `CST-Reader-arm64.dmg` (Apple Silicon)
-   - `CST-Reader-x64.dmg` (Intel)
-3. Wait for uploads to complete
+2. Drag and drop or select all six files:
+   - `CST-Reader-arm64.dmg` (macOS, Apple Silicon)
+   - `CST-Reader-x64.dmg` (macOS, Intel)
+   - `CST-Reader-5.0.0-beta.X-win-x64-setup.exe`
+   - `CST-Reader-5.0.0-beta.X-win-arm64-setup.exe`
+   - `CST-Reader-5.0.0-beta.X-win-x64-portable.zip`
+   - `CST-Reader-5.0.0-beta.X-win-arm64-portable.zip`
+3. Wait for uploads to complete (the Windows artifacts are ~200–250 MB each)
 4. Verify checksums if desired
 5. Click **"Publish release"**
 
@@ -288,7 +418,11 @@ Upload the DMG installers to the release.
 # Attach binaries to draft release
 gh release upload v5.0.0-beta.X \
   dist/CST-Reader-arm64.dmg \
-  dist/CST-Reader-x64.dmg
+  dist/CST-Reader-x64.dmg \
+  dist/CST-Reader-5.0.0-beta.X-win-x64-setup.exe \
+  dist/CST-Reader-5.0.0-beta.X-win-arm64-setup.exe \
+  dist/CST-Reader-5.0.0-beta.X-win-x64-portable.zip \
+  dist/CST-Reader-5.0.0-beta.X-win-arm64-portable.zip
 
 # Publish the release
 gh release edit v5.0.0-beta.X --draft=false
@@ -298,14 +432,33 @@ gh release edit v5.0.0-beta.X --draft=false
 
 1. Visit the release page: `https://github.com/fsnow/cst/releases/tag/v5.0.0-beta.X`
 2. Verify:
-   - Both DMG files are attached
+   - All four platform builds are attached (2 DMG + 2 Windows installers, plus the portable zips)
    - Release notes are correct
    - Pre-release badge is shown (for betas)
    - Download links work
 
+### Update the WinGet Manifest (#410)
+
+Windows distribution also goes through WinGet (`fsnow.CSTReader`). The manifest needs one `Installers`
+entry per architecture, each with the `InstallerUrl` pointing at the published GitHub release asset and
+the `InstallerSha256` printed by `package-windows.ps1`:
+
+```yaml
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fsnow/cst/releases/download/v5.0.0-beta.X/CST-Reader-5.0.0-beta.X-win-x64-setup.exe
+    InstallerSha256: <sha printed by package-windows.ps1 -Arch x64>
+  - Architecture: arm64
+    InstallerUrl: https://github.com/fsnow/cst/releases/download/v5.0.0-beta.X/CST-Reader-5.0.0-beta.X-win-arm64-setup.exe
+    InstallerSha256: <sha printed by package-windows.ps1 -Arch arm64>
+```
+
+WinGet picks the right one per machine. The `ProductCode` is the Inno Setup `AppId` + `_is1` and must
+stay stable across releases.
+
 ---
 
-## Step 4: Update welcome-updates.json
+## Step 5: Update welcome-updates.json
 
 The `welcome-updates.json` file controls update notifications shown in the app's welcome page.
 

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -83,12 +83,19 @@
     <!-- WebView packages for different architectures -->
     <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'" />
     <PackageReference Include="WebViewControl-Avalonia" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == 'osx-x64'" />
-    <!-- Windows (#20/#28): the plain WebViewControl-Avalonia package carries the Windows (win-x64 / win-arm64) CEF natives. -->
+    <!-- Windows (#20/#28): the CEF natives are split by arch across two packages. The plain
+         WebViewControl-Avalonia carries chromiumembeddedframework.runtime.win-x64; the -ARM64 variant carries
+         chromiumembeddedframework.runtime.win-arm64 (both at CEF 120.1.8). CefGlue.Common.targets already
+         handles win-arm64 - it copies from chromiumembeddedframework.runtime.$(CefGlueTargetPlatform) - so
+         picking the right package is all that's needed. Getting this wrong publishes with NO libcef.dll at all
+         (RID-mismatched natives are silently dropped) and every WebView fails at CEF init. -->
     <PackageReference Include="WebViewControl-Avalonia" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == 'win-x64'" />
-    <PackageReference Include="WebViewControl-Avalonia" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == 'win-arm64'" />
+    <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == 'win-arm64'" />
     <!-- Fallback for development when RuntimeIdentifier is not set (plain `dotnet run`): pick by host OS so
-         `dotnet run` works everywhere without an explicit -r. Windows host -> plain (Windows) package;
-         everything else keeps the macOS/Linux ARM64 package (the Apple-Silicon dev default). -->
+         `dotnet run` works everywhere without an explicit -r. On an ARM64 Windows host this Windows branch is
+         not reached - Directory.Build.props pins RuntimeIdentifier=win-arm64 there (see the comment in that
+         file for why it has to happen that early), so the win-arm64 reference above wins. That leaves this
+         line covering x64 Windows hosts. -->
     <PackageReference Include="WebViewControl-Avalonia" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == '' and '$(OS)' == 'Windows_NT'" />
     <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == '' and '$(OS)' != 'Windows_NT'" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />

--- a/src/CST.Avalonia/CST.Avalonia.iss
+++ b/src/CST.Avalonia/CST.Avalonia.iss
@@ -6,8 +6,11 @@
 #ifndef AppVersion
   #define AppVersion "5.0.0"
 #endif
+#ifndef Arch
+  #define Arch "x64"
+#endif
 #ifndef PublishDir
-  #define PublishDir "bin\Release\net10.0\win-x64\publish"
+  #define PublishDir "bin\Release\net10.0\win-" + Arch + "\publish"
 #endif
 #ifndef OutputDir
   #define OutputDir "dist"
@@ -27,13 +30,20 @@ DefaultGroupName=CST Reader
 UninstallDisplayName=CST Reader
 UninstallDisplayIcon={app}\CST.Avalonia.exe
 OutputDir={#OutputDir}
-OutputBaseFilename=CST-Reader-{#AppVersion}-win-x64-setup
+OutputBaseFilename=CST-Reader-{#AppVersion}-win-{#Arch}-setup
 Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
-; x64compatible requires Inno Setup 6.3+ (also allows install on ARM64 via x64 emulation). Built with 6.7.x.
+; Requires Inno Setup 6.3+ for the "x64compatible"/"arm64" identifiers. Built with 6.7.x.
+; The two installers share an AppId on purpose: on an ARM64 machine either will install (the x64 one runs under
+; emulation), and installing the native arm64 build over an existing x64 install upgrades it in place.
+#if Arch == "arm64"
+ArchitecturesAllowed=arm64
+ArchitecturesInstallIn64BitMode=arm64
+#else
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
+#endif
 ; Per-user install so no UAC prompt; {autopf} resolves to %LOCALAPPDATA%\Programs under lowest privileges.
 PrivilegesRequired=lowest
 

--- a/src/CST.Avalonia/Directory.Build.props
+++ b/src/CST.Avalonia/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+
+  <!--
+    ARM64 Windows dev builds: pin the RID so CEF resolves to the ARM64 natives.
+
+    Why this file exists (#28): CefGlue.Common.props derives $(CefGlueTargetPlatform) from
+    $(RuntimeIdentifier), and when no RID is set on Windows it falls back to win-x64 unconditionally -
+    it only honours $(Platform) == 'ARM64', which the SDK leaves at 'AnyCPU'. So on an ARM64 Windows
+    box a bare `dotnet build` / `dotnet run` wires the x64 CEF paths (native libcef.dll *and* the
+    per-arch CefGlueBrowserProcess helper) into an arm64 process, and every WebView dies at CEF init.
+
+    Setting the RID here rather than in the .csproj is deliberate: Directory.Build.props is imported by
+    Microsoft.Common.props BEFORE the NuGet-generated nuget.g.props that pulls in CefGlue.Common.props,
+    so CefGlue sees a non-empty RuntimeIdentifier and takes its '$(RuntimeIdentifier)' != '' branch.
+    The same assignment inside CST.Avalonia.csproj would land too late - CefGlueTargetPlatform, and the
+    CefGlueBrowserProcessFiles item built from it, are already evaluated by then.
+
+    Scope is intentionally narrow - it only fires when ALL of these hold:
+      - no explicit RID (an explicit `-r` always wins; this never overrides the packaging script)
+      - Windows host (macOS/Linux are untouched)
+      - ARM64 host (x64 Windows keeps its existing RID-less behaviour and output paths)
+
+    Side effect: output moves to bin\<Config>\net10.0\win-arm64\. That is expected.
+  -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''
+                        and '$(OS)' == 'Windows_NT'
+                        and '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <!-- Framework-dependent: keeps plain `dotnet build` fast and matches the previous RID-less
+         behaviour. package-windows.ps1 passes an explicit RID and self-contained flag, so the
+         packaging path never reaches this PropertyGroup. -->
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+
+</Project>

--- a/src/CST.Avalonia/Services/BundledResourceLocator.cs
+++ b/src/CST.Avalonia/Services/BundledResourceLocator.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Locates a bundled resource directory (<c>xsl</c>, <c>dictionaries</c>) that ships with the app and is
+/// seeded into the per-user data directory on first run.
+///
+/// The same folder lives in three different places depending on how the app was started, so both callers
+/// need the identical precedence - and, more importantly, the identical handling of build-output depth.
+/// </summary>
+public static class BundledResourceLocator
+{
+    /// <summary>
+    /// How far up the ancestor chain to look for the source-tree copy. bin/&lt;Config&gt;/&lt;tfm&gt;/&lt;rid&gt;
+    /// is four levels below the project directory; the extra headroom absorbs any future nesting.
+    /// </summary>
+    private const int MaxSourceTreeDepth = 6;
+
+    /// <summary>
+    /// Resolves <paramref name="resourceDirName"/>, or null when none of the known locations has it.
+    /// </summary>
+    public static string? Resolve(string resourceDirName)
+    {
+        var asmDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) ?? "";
+
+        // Development: the copy in the project directory. Walk up the ancestors rather than hopping a
+        // fixed number of levels - the output depth is not constant. A RID-less build lands in
+        // bin/<Config>/<tfm>, but setting a RuntimeIdentifier adds a segment (bin/<Config>/<tfm>/<rid>),
+        // which is the default on ARM64 Windows (see src/CST.Avalonia/Directory.Build.props). A hardcoded
+        // hop count silently resolved to the wrong directory there, and the app fell back to an empty
+        // user directory - books rendered as "XSL file not found". (#28)
+        var ancestor = Directory.GetParent(asmDir);
+        for (var i = 0; i < MaxSourceTreeDepth && ancestor != null; i++, ancestor = ancestor.Parent)
+        {
+            var candidate = Path.Combine(ancestor.FullName, resourceDirName);
+            if (Directory.Exists(candidate))
+                return candidate;
+        }
+
+        // Packaged beside the executable (Windows/Linux self-contained publish): <app>/<name>. (#403)
+        var beside = Path.Combine(asmDir, resourceDirName);
+        if (Directory.Exists(beside))
+            return beside;
+
+        // Packaged .app: Contents/MacOS/ -> ../Resources/<name>
+        var bundle = Path.Combine(asmDir, "..", "Resources", resourceDirName);
+        if (Directory.Exists(bundle))
+            return bundle;
+
+        return null;
+    }
+}

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -116,24 +116,9 @@ public sealed class DictionaryService : IDictionaryService
         return File.ReadAllBytes(a).AsSpan().SequenceEqual(File.ReadAllBytes(b));
     }
 
-    // The bundled dictionaries live in the dev project dir, or under Resources/ in a packaged .app.
-    private static string? ResolveBundledDictionariesDir()
-    {
-        var asmDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) ?? "";
-        // Development: bin/<cfg>/<tfm>/ -> ../../../dictionaries (the project's dictionaries/ folder)
-        var dev = Path.Combine(asmDir, "..", "..", "..", "dictionaries");
-        if (Directory.Exists(dev))
-            return dev;
-        // Packaged beside the executable (Windows/Linux self-contained publish): <app>/dictionaries. (#403)
-        var beside = Path.Combine(asmDir, "dictionaries");
-        if (Directory.Exists(beside))
-            return beside;
-        // Packaged .app: Contents/MacOS/ -> ../Resources/dictionaries
-        var bundle = Path.Combine(asmDir, "..", "Resources", "dictionaries");
-        if (Directory.Exists(bundle))
-            return bundle;
-        return null;
-    }
+    // The bundled dictionaries live in the dev project dir, beside the executable, or under Resources/
+    // in a packaged .app. See BundledResourceLocator for why the dev lookup cannot use a fixed hop count.
+    private static string? ResolveBundledDictionariesDir() => BundledResourceLocator.Resolve("dictionaries");
 
     public IReadOnlyList<string> AvailableLanguages
     {

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -1290,44 +1290,14 @@ namespace CST.Avalonia.ViewModels
         {
             try
             {
-                string? sourceXslDir = null;
-
-                // First, try to find XSL files in development environment
-                var assemblyLocation = System.Reflection.Assembly.GetExecutingAssembly().Location;
-                var projectXslPath = Path.Combine(
-                    Path.GetDirectoryName(assemblyLocation) ?? "",
-                    "..", "..", "..", "Xsl");
-
-                if (Directory.Exists(projectXslPath))
-                {
-                    sourceXslDir = projectXslPath;
-                    _logger.Information("Found XSL files in development directory: {Path}", projectXslPath);
-                }
-                else
-                {
-                    // Packaged beside the executable (Windows/Linux self-contained publish): <app>/xsl. (#403)
-                    var besideExePath = Path.Combine(
-                        Path.GetDirectoryName(assemblyLocation) ?? "", "xsl");
-
-                    // Try app bundle location for production (macOS: Contents/MacOS -> ../Resources/xsl)
-                    var bundleResourcesPath = Path.Combine(
-                        Path.GetDirectoryName(assemblyLocation) ?? "",
-                        "..", "Resources", "xsl");
-
-                    if (Directory.Exists(besideExePath))
-                    {
-                        sourceXslDir = besideExePath;
-                        _logger.Information("Found XSL files next to the executable: {Path}", besideExePath);
-                    }
-                    else if (Directory.Exists(bundleResourcesPath))
-                    {
-                        sourceXslDir = bundleResourcesPath;
-                        _logger.Information("Found XSL files in app bundle: {Path}", bundleResourcesPath);
-                    }
-                }
-
+                // Dev source tree, beside the executable, or the macOS .app Resources dir. The dev lookup
+                // deliberately walks ancestors instead of hopping a fixed number of levels - see
+                // BundledResourceLocator. (#28)
+                string? sourceXslDir = BundledResourceLocator.Resolve("xsl");
                 if (sourceXslDir != null)
                 {
+                    _logger.Information("Found XSL files at: {Path}", sourceXslDir);
+
                     var xslFiles = Directory.GetFiles(sourceXslDir, "*.xsl");
                     int copiedCount = 0;
                     foreach (var xslFile in xslFiles)

--- a/src/CST.Avalonia/package-windows.ps1
+++ b/src/CST.Avalonia/package-windows.ps1
@@ -10,17 +10,20 @@
   Both land in dist/. Distribution is via GitHub Releases + WinGet (fsnow.CSTReader); unsigned for beta. (#28)
 
 .PARAMETER Arch
-  Target architecture. Only x64 is supported for now (ARM64 deferred, #28).
+  Target architecture: x64 or arm64. Each produces its own zip + installer; both are shipped per release.
+  The two builds differ in more than the RID - CST.Avalonia.csproj selects WebViewControl-Avalonia (x64) vs
+  WebViewControl-Avalonia-ARM64 (arm64), which is what supplies the matching native CEF.
 
 .PARAMETER NoInstaller
   Skip the InnoSetup step (portable zip only).
 
 .EXAMPLE
   ./package-windows.ps1
+  ./package-windows.ps1 -Arch arm64
   ./package-windows.ps1 -NoInstaller
 #>
 param(
-    [ValidateSet('x64')]
+    [ValidateSet('x64','arm64')]
     [string]$Arch = 'x64',
     [switch]$NoInstaller
 )
@@ -103,7 +106,7 @@ if (-not $iscc) {
 }
 
 Write-Host "`nBuilding InnoSetup installer with $iscc ..." -ForegroundColor Yellow
-& $iscc "/DAppVersion=$Version" "/DPublishDir=$PublishDir" "/DOutputDir=$DistDir" (Join-Path $ProjectDir 'CST.Avalonia.iss')
+& $iscc "/DAppVersion=$Version" "/DArch=$Arch" "/DPublishDir=$PublishDir" "/DOutputDir=$DistDir" (Join-Path $ProjectDir 'CST.Avalonia.iss')
 if ($LASTEXITCODE -ne 0) { throw "ISCC failed ($LASTEXITCODE)" }
 
 $setup = Join-Path $DistDir "CST-Reader-$Version-$RID-setup.exe"


### PR DESCRIPTION
Adds a native Windows ARM64 build and packaging path, verified end to end on a Windows 11 ARM64 VM.

## The defect this uncovered

`package-windows.ps1` refused ARM64 outright (`[ValidateSet('x64')]`). That turned out to be masking a real bug rather than just a missing flag.

The csproj claimed the plain `WebViewControl-Avalonia` package carried both Windows CEF architectures. It does not — it depends only on `chromiumembeddedframework.runtime.win-x64`. `WebViewControl-Avalonia-ARM64` carries the `win-arm64` runtime at the same CEF 120.1.8, plus the matching per-arch `CefGlueBrowserProcess` helper (the plain package ships `bin/{linux-x64,osx-x64,win-x64}` only).

The failure mode was quiet: `dotnet publish -r win-arm64 --self-contained` **exited 0 but shipped no `libcef.dll` at all**, because RID-mismatched natives are silently dropped. The managed CefGlue assemblies were present, so the app built and launched — and then failed at CEF init, i.e. every book view.

`CefGlue.Common.targets` already handles `win-arm64` (it copies from `chromiumembeddedframework.runtime.$(CefGlueTargetPlatform)`). Only the package choice was wrong.

## Changes

**`#28: resolve bundled xsl/dictionaries by walking ancestors, not a fixed hop count`**
Both bundled-resource lookups hardcoded three `..` hops, assuming the RID-less output layout. Any RID-specific build adds a segment, so three hops landed on `bin/` and the app fell through to an empty user directory — every book rendered "XSL file not found". Replaced with a bounded upward search shared via `BundledResourceLocator`. Ordered first so no commit in history is broken by the RID pin that follows. Also fixes the XSL branch searching for `"Xsl"` when the real directory is lowercase `xsl` — that only ever worked because Windows and default APFS are case-insensitive, and would have broken on Linux.

**`#28: build and package CST Reader for Windows ARM64`**
- csproj selects `WebViewControl-Avalonia-ARM64` for `win-arm64`
- New `Directory.Build.props` pins `RuntimeIdentifier=win-arm64` for RID-less builds on ARM64 Windows hosts. `CefGlue.Common.props` hardcodes `CefGlueTargetPlatform=win-x64` for *any* RID-less Windows build (it only honours `Platform=ARM64`, which the SDK leaves at `AnyCPU`), so a bare `dotnet build` wired x64 CEF paths into an arm64 process. This must live in `Directory.Build.props`, not the csproj: `Microsoft.Common.props` imports it *before* the NuGet-generated props that pull in `CefGlue.Common.props`. An explicit `-r` always wins, so packaging is unaffected.
- `package-windows.ps1` accepts `-Arch arm64` and passes `/DArch` to ISCC
- `CST.Avalonia.iss` parameterizes the output filename and architecture gate (`arm64` vs `x64compatible`). Both installers keep the same `AppId`, so a native arm64 install upgrades an emulated x64 one in place.

**`#28: document the Windows release path in RELEASE_PROCESS.md`**
The release doc was macOS-only — it never mentioned Windows, `package-windows.ps1` or WinGet, even though Windows x64 already shipped. Adds a four-build shipping matrix, Windows toolchain requirements, a "Step 1b: Build Windows Packages" section, Windows entries in the release-notes template, and a WinGet manifest section. Also renumbers the tail: headings ran 1a, 1b, 2, 3, **3**, 4 against an overview promising five steps.

## Verification (Windows 11 ARM64)

| Check | Result |
|---|---|
| `dotnet build`, `dotnet run` (no `-r`) | CEF initializes, welcome page renders |
| `dotnet test` | 973/973 pass |
| Publish output | `libcef.dll`, `chrome_elf.dll`, app host, browser-process helper all **ARM64** by PE header |
| `package-windows.ps1 -Arch arm64` | 218 MB portable zip + 149 MB installer |
| Silent install + launch | exit 0, no UAC prompt, 681 files, CEF up, book renders |

## Not covered

- **Windows x64 is unverified here** — this VM can't build it natively. The `win-x64` condition is unchanged, but please re-run `package-windows.ps1` on an x64 machine before release.
- Keyboard shortcuts are hardcoded to `Cmd` (→ `KeyModifiers.Meta` → the **Windows key**), so most collide with OS shortcuts on Windows. Tracked separately; not in this PR.
