### PR TITLE
#530: adopt MCP 2026-07-28 — SDK 2.0.0, stateless core

### DIFF
--- a/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
+++ b/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <!-- MCP client, to round-trip the in-app /mcp endpoint the way Claude Desktop's bridge does (#191). -->
-    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
+    <PackageReference Include="ModelContextProtocol" Version="2.0.0" />
   </ItemGroup>
 
   <!-- Needed to run LocalApiServer (hosts ASP.NET Core) in tests. -->

--- a/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/LocalApiIntegrationTests.cs
@@ -269,6 +269,97 @@ namespace CST.Avalonia.Tests.Integration
             Assert.Contains("dhamma", text + structured);
         }
 
+        [Fact]
+        public async Task Mcp_serves_the_2026_07_28_stateless_core()
+        {
+            // #530. The integration tests above drive the SDK client against the SDK server, so they pass
+            // whether or not the transport is stateless — both ends moved to 2.0.0 together. These assert the
+            // wire behaviour the 2026-07-28 revision actually requires, so a future SDK bump that silently
+            // reverts to session affinity fails here rather than in a user's client.
+
+            // The SDK's own default, pinned. 2.0.0 made stateless the default per SEP-2567; if a later release
+            // flips it back, the two assertions below would start passing for the wrong reason.
+            Assert.True(new ModelContextProtocol.AspNetCore.HttpServerTransportOptions().Stateless);
+
+            using var http = new HttpClient { BaseAddress = new System.Uri(_api.BaseUrl) };
+            http.DefaultRequestHeaders.Add("Authorization", "Bearer " + _api.Token);
+            http.DefaultRequestHeaders.Add("Accept", "application/json, text/event-stream");
+
+            // A stateless server mints no session, so it must not hand back an Mcp-Session-Id for a client to
+            // echo. A tool call is the strongest probe: under the old core this is exactly where affinity was
+            // required, since the call had to reach the process that ran initialize.
+            var call = await http.PostAsync("/mcp", Json(
+                """{"jsonrpc":"2.0","id":1,"method":"tools/list"}"""));
+            Assert.Equal(HttpStatusCode.OK, call.StatusCode);
+            Assert.False(call.Headers.Contains("Mcp-Session-Id"),
+                "stateless servers must not mint a session id");
+
+            // ...and the call must succeed with NO prior initialize on this connection. Under the pre-2026-07-28
+            // core an uninitialized session was an error; statelessly it is the normal case.
+            var body = await call.Content.ReadAsStringAsync();
+            Assert.Contains("search", body);
+            Assert.DoesNotContain("\"error\"", body);
+
+            // The standalone SSE endpoint is disabled in stateless mode (no unsolicited server-to-client
+            // messages), so a GET must not open a stream. Anything but 200-with-a-stream is acceptable.
+            var sse = await http.GetAsync("/mcp", HttpCompletionOption.ResponseHeadersRead);
+            Assert.NotEqual("text/event-stream", sse.Content.Headers.ContentType?.MediaType);
+        }
+
+        [Fact]
+        public async Task Mcp_serves_both_the_2026_07_28_contract_and_down_level_clients()
+        {
+            // #530. Two callers must both work, and only one of them is exercised by the SDK-client tests:
+            //
+            //   modern  — declares MCP-Protocol-Version, and must then ALSO send the Mcp-Method / Mcp-Name
+            //             routing headers and the _meta block. The server enforces all of it: omit any one
+            //             and the request is rejected, which is easy to get wrong by hand.
+            //   legacy  — sends none of it and is served anyway (the fallback the SDK promises for a mixed
+            //             ecosystem). The stateless test above is the legacy path.
+            //
+            // Both are verified here so a future SDK bump cannot quietly drop either half.
+            using var http = new HttpClient { BaseAddress = new System.Uri(_api.BaseUrl) };
+            http.DefaultRequestHeaders.Add("Authorization", "Bearer " + _api.Token);
+            http.DefaultRequestHeaders.Add("Accept", "application/json, text/event-stream");
+
+            const string Version = "2026-07-28";
+            const string Meta = "\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\"" + Version + "\","
+                              + "\"io.modelcontextprotocol/clientCapabilities\":{}}";
+
+            async Task<string> PostAsync(string method, string? name, string paramsBody, bool sendRouting)
+            {
+                var req = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+                {
+                    Content = Json("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"" + method
+                                 + "\",\"params\":{" + paramsBody + "}}"),
+                };
+                req.Headers.Add("MCP-Protocol-Version", Version);
+                if (sendRouting)
+                {
+                    req.Headers.Add("Mcp-Method", method);
+                    if (name is not null) req.Headers.Add("Mcp-Name", name);
+                }
+                var resp = await http.SendAsync(req);
+                return await resp.Content.ReadAsStringAsync();
+            }
+
+            // server/discover replaces the initialize handshake, and must advertise the revision we claim.
+            var discover = await PostAsync("server/discover", null, Meta, sendRouting: true);
+            Assert.Contains(Version, discover);
+            Assert.DoesNotContain("\"error\"", discover);
+
+            // A real tool call over the modern contract reaches the tool layer and returns corpus data.
+            var call = await PostAsync("tools/call", "search",
+                Meta + ",\"name\":\"search\",\"arguments\":{\"query\":\"dhamma\"}", sendRouting: true);
+            Assert.DoesNotContain("\"error\"", call);
+            Assert.Contains("dhamma", call);
+
+            // Declaring the version but omitting the routing headers is an error, not a silent success — this
+            // is what proves the server really enforces the new contract rather than ignoring the headers.
+            var rejected = await PostAsync("tools/list", null, Meta, sendRouting: false);
+            Assert.Contains("\"error\"", rejected);
+        }
+
         // Connects the real MCP client over Streamable HTTP with the bearer, as Claude Desktop's mcp-remote
         // bridge does.
         private async Task<McpClient> ConnectMcpAsync()

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -114,7 +114,7 @@
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="ReactiveUI" Version="23.2.28" />
     <!-- MCP surface (#191): Streamable HTTP transport mounted in-process at /mcp on the loopback API server. -->
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.0.0" />
     <!-- Microsoft.Extensions.DependencyInjection / .Logging are deliberately NOT referenced here: the
          Microsoft.AspNetCore.App FrameworkReference above already supplies them, and referencing them
          explicitly warned NU1510 ("will not be pruned"). -->

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -178,6 +178,13 @@ namespace CST.Avalonia.Services.LocalApi
             // app's --mcp-bridge relay; code-capable agents keep hitting /v1 directly. Registered only when the
             // MCP permission is on (#278 Phase 4) — separate from the /v1 surface. Tool groups are registered only
             // when their backing service is present (mirroring the /v1 wiring); 'books' needs no service.
+            //
+            // SDK 2.0.0 implements MCP 2026-07-28 (#530). The transport is STATELESS BY DEFAULT there (SEP-2567):
+            // no session is minted, no Mcp-Session-Id is issued, the standalone SSE endpoint is off, and
+            // server/discover replaces the initialize handshake — with the SDK falling back for down-level
+            // clients, so a mixed ecosystem is its problem rather than ours. Nothing below opts into it; it is
+            // simply the default, and a wire-level test pins that so a later SDK bump can't quietly revert us to
+            // session affinity. Stateless also disables sampling, elicitation and roots — we use none of them.
             if (_mcpEnabled)
             {
                 var mcp = builder.Services.AddMcpServer().WithHttpTransport();
@@ -221,9 +228,15 @@ namespace CST.Avalonia.Services.LocalApi
             // unbounded, so a subagent fan-out (or Chat + Cowork + Code at once) can saturate the thread pool and
             // starve the UI — and, because Claude Desktop is one-error-and-done, a single load-induced timeout
             // permanently kills that client's session. Gate the heavy tool CALLS (POSTs to /v1 + /mcp) to
-            // ~ProcessorCount-1 concurrent and QUEUE the rest (FIFO). GETs — discovery, books, and the long-lived
-            // MCP SSE stream — are left unlimited so a stream can't hold a permit forever. Queue is deep because a
-            // 503 rejection would itself be the fatal one-error; we queue rather than reject under realistic load.
+            // ~ProcessorCount-1 concurrent and QUEUE the rest (FIFO). GETs — discovery and books — are left
+            // unlimited. Queue is deep because a 503 rejection would itself be the fatal one-error; we queue
+            // rather than reject under realistic load.
+            //
+            // The original rationale for exempting GETs was also to stop a long-lived MCP SSE stream from holding
+            // a permit forever. That stream is gone since the 2026-07-28 stateless core (#530) — the standalone
+            // SSE endpoint is disabled — so ALL MCP traffic is now POST, including the cheap discovery and
+            // tools/list calls that used to ride the session. They take a permit briefly; the cap is on
+            // concurrency, not rate, so this costs nothing but is worth knowing when reading the numbers.
             int toolPermits = Math.Max(1, Environment.ProcessorCount - 1);
             builder.Services.AddRateLimiter(options =>
             {

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
@@ -19,9 +19,15 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
     /// The <c>--mcp-bridge</c> relay (#278): a TRANSPARENT stdio ↔ <c>/mcp</c> pump. An MCP chat client (Claude
     /// Desktop) spawns CST Reader with <c>--mcp-bridge</c> and pipes its stdio; this relays JSON-RPC between that
     /// stdio and the running app's loopback <c>/mcp</c> (Streamable HTTP + bearer). So the client config carries
-    /// no port/token and the API can stay ephemeral. Transparent = no tool re-declaration: the client's own
-    /// <c>initialize</c> bootstraps the session and the HTTP transport manages <c>Mcp-Session-Id</c> + the SSE
-    /// stream around it (verified against the SDK internals — <c>ConnectAsync</c> does no handshake).
+    /// no port/token and the API can stay ephemeral. Transparent = no tool re-declaration: whatever bootstrap the
+    /// client performs is relayed through untouched (verified against the SDK internals — <c>ConnectAsync</c> does
+    /// no handshake of its own).
+    ///
+    /// <para>Since MCP 2026-07-28 the server is stateless (#530): there is no <c>Mcp-Session-Id</c> to carry and no
+    /// standalone SSE stream to hold open, and <c>server/discover</c> replaces the <c>initialize</c> handshake. That
+    /// makes the relay's job strictly simpler — being transparent, it needed no change. A DOWN-LEVEL client that
+    /// still sends <c>initialize</c> also keeps working: the SDK falls back for it, and the bridge is not the thing
+    /// deciding.</para>
     /// </summary>
     internal static class McpBridge
     {


### PR DESCRIPTION
Closes #530.

Bumps `ModelContextProtocol.AspNetCore` (app) and `ModelContextProtocol` (tests) **1.4.1 → 2.0.0**, which implements the 2026-07-28 revision.

## The upgrade is a non-event; the behaviour change is not

The issue anticipated breaking API changes from the major bump. There are none for us — every call we make (`AddMcpServer` / `WithHttpTransport` / `WithTools` / `WithResources` / `MapMcp`) is unchanged, and the build is clean with no deprecation warnings.

**Statelessness is the SDK's default** under SEP-2567, so we opt into nothing. That is exactly why this warranted tests rather than a version-number edit: the behaviour changed underneath us *without the code changing*.

## What changed on the wire

Verified against the **running app**, not the test server:

| | |
|---|---|
| `Mcp-Session-Id` | no longer minted — no session affinity required |
| `tools/call` with no prior `initialize` | **succeeds** — statelessly the normal case, previously an error |
| standalone SSE `GET /mcp` | gone |
| `server/discover` | replaces the `initialize` handshake, advertises `2026-07-28` |

A client that declares `MCP-Protocol-Version` must **also** send the `Mcp-Method` / `Mcp-Name` routing headers *and* `_meta` (`protocolVersion` + `clientCapabilities`) — omit any one and the request is rejected. A client that declares none of it is still served, which is the down-level fallback.

## End-to-end verification

All **13 tools across 7 tool types** exercised against the real app under the full contract — `search`, `occurrences`, `passage`, `books`, `convert`, `scripts`, `dictionary_lookup`, `dictionary_languages`, `lemma_lookup`, `lemma_forms`, `lemma_forms_union`, `sandhi_split`, `navigate` — plus `resources/list` for the `llms.txt` resource. `navigate` returned `presented: true`, i.e. it drove the UI.

## Two new tests, and why they're needed

The existing MCP tests drive the SDK client against the SDK server, so they pass whether or not the transport is stateless — **both ends moved to 2.0.0 together**. The new tests assert the wire behaviour directly: the absent session header, the initialize-free call, the disabled SSE `GET`, the enforced modern contract, and the down-level path. A future SDK release that reverts to session affinity fails here rather than in a user's client.

## The bridge needed no change

`--mcp-bridge` (#278) is a transparent pump — it never parsed the session header it was forwarding, so removing that header changes nothing for it. Its four end-to-end tests pass unchanged. Comments describing the old session/SSE mechanics are corrected, including the rate-limiter note: `GET`s are still exempt, but the long-lived-SSE rationale for it no longer exists, and all MCP traffic including discovery is now `POST`.

## Testing

**1015/1015.**

Unblocks #531 (MCP Apps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)