### PR TITLE
Normalize the 14 book stylesheets to one common form (#42)

### DIFF
--- a/src/CST.Avalonia/xsl/tipitaka-beng.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-beng.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -53,7 +53,6 @@ function getStyleClass (className) {
 }
 </script>
 <style>
-
 body { 
   font-family: "BN BIDISHA Opentype", Vrinda;
   background: white;
@@ -72,40 +71,40 @@ p {
   margin-top: 0in; margin-bottom: 0.5cm;
 }
 
-.indent { font-size: 14pt; text-indent: 2em; margin-left: 3em;}
+.indent { font-size: 12pt; text-indent: 2em; margin-left: 3em;}
 
-.bodytext { font-size: 14pt; text-indent: 2em;}
+.bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 14pt; margin-bottom: -16pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
-.centered { font-size: 14pt; text-align:center;}
+.centered { font-size: 12pt; text-align:center;}
 
-.unindented { font-size: 14pt;}
+.unindented { font-size: 12pt;}
 
-.book { font-size: 24pt; text-align:center; font-weight: bold;}
+.book { font-size: 21pt; text-align:center; font-weight: bold;}
 
-.chapter { font-size: 22pt; text-align:center; font-weight: bold;}
+.chapter { font-size: 18pt; text-align:center; font-weight: bold;}
 
-.nikaya { font-size: 28pt; text-align:center; font-weight: bold;}
+.nikaya { font-size: 24pt; text-align:center; font-weight: bold;}
 
-.title { font-size: 14pt; text-align:center; font-weight: bold;}
+.title { font-size: 12pt; text-align:center; font-weight: bold;}
 
-.subhead { font-size: 14pt; text-align:center; font-weight: bold;}
+.subhead { font-size: 12pt; text-align:center; font-weight: bold;}
 
-.subsubhead { font-size: 14pt; text-align:center; font-weight: bold;}
+.subsubhead { font-size: 12pt; text-align:center; font-weight: bold;}
 
 /* Gatha line 1 */
-.gatha1 { font-size: 14pt; margin-bottom: 0em; margin-left: 4em;}
+.gatha1 { font-size: 12pt; margin-bottom: 0em; margin-left: 4em;}
 
 /* Gatha line 2 */
-.gatha2 { font-size: 14pt; margin-bottom: 0em; margin-left: 4em;}
+.gatha2 { font-size: 12pt; margin-bottom: 0em; margin-left: 4em;}
 
 /* Gatha line 3 */
-.gatha3 { font-size: 14pt; margin-bottom: 0em; margin-left: 4em;}
+.gatha3 { font-size: 12pt; margin-bottom: 0em; margin-left: 4em;}
 
 /* Gatha last line */
-.gathalast { font-size: 14pt; margin-bottom: 0.5cm; margin-left: 4em;}
+.gathalast { font-size: 12pt; margin-bottom: 0.5cm; margin-left: 4em;}
 
 /* Dark Mode Support */
 @media (prefers-color-scheme: dark) {
@@ -351,5 +350,5 @@ p {
 </xsl:attribute>
 </a>
 </xsl:template>
-  
+
 </xsl:stylesheet>

--- a/src/CST.Avalonia/xsl/tipitaka-cyrl.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-cyrl.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -75,7 +75,7 @@ p {
 
 .bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 12pt; margin-bottom: -18pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
 .centered { font-size: 12pt; text-align:center;}
@@ -350,5 +350,5 @@ p {
 </xsl:attribute>
 </a>
 </xsl:template>
-  
+
 </xsl:stylesheet>

--- a/src/CST.Avalonia/xsl/tipitaka-deva.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-deva.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -75,7 +75,7 @@ p {
 
 .bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 12pt; margin-bottom: -18pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
 .centered { font-size: 12pt; text-align:center;}
@@ -350,5 +350,5 @@ p {
 </xsl:attribute>
 </a>
 </xsl:template>
-  
+
 </xsl:stylesheet>

--- a/src/CST.Avalonia/xsl/tipitaka-gujr.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-gujr.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -75,7 +75,7 @@ p {
 
 .bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 12pt; margin-bottom: -18pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
 .centered { font-size: 12pt; text-align:center;}

--- a/src/CST.Avalonia/xsl/tipitaka-guru.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-guru.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -75,7 +75,7 @@ p {
 
 .bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 12pt; margin-bottom: -19.5pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
 .centered { font-size: 12pt; text-align:center;}
@@ -343,13 +343,12 @@ p {
 </p>
 </xsl:template>
 
-  <xsl:template match="pb">
-    <a>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@ed"/>
-        <xsl:value-of select="@n"/>
-      </xsl:attribute>
-    </a>
-  </xsl:template>
+<xsl:template match="pb">
+<a>
+<xsl:attribute name="name">
+<xsl:value-of select="@ed"/><xsl:value-of select="@n"/>
+</xsl:attribute>
+</a>
+</xsl:template>
 
 </xsl:stylesheet>

--- a/src/CST.Avalonia/xsl/tipitaka-khmr.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-khmr.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -75,7 +75,7 @@ p {
 
 .bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 12pt; margin-bottom: -18pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
 .centered { font-size: 12pt; text-align:center;}
@@ -343,13 +343,12 @@ p {
 </p>
 </xsl:template>
 
-  <xsl:template match="pb">
-    <a>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@ed"/>
-        <xsl:value-of select="@n"/>
-      </xsl:attribute>
-    </a>
-  </xsl:template>
+<xsl:template match="pb">
+<a>
+<xsl:attribute name="name">
+<xsl:value-of select="@ed"/><xsl:value-of select="@n"/>
+</xsl:attribute>
+</a>
+</xsl:template>
 
 </xsl:stylesheet>

--- a/src/CST.Avalonia/xsl/tipitaka-knda.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-knda.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -53,10 +53,6 @@ function getStyleClass (className) {
 }
 </script>
 <style>
-/* 
-  Tipitaka stylesheet for Unicode Kannada encoding. 
-*/
-
 body { 
   font-family: Tunga, "Arial Unicode MS";
   background: white;
@@ -79,7 +75,7 @@ p {
 
 .bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 12pt; margin-bottom: -20pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
 .centered { font-size: 12pt; text-align:center;}
@@ -347,13 +343,12 @@ p {
 </p>
 </xsl:template>
 
-  <xsl:template match="pb">
-    <a>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@ed"/>
-        <xsl:value-of select="@n"/>
-      </xsl:attribute>
-    </a>
-  </xsl:template>
+<xsl:template match="pb">
+<a>
+<xsl:attribute name="name">
+<xsl:value-of select="@ed"/><xsl:value-of select="@n"/>
+</xsl:attribute>
+</a>
+</xsl:template>
 
 </xsl:stylesheet>

--- a/src/CST.Avalonia/xsl/tipitaka-mlym.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-mlym.xsl
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
-<xsl:template match = "/" >
+<xsl:template match = "/" > 
 <html>
 <head>
 <title></title>
 <script>
 function setHitsVisibility(isVisible)
-{
+{ 
   var c = getStyleClass('hit');
   if (isVisible)
   {
@@ -48,12 +48,12 @@ function getStyleClass (className) {
 			}
 		}
 	}
-
+	
 	return null;
 }
 </script>
 <style>
-body {
+body { 
   font-family: Kartika;
   background: white;
 }
@@ -75,7 +75,7 @@ p {
 
 .bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 12pt; margin-bottom: -13pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
 .centered { font-size: 12pt; text-align:center;}
@@ -174,7 +174,7 @@ p {
 
 <xsl:template match='p[@rend="bodytext"]'>
 <p class="bodytext">
-  <!-- if the n attribute is set, create an HTML anchor for the paragraph in the form pr### -->
+  <!-- if the n attribute is set, create an HTML anchor for the paragraph in the form para### -->
   <xsl:if test="@n">
     <a>
       <xsl:attribute name="name">
@@ -343,13 +343,12 @@ p {
 </p>
 </xsl:template>
 
-  <xsl:template match="pb">
-    <a>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@ed"/>
-        <xsl:value-of select="@n"/>
-      </xsl:attribute>
-    </a>
-  </xsl:template>
+<xsl:template match="pb">
+<a>
+<xsl:attribute name="name">
+<xsl:value-of select="@ed"/><xsl:value-of select="@n"/>
+</xsl:attribute>
+</a>
+</xsl:template>
 
 </xsl:stylesheet>

--- a/src/CST.Avalonia/xsl/tipitaka-mymr.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-mymr.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -53,58 +53,58 @@ function getStyleClass (className) {
 }
 </script>
 <style>
-	body {
-	font-family: Padauk,Tharlon,Myanmar1;
-	background: white;
-	}
+body { 
+  font-family: Padauk,Tharlon,Myanmar1;
+  background: white;
+}
 
-	span {}
-	.note {color: blue}
-	.bld {font-weight: bold; }
-	.paranum {font-weight: bold; }
-	.hit {background-color: blue; color: white; }
-	.context {background-color: green; color: white; }
+span {}
+.note {color: blue}
+.bld {font-weight: bold; }
+.paranum {font-weight: bold; }
+.hit {background-color: blue; color: white; }
+.context {background-color: green; color: white; }
 
-	p {
-	border-top: 0in; border-bottom: 0in;
-	padding-top: 0in; padding-bottom: 0in;
-	margin-top: 0in; margin-bottom: 0.5cm;
-	}
+p {
+  border-top: 0in; border-bottom: 0in;
+  padding-top: 0in; padding-bottom: 0in;
+  margin-top: 0in; margin-bottom: 0.5cm;
+}
 
-	.indent { font-size: 17pt; text-indent: 2em; margin-left: 3em;}
+.indent { font-size: 12pt; text-indent: 2em; margin-left: 3em;}
 
-	.bodytext { font-size: 17pt; text-indent: 2em;}
+.bodytext { font-size: 12pt; text-indent: 2em;}
 
-	.hangnum { font-size: 17pt; margin-bottom: -14.4pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
-	/* Namo tassa, and nitthita -- no unique structural distinction */
-	.centered { font-size: 17pt; text-align:center;}
+/* Namo tassa, and nitthita -- no unique structural distinction */
+.centered { font-size: 12pt; text-align:center;}
 
-	.unindented { font-size: 17pt;}
+.unindented { font-size: 12pt;}
 
-	.book { font-size: 21pt; text-align:center; font-weight: bold;}
+.book { font-size: 21pt; text-align:center; font-weight: bold;}
 
-	.chapter { font-size: 19pt; text-align:center; font-weight: bold;}
+.chapter { font-size: 18pt; text-align:center; font-weight: bold;}
 
-	.nikaya { font-size: 24pt; text-align:center; font-weight: bold;}
+.nikaya { font-size: 24pt; text-align:center; font-weight: bold;}
 
-	.title { font-size: 17pt; text-align:center; font-weight: bold;}
+.title { font-size: 12pt; text-align:center; font-weight: bold;}
 
-	.subhead { font-size: 17pt; text-align:center; font-weight: bold;}
+.subhead { font-size: 12pt; text-align:center; font-weight: bold;}
 
-	.subsubhead { font-size: 17pt; text-align:center; font-weight: bold;}
+.subsubhead { font-size: 12pt; text-align:center; font-weight: bold;}
 
-	/* Gatha line 1 */
-	.gatha1 { font-size: 17pt; margin-bottom: 0em; margin-left: 4em;}
+/* Gatha line 1 */
+.gatha1 { font-size: 12pt; margin-bottom: 0em; margin-left: 4em;}
 
-	/* Gatha line 2 */
-	.gatha2 { font-size: 17pt; margin-bottom: 0em; margin-left: 4em;}
+/* Gatha line 2 */
+.gatha2 { font-size: 12pt; margin-bottom: 0em; margin-left: 4em;}
 
-	/* Gatha line 3 */
-	.gatha3 { font-size: 17pt; margin-bottom: 0em; margin-left: 4em;}
+/* Gatha line 3 */
+.gatha3 { font-size: 12pt; margin-bottom: 0em; margin-left: 4em;}
 
-	/* Gatha last line */
-	.gathalast { font-size: 17pt; margin-bottom: 0.5cm; margin-left: 4em;}
+/* Gatha last line */
+.gathalast { font-size: 12pt; margin-bottom: 0.5cm; margin-left: 4em;}
 
 /* Dark Mode Support */
 @media (prefers-color-scheme: dark) {

--- a/src/CST.Avalonia/xsl/tipitaka-sinh.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-sinh.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>

--- a/src/CST.Avalonia/xsl/tipitaka-telu.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-telu.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -75,7 +75,7 @@ p {
 
 .bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 12pt; margin-bottom: -20pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
 .centered { font-size: 12pt; text-align:center;}
@@ -343,13 +343,12 @@ p {
 </p>
 </xsl:template>
 
-  <xsl:template match="pb">
-    <a>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@ed"/>
-        <xsl:value-of select="@n"/>
-      </xsl:attribute>
-    </a>
-  </xsl:template>
+<xsl:template match="pb">
+<a>
+<xsl:attribute name="name">
+<xsl:value-of select="@ed"/><xsl:value-of select="@n"/>
+</xsl:attribute>
+</a>
+</xsl:template>
 
 </xsl:stylesheet>

--- a/src/CST.Avalonia/xsl/tipitaka-thai.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-thai.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -71,40 +71,40 @@ p {
   margin-top: 0in; margin-bottom: 0.5cm;
 }
 
-.indent { font-size: 15pt; text-indent: 2em; margin-left: 3em;}
+.indent { font-size: 12pt; text-indent: 2em; margin-left: 3em;}
 
-.bodytext { font-size: 15pt; text-indent: 2em;}
+.bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 15pt; margin-bottom: -18pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
-.centered { font-size: 15pt; text-align:center;}
+.centered { font-size: 12pt; text-align:center;}
 
-.unindented { font-size: 15pt;}
+.unindented { font-size: 12pt;}
 
-.book { font-size: 25pt; text-align:center; font-weight: bold;}
+.book { font-size: 21pt; text-align:center; font-weight: bold;}
 
-.chapter { font-size: 21pt; text-align:center; font-weight: bold;}
+.chapter { font-size: 18pt; text-align:center; font-weight: bold;}
 
-.nikaya { font-size: 30pt; text-align:center; font-weight: bold;}
+.nikaya { font-size: 24pt; text-align:center; font-weight: bold;}
 
-.title { font-size: 15pt; text-align:center; font-weight: bold;}
+.title { font-size: 12pt; text-align:center; font-weight: bold;}
 
-.subhead { font-size: 15pt; text-align:center; font-weight: bold;}
+.subhead { font-size: 12pt; text-align:center; font-weight: bold;}
 
 .subsubhead { font-size: 12pt; text-align:center; font-weight: bold;}
 
 /* Gatha line 1 */
-.gatha1 { font-size: 15pt; margin-bottom: 0em; margin-left: 4em;}
+.gatha1 { font-size: 12pt; margin-bottom: 0em; margin-left: 4em;}
 
 /* Gatha line 2 */
-.gatha2 { font-size: 15pt; margin-bottom: 0em; margin-left: 4em;}
+.gatha2 { font-size: 12pt; margin-bottom: 0em; margin-left: 4em;}
 
 /* Gatha line 3 */
-.gatha3 { font-size: 15pt; margin-bottom: 0em; margin-left: 4em;}
+.gatha3 { font-size: 12pt; margin-bottom: 0em; margin-left: 4em;}
 
 /* Gatha last line */
-.gathalast { font-size: 15pt; margin-bottom: 0.5cm; margin-left: 4em;}
+.gathalast { font-size: 12pt; margin-bottom: 0.5cm; margin-left: 4em;}
 
 /* Dark Mode Support */
 @media (prefers-color-scheme: dark) {
@@ -343,13 +343,12 @@ p {
 </p>
 </xsl:template>
 
-  <xsl:template match="pb">
-    <a>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@ed"/>
-        <xsl:value-of select="@n"/>
-      </xsl:attribute>
-    </a>
-  </xsl:template>
+<xsl:template match="pb">
+<a>
+<xsl:attribute name="name">
+<xsl:value-of select="@ed"/><xsl:value-of select="@n"/>
+</xsl:attribute>
+</a>
+</xsl:template>
 
 </xsl:stylesheet>

--- a/src/CST.Avalonia/xsl/tipitaka-tibt.xsl
+++ b/src/CST.Avalonia/xsl/tipitaka-tibt.xsl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" > 
+<xsl:stylesheet xmlns:xsl = "http://www.w3.org/1999/XSL/Transform" version = "1.0" >
 
 <xsl:template match = "/" > 
 <html>
@@ -75,7 +75,7 @@ p {
 
 .bodytext { font-size: 12pt; text-indent: 2em;}
 
-.hangnum { font-size: 12pt; margin-bottom: -24pt; text-indent: 2em;}
+.hangnum { font-size: 12pt; margin-bottom: -14.4pt; text-indent: 2em;}
 
 /* Namo tassa, and nitthita -- no unique structural distinction */
 .centered { font-size: 12pt; text-align:center;}
@@ -343,13 +343,12 @@ p {
 </p>
 </xsl:template>
 
-  <xsl:template match="pb">
-    <a>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@ed"/>
-        <xsl:value-of select="@n"/>
-      </xsl:attribute>
-    </a>
-  </xsl:template>
+<xsl:template match="pb">
+<a>
+<xsl:attribute name="name">
+<xsl:value-of select="@ed"/><xsl:value-of select="@n"/>
+</xsl:attribute>
+</a>
+</xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Groundwork for #42 (user-configurable book fonts). The 14 `tipitaka-*.xsl` files are now **byte-identical apart from their single `font-family` line** — verified by hashing each file with that line stripped and getting one distinct hash.

That is the prerequisite for injecting the face at render time and, after that, collapsing 14 stylesheets into one. Holding the collapse itself until #42's injection mechanism exists to consume it.

## What changed

**Font sizes flattened to 12 / 18 / 21 / 24pt.** Three scripts diverged:

| | body | headings |
|---|---|---|
| 11 scripts | 12 | 18 / 21 / 24 |
| beng | 14 | 22 / 24 / 28 |
| mymr | 17 | 19 / 21 / 24 |
| thai | 15 | 21 / 25 / 30 |

Those values were tuned by eye roughly twenty years ago against a Windows font set that no longer exists — guesses about machines we cannot see, not durable calibration. Per-script sizing is superseded by zoom (#572), which stores one calibration number per script.

Flattening also absorbed two strays: thai's `.subsubhead` was 12pt against its own 15pt body (every other script has them equal), and mymr's `.hangnum` negative margin was still the 12pt-derived −14.4pt despite a 17pt body.

**`.hangnum` margin-bottom unified to latn's −14.4pt.** It previously held *seven* different values for identical typography:

```
-13     mlym
-14.4   latn sinh mymr
-16     beng
-18     cyrl deva gujr khmr thai
-19.5   guru
-20     knda telu
-24     tibt
```

−14.4pt ≈ 0.5cm, which exactly cancels the `0.5cm` bottom margin the `p` rule sets — so it is the value matching the apparent intent ("no gap after a hanging-number line"). The others over- or under-shoot.

Everything else was whitespace and comments: mymr's tab indentation became spaces, knda lost a header comment, mlym's comment wording aligned with latn.

## Verification

Because 13 files were rebuilt from latn rather than patched in place, output was compared directly. For every changed script, a book was rendered through both the old and new stylesheet:

- **Generated page anchors identical** in all of them (23 anchors each). This is what closes the one cosmetic change that *could* have altered output — 8 files had `<xsl:value-of select="@ed"/><xsl:value-of select="@n"/>` split across two lines, and joining them relies on XSLT stripping whitespace-only text nodes. Four files (telu, tibt, guru, khmr) render byte-identical despite that change, confirming it.
- **All non-`<style>` output identical**, except mlym, which differs by exactly two trailing spaces inside its embedded JavaScript — one gained, one lost.
- **Structural parse comparison**: node counts unchanged across all 14; the only structural delta anywhere is the `.hangnum` rule.

Full suite: **1025 passed, 0 failed.**

## Sequencing

This **shrinks beng, mymr and thai body text** — mymr from 17pt to 12pt, a 30% reduction. Readers of those scripts currently have no way to compensate: there is no zoom at all on macOS, and on Windows only the undiscoverable Ctrl+scroll that loses the reading position (#571).

The flattening is only safe *because* zoom replaces what it removes, so this should land as part of the beta 6 font cluster rather than ahead of #572.

Refs #42, #572.
