### PR TITLE
docs: what the friction loop teaches on its second run (#260)

### DIFF
--- a/docs/testing/LOCAL_API_COLD_TESTS.md
+++ b/docs/testing/LOCAL_API_COLD_TESTS.md
@@ -103,6 +103,38 @@ because "report the matching word-forms" leads there once the tools exist. Capab
 acquire coverage as the surface grows, so the table is only trustworthy when rebuilt from what the
 cells actually called.
 
+## Deciding what to act on — a judgment call, not a queue
+
+**These runs are non-deterministic.** The same prompt, model and surface can produce a different
+path and a different set of complaints on the next run. A friction report is evidence, not a work
+list, and turning every item into an issue would bloat the docs and over-constrain the API — which
+would itself damage the pointer-index shape the loop was built to protect.
+
+Questions worth asking of each finding, roughly in order of weight:
+
+- **Does it MISLEAD, or merely annoy?** This is the main axis. `search.md` describing a shipped
+  feature as available *"if/when the API offers it"* sent every cell down the inferior path — that
+  misleads, and is worth fixing at once. "`search.md` is dense prose that punishes skimming" is a
+  style opinion from one cell about a doc that nevertheless taught it correctly; acting on it risks
+  trading precision for readability in a document whose precision is the point.
+- **Did more than one cell find it independently?** The strongest available signal. Of this round's
+  findings only `/v1/status` answering unauthenticated was hit separately by two cells, and it needed
+  no further verification.
+- **Does it reproduce by hand?** Necessary before filing anything. Several first probes this round
+  were confounded by unrelated behaviour.
+- **Is the friction actually the docs WORKING?** An agent grumbling about noise in the regex
+  inflection family is not reporting a defect: the doc warns about exactly that noise, and the
+  warning is load-bearing. Agents sometimes complain about a difficulty the surface has already told
+  them is inherent.
+- **Would fixing it help the target audience?** The surface targets frontier models. A complaint only
+  a weak cell raised, which every frontier cell handled cleanly, is usually not worth doc bulk.
+- **Is it a defect or a feature request?** "No sutta-level addressing" is a real gap, but it belongs
+  in the feature backlog, not in a friction fix. The loop finds both; only the first kind belongs in
+  this cycle.
+
+A finding that fails these tests is not necessarily wrong — non-determinism cuts both ways, and an
+unreproduced item may simply be rare. Record it and move on rather than fixing it or deleting it.
+
 ## What makes it a valid test
 
 Every prompt carries the same hard constraint: **use only the API and what it says about itself** —

--- a/docs/testing/LOCAL_API_COLD_TESTS.md
+++ b/docs/testing/LOCAL_API_COLD_TESTS.md
@@ -48,6 +48,61 @@ Two consequences worth holding onto:
   model. It is the reason the Codex cell matters more than its share of the grid, and the reason a
   new model shipping is a reason to re-run rather than to assume the surface still teaches.
 
+## Re-running the loop on a mature surface
+
+The section above describes the loop that *built* the surface. Running it again later is a different
+exercise, and the first re-run (2026-08-02, four Claude cells + Codex on prompt 4) is where these
+were learned.
+
+**The yield changes character.** During development, friction reports drove design: agents could not
+complete tasks, and the fixes were structural. On a mature surface the tasks all succeed — every
+cell completed all five, none was blocked — and what surfaces instead is *edge material the original
+loop never probed*: an auth exception, a metadata contract, a misnamed key, a doc section that reads
+as truncated. Do not read "no blocking failures" as "nothing to fix"; read it as the loop having
+moved from construction to diagnosis.
+
+**Doc drift is the dominant failure mode on a re-run, and only this loop catches it.** The sharpest
+find was `search.md` describing lemma lookup as available *"if/when the API offers it"* — accurate
+when written, obsolete once `/v1/forms/{lemmaId}` shipped, and never updated. Every cell dutifully
+built the inferior regex family and discovered the better tool only at the last task. No unit test
+can see that: the code is correct, the docs merely describe a shipped feature as hypothetical. It is
+a **regression introduced by success**, and a cold agent is the only detector we have for it.
+Whenever the surface grows, assume the docs now lie somewhere and re-run.
+
+**Sloppiness in the runner is a feature.** Two real defects were found by making the mistake
+naturally rather than by testing for it — sending `highlight` instead of `terms` to `navigate`, and
+omitting the required `language` from `dictionary_lookup`. A careful operator who reads the docs
+first will not find these. When re-running, let the first attempt at each call be the naive one.
+
+**Treat a cell's report as a lead, not a result.** Every actionable claim from this round was
+re-verified by hand before it reached an issue, and several first probes were confounded — a 409 that
+was duplicate-suppression rather than a rejected key, a 404 that was a non-existent bookId rather
+than a bad parameter, an `awk` range that silently matched its own terminator. Cross-cell
+corroboration is the strongest signal available: of this round's findings only one (`/v1/status`
+answering unauthenticated) was found independently by two cells, and it needed no verification.
+
+**Separate harness artifacts from surface findings.** They look identical in a report. This round
+produced two: the Codex cell died on a usage quota mid-run, and one Claude cell's `Write` was refused
+by subagent policy (*"Subagents should return findings as text"*), so prompt 4's "write the report to
+a markdown file" silently failed for that cell alone while the others complied. Neither says anything
+about the API.
+
+**Match the prompt to the cell's constraints.** Prompt 4 was the wrong choice for a quota-limited
+cell: it writes its report only at the end, so the quota took the report with it. Prompt 1 exists for
+exactly this and writes per task. Comparability across cells is worth less than surviving the run.
+
+**Equalise the harnesses deliberately.** The Codex cell gets isolation for free by running from
+`/tmp/<workdir>`; a Claude Code subagent starts *inside the repo* and can satisfy the whole task by
+reading `llms.txt` from source — passing for entirely the wrong reason. Each cell was therefore given
+a scratch directory and told the working directory was off limits. That is harness setup, not a
+change to the prompt, and it must be applied to every cell or the cells are not comparable.
+
+**Derive coverage from observed runs, not from reading the prompts.** The coverage table below was
+written by reading prompt texts and was wrong within hours: prompt 4 does reach the lemma surface,
+because "report the matching word-forms" leads there once the tools exist. Capability-shaped prompts
+acquire coverage as the surface grows, so the table is only trustworthy when rebuilt from what the
+cells actually called.
+
 ## What makes it a valid test
 
 Every prompt carries the same hard constraint: **use only the API and what it says about itself** —


