### PR TITLE
#511/#518: complete Windows keyboard-shortcut coverage (and fix the popup hole from #509)

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1312,6 +1312,75 @@ public partial class App : Application
 
     // Public method to set up menu events for floating windows
     /// <summary>
+    /// Registers the floating window's shortcuts as real key bindings on Windows/Linux. (#511)
+    ///
+    /// macOS gets these from the system menu bar that <see cref="SetupFloatingWindowMenu"/> builds, and its
+    /// accelerators are real OS-level key equivalents. Off macOS there is no such menu - and even where one
+    /// is rendered, Avalonia's NativeMenuBarPresenter binds a gesture to the display-only
+    /// <c>MenuItem.InputGesture</c> and never to <c>MenuItem.HotKey</c>, so a menu dispatches nothing. The
+    /// bindings below are therefore the only route once focus leaves the book's WebView.
+    ///
+    /// Verified before this change: inside a floated book the JS relay in BookDisplayView already handled
+    /// these, and BookDisplayView.OnKeyDown covered G/C/A across the whole view subtree - but D, F, O and P
+    /// were no-ops anywhere outside the WebView, with Avalonia receiving the keystroke and nothing acting
+    /// on it. Every action here is the same one the macOS menu item invokes.
+    ///
+    /// macOS is excluded deliberately: a binding here plus the system menu's accelerator would fire twice.
+    /// </summary>
+    public void RegisterFloatingWindowShortcuts(Window window)
+    {
+        if (OperatingSystem.IsMacOS()) return;
+
+        try
+        {
+            // Deliberately a bubbling AddHandler rather than window.KeyBindings. Measured on Windows: with a
+            // ComboBox dropdown open the keystroke reaches BookDisplayView's AddHandler (logged, with
+            // Source=ComboBoxItem) but never fires Window.KeyBindings - an open dropdown lives in its own
+            // PopupRoot, so the event routes through the logical chain without reaching the Window. A handler
+            // on the same routed-event path sees everything the view sees. (#511)
+            //
+            // Bubble, and NOT handledEventsToo, is what keeps this single-dispatch: BookDisplayView
+            // registers a TUNNEL handler, and the whole tunnel phase completes before any bubble handler
+            // runs - so it claims G/C/A and sets e.Handled first, and this handler then only sees
+            // keystrokes nothing has claimed. (It is the tunnel/bubble ordering that guarantees this, not
+            // proximity in the tree. fable review)
+            var shortcuts = new (KeyGesture Gesture, Action Invoke)[]
+            {
+                (PlatformGesture.Parse("g"),        () => OnGoToMenuItemClickFromFloatingWindow(window)),
+                (PlatformGesture.Parse("e"),        () => OnViewSourceFromFloatingWindow(window, source2010: false)),
+                (PlatformGesture.Parse("shift+e"),  () => OnViewSourceFromFloatingWindow(window, source2010: true)),
+                (PlatformGesture.Parse("d"),        () => _ = SimpleTabbedWindow.LookUpInDictionaryAsync(FindActiveBookInFloatingWindow(window))),
+                (PlatformGesture.Parse("f"),        () => _ = SimpleTabbedWindow.SearchForSelectionAsync(FindActiveBookInFloatingWindow(window))),
+                (PlatformGesture.Parse("w"),        () => OnCloseTabFromFloatingWindow(window)),
+                (PlatformGesture.Parse("o"),        () => SimpleTabbedWindow.RevealSelectBookPanel()),
+                (PlatformGesture.Parse("p"),        () => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.Print()),
+                (PlatformGesture.Parse("shift+p"),  () => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.PrintSelection()),
+                (PlatformGesture.Parse("OemComma"), () => _ = ShowSettingsWindow()),
+            };
+
+            window.AddHandler(InputElement.KeyDownEvent, (object? s, KeyEventArgs e) =>
+            {
+                foreach (var (gesture, invoke) in shortcuts)
+                {
+                    if (!gesture.Matches(e)) continue;
+
+                    Log.Debug("*** FLOATING WINDOW SHORTCUT: {Gesture} ***", gesture);
+                    e.Handled = true;
+                    invoke();
+                    return;
+                }
+            }, global::Avalonia.Interactivity.RoutingStrategies.Bubble);
+
+            Log.Information("Registered {Count} shortcuts for floating window: {WindowTitle}",
+                shortcuts.Length, window.Title);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to register floating-window key bindings");
+        }
+    }
+
+    /// <summary>
     /// Builds and wires the native View/Tools menu for a floating dock window (macOS). This is the single
     /// source for the floating-window menu - it creates the items, syncs their initial state, attaches the
     /// click handlers, tracks the toggle items for cross-window state sync, and assigns the menu to the

