### PR TITLE
#540 follow-up: a missing page belongs to the PDF, not the book

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,7 @@ Exploratory research and investigations:
 - [MAUI Blazor POC Results](research/MAUI_BLAZOR_POC_RESULTS.md) - POC findings and conclusions
 - [Rendering Requirements](research/RENDERING_REQUIREMENTS.md) - Content rendering needs analysis
 - [Search Index Shrink Spike](research/SEARCH_INDEX_SHRINK_SPIKE.md) - #55 dropping redundant term vectors / norms / payloads (~135 MB → ~75 MB)
+- [Source PDF Pagination](research/SOURCE_PDF_PAGINATION.md) - #540 pages missing from the scans (derived from XML page-marker gaps; fixed for navigation) and why two-page spreads reverse (Chrome's fixed pairing vs Preview's; why not to patch the PDFs)
 - [Structural Markup Inventory](research/STRUCTURAL_MARKUP_INVENTORY.md) - corpus `<div>` coverage (78/217 structured); ground truth for the book-mapping / navigation cluster (#24/#76/#174/#314/#266). Regenerable via `structural_markup_inventory.py`
 - [Strategic Technology Options](research/STRATEGIC_TECHNOLOGY_OPTIONS.md) - Technology direction evaluation
 

--- a/docs/research/SOURCE_PDF_PAGINATION.md
+++ b/docs/research/SOURCE_PDF_PAGINATION.md
@@ -1,0 +1,147 @@
+# Source PDF Pagination — missing pages and two-page spreads
+
+Findings from the #540 investigation (2026-07-31). Covers two separable problems:
+
+1. **Navigation** — pages missing from the scans throw off which PDF page we open. *Fixed* (#540).
+2. **Spreads** — recto/verso reverse in two-page view. *Not fixed, and deliberately so* — the defect is
+   in our viewer, and correcting the files would break them in standards-respecting viewers.
+
+Both trace to the same fact: **the scans are not page-complete.** The PDFs were produced by a different
+group within VRI from the Tipitaka.org team that produced the texts, and blank pages were passed over.
+
+---
+
+## 1. Missing pages (navigation) — FIXED
+
+### The defect
+
+CST4's formula assumed the scan holds every printed page:
+
+```csharp
+pdfPage = source.PageStart + (printPage - 1);
+```
+
+One skipped page throws off everything after it, and the error **accumulates**. In AN 2-3-4 Aṭṭha
+(`s0402a`, `PageStart` 19) blanks at print pages 68 and 248 made Tikanipāta land one page late and
+Catukkanipāta two.
+
+### The fix
+
+`Sources.Source.PdfPageFor()` subtracts the skips recorded in a per-PDF `MissingPages` array:
+
+```
+pdfPage = PageStart + (printPage - 1) - |{ missing pages < printPage }|
+```
+
+### How the seed values were derived
+
+**A blank page leaves two traces, and we hold one of them.** It has no text, so it produces no `<pb>`
+marker in the XML *and* nothing for the scanner to capture. Holes in a book's Myanmar page sequence
+therefore predict pages absent from the PDF. `s0402a` runs 1–397 with exactly two holes: 68 and 248.
+
+Seeded **45 pages across 22 canonical books**; 16 have a PDF mapped today (21 `addSource` entries once
+the paired 2010 editions are counted).
+
+Two categories were excluded deliberately:
+
+| excluded | why |
+|---|---|
+| `e*` books — 3,344 gap pages | They come in **runs** of consecutive missing markers: unmarked regions, not blank pages. Subtracting them would be badly wrong. No canonical book has a run — every canonical gap is isolated, which is what a single blank leaf looks like. |
+| `vin01a` (1.223, 1.329), `vin07t` (2.66, 2.82, 2.270), `vin11t` (2.128, 2.400) | Their Myanmar numbering restarts per volume, so a bare page number is ambiguous until source entries carry volume segments (#546). |
+
+### Caveats
+
+- **The derivation is a correlation, not proof.** An XML gap could be a *dropped marker* rather than a
+  blank leaf, in which case we subtract where we shouldn't. That failure looks like a page that was
+  right before and is now one *early*.
+- **The 2010 arrays are unverified.** They carry the same seed as 1957 on the assumption that both
+  scans skipped the same pages — which is exactly what may not hold, given they came from different
+  groups. Five books have both editions: `abh03m10`, `abh03m11`, `abh03m4`, `s0201m`, `s0510m2`.
+- Arrays are **per PDF, not per book**. Correcting one edition must not be taken to imply the other.
+- `PdfPageFor` stops counting at the first entry ≥ the target, so an array must stay ascending. A test
+  guards this against hand-edits during QA.
+
+---
+
+## 2. Two-page spreads — NOT fixed, by choice
+
+### The symptom
+
+In two-page view the recto and verso reverse, putting the page numbers in the **gutter** instead of the
+fore-edge. Each missing leaf also *flips* parity for the remainder of the volume.
+
+### Pairing conventions are viewer-specific, and opposite
+
+For a book, print page 1 is a recto (right-hand); spreads run (2,3), (4,5) with **even left, odd right**.
+
+| viewer | pairing | correct `PageStart` | our mapped entries |
+|---|---|---|---|
+| Preview / Acrobat "Two-Up (Cover Page)" | page 1 alone, then (2,3), (4,5) | **odd** | 125 |
+| Chrome / CEF (our viewer) | (1,2), (3,4) | **even** | 69 |
+
+Confirmed empirically: `Duka-tika-catukkanipāta-aṭṭhakathā.pdf` (`PageStart` 19, odd) reads **correctly
+in Preview** — fore-edge numbers through the TOC and body — until the genuine missing leaf at page 68.
+
+### Chrome's viewer cannot be configured
+
+`pdf/document_layout.cc` hard-codes the pairing on the 0-based page index:
+
+```cpp
+if (i % 2 == 0)  page_rect = draw_utils::GetLeftRectForTwoUpView(...);
+else             page_rect = draw_utils::GetRightRectForTwoUpView(...);
+```
+
+- The only spread settings are `PageSpread::kOneUp` and `kTwoUpOdd`. There is no `kTwoUpEven`.
+- **Nothing in the layout path reads the document catalog**, so `/PageLayout /TwoColumnRight` is
+  ignored. (Neither VRI PDF sets it in any case — verified by inflating the object streams.)
+- The URL fragment supports only `page=` and `nameddest=` (plus partial `zoom=`); there is no spread
+  parameter. [crbug 64309](https://issues.chromium.org/issues/40483153) is the standing request.
+
+**The page count is the only thing that changes pairing.**
+
+### Why we are not "fixing" the PDFs
+
+Inserting a leading blank leaf to satisfy our viewer would **break the same file in Preview** — the 125
+books that read correctly today would start reading wrong. Chrome is the outlier; deforming the corpus
+to compensate for one viewer's non-standard pairing makes the data worse everywhere else.
+
+If in-app spreads ever become a goal, the only safe shape is a **derived copy that the app renders, with
+the downloaded original untouched** (the originals are a preservation mechanism). The cheapest technique
+is an *incremental update* appending one blank page object plus a new xref — a few KB, no re-encoding of
+the 57 MB of scanned images — rather than a full rewrite through `PdfPig`'s builder.
+
+### Front matter
+
+Front matter carries its own numbered sequence (the TOC numbers from `[1]` in square brackets), so
+parity must come out right more than once per volume, independently. The general invariant is:
+
+> **Every sequence start — title page, TOC `[1]`, body `1` — must land on a recto.**
+
+Blank-verso insertions adjust the *distances* between sequence starts so that one global parity can
+satisfy all of them at once. Nothing we hold predicts where those belong; the XML says nothing about
+front matter, so it would be per-file inspection. In practice this is near-moot: under Preview's
+convention the sample book needs only a blank before the title page, a cosmetic nit.
+
+Note that any insertion **before** print page 1 shifts `PageStart`, so a patched PDF and the
+`Sources.cs` value must move together — an argument for deriving `PageStart` from an insertion list
+rather than storing both, should this ever be built.
+
+---
+
+## QA notes
+
+- **Parity transitions localize missing leaves.** Absolute parity says nothing (it depends on the viewer
+  and on the front matter), but each missing leaf *flips* it — so the point where numbers jump to the
+  gutter marks a missing page. Sequence, not state.
+- Books worth exercising: `s0402a` (blanks at 68, 248 — accumulation), `s0404a` (256, 286, 342 — three
+  steps), `abh03m11` (11 blanks, the densest), `s0403a` / `s0514a2` / `vin02t` (2 each).
+- A wrong page in a book *not* on the seeded list is a different defect — most likely #546 if the status
+  bar shows a `2.NNNN` page in one of the twelve volume-restart books.
+
+## Related
+
+- #540 — missing pages (this fix)
+- #546 — 12 books whose Myanmar numbering restarts per volume; `MissingPages` should move to a segment
+- #76 — one-to-many / many-to-many source model. **Its upstream blocker is resolved**: it was deferred
+  waiting on VRI to guarantee page-complete scans, and recording the skips on our side removes that
+  dependency.

--- a/src/CST.Avalonia.Tests/Models/SourcePdfPageTests.cs
+++ b/src/CST.Avalonia.Tests/Models/SourcePdfPageTests.cs
@@ -85,7 +85,8 @@ namespace CST.Avalonia.Tests.Models
                 "abh03a.att.xml", "abh03m10.mul.xml", "abh03m11.mul.xml", "abh03m4.mul.xml",
                 "abh03t.tik.xml", "s0201m.mul.xml", "s0402a.att.xml", "s0403a.att.xml",
                 "s0403t.tik.xml", "s0404a.att.xml", "s0404t.tik.xml", "s0508a2.att.xml",
-                "s0510m2.mul.xml", "s0514a2.att.xml", "s0514a3.att.xml", "vin02t.tik.xml",
+                "s0510m2.mul.xml", "s0511m.mul.xml", "s0512m.mul.xml", "s0514a2.att.xml",
+                "s0514a3.att.xml", "vin02t.tik.xml",
             };
             var seen = 0;
             foreach (var book in books)
@@ -100,7 +101,32 @@ namespace CST.Avalonia.Tests.Models
                     Assert.Equal(s.MissingPages.Distinct().Count(), s.MissingPages.Length);
                 }
             }
-            Assert.Equal(21, seen);
+            Assert.Equal(23, seen);
+        }
+
+        [Fact]
+        public void MissingPagesPropagateToSiblingBooksSharingOnePdf()
+        {
+            // A missing page belongs to the PDF, not the book. Where several books share one scan and
+            // one continuous page sequence, a gap found in the book that CONTAINS it shifts every
+            // sibling that follows it — but the gap is only visible in that one book's XML, so the
+            // seeding pass missed the siblings. (Apadāna-2 page 186, found in QA.)
+            foreach (var book in new[] { "s0511m.mul.xml", "s0512m.mul.xml" })
+            {
+                var s = Sources.Inst.GetSource(book, Sources.SourceType.Burmese2010);
+                Assert.NotNull(s);
+                Assert.Equal(new[] { 186 }, s!.MissingPages);
+            }
+
+            // s0404a continues s0403a's sequence in the same PDF, so it carries that book's blanks too.
+            var an = Sources.Inst.GetSource("s0404a.att.xml", Sources.SourceType.Burmese1957);
+            Assert.Equal(new[] { 86, 144, 256, 286, 342 }, an!.MissingPages);
+
+            // The counter-case: s0404t's PageStart (18, against s0403t's 19) ALREADY absorbs the blank
+            // at 148. Adding it would double-count and land a page early. Pinned so it stays empty.
+            var tik = Sources.Inst.GetSource("s0404t.tik.xml", Sources.SourceType.Burmese1957);
+            Assert.Equal(new[] { 266 }, tik!.MissingPages);
+            Assert.Equal(18, tik.PageStart);
         }
 
         [Fact]

