### PR TITLE
#551: don't let a fractional scrollY parse to zero and mis-restore the reading position

### DIFF
--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -995,7 +995,12 @@ public partial class BookDisplayView : UserControl
                     }} catch(ptErr) {{ }}
 
                     // ATOMIC UPDATE: Send all status info in one message with tab ID including chapter and best anchor
-                    document.title = 'CST_STATUS_UPDATE:VRI=' + vri + '|MYANMAR=' + myanmar + '|PTS=' + pts + '|THAI=' + thai + '|OTHER=' + other + '|PARA=' + para + '|CHAPTER=' + currentChapter + '|ANCHOR=' + bestAnchor + '|SCROLL=' + scrollY + '|PTA=' + ptA + '|PTAP=' + ptAP + '|PTB=' + ptB + '|PTBP=' + ptBP + '|TAB:__TAB_ID_PLACEHOLDER__';
+                    // SCROLL is ROUNDED. On a Retina display scroll offsets quantize to half CSS pixels, so
+                    // scrollIntoView (chapter jump / anchor restore) rests at the element's fractional layout
+                    // position and scrollY comes out like 76563.5. The C# side parsed that as an int, which
+                    // silently failed and left 0 — poisoning the reading-position token. Matches what
+                    // GetCurrentPositionTokenAsync has always emitted. (#551)
+                    document.title = 'CST_STATUS_UPDATE:VRI=' + vri + '|MYANMAR=' + myanmar + '|PTS=' + pts + '|THAI=' + thai + '|OTHER=' + other + '|PARA=' + para + '|CHAPTER=' + currentChapter + '|ANCHOR=' + bestAnchor + '|SCROLL=' + Math.round(scrollY) + '|PTA=' + ptA + '|PTAP=' + ptAP + '|PTB=' + ptB + '|PTBP=' + ptBP + '|TAB:__TAB_ID_PLACEHOLDER__';
                 }} catch(e) {{
                     // Emit nothing on error — an all-'*' title would clobber a good readout (#432
                     // constraint). The next scroll tick retries. (#423)
@@ -1845,7 +1850,19 @@ public partial class BookDisplayView : UserControl
                     else if (part.StartsWith("PTA=")) ptA = part.Substring(4);
                     else if (part.StartsWith("PTBP=")) ptBP = part.Substring(5);
                     else if (part.StartsWith("PTB=")) ptB = part.Substring(4);
-                    else if (part.StartsWith("SCROLL=")) int.TryParse(part.Substring(7), out scrollY);
+                    // Parse as a DOUBLE with InvariantCulture, then round. `int.TryParse` here silently failed
+                    // on a fractional value (Retina half-pixel scroll offsets, e.g. "76563.5") and left the
+                    // out-param at 0 — which made the reading-position capture compute fraction 0 and pin the
+                    // restore to the anchor ABOVE the reader. The JS now rounds too; this is the second line of
+                    // defence so an unrounded value degrades to a half-pixel error instead of a silent zero.
+                    // InvariantCulture is required: JS always emits '.' as the decimal separator, which a
+                    // comma-decimal locale would otherwise reject the same way. (#551)
+                    else if (part.StartsWith("SCROLL="))
+                    {
+                        if (double.TryParse(part.Substring(7), System.Globalization.NumberStyles.Any,
+                                System.Globalization.CultureInfo.InvariantCulture, out var scrollParsed))
+                            scrollY = (int)Math.Round(scrollParsed);
+                    }
                     else if (part.StartsWith("CACHE_BUILT="))
                     {
                         isCacheBuilt = true;


### PR DESCRIPTION
Fixes #551 — jumping to a chapter, switching tabs, and coming back landed **two paragraphs above** the heading, the same place every time.

## Root cause
The status-tick JS emitted `scrollY` **unrounded**. On a Retina display scroll offsets quantize to half CSS pixels, and `scrollIntoView` (chapter jump / anchor restore) rests at the element's fractional layout position — so the value is e.g. `76563.5`. The C# side parsed it with `int.TryParse`, which **fails** on that and leaves the out-param at its default: **0**.

One tick, the same message, before and after parsing:
```
ANCHOR=dn1_13|SCROLL=76563.5|PTA=V1.0213|PTAP=76468|PTB=dn1_13|PTBP=76564
Status values - ... Anchor: dn1_13, Scroll: 0
```

That zero flows into the rolling reading-position capture:
```csharp
fraction = Clamp01((scrollTop - abovePos) / denom)   // (0 - 76468)/96 → negative → 0
```
The true fraction is `(76563.5 − 76468)/96 ≈ 0.995` — essentially *at* the heading. `Fraction = 0` means "pin to the upper anchor", so the restore lands on the `V1.0213` page marker ~96 px above it.

This explains every property of the bug:
- **Deterministic** — same element, same layout, same `.5` every time.
- **Machine-dependent** — the `.5` comes from `devicePixelRatio = 2`; a display whose layout lands on whole pixels never emits a fraction, which is why a second macOS box could not reproduce it.
- **Invisible in the UI** — page references, paragraph, chapter and `ANCHOR` are all computed JS-side from the *real* `scrollY` and arrive as strings. Only the C#-parsed number was corrupted, so the status bar stayed correct and hid the fault.

## Fix — two lines of defence
1. **Emit `Math.round(scrollY)`** in the status-tick JS, matching what `GetCurrentPositionTokenAsync` has always emitted.
2. **Parse with `double.TryParse` + `InvariantCulture`, then round**, so an unrounded value degrades to a half-pixel error instead of a silent zero. InvariantCulture matters independently of this bug: JS always emits `.` as the decimal separator, which a comma-decimal locale would have rejected the same way.

## Also fixed
The **resize snapshot/restore** path reuses the same token, so resizing the window while parked at a chapter heading relocated the reader identically. Same root cause, different trigger.

## Verification
- **Confirmed by hand** on the original repro (DN1 → `13. Tevijjasuttaṃ` → open PDFs → switch back): now lands on the heading.
- **Fable-reviewed twice** — first the diagnosis (which corrected an earlier theory that the JS was reading 0; it wasn't, the parse was discarding it), then the patch. Confirmed `SCROLL=` was the **only** numeric field on this path exposed to the trap — `PTAP`/`PTBP` are already rounded in JS and parsed with `double`/InvariantCulture — and verified the arithmetic end to end: `fraction` becomes `1.0`, restore lands exactly on `dn1_13`.
- Full suite: **1013 passed, 0 failed.**

## Follow-up
#552 — `_lastKnownScrollY` is written but never read. Its `if (scrollY > 0)` guard encoded the correct belief that a zero here is untrustworthy, but protected nothing, while the capture two lines below consumed the same unguarded value. A guard on dead state reads as "handled" when it isn't.

Closes #551.