### PR DESCRIPTION
The first re-run of the RSI/friction loop since the AI features were built — 2026-08-02, four Claude cells plus Codex on prompt 4. The existing section describes the loop that *built* the surface; running it again turns out to be a different exercise, and nothing recorded how.

## The yield changes character

Building: agents fail tasks, fixes are structural. Mature: **every cell completed all five tasks, none was blocked** — and what surfaced instead was edge material the original loop never probed. "No blocking failures" must not be read as "nothing to fix"; the loop has moved from construction to diagnosis.

## Doc drift is the dominant re-run failure, and only this loop catches it

`search.md` described lemma lookup as available *"if/when the API offers it"* — accurate when written, obsolete once `/v1/forms/{lemmaId}` shipped, never updated. Every cell dutifully built the inferior regex family and found the better tool only at the last task.

No unit test can see that: the code is correct, the docs merely describe a shipped feature as hypothetical. It is a **regression introduced by success**.

## Sloppiness in the runner is a feature

Two real defects were found by making the mistake naturally rather than testing for it — `highlight` instead of `terms` on navigate, and omitting the required `language` on `dictionary_lookup`. A careful operator who reads the docs first finds neither.

## Findings are evidence, not a work list

The second commit records that these runs are **non-deterministic** and acting on every item would bloat the docs and over-constrain the API — damaging the pointer-index shape the loop exists to protect. The main axis is whether a finding **misleads or merely annoys**; a doc that sent every cell down the wrong path is worth fixing at once, while "dense prose that punishes skimming" is one cell's style opinion about a document that nevertheless taught it correctly.

Also weighted: independent corroboration by two cells (the strongest signal — only `/v1/status` qualified this round); reproduces by hand; whether the friction is actually the docs *working*; whether it helps the frontier target audience; and defect versus feature request.

## Also recorded

Treat a cell's report as a lead and verify it — several first probes this round were confounded. Separate harness artifacts from surface findings, because a usage quota and a subagent `Write` refusal look identical to a defect in a report. Match the prompt to the cell's constraints. Equalise harnesses deliberately, since a Claude Code subagent starts inside the repo and can pass by reading `llms.txt` from source. And derive coverage from observed runs rather than from reading prompts.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)