### PR TITLE
#536: downloaded dictionaries go live without a restart

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -580,6 +580,21 @@ public partial class App : Application
             if (dpdUpdateService != null)
             {
                 dpdUpdateService.StatusChanged += message => Log.Information("DPD Asset Status: {Message}", message);
+                // An asset that lands mid-session must become usable WITHOUT a restart (#536). The registry
+                // already evaluates IsAvailable live, so the only thing that cannot notice on its own is the
+                // DPD lemma provider, which binds availability at construction — reopen it here. The dictionary
+                // panel rebuilds its own picker off this same event.
+                dpdUpdateService.AssetInstalled += id =>
+                {
+                    if (!string.Equals(id, "dpd", StringComparison.OrdinalIgnoreCase))
+                        return;
+                    if (ServiceProvider?.GetService<CST.Lemma.ILemmaProvider>() is Services.ReopenableLemmaProvider reopenable)
+                    {
+                        reopenable.Reopen();
+                        Log.Information("Reopened the lemma provider after the {Id} asset was installed; available={Available}",
+                            id, reopenable.IsAvailable);
+                    }
+                };
                 _ = Task.Run(() => dpdUpdateService.CheckAndUpdateAsync());
             }
         }
@@ -1120,10 +1135,12 @@ public partial class App : Application
 
         // Lemma/dictionary/sandhi (dpd-cst-subset asset — our derived DPD subset for CST). NOT AI-gated — a core
         // reading/search feature; availability is driven by FILE PRESENCE alone (no setting), degrading to "off"
-        // when absent. Seeded/downloaded to <app-support>/CSTReader/dpd-cst-subset/. (Opened once at startup, so a
-        // manually dropped-in file activates on the next launch.)
+        // when absent. Seeded/downloaded to <app-support>/CSTReader/dpd-cst-subset/.
+        // Wrapped in ReopenableLemmaProvider because SqliteLemmaProvider binds IsAvailable in its constructor:
+        // on a first run the asset downloads AFTER startup, so the raw provider stayed unavailable for the whole
+        // session and DPD only appeared after a restart. The wrapper is reopened on AssetInstalled. (#536)
         var dpdCstSubsetPath = Services.DpdUpdateService.DpdSubsetPath;
-        services.AddSingleton<CST.Lemma.ILemmaProvider>(_ => new CST.Lemma.SqliteLemmaProvider(dpdCstSubsetPath));
+        services.AddSingleton<CST.Lemma.ILemmaProvider>(_ => new Services.ReopenableLemmaProvider(dpdCstSubsetPath));
         services.AddSingleton<ILemmaSearchService, LemmaSearchService>();
         services.AddSingleton<ILemmaReportService, LemmaReportService>();
 
@@ -1133,9 +1150,11 @@ public partial class App : Application
         // The dictionary SOURCE registry — the single list the API (and later the UI, #466) enumerates and
         // queries. Sources: each bundled flat-file dictionary, DPD (when dpd-cst-subset is installed), and each
         // downloaded lexicon (DPPN — present-iff its file exists). (#109/#466)
-        // NOTE: the source set is fixed when the registry is first resolved. A DERIVED asset (dpd-cst-subset,
-        // dppn.db) installed mid-session still flips available (its source checks the file live); a flat-file
-        // language dir ADDED mid-session only becomes a source on the next launch. (fable LOW-2)
+        // NOTE: the source set is fixed when the registry is first resolved, but AVAILABILITY is live —
+        // Registry.Available re-evaluates IsAvailable on every read. A DERIVED asset (dpd-cst-subset, dppn.db)
+        // installed mid-session therefore goes live once something re-queries: DpdUpdateService.AssetInstalled
+        // reopens the lemma provider and the dictionary panel rebuilds its picker (#536). A flat-file language
+        // dir ADDED mid-session still only becomes a source on the next launch. (fable LOW-2)
         var dppnPath = Services.DpdUpdateService.DppnLexiconPath;
         services.AddSingleton(sp => Services.Dictionaries.DictionarySourceFactory.Build(
             sp.GetRequiredService<IDictionaryService>(),

--- a/src/CST.Avalonia/Services/DpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/DpdUpdateService.cs
@@ -51,6 +51,8 @@ public sealed class DpdUpdateService : IDpdUpdateService
     private int _busy;
 
     public event Action<string>? StatusChanged;
+    /// <inheritdoc />
+    public event Action<string>? AssetInstalled;
     public event Action<long, long>? DownloadProgressChanged;
     public bool IsBusy => Volatile.Read(ref _busy) == 1;
 
@@ -152,7 +154,7 @@ public sealed class DpdUpdateService : IDpdUpdateService
         }
 
         StatusChanged?.Invoke(
-            anyInstalled ? "Dictionary data installed (active after restart)."
+            anyInstalled ? "Dictionary data installed."
             : anyFailed  ? "Could not update some dictionary data."
             : "Dictionary data is up to date.");
     }