--- a/src/CST.Avalonia/Input/WebViewShortcutRelay.cs
+++ b/src/CST.Avalonia/Input/WebViewShortcutRelay.cs
@@ -1,0 +1,137 @@
+using System;
+using Avalonia.Threading;
+using CST.Avalonia.Views;
+using Serilog;
+
+namespace CST.Avalonia.Input;
+
+/// <summary>
+/// Forwards window-level keyboard shortcuts out of a WebView that would otherwise swallow them. (#518)
+///
+/// When CEF holds focus it takes the keystroke before Avalonia sees it, so a window <c>KeyBinding</c>
+/// never fires. <c>BookDisplayView</c> has long solved this with its own JavaScript keydown capture, but
+/// the Welcome page, the Dictionary meaning pane and the PDF viewer had no capture at all - so every
+/// shortcut was dead while focus was in one of them. That is most visible on Welcome, which holds focus
+/// at startup.
+///
+/// This is the same title-channel trick <c>BookDisplayView</c> uses, reduced to the shortcuts that make
+/// sense outside a book: no View Source, no Go To, no Print, since those act on a book. Each message is
+/// tagged with the view's id so a background view cannot act on a keystroke aimed at the visible one, and
+/// carries a sequence number because an identical consecutive title does not raise <c>TitleChanged</c>.
+///
+/// Deliberately NOT macOS-guarded, unlike the window-level handlers. The <c>preventDefault</c> below
+/// consumes the key equivalent before AppKit hands it to the NSMenu, so exactly one route still fires -
+/// this is the mechanism <c>BookDisplayView</c> has shipped for the same combos since #443. What it does
+/// change on macOS is <em>which</em> route: see the DICTIONARY/SEARCH cases below.
+/// </summary>
+public static class WebViewShortcutRelay
+{
+    public const string MessagePrefix = "CST_VIEW_SHORTCUT:";
+
+    /// <summary>
+    /// JavaScript to inject once the page has loaded. <paramref name="viewId"/> identifies the view in the
+    /// messages it pushes back.
+    ///
+    /// <paramref name="includeFind"/> controls Ctrl/Cmd+F. The PDF viewer passes false: Chromium's
+    /// find-in-page is the one shortcut users genuinely want there, and intercepting it would trade that
+    /// away for "Search for Selection" with no selection - a straight downgrade. (fable review)
+    /// </summary>
+    public static string BuildScript(string viewId, bool includeFind = true) => @"
+        (function() {
+            if (window.__cstViewShortcuts) { return; }   // idempotent: re-injection must not double-bind
+            window.__cstViewShortcuts = true;
+
+            function send(name) {
+                document.title = '" + MessagePrefix + @"' + name
+                    + '|VIEW:" + viewId + @"'
+                    + '|SEQ:' + (window.__cstViewSeq = (window.__cstViewSeq || 0) + 1);
+            }
+
+            document.addEventListener('keydown', function(event) {
+                if (!(event.metaKey || event.ctrlKey)) { return; }
+                var k = (event.key || '').toLowerCase();
+                var name = null;
+
+                // Deliberately NOT forwarded: e/g/p and shift variants are book commands, and w is
+                // handled per-view where a closable tab exists.
+                if (k === 'o' && !event.shiftKey) { name = 'SELECT_BOOK'; }
+                else if (k === 'd' && !event.shiftKey) { name = 'DICTIONARY'; }
+                else if (k === 'f' && !event.shiftKey && " + (includeFind ? "true" : "false") + @") { name = 'SEARCH'; }
+                else if (k === ',') { name = 'SETTINGS'; }
+
+                if (name === null) { return; }
+
+                // Suppress Chromium's own handling (Ctrl+O open-file, Ctrl+F find bar) as well as any
+                // further propagation, so exactly one route acts on the keystroke.
+                event.preventDefault();
+                event.stopPropagation();
+                if (event.repeat) { return; }
+                send(name);
+            }, true);   // capture phase, ahead of any page handlers
+        })();
+    ";
+
+    /// <summary>
+    /// Handles a title-channel message if it is one of ours and is addressed to <paramref name="viewId"/>.
+    /// Returns true when handled. Safe to call from the CEF thread - the action is posted to the UI thread.
+    /// </summary>
+    public static bool TryHandle(string? title, string viewId, ILogger logger)
+    {
+        if (string.IsNullOrEmpty(title) || !title.StartsWith(MessagePrefix, StringComparison.Ordinal))
+            return false;
+
+        try
+        {
+            var parts = title.Split('|');
+            var command = parts[0].Substring(MessagePrefix.Length);
+            var messageViewId = parts.Length > 1 && parts[1].StartsWith("VIEW:", StringComparison.Ordinal)
+                ? parts[1].Substring("VIEW:".Length)
+                : "";
+
+            if (messageViewId != viewId)
+                return false;
+
+            // Include the view id: all three relaying views otherwise log identically, which makes
+            // "did the Dictionary pane's relay fire, or the Welcome page's?" unanswerable from the log.
+            logger.Debug("*** VIEW SHORTCUT REQUESTED FROM JAVASCRIPT: {Command} (view {ViewId}) ***",
+                command, viewId);
+
+            // Runs on the CEF thread; every one of these touches the dock layout or shows a dialog. (BOOK-2)
+            Dispatcher.UIThread.Post(() =>
+            {
+                switch (command)
+                {
+                    case "SELECT_BOOK":
+                        SimpleTabbedWindow.RevealSelectBookPanel();
+                        break;
+                    case "SETTINGS":
+                        _ = App.ShowSettingsWindow();
+                        break;
+                    // No book is focused in these views, so both simply reveal their tool with no selection.
+                    //
+                    // This is a deliberate behaviour change on macOS, where these keys were not previously
+                    // dead: the native menu fired but its focus resolution "comes back empty and falls back
+                    // to the first split's book" (the #443 wrong-book bug), so ⌘D/⌘F acted on some other
+                    // book's selection. Revealing the tool with no selection is the honest answer from a
+                    // view that has no book. Not a regression, but not a no-op either. (fable review)
+                    case "DICTIONARY":
+                        _ = SimpleTabbedWindow.LookUpInDictionaryAsync(null);
+                        break;
+                    case "SEARCH":
+                        _ = SimpleTabbedWindow.SearchForSelectionAsync(null);
+                        break;
+                    default:
+                        logger.Warning("Unknown view shortcut command: {Command}", command);
+                        break;
+                }
+            });
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.Error("Error processing view shortcut from JavaScript | {Details}", ex.Message);
+            return false;
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1868,14 +1868,14 @@ namespace CST.Avalonia.Services
                 hostWindow.Factory = this;
                 HostWindows.Add(hostWindow);
 
-                // Set up View menu for this floating window (macOS only)
-                if (OperatingSystem.IsMacOS())
+                // Give this floating window its shortcuts. The two calls are complementary and each guards
+                // its own platform: the native menu is macOS-only, the key bindings are everywhere else,
+                // because off macOS a NativeMenuBar gesture is decoration and dispatches nothing. (#511)
+                if (Application.Current is App app)
                 {
-                    if (Application.Current is App app)
-                    {
-                        app.SetupFloatingWindowMenu(hostWindow);
-                        Log.Debug("*** View menu setup completed for floating window ***");
-                    }
+                    app.SetupFloatingWindowMenu(hostWindow);          // no-op off macOS
+                    app.RegisterFloatingWindowShortcuts(hostWindow);  // no-op on macOS
+                    Log.Debug("*** Menu/shortcut setup completed for floating window ***");
                 }
 
                 Log.Debug("*** Host window created successfully ***");

--- a/src/CST.Avalonia/Views/DictionaryPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/DictionaryPanel.axaml.cs
@@ -3,6 +3,7 @@ using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
+using CST.Avalonia.Input;
 using CST.Avalonia.Services;
 using CST.Avalonia.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,6 +17,10 @@ public partial class DictionaryPanel : UserControl
     private IDisposable? _meaningSub;
     private WebView? _meaningWebView;
     private DictionaryViewModel? _vm;
+
+    // Tags this view's shortcut messages so a background WebView can't act on a keystroke aimed at the
+    // visible one - the same guard BookDisplayView applies with its tab id. (#518)
+    private readonly string _shortcutViewId = "dict_" + Guid.NewGuid().ToString("n").Substring(0, 8);
 
     public DictionaryPanel()
     {
@@ -61,6 +66,8 @@ public partial class DictionaryPanel : UserControl
             {
                 _meaningWebView.BeforeNavigate -= OnBeforeNavigate;
                 _meaningWebView.PopupOpening -= OnPopupOpening;
+                _meaningWebView.Navigated -= OnMeaningNavigated;
+                _meaningWebView.TitleChanged -= OnShortcutTitleChanged;
                 _meaningWebView.Dispose();
             }
         }
@@ -88,6 +95,13 @@ public partial class DictionaryPanel : UserControl
             _meaningWebView.BeforeNavigate += OnBeforeNavigate;
             _meaningWebView.PopupOpening -= OnPopupOpening;
             _meaningWebView.PopupOpening += OnPopupOpening;
+
+            // #518: CEF swallows keystrokes while the meaning pane has focus, so window shortcuts were
+            // dead here. Navigated fires for LoadHtml too, which is where the relay gets (re-)injected.
+            _meaningWebView.Navigated -= OnMeaningNavigated;
+            _meaningWebView.Navigated += OnMeaningNavigated;
+            _meaningWebView.TitleChanged -= OnShortcutTitleChanged;
+            _meaningWebView.TitleChanged += OnShortcutTitleChanged;
         }
 
         if (DataContext is DictionaryViewModel vm)
@@ -102,6 +116,27 @@ public partial class DictionaryPanel : UserControl
                 .Throttle(TimeSpan.FromMilliseconds(60))
                 .Subscribe(html => Dispatcher.UIThread.Post(() => LoadMeaning(html)));
         }
+    }
+
+    // #518: re-inject after every load - LoadHtml replaces the document, dropping the previous listener.
+    // The script is idempotent, so repeating it is harmless.
+    private void OnMeaningNavigated(string url, string frameName)
+    {
+        try
+        {
+            _meaningWebView?.ExecuteScript(WebViewShortcutRelay.BuildScript(_shortcutViewId));
+            Serilog.Log.Debug("DictionaryPanel: shortcut relay injected (view {ViewId})", _shortcutViewId);
+        }
+        catch (Exception)
+        {
+            // Mid-teardown or re-parent: the next load re-injects. Shortcuts staying dead here is not
+            // worth risking the CEF lifecycle over.
+        }
+    }
+
+    private void OnShortcutTitleChanged()
+    {
+        WebViewShortcutRelay.TryHandle(_meaningWebView?.Title, _shortcutViewId, Serilog.Log.Logger);
     }
 
     private void LoadMeaning(string? html)

