### PR TITLE
Welcome page: fix the Quick Start search instruction (there is no search icon)

### DIFF
--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -397,9 +397,9 @@
     <div class="quick-start">
         <h3>🚀 Quick Start</h3>
         <ul>
-            <li><strong>Open books:</strong> Double-click any text in the left panel, or select it and press Enter</li>
+            <li><strong>Open books:</strong> In the <strong>Select a Book</strong> tab, double-click a text &mdash; or select it and press Enter</li>
             <li><strong>Change script:</strong> Use the dropdown at the top (applies to all open books)</li>
-            <li><strong>Search:</strong> Click search icon, enter Pāli text, optionally filter by book categories</li>
+            <li><strong>Search:</strong> Open the <strong>Search</strong> tab in the left panel (or View &rsaquo; Search), enter Pāli text, and optionally filter by book categories</li>
             <li><strong>Dictionary:</strong> Select a word and press &#8984;D / Ctrl+D</li>
             <li><strong>Settings:</strong> Choose fonts for each script, and which dictionaries to use</li>
         </ul>


### PR DESCRIPTION
Quick Start told users to **"Click search icon"**. There is no search icon.

Search is a **tab in the left tool panel** titled `Search` — alongside `Select a Book` and `Dictionary` (the titles come from the tool ViewModels, and the View menu carries the same three entries).

```diff
- <li><strong>Search:</strong> Click search icon, enter Pāli text, optionally filter by book categories</li>
+ <li><strong>Search:</strong> Open the <strong>Search</strong> tab in the left panel (or View › Search), enter Pāli text, and optionally filter by book categories</li>
```

Also named the tabs in the adjacent lines, so "the left panel" says which tab it means:

```diff
- <li><strong>Open books:</strong> Double-click any text in the left panel, or select it and press Enter</li>
+ <li><strong>Open books:</strong> In the <strong>Select a Book</strong> tab, double-click a text — or select it and press Enter</li>
```

I audited the rest of the page for other stale UI references (`click` / `icon` / `button` / `toolbar` / `press`) — this was the only remaining one. The Float/Dock button instruction was the other, already fixed in #524.

Build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)