### PR TITLE
Add data-directory migrations; retire the en/hi dictionary ids

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DataMigrationsTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DataMigrationsTests.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+// #564: #522 renamed the bundled dictionary ids (en -> vri-childers, hi -> vri-hindi) but nothing removed
+// the superseded directories, and seeding only writes what is MISSING - so an install carried over from
+// beta 5 held both generations and the Settings Dictionary tab listed every entry twice.
+//
+// This migration DELETES user-visible content, so the guards matter more than the happy path: most of
+// these tests pin the cases where it must decline to act.
+public class DataMigrationsTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _data;
+    private readonly string _bundled;
+
+    public DataMigrationsTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cst-migrations-" + Guid.NewGuid().ToString("n"));
+        _data = Path.Combine(_root, "data");
+        _bundled = Path.Combine(_root, "bundled");
+        Directory.CreateDirectory(_data);
+        Directory.CreateDirectory(_bundled);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private DataMigrations.Context Context(bool withBundled = true) => new()
+    {
+        DataDirectory = _data,
+        BundledDictionariesDirectory = withBundled ? _bundled : null,
+    };
+
+    private string DataDict(string id)
+    {
+        var dir = Path.Combine(_data, "dictionaries", id);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private void SeededDictionary(string id, string txtName = "dict.txt")
+    {
+        var dir = DataDict(id);
+        File.WriteAllText(Path.Combine(dir, txtName), "word\ndefinition\n");
+        File.WriteAllText(Path.Combine(dir, "source.json"), "{}");
+    }
+
+    private void BundledDictionary(string id)
+    {
+        Directory.CreateDirectory(Path.Combine(_bundled, id));
+    }
+
+    private static bool Applied(ApplicationState s) =>
+        s.AppliedDataMigrations.Contains("2026-08-retire-en-hi-dictionary-ids");
+
+    [Fact]
+    public void RemovesRetiredIds_WhenTheAppShipsTheirReplacements()
+    {
+        SeededDictionary("en");
+        SeededDictionary("hi");
+        SeededDictionary("vri-childers");
+        SeededDictionary("vri-hindi");
+        BundledDictionary("vri-childers");
+        BundledDictionary("vri-hindi");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context());
+
+        Assert.False(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+        Assert.False(Directory.Exists(Path.Combine(_data, "dictionaries", "hi")));
+        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "vri-childers")));
+        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "vri-hindi")));
+        Assert.True(Applied(state));
+    }
+
+    [Fact]
+    public void RemovesRetiredId_EvenBeforeTheReplacementHasBeenSeeded()
+    {
+        // The case that actually matters: on the first launch after upgrading, migrations run before
+        // DictionaryService seeds, so the replacement is not in the data directory yet. Keying off the
+        // BUNDLED copy is what makes the duplicate disappear that same session instead of the next one.
+        SeededDictionary("en");
+        BundledDictionary("vri-childers");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context());
+
+        Assert.False(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+    }
+
+    [Fact]
+    public void KeepsRetiredId_WhenTheAppDoesNotShipAReplacement()
+    {
+        // Removing it here would delete the only copy of that dictionary.
+        SeededDictionary("en");
+        var state = new ApplicationState();
+
+        var notes = DataMigrations.Run(state, Context());
+
+        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+        Assert.Contains(notes, n => n.Contains("does not ship"));
+    }
+
+    [Fact]
+    public void KeepsRetiredId_WhenItHoldsFilesWeDidNotSeed()
+    {
+        SeededDictionary("en");
+        File.WriteAllText(Path.Combine(_data, "dictionaries", "en", "notes.md"), "mine");
+        BundledDictionary("vri-childers");
+        var state = new ApplicationState();
+
+        var notes = DataMigrations.Run(state, Context());
+
+        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+        Assert.Contains(notes, n => n.Contains("did not seed"));
+    }
+
+    [Fact]
+    public void KeepsRetiredId_WhenItHoldsASubdirectory()
+    {
+        SeededDictionary("en");
+        Directory.CreateDirectory(Path.Combine(_data, "dictionaries", "en", "extra"));
+        BundledDictionary("vri-childers");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context());
+
+        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+    }
+
+    [Fact]
+    public void DoesNothing_WhenTheBundledDictionariesCannotBeFound()
+    {
+        // Without sight of what the app ships we cannot tell "superseded" from "the only copy".
+        SeededDictionary("en");
+        var state = new ApplicationState();
+
+        var notes = DataMigrations.Run(state, Context(withBundled: false));
+
+        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+        Assert.Contains(notes, n => n.Contains("bundled dictionaries not found"));
+    }
+
+    [Fact]
+    public void RunsEachMigrationOnlyOnce()
+    {
+        SeededDictionary("en");
+        BundledDictionary("vri-childers");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context());
+        var idsAfterFirst = state.AppliedDataMigrations.ToList();
+
+        // A second pass must not re-record the id (and, re-created here, must not act again either).
+        SeededDictionary("en");
+        var notes = DataMigrations.Run(state, Context());
+
+        Assert.Equal(idsAfterFirst, state.AppliedDataMigrations);
+        Assert.Empty(notes);
+        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+    }
+
+    [Fact]
+    public void IsIdempotent_WhenTheRecordIsLostButTheWorkIsDone()
+    {
+        // A data directory restored from backup, or a state file rolled back, can present an already-migrated
+        // tree with no record of it. Re-running must be harmless rather than destructive.
+        SeededDictionary("vri-childers");
+        BundledDictionary("vri-childers");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context());
+
+        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "vri-childers")));
+        Assert.True(Applied(state));
+    }
+
+    [Fact]
+    public void ToleratesAMissingDictionariesDirectory()
+    {
+        var state = new ApplicationState();
+
+        var notes = DataMigrations.Run(state, Context());
+
+        Assert.True(Applied(state));
+        Assert.Contains(notes, n => n.Contains("nothing to do"));
+    }
+
+    [Fact]
+    public void MigrationIdsAreUniqueAndStable()
+    {
+        var ids = DataMigrations.All.Select(m => m.Id).ToList();
+        Assert.Equal(ids.Count, ids.Distinct(StringComparer.Ordinal).Count());
+        Assert.All(ids, id => Assert.False(string.IsNullOrWhiteSpace(id)));
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -606,6 +606,34 @@ public partial class App : Application
     }
 
     /// <summary>