--- a/src/CST.Core/Sources.cs
+++ b/src/CST.Core/Sources.cs
@@ -420,8 +420,8 @@ public class Sources
 		addSource("s0509m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_VimanavattuTherigatha_2010}");
 		addSource("s0510m1.mul.xml", SourceType.Burmese2010, 25, $"{Burmese2010Mula}/{KN_Apadana1_2010}");
 		addSource("s0510m2.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_Apadana2Buddhavamsa_2010}", new[] { 186 });
-		addSource("s0511m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_Apadana2Buddhavamsa_2010}");
-		addSource("s0512m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_Apadana2Buddhavamsa_2010}");
+		addSource("s0511m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_Apadana2Buddhavamsa_2010}", new[] { 186 });
+		addSource("s0512m.mul.xml", SourceType.Burmese2010, 19, $"{Burmese2010Mula}/{KN_Apadana2Buddhavamsa_2010}", new[] { 186 });
 		addSource("s0513m.mul.xml", SourceType.Burmese2010, 31, $"{Burmese2010Mula}/{KN_Jataka1_2010}");
 		addSource("s0514m.mul.xml", SourceType.Burmese2010, 9, $"{Burmese2010Mula}/{KN_Jataka2_2010}");
 		addSource("s0515m.mul.xml", SourceType.Burmese2010, 9, $"{Burmese2010Mula}/{KN_Mahaniddesa_2010}");