--- a/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using ReactiveUI;
 using WebViewControl;
+using CST.Avalonia.Input;
 using CST.Avalonia.ViewModels;
 using Serilog;
 
@@ -35,6 +36,7 @@ public partial class PdfDisplayView : UserControl
             if (_webView != null)
             {
                 _webView.Navigated += OnNavigationCompleted;
+                _webView.TitleChanged += OnShortcutTitleChanged;   // #518
                 _logger.Debug("PDF WebView control found and events attached");
             }
             else
@@ -49,6 +51,45 @@ public partial class PdfDisplayView : UserControl
         }
     }
 
+    // Tags this view's shortcut messages so a background WebView can't act on a keystroke aimed at the
+    // visible one - the same guard BookDisplayView applies with its tab id. (#518)
+    private readonly string _shortcutViewId = "pdf_" + Guid.NewGuid().ToString("n").Substring(0, 8);
+
+    // #518: the PDF viewer is a CEF WebView with no keyboard capture, so window shortcuts are dead while
+    // it has focus. Unlike the other two this loads a URL rather than LoadHtml, but the injection point is
+    // the same - after navigation completes.
+    //
+    // MEASURED LIMITATION (Windows, 2026-08-05): this does NOT actually restore shortcuts here. The relay
+    // injects cleanly - twice, in fact, since Navigated fires per frame - but Ctrl+D and Ctrl+F produce
+    // nothing. Chromium renders the PDF in an internal plugin frame that ExecuteScript cannot reach and
+    // that consumes keystrokes itself, so our listener never sees them. Predicted in review before it was
+    // tested, and confirmed.
+    //
+    // Kept rather than removed: it is inert, it costs nothing, and it starts working the moment this view
+    // shows anything that is not a plugin-rendered PDF. Ctrl+F is deliberately excluded (includeFind:
+    // false) so that if the plugin frame ever does become reachable, we do not take find-in-page away.
+    // The PDF viewer therefore remains an open item on #518.
+    private void InjectShortcutRelay()
+    {
+        try
+        {
+            // includeFind: false — leave Ctrl+F to Chromium's find-in-page, which is the shortcut that
+            // actually matters in a PDF. (fable review)
+            _webView?.ExecuteScript(WebViewShortcutRelay.BuildScript(_shortcutViewId, includeFind: false));
+            _logger.Debug("PdfDisplayView: shortcut relay injected (view {ViewId})", _shortcutViewId);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: the PDF still displays, the shortcuts simply stay dead here.
+            _logger.Warning("PdfDisplayView: failed to inject shortcut relay | {Details}", ex.Message);
+        }
+    }
+
+    private void OnShortcutTitleChanged()
+    {
+        WebViewShortcutRelay.TryHandle(_webView?.Title, _shortcutViewId, _logger);
+    }
+
     private void DisposeWebView()
     {
         if (_webView != null)
@@ -57,6 +98,7 @@ public partial class PdfDisplayView : UserControl
             {
                 _logger.Information("Disposing PDF WebView");
                 _webView.Navigated -= OnNavigationCompleted;
+                _webView.TitleChanged -= OnShortcutTitleChanged;   // #518
                 _webView.Dispose();
                 _webView = null;
                 _hasPdfLoaded = false;  // Reset so PDF reloads after recreate
@@ -150,9 +192,16 @@ public partial class PdfDisplayView : UserControl
         }
     }
 