+    // #564: apply any pending user-data migrations and persist the record of what ran. Failures are
+    // logged and left unrecorded so they retry next launch; they never block startup.
+    private static void RunDataMigrations(IApplicationStateService stateService)
+    {
+        try
+        {
+            var context = new DataMigrations.Context
+            {
+                DataDirectory = AppConstants.DataDirectory,
+                BundledDictionariesDirectory = BundledResourceLocator.Resolve("dictionaries"),
+            };
+
+            var notes = DataMigrations.Run(stateService.Current, context);
+            foreach (var note in notes)
+                Log.Information("Data migration: {Note}", note);
+
+            // Only dirty the state when something was actually recorded, so a clean install does not
+            // rewrite the state file on every launch just to say nothing happened.
+            if (notes.Count > 0)
+                stateService.MarkDirty();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Data migrations failed; continuing startup");
+        }
+    }
+
+    /// <summary>
     /// Load application state on startup - equivalent to CST4 AppState.Deserialize()
     /// </summary>
     private async Task LoadApplicationStateAsync()
@@ -619,6 +647,12 @@ public partial class App : Application
                 stateService.StateChanged += OnApplicationStateChanged;
                 
                 await stateService.LoadStateAsync();
+
+                // #564: migrate the user DATA directory before anything reads it. Runs here rather
+                // than inside a service so ordering is explicit: DictionaryService seeds on
+                // construction, and a migration that needed the seeded result would be too late on
+                // the very launch that matters (the first one after an upgrade).
+                RunDataMigrations(stateService);
 
                 // Manually handle initial state restoration without StateChanged events
                 await InitializeFromLoadedState(stateService.Current);

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -40,6 +40,14 @@ public class ApplicationState
     // Open Book Windows (tabs)
     public List<BookWindowState> BookWindows { get; set; } = new();
 
+    /// <summary>
+    /// Ids of on-disk data migrations already applied (see <see cref="Services.DataMigrations"/>).
+    /// Tracked by id rather than a version number so migrations can be added out of order and each runs
+    /// exactly once. Distinct from <see cref="Version"/>, which versions the shape of THIS file; these
+    /// migrate the user data directory around it (dictionaries, indexes, downloaded assets). (#564)
+    /// </summary>
+    public List<string> AppliedDataMigrations { get; set; } = new();
+
     // Application Preferences
     public ApplicationPreferences Preferences { get; set; } = new();
 }

