### PR TITLE
#542: resolve the page marker that governs the current section, not the last one seen

### DIFF
--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -1208,31 +1208,65 @@ public partial class BookDisplayView : UserControl
 
                             // PERFORMANCE OPTIMIZATION: Use pre-sorted lists instead of expensive sorting on every call
                             // The findBestAnchor function now works on the pre-sorted lists
-                            // Two cases:
-                            // 1. Normal/scrolled: last anchor at or before the current position
-                            // 2. Above the FIRST marker (book title / namo tassa / a chapter heading that
-                            //    precedes the first page marker): resolve to the first anchor in the book.
-                            //    This fallback was previously gated on scrollY < 100, but a chapter-list
-                            //    jump can land the scroll above the first markers yet past 100px, which
-                            //    returned '*' — the #423 case-2 defect. Anywhere above the first marker,
-                            //    the first page IS the current page, so no threshold. (#423)
+                            //
+                            // Which marker governs a position (#542):
+                            // 1. Normally the last marker at or before it — you are inside the region it governs.
+                            // 2. But a section's page marker sits AFTER its heading block(s): the markers derive
+                            //    from page-number footnotes in the CST texts, and for a sutta the marker lands
+                            //    after the first word of the first body paragraph. So anywhere between a section's
+                            //    start and its first marker, 'last at or before' returns the PREVIOUS section's
+                            //    last page — one page early, or at a sub-book boundary an entire sub-book early.
+                            //    There the governing marker is the next one DOWN, not the last one up.
+                            // 3. Case 2 of the old code (above the very first marker in the document) is the same
+                            //    phenomenon at the top of the book, and is subsumed by the rule below.
+                            //
+                            // The <div> is the signal, not the heading styling: div boundaries were placed by hand
+                            // and coincide with the printed page turn, whereas rend classes do not — at the
+                            // Tikanipāta boundary in s0402a.att.xml, rend='centre' is used BOTH for the previous
+                            // book's closing attribution (old page) and for the salutation that opens the new one
+                            // (new page). The div opens exactly at the salutation, so it separates them correctly.
+                            //
+                            // Books with no div markup have no chapter anchors, so sectionStart stays -1 and the
+                            // behaviour is exactly as before — no regression where the markup is absent.
+                            var sectionStart = -1;
+                            var chapterList = this.sortedChapterAnchors;
+                            if (chapterList && chapterList.length > 0) {{
+                                for (var ci = 0; ci < chapterList.length; ci++) {{
+                                    if (chapterList[ci].position <= docPos) {{
+                                        sectionStart = chapterList[ci].position;
+                                    }} else {{
+                                        break;
+                                    }}
+                                }}
+                            }}
+
                             function findBestAnchor(sortedAnchors) {{
                                 if (!sortedAnchors || sortedAnchors.length === 0) {{
                                     return null;
                                 }}
 
-                                // Case 1: Linear search for anchor at or before current position
+                                // Last marker at or before the position, and the first one after it.
                                 var bestAnchor = null;
+                                var firstAfter = null;
                                 for (var i = 0; i < sortedAnchors.length; i++) {{
                                     if (sortedAnchors[i].position <= docPos) {{
                                         bestAnchor = sortedAnchors[i];
                                     }} else {{
-                                        // Since the list is sorted, we can stop here
+                                        // Since the list is sorted, the first one past docPos is the next marker.
+                                        firstAfter = sortedAnchors[i];
                                         break;
                                     }}
                                 }}
 
-                                // Case 2: No anchor at-or-before ⇒ we are above the first marker — return it
+                                // No marker since this section began ⇒ we are ahead of the marker that governs
+                                // it ⇒ look DOWN. A marker exactly AT the section start does govern it, hence <.
+                                if (sectionStart >= 0 && firstAfter &&
+                                    (!bestAnchor || bestAnchor.position < sectionStart)) {{
+                                    return firstAfter;
+                                }}
+
+                                // Above the first marker with nothing following (or no section info): the first
+                                // marker in the book IS the current page. (former Case 2, #423)
                                 if (!bestAnchor) {{
                                     bestAnchor = sortedAnchors[0];
                                 }}


### PR DESCRIPTION
Fixes #542. At a section boundary the status bar showed the **previous** section's page — and at a sub-book boundary, the previous *sub-book's* last page, across a band seven block elements tall. View Source and Go To read the same cache, so all three were wrong together.

## Cause

Page markers derive from **page-number footnotes in the CST texts**, so a section's marker sits *after* its heading block(s) — for a sutta, after the first word of the first body paragraph:

```xml
<head rend="chapter">१. ब्रह्मजालसुत्तं</head>
<p rend="subhead">परिब्बाजककथा</p>
<p rend="bodytext"><hi rend="paranum">१</hi><hi rend="dot">.</hi> एवं <pb ed="M" n="1.0001"/>…
```

`findBestAnchor` took the last marker at or before the position — which, anywhere in that band, is the previous section's.

## Why the `<div>`, not the heading classes

The `<div>` boundaries were **placed by hand** and coincide with the printed page turn. The `rend` classes do not. At the Tikanipāta boundary in `s0402a.att.xml`:

```
<p rend="centre">   Manorathapūraṇiyā aṅguttaranikāya-aṭṭhakathāya   <- OLD page (closing)
</div>
<div id="an3" type="book">
  <p rend="centre"> ॥ Namo tassa … ॥                                 <- NEW page (opens the book)
```

`rend="centre"` carries **both** the previous book's closing attribution and the salutation that opens the new one — and the closings genuinely belong to the old page. No class-based rule can separate them; the div opens exactly at the salutation and does.

## The rule

```js
// current section = last chapter anchor at or before docPos
if (no page marker has appeared since that section began && a marker follows)
    -> use the NEXT marker (look down)
else
    -> last marker at or before (unchanged)
```

**Retires the old Case 2** ("above the first marker in the document → use the first"). That was this same rule at the top of the book, and it had already produced one threshold bug (#423). One rule now covers the sutta boundary, the sub-book boundary and the document start.

**No new data**: `sortedChapterAnchors` was already built and sorted.

## Safety where markup is absent

Books with no `<div>` markup have no chapter anchors, so `sectionStart` stays `-1`, the rule never fires, and behaviour is byte-for-byte as before. That matters for the ~68 canonical books still lacking markup (#422 goal 6).

## Verification

- `node --check` on the generated JS (it lives in a C# interpolated string).
- **8-case simulation** over realistic anchor geometry — all pass:
  closings keep the old page · salutation onward takes the new one · headings in the new section · body text after the marker · next page region · top of book · **no div markup → unchanged** · end-of-document → last known.
- **1003/1003** tests.
- **Confirmed by hand on macOS** at the Tikanipāta boundary in `s0402a.att.xml`.

## Note
Testing surfaced that View Source can still land one page off there — a *separate* defect (#540): the source PDF has a numbered-but-unscanned blank page, which the single linear offset cannot express. The anchor resolution in this PR is correct; the PDF page arithmetic is the remaining half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)