### PR TITLE
#540: account for printed pages missing from the scanned source PDFs

### DIFF
--- a/src/CST.Avalonia.Tests/Models/SourcePdfPageTests.cs
+++ b/src/CST.Avalonia.Tests/Models/SourcePdfPageTests.cs
@@ -1,0 +1,117 @@
+using System.Linq;
+using CST;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Models
+{
+    /// <summary>
+    /// Mapping a printed page number to a page of the scanned source PDF. (#540)
+    ///
+    /// CST4 used PageStart + (page - 1), which assumes the scan holds every printed page. It does not:
+    /// blank pages were passed over, so from the first skip onward every page is off by one, and the
+    /// error accumulates with each further skip. <see cref="Sources.Source.MissingPages"/> records the
+    /// skipped printed pages per PDF.
+    /// </summary>
+    public class SourcePdfPageTests
+    {
+        private static Sources.Source Src(int pageStart, params int[] missing) =>
+            new(Sources.SourceType.Burmese1957, pageStart, "x.pdf", missing);
+
+        [Fact]
+        public void WithNoMissingPages_IsTheOriginalLinearFormula()
+        {
+            var s = Src(19);
+            Assert.Equal(19, s.PdfPageFor(1));
+            Assert.Equal(87, s.PdfPageFor(69));
+        }
+
+        [Fact]
+        public void PagesBeforeTheBlankAreUnaffected()
+        {
+            var s = Src(19, 68);
+            Assert.Equal(19, s.PdfPageFor(1));
+            Assert.Equal(85, s.PdfPageFor(67));   // last page before the blank
+        }
+
+        [Fact]
+        public void PagesAfterTheBlankShiftBackByOne()
+        {
+            // s0402a: print page 68 is blank, so Tikanipāta at Myanmar 2.0069 is PDF 86, not 87.
+            var s = Src(19, 68);
+            Assert.Equal(86, s.PdfPageFor(69));
+        }
+
+        [Fact]
+        public void SkipsAccumulate()
+        {
+            // The same book's second blank at 248 makes Catukkanipāta (Myanmar 2.0249) off by two.
+            var s = Src(19, 68, 248);
+            Assert.Equal(86, s.PdfPageFor(69));    // one blank passed
+            Assert.Equal(265, s.PdfPageFor(249));  // two blanks passed
+        }
+
+        [Fact]
+        public void TheBlankPageItselfResolvesToTheFollowingPage()
+        {
+            // Nothing was scanned for print page 68, so the honest answer is where 68 would have been —
+            // which is the page that follows it. Landing there beats refusing to open the PDF.
+            var s = Src(19, 68);
+            Assert.Equal(86, s.PdfPageFor(68));
+            Assert.Equal(86, s.PdfPageFor(69));
+        }
+
+        [Fact]
+        public void NeverReturnsAPageBeforeTheStartOfThePdf()
+        {
+            Assert.Equal(1, Src(19).PdfPageFor(-50));
+        }
+
+        [Fact]
+        public void MissingPagesDefaultsToEmptyNotNull()
+        {
+            var s = new Sources.Source(Sources.SourceType.Burmese1957, 5, "x.pdf");
+            Assert.NotNull(s.MissingPages);
+            Assert.Empty(s.MissingPages);
+            Assert.Equal(5, s.PdfPageFor(1));
+        }
+
+        [Fact]
+        public void EverySeededArrayIsAscendingDistinctAndPositive()
+        {
+            // PdfPageFor stops counting at the first entry >= the target, so an unsorted array would
+            // silently undercount. This guards hand-edits made during QA.
+            var books = new[]
+            {
+                "abh03a.att.xml", "abh03m10.mul.xml", "abh03m11.mul.xml", "abh03m4.mul.xml",
+                "abh03t.tik.xml", "s0201m.mul.xml", "s0402a.att.xml", "s0403a.att.xml",
+                "s0403t.tik.xml", "s0404a.att.xml", "s0404t.tik.xml", "s0508a2.att.xml",
+                "s0510m2.mul.xml", "s0514a2.att.xml", "s0514a3.att.xml", "vin02t.tik.xml",
+            };
+            var seen = 0;
+            foreach (var book in books)
+            {
+                foreach (Sources.SourceType t in System.Enum.GetValues<Sources.SourceType>())
+                {
+                    var s = Sources.Inst.GetSource(book, t);
+                    if (s is null || s.MissingPages.Length == 0) continue;
+                    seen++;
+                    Assert.All(s.MissingPages, p => Assert.True(p > 0, $"{book}/{t}: page {p}"));
+                    Assert.Equal(s.MissingPages.OrderBy(p => p).ToArray(), s.MissingPages);
+                    Assert.Equal(s.MissingPages.Distinct().Count(), s.MissingPages.Length);
+                }
+            }
+            Assert.Equal(21, seen);
+        }
+
+        [Fact]
+        public void TheSeedForAnAtthakathaMatchesTheGapsInItsPageMarkers()
+        {
+            // The seed came from holes in the XML's Myanmar page-break markers. Pinned so that a future
+            // QA correction is a deliberate edit rather than an accident.
+            var s = Sources.Inst.GetSource("s0402a.att.xml", Sources.SourceType.Burmese1957);
+            Assert.NotNull(s);
+            Assert.Equal(new[] { 68, 248 }, s!.MissingPages);
+            Assert.Equal(19, s.PageStart);
+        }
+    }
+}

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -1535,9 +1535,10 @@ namespace CST.Avalonia.ViewModels
                 return;
             }
 