--- a/src/CST.Avalonia/Services/DataMigrations.cs
+++ b/src/CST.Avalonia/Services/DataMigrations.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CST.Avalonia.Models;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// One-time migrations of the user DATA directory (dictionaries, downloaded assets, indexes).
+///
+/// Distinct from <see cref="ApplicationStateValidator.Migrate"/>, which upgrades the shape of the state
+/// FILE and is deliberately pure. These reshape what sits on disk around it, so they do I/O — but they
+/// stay free of DI and of app services so they remain directly unit-testable against a temp directory.
+///
+/// Applied migrations are recorded by id in <see cref="ApplicationState.AppliedDataMigrations"/>, so each
+/// runs exactly once. Ids are permanent: renaming one re-runs it on every existing install.
+///
+/// **Write every migration to be idempotent anyway.** The recorded id is the primary guard, but a
+/// migration can also meet a half-finished state from an interrupted run, or a data directory restored
+/// from backup while the state file moved on. Belt and braces is cheap here; a destructive migration that
+/// assumes it is running on a pristine "before" state is not.
+/// </summary>
+public static class DataMigrations
+{
+    /// <summary>Inputs a migration may act on. No services, no DI — everything is a plain path.</summary>
+    public sealed class Context
+    {
+        /// <summary>The user data root (…/CSTReader).</summary>
+        public required string DataDirectory { get; init; }
+
+        /// <summary>
+        /// The bundled dictionaries shipped with the app, or null if they could not be located. A migration
+        /// that deletes user-visible content should consult this rather than assume: if we cannot see what
+        /// the app ships, we cannot safely conclude anything is redundant.
+        /// </summary>
+        public string? BundledDictionariesDirectory { get; init; }
+    }
+
+    public sealed record Migration(string Id, string Description, Action<Context, List<string>> Apply);
+
+    /// <summary>Ordered. Append new migrations; never renumber or rename existing ids.</summary>
+    public static readonly IReadOnlyList<Migration> All = new List<Migration>
+    {
+        new("2026-08-retire-en-hi-dictionary-ids",
+            "Remove the superseded en/hi dictionary directories left behind by the #522 rename",
+            RetireEnHiDictionaryIds),
+    };
+
+    /// <summary>
+    /// Apply any migrations not yet recorded in <paramref name="state"/>, in order. Returns human-readable
+    /// notes for logging. A failing migration is recorded as failed and does NOT block the others, and is
+    /// NOT marked applied — so it will be retried next launch rather than silently skipped forever.
+    /// </summary>
+    public static IReadOnlyList<string> Run(ApplicationState state, Context context)
+    {
+        var notes = new List<string>();
+        if (state == null) return notes;
+
+        var applied = state.AppliedDataMigrations ??= new List<string>();
+
+        foreach (var migration in All)
+        {
+            if (applied.Contains(migration.Id, StringComparer.Ordinal))
+                continue;
+
+            try
+            {
+                var before = notes.Count;
+                migration.Apply(context, notes);
+                applied.Add(migration.Id);
+
+                // Only announce migrations that actually did something; a no-op on a clean install is the
+                // common case and does not deserve a line in everyone's log.
+                if (notes.Count == before)
+                    notes.Add($"migration {migration.Id}: nothing to do");
+            }
+            catch (Exception ex)
+            {
+                notes.Add($"migration {migration.Id} FAILED (will retry next launch): {ex.Message}");
+            }
+        }
+
+        return notes;
+    }
+
+    // ===== migrations =====
+
+    /// <summary>
+    /// #522 renamed the bundled dictionary ids (en → vri-childers, hi → vri-hindi) but nothing removed the
+    /// superseded directories from an existing install, and seeding only ever writes what is MISSING. So an
+    /// install carried over from beta 5 ends up with both generations on disk. Because
+    /// <c>DictionaryService.AvailableLanguages</c> enumerates directories, and each retired id carries the
+    /// same displayName as its replacement, every affected user sees each dictionary listed twice. (#564)
+    ///
+    /// Deliberately keyed off the BUNDLED dictionaries, not the seeded ones. On the first launch after
+    /// upgrading, the replacement has not been seeded into the data directory yet — migrations run before
+    /// DictionaryService is constructed — so a check against the data directory would find no replacement,
+    /// do nothing, and leave the duplicates visible for that whole session.
+    /// </summary>
+    private static void RetireEnHiDictionaryIds(Context context, List<string> notes)
+    {
+        var retired = new (string Old, string New)[] { ("en", "vri-childers"), ("hi", "vri-hindi") };
+
+        var dictionaries = Path.Combine(context.DataDirectory, "dictionaries");
+        if (!Directory.Exists(dictionaries)) return;
+
+        // Without sight of the bundled dictionaries we cannot tell "superseded" from "the only copy".
+        if (context.BundledDictionariesDirectory is not { } bundled || !Directory.Exists(bundled))
+        {
+            notes.Add("retire-en-hi: bundled dictionaries not found; leaving the data directory alone");
+            return;
+        }
+
+        foreach (var (oldId, newId) in retired)
+        {
+            var oldDir = Path.Combine(dictionaries, oldId);
+            if (!Directory.Exists(oldDir)) continue;
+
+            // The app must actually ship the replacement, or removing the old one loses the dictionary.
+            if (!Directory.Exists(Path.Combine(bundled, newId)))
+            {
+                notes.Add($"retire-en-hi: '{oldId}' kept — the app does not ship '{newId}'");
+                continue;
+            }
+
+            // Only remove what we put there. Anything else means the user (or a future drop-in source) has
+            // added files, and a rename cleanup has no business deleting those.
+            var unexpected = Directory.EnumerateFiles(oldDir)
+                .Select(Path.GetFileName)
+                .Where(name => !IsSeededFileName(name))
+                .ToList();
+            if (unexpected.Count > 0 || Directory.EnumerateDirectories(oldDir).Any())
+            {
+                notes.Add($"retire-en-hi: '{oldId}' kept — it holds files we did not seed ({string.Join(", ", unexpected)})");
+                continue;
+            }
+
+            Directory.Delete(oldDir, recursive: true);
+            notes.Add($"retire-en-hi: removed superseded dictionary id '{oldId}' (replaced by '{newId}')");
+        }
+    }
+
+    // The only files seeding ever writes into a bundled dictionary directory: the flat-file dictionary
+    // itself and the app-owned source.json metadata.
+    private static bool IsSeededFileName(string? name) =>
+        name is not null &&
+        (name.EndsWith(".txt", StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(name, "source.json", StringComparison.OrdinalIgnoreCase));
+}


### PR DESCRIPTION
Fixes the duplicated dictionary entries in the Settings → Dictionary tab, and establishes the data-migration mechanism this is the first instance of.

## The bug

#522 renamed the bundled dictionary ids (`en` → `vri-childers`, `hi` → `vri-hindi`), but nothing removed the superseded directories from an existing install — and seeding only ever writes what is **missing**. So an install carried over from beta 5 keeps both generations on disk:

```
dictionaries/en             Jul 25   <- beta 5
dictionaries/hi             Jul 25   <- beta 5
dictionaries/vri-childers   Jul 27   <- post-#522
dictionaries/vri-hindi      Jul 27   <- post-#522
```

They're byte-identical pairs. Since `DictionaryService.AvailableLanguages` enumerates *directories*, and each retired id carries the same `displayName` as its replacement, every affected entry is listed twice.

#522's note that *"beta 5 is a clean start so nothing needs migrating"* held for the `ApplicationState` fields it was discussing, but not for the on-disk directories, which survive. **Beta 6 is not planned to require a clean start, so every upgrader would hit this.**

## The mechanism

`DataMigrations` owns one-time migrations of the user **data** directory. Deliberately separate from `ApplicationStateValidator.Migrate`, which upgrades the shape of the state **file** and is documented as pure — these do I/O, so folding them in would break that contract and its testability. They stay free of DI and app services, taking plain paths, so they unit-test against a temp directory.

Applied migrations are recorded **by id** in `ApplicationState.AppliedDataMigrations`. Ids rather than a version number, so migrations can be added out of order, each still runs exactly once, and the state file says plainly what has run. A failing migration is logged and left **unrecorded** — it retries next launch rather than being silently skipped forever — and blocks neither the other migrations nor startup.

## Two decisions worth reviewing

**It keys off the BUNDLED dictionaries, not the seeded ones.** Migrations run right after the state loads, which is *before* `DictionaryService` is constructed and seeds. So on the first launch after an upgrade, checking the data directory would find no replacement, do nothing, and leave the duplicates visible for that entire session. Checking what the app *ships* fixes them on the launch that matters. There's a test for exactly this ordering.

**It declines to act rather than guessing.** A retired directory is kept if:
- the app doesn't ship a replacement — removing it would delete the only copy
- it holds any file we didn't seed, or any subdirectory — someone's own content isn't ours to delete
- the bundled dictionaries can't be located at all — then "superseded" is indistinguishable from "the only copy"

Migrations are also written to be idempotent despite the recorded id, since a restored backup or a rolled-back state file can present a half-migrated tree.

## Not needed

Stored preferences migrate themselves: `DictionarySourcePreferenceService` already filters by `availableIds.Contains(...)`, so a dangling `"en"` drops out on its own.

## Verification

Recreated the duplicate state on Windows 11 ARM64 and ran the real app:

```
13:55:32  removed superseded dictionary id 'en' (replaced by 'vri-childers')
13:55:32  removed superseded dictionary id 'hi' (replaced by 'vri-hindi')
13:57:31  migration 2026-08-retire-en-hi-dictionary-ids: nothing to do   <- second launch
```

`appliedDataMigrations` persisted to the state file, so it won't re-run. **10 new tests** — most pinning the cases where it must decline — and **1025/1025 pass**.

Platform-agnostic: the same duplication exists on any beta 5 install, macOS included.
