### PR TITLE
#510: activate the main window on startup so the macOS menus populate

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -208,6 +208,12 @@ public partial class App : Application
 
             // Show the window BEFORE starting initialization
             MainWindow.Show();
+            // ...and make it the KEY window. macOS renders window-level menus (File/View/Tools/Window, declared
+            // in SimpleTabbedWindow.axaml) only for the key window — without this the app can come up frontmost
+            // but keyless, showing just the inert application menu from App.axaml until the user clicks the
+            // window. Show() alone leaves that to OS goodwill, which doesn't hold when the launching process
+            // keeps focus (e.g. started from a terminal). (#510)
+            MainWindow.Activate();
 
             // Start background initialization tasks that depend on settings
             var initTask = Task.Run(async () =>


### PR DESCRIPTION
Fixes #510 — on macOS the app launched showing only an inert **CST Reader** application menu, with **File / View / Tools / Window missing** until you clicked the main window.

## Cause
macOS renders *window-level* menus only for the **key window**. Those four menus are declared in `SimpleTabbedWindow.axaml`'s `NativeMenu.Menu`, so until the main window became key, macOS fell back to the application-level menu in `App.axaml` — which contains only Preferences.

Startup called `MainWindow.Show()` but never `Activate()`, leaving key-window status to the OS. That holds when a bundled `.app` is launched from Finder, but not when the launching process keeps focus — e.g. `dotnet run` from a terminal. The tell was that the "CST Reader" menu appeared at all: the app *was* frontmost, it just had no key window.

## Fix
One line after `Show()`:

```csharp
MainWindow.Activate();
```

with a comment recording the key-window mechanism so it doesn't get tidied away later.

## Verification
- **Confirmed by hand**: menus populate immediately on launch, no click required.
- Build clean; full suite **984 passed, 0 failed**.

Also relevant to #507, which needs the mcp-bridge to be able to launch and activate the app.

Closes #510.