-            // Calculate target PDF page using CST4 formula: pdfPage = source.PageStart + (currentMyanmarPage - 1)
-            int pdfPage = source.PageStart + (currentPage - 1);
-            if (pdfPage < 1) pdfPage = 1;
+            // CST4's formula was PageStart + (page - 1), which assumes every printed page occupies a page
+            // of the PDF. Blank pages the scanner passed over break that, and the error accumulates down
+            // the volume, so the page count comes from the source itself now. (#540)
+            int pdfPage = source.PdfPageFor(currentPage);
 
             _logger.Information("Showing source PDF: {SourceType} for {BookFilename}, Myanmar page {MyanmarPage} -> PDF page {PdfPage}",
                 sourceType, _book.FileName, currentPage, pdfPage);

--- a/src/CST.Core/Sources.cs
+++ b/src/CST.Core/Sources.cs
@@ -304,7 +304,7 @@ public class Sources
 		addSource("s0103m.mul.xml", SourceType.Burmese1957, 10, $"{Burmese1957Sutta}/{DN_Pathikavagga_1957}");
 
 		// --- Sutta Pitaka - Majjhima Nikāya ---
-		addSource("s0201m.mul.xml", SourceType.Burmese1957, 16, $"{Burmese1957Sutta}/{MN_Mulapannasa_1957}");
+		addSource("s0201m.mul.xml", SourceType.Burmese1957, 16, $"{Burmese1957Sutta}/{MN_Mulapannasa_1957}", new[] { 379 });
 		addSource("s0202m.mul.xml", SourceType.Burmese1957, 7, $"{Burmese1957Sutta}/{MN_Majjhimapannasa_1957}");
 		addSource("s0203m.mul.xml", SourceType.Burmese1957, 7, $"{Burmese1957Sutta}/{MN_Uparipannasa_1957}");
 
@@ -339,7 +339,7 @@ public class Sources
 		addSource("s0508m.mul.xml", SourceType.Burmese1957, 16, $"{Burmese1957Sutta}/{KN_VimanavattuTherigatha_1957}");
 		addSource("s0509m.mul.xml", SourceType.Burmese1957, 15, $"{Burmese1957Sutta}/{KN_VimanavattuTherigatha_1957}");
 		addSource("s0510m1.mul.xml", SourceType.Burmese1957, 20, $"{Burmese1957Sutta}/{KN_Apadana1_1957}");
-		addSource("s0510m2.mul.xml", SourceType.Burmese1957, 16, $"{Burmese1957Sutta}/{KN_Apadana2Buddhavamsa_1957}");
+		addSource("s0510m2.mul.xml", SourceType.Burmese1957, 16, $"{Burmese1957Sutta}/{KN_Apadana2Buddhavamsa_1957}", new[] { 186 });
 		addSource("s0511m.mul.xml", SourceType.Burmese1957, 13, $"{Burmese1957Sutta}/{KN_Apadana2Buddhavamsa_1957}");
 		addSource("s0512m.mul.xml", SourceType.Burmese1957, 13, $"{Burmese1957Sutta}/{KN_Apadana2Buddhavamsa_1957}");
 		addSource("s0513m.mul.xml", SourceType.Burmese1957, 27, $"{Burmese1957Sutta}/{KN_Jataka1_1957}");
