### PR TITLE
#527: tell users the AI settings need a restart; fix the oracle tests #522 broke

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionaryOracleTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryOracleTests.cs
@@ -21,7 +21,15 @@ public class DictionaryOracleTests
         Environment.GetEnvironmentVariable("HOME") ?? "/Users/fsnow",
         "Library/Application Support/CSTReader/dictionaries");
 
-    private static bool DataPresent => Directory.Exists(Root);
+    // Source ids are the directory names under dictionaries/ (#522 renamed en -> vri-childers, hi -> vri-hindi).
+    private const string Childers = "vri-childers";
+    private const string Hindi = "vri-hindi";
+
+    // Guard on the SPECIFIC dictionary a test needs, not just the root. A root-only check kept returning
+    // true after #522 renamed the language directories, so these tests ran against ids that no longer
+    // existed and failed instead of no-op'ing the way the class contract says they should.
+    private static bool DataPresent(string sourceId) =>
+        Directory.Exists(Path.Combine(Root, sourceId));
 
     private static async Task<(string[] words, string firstMeaning)> LookupLatn(string lang, string query)
     {
@@ -37,8 +45,8 @@ public class DictionaryOracleTests
     [Fact]
     public async Task Samayam_English_ResolvesToSamayo()
     {
-        if (!DataPresent) return;
-        var (words, meaning) = await LookupLatn("en", Samayam);
+        if (!DataPresent(Childers)) return;
+        var (words, meaning) = await LookupLatn(Childers, Samayam);
         Assert.Equal(new[] { "samayo" }, words);
         Assert.Contains("Agreement, combination", meaning);
     }
@@ -46,16 +54,16 @@ public class DictionaryOracleTests
     [Fact]
     public async Task Samayam_Hindi_ResolvesToSamayaAndSamayantara()
     {
-        if (!DataPresent) return;
-        var (words, _) = await LookupLatn("hi", Samayam);
+        if (!DataPresent(Hindi)) return;
+        var (words, _) = await LookupLatn(Hindi, Samayam);
         Assert.Equal(new[] { "samaya", "samayantara" }, words);
     }
 
     [Fact]
     public async Task Abbhuto_English_MergesDuplicateHeadword()
     {
-        if (!DataPresent) return;
-        var (words, meaning) = await LookupLatn("en", "abbhuto");
+        if (!DataPresent(Childers)) return;
+        var (words, meaning) = await LookupLatn(Childers, "abbhuto");
         Assert.Equal("abbhuto", words[0]);
         // Both definitions of the repeated headword, joined by the separator sentinel (the renderer
         // turns that sentinel into a visual break — see MeaningParserTests, DICT-1).

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -429,13 +429,20 @@
                                                  Margin="0,10,0,0"/>
                                         <TextBlock Text="Master switch. When off, nothing AI-related runs. Two access modes are available below: a local API for code agents, and MCP for chat clients like Claude Desktop."
                                                   Classes="SettingDescription"/>
+                                        <!-- #527: the API server reads these settings once, at startup
+                                             (App.StartLocalApiIfEnabledAsync), so a toggle here does nothing until
+                                             relaunch. Without this note the feature simply looks broken. -->
+                                        <TextBlock Text="⚠ Takes effect after you restart CST Reader."
+                                                  Classes="SettingDescription"
+                                                  FontWeight="SemiBold"
+                                                  Margin="0,6,0,0"/>
                                     </StackPanel>
                                 </Border>
 
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
                                         <TextBlock Text="Access for AI Clients" Classes="SettingLabel"/>
-                                        <TextBlock Text="A loopback-only server that exposes read access to the corpus (search, dictionary, passages). Two surfaces run on it independently — enable either or both."
+                                        <TextBlock Text="A loopback-only server that exposes read access to the corpus (search, dictionary, passages). Two surfaces run on it independently — enable either or both. Changes here also take effect after a restart."
                                                   Classes="SettingDescription"/>
 
                                         <!-- REST surface (/v1): for code agents. -->


### PR DESCRIPTION
Two changes. The second was found while running the suite for the first.

## 1. Settings: say that AI needs a restart (#527)

Enabling **Settings ▸ AI** does nothing until you relaunch — no API server, no `local-api.json`, and an MCP client cannot connect. Nothing in the UI said so, so the reasonable conclusion was that the feature was broken.

It is deliberate, and the code says so:

```csharp
/// changes to the setting take effect on restart (live toggle is a later iteration). (#186)
private async Task StartLocalApiIfEnabledAsync(ISettingsService settingsService)
{
    var ai = settingsService.Settings.Ai;
    if (!ai.ServerShouldRun) return;
```

`StartAsync` is called only from that startup path; `StopAsync` only at shutdown; nothing watches for settings changes.

Adds **"⚠ Takes effect after you restart CST Reader."** under the master switch, and a matching clause on the access-mode group. A live toggle is the fuller fix and stays open on #527 — it means starting and stopping a Kestrel host, the handshake file and the MCP surface safely while a client may be connected.

## 2. Fix three oracle tests that #522 broke

`DictionaryOracleTests` pins `DictionaryService` against **real CST4 behaviour on the real installed dictionaries**, and it hardcoded the source ids:

```csharp
var (words, meaning) = await LookupLatn("en", Samayam);
```

#522 renamed those directories `en → vri-childers` and `hi → vri-hindi`, so the lookups resolved to nothing:

```
Failed  Samayam_English_ResolvesToSamayo
Failed  Samayam_Hindi_ResolvesToSamayaAndSamayantara
Failed  Abbhuto_English_MergesDuplicateHeadword
```

**Why #522 went green anyway:** the suite ran before I migrated my own data directory, so `en/` and `hi/` were still on disk at that moment. The failure only appeared once the local layout matched what the code now expects.

**Also fixed the guard that hid it.** `DataPresent` checked only that the dictionaries **root** existed:

```csharp
private static bool DataPresent => Directory.Exists(Root);
```

The root survived the rename; the language directories did not. So instead of no-op'ing — which is what the class contract promises for a machine without the data — the tests ran against ids that no longer existed and failed. It now guards on the specific dictionary each test needs.

**Verified they genuinely execute** rather than silently skipping: 34 ms / 17 ms / 13 ms against real data. So this doubles as independent confirmation that the #522 consolidation still resolves correctly against the CST4 oracle values.

`DictionaryServiceTests` also contains `"en"`/`"hi"`, but those are arbitrary labels for fixtures it writes into a temp directory — self-contained, unaffected, and left alone.

## Verification
- **1003/1003 pass.**
- Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)