@@ -180,10 +182,22 @@ public sealed class DpdUpdateService : IDpdUpdateService
         var archiveBytes = await DownloadWithProgressAsync(archiveAsset.BrowserDownloadUrl, entry.CompressedBytes, ct).ConfigureAwait(false);
 
         StatusChanged?.Invoke("Installing dictionary data...");
-        InstallFromGzip(archiveBytes, entry.Sha256, desc.InstallPath, desc.ProbeUsable);
+        var staged = InstallFromGzip(archiveBytes, entry.Sha256, desc.InstallPath, desc.ProbeUsable);
 
-        _logger.LogInformation("Installed {Id} (source {Src}, converter {Conv}, ~{Mb} MB). Active on next launch.",
+        // Only claim a restart is needed when the asset actually WAS staged. It normally goes live in place,
+        // and saying otherwise both misled users and made the (real) "needs a restart to appear" bug look
+        // like intended behaviour. (#536)
+        _logger.LogInformation(
+            staged
+                ? "Installed {Id} (source {Src}, converter {Conv}, ~{Mb} MB). Staged — active on next launch."
+                : "Installed {Id} (source {Src}, converter {Conv}, ~{Mb} MB). Active now.",
             desc.Id, entry.SourceVersion, entry.ConverterVersion, entry.RawBytes / 1024 / 1024);
+
+        // Tell the app an asset landed so it can pick it up WITHOUT a restart: the DPD lemma provider binds
+        // its availability at construction and must be reopened, and the dictionary picker has to re-query
+        // the registry. A staged install is deliberately NOT announced — it is not live yet. (#536)
+        if (!staged)
+            AssetInstalled?.Invoke(desc.Id);
         return true;
     }
 
@@ -328,8 +342,11 @@ public sealed class DpdUpdateService : IDpdUpdateService
     // Verify the gzip archive's SHA-256, decompress to a temp file, probe it is a USABLE asset, then atomically
     // install (or stage for next launch on Windows). The existing asset is untouched until then, so a
     // failed/corrupt/wrong-schema download never destroys a good install. (fable — preservation)
