### PR TITLE
#542 follow-up: only a BOOK boundary starts a new page, not every section

### DIFF
--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -1228,14 +1228,29 @@ public partial class BookDisplayView : UserControl
                             //
                             // Books with no div markup have no chapter anchors, so sectionStart stays -1 and the
                             // behaviour is exactly as before — no regression where the markup is absent.
-                            var sectionStart = -1;
+                            // Only a BOOK-level div starts a new printed page. A vagga / sutta / samyutta /
+                            // pannasaka boundary falls mid-page, so the heading there is still on the PREVIOUS
+                            // marker's page and 'last at or before' is already correct — looking forward at those
+                            // boundaries jumps a page early. Verified: '(7) 2. Sukhavaggavannana' (div an2_2_2,
+                            // type=vagga) sits on printed Myanmar page 53, and <pb M 2.0053/> precedes it.
+                            //
+                            // Book-level divs are identifiable from the anchor name alone: across the s-corpus
+                            // every type='book' id has NO underscore (88/88) and every other type has one
+                            // (vagga, sutta, samyutta, pannasaka, nipata, peyyala, chapter, intro, vimana).
+                            // The DOM anchors carry exactly these ids, so no extra markup is needed.
+                            // Track the most recent BOOK-level anchor, not merely the last anchor: a book div is
+                            // immediately followed by its nested pannasaka/vagga divs, so by the time you reach the
+                            // title or vagga heading the LAST anchor is a nested one and the book start would be
+                            // missed.
+                            var bookStart = -1;
                             var chapterList = this.sortedChapterAnchors;
                             if (chapterList && chapterList.length > 0) {{
                                 for (var ci = 0; ci < chapterList.length; ci++) {{
-                                    if (chapterList[ci].position <= docPos) {{
-                                        sectionStart = chapterList[ci].position;
-                                    }} else {{
+                                    if (chapterList[ci].position > docPos) {{
                                         break;
+                                    }}
+                                    if (chapterList[ci].name.indexOf('_') === -1) {{
+                                        bookStart = chapterList[ci].position;
                                     }}
                                 }}
                             }}
@@ -1258,10 +1273,11 @@ public partial class BookDisplayView : UserControl
                                     }}
                                 }}
 
-                                // No marker since this section began ⇒ we are ahead of the marker that governs
-                                // it ⇒ look DOWN. A marker exactly AT the section start does govern it, hence <.
-                                if (sectionStart >= 0 && firstAfter &&
-                                    (!bestAnchor || bestAnchor.position < sectionStart)) {{
+                                // A new BOOK starts a new printed page, and its marker sits after the heading
+                                // stack — so with no marker since this book began we are ahead of the one that
+                                // governs it: look DOWN. A marker exactly AT the section start governs it, hence <.
+                                if (bookStart >= 0 && firstAfter &&
+                                    (!bestAnchor || bestAnchor.position < bookStart)) {{
                                     return firstAfter;
                                 }}
 


### PR DESCRIPTION
Follow-up to #543, which over-fired. Found immediately in testing.

## The regression

#543 looked forward at **every** div boundary. But only a **book** starts a new printed page — a vagga / sutta / samyutta / pannasaka boundary falls mid-page, so the heading there is still on the previous marker's page.

Seen at **`(7) 2. Sukhavaggavaṇṇanā`** (`div an2_2_2`, `type="vagga"`) in `s0402a.att.xml`:

```xml
<p rend="bodytext"> ६४. … <pb ed="M" n="2.0053"/><pb ed="V" n="2.0051"/>
</div>
<div id="an2_2_2" type="vagga">
  <head rend="chapter"> (७) २. सुखवग्गवण्णना        <- still on printed page 53
```

The heading is on **printed Myanmar page 53**; the status bar showed **2.54**.

## Why "book" is the right test

Only book divs begin a new printed page — which is exactly why the salutation appears at them and nowhere else. Across DN/MN/SN/AN:

| div type | count | opens with a salutation |
|---|---:|---:|
| **book** | 66 | **27** |
| vagga | 356 | 0 |
| samyutta | 170 | 0 |
| sutta | 104 | 0 |
| pannasaka | 48 | 0 |
| peyyala | 18 | 0 |

## The discriminator is already in the DOM

Anchors carry the div `id`, and across **all 217 corpus files**:

> `type="book"` ⟺ the id has **no underscore** — **zero violations**.

Every other type (vagga, sutta, samyutta, pannasaka, nipata, peyyala, chapter, intro, vimana) has one. So no new markup, no XSL change, no reseeding.

## Second bug this exposed

Tracking the *last* anchor was insufficient: a book div is immediately followed by its nested pannasaka/vagga divs, so at the title or vagga heading the last anchor is nested and the book start is missed. The Tikanipāta boundary read correctly at the salutation but **not a few lines further down**. Now tracks the most recent **book-level** anchor.

## Safety

**139 of 217 files have no div ids at all** — the rule stays inert and behaviour is unchanged for every unmarked book.

## Verification

Simulation over both boundary types, all passing:

- vagga heading keeps its page (the regression)
- book boundary takes the new page — at the salutation **and** at the nested headings
- closings before the book div keep the old page
- mid-paragraph unchanged · sutta boundary mid-page · top of book · no div markup · end of document

**1003/1003** tests.

## Note
An independent plausibility check was suggested during review: a marker several paragraph anchors away cannot be governing the current position, which rules out 2.54 here on its own. It agrees with this fix. Not implemented, because it is insufficient alone — at this same boundary the next **V** marker *is* in the very next paragraph, so a distance test would still have looked forward and been wrong for VRI pages, while the div test is right for both editions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)