-    private void OnNavigationCompleted(object? sender, string url)
+    // WebViewControl's Navigated delegate is (string url, string frameName). This previously declared
+    // (object? sender, string url), which bound contravariantly and silently shifted the arguments - the
+    // log printed the frame name as the URL. (fable review)
+    private void OnNavigationCompleted(string url, string frameName)
     {
-        _logger.Information("PDF navigation completed: {Url}", url);
+        _logger.Information("PDF navigation completed: {Url} (frame: {Frame})", url, frameName);
+
+        // Re-inject after every navigation - a new document drops the previous listener. The script
+        // guards itself against double-binding, so repeating it is safe. (#518)
+        InjectShortcutRelay();
     }
 
     private void OnWebViewLifecycleOperationChanged(WebViewLifecycleOperation operation)

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -691,17 +691,6 @@ public partial class SimpleTabbedWindow : Window
         }
     }
 
-    // Minimal ICommand for the KeyBindings below. KeyBinding needs an ICommand and these are plain
-    // void handlers, so a relay is all that is required - no ReactiveCommand scheduler in a Window.
-    private sealed class MenuShortcutCommand : System.Windows.Input.ICommand
-    {
-        private readonly Action _invoke;
-        public MenuShortcutCommand(Action invoke) => _invoke = invoke;
-        public event EventHandler? CanExecuteChanged { add { } remove { } }
-        public bool CanExecute(object? parameter) => true;
-        public void Execute(object? parameter) => _invoke();
-    }
-
     /// <summary>
     /// Binds the menu shortcuts as real window accelerators on Windows/Linux.
     ///
