### PR TITLE
#564: populate the Window and Open Recent menus on Windows

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1531,7 +1531,7 @@ public partial class App : Application
     // SetupFloatingWindowMenu), register it for population, and keep it fresh as this window closes/activates.
     private void RegisterWindowMenu(Window owner)
     {
-        if (!OperatingSystem.IsMacOS()) return;
+        // Not macOS-only (#564): the in-window NativeMenuBar renders this submenu too, so it must be registered there.
         var menu = NativeMenu.GetMenu(owner);
         var windowItem = menu?.OfType<NativeMenuItem>().FirstOrDefault(i => (i.Header as string) == "Window");
         if (windowItem?.Menu is not NativeMenu submenu) return;
@@ -1580,7 +1580,7 @@ public partial class App : Application
     // windows); called on window open/close/retitle/activate. Public so CstDockFactory can call it.
     public void RebuildWindowMenus()
     {
-        if (!OperatingSystem.IsMacOS()) return;
+        // No platform guard (#564): _windowMenus only holds windows that registered.
         try
         {
             var windows = GetListedWindows();
@@ -1612,6 +1612,10 @@ public partial class App : Application
         // macOS only displays a window's menu bar while that window is frontmost (the premise this whole
         // per-window menu design rests on), so the menu you are looking at necessarily belongs to the front
         // window, and marking its owner is exact by construction.
+        //
+        // The same holds on Windows/Linux, for a different reason (#564): only the main window carries an
+        // in-window NativeMenuBar there (floating windows get none), and opening that menu requires clicking
+        // it, which activates its window. So by the time the list is visible, owner is frontmost either way.
         //
         // Every previous attempt here tried to keep a global guess in sync and drifted out of it: reading
         // each window's Window.IsActive ticked SEVERAL entries at once (it can read true for more than one
@@ -1656,7 +1660,7 @@ public partial class App : Application
     // when the window closes. Subscribes once to the list/script change signals.
     private void RegisterRecentMenu(Window owner)
     {
-        if (!OperatingSystem.IsMacOS()) return;
+        // Not macOS-only (#564): File > Open Recent lives in the same in-window menu bar, blank for the same reason.
         var menu = NativeMenu.GetMenu(owner);
         var fileItem = menu?.OfType<NativeMenuItem>().FirstOrDefault(i => (i.Header as string) == "File");
         var recentItem = (fileItem?.Menu)?.OfType<NativeMenuItem>().FirstOrDefault(i => (i.Header as string) == "Open Recent");
@@ -1685,7 +1689,7 @@ public partial class App : Application
     // change, window-create, and once after state has loaded.
     private void RebuildRecentMenus()
     {
-        if (!OperatingSystem.IsMacOS()) return;
+        // No platform guard (#564): _recentMenus only holds windows that registered.
         try
         {
             var recent = ServiceProvider?.GetService<RecentBooksService>();

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -733,6 +733,9 @@ public partial class SimpleTabbedWindow : Window
             (PlatformGesture.Parse("f"),       () => OnSearchForSelectionClick(this, EventArgs.Empty)),
             (PlatformGesture.Parse("e"),       () => OnViewSource1957Click(this, EventArgs.Empty)),
             (PlatformGesture.Parse("shift+e"), () => OnViewSource2010Click(this, EventArgs.Empty)),
+            // #564: the Window menu's Minimize item declares this gesture, and a NativeMenuBar gesture
+            // dispatches nothing off macOS - so without this entry the menu would advertise a dead shortcut.
+            (PlatformGesture.Parse("m"), () => WindowState = global::Avalonia.Controls.WindowState.Minimized),
             // Settings lives in the macOS app menu, so it has no NativeMenu declaration here to mirror -
             // see AddSettingsMenuItemOffMacOS, which adds the Tools entry this shortcut matches.
             (PlatformGesture.Parse("OemComma"), () =>


### PR DESCRIPTION
Fixes the blank **Window** menu reported in #564 — and the identical, unreported blankness in **File → Open Recent**.

## The bug

`SimpleTabbedWindow.axaml` declares a `Window` top-level menu and a `File → Open Recent` submenu, and the in-window `<NativeMenuBar/>` **renders both on Windows**. But the four helpers that fill them at runtime each began with:

```csharp
if (!OperatingSystem.IsMacOS()) return;
```

So nothing registered or populated them. The result: menus that exist, open, and show nothing — exactly as reported.

Removing those guards is the whole fix. The machinery is already platform-agnostic: `GetListedWindows` enumerates `desktop.Windows`, and menu **items** dispatch on click everywhere — it's only NativeMenuBar *gestures* that are display-only off macOS.

## Open Recent was not in the report

It carries the identical guard and lives in the same menu bar, so it was blank for exactly the same reason. Fixing only the reported menu would have left its twin — worth knowing the report understated the scope.

## The checkmark needed re-justifying, not just enabling

`win == owner` is exact on macOS *because* only the frontmost window displays its menu bar. That premise doesn't transfer, so I didn't want to enable the code on the strength of a macOS-only argument.

It holds off macOS for a different reason, now documented in the comment: only the main window has a menu bar there (floating windows get none), and opening it requires clicking it, which activates that window. So `owner` is frontmost by the time the list is visible. "CST Reader" being permanently ticked on Windows is therefore **correct rather than stale** — confirmed with the maintainer in testing.

## Also

**Ctrl+M wired** in the main window: the Window menu's Minimize item declares that gesture, and NativeMenuBar gestures dispatch nothing off macOS, so the menu would otherwise advertise a dead shortcut.

**Floating windows still have no menu bar on Windows**, left alone deliberately. VS Code — the reference for this app's docking UI — shows no menus on its floated editor windows either, so this looks like a reasonable resting point rather than a gap. (Not claiming a platform standard; Windows apps vary too much for that.)

## Verification (Windows 11 ARM64)

- Window menu lists "CST Reader" and floated windows by title; clicking an entry brings that window forward
- Floated windows appear in the list — the #565a `Opened` fix reaching Windows for the first time
- File → Open Recent lists recent books
- 1015/1015 tests pass

**macOS is unaffected**: the guards only ever suppressed work it was already doing, and nothing else in these paths changed.

## Not in scope

The other two items in #564 are already resolved: the missing dock/unfloat button is by design (#476 replaced it with drag), and drag-back-to-dock could not be reproduced on Merlin — the maintainer believes that one was user error.

Closes #564.