-    internal static void InstallFromGzip(byte[] archive, string expectedSha256, string finalPath, Func<string, bool> probeUsable)
+    /// <returns>true when the asset was STAGED for next launch (the target was locked); false when it went
+    /// live in place and is usable immediately. (#536)</returns>
+    internal static bool InstallFromGzip(byte[] archive, string expectedSha256, string finalPath, Func<string, bool> probeUsable)
     {
+        bool staged = false;
         string actual = Convert.ToHexString(SHA256.HashData(archive)).ToLowerInvariant();
         if (!string.Equals(actual, expectedSha256, StringComparison.OrdinalIgnoreCase))
             throw new InvalidDataException(
@@ -354,6 +371,7 @@ public sealed class DpdUpdateService : IDpdUpdateService
             try
             {
                 File.Move(tmp, finalPath, overwrite: true);
+                staged = false;
                 // Supersede any earlier staged install so a stale one can't later regress the asset. (fable, #394)
                 // Log a failed delete: if it lingers, ApplyPendingInstall would move the OLDER file back over this
                 // fresh one on next launch (self-heals on the next update check, but worth surfacing). (fable LOW-1)
@@ -373,12 +391,15 @@ public sealed class DpdUpdateService : IDpdUpdateService
             {
                 // Windows: the live db is open → stage beside it and swap on next launch (existing asset intact). (#394)
                 File.Move(tmp, finalPath + PendingSuffix, overwrite: true);
+                staged = true;
             }
         }
         finally
         {
             if (File.Exists(tmp)) { try { File.Delete(tmp); } catch { /* best effort */ } }
         }
+
+        return staged;
     }
 
     /// <summary>

--- a/src/CST.Avalonia/Services/IDpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/IDpdUpdateService.cs
@@ -17,6 +17,11 @@ public interface IDpdUpdateService
     /// <summary>Human-readable progress for a status banner (same UX as the XML update).</summary>
     event Action<string>? StatusChanged;
 
+    /// <summary>Raised with the asset id ("dpd", "dppn") when an asset has been installed and is USABLE NOW.
+    /// A staged install (swapped on next launch, #394) does not raise it. Consumers use this to go live
+    /// without a restart — reopening the lemma provider and rebuilding the dictionary picker. (#536)</summary>
+    event Action<string>? AssetInstalled;
+
     /// <summary>Download progress: (bytesSoFar, totalBytes). totalBytes may be 0 if the length is unknown.</summary>
     event Action<long, long>? DownloadProgressChanged;
 

--- a/src/CST.Avalonia/Services/ReopenableLemmaProvider.cs
+++ b/src/CST.Avalonia/Services/ReopenableLemmaProvider.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using CST.Lemma;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// An <see cref="ILemmaProvider"/> that can be re-opened when the underlying asset appears or changes.
+///
+/// <para><see cref="SqliteLemmaProvider"/> binds availability in its constructor — it returns early when the
+/// file is missing, so <c>IsAvailable</c> stays false for the life of the instance. Since it is registered as
+/// a DI singleton, a first run that downloads <c>dpd-cst-subset.db</c> AFTER startup left DPD permanently
+/// unavailable for that session: the dictionary only appeared after a restart. (#536)</para>
+///
+/// <para>This wrapper keeps the singleton reference that <c>LemmaSearchService</c>, <c>LemmaReportService</c>
+/// and <c>DpdDictionarySource</c> already hold, and swaps the inner provider underneath them on
+/// <see cref="Reopen"/> — so an asset that lands mid-session goes live with no restart and no re-wiring.</para>
+/// </summary>
+public sealed class ReopenableLemmaProvider : ILemmaProvider
+{
+    private readonly string _assetPath;
+    private readonly object _gate = new();
+    private ILemmaProvider _inner;
+
+    /// <summary>
+    /// Superseded inner providers, disposed only when this wrapper is.
+    ///
+    /// A caller can be mid-query on the previous instance when <see cref="Reopen"/> swaps it — every member
+    /// below reads the reference under the lock and then calls OUTSIDE it, so disposing eagerly would race a
+    /// live query into <c>ObjectDisposedException</c>. Retiring instead of disposing costs one idle SQLite
+    /// connection per reopen, and a reopen happens at most once or twice per session (an asset install).
+    /// </summary>
+    private readonly List<ILemmaProvider> _retired = new();
+
+    public ReopenableLemmaProvider(string assetPath)
+    {
+        _assetPath = assetPath;
+        _inner = new SqliteLemmaProvider(assetPath);
+    }
+
+    /// <summary>
+    /// Rebuild the inner provider from the asset path — call after the asset has been installed and is live.
+    /// Safe to call when the asset is still absent (the new inner is simply unavailable, as before).
+    /// </summary>
+    public void Reopen()
+    {
+        var fresh = new SqliteLemmaProvider(_assetPath);
+        lock (_gate)
+        {
+            _retired.Add(_inner);
+            _inner = fresh;
+        }
+    }
+
+    private ILemmaProvider Current
+    {
+        get { lock (_gate) return _inner; }
+    }
+
+    public bool IsAvailable => Current.IsAvailable;
+    public DpdLemmaMeta? Meta => Current.Meta;
+    public FormResolution? ResolveForm(string form) => Current.ResolveForm(form);
+    public LemmaExpansion? ExpandLemma(long lemmaId, bool includeFamily = false) => Current.ExpandLemma(lemmaId, includeFamily);
+    public FormDeconstruction? Deconstruct(string form) => Current.Deconstruct(form);
+    public LemmaCandidate? GetLemma(long lemmaId) => Current.GetLemma(lemmaId);
+    public LemmaDetail? GetDetail(long lemmaId) => Current.GetDetail(lemmaId);
+
+    public void Dispose()
+    {
+        List<ILemmaProvider> toDispose;
+        lock (_gate)
+        {
+            toDispose = new List<ILemmaProvider>(_retired) { _inner };
+            _retired.Clear();
+        }
+        foreach (var p in toDispose)
+        {
+            try { p.Dispose(); } catch { /* best effort — teardown */ }
+        }
+    }
+}

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -28,6 +28,7 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
 {
     private readonly DictionarySourceRegistry _registry;
     private readonly DictionarySourcePreferenceService _sourcePrefs;
+    private readonly IDpdUpdateService _dpdUpdates;
     private readonly IScriptService _scriptService;
     private readonly IFontService _fontService;
     private readonly IApplicationStateService _stateService;
@@ -39,6 +40,7 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
     private EventHandler? _fontChangedHandler;
     // Live enable/order-preference handler, so the picker rebuilds when Settings changes the sources (#479).
     private EventHandler? _sourcePrefsChangedHandler;
+    private Action<string>? _assetInstalledHandler;
 
     // <see>-link navigation history (manual typing does NOT push history; only followed links do).
     private readonly Stack<string> _backStack = new();
@@ -57,6 +59,7 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
     public DictionaryViewModel(
         DictionarySourceRegistry registry,
         DictionarySourcePreferenceService sourcePrefs,
+        IDpdUpdateService dpdUpdates,
         IScriptService scriptService,
         IFontService fontService,
         IApplicationStateService stateService,
@@ -64,6 +67,7 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
     {
         _registry = registry;
         _sourcePrefs = sourcePrefs;
+        _dpdUpdates = dpdUpdates;
         _scriptService = scriptService;
         _fontService = fontService;
         _stateService = stateService;
@@ -159,6 +163,13 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         // Dispose. Marshalled to the UI thread — the preference service raises on the caller's thread.
         _sourcePrefsChangedHandler = (_, _) => Dispatcher.UIThread.Post(() => RebuildSources(preferFirstEnabled: true));
         _sourcePrefs.Changed += _sourcePrefsChangedHandler;
+
+        // A downloaded dictionary (DPD, DPPN) that lands mid-session must show up without a restart (#536).
+        // The registry evaluates availability live, so the picker just has to re-query — but nothing told it
+        // to. On a FIRST RUN the assets download after startup, which is exactly when this matters.
+        // preferFirstEnabled is deliberately false: an asset arriving must not move the user's selection.
+        _assetInstalledHandler = _ => Dispatcher.UIThread.Post(() => RebuildSources());
+        _dpdUpdates.AssetInstalled += _assetInstalledHandler;
     }
 
     /// <summary>Recompute <see cref="Sources"/> (and the picker-width measurer) from the enable/order
@@ -396,6 +407,8 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
             _fontService.FontSettingsChanged -= _fontChangedHandler;
         if (_sourcePrefsChangedHandler != null)
             _sourcePrefs.Changed -= _sourcePrefsChangedHandler;
+        if (_assetInstalledHandler != null)
+            _dpdUpdates.AssetInstalled -= _assetInstalledHandler;
         _disposables.Dispose();
     }
 }


### PR DESCRIPTION
Fixes #536 — on a clean install, DPD and DPPN downloaded successfully but did not appear in the dictionary panel until the app was restarted. This is the **first-run path**, so every new user hits it.

## The files were never the problem

`InstallFromGzip` moves the asset into place directly; staging to `.pending` only happens when the target is locked (Windows, #394). On a clean install there is no existing db and no open handle, so the asset is **live on disk immediately**. The restart was needed only because nothing re-read it.

## Two gaps, at different layers

**1. DPD could never become available.** `SqliteLemmaProvider` binds availability in its constructor:

```csharp
public bool IsAvailable { get; }
public SqliteLemmaProvider(string? assetPath)
{
    if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath))
        return;   // IsAvailable stays false — forever, for this instance
```

It is a DI singleton, so an asset arriving after startup left DPD unavailable for the entire session no matter what landed on disk.

New `ReopenableLemmaProvider` keeps the singleton reference that `LemmaSearchService`, `LemmaReportService` and `DpdDictionarySource` already hold, and swaps the inner provider on `Reopen()`.

Superseded instances are **retired rather than disposed**: every member reads the reference under the lock and then calls *outside* it, so eager disposal would race a live query into `ObjectDisposedException`. Cost is one idle SQLite connection per reopen, and a reopen happens at most once or twice per session.

**2. Nothing told the picker to re-query.** The read path was already fully live —

```csharp
public IReadOnlyList<IDictionarySource> Available => _sources.Where(s => s.IsAvailable).ToList();
```

— and `GetRows()` re-reads it every call, even appending newly installed sources (#479). But `RebuildSources()` only ran at construction, on a preference edit, and in `ApplyState`. So a source that *did* flip still never showed up.

## The fix

`IDpdUpdateService.AssetInstalled` — raised with the asset id after an install that is **usable now**. A staged install deliberately does not raise it, because it is not live yet.

- **App** reopens the lemma provider on it (DPD only).
- **`DictionaryViewModel`** rebuilds its picker, with `preferFirstEnabled: false` so an arriving asset never moves the user's current selection. Unsubscribed in `Dispose`.

## Also: the log was lying

```csharp
_logger.LogInformation("Installed {Id} ... Active on next launch.", ...);   // unconditional
```

That fired even on the in-place path. It was wrong, and it helped make "you must restart" look like intended behaviour. It now distinguishes staged from live, and the batch status no longer says "active after restart".

## Verification

Deleted `dpd-cst-subset` to simulate a first run, relaunched, and let it download:

```
Installed dpd (source v0.4.20260531, converter 3, ~223 MB). Active now.
Reopened the lemma provider after the dpd asset was installed; available=True
DPD Asset Status: Dictionary data installed.
```

`available=True` is the point — that was `false` for the whole session before this change. Asset confirmed on disk (223 MB), no restart involved.

**1003/1003 tests pass.**

## Note
A flat-file dictionary *directory* added mid-session still requires a restart — that path is unchanged and is not what #536 reported. The comment in `App.axaml.cs` has been corrected to describe availability as live while the source *set* is fixed at resolve time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)