@@ -721,33 +710,54 @@ public partial class SimpleTabbedWindow : Window
     {
         if (OperatingSystem.IsMacOS()) return;
 
-        void Bind(string gesture, Action invoke) => KeyBindings.Add(new KeyBinding
+        // A bubbling AddHandler, NOT KeyBindings. Measured on Windows: with a ComboBox dropdown open the
+        // keystroke reaches BookDisplayView's AddHandler (logged, Source=ComboBoxItem) but never fires
+        // Window.KeyBindings - an open dropdown lives in its own PopupRoot, so the event routes through the
+        // logical chain without reaching the Window. The original KeyBindings form of this method therefore
+        // left every shortcut dead whenever a dropdown had focus. Confirmed by direct A/B: the same
+        // keystroke in the same state worked in a floating window (AddHandler) and did nothing here. (#511)
+        //
+        // Bubble, and NOT handledEventsToo, is what keeps this single-dispatch: BookDisplayView registers a
+        // TUNNEL handler, and the whole tunnel phase completes before any bubble handler runs - so it claims
+        // G/C/A and sets e.Handled first, and this handler only sees keystrokes nothing has claimed. (It is
+        // the tunnel/bubble ordering that guarantees this, not proximity in the tree. fable review)
+        var shortcuts = new (KeyGesture Gesture, Action Invoke)[]
         {
-            Gesture = PlatformGesture.Parse(gesture),
-            Command = new MenuShortcutCommand(invoke)
-        });
+            // Same set, and the same handlers, as the NativeMenu declarations in SimpleTabbedWindow.axaml.
+            (PlatformGesture.Parse("o"),       () => OnSelectBookClick(this, EventArgs.Empty)),
+            (PlatformGesture.Parse("p"),       () => OnPrintClick(this, EventArgs.Empty)),
+            (PlatformGesture.Parse("shift+p"), () => OnPrintSelectionClick(this, EventArgs.Empty)),
+            (PlatformGesture.Parse("w"),       () => OnCloseTabClick(this, EventArgs.Empty)),
+            (PlatformGesture.Parse("g"),       () => OnGoToMenuItemClick(this, EventArgs.Empty)),
+            (PlatformGesture.Parse("d"),       () => OnLookUpInDictionaryClick(this, EventArgs.Empty)),
+            (PlatformGesture.Parse("f"),       () => OnSearchForSelectionClick(this, EventArgs.Empty)),
+            (PlatformGesture.Parse("e"),       () => OnViewSource1957Click(this, EventArgs.Empty)),
+            (PlatformGesture.Parse("shift+e"), () => OnViewSource2010Click(this, EventArgs.Empty)),
+            // Settings lives in the macOS app menu, so it has no NativeMenu declaration here to mirror -
+            // see AddSettingsMenuItemOffMacOS, which adds the Tools entry this shortcut matches.
+            (PlatformGesture.Parse("OemComma"), () =>
+            {
+                // Logged like the menu handlers above: without it the log cannot answer "did the shortcut
+                // fire, or did the dialog fail to open?", which is exactly the question that comes up.
+                _logger.Information("Settings opened via keyboard shortcut from window: {WindowTitle}", this.Title);
+                _ = App.ShowSettingsWindow();
+            }),
+        };
 
