### PR TITLE
#500: print search-hit highlights legibly (@media print reset in the book XSL)

### DIFF
--- a/src/CST.Avalonia/Xsl/tipitaka-beng.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-beng.xsl
@@ -128,6 +128,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-cyrl.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-cyrl.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-deva.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-deva.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-gujr.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-gujr.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-guru.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-guru.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-khmr.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-khmr.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-knda.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-knda.xsl
@@ -131,6 +131,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-latn.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-latn.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-mlym.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-mlym.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-mymr.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-mymr.xsl
@@ -127,6 +127,30 @@ function getStyleClass (className) {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-sinh.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-sinh.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-telu.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-telu.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-thai.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-thai.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/src/CST.Avalonia/Xsl/tipitaka-tibt.xsl
+++ b/src/CST.Avalonia/Xsl/tipitaka-tibt.xsl
@@ -127,6 +127,30 @@ p {
     color: white;
   }
 }
+
+/* Print (#500). Browsers omit backgrounds when printing, so the white-on-blue/green
+   highlight spans print white-on-white - invisible. Reset them to plain black text,
+   keeping hits bold so they stay findable on paper.
+   !important is required on two counts: it overrides the dark-mode rules above, and it
+   beats the inline colors the highlight script sets on each span (BookDisplayView, #224)
+   - those are normal inline declarations, which lose to an important rule.
+   The body/.note resets make dark-mode printing deterministic instead of depending on
+   whether the browser forces a light color-scheme for print. */
+@media print {
+  body { background: white !important; color: black !important; }
+  .note { color: black !important; }
+  .hit {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+    font-weight: bold;
+  }
+  .context {
+    background: none !important;
+    background-color: transparent !important;
+    color: black !important;
+  }
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
Fixes #500 — search-hit highlights printed invisibly. Found while implementing printing (#112).

## Problem
`.hit` renders white-on-blue and `.context` white-on-green. Browsers **omit backgrounds when printing** by default, so those spans printed as **white text on white paper** — the highlighted words simply vanished, in both whole-book and Print-Selection output.

## Fix
An `@media print` block added to all **14 book stylesheets**, placed after the dark-mode rules:

```css
@media print {
  body { background: white !important; color: black !important; }
  .note { color: black !important; }
  .hit { background: none !important; background-color: transparent !important;
         color: black !important; font-weight: bold; }
  .context { background: none !important; background-color: transparent !important;
             color: black !important; }
}
```

- `.hit` / `.context` lose their backgrounds and print black; **hits stay bold** so they're still findable on the page.
- The `body` / `.note` resets make **dark-mode printing deterministic** — the second item the issue asked to verify — rather than depending on whether the browser forces a light color-scheme for print.
- `!important` is needed on two counts: it overrides the dark-mode rules above, **and** it beats the inline colors the highlight script writes onto each span (`BookDisplayView`, #224). Those are normal inline declarations, which lose to an important stylesheet rule — so the currently-selected red hit prints legibly too.

## Notes
- The stylesheets edited are **`src/CST.Avalonia/Xsl/`**, the app's own set. The issue text cited `src/Cst4/Xsl/`, which is the **legacy CST4** copy — it has no dark-mode block and isn't what the app loads.
- **No seeding/propagation change.** XSL is seeded into the user data directory only when it's empty, so a stale copy would normally shadow this — but beta users are being instructed to delete their `CSTReader` directory, so the updated stylesheets are seeded fresh. (#181 remains the general answer for resource migration.)
- `report-all-words-latn.xsl` is untouched — it carries no hit styling.

## Verification
- All 14 files still parse as valid XML; UTF-8 BOM preserved.
- To see it locally: `rm ~/Library/Application\ Support/CSTReader/xsl/tipitaka-*.xsl`, relaunch, print a search hit.

Closes #500.
