### PR TITLE
#565: fix the Window menu — missing floating window, and the mark on the wrong one

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1538,12 +1538,21 @@ public partial class App : Application
 
         _windowMenus[owner] = submenu;
 
-        // #322 follow-up: the active-window checkmark renders win.IsActive, so refresh whenever ANY window's
-        // active state changes. The Activated event alone was insufficient — it never fired on focus LOSS and
-        // its timing vs. IsActive was unreliable — and once A8-5 removed the incidental title-path rebuilds
-        // that used to paper over the gap, the checkmark went stale until an unrelated rebuild (e.g. a global
-        // script change). Tracking IsActive directly is the exact signal, and fires on both sides of a switch.
+        // Historically (#322) this existed to keep the active-window CHECKMARK fresh, back when the mark was
+        // rendered from each window's Window.IsActive. It no longer serves that purpose — PopulateWindowMenu
+        // now marks this menu's own owner, which cannot go stale. Kept as a cheap belt-and-braces refresh of
+        // the window LIST itself (open/close/retitle are covered by Opened/Closed/UpdateHostWindowTitle, so
+        // this is defensive rather than load-bearing).
         var activeSub = owner.GetObservable(Window.IsActiveProperty).Subscribe(new AnonymousObserver<bool>(_ => RebuildWindowMenus()));
+
+        // #565a: rebuild once the window is actually SHOWN. Registration happens inside
+        // CstDockFactory.CreateCstHostWindow — before Dock shows the window — and GetListedWindows()
+        // enumerates desktop.Windows, which only holds shown windows. So the rebuild above ran with the new
+        // window still invisible to it, and nothing re-ran afterwards: a freshly floated window was missing
+        // from every Window menu until some unrelated activation change happened to refresh them (switching
+        // apps and back). Hooking Opened makes the refresh independent of whether the new window takes focus.
+        owner.Opened += (_, _) => RebuildWindowMenus();
+
         owner.Closed += (_, _) => { activeSub.Dispose(); _windowMenus.Remove(owner); RebuildWindowMenus(); };
     }
 
@@ -1597,7 +1606,19 @@ public partial class App : Application
 
         submenu.Add(new NativeMenuItemSeparator());
 
-        // One entry per open window; checkmark on the active one; click brings it to the front.
+        // One entry per open window; checkmark on the frontmost one; click brings it to the front.
+        //
+        // The checkmark is `win == owner` — this menu's OWN window — not a global "who is active" lookup.
+        // macOS only displays a window's menu bar while that window is frontmost (the premise this whole
+        // per-window menu design rests on), so the menu you are looking at necessarily belongs to the front
+        // window, and marking its owner is exact by construction.
+        //
+        // Every previous attempt here tried to keep a global guess in sync and drifted out of it: reading
+        // each window's Window.IsActive ticked SEVERAL entries at once (it can read true for more than one
+        // window after the app itself loses and regains focus, #565b), and tracking the most recently
+        // activated window put the mark on the wrong window, because WindowBase raises Activated BEFORE it
+        // sets IsActive. Resolving locally removes that entire class of bug — there is no shared state left
+        // to go stale. (#565b, and the #322 staleness it supersedes)
         foreach (var (win, title) in windows)
         {
             var target = win;
@@ -1605,7 +1626,7 @@ public partial class App : Application
             {
                 Header = title,
                 ToggleType = NativeMenuItemToggleType.CheckBox,
-                IsChecked = win.IsActive
+                IsChecked = ReferenceEquals(win, owner)
             };
             item.Click += (_, _) => ActivateWindow(target);
             submenu.Add(item);


### PR DESCRIPTION
Fixes #565 — two defects in the macOS Window menu (#284), both found in testing.

## A — a newly floated window was missing from the menu
…until you switched apps and back.

`SetupFloatingWindowMenu` → `RegisterWindowMenu` → `RebuildWindowMenus()` all run inside `CstDockFactory.CreateCstHostWindow()`, i.e. **before Dock shows the window**, while `GetListedWindows()` enumerates `desktop.Windows` — which only holds *shown* windows. From the log, ~19 ms too early:

```
11:19:12.285  CreateCstHostWindow()                            ← rebuild fires here
11:19:12.304  CleanupEmptySplits (Main + 1 floating windows)   ← only now enumerable
```

`RegisterWindowMenu` hooked `Closed` and `IsActiveProperty` but **not `Opened`**, so nothing rebuilt once the window actually existed — only an unrelated activation change rescued it, which is why it looked intermittent.

**Fix:** hook `Opened` too. Safe by Avalonia's own ordering — `ShowCore` raises `WindowOpenedEvent` (what the lifetime uses to add to `desktop.Windows`, `Window.cs:770`) *before* the CLR `Opened` event (`:868`).

## B — more than one window showed a checkmark
The mark was rendered per entry from `win.IsActive`, which can read true for **several** windows at once once the application itself has lost and regained focus.

A first attempt resolved a single "active window" by tracking the most recently activated one. It was reviewed and approved — and in testing it put the mark on the **wrong** window, because `WindowBase` raises `Activated` *before* it sets `IsActive`.

**Fix:** mark this menu's **own owner**:

```csharp
IsChecked = ReferenceEquals(win, owner)
```

macOS only displays a window's menu bar while that window is frontmost — the premise the per-window menu design already rests on, asserted three times in this very file. So the menu on screen necessarily belongs to the front window, and marking its owner is **exact by construction**.

This *supersedes* rather than extends the earlier approaches. Both reading `IsActive` per window (#322, #565b) and tracking a most-recently-activated window tried to keep a **global** guess in sync and drifted out of it. Resolving locally deletes the shared state and with it the whole class of bug: no `_lastActivatedWindow`, no `Activated` handler, no active-window resolution.

**The net functional change is two lines** — everything else in the diff is explanation:

```diff
+ owner.Opened += (_, _) => RebuildWindowMenus();
- IsChecked = win.IsActive
+ IsChecked = ReferenceEquals(win, owner)
```

The pre-existing `IsActiveProperty` subscription is kept but re-commented: it no longer serves the checkmark and is now only a defensive refresh of the window *list* (open/close/retitle are covered by `Opened`/`Closed`/`UpdateHostWindowTitle`). It could be removed as a follow-up.

## Verification
- **Manually confirmed**: floated window listed immediately; exactly one mark, following the front window across app switches.
- **Fable-reviewed twice.** The first pass verified the `Opened` ordering against the Avalonia 11.3.6 sources. The second re-reviewed the changed approach and confirmed the thing manual testing can't: **no window in this app can display a Window menu it doesn't own** — Settings and Go To set no `NativeMenu`, and the app-level menu contains only "Preferences…", no Window submenu. Also confirmed the exactly-one-mark invariant holds and that removing `_lastActivatedWindow` leaves nothing rooting closed windows.
- Full suite: **1015 passed, 0 failed.**

Closes #565.
