### PR TITLE
fix: remove duplicate Avalonia resource items that could crash startup

### DIFF
--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -27,8 +27,21 @@
 
   <ItemGroup>
     <Folder Include="Models\" />
-    <AvaloniaResource Include="Assets\**" />
-    <AvaloniaResource Include="Styles\DockStyles.axaml" />
+    <!-- Both of these previously produced a resource embedded TWICE under one avares path, and Avalonia's
+         AssemblyDescriptor builds a Dictionary keyed by that path - so a duplicate throws
+         "An item with the same key has already been added" during AppBuilder.Setup(), i.e. an instant
+         startup crash with no window and a stack trace that names Avalonia internals rather than this file.
+         It normally stayed latent because the duplicates collapse when the build writes obj/ cleanly; an
+         interrupted build (a sleeping VM, in the case that surfaced it) leaves obj/ inconsistent and bakes
+         both copies in. Keeping the item lists duplicate-free removes the trap rather than relying on luck.
+
+         cst.ico: <ApplicationIcon> already contributes it as an AvaloniaResource, so the Assets glob must
+         not add it a second time. Nothing references it by avares path, so excluding it here is safe. -->
+    <AvaloniaResource Include="Assets\**" Exclude="Assets\cst.ico" />
+    <!-- DockStyles.axaml is deliberately NOT listed: the SDK already includes every .axaml as AvaloniaXaml,
+         which embeds it at the same /Styles/DockStyles.axaml path. Listing it here as well was the exact
+         duplicate that crashed startup. -->
+
     <None Include="Info.plist" Condition="'$(OS)' == 'macOS'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
fix: remove duplicate Avalonia resource items that could crash startup

Two resources were being contributed twice, and Avalonia's AssemblyDescriptor builds a Dictionary keyed
by avares path - so a duplicate throws "An item with the same key has already been added" during
AppBuilder.Setup(). That is an instant startup crash: no window, and a stack trace naming Avalonia
internals rather than the csproj line responsible.

- Styles\DockStyles.axaml was listed explicitly as AvaloniaResource while the SDK already includes every
  .axaml as AvaloniaXaml, which embeds it at the same /Styles/DockStyles.axaml path. Removing the
  explicit line leaves it included via AvaloniaXaml - the correct item type for .axaml. Verified it is
  still embedded: App.axaml pulls it in with StyleInclude Source="avares://.../Styles/DockStyles.axaml",
  which throws at startup if the resource is missing, and the app starts clean.
- Assets\cst.ico was contributed by both the Assets\** glob and <ApplicationIcon>. Suppressing
  ApplicationIcon drops the item count 2 -> 1, confirming the source. Excluded from the glob so the
  ApplicationIcon copy is the only one; nothing references it by avares path.

Why this stayed latent: the duplicates collapse when the build writes obj/ cleanly, so ordinary builds
were fine. An interrupted build leaves obj/ inconsistent and bakes both copies in - which is how it
surfaced, when a VM slept mid-build and the next run crashed on startup. Deleting obj/ "fixed" it, which
makes the real cause easy to miss. Keeping the item lists duplicate-free removes the trap instead of
relying on the build never being interrupted.

Verified: AvaloniaResource now has 29 items with no duplicate identities (was 31 with two), a clean
build from a deleted obj/ starts with no exception, and 996/996 tests pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