@@ -358,14 +358,14 @@ public class Sources
 		addSource("abh03m1.mul.xml", SourceType.Burmese1957, 8, $"{Burmese1957Abhidhamma}/{Abh_DhatukathaPuggalapannatti_1957}");
 		addSource("abh03m2.mul.xml", SourceType.Burmese1957, 8, $"{Burmese1957Abhidhamma}/{Abh_DhatukathaPuggalapannatti_1957}");
 		addSource("abh03m3.mul.xml", SourceType.Burmese1957, 16, $"{Burmese1957Abhidhamma}/{Abh_Kathavatthu_1957}");
-		addSource("abh03m4.mul.xml", SourceType.Burmese1957, 10, $"{Burmese1957Abhidhamma}/{Abh_Yamaka1_1957}");
+		addSource("abh03m4.mul.xml", SourceType.Burmese1957, 10, $"{Burmese1957Abhidhamma}/{Abh_Yamaka1_1957}", new[] { 16 });
 		addSource("abh03m5.mul.xml", SourceType.Burmese1957, 12, $"{Burmese1957Abhidhamma}/{Abh_Yamaka2_1957}");
 		addSource("abh03m6.mul.xml", SourceType.Burmese1957, 1, $"{Burmese1957Abhidhamma}/{Abh_Yamaka3_1957}"); // TODO: PDF is 0 bytes in SharePoint
 		addSource("abh03m7.mul.xml", SourceType.Burmese1957, 30, $"{Burmese1957Abhidhamma}/{Abh_Patthana1_1957}");
 		addSource("abh03m8.mul.xml", SourceType.Burmese1957, 28, $"{Burmese1957Abhidhamma}/{Abh_Patthana2_1957}");
 		addSource("abh03m9.mul.xml", SourceType.Burmese1957, 7, $"{Burmese1957Abhidhamma}/{Abh_Patthana3_1957}");
-		addSource("abh03m10.mul.xml", SourceType.Burmese1957, 10, $"{Burmese1957Abhidhamma}/{Abh_Patthana4_1957}");
-		addSource("abh03m11.mul.xml", SourceType.Burmese1957, 6, $"{Burmese1957Abhidhamma}/{Abh_Patthana5_1957}");
+		addSource("abh03m10.mul.xml", SourceType.Burmese1957, 10, $"{Burmese1957Abhidhamma}/{Abh_Patthana4_1957}", new[] { 466 });
+		addSource("abh03m11.mul.xml", SourceType.Burmese1957, 6, $"{Burmese1957Abhidhamma}/{Abh_Patthana5_1957}", new[] { 62, 122, 158, 196, 214, 306, 326, 348, 376, 402, 424 });
 
 		// =============================================
 		// 2010 Edition Mappings
@@ -384,7 +384,7 @@ public class Sources
 		addSource("s0103m.mul.xml", SourceType.Burmese2010, 13, $"{Burmese2010Mula}/{DN_Pathikavagga_2010}");
 
 		// --- Sutta Pitaka - Majjhima Nikāya ---
-		addSource("s0201m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{MN_Mulapannasa_2010}");
+		addSource("s0201m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{MN_Mulapannasa_2010}", new[] { 379 });
 		addSource("s0202m.mul.xml", SourceType.Burmese2010, 11, $"{Burmese2010Mula}/{MN_Majjhimapannasa_2010}");
 		addSource("s0203m.mul.xml", SourceType.Burmese2010, 11, $"{Burmese2010Mula}/{MN_Uparipannasa_2010}");
 
@@ -419,7 +419,7 @@ public class Sources
 		addSource("s0508m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_VimanavattuTherigatha_2010}");
 		addSource("s0509m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_VimanavattuTherigatha_2010}");
 		addSource("s0510m1.mul.xml", SourceType.Burmese2010, 25, $"{Burmese2010Mula}/{KN_Apadana1_2010}");
