### PR TITLE
#28: make menu shortcuts work on Windows (modifier, accelerators, and unreachable Settings)

### DIFF
--- a/src/CST.Avalonia.Tests/Input/PlatformGestureTests.cs
+++ b/src/CST.Avalonia.Tests/Input/PlatformGestureTests.cs
@@ -1,0 +1,73 @@
+using System;
+using Avalonia.Input;
+using CST.Avalonia.Input;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Input;
+
+// #28: every menu shortcut used to be spelled "Cmd+X". Avalonia parses Cmd/Win/Meta/Super to the same
+// KeyModifiers.Meta, and on Windows Meta is the *Windows key* - so the shortcuts were bound to Win+D,
+// Win+F and friends, most of which Windows reserves for itself and never delivers to the app.
+// These tests pin the platform mapping so the regression cannot come back silently.
+//
+// Application.Current is null under the headless test host, so these also exercise PlatformGesture's
+// OS-check fallback - the path that has to be right when XAML is parsed before PlatformSettings exists.
+public class PlatformGestureTests
+{
+    private static KeyModifiers ExpectedCommandModifier =>
+        OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control;
+
+    [Fact]
+    public void CommandModifier_MatchesTheHostPlatform()
+    {
+        Assert.Equal(ExpectedCommandModifier, PlatformGesture.CommandModifier);
+    }
+
+    [Fact]
+    public void CommandModifier_IsNeverMetaOffMacOS()
+    {
+        if (OperatingSystem.IsMacOS())
+            return;
+
+        // The whole point: on Windows/Linux, Meta is the Windows/Super key and must never be used.
+        Assert.NotEqual(KeyModifiers.Meta, PlatformGesture.CommandModifier);
+    }
+
+    [Theory]
+    [InlineData("d", Key.D)]
+    [InlineData("o", Key.O)]
+    [InlineData("OemComma", Key.OemComma)]
+    public void Parse_BindsTheKeyToThePlatformCommandModifier(string gesture, Key expectedKey)
+    {
+        var parsed = PlatformGesture.Parse(gesture);
+
+        Assert.Equal(expectedKey, parsed.Key);
+        Assert.Equal(ExpectedCommandModifier, parsed.KeyModifiers);
+    }
+
+    [Theory]
+    [InlineData("shift+e", Key.E)]
+    [InlineData("shift+p", Key.P)]
+    public void Parse_KeepsAdditionalModifiersAlongsideTheCommandModifier(string gesture, Key expectedKey)
+    {
+        var parsed = PlatformGesture.Parse(gesture);
+
+        Assert.Equal(expectedKey, parsed.Key);
+        Assert.Equal(ExpectedCommandModifier | KeyModifiers.Shift, parsed.KeyModifiers);
+    }
+
+    [Fact]
+    public void Parse_IsCaseInsensitive_MatchingAvaloniaGestureParsing()
+    {
+        Assert.Equal(PlatformGesture.Parse("d"), PlatformGesture.Parse("D"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Parse_RejectsAGestureWithNoKey(string? gesture)
+    {
+        Assert.Throws<ArgumentException>(() => PlatformGesture.Parse(gesture!));
+    }
+}

--- a/src/CST.Avalonia/App.axaml
+++ b/src/CST.Avalonia/App.axaml
@@ -6,6 +6,7 @@
              xmlns:vm="using:CST.Avalonia.ViewModels"
              xmlns:views="using:CST.Avalonia.Views"
              xmlns:dock="using:Dock.Model.Mvvm.Controls"
+             xmlns:input="using:CST.Avalonia.Input"
              RequestedThemeVariant="Default">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 
@@ -92,8 +93,10 @@
     <!-- Native Menu for macOS - Application level (goes into CST Reader app menu) -->
     <NativeMenu.Menu>
         <NativeMenu>
-            <!-- Preferences in app menu following macOS convention -->
-            <NativeMenuItem Header="Preferences..." Gesture="Cmd+OemComma" />
+            <!-- Preferences in app menu following macOS convention. This application-level NativeMenu is
+                 only realised as the macOS app menu, so the gesture is ⌘, in practice - but it resolves
+                 per platform like every other shortcut rather than hardcoding the modifier. (#28) -->
+            <NativeMenuItem Header="Preferences..." Gesture="{input:CommandGesture OemComma}" />
         </NativeMenu>
     </NativeMenu.Menu>
 </Application>

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1661,7 +1661,10 @@ public partial class App : Application
         }
     }
 
-    private async Task ShowSettingsWindow()
+    // #28: also invoked from the Windows/Linux Tools menu. The macOS Preferences item lives in the
+    // application-level NativeMenu, which is only ever realised as the macOS app menu - off macOS the
+    // in-window <NativeMenuBar/> renders the *window's* menu, so Settings had no entry point at all.
+    internal static async Task ShowSettingsWindow()
     {
         try
         {

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -22,6 +22,7 @@ using CST.Avalonia.Views;
 using CST.Avalonia.Services;
 using CST.Avalonia.Models;
 using CST.Avalonia.Constants;
+using CST.Avalonia.Input;
 using Dock.Model.Core;
 using Dock.Model.Mvvm.Controls;
 using CST;
@@ -1346,7 +1347,7 @@ public partial class App : Application
             viewMenu.Add(dictionaryItem);
 
             // Tools menu: Go To... + View Source (floating windows are book-centric)
-            var goToItem = new NativeMenuItem { Header = "Go To...", Gesture = KeyGesture.Parse("Cmd+G") };
+            var goToItem = new NativeMenuItem { Header = "Go To...", Gesture = PlatformGesture.Parse("G") };
             goToItem.Click += (s, e) =>
             {
                 Log.Information("Go To menu item clicked via Tools menu (floating window)");
@@ -1354,19 +1355,19 @@ public partial class App : Application
             };
 
             // View Source as app-level shortcuts so they work without the WebView having focus. (Cmd+E/Shift+Cmd+E)
-            var viewSource1957Item = new NativeMenuItem { Header = "View Source (1957 ed.)", Gesture = KeyGesture.Parse("Cmd+E") };
+            var viewSource1957Item = new NativeMenuItem { Header = "View Source (1957 ed.)", Gesture = PlatformGesture.Parse("E") };
             viewSource1957Item.Click += (s, e) => OnViewSourceFromFloatingWindow(window, source2010: false);
-            var viewSource2010Item = new NativeMenuItem { Header = "View Source (2010 ed.)", Gesture = KeyGesture.Parse("Cmd+Shift+E") };
+            var viewSource2010Item = new NativeMenuItem { Header = "View Source (2010 ed.)", Gesture = PlatformGesture.Parse("Shift+E") };
             viewSource2010Item.Click += (s, e) => OnViewSourceFromFloatingWindow(window, source2010: true);
 
             // #448: Look Up in Dictionary (Cmd+D) and Search for Selection (Cmd+F). These were declared only
             // in the main window's Tools menu, and macOS shows the menu bar of whichever window is active —
             // so with a floated book focused they were dead keys. Both act on the floated book's selection
             // and reveal their tool in the main window.
-            var lookUpItem = new NativeMenuItem { Header = "Look Up in Dictionary", Gesture = KeyGesture.Parse("Cmd+D") };
+            var lookUpItem = new NativeMenuItem { Header = "Look Up in Dictionary", Gesture = PlatformGesture.Parse("D") };
             lookUpItem.Click += async (s, e) =>
                 await SimpleTabbedWindow.LookUpInDictionaryAsync(FindActiveBookInFloatingWindow(window));
-            var searchSelectionItem = new NativeMenuItem { Header = "Search for Selection", Gesture = KeyGesture.Parse("Cmd+F") };
+            var searchSelectionItem = new NativeMenuItem { Header = "Search for Selection", Gesture = PlatformGesture.Parse("F") };
             searchSelectionItem.Click += async (s, e) =>
                 await SimpleTabbedWindow.SearchForSelectionAsync(FindActiveBookInFloatingWindow(window));
 
@@ -1378,18 +1379,18 @@ public partial class App : Application
             toolsMenu.Add(viewSource2010Item);
 
             // #110: File > Close Tab (⌘W) — closes the active document tab in this floating window.
-            var closeTabItem = new NativeMenuItem { Header = "Close Tab", Gesture = KeyGesture.Parse("Cmd+W") };
+            var closeTabItem = new NativeMenuItem { Header = "Close Tab", Gesture = PlatformGesture.Parse("W") };
             closeTabItem.Click += (s, e) => OnCloseTabFromFloatingWindow(window);
             // #111: Select a Book (Cmd+O) — the tree lives in the main window, so this reveals and focuses
             // it there, the same as the main window's File menu item.
-            var selectBookMenuItem = new NativeMenuItem { Header = "Select a Book", Gesture = KeyGesture.Parse("Cmd+O") };
+            var selectBookMenuItem = new NativeMenuItem { Header = "Select a Book", Gesture = PlatformGesture.Parse("O") };
             selectBookMenuItem.Click += (s, e) => SimpleTabbedWindow.RevealSelectBookPanel();
 
             // #112: Print (Cmd+P) and Print Selection (Shift+Cmd+P) the floated book — same native
             // window.print() path as the main window.
-            var printItem = new NativeMenuItem { Header = "Print…", Gesture = KeyGesture.Parse("Cmd+P") };
+            var printItem = new NativeMenuItem { Header = "Print…", Gesture = PlatformGesture.Parse("P") };
             printItem.Click += (s, e) => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.Print();
-            var printSelectionItem = new NativeMenuItem { Header = "Print Selection…", Gesture = KeyGesture.Parse("Cmd+Shift+P") };
+            var printSelectionItem = new NativeMenuItem { Header = "Print Selection…", Gesture = PlatformGesture.Parse("Shift+P") };
             printSelectionItem.Click += (s, e) => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.PrintSelection();
 
             var fileMenu = new NativeMenu();
@@ -1496,7 +1497,7 @@ public partial class App : Application
         submenu.Items.Clear();
 
         // Minimize acts on the window whose menu bar is showing (its owner).
-        var minimize = new NativeMenuItem { Header = "Minimize", Gesture = KeyGesture.Parse("Cmd+M") };
+        var minimize = new NativeMenuItem { Header = "Minimize", Gesture = PlatformGesture.Parse("M") };
         minimize.Click += (_, _) => { try { owner.WindowState = global::Avalonia.Controls.WindowState.Minimized; } catch { /* ignore */ } };
         submenu.Add(minimize);
 

--- a/src/CST.Avalonia/Input/CommandGestureExtension.cs
+++ b/src/CST.Avalonia/Input/CommandGestureExtension.cs
@@ -1,0 +1,26 @@
+using System;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+
+namespace CST.Avalonia.Input;
+
+/// <summary>
+/// XAML form of <see cref="PlatformGesture"/>, so menu declarations stay declarative:
+/// <c>Gesture="{input:CommandGesture o}"</c> yields ⌘O on macOS and Ctrl+O on Windows/Linux.
+///
+/// Write the gesture *without* its command modifier - "o", "shift+e", "OemComma". Spelling the modifier
+/// out ("cmd+o") is exactly the bug this replaces.
+/// </summary>
+public sealed class CommandGestureExtension : MarkupExtension
+{
+    public CommandGestureExtension()
+    {
+    }
+
+    public CommandGestureExtension(string gesture) => Gesture = gesture;
+
+    /// <summary>The gesture minus its command modifier, e.g. "shift+p".</summary>
+    public string Gesture { get; set; } = string.Empty;
+
+    public override object ProvideValue(IServiceProvider serviceProvider) => PlatformGesture.Parse(Gesture);
+}

--- a/src/CST.Avalonia/Input/PlatformGesture.cs
+++ b/src/CST.Avalonia/Input/PlatformGesture.cs
@@ -1,0 +1,43 @@
+using System;
+using Avalonia;
+using Avalonia.Input;
+
+namespace CST.Avalonia.Input;
+
+/// <summary>
+/// Builds menu shortcuts using the platform's own "command" modifier: Meta (⌘) on macOS, Control on
+/// Windows and Linux.
+///
+/// Every shortcut used to be spelled literally as "Cmd+X". Avalonia parses Cmd, Win, Meta and Super to
+/// the same <see cref="KeyModifiers.Meta"/>, and on Windows Meta is the *Windows key* - so the shortcuts
+/// were bound to Win+D, Win+F and friends. Most of those are reserved by Windows itself (Win+D shows the
+/// desktop, Win+E opens Explorer, Win+G opens Game Bar), so the app never even saw the keystroke. (#28)
+///
+/// Avalonia has no platform-adaptive token to write in a gesture string - "$ctrl+D" is a parse error -
+/// so the substitution has to happen here.
+/// </summary>
+public static class PlatformGesture
+{
+    /// <summary>
+    /// The platform's command modifier. Prefers Avalonia's own answer so this tracks any future platform
+    /// it learns about; falls back to an OS check because <see cref="Application.PlatformSettings"/> is
+    /// not guaranteed to be initialised at XAML parse time, and a null here would break startup.
+    /// </summary>
+    public static KeyModifiers CommandModifier =>
+        Application.Current?.PlatformSettings?.HotkeyConfiguration.CommandModifiers
+        ?? (OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control);
+
+    /// <summary>
+    /// Parses a gesture written *without* its command modifier - "o", "shift+e", "OemComma" - and returns
+    /// it bound to the platform's command modifier. Delegates to Avalonia's parser so the accepted key
+    /// names stay identical to a hand-written gesture string.
+    /// </summary>
+    public static KeyGesture Parse(string gesture)
+    {
+        if (string.IsNullOrWhiteSpace(gesture))
+            throw new ArgumentException("Gesture must name at least a key.", nameof(gesture));
+
+        var prefix = CommandModifier == KeyModifiers.Meta ? "Cmd+" : "Ctrl+";
+        return KeyGesture.Parse(prefix + gesture);
+    }
+}

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -2021,6 +2021,49 @@ public partial class BookDisplayView : UserControl
                 _logger.Error("Error processing Go To request from JavaScript | {Details}", ex.Message);
             }
         }
+        // #28: Look Up in Dictionary requested from JavaScript (⌘/Ctrl+D while this book's WebView has
+        // focus). Like CST_GOTO, the message arrives on the focused book's own view, so it is inherently
+        // the right book. LookUpInDictionaryAsync then does its own title round-trip to pull the current
+        // selection (CST_LOOKUP_SEL), which is why this must not run on the CEF thread.
+        else if (title != null && title.StartsWith("CST_LOOKUP_REQUESTED:"))
+        {
+            try
+            {
+                var parts = title.Split('|');
+                var messageTabId = parts.Length > 1 && parts[1].StartsWith("TAB:") ? parts[1].Substring(4) : "";
+
+                if (messageTabId == _tabId)
+                {
+                    _logger.Debug("*** LOOK UP IN DICTIONARY REQUESTED FROM JAVASCRIPT ***");
+                    Dispatcher.UIThread.Post(async () =>
+                        await SimpleTabbedWindow.LookUpInDictionaryAsync(_viewModel));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Error processing Look Up in Dictionary request from JavaScript | {Details}", ex.Message);
+            }
+        }
+        // #28: Search for Selection requested from JavaScript (⌘/Ctrl+F while this book's WebView has focus).
+        else if (title != null && title.StartsWith("CST_SEARCH_SELECTION_REQUESTED:"))
+        {
+            try
+            {
+                var parts = title.Split('|');
+                var messageTabId = parts.Length > 1 && parts[1].StartsWith("TAB:") ? parts[1].Substring(4) : "";
+
+                if (messageTabId == _tabId)
+                {
+                    _logger.Debug("*** SEARCH FOR SELECTION REQUESTED FROM JAVASCRIPT ***");
+                    Dispatcher.UIThread.Post(async () =>
+                        await SimpleTabbedWindow.SearchForSelectionAsync(_viewModel));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Error processing Search for Selection request from JavaScript | {Details}", ex.Message);
+            }
+        }
         // Check for JS log messages
         else if (title != null && title.StartsWith("CST_LOG_MSG::"))
         {
@@ -2147,6 +2190,32 @@ public partial class BookDisplayView : UserControl
                                     if (event.repeat) return false;
                                     window.cstLogger.log('DEBUG', 'Go To shortcut detected in JavaScript');
                                     document.title = 'CST_GOTO:|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                                    return false;
+                                }
+
+                                // #28: Cmd+D / Ctrl+D (Look Up in Dictionary). Same reason as Go To below -
+                                // CEF holds focus while reading, so the window KeyBindings never see this.
+                                // On Windows this is the whole shortcut: NativeMenuBar gestures are
+                                // display-only there, so without this forward Ctrl+D is a dead key in a book.
+                                // Match 'd' and 'D' (Caps Lock yields 'D' in Chromium); !shiftKey keeps any
+                                // future ⇧⌘D free. preventDefault also stops Chromium's bookmark dialog.
+                                if ((event.key === 'd' || event.key === 'D') && !event.shiftKey && (event.metaKey || event.ctrlKey)) {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                    if (event.repeat) return false;
+                                    window.cstLogger.log('DEBUG', 'Look Up in Dictionary shortcut detected in JavaScript');
+                                    document.title = 'CST_LOOKUP_REQUESTED:|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                                    return false;
+                                }
+
+                                // #28: Cmd+F / Ctrl+F (Search for Selection). preventDefault also suppresses
+                                // Chromium's own find bar, which would otherwise open over the book.
+                                if ((event.key === 'f' || event.key === 'F') && !event.shiftKey && (event.metaKey || event.ctrlKey)) {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                    if (event.repeat) return false;
+                                    window.cstLogger.log('DEBUG', 'Search for Selection shortcut detected in JavaScript');
+                                    document.title = 'CST_SEARCH_SELECTION_REQUESTED:|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
                                     return false;
                                 }
 

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:dock="using:Dock.Avalonia.Controls"
         xmlns:vm="using:CST.Avalonia.ViewModels"
+        xmlns:input="using:CST.Avalonia.Input"
         x:Class="CST.Avalonia.Views.SimpleTabbedWindow"
         x:DataType="vm:LayoutViewModel"
         Title="CST Reader"
@@ -12,22 +13,25 @@
     <!-- Native Menu for macOS - Window level (creates top-level menus in menu bar) -->
     <NativeMenu.Menu>
         <NativeMenu>
-            <!-- File Menu (#110): ⌘W closes the active document tab (book or PDF) in the focused window -->
+            <!-- File Menu (#110): ⌘/Ctrl+W closes the active document tab (book or PDF) in the focused window.
+                 Gestures use {input:CommandGesture} so the modifier resolves per platform - ⌘ on macOS,
+                 Ctrl on Windows/Linux. Spelling "cmd+w" here bound them to the Windows key, which Windows
+                 itself reserves for most of these letters. (#28) -->
             <NativeMenuItem Header="File">
                 <NativeMenu>
-                    <!-- #111: ⌘O reveals the book tree and focuses it; it never hides the panel
+                    <!-- #111: ⌘/Ctrl+O reveals the book tree and focuses it; it never hides the panel
                          (the View menu checkbox does that). CST4's Ctrl+O opened the book dialog. -->
-                    <NativeMenuItem Header="Select a Book" Click="OnSelectBookClick" Gesture="cmd+o" />
+                    <NativeMenuItem Header="Select a Book" Click="OnSelectBookClick" Gesture="{input:CommandGesture o}" />
                     <!-- #44: populated at runtime from the recent-books MRU list by App.RebuildRecentMenus -->
                     <NativeMenuItem Header="Open Recent">
                         <NativeMenu />
                     </NativeMenuItem>
                     <NativeMenuItemSeparator />
                     <!-- #112: print the active book via the platform print dialog (window.print()) -->
-                    <NativeMenuItem Header="Print…" Click="OnPrintClick" Gesture="cmd+p" />
-                    <NativeMenuItem Header="Print Selection…" Click="OnPrintSelectionClick" Gesture="cmd+shift+p" />
+                    <NativeMenuItem Header="Print…" Click="OnPrintClick" Gesture="{input:CommandGesture p}" />
+                    <NativeMenuItem Header="Print Selection…" Click="OnPrintSelectionClick" Gesture="{input:CommandGesture shift+p}" />
                     <NativeMenuItemSeparator />
-                    <NativeMenuItem Header="Close Tab" Click="OnCloseTabClick" Gesture="cmd+w" />
+                    <NativeMenuItem Header="Close Tab" Click="OnCloseTabClick" Gesture="{input:CommandGesture w}" />
                 </NativeMenu>
             </NativeMenuItem>
 
@@ -43,11 +47,11 @@
             <!-- Tools Menu -->
             <NativeMenuItem Header="Tools">
                 <NativeMenu>
-                    <NativeMenuItem Header="Go To..." Click="OnGoToMenuItemClick" Gesture="cmd+g" />
-                    <NativeMenuItem Header="Look Up in Dictionary" Click="OnLookUpInDictionaryClick" Gesture="cmd+d" />
-                    <NativeMenuItem Header="Search for Selection" Click="OnSearchForSelectionClick" Gesture="cmd+f" />
-                    <NativeMenuItem Header="View Source (1957 ed.)" Click="OnViewSource1957Click" Gesture="cmd+e" />
-                    <NativeMenuItem Header="View Source (2010 ed.)" Click="OnViewSource2010Click" Gesture="cmd+shift+e" />
+                    <NativeMenuItem Header="Go To..." Click="OnGoToMenuItemClick" Gesture="{input:CommandGesture g}" />
+                    <NativeMenuItem Header="Look Up in Dictionary" Click="OnLookUpInDictionaryClick" Gesture="{input:CommandGesture d}" />
+                    <NativeMenuItem Header="Search for Selection" Click="OnSearchForSelectionClick" Gesture="{input:CommandGesture f}" />
+                    <NativeMenuItem Header="View Source (1957 ed.)" Click="OnViewSource1957Click" Gesture="{input:CommandGesture e}" />
+                    <NativeMenuItem Header="View Source (2010 ed.)" Click="OnViewSource2010Click" Gesture="{input:CommandGesture shift+e}" />
                 </NativeMenu>
             </NativeMenuItem>
 

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -12,6 +12,7 @@ using Avalonia.VisualTree;
 using CST.Avalonia.ViewModels;
 using CST.Avalonia.Services;
 using CST.Avalonia.Models;
+using CST.Avalonia.Input;
 using CST;
 using CST.Conversion;
 using Serilog;
@@ -56,7 +57,10 @@ public partial class SimpleTabbedWindow : Window
         
         // Initialize window state management
         InitializeWindowStateManagement();
-        
+
+        // #28: off macOS the menu's gestures are decorative until we bind them ourselves.
+        RegisterMenuShortcutKeyBindings();
+
         // Add diagnostic logging for focus and keyboard events
         GotFocus += (s, e) => _logger.Debug("FOCUS: SimpleTabbedWindow GotFocus. Source: {Source}", e.Source?.GetType().Name);
         LostFocus += (s, e) => _logger.Debug("FOCUS: SimpleTabbedWindow LostFocus. Source: {Source}", e.Source?.GetType().Name);
@@ -646,6 +650,56 @@ public partial class SimpleTabbedWindow : Window
                 _logger.Information("Restored WebView in window: {WindowTitle}", window.Title);
             }
         }
+    }
+
+    // Minimal ICommand for the KeyBindings below. KeyBinding needs an ICommand and these are plain
+    // void handlers, so a relay is all that is required - no ReactiveCommand scheduler in a Window.
+    private sealed class MenuShortcutCommand : System.Windows.Input.ICommand
+    {
+        private readonly Action _invoke;
+        public MenuShortcutCommand(Action invoke) => _invoke = invoke;
+        public event EventHandler? CanExecuteChanged { add { } remove { } }
+        public bool CanExecute(object? parameter) => true;
+        public void Execute(object? parameter) => _invoke();
+    }
+
+    /// <summary>
+    /// Binds the menu shortcuts as real window accelerators on Windows/Linux.
+    ///
+    /// The in-window &lt;NativeMenuBar/&gt; only ever *displayed* them: NativeMenuBarPresenter binds
+    /// NativeMenuItem.Gesture to MenuItem.InputGesture, which is decoration, and never to MenuItem.HotKey,
+    /// which is what registers an accelerator. So off macOS every menu shortcut was dead - the menu showed
+    /// "Ctrl+D" and pressing it did nothing. Only ⌘/Ctrl+G, W, E, C and A appeared to work, because those
+    /// are separately forwarded out of the book WebView by JavaScript. (#28)
+    ///
+    /// macOS is deliberately excluded: the system menu bar already registers these gestures, and a second
+    /// binding here would invoke each command twice.
+    ///
+    /// This covers focus anywhere in Avalonia's own controls. When a book WebView holds focus, CEF takes
+    /// the keystroke before Avalonia sees it - that case is handled by the JS capture in BookDisplayView.
+    /// </summary>
+    private void RegisterMenuShortcutKeyBindings()
+    {
+        if (OperatingSystem.IsMacOS()) return;
+
+        void Bind(string gesture, Action invoke) => KeyBindings.Add(new KeyBinding
+        {
+            Gesture = PlatformGesture.Parse(gesture),
+            Command = new MenuShortcutCommand(invoke)
+        });
+
+        // Same set, and the same handlers, as the NativeMenu declarations in SimpleTabbedWindow.axaml.
+        Bind("o", () => OnSelectBookClick(this, EventArgs.Empty));
+        Bind("p", () => OnPrintClick(this, EventArgs.Empty));
+        Bind("shift+p", () => OnPrintSelectionClick(this, EventArgs.Empty));
+        Bind("w", () => OnCloseTabClick(this, EventArgs.Empty));
+        Bind("g", () => OnGoToMenuItemClick(this, EventArgs.Empty));
+        Bind("d", () => OnLookUpInDictionaryClick(this, EventArgs.Empty));
+        Bind("f", () => OnSearchForSelectionClick(this, EventArgs.Empty));
+        Bind("e", () => OnViewSource1957Click(this, EventArgs.Empty));
+        Bind("shift+e", () => OnViewSource2010Click(this, EventArgs.Empty));
+
+        _logger.Information("Registered {Count} menu shortcut key bindings (NativeMenuBar gestures are display-only off macOS)", KeyBindings.Count);
     }
 
     private void OnGoToMenuItemClick(object? sender, EventArgs e)

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -60,6 +60,8 @@ public partial class SimpleTabbedWindow : Window
 
         // #28: off macOS the menu's gestures are decorative until we bind them ourselves.
         RegisterMenuShortcutKeyBindings();
+        // #28: and Settings has no entry point off macOS until we add one.
+        AddSettingsMenuItemOffMacOS();
 
         // Add diagnostic logging for focus and keyboard events
         GotFocus += (s, e) => _logger.Debug("FOCUS: SimpleTabbedWindow GotFocus. Source: {Source}", e.Source?.GetType().Name);
@@ -698,8 +700,59 @@ public partial class SimpleTabbedWindow : Window
         Bind("f", () => OnSearchForSelectionClick(this, EventArgs.Empty));
         Bind("e", () => OnViewSource1957Click(this, EventArgs.Empty));
         Bind("shift+e", () => OnViewSource2010Click(this, EventArgs.Empty));
+        // Settings lives in the macOS app menu, so it has no NativeMenu declaration here to mirror -
+        // see AddSettingsMenuItemOffMacOS, which adds the Tools entry this shortcut matches.
+        Bind("OemComma", () => _ = App.ShowSettingsWindow());
 
         _logger.Information("Registered {Count} menu shortcut key bindings (NativeMenuBar gestures are display-only off macOS)", KeyBindings.Count);
+    }
+
+    /// <summary>
+    /// Adds Tools &gt; Settings on Windows/Linux.
+    ///
+    /// Preferences is declared in App.axaml's *application*-level NativeMenu, which Avalonia only ever
+    /// realises as the macOS application menu. Off macOS the in-window &lt;NativeMenuBar/&gt; renders the
+    /// *window's* menu (File/View/Tools/Window), so that declaration is never shown and the Settings
+    /// dialog was completely unreachable - no menu item, and no working shortcut either. (#28)
+    ///
+    /// Added here rather than in SimpleTabbedWindow.axaml because it must not appear on macOS, where
+    /// Preferences belongs in the application menu per the platform convention.
+    /// </summary>
+    private void AddSettingsMenuItemOffMacOS()
+    {
+        if (OperatingSystem.IsMacOS()) return;
+
+        try
+        {
+            var toolsMenu = NativeMenu.GetMenu(this)?
+                .Items.OfType<NativeMenuItem>()
+                .FirstOrDefault(i => i.Header?.ToString() == "Tools")?.Menu;
+
+            if (toolsMenu == null)
+            {
+                _logger.Warning("Tools menu not found - Settings will be reachable only via its keyboard shortcut");
+                return;
+            }
+
+            var settingsItem = new NativeMenuItem
+            {
+                Header = "Settings…",
+                Gesture = PlatformGesture.Parse("OemComma")
+            };
+            settingsItem.Click += async (s, e) =>
+            {
+                _logger.Information("Settings opened from the Tools menu");
+                await App.ShowSettingsWindow();
+            };
+
+            toolsMenu.Add(new NativeMenuItemSeparator());
+            toolsMenu.Add(settingsItem);
+            _logger.Information("Added Tools > Settings (macOS shows Preferences in the application menu instead)");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Failed to add the Settings menu item");
+        }
     }
 
     private void OnGoToMenuItemClick(object? sender, EventArgs e)


### PR DESCRIPTION
Makes the menu shortcuts work on Windows. Beta 5 is the first release with Windows support, and **none of them have ever worked there** — two independent bugs, plus a third that left the Settings dialog unreachable entirely.

Verified end to end on Windows 11 ARM64. The x64 half was corroborated by an earlier failing test on a Windows x64 laptop, so this is platform-wide, not architecture-specific.

## Bug 1 — the modifier was the Windows key

Every gesture was spelled literally as `Cmd+X`. Avalonia parses `Cmd`, `Win`, `Meta` and `Super` to the same `KeyModifiers.Meta`, and on Windows Meta *is* the Windows key. Verified against Avalonia 11.3.6:

```
Cmd+D      -> Key=D Modifiers=Meta
Ctrl+D     -> Key=D Modifiers=Control
Win+D      -> Key=D Modifiers=Meta      <- same thing as Cmd
$ctrl+D    -> PARSE ERROR               <- no platform-adaptive token exists
```

Worse than merely wrong: Windows reserves most of these, so the app never saw the keystroke. `Cmd+D` (Dictionary) *hid the app* — Win+D is Show Desktop. Also Win+E → Explorer, Win+G → Game Bar, Win+P → display projection, Win+F → Feedback Hub.

Since Avalonia has no adaptive token, the substitution happens in code. `PlatformGesture` takes a gesture written *without* its command modifier (`"d"`, `"shift+e"`) and binds it to the platform's — preferring Avalonia's own `PlatformSettings.HotkeyConfiguration.CommandModifiers`, falling back to an OS check because `PlatformSettings` isn't guaranteed to exist when XAML is parsed. `CommandGestureExtension` is the XAML form, so declarations stay declarative:

```xml
<NativeMenuItem Header="Look Up in Dictionary" Gesture="{input:CommandGesture d}" />
```

## Bug 2 — the gestures were never accelerators off macOS

Fixing the modifier corrected the *display* and nothing else. `NativeMenuBarPresenter` binds the gesture to the display-only property:

```csharp
[!MenuItem.InputGestureProperty] = nativeItem.GetObservable(NativeMenuItem.GestureProperty).ToBinding(),
```

`InputGesture` only draws the shortcut text next to the label. Registering a real accelerator requires `MenuItem.HotKey`, which the presenter never sets. So the in-window `<NativeMenuBar/>` has always shown shortcuts wired to nothing. macOS was unaffected because the system menu bar registers accelerators itself.

Only Ctrl+G/W/E/C/A ever appeared to work — those are separately forwarded out of the book WebView by JavaScript for unrelated reasons (#443, #110). That asymmetry is what made the bug diagnosable: in testing, G worked and D/F/O/P didn't, exactly matching which keys have a JS path.

Two fixes, because focus lands in two different places:

- **`SimpleTabbedWindow` registers all ten gestures as window `KeyBindings`**, off macOS only — macOS already registers them and a second binding would fire each command twice. Covers focus anywhere in Avalonia's own controls.
- **The JS capture now also forwards Ctrl/Cmd+D and Ctrl/Cmd+F.** When a book WebView has focus, CEF takes the keystroke before Avalonia sees it — the common case while reading. Follows the existing forwards for G, W, E, C, A. `preventDefault` also suppresses Chromium's bookmark dialog on Ctrl+D and its find bar on Ctrl+F.

## Bug 3 — Settings was unreachable on Windows

Preferences is declared in App.axaml's *application*-level NativeMenu, which Avalonia only realises as the macOS app menu. Off macOS the `<NativeMenuBar/>` renders the *window's* menu (File/View/Tools/Window), so that declaration was never shown. Its `Cmd+OemComma` gesture was doubly dead: wrong modifier, on a menu that isn't rendered. There was no other entry point — the dialog simply could not be opened.

Adds **Tools > Settings…** plus **Ctrl+,**, both off macOS only, where Preferences stays in the app menu per platform convention. `ShowSettingsWindow` becomes `internal static` — it only ever touched static members, so that's a visibility change, not a behavioural one.

## Verification (Windows 11 ARM64)

Ctrl+D, F, O and P all confirmed working in the running app, and the log shows **both mechanisms** live: D/O/P came through the window KeyBindings (they log their menu handler), while **F reached `SearchForSelectionAsync` without its click handler** — i.e. via the JS forward, with CEF holding focus.

```
17:07:14 Look Up in Dictionary (Cmd+D) from window: CST Reader
17:07:14 Looked up 'bhikkhusatehi' in the dictionary
17:07:21 Search for selection: 'pañcamattehi'        <- JS path, no click handler
17:07:43 [Layout] Show Select a Book panel requested
17:07:55 Print (Cmd+P) from window: CST Reader
```

Startup logs confirm registration: `Registered 10 menu shortcut key bindings` and `Added Tools > Settings`. Zero errors. **984/984 tests pass** (11 new, pinning that the modifier is never Meta off macOS; they run with `Application.Current` null, which also exercises the fallback).

## Notes for review

- **macOS needs a regression pass.** Every change is guarded to leave macOS on its existing path, but that's reasoned, not tested — I have no Mac. The double-invocation risk (window KeyBindings *plus* system menu accelerators) is the specific thing to check.
- **One gap deliberately left.** `SetupFloatingWindowMenu` returns early off macOS, so floating windows still have no menu or shortcuts on Windows. Separate from these three bugs; worth its own issue.
- **Debugging note.** The JS-forward breadcrumbs log at Debug and the shipped default `LogLevel` is Information, so `REQUESTED FROM JAVASCRIPT` lines won't appear in a normal log. The two paths are still distinguishable by whether the menu click handler logged.
