### PR TITLE
#441: restored hit counter clamps to the last hit, agreeing with the viewport

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/RestoreHitIndexTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/RestoreHitIndexTests.cs
@@ -1,0 +1,71 @@
+using CST.Avalonia.ViewModels;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+// #441: the restored hit COUNTER and the restored VIEWPORT must agree. The viewport clamps a saved hit to
+// the last hit (BookDisplayView: Math.Min(savedHit, total)); the counter used to collapse an out-of-range
+// index to 1, so the reader showed the last hit while the indicator read "1 of M" — and stepping to the
+// next hit then started from the wrong place.
+public class RestoreHitIndexTests
+{
+    // ---- the bug: out-of-range saved index ----
+
+    [Theory]
+    [InlineData(14, 13)]   // one past the end
+    [InlineData(99, 13)]   // far past the end
+    [InlineData(2, 1)]     // book has a single hit
+    public void Out_of_range_saved_hit_clamps_to_the_last_hit_not_to_1(int saved, int totalHits)
+    {
+        // Matches the viewport's own Math.Min(savedHit, total).
+        Assert.Equal(totalHits, BookDisplayViewModel.ClampRestoreHitIndex(saved, totalHits));
+    }
+
+    [Fact]
+    public void Counter_and_viewport_agree_for_every_saved_index_up_to_well_past_the_end()
+    {
+        const int totalHits = 13;
+        for (var saved = 1; saved <= totalHits * 3; saved++)
+        {
+            var viewport = System.Math.Min(saved, totalHits);   // BookDisplayView's clamp
+            var counter = BookDisplayViewModel.ClampRestoreHitIndex(saved, totalHits);
+            Assert.Equal(viewport, counter);
+        }
+    }
+
+    // ---- unchanged behaviour ----
+
+    [Theory]
+    [InlineData(1, 13)]
+    [InlineData(7, 13)]
+    [InlineData(13, 13)]
+    public void In_range_saved_hit_is_returned_as_is(int saved, int totalHits)
+    {
+        Assert.Equal(saved, BookDisplayViewModel.ClampRestoreHitIndex(saved, totalHits));
+    }
+
+    [Fact]
+    public void No_saved_hit_falls_back_to_the_first_hit()
+    {
+        Assert.Equal(1, BookDisplayViewModel.ClampRestoreHitIndex(null, 13));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void Non_positive_saved_hit_falls_back_to_the_first_hit(int saved)
+    {
+        Assert.Equal(1, BookDisplayViewModel.ClampRestoreHitIndex(saved, 13));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    public void No_hits_in_the_book_yields_1_whatever_was_saved(int totalHits)
+    {
+        // The highlight pipeline only consults this when totalHits > 0, but the guard must hold:
+        // returning a saved index here would put the counter above a zero total.
+        Assert.Equal(1, BookDisplayViewModel.ClampRestoreHitIndex(9, totalHits));
+        Assert.Equal(1, BookDisplayViewModel.ClampRestoreHitIndex(null, totalHits));
+    }
+}

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -1328,12 +1328,28 @@ namespace CST.Avalonia.ViewModels
         }
 
         // Returns the saved hit to restore, clamped to [1, totalHits]; falls back to 1
-        // for a fresh open (no saved index) or an out-of-range value.
+        // for a fresh open (no saved index).
         private int ResolveRestoreHitIndex(int totalHits)
+            => ClampRestoreHitIndex(_initialCurrentHitIndex, totalHits);
+
+        /// <summary>
+        /// Resolves a saved hit index against the book's real hit count.
+        ///
+        /// An out-of-range saved index clamps DOWN to the last hit rather than collapsing to 1, so this
+        /// agrees with the viewport, which does its own <c>Math.Min(savedHit, total)</c> in
+        /// <c>BookDisplayView.OnBookContentLoaded</c>. The two used to disagree: the reader scrolled to the
+        /// last hit while the counter read "1 of M", and stepping to the next hit then started from the
+        /// wrong place. Reachable from any caller supplying an index it didn't derive from the current
+        /// result set — restored state, and <c>POST /v1/navigate</c> with a hit beyond the match count
+        /// (whose clamping is already documented in llms.txt). (#441)
+        ///
+        /// Pure and static so it is directly testable — constructing a BookDisplayViewModel needs live services.
+        /// </summary>
+        internal static int ClampRestoreHitIndex(int? savedHitIndex, int totalHits)
         {
             if (totalHits <= 0) return 1;
-            if (_initialCurrentHitIndex is int saved && saved >= 1 && saved <= totalHits)
-                return saved;
+            if (savedHitIndex is int saved && saved >= 1)
+                return Math.Min(saved, totalHits);
             return 1;
         }
 


### PR DESCRIPTION
Fixes #441.

## Problem
When a saved or requested hit index exceeded the book's hit count, the two halves of the restore disagreed:

| | Behaviour | Where |
|---|---|---|
| **Viewport** | clamps to the **last** hit — `Math.Min(savedHit, total)` | `BookDisplayView.axaml.cs:1557` |
| **Counter** | collapsed to **1** for any out-of-range value | `ResolveRestoreHitIndex` |

So the reader scrolled to the last hit while the "N of M" indicator read **hit 1** — and stepping to the next hit then started from the wrong place.

Reachable from any caller that supplies a hit index it didn't derive from the current result set: restored session state, and `POST /v1/navigate` with a `hit` beyond the match count (the landing is already documented in `llms.txt`; the counter was the dishonest half).

## Fix
Clamp **down to the last hit** rather than resetting to 1, matching the viewport exactly.

The logic moves to a pure static `ClampRestoreHitIndex(int? savedHitIndex, int totalHits)` so it's directly testable — constructing a `BookDisplayViewModel` needs live services. The private instance method now delegates to it, so the call site is unchanged.

```csharp
internal static int ClampRestoreHitIndex(int? savedHitIndex, int totalHits)
{
    if (totalHits <= 0) return 1;
    if (savedHitIndex is int saved && saved >= 1)
        return Math.Min(saved, totalHits);   // was: saved <= totalHits ? saved : 1
    return 1;
}
```

## Behaviour table

| Saved index | Total hits | Before | After |
|---|---|---|---|
| 14 | 13 | **1** ❌ | **13** ✅ |
| 7 | 13 | 7 | 7 |
| 13 | 13 | 13 | 13 |
| none | 13 | 1 | 1 |
| 0 / negative | 13 | 1 | 1 |
| anything | 0 | 1 | 1 |

## Tests
12 new tests in `ViewModels/RestoreHitIndexTests.cs`, including one that asserts the counter and the viewport agree for **every** saved index from 1 to well past the end (it recomputes the view's own `Math.Min` clamp and compares). The out-of-range cases fail against the old implementation.

**996/996 pass** on macOS (984 + 12 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)