@@ -480,7 +480,7 @@ public class Sources
 		addSource("s0401a.att.xml", SourceType.Burmese1957, 3, $"{Burmese1957Atthakatha}/{Att_AN_Ekakanipata_1957}");
 		addSource("s0402a.att.xml", SourceType.Burmese1957, 19, $"{Burmese1957Atthakatha}/{Att_AN_DukaTikaCatukka_1957}", new[] { 68, 248 });
 		addSource("s0403a.att.xml", SourceType.Burmese1957, 27, $"{Burmese1957Atthakatha}/{Att_AN_Pancakanipata_1957}", new[] { 86, 144 });
-		addSource("s0404a.att.xml", SourceType.Burmese1957, 27, $"{Burmese1957Atthakatha}/{Att_AN_Pancakanipata_1957}", new[] { 256, 286, 342 });
+		addSource("s0404a.att.xml", SourceType.Burmese1957, 27, $"{Burmese1957Atthakatha}/{Att_AN_Pancakanipata_1957}", new[] { 86, 144, 256, 286, 342 });
 
 		// --- KN Atthakatha ---
 		addSource("s0501a.att.xml", SourceType.Burmese1957, 4, $"{Burmese1957Atthakatha}/{Att_KN_Khuddakapatha_1957}");


### PR DESCRIPTION
Found in QA — Apadānapāḷi-2 is missing printed page 186 in **both** editions, which is the first independent confirmation that the two scans skip the same page.