-		addSource("s0510m2.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_Apadana2Buddhavamsa_2010}");
+		addSource("s0510m2.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_Apadana2Buddhavamsa_2010}", new[] { 186 });
 		addSource("s0511m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_Apadana2Buddhavamsa_2010}");
 		addSource("s0512m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_Apadana2Buddhavamsa_2010}");
 		addSource("s0513m.mul.xml", SourceType.Burmese2010, 31, $"{Burmese2010Mula}/{KN_Jataka1_2010}");
@@ -438,14 +438,14 @@ public class Sources
 		addSource("abh03m1.mul.xml", SourceType.Burmese2010, 11, $"{Burmese2010Mula}/{Abh_DhatukathaPuggalapannatti_2010}");
 		addSource("abh03m2.mul.xml", SourceType.Burmese2010, 11, $"{Burmese2010Mula}/{Abh_DhatukathaPuggalapannatti_2010}");
 		addSource("abh03m3.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{Abh_Kathavatthu_2010}");
-		addSource("abh03m4.mul.xml", SourceType.Burmese2010, 15, $"{Burmese2010Mula}/{Abh_Yamaka1_2010}");
+		addSource("abh03m4.mul.xml", SourceType.Burmese2010, 15, $"{Burmese2010Mula}/{Abh_Yamaka1_2010}", new[] { 16 });
 		addSource("abh03m5.mul.xml", SourceType.Burmese2010, 15, $"{Burmese2010Mula}/{Abh_Yamaka2_2010}");
 		addSource("abh03m6.mul.xml", SourceType.Burmese2010, 13, $"{Burmese2010Mula}/{Abh_Yamaka3_2010}");
 		addSource("abh03m7.mul.xml", SourceType.Burmese2010, 35, $"{Burmese2010Mula}/{Abh_Patthana1_2010}");
 		addSource("abh03m8.mul.xml", SourceType.Burmese2010, 31, $"{Burmese2010Mula}/{Abh_Patthana2_2010}");
 		addSource("abh03m9.mul.xml", SourceType.Burmese2010, 13, $"{Burmese2010Mula}/{Abh_Patthana3_2010}");
-		addSource("abh03m10.mul.xml", SourceType.Burmese2010, 13, $"{Burmese2010Mula}/{Abh_Patthana4_2010}");
-		addSource("abh03m11.mul.xml", SourceType.Burmese2010, 11, $"{Burmese2010Mula}/{Abh_Patthana5_2010}");
+		addSource("abh03m10.mul.xml", SourceType.Burmese2010, 13, $"{Burmese2010Mula}/{Abh_Patthana4_2010}", new[] { 466 });
+		addSource("abh03m11.mul.xml", SourceType.Burmese2010, 11, $"{Burmese2010Mula}/{Abh_Patthana5_2010}", new[] { 62, 122, 158, 196, 214, 306, 326, 348, 376, 402, 424 });
 
 		// =============================================
 		// 1957 Atthakatha (Commentary) Mappings
@@ -478,9 +478,9 @@ public class Sources
 
 		// --- AN Atthakatha ---
 		addSource("s0401a.att.xml", SourceType.Burmese1957, 3, $"{Burmese1957Atthakatha}/{Att_AN_Ekakanipata_1957}");
-		addSource("s0402a.att.xml", SourceType.Burmese1957, 19, $"{Burmese1957Atthakatha}/{Att_AN_DukaTikaCatukka_1957}");
-		addSource("s0403a.att.xml", SourceType.Burmese1957, 27, $"{Burmese1957Atthakatha}/{Att_AN_Pancakanipata_1957}");
-		addSource("s0404a.att.xml", SourceType.Burmese1957, 27, $"{Burmese1957Atthakatha}/{Att_AN_Pancakanipata_1957}");
+		addSource("s0402a.att.xml", SourceType.Burmese1957, 19, $"{Burmese1957Atthakatha}/{Att_AN_DukaTikaCatukka_1957}", new[] { 68, 248 });
+		addSource("s0403a.att.xml", SourceType.Burmese1957, 27, $"{Burmese1957Atthakatha}/{Att_AN_Pancakanipata_1957}", new[] { 86, 144 });
+		addSource("s0404a.att.xml", SourceType.Burmese1957, 27, $"{Burmese1957Atthakatha}/{Att_AN_Pancakanipata_1957}", new[] { 256, 286, 342 });
 
 		// --- KN Atthakatha ---
 		addSource("s0501a.att.xml", SourceType.Burmese1957, 4, $"{Burmese1957Atthakatha}/{Att_KN_Khuddakapatha_1957}");