-        // Same set, and the same handlers, as the NativeMenu declarations in SimpleTabbedWindow.axaml.
-        Bind("o", () => OnSelectBookClick(this, EventArgs.Empty));
-        Bind("p", () => OnPrintClick(this, EventArgs.Empty));
-        Bind("shift+p", () => OnPrintSelectionClick(this, EventArgs.Empty));
-        Bind("w", () => OnCloseTabClick(this, EventArgs.Empty));
-        Bind("g", () => OnGoToMenuItemClick(this, EventArgs.Empty));
-        Bind("d", () => OnLookUpInDictionaryClick(this, EventArgs.Empty));
-        Bind("f", () => OnSearchForSelectionClick(this, EventArgs.Empty));
-        Bind("e", () => OnViewSource1957Click(this, EventArgs.Empty));
-        Bind("shift+e", () => OnViewSource2010Click(this, EventArgs.Empty));
-        // Settings lives in the macOS app menu, so it has no NativeMenu declaration here to mirror -
-        // see AddSettingsMenuItemOffMacOS, which adds the Tools entry this shortcut matches.
-        Bind("OemComma", () =>
+        AddHandler(KeyDownEvent, (object? s, KeyEventArgs e) =>
         {
-            // Logged like the menu handlers above: without it the log cannot answer "did the shortcut
-            // fire, or did the dialog fail to open?", which is exactly the question that comes up.
-            _logger.Information("Settings opened via keyboard shortcut from window: {WindowTitle}", this.Title);
-            _ = App.ShowSettingsWindow();
-        });
+            foreach (var (gesture, invoke) in shortcuts)
+            {
+                if (!gesture.Matches(e)) continue;
 
-        _logger.Information("Registered {Count} menu shortcut key bindings (NativeMenuBar gestures are display-only off macOS)", KeyBindings.Count);
+                _logger.Debug("*** MAIN WINDOW SHORTCUT: {Gesture} ***", gesture);
+                e.Handled = true;
+                invoke();
+                return;
+            }
+        }, RoutingStrategies.Bubble);
+
+        _logger.Information("Registered {Count} menu shortcuts (NativeMenuBar gestures are display-only off macOS)", shortcuts.Length);
     }
 
     /// <summary>

