### PR TITLE
#535: keep the restored main-window position (don't capture geometry after close)

### DIFF
--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -29,6 +29,9 @@ public partial class SimpleTabbedWindow : Window
     private ComboBox? _paliScriptCombo;
     private readonly ILogger _logger;
     private bool _isInitialized = false;
+    // Set once Closing has taken its final geometry capture; blocks any later capture from overwriting it
+    // with a destroyed window's 0,0 Position. (#535)
+    private bool _geometryCaptureFrozen = false;
     private DateTime _lastSaveTime = DateTime.MinValue;
 
     // Drag monitoring fields
@@ -122,7 +125,19 @@ public partial class SimpleTabbedWindow : Window
         // Final geometry capture, bypassing the debounce: the 500ms leading-edge throttle drops the
         // trailing events of a resize/move, so without this the last ~500ms of geometry changes were
         // lost when the window was closed with the red button. (DOCK-6)
-        SaveWindowState(force: true);
+        //
+        // Skipped once shutdown is underway. On Cmd+Q the ShutdownRequested handler has ALREADY captured
+        // this window's geometry while it was still alive (App.SaveApplicationStateAsync) and has since
+        // DISPOSED the ServiceProvider — so capturing again here only resolves a disposed provider and
+        // throws ObjectDisposedException, which the catch below swallowed after logging an Error on every
+        // clean quit. On the red-button path IsShuttingDown is still false (Closing runs before
+        // ShutdownRequested), so the capture below is the good one and still runs. (#535, DOCK-2)
+        if (!App.IsShuttingDown)
+            SaveWindowState(force: true);
+        // This is the last moment the native window can report a real Position. Freeze geometry capture
+        // so the shutdown-path capture that runs after the window is destroyed can't replace it with
+        // 0,0. Set AFTER the capture above, which is the good one. (#535)
+        _geometryCaptureFrozen = true;
 
         // Clean up drag monitoring timer
         if (_dragMonitoringTimer != null)
@@ -415,6 +430,28 @@ public partial class SimpleTabbedWindow : Window
     {
         try
         {
+            // Once Closing has captured the final geometry, refuse every later capture. `Position` is
+            // platform-backed and reads 0,0 after the native window is destroyed, while Width/Height are
+            // styled properties that keep their values — so a post-close capture silently replaced a good
+            // position with the origin, and the window reopened at 0,0 with the right size.
+            //
+            // That is exactly what happened on the red-button path: Closing captured the true position,
+            // the window was destroyed, then the lifetime raised ShutdownRequested and
+            // App.SaveApplicationStateAsync's forced capture ran against the dead window and overwrote it.
+            // (Cmd+Q was unaffected: there ShutdownRequested runs BEFORE Closing, while the window is
+            // still alive.) Freezing here fixes both orderings at a single point, and is safe because no
+            // capture after Closing can be more accurate than the one Closing just took. (#535)
+            //
+            // The flag is never reset, which is correct while ShutdownMode is OnMainWindowClose (closing
+            // this window IS quitting, so the instance is never reused). If a future handler ever CANCELS
+            // the main window's Closing — nothing does today — the window would stay alive with geometry
+            // persistence silently switched off, and this would need to reset on the cancelled close.
+            if (_geometryCaptureFrozen)
+            {
+                _logger.Debug("Skipping window-state capture: geometry frozen at close (#535)");
+                return;
+            }
+
             // Debounce saves to prevent excessive updates during window resizing; the debounce is
             // leading-edge, so the trailing events are covered by the forced captures at closing
             // and shutdown. (DOCK-6)


### PR DESCRIPTION
Fixes #535 — the main window restored its **size** but always reopened at **0,0**.

## Root cause
`Window.Position` is **platform-backed** and reads `0,0` once the native window is destroyed, while `Width`/`Height` are styled properties that keep their values. So a capture taken *after* the window is gone silently replaces a good position with the origin and leaves the size intact — exactly the reported symptom, on both macOS and Windows.

Two forced captures run at exit, and their order flips depending on how you quit:

| Exit path | Order | Result |
|---|---|---|
| **Cmd+Q** | `ShutdownRequested` → `App.SaveApplicationStateAsync` captures **while the window is still open** → `ForceSaveAsync` writes → window closes after | ✅ position correct |
| **Red button** | `Closing` captures the true position → **window destroyed** → lifetime raises `ShutdownRequested` → that same capture runs against the **dead window** → `0,0` overwrites it | ❌ position lost |

That split was confirmed by hand before writing any code: Cmd+Q preserved the position, the red button did not — which located the culprit at the *shutdown* capture, not (as first suspected) at `OnWindowClosing`.

## Fix — two guards, two different call sites
1. **`_geometryCaptureFrozen`** — set in `OnWindowClosing` immediately *after* its (good) capture; `SaveWindowState` then refuses every later capture. `Closing` is the last moment the native window can report a real `Position`, so nothing afterward can be more accurate. This is what blocks `App.SaveApplicationStateAsync`'s post-destroy capture on the red-button path, and also any straggler `PositionChanged`/`PropertyChanged` capture during teardown.

2. **Skip the `Closing` capture when `App.IsShuttingDown`** — fixes a pre-existing blemish surfaced during review. On Cmd+Q the shutdown handler has already captured this window's geometry *while it was alive* and has since **disposed the ServiceProvider**, so this capture only resolved a disposed provider and threw `ObjectDisposedException` — swallowed after logging an **Error on every clean quit**. Its result could never reach disk anyway (it runs after `ForceSaveAsync`, in-memory only, with the save timer already disposed). On the red-button path the flag is still false, so the good capture still runs.

Neither guard subsumes the other: `IsShuttingDown` is true at the shutdown capture on *every* path, so it can't distinguish the post-destroy case; and the freeze flag isn't set yet when `Closing` makes its own attempt.

**Deliberately not** "refuse to write `0,0`" — a window can legitimately sit at the origin. Both guards key on **when** a read is trustworthy, not on the value.

## Verification
- **Confirmed by hand** on both quit paths — position now restores after a red-button close, and Cmd+Q still works.
- **Fable-reviewed twice**: the freeze fix, then the shutdown guard. Second pass verified the `IsShuttingDown` ordering at line level, enumerated every path where geometry could be lost (none that matters — where the capture is skipped, it could not have reached disk), confirmed both guards are needed, and checked the Windows/Linux equivalents including session-end (`WM_QUERYENDSESSION` raises `ShutdownRequested` first, like Cmd+Q, so no platform skips its only good capture).
- Full suite: **1003 passed, 0 failed.**

Known residual (info-level, not worth holding): red-buttoning the window *during* an in-flight Cmd+Q save leaves the position up to 500 ms stale — a milliseconds-wide race, bounded by the existing debounce.

Closes #535.