@@ -491,7 +491,7 @@ public class Sources
 		addSource("s0506a.att.xml", SourceType.Burmese1957, 7, $"{Burmese1957Atthakatha}/{Att_KN_Vimanavatthu_1957}");
 		addSource("s0507a.att.xml", SourceType.Burmese1957, 6, $"{Burmese1957Atthakatha}/{Att_KN_Petavatthu_1957}");
 		addSource("s0508a1.att.xml", SourceType.Burmese1957, 11, $"{Burmese1957Atthakatha}/{Att_KN_Theragatha1_1957}");
-		addSource("s0508a2.att.xml", SourceType.Burmese1957, 7, $"{Burmese1957Atthakatha}/{Att_KN_Theragatha2_1957}");
+		addSource("s0508a2.att.xml", SourceType.Burmese1957, 7, $"{Burmese1957Atthakatha}/{Att_KN_Theragatha2_1957}", new[] { 360 });
 		addSource("s0509a.att.xml", SourceType.Burmese1957, 7, $"{Burmese1957Atthakatha}/{Att_KN_Therigatha_1957}");
 		addSource("s0510a.att.xml", SourceType.Burmese1957, 4, $"{Burmese1957Atthakatha}/{Att_KN_Apadana1_1957}");
 		addSource("s0511a.att.xml", SourceType.Burmese1957, 5, $"{Burmese1957Atthakatha}/{Att_KN_Buddhavamsa_1957}");
@@ -501,8 +501,8 @@ public class Sources
 		addSource("s0513a3.att.xml", SourceType.Burmese1957, 10, $"{Burmese1957Atthakatha}/{Att_KN_Jataka3_1957}");
 		addSource("s0513a4.att.xml", SourceType.Burmese1957, 8, $"{Burmese1957Atthakatha}/{Att_KN_Jataka4_1957}");
 		addSource("s0514a1.att.xml", SourceType.Burmese1957, 6, $"{Burmese1957Atthakatha}/{Att_KN_Jataka5_1957}");
-		addSource("s0514a2.att.xml", SourceType.Burmese1957, 4, $"{Burmese1957Atthakatha}/{Att_KN_Jataka6_1957}");
-		addSource("s0514a3.att.xml", SourceType.Burmese1957, 4, $"{Burmese1957Atthakatha}/{Att_KN_Jataka7_1957}");
+		addSource("s0514a2.att.xml", SourceType.Burmese1957, 4, $"{Burmese1957Atthakatha}/{Att_KN_Jataka6_1957}", new[] { 38, 118 });
+		addSource("s0514a3.att.xml", SourceType.Burmese1957, 4, $"{Burmese1957Atthakatha}/{Att_KN_Jataka7_1957}", new[] { 150 });
 		addSource("s0515a.att.xml", SourceType.Burmese1957, 4, $"{Burmese1957Atthakatha}/{Att_KN_Mahaniddesa_1957}");
 		addSource("s0516a.att.xml", SourceType.Burmese1957, 5, $"{Burmese1957Atthakatha}/{Att_KN_CulaniddesaNetti_1957}");
 		addSource("s0517a.att.xml", SourceType.Burmese1957, 6, $"{Burmese1957Atthakatha}/{Att_KN_Patisambhida1_1957}");
@@ -511,7 +511,7 @@ public class Sources
 		// --- Abhidhamma Atthakatha ---
 		addSource("abh01a.att.xml", SourceType.Burmese1957, 14, $"{Burmese1957Atthakatha}/{Att_Abh_Dhammasangani_1957}");
 		addSource("abh02a.att.xml", SourceType.Burmese1957, 9, $"{Burmese1957Atthakatha}/{Att_Abh_Vibhanga_1957}");
-		addSource("abh03a.att.xml", SourceType.Burmese1957, 13, $"{Burmese1957Atthakatha}/{Att_Abh_Pancappakarana_1957}");
+		addSource("abh03a.att.xml", SourceType.Burmese1957, 13, $"{Burmese1957Atthakatha}/{Att_Abh_Pancappakarana_1957}", new[] { 24 });
 
 		// =============================================
 		// 1957 Tika (Sub-Commentary) Mappings