That page was already seeded. But **29 source PDFs back 2–5 books each**, and the seeding pass in #547 ran per XML book, so only the book that *contains* a gap got the array. Siblings sharing the same scan and sitting after the gap got nothing.

Page 186 is the blank verso before `Therīapadānapāḷi` opens on a recto at 187 — the Myanmar sequence runs 185 → 187. Buddhavaṃsa (`s0511m`) and Cariyāpiṭaka (`s0512m`) live in that same PDF past 186 and were reading a page late.

## Fixed

Only where the sibling's `PageStart` does **not** already absorb the skip:

| entry | before | after |
|---|---|---|
| `s0404a` 1957 | `{256, 286, 342}` | `{86, 144, 256, 286, 342}` |
| `s0511m` 2010 | — | `{186}` |
| `s0512m` 2010 | — | `{186}` |

## Deliberately not fixed

`s0404t`'s `PageStart` is 18 against `s0403t`'s 19, so it **already absorbs** the blank at 148. Propagating it there would double-count and land a page early — the naive fix would have broken a book that currently works. Now pinned by a test so it stays empty.

Apadāna-2 **1957** is the same shape: `PageStart` 13 against 16 absorbs three skips while only one is known. Left alone pending #549.

## The hazard this exposes

The same fact is encodable either in `PageStart` or in `MissingPages`, and which one is in use isn't visible locally — you have to cross-check against a sibling. #549 covers normalizing that, along with **~19 further missing pages** inferred from `PageStart` deltas across shared PDFs: pages *with text* that were dropped from the scan, which leave no gap in the XML for the derivation to find.

## Testing

**1013/1013.** New test covers both directions — the propagation, and the counter-case that must stay empty.

Untested prediction worth checking: Buddhavaṃsa and Cariyāpiṭaka in the **2010** edition should now land correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)