### PR TITLE
Fix NU1510: drop package refs already supplied by the ASP.NET Core framework

### DIFF
--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -102,8 +102,9 @@
     <PackageReference Include="ReactiveUI" Version="23.2.28" />
     <!-- MCP surface (#191): Streamable HTTP transport mounted in-process at /mcp on the loopback API server. -->
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <!-- Microsoft.Extensions.DependencyInjection / .Logging are deliberately NOT referenced here: the
+         Microsoft.AspNetCore.App FrameworkReference above already supplies them, and referencing them
+         explicitly warned NU1510 ("will not be pruned"). -->
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />


### PR DESCRIPTION
Silences the two `NU1510` warnings that appeared on every build.

## Cause
`CST.Avalonia.csproj` referenced `Microsoft.Extensions.DependencyInjection` and `Microsoft.Extensions.Logging` explicitly at 10.0.9. But the project also carries:

```xml
<FrameworkReference Include="Microsoft.AspNetCore.App" />
```

(added for the loopback Kestrel local-API server), and that shared framework **already supplies both packages**. NuGet flagged them as prunable — which is exactly what NU1510 reports:

```
warning NU1510: PackageReference Microsoft.Extensions.DependencyInjection will not be pruned.
                Consider removing this package from your dependencies, as it is likely unnecessary.
warning NU1510: PackageReference Microsoft.Extensions.Logging will not be pruned. ...
```

## Change
Removes both `PackageReference` lines, with a comment in their place so they don't get re-added by someone seeing the `using` statements and assuming a missing dependency.

Nothing else changes — the assemblies still resolve through the framework.

## Verification (macOS)
- **NU1510 count across the full solution: 0**
- Build succeeds
- **973/973 tests pass** — DI and logging are used throughout the app, so the suite is meaningful coverage that resolution still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)