@@ -541,8 +541,8 @@ public class Sources
 		// --- AN Tika ---
 		addSource("s0401t.tik.xml", SourceType.Burmese1957, 16, $"{Burmese1957Tika}/{Tik_AN_Ekakanipata_1957}");
 		addSource("s0402t.tik.xml", SourceType.Burmese1957, 17, $"{Burmese1957Tika}/{Tik_AN_DukaTikaCatukka_1957}");
-		addSource("s0403t.tik.xml", SourceType.Burmese1957, 19, $"{Burmese1957Tika}/{Tik_AN_Pancakanipata_1957}");
-		addSource("s0404t.tik.xml", SourceType.Burmese1957, 18, $"{Burmese1957Tika}/{Tik_AN_Pancakanipata_1957}");
+		addSource("s0403t.tik.xml", SourceType.Burmese1957, 19, $"{Burmese1957Tika}/{Tik_AN_Pancakanipata_1957}", new[] { 148 });
+		addSource("s0404t.tik.xml", SourceType.Burmese1957, 18, $"{Burmese1957Tika}/{Tik_AN_Pancakanipata_1957}", new[] { 266 });
 
 		// --- KN Tika ---
 		addSource("s0519t.tik.xml", SourceType.Burmese1957, 7, $"{Burmese1957Tika}/{Tik_KN_Netti_1957}");
@@ -550,12 +550,12 @@ public class Sources
 		// --- Vinaya Tika (Saratthadipani) ---
 		addSource("vin01t1.tik.xml", SourceType.Burmese1957, 14, $"{Burmese1957Tika}/{Tik_Vin_Saratthadipani1_1957}");
 		addSource("vin01t2.tik.xml", SourceType.Burmese1957, 9, $"{Burmese1957Tika}/{Tik_Vin_Saratthadipani2_1957}");
-		addSource("vin02t.tik.xml", SourceType.Burmese1957, 21, $"{Burmese1957Tika}/{Tik_Vin_Saratthadipani3_1957}");
+		addSource("vin02t.tik.xml", SourceType.Burmese1957, 21, $"{Burmese1957Tika}/{Tik_Vin_Saratthadipani3_1957}", new[] { 130, 364 });
 
 		// --- Abhidhamma Tika ---
 		addSource("abh01t.tik.xml", SourceType.Burmese1957, 16, $"{Burmese1957Tika}/{Tik_Abh_Dhammasangani_1957}");
 		addSource("abh02t.tik.xml", SourceType.Burmese1957, 9, $"{Burmese1957Tika}/{Tik_Abh_Vibhanga_1957}");
-		addSource("abh03t.tik.xml", SourceType.Burmese1957, 20, $"{Burmese1957Tika}/{Tik_Abh_Pancappakarana_1957}");
+		addSource("abh03t.tik.xml", SourceType.Burmese1957, 20, $"{Burmese1957Tika}/{Tik_Abh_Pancappakarana_1957}", new[] { 46 });
 
 		// =============================================
 		// Anya (Other Texts) Mappings
@@ -630,14 +630,15 @@ public class Sources
 		addSource("e1209n.nrf.xml", SourceType.BurmeseAnya, 1, $"{BurmeseAnyaSihala}/9. Telakaṭāhagāthā Pali Burmese English.pdf");
 	}
 
-	private void addSource(string filename, SourceType sourceType, int pageStart, string path)
+	private void addSource(string filename, SourceType sourceType, int pageStart, string path,
+		int[]? missingPages = null)
 	{
 		if (!sourcesMap.TryGetValue(filename, out var d))
 		{
 			d = new Dictionary<SourceType, Source>();
 			sourcesMap[filename] = d;
 		}
-		d[sourceType] = new Source(sourceType, pageStart, path);
+		d[sourceType] = new Source(sourceType, pageStart, path, missingPages);
 	}
 
 	public Source? GetSource(string filename, SourceType sourceType)
