### PR TITLE
docs: capture the cold-agent test method for the AI surfaces (#260)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,7 @@ External resources and CST4 feature references:
 
 ### 🧪 **testing/** - Test Plans & Results
 - [AI testing prompts](testing/ai-prompts/README.md) - prompts handed to a cold AI agent to exercise the local API / MCP surface; doubles as a fixed eval set across model releases
+- [Local API cold tests](testing/LOCAL_API_COLD_TESTS.md) - the five cold-agent prompts the AI features were actually developed against, plus the model matrix (Opus / Fable / Sonnet / Haiku / Codex) and the four signals each run is scored on
 - [UI Smoke Test](testing/UI_SMOKE_TEST.md) - printable click-through checklist for validating a build on a target machine (esp. bare-metal Windows), with a Windows-specific risk map
 - [Beta 3 Testing](testing/BETA_3_TESTING.md) - Beta 3 test results and notes
 - [Dictionary CST4 Capture Plan](testing/DICTIONARY_CST4_CAPTURE_PLAN.md) - CST4 Dictionary lookups to screenshot as regression oracles (#25)

--- a/docs/testing/LOCAL_API_COLD_TESTS.md
+++ b/docs/testing/LOCAL_API_COLD_TESTS.md
@@ -1,0 +1,441 @@
+# Local API cold tests
+
+The prompts we hand to a **cold agent** to exercise CST Reader's local HTTP API and MCP surface
+(*surface C*), and the model matrix we run them across. Referenced from
+[AI_INTEGRATION.md](../features/planned/AI_INTEGRATION.md) §14.
+
+These are not hypothetical. **This is how the AI features were developed** — run as a fan-out of
+subagents, one per model, with the friction reports driving the design of `llms.txt`, the tool
+descriptions, and the error messages. They are recorded here verbatim so later runs stay comparable.
+
+> **Do not reword a prompt.** The task and its phrasing are the instrument. An edited task breaks
+> comparability with every earlier run, exactly as in
+> [ai-prompts/README.md](ai-prompts/README.md). If a feature changes such that a prompt must change,
+> add a new prompt rather than editing one in place, and say so in the results log.
+
+## Scope and priority
+
+**The surface targets frontier models.** Catering to non-frontier models is not a priority, and the
+five-model matrix below is likely sufficient. That is a deliberate scoping decision, not an untested
+assumption — see the competence findings below for what "non-frontier" currently means in practice.
+
+This matters when reading a friction report: a finding from a weak model that a frontier model
+handles cleanly is **not automatically a defect in the surface**. The §14 principle — that the doc
+shape is calibrated to the weakest agent we intend to support — is bounded by *intend to support*,
+and that floor sits at Haiku, not at a 7B local model.
+
+## How the surface was built: the friction loop
+
+These prompts were not a test applied to a finished API. They *were* the development method — a
+recursive self-improvement loop:
+
+1. Fan out subagents, one per model, each given a prompt and the API-only constraint.
+2. Collect the friction reports.
+3. Fix whatever caused friction — `llms.txt`, a tool description, an error message, a default.
+4. Re-run.
+
+**The termination condition was zero friction, not "good enough."** That is a stronger bar than it
+sounds: every guessed parameter, every endpoint tried and abandoned, every place the agent wanted to
+peek at the source counted as a defect in the surface. The loop ran until a cold agent could complete
+every task without a wrong turn.
+
+Two consequences worth holding onto:
+
+- **A friction report is a bug report about the documentation**, not a transcript to skim. The whole
+  value is in what the agent had to guess.
+- **The surface is tuned to the models that ran the loop.** That is the in-family overfitting risk
+  §14 names, stated concretely: the bar was set by Claude models reading docs written by a Claude
+  model. It is the reason the Codex cell matters more than its share of the grid, and the reason a
+  new model shipping is a reason to re-run rather than to assume the surface still teaches.
+
+## What makes it a valid test
+
+Every prompt carries the same hard constraint: **use only the API and what it says about itself** —
+no source code, no git repo, no on-disk docs. That constraint is the whole point. If the agent
+flails, the surface is under-documented; it is not the agent's failure. A prompt that tempts the
+agent toward the source asks it to record that temptation as a finding instead.
+
+## The model matrix
+
+| Cell | Why it is in the matrix |
+| --- | --- |
+| **Opus** | The ceiling — strongest coding agent. Establishes what the surface can support at best. |
+| **Fable** | Second frontier reading, in-family. Also our design/review model, so a useful cross-check. |
+| **Sonnet** | The realistic median for an agent driving the API day to day. |
+| **Haiku** | The floor. The doc shape is calibrated to *the weakest agent we intend to support*, so this cell sets the spec rather than confirming it. |
+| **Codex** | The only genuinely **out-of-family** cell we run, and so the only check on in-family overfitting — Claude writing docs that Claude then reads and rates well. Read its findings with the capability confound in mind (see *How to read a result*): the cell runs a mid-tier model, so a failure is not self-evidently a surface defect. |
+
+### Running the Codex cell
+
+**Egret is the machine.** The AI features were developed and tested there, and Codex is installed
+only there — so the out-of-family cell cannot be run from anywhere else.
+
+From a scratch workdir:
+
+```bash
+cd /tmp/<workdir> && codex exec \
+  --skip-git-repo-check \
+  -s workspace-write \
+  -c 'sandbox_permissions=["disk-full-read-access"]' \
+  -c 'sandbox_workspace_write.network_access=true' \
+  --model gpt-5.6-terra \
+  "$(cat /path/to/prompt.txt)" < /dev/null > out.log 2> err.log
+```
+
+Four things that each silently no-op or hang:
+
+1. **`codex exec`, not bare `codex`** — bare `codex "prompt"` opens the interactive TUI and hangs.
+2. **`--skip-git-repo-check`** — otherwise it refuses in a non-git workdir ("Not inside a trusted
+   directory").
+3. **`< /dev/null`** — without it, `codex exec` blocks on *"Reading additional input from stdin…"*.
+4. **No `timeout` on macOS.** Don't wrap the run; background it and kill by pid.
+
+The sandbox flags let it read `local-api.json` outside the workdir and reach `127.0.0.1` without
+approval prompts. Default runs report `reasoning effort: none`; for a harder run add
+`-c model_reasoning_effort="high"`.
+
+**If a run hangs with empty logs, it is almost certainly a macOS security prompt, not a bad
+command.** A Codex auto-update re-triggers the one-time warning, and on a headless machine the run
+sits at 0% CPU producing nothing until it is dismissed *at the machine*. The tell is a live
+`CoreServicesUIAgent` process. Seen 2026-07-19 (13 minutes of nothing; ~60s after dismissal) and
+again 2026-08-02 after the 0.146.0 update. Do not kill and conclude the invocation is wrong.
+
+## The harness is the second axis — and it is not a detail
+
+The matrix is **model × harness**, and the harness is not a delivery mechanism for the same test.
+Observed during development: **defects surfaced in Claude Chat + MCP that Claude Code never found**,
+and on some tasks Chat was simply the better Pāli researcher.
+
+The mechanism is escape hatches. A coding harness has a shell, a filesystem and a bias toward
+solving problems with code — so when a tool description is unclear it can `curl` around the tool,
+read the source, or write a script to brute-force the shape. **It routes around surface defects,
+which hides them.** A chat client with only MCP has none of those exits: it must use the tools
+exactly as described, which is precisely the experience the surface is supposed to deliver. Fewer
+escape hatches makes it the more honest test of the tool layer, not the weaker one.
+
+The role difference compounds it. A coding harness is prompted to complete a task mechanically; a
+chat client engages with the scholarly question as asked. The same model in the two harnesses is
+effectively two different researchers, and the surface has to serve both.
+
+### Each surface has an intended audience — test it in that audience's harness
+
+This is not "also spot-check in Chat." The two surfaces are built for two different clients:
+
+| Surface | Intended audience | Therefore validated in |
+| --- | --- | --- |
+| **`/v1` HTTP API** | code-capable agents | a coding agent (Claude Code, Codex CLI) |
+| **MCP** | chat clients | Claude Chat + MCP |
+
+Testing MCP from a coding agent is the wrong harness for MCP: the shell lets it `curl` past any tool
+description that fails to teach, which is the exact defect the run exists to find. And the reverse
+cannot be done at all — a chat client has no shell with which to exercise `/v1`.
+
+**Standing rule: a change to the AI features gets a full run of BOTH surfaces, each in its own
+harness.** Not one, not a sample. Passing in Claude Code is weaker evidence for anything MCP-shaped,
+because Code can succeed *despite* the text rather than because of it. Green in Code and red in Chat
+is the expected direction of disagreement; the reverse is worth investigating.
+
+## What we know about model competence in Pāli
+
+Observed across the development runs. These are findings, and they constrain how a result is read.
+
+**Frontier models understand Pāli, and understand it well.** This is remarkable and worth stating
+plainly: Pāli is certainly not a target of anyone's post-training, and the canon is a few million
+words — nothing at web scale. The competence is an emergent consequence of pre-training, presumably
+from the derived material rather than the canon itself: a century and a half of philology, the
+dictionaries, the grammars, and large volumes of aligned translation. Nobody aimed at it.
+
+**Script makes no difference.** Frontier models reason about Pāli **equally well in Latin,
+Devanagari, and the other supported scripts.** There is no romanized-versus-Devanagari competence
+gap. Do not theorize one into existence from corpus-composition arguments — it has been checked.
+
+**Small local models cannot do this at all.** Models small enough to run on Apple Silicon under
+ollama have consistently failed: they hallucinate Pāli badly. This is what the long tail looks like
+under parameter reduction — low-resource language knowledge lives in rarely-activated weights and is
+the first thing to go. Scale is the operative variable, so this is unlikely to be fixed by
+fine-tuning a small model.
+
+**Near-frontier Chinese models are an open question, not an out-of-family guarantee.** They are
+worth testing and would yield useful data. But they are **largely a product of distillation from
+Western frontier models**, so a distilled model may inherit the very doc-reading priors we are trying
+to test independently. Treat "this is an out-of-family cell" as a hypothesis to be checked — genuine
+independence should show up as *differently shaped* friction, not merely more of it — rather than as
+the reason for running it.
+
+### Candidate cells not yet run
+
+| Candidate | Standing |
+| --- | --- |
+| **Kimi K3** (Moonshot, open-weight ~2026-07-27) | 2.8T total / 104B active MoE, 1M context, native multimodal, MXFP4; benchmarks claim frontier parity. **Not locally runnable** — weights alone are ~1.4 TB and MoE needs experts resident, so cloud only, never Apple Silicon. Independence uncertain per the distillation caveat above. |
+| Open models generally | The live alternative for widening out-of-family coverage. Untested. |
+| Frontier out-of-family (newest Codex tier) | Out of scope. The Codex cell runs a mid-tier model, so its findings carry a capability confound — read them against the Haiku row to separate "surface unclear" from "model weaker". |
+
+## What to watch — the four signals
+
+From AI_INTEGRATION.md §14. Score every run on all four; they are what the prompts are *for*.
+
+| Signal | Question | What it decides |
+| --- | --- | --- |
+| **Pointer discipline** | Does it fetch the right `/docs/*`, or only read inline? | Monolith vs pointer-index doc shape (§8) |
+| **Invention rate** | Hallucinated endpoints or parameters? | How prescriptive `llms.txt` must be |
+| **Tool-loop hold** | Does it sustain `search → occurrences → passage`, or collapse to one call and a guess? | Whether multi-step workflows need scaffolding |
+| **Script compliance** | Does it honour the romanized default and `outputScript`? | Whether script handling is discoverable |
+
+### How to read a result
+
+Three confounds, each of which has already caused a wrong reading at least once:
+
+- **A poor Devanagari run is evidence about OUR `outputScript` handling, not about the model's
+  Pāli.** Since script makes no difference to frontier competence, a Devanagari failure in prompt 3
+  or 5 localises to the surface — a leaked Latin value, an endpoint ignoring the parameter. Do not
+  discount it as the model struggling with the script.
+- **A Claude Code pass is weak evidence** (see the harness section). Re-run in Chat + MCP before
+  calling a documentation change validated.
+- **A Codex finding carries a capability confound** while that cell runs a mid-tier model. Compare
+  against Haiku: if the in-family floor clears a hurdle the out-of-family cell trips on, the problem
+  is comprehension of *our text*; if both trip, suspect capability.
+
+## The prompts
+
+
+### 1. Codex early run — write-as-you-go
+
+The original Codex prompt. Writes the friction log **per task, immediately**, so a run that exhausts its token budget still leaves usable evidence. Use this shape for any long or expensive run.
+
+Exercises: books → search → occurrences → passage → dictionary.
+
+```text
+Read  ~/Library/Application Support/CSTReader/local-api.json
+
+Figure out how to use the API from there — it's meant to be self-describing —
+and complete the research tasks below. Use curl.
+
+Constraint (this is the actual test): rely ONLY on the API itself. Do NOT read
+CST Reader's source code, its git repo, or any on-disk docs — the point is to
+find out whether the API documents itself well enough for a fresh agent. If
+you're tempted to look at the source, note it as a finding instead.
+
+Create a document codex-friction-log.md in your working directory first. 
+Write to the document per task, immediately after each task 
+because I might run out of tokens during the run: 
+did it work? Show the exact requests and a short result.
+anything unclear, missing, or surprising; anything you had to
+  guess; any endpoint that errored; and whether you could finish everything
+  without looking at the source.
+
+Tasks:
+1. List the available books and identify the mūla (root) text of the Dīgha Nikāya.
+2. Search for "mettā"; report the matching word-forms and roughly where they occur.
+3. Pick one form and show several occurrences in context, with their citations.
+4. Read the passage around one occurrence, then page forward to more text.
+5. Look up "mettā" in a dictionary and give the gloss.
+```
+
+### 2. Smoke test — orientation and one search
+
+The shortest cell. Answers only: is the service identifiable, does auth work, is it healthy, and can it count one term. Use when checking that a build's surface is alive rather than scoring it.
+
+```text
+Read the file ~/Library/Application Support/CSTReader/local-api.json — it describes a local HTTP API.
+Follow whatever it points you to, connect to the API, and report back briefly:
+(1) what this service is, (2) whether you were able to authenticate, and (3) the result of its
+health/status check. Use ONLY the API and what it tells you about itself — no source code or other docs.
+
+Using that same API, search the corpus for the exact word "mettā" and tell me how many times it
+occurs and in how many books. One or two calls is enough — keep it brief.
+```
+
+### 3. Deep research — Devanagari throughout
+
+The hardest prompt. Adds a **standing script constraint** (Devanagari for all Pāli *and* all book names) on top of five multi-step tasks, then asks where the output leaked Latin. This is the strongest test of script compliance and of proximity/co-occurrence search, and it deliberately requires addressing a paragraph *by number* rather than paging.
+
+```text
+See ~/Library/Application Support/CSTReader/local-api.json. It points to a local HTTP API for a
+Pāli text reader. Using ONLY that API and whatever it tells you about itself, do the tasks below
+and then write me a friction report. Do NOT read the app's source code, git repo, or any on-disk
+docs — the API's own self-description is the whole contract under test.
+
+Standing constraint: I read Devanagari, not romanized Latin. Give me all Pāli text and all
+book/reference names in Devanagari throughout. Fall back to Latin only if some value genuinely
+cannot be converted — and if so, flag it.
+
+1. Catalog orientation. How many books are in the Abhidhamma Piṭaka, and what are the seven books
+   of its mūla (root) layer? Give their names in Devanagari.
+
+2. Term study — paññā. Report the full inflectional family of the stem paññā: the distinct
+   case-forms and their occurrence counts, kept separate from unrelated look-alikes and from longer
+   compounds. Where is it concentrated across the three Piṭakas?
+
+3. Co-occurrence. Find passages where avijjā and saṅkhāra occur close together (the opening links
+   of dependent origination), restricted to commentarial texts only. Give a couple of cited examples
+   in context. If the API can't express a proximity/co-occurrence query directly, say so and
+   approximate however it does allow.
+
+4. Read + variants. Take one of those hits, read the surrounding passage, and include the variant
+   readings (the footnote/edition variants) for it. Then open the paragraph that immediately follows
+   it — addressed by its paragraph number, not by paging through cursors.
+
+5. Cross-script. Give me the canonical dictionary gloss of paññā, and separately show me the single
+   word paññā rendered in every script the reader supports.
+
+End with a friction report: which endpoints each task needed, anything you had to guess, any mismatch
+between what the docs promised and what actually came back, and whether the Devanagari output was
+correct and complete on every endpoint (or where it leaked Latin / was wrong). Write the report to 
+markdown and return the path. 
+```
+
+### 4. Standard research run
+
+The baseline five-task run with a friction log written to markdown. The default cell for cross-model comparison — closest to prompt 1 without the per-task write discipline.
+
+```text
+Read  ~/Library/Application Support/CSTReader/local-api.json
+
+Figure out how to use the API from there — it's meant to be self-describing —
+and complete the research tasks below. Use curl.
+
+Constraint (this is the actual test): rely ONLY on the API itself. Do NOT read
+CST Reader's source code, its git repo, or any on-disk docs — the point is to
+find out whether the API documents itself well enough for a fresh agent. If
+you're tempted to look at the source, note it as a finding instead.
+
+Tasks:
+1. List the available books and identify the mūla (root) text of the Dīgha Nikāya.
+2. Search for "mettā"; report the matching word-forms and roughly where they occur.
+3. Pick one form and show several occurrences in context, with their citations.
+4. Read the passage around one occurrence, then page forward to more text.
+5. Look up "mettā" in a dictionary and give the gloss.
+
+Report:
+- Per task: did it work? Show the exact requests and a short result.
+- A friction log: anything unclear, missing, or surprising; anything you had to
+  guess; any endpoint that errored; and whether you could finish everything
+  without looking at the source.
+- Write the report to markdown file and return the path
+```
+
+### 5. Hindi-language run
+
+Prompt 4's tasks, posed in Hindi, requiring Devanagari output and Hindi commentary. Tests whether a non-English-speaking user's agent can use the surface at all — the friction log stays in English so runs remain comparable.
+
+```text
+~/Library/Application Support/CSTReader/local-api.json पढ़ें।
+
+वहाँ से पता लगाएँ कि API का उपयोग कैसे करना है — यह स्व-वर्णनकारी
+(self-describing) होने के लिए बनाया गया है — और नीचे दिए गए शोध कार्यों को
+पूरा करें। curl का उपयोग करें।
+
+भाषा: यह प्रॉम्प्ट एक हिंदी-भाषी उपयोगकर्ता के लिए है। सभी पालि सामग्री
+देवनागरी लिपि में हो (रोमन/IAST में नहीं) — इसमें खोज शब्द, शब्द-रूप, पाठ के
+अंश, उद्धरण और शब्दकोश-अर्थ शामिल हैं। यदि API लिपि चुनने का विकल्प देता है,
+तो देवनागरी चुनें; अन्यथा परिणामों को देवनागरी में लिप्यंतरित करें। अपनी
+टिप्पणियाँ और उत्तर हिंदी में लिखें। (घर्षण-लॉग / friction log अंग्रेज़ी में
+रह सकता है।)
+
+प्रतिबंध (यही असली परीक्षण है): केवल API पर ही निर्भर रहें। CST Reader का
+सोर्स कोड, उसका git repo, या डिस्क पर मौजूद कोई भी दस्तावेज़ न पढ़ें —
+उद्देश्य यह जानना है कि क्या API किसी नए एजेंट के लिए खुद को पर्याप्त रूप से
+दस्तावेज़ित करता है। यदि आपको सोर्स देखने का मन हो, तो इसके बजाय उसे एक
+निष्कर्ष (finding) के रूप में नोट करें।
+
+कार्य:
+1. उपलब्ध ग्रंथों की सूची बनाएँ और दीघनिकाय के मूल पाठ की पहचान करें।
+2. "मेत्ता" खोजें; मिलते-जुलते शब्द-रूपों की रिपोर्ट दें और वे लगभग कहाँ
+   आते हैं।
+3. एक रूप चुनें और उसके कई प्रयोगों को संदर्भ सहित उनके उद्धरणों के साथ
+   दिखाएँ।
+4. किसी एक प्रयोग के आसपास का अंश पढ़ें, फिर आगे बढ़कर अधिक पाठ देखें।
+5. शब्दकोश में "मेत्ता" देखें और उसका अर्थ दें।
+
+रिपोर्ट:
+- प्रत्येक कार्य के लिए: क्या यह काम कर गया? सटीक अनुरोध (requests) और एक
+  संक्षिप्त परिणाम दिखाएँ।
+- A friction log: anything unclear, missing, or surprising; anything you had to
+  guess; any endpoint that errored; and whether you could finish everything
+  without looking at the source.
+- Write the report to markdown file (in English) and return the path
+```
+
+## Coverage — and what no prompt reaches
+
+| Surface | 1 | 2 | 3 | 4 | 5 | ai-prompts |
+| --- | :-: | :-: | :-: | :-: | :-: | :-: |
+| `books` / catalog | ● | | ● | ● | ● | |
+| `search` | ● | ● | ● | ● | ● | ● |
+| `occurrences` | ● | | ● | ● | ● | ● |
+| `passage` | ● | | ● | ● | ● | ● |
+| passage variants (footnote apparatus) | | | ● | | | |
+| paragraph-addressed navigation (not paging) | | | ● | | | |
+| proximity / co-occurrence search | | | ● | | | |
+| `dictionary_lookup` | ● | | ● | ● | ● | |
+| `convert` / `scripts` | | | ● | | | |
+| status / health | | ● | | | | |
+| `navigate` (drive the reader) | | | | | | ● |
+| **`lemma_lookup`, `lemma_forms`, `lemma_forms_union`** | | | | | | |
+| **`sandhi_split`** | | | | | | |
+| **`dictionary_languages`** | | | | | | |
+| **`llms.txt` as an MCP *resource*** | | | | | | |
+
+The bolded rows have **no cold-agent prompt at all**. They matter disproportionately because several
+of them require the agent to *discover a required argument* — `dictionary_lookup` needs `language`,
+`occurrences` needs `bookId` + `term` — which is exactly the kind of thing a friction run is for.
+
+Note that prompt 3 asks for "the full inflectional family of the stem paññā … kept separate from
+unrelated look-alikes and from longer compounds." That is written **capability-shaped rather than
+endpoint-shaped**, so it remains a valid task as the surface grows: an agent would once have had to
+approximate it with `search`, and can now solve it directly with the lemma tools. Prompts written
+this way do not go stale. Prefer that style when adding one.
+
+### Prompts that were lost
+
+Other prompts from the original loop were **not captured** — generated in-session and never saved.
+Their *fixes* survive, fossilised in `llms.txt`, the tool descriptions, the romanized-by-default
+decision, and the error messages. What is gone is coverage knowledge: we can no longer say which
+parts of the surface were hammered and which were never touched. Hence the table above, built from
+the other direction. **Capture a prompt when you run it.**
+
+## Results log
+
+One row per run. This is the point of keeping the prompts in the repo: the same task, re-run as new
+models ship, gives a comparable read on how well the surface teaches an agent that has never seen it
+— and on how much of any improvement is the model rather than our documentation.
+
+| Date | Model | Harness | Prompt | Pointer discipline | Invention rate | Tool-loop hold | Script compliance | Friction report |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 2026-08-02 | gpt-5.6-terra | Codex CLI (headless, Egret) | 2 (smoke) | ✅ index → topic slice | ✅ none | n/a (1–2 calls) | ✅ | none — clean run |
+
+**2026-08-02, prompt 2.** Four calls, no wrong turns: `GET /llms.txt` → `GET /docs/search.md` →
+`GET /v1/status` → `POST /v1/search {"query":"mettā","mode":"Exact"}`. Answered **393 occurrences in
+104 books**, matching ground truth exactly. Notable: it followed the index to the *topic slice*
+rather than pulling `/llms-full.txt` wholesale, and chose `mode:"Exact"` unprompted from "the exact
+word" — both are the pointer-index doc shape (§8) working as intended. No 4xx responses; the only
+strings resembling errors in the transcript are the docs *describing* error codes.
+
+This is the first recorded row. It is a low bar — prompt 2 is the smoke test — so it establishes the
+pipeline, not the surface.
+
+Record the **harness** on every row — Claude Code, Claude Chat + MCP, Codex CLI, or whatever else.
+A row without it cannot be compared against another, because the harness changes the result as much
+as the model does.
+
+Runs that predate this file drove the original design of `llms.txt`, the tool descriptions and the
+error messages; their friction reports were not kept in the repo.
+
+## Outstanding
+
+- **#530 owes a full two-surface run.** The MCP surface moved to the 2026-07-28 stateless core and
+  was verified with raw `curl` against the running app — a coding-agent harness exercising the
+  *chat-client* surface, i.e. the wrong harness for what changed. The tool descriptions have not been
+  re-exercised by a client that must rely on them. Owed: a Chat + MCP run, and a coding-agent run
+  over `/v1`.
+- Prompts 1, 3, 4 and 5 have no recorded run in any cell; only the smoke test has been logged.
+- No prompt covers the lemma family, `dictionary_languages`, or the `llms.txt` MCP resource.
+- The results log is empty: the runs that built the surface predate this file.
+
+## Related
+
+- **#260** — cross-harness / cross-model validation of the local API. This file is its instrument.
+- [ai-prompts/](ai-prompts/README.md) — task-shaped prompts for specific features (`navigate`,
+  citation fidelity), same method, scored the same way.
+- [AI_INTEGRATION.md](../features/planned/AI_INTEGRATION.md) §14 — why cross-model testing *sets*
+  the spec rather than confirming it.


### PR DESCRIPTION
`AI_INTEGRATION.md` §14 has pointed at `docs/testing/LOCAL_API_COLD_TESTS.md` since it was written. **The file never existed.** This is it.

The five prompts are fsnow's own capture from the development runs, reproduced **byte-for-byte** — verified programmatically, not by eye — because they are the instrument: an edited task breaks comparability with every earlier run. The only change is lifting fsnow's annotation off prompt 1 so a runner pastes the prompt alone.

## What was undocumented and is now recorded

**The method.** These prompts were not a test applied to a finished API — they *were* the development method, a recursive loop of cold subagents whose friction reports drove the design of `llms.txt`, the tool descriptions and the error messages. The termination condition was **zero friction, not "good enough"**: every guessed parameter or abandoned endpoint counted as a defect in the surface, not the agent.

**The harness axis** — the non-obvious half. Defects surfaced in Claude Chat + MCP that Claude Code never found, because a coding harness has a shell and can `curl` around a tool description that fails to teach. It routes around defects, hiding them, so **a Claude Code pass is the weaker evidence**. And the surfaces have different intended audiences:

| Surface | Audience | Validated in |
|---|---|---|
| `/v1` HTTP API | coding agents | a coding agent |
| MCP | chat clients | Claude Chat + MCP |

So an AI-features change owes a full run of **both**, each in its own harness. #530 is logged as owing exactly that — it was verified from the shell only, which is the wrong harness for what changed.

**Competence findings** that constrain how a result is read: frontier Pāli understanding is real and emergent rather than aimed at; **script makes no difference**, so a Devanagari failure localises to our `outputScript` handling and not to the model; small local models fail badly, and that is a scale property; near-frontier Chinese models are largely distilled from Western frontier models, so treating them as out-of-family is a hypothesis to test rather than a premise.

**Operational knowledge that existed only in an agent's memory**: the working `codex exec` invocation, its four hang-or-no-op gotchas, and the update-triggered macOS security prompt whose tell is a live `CoreServicesUIAgent`. Egret is the only machine with Codex installed.

**Coverage**, built from the other direction because the other prompts from the original loop were lost — generated in-session, never saved. Their fixes survive in the surface; the coverage knowledge did not. The lemma family, `dictionary_languages` and the `llms.txt` MCP resource have no prompt at all.

## First recorded results row

`gpt-5.6-terra` via headless Codex on prompt 2 — a clean four-call run:

```
GET /llms.txt → GET /docs/search.md → GET /v1/status → POST /v1/search {"query":"mettā","mode":"Exact"}
```

**393 occurrences in 104 books**, matching ground truth exactly. It reached the topic slice from the index rather than pulling `/llms-full.txt`, and chose `mode:"Exact"` unprompted from "the exact word" — the pointer-index doc shape (§8) working on an out-of-family model. Logged with the caveat that a smoke test establishes the pipeline, not the surface.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)