### PR TITLE
#552: remove the write-only scroll-tracking fields

### DIFF
--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -71,9 +71,9 @@ public partial class BookDisplayView : UserControl
         catch { /* temp dir unavailable — ignore */ }
     }
 
-    // C# scroll tracking for reliable status bar updates
-    private int _lastKnownScrollY = 0;
-    private DateTime _lastScrollTime = DateTime.MinValue;
+    // C# scroll tracking for reliable status bar updates. The timer drives the status tick; the scroll
+    // position itself is NOT tracked here — the status values are computed JS-side from the live scrollY
+    // and arrive as strings, and the reading position is carried by the #434 token. (#552)
     private System.Timers.Timer? _scrollTimer;
     private string _lastKnownVri = "*";
     private string _lastKnownMyanmar = "*";
@@ -780,10 +780,6 @@ public partial class BookDisplayView : UserControl
         if (_scrollTimer != null) return;
 
         _logger.Debug("SetupCSharpScrollTracking called");
-
-        // Set up initial scroll position tracking
-        _lastKnownScrollY = 0;
-        _lastScrollTime = DateTime.Now;
 
         // Create the timer immediately on the UI thread.
         _logger.Debug("Creating scroll timer");
@@ -1886,9 +1882,6 @@ public partial class BookDisplayView : UserControl
                 {
                     // Handle status update
                     _logger.Debug("Status values - VRI: {Vri}, Myanmar: {Myanmar}, PTS: {Pts}, Thai: {Thai}, Other: {Other}, Para: {Para}, Chapter: {Chapter}, Anchor: {Anchor}, Scroll: {ScrollY}", vri, myanmar, pts, thai, other, para, chapter, anchor, scrollY);
-
-                    // Update scroll position
-                    if (scrollY > 0) _lastKnownScrollY = scrollY;
 
                     // #434 rolling capture: keep the freshest reading-position token so a tab reattach can
                     // restore the exact position (#31). Computed via the unit-tested ReadingPositionMath. Only


### PR DESCRIPTION
Fixes #552 — removes write-only scroll-tracking state from `BookDisplayView`.

## What was dead
`_lastKnownScrollY` and `_lastScrollTime` were declared, initialised, written — and **never read anywhere in `src/`**:

```
:75   private int _lastKnownScrollY = 0;            (declare)
:76   private DateTime _lastScrollTime = ...;       (declare)
:785  _lastKnownScrollY = 0;                        (reset)
:786  _lastScrollTime = DateTime.Now;               (reset)
:1891 if (scrollY > 0) _lastKnownScrollY = scrollY; (write)
```

## Why remove it rather than leave it
Because the guard on that last line **actively concealed a real bug**.

`if (scrollY > 0)` encodes the correct belief that a zero `scrollY` here is untrustworthy. But since nothing ever read the field, that defence protected nothing — while the reading-position capture *two lines below* consumed the same value **unguarded** and was silently poisoned by it (#551: a fractional `scrollY` failed `int.TryParse` and arrived as 0, pinning the restore to the anchor above the reader).

A guard on dead state reads as "this case is handled" when it is not. That's the specific hazard worth deleting.

## Scope note
Both fields are removed, not just the one named in the issue: they were declared adjacently and written as a **pair in the same two-line block**, so removing `_lastKnownScrollY` alone would have left an identical dead sibling behind.

`_scrollTimer` — the live member of that group — is untouched. Its comment now states what *is* and isn't tracked, so a future reader doesn't reintroduce a dependency on state nobody maintains.

## Verification
- No references remain (`grep` across `src/`); build clean with no unused-field warnings.
- **No behavior change** — every removed statement was a write to state with no consumers.
- Full suite: **1013 passed, 0 failed.**
- Trial-merged against #553 (the #551 fix, same file): **clean, no conflict** — the two can land in either order.

Closes #552.