@@ -689,11 +690,12 @@ public class Sources
 
 	public class Source
 	{
-		public Source(SourceType sourceType, int pageStart, string path)
+		public Source(SourceType sourceType, int pageStart, string path, int[]? missingPages = null)
 		{
 			SourceType = sourceType;
 			PageStart = pageStart;
 			Path = path;
+			MissingPages = missingPages ?? Array.Empty<int>();
 		}
 
 		/// <summary>
@@ -704,5 +706,35 @@ public class Sources
 
 		public SourceType SourceType { get; set; }
 		public int PageStart { get; set; }
+
+		/// <summary>
+		/// Print page numbers that exist in the printed volume but have NO page in this PDF — blank
+		/// pages the scanner passed over. Ascending. (#540)
+		///
+		/// <para>Without this, one skipped page throws off every page after it, and the error accumulates:
+		/// s0402a has blanks at 68 and 248, so Tikanipāta landed one page late and Catukkanipāta two.</para>
+		///
+		/// <para>PER PDF, not per book. The seed values were derived from gaps in the XML page-break
+		/// markers — a blank page has no text, so it leaves no marker AND nothing to scan — but the
+		/// scanning was done by a different group within VRI from the one that produced the texts, so
+		/// the two Burmese editions may well skip different pages. Correct an entry when QA finds an
+		/// off-by-one; do not assume the paired edition needs the same correction.</para>
+		/// </summary>
+		public int[] MissingPages { get; set; }
+
+		/// <summary>
+		/// PDF page for a printed page number, accounting for pages absent from the scan.
+		/// </summary>
+		public int PdfPageFor(int printPage)
+		{
+			int skipped = 0;
+			foreach (int p in MissingPages)
+			{
+				if (p >= printPage) break;   // MissingPages is ascending
+				skipped++;
+			}
+			int pdfPage = PageStart + (printPage - 1) - skipped;
+			return pdfPage < 1 ? 1 : pdfPage;
+		}
 	}
 }


### PR DESCRIPTION
Closes #540.

## The defect

View Source PDF landed one page late from the Tikanipāta boundary onward in AN 2-3-4 Aṭṭha. CST4's formula assumes the scan holds every printed page:

```csharp
pdfPage = source.PageStart + (currentPage - 1);
```

Blank pages were passed over during scanning, so from the first skip onward every page is off — and the error **accumulates**. The same book had a second blank at 248, which would have made Catukkanipāta off by two.

`Source.PdfPageFor()` now subtracts the skips recorded in a new per-PDF `MissingPages` array.

## Where the seed values came from

A blank page has no text, so it leaves no `<pb>` marker in the XML *and* nothing for the scanner to capture. Holes in a book's Myanmar page sequence therefore predict pages absent from the PDF. `s0402a` runs 1–397 with exactly two holes — 68 and 248 — which is the page Frank hit plus the one waiting further down.

Seeded **45 pages across 22 canonical books**; 16 have a PDF mapped today (21 `addSource` entries once the paired 2010 editions are counted).

Two deliberate exclusions:

| excluded | why |
|---|---|
| `e*` books — 3,344 gap pages | They come in **runs** of consecutive missing markers: unmarked regions, not blank pages. Subtracting them would be badly wrong. No canonical book has a run — every canonical gap is isolated, which is what a single blank leaf looks like. |
| `vin01a`, `vin07t`, `vin11t` | Their Myanmar numbering restarts per volume, so a bare page number is ambiguous until source entries carry volume segments (#546). Their blanks are recorded there. |

## The arrays are per PDF, not per book

The scans were produced by a different group within VRI from the one that produced the texts, so the two Burmese editions may well skip different pages. The 2010 values are the same seed and are **not** independently confirmed — correcting one edition must not be taken to imply the other. The doc comment says so, since the natural instinct on seeing two identical arrays is to factor them together.

## Scope

This fixes **navigation only**. A missing leaf also reverses recto/verso for the rest of the volume in two-page view, pushing the page numbers into the gutter. That is a property of the file — no page-index arithmetic reaches it, and the PDFium viewer takes only `#page=N`, with no parameter for spread parity. A corrected PDF would fix both, and is a separate decision.

## Testing

9 new tests: the linear case, pages before and after a blank, accumulation across two blanks, the blank page itself, the floor at page 1, the empty default, and a guard that every seeded array is ascending, distinct and positive — `PdfPageFor` stops at the first entry ≥ the target, so an unsorted hand-edit during QA would silently undercount.

**1012/1012 pass.**

Worth checking by hand: AN 2-3-4 Aṭṭha at Myanmar 2.0069 → PDF 86 (was 87), and at 2.0249 → PDF 265, correcting an off-by-two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)