--- a/src/CST.Avalonia/Views/WelcomeView.axaml.cs
+++ b/src/CST.Avalonia/Views/WelcomeView.axaml.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Threading;
 using WebViewControl;
+using CST.Avalonia.Input;
 using CST.Avalonia.ViewModels;
 using Serilog;
 
@@ -17,6 +18,10 @@ namespace CST.Avalonia.Views
         private bool _isWebViewReady = false;
         private bool _hasLoadedContent = false;
 
+        // Tags this view's shortcut messages so a background WebView can't act on a keystroke aimed at
+        // the visible one - the same guard BookDisplayView applies with its tab id. (#518)
+        private readonly string _shortcutViewId = "welcome_" + Guid.NewGuid().ToString("n").Substring(0, 8);
+
         public WelcomeView()
         {
             InitializeComponent();
@@ -28,6 +33,7 @@ namespace CST.Avalonia.Views
             {
                 _webView.WebViewInitialized += OnWebViewInitialized;
                 _webView.Navigated += OnNavigated;
+                _webView.TitleChanged += OnShortcutTitleChanged;   // #518
 
                 // Log WebView state
                 Log.Information("WelcomeView: WebView control found and event handlers attached");
@@ -98,9 +104,37 @@ namespace CST.Avalonia.Views
             _ = TryLoadHtmlContent();
         }
 
+        // #518: the Welcome page is a CEF WebView with no keyboard capture, so while it has focus every
+        // shortcut was dead - and it is the tab that holds focus at startup, making it the first thing a
+        // new user tries a shortcut from. Inject the relay once the page is up.
+        private void InjectShortcutRelay()
+        {
+            if (_webView == null) return;
+
+            try
+            {
+                _webView.ExecuteScript(WebViewShortcutRelay.BuildScript(_shortcutViewId));
+                Log.Debug("WelcomeView: shortcut relay injected");
+            }
+            catch (Exception ex)
+            {
+                // Non-fatal: the page still works, the shortcuts simply stay dead here.
+                Log.Warning("WelcomeView: failed to inject shortcut relay | {Details}", ex.Message);
+            }
+        }
+
+        private void OnShortcutTitleChanged()
+        {
+            WebViewShortcutRelay.TryHandle(_webView?.Title, _shortcutViewId, Log.Logger);
+        }
+
         private void OnNavigated(string url, string frameName)
         {
             Log.Information("WelcomeView: WebView navigated to: {Url} in frame: {Frame}", url, frameName);
+
+            // Re-inject after every navigation: a reload drops the previous document's listener. The
+            // script guards itself against double-binding, so repeating it is safe.
+            InjectShortcutRelay();
 
             // Check if this is an external URL that we need to redirect
             if (IsExternalUrl(url))


### PR DESCRIPTION
Closes the two remaining Windows keyboard gaps — **#511** (floating windows) and **#518** (WebViews with no capture) — and fixes a third that turned up while testing: shortcuts added in #509 were dead in the *main* window whenever a dropdown had focus.

All verified on Windows 11 ARM64 against a live app. Reviewed by fable before commit; findings addressed below.

## 1. Floating windows had no shortcuts outside the WebView (#511)

`App.SetupFloatingWindowMenu` returns early off macOS, so a floated book got no menu and no key handling. `Ctrl+D`/`F`/`O`/`P` were no-ops once focus left the page.

The failing case was isolated cleanly beforehand: Avalonia **received** those keystrokes (they logged) and nothing acted on them — so nothing was swallowing anything, there was simply no handler. The fix is purely additive: `RegisterFloatingWindowShortcuts` wires the *same* App handlers the macOS menu items already invoke, so there's no second copy of the logic.

## 2. `Window.KeyBindings` don't fire inside a popup — so #509 had a hole

Found while testing the above. An open ComboBox dropdown lives in its own `PopupRoot`, so the event routes through the logical chain — reaching `BookDisplayView`'s handler, which logs it — without ever reaching the Window.

Isolated by direct A/B on the same keystroke in the same focus state:

| Window | Mechanism | Ctrl+D, dropdown open |
|---|---|---|
| Floated (`CstHostWindow`) | `AddHandler` | **works** |
| Main (`SimpleTabbedWindow`) | `KeyBindings` (#509) | **dead** |

Only the mechanism differed. So every shortcut added in #509 was dead whenever a dropdown had focus — the chapter list being the obvious one. Both windows now use a bubbling `AddHandler` on the same routed-event path, with manual `KeyGesture.Matches`.

**Single dispatch comes from phase ordering, not luck.** `BookDisplayView` registers a **Tunnel** handler, and the whole tunnel phase completes before any bubble handler runs — so it claims `G`/`C`/`A` and sets `e.Handled` first; these handlers use `Bubble` *without* `handledEventsToo` and only see keystrokes nothing has claimed. Verified: `Ctrl+G` in a floated window with the dropdown open fired **exactly once**, via `BookDisplayView`, with no window-handler line.

## 3. Three WebViews had no keyboard capture at all (#518)

CEF consumes keystrokes before Avalonia sees them. `BookDisplayView` has long solved this with an injected JS keydown capture posting back via `document.title`; the Welcome page, Dictionary meaning pane and PDF viewer had nothing. Most visible on Welcome, which holds focus at startup — the first place a new user tries a shortcut.

`WebViewShortcutRelay` generalises that mechanism, reduced to what means something outside a book: Select a Book, Dictionary, Search, Settings. Messages carry the view's id (a background WebView can't act on a keystroke aimed at the visible one) and a sequence number (an identical consecutive title doesn't raise `TitleChanged`). The script is idempotent, so re-injection after reload/`LoadHtml` is safe.

## Verification

| Surface | Result |
|---|---|
| Welcome page — `Ctrl+O` | ✅ dispatches (`view welcome_*`) |
| Dictionary meaning pane — `Ctrl+O` | ✅ injects on render, dispatches (`view dict_*`) |
| Main window, dropdown open — `Ctrl+D` | ✅ now dispatches (was a confirmed no-op) |
| Floating window, dropdown open — `Ctrl+D` | ✅ now dispatches (was a confirmed no-op) |
| Main window — `Ctrl+E` | ✅ dispatches via the reworked handler |
| Double-fire canary — `Ctrl+G` | ✅ exactly one dispatch |
| **PDF viewer** | ❌ **not fixed — see below** |

1015/1015 tests pass.

## PDF viewer: not fixed, deliberately kept, documented

The relay injects cleanly — twice, since `Navigated` fires per frame — but `Ctrl+D` produces nothing. Chromium renders the PDF in an internal plugin frame that `ExecuteScript` can't reach and that consumes keystrokes itself. Predicted in review before it was tested, then confirmed on the running app.

The wiring is kept because it's inert, costs nothing, and starts working for any non-plugin content in that view. `PdfDisplayView` documents the measured limitation so nobody assumes otherwise. **The PDF viewer remains an open item on #518.**

`Ctrl+F` is deliberately excluded there (`includeFind: false`): intercepting it would have traded Chromium's find-in-page — the one shortcut that genuinely matters in a PDF — for "Search for Selection" with no selection. Raised in review.

## macOS

The window handlers are macOS-guarded (it gets real OS-level accelerators from the system menu bar; a second handler would double-fire).

**The relay deliberately is not**, and this is the one behaviour change worth flagging. `preventDefault` consumes the key equivalent before AppKit reaches the NSMenu — the mechanism `BookDisplayView` has used for these same combos since #443 — so exactly one route still fires. But it changes *which*: ⌘D/⌘F in these views previously fired the native menu, whose focus resolution falls back to "the first split's book" (the #443 wrong-book bug), acting on an unrelated book's selection. They now reveal the tool with no selection — the honest answer from a view with no book. Better, but a change, and **macOS is untested here**.

## Also fixed

A pre-existing bug in `PdfDisplayView.OnNavigationCompleted`: its `(object? sender, string url)` signature bound *contravariantly* to WebViewControl's `Navigated(string url, string frameName)`, silently shifting the arguments so the log printed the frame name as the URL. Found in review.

## Review notes

fable's review also caught an orphaned `ShortcutCommand.cs` (the `KeyBindings`→`AddHandler` rework deleted its only consumer — now removed) and corrected my explanation of why single-dispatch holds: I'd attributed it to tree proximity when it's actually tunnel/bubble phase ordering. Conclusion unchanged, reasoning fixed in the comments.
