### PR TITLE
Harden the en/hi dictionary migration against deleting user content

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DataMigrationsTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DataMigrationsTests.cs
@@ -341,6 +341,7 @@ public class DataMigrationsTests : IDisposable
     [InlineData(".DS_Store")]
     [InlineData("Thumbs.db")]
     [InlineData("desktop.ini")]
+    [InlineData(".localized")]
     public void RemovesRetiredId_DespiteOperatingSystemJunkFiles(string junk)
     {
         // A dictionaries folder that was ever browsed in Finder or Explorer picks these up. Treating them
@@ -395,5 +396,50 @@ public class DataMigrationsTests : IDisposable
         var notes = DataMigrations.Run(state, Context(), migrations);
 
         Assert.Contains(notes, n => n.Contains(DataMigrations.FailureMarker, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void PartialSuccess_DeletesTheCleanDirectory_KeepsTheOther_AndRecordsNothing()
+    {
+        // The mixed case: one retired id is redundant, the other is not. The successful half must still
+        // happen, and the migration must stay unrecorded so the kept half is re-evaluated later.
+        SeededDictionary("en");
+        File.WriteAllText(Path.Combine(DataPath("en"), "my-glossary.txt"), "my own notes");
+        SeededDictionary("hi");
+        BundledDictionary("vri-childers");
+        BundledDictionary("vri-hindi");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context());
+
+        Assert.False(Directory.Exists(DataPath("hi")));   // clean: removed
+        Assert.True(Directory.Exists(DataPath("en")));    // has user content: kept
+        Assert.False(Applied(state));                     // unrecorded, so en/ gets another look
+    }
+
+    [Fact]
+    public void PartialSuccess_ReRunIsANoOpForTheHalfAlreadyDone()
+    {
+        // Because nothing was recorded, the whole migration runs again next launch. The already-deleted
+        // directory must not produce a second note or any further action.
+        SeededDictionary("en");
+        var glossary = Path.Combine(DataPath("en"), "my-glossary.txt");
+        File.WriteAllText(glossary, "my own notes");
+        SeededDictionary("hi");
+        BundledDictionary("vri-childers");
+        BundledDictionary("vri-hindi");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context());
+
+        var second = DataMigrations.Run(state, Context());
+        Assert.DoesNotContain(second, n => n.Contains("'hi'"));
+
+        // ...and once the blocker is gone, the remaining half completes and the migration is recorded.
+        File.Delete(glossary);
+        DataMigrations.Run(state, Context());
+
+        Assert.False(Directory.Exists(DataPath("en")));
+        Assert.True(Applied(state));
     }
 }

--- a/src/CST.Avalonia.Tests/Services/DataMigrationsTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DataMigrationsTests.cs
@@ -12,10 +12,13 @@ namespace CST.Avalonia.Tests.Services;
 // the superseded directories, and seeding only writes what is MISSING - so an install carried over from
 // beta 5 held both generations and the Settings Dictionary tab listed every entry twice.
 //
-// This migration DELETES user-visible content, so the guards matter more than the happy path: most of
+// This migration DELETES user-visible content, so the guards matter far more than the happy path: most of
 // these tests pin the cases where it must decline to act.
 public class DataMigrationsTests : IDisposable
 {
+    private const string TxtName = "dict.txt";
+    private const string ShippedContent = "word\ndefinition\n";
+
     private readonly string _root;
     private readonly string _data;
     private readonly string _bundled;
@@ -47,23 +50,32 @@ public class DataMigrationsTests : IDisposable
         return dir;
     }
 
-    private void SeededDictionary(string id, string txtName = "dict.txt")
+    private void SeededDictionary(string id, string content = ShippedContent)
     {
         var dir = DataDict(id);
-        File.WriteAllText(Path.Combine(dir, txtName), "word\ndefinition\n");
+        File.WriteAllText(Path.Combine(dir, TxtName), content);
         File.WriteAllText(Path.Combine(dir, "source.json"), "{}");
     }
 
-    private void BundledDictionary(string id)
+    // Redundancy is judged by byte-equality against what the app SHIPS, so the bundled copy has to carry
+    // the same file and content the seeded copy would.
+    private void BundledDictionary(string id, string content = ShippedContent)
     {
-        Directory.CreateDirectory(Path.Combine(_bundled, id));
+        var dir = Path.Combine(_bundled, id);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, TxtName), content);
+        File.WriteAllText(Path.Combine(dir, "source.json"), "{}");
     }
 
     private static bool Applied(ApplicationState s) =>
         s.AppliedDataMigrations.Contains("2026-08-retire-en-hi-dictionary-ids");
 
+    private string DataPath(string id) => Path.Combine(_data, "dictionaries", id);
+
+    // ===== the happy path =====
+
     [Fact]
-    public void RemovesRetiredIds_WhenTheAppShipsTheirReplacements()
+    public void RemovesRetiredIds_WhenTheyMatchWhatTheAppShips()
     {
         SeededDictionary("en");
         SeededDictionary("hi");
@@ -75,26 +87,72 @@ public class DataMigrationsTests : IDisposable
 
         DataMigrations.Run(state, Context());
 
-        Assert.False(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
-        Assert.False(Directory.Exists(Path.Combine(_data, "dictionaries", "hi")));
-        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "vri-childers")));
-        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "vri-hindi")));
+        Assert.False(Directory.Exists(DataPath("en")));
+        Assert.False(Directory.Exists(DataPath("hi")));
+        Assert.True(Directory.Exists(DataPath("vri-childers")));
+        Assert.True(Directory.Exists(DataPath("vri-hindi")));
         Assert.True(Applied(state));
     }
 
     [Fact]
-    public void RemovesRetiredId_EvenBeforeTheReplacementHasBeenSeeded()
+    public void RemovesRetiredId_EvenWhenTheReplacementIsNotInTheDataDirectoryYet()
     {
-        // The case that actually matters: on the first launch after upgrading, migrations run before
-        // DictionaryService seeds, so the replacement is not in the data directory yet. Keying off the
-        // BUNDLED copy is what makes the duplicate disappear that same session instead of the next one.
+        // Judged against the BUNDLED copy, so this does not depend on DictionaryService having seeded first.
         SeededDictionary("en");
         BundledDictionary("vri-childers");
         var state = new ApplicationState();
 
         DataMigrations.Run(state, Context());
 
-        Assert.False(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+        Assert.False(Directory.Exists(DataPath("en")));
+    }
+
+    [Fact]
+    public void RemovesRetiredId_WhenOnlySourceJsonDiffers()
+    {
+        // source.json is app-owned metadata that seeding already refreshes from the bundle, so a difference
+        // there is ours, not the user's - it must not block the cleanup.
+        SeededDictionary("en");
+        File.WriteAllText(Path.Combine(DataPath("en"), "source.json"), "{\"displayName\":\"older\"}");
+        BundledDictionary("vri-childers");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context());
+
+        Assert.False(Directory.Exists(DataPath("en")));
+    }
+
+    // ===== the guards that stop this deleting real content =====
+
+    [Fact]
+    public void KeepsRetiredId_WhenItHoldsAUserAddedDictionaryFile()
+    {
+        // The loader merges EVERY *.txt in a dictionary directory, so a glossary dropped into en/ is live
+        // content. An earlier draft whitelisted "any .txt" and would have deleted it.
+        SeededDictionary("en");
+        File.WriteAllText(Path.Combine(DataPath("en"), "my-glossary.txt"), "mine\nown notes\n");
+        BundledDictionary("vri-childers");
+        var state = new ApplicationState();
+
+        var notes = DataMigrations.Run(state, Context());
+
+        Assert.True(File.Exists(Path.Combine(DataPath("en"), "my-glossary.txt")));
+        Assert.Contains(notes, n => n.Contains("my-glossary.txt") && n.Contains("does not ship"));
+    }
+
+    [Fact]
+    public void KeepsRetiredId_WhenTheDictionaryFileWasEditedInPlace()
+    {
+        // Seeding is write-if-missing precisely so an existing install's data is never clobbered, so an
+        // edited dictionary keeps its edits - and the shipped replacement does not have them.
+        SeededDictionary("en", content: "word\nMY EDITED DEFINITION\n");
+        BundledDictionary("vri-childers", content: ShippedContent);
+        var state = new ApplicationState();
+
+        var notes = DataMigrations.Run(state, Context());
+
+        Assert.True(Directory.Exists(DataPath("en")));
+        Assert.Contains(notes, n => n.Contains("differs from the shipped copy"));
     }
 
     [Fact]
@@ -106,48 +164,81 @@ public class DataMigrationsTests : IDisposable
 
         var notes = DataMigrations.Run(state, Context());
 
-        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+        Assert.True(Directory.Exists(DataPath("en")));
         Assert.Contains(notes, n => n.Contains("does not ship"));
-    }
-
-    [Fact]
-    public void KeepsRetiredId_WhenItHoldsFilesWeDidNotSeed()
-    {
-        SeededDictionary("en");
-        File.WriteAllText(Path.Combine(_data, "dictionaries", "en", "notes.md"), "mine");
-        BundledDictionary("vri-childers");
-        var state = new ApplicationState();
-
-        var notes = DataMigrations.Run(state, Context());
-
-        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
-        Assert.Contains(notes, n => n.Contains("did not seed"));
     }
 
     [Fact]
     public void KeepsRetiredId_WhenItHoldsASubdirectory()
     {
         SeededDictionary("en");
-        Directory.CreateDirectory(Path.Combine(_data, "dictionaries", "en", "extra"));
+        Directory.CreateDirectory(Path.Combine(DataPath("en"), "extra"));
         BundledDictionary("vri-childers");
         var state = new ApplicationState();
 
-        DataMigrations.Run(state, Context());
+        var notes = DataMigrations.Run(state, Context());
 
-        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+        Assert.True(Directory.Exists(DataPath("en")));
+        Assert.Contains(notes, n => n.Contains("subdirectory"));
     }
 
+    // ===== runner contract: retry vs record =====
+
     [Fact]
-    public void DoesNothing_WhenTheBundledDictionariesCannotBeFound()
+    public void DoesNotRecordAMigrationThatDefers()
     {
-        // Without sight of what the app ships we cannot tell "superseded" from "the only copy".
+        // Without sight of the bundled dictionaries we cannot tell "superseded" from "the only copy". That
+        // is an environment problem, and recording it would forfeit the cleanup permanently.
         SeededDictionary("en");
         var state = new ApplicationState();
 
         var notes = DataMigrations.Run(state, Context(withBundled: false));
 
-        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
-        Assert.Contains(notes, n => n.Contains("bundled dictionaries not found"));
+        Assert.True(Directory.Exists(DataPath("en")));
+        Assert.False(Applied(state));
+        Assert.Contains(notes, n => n.Contains("deferring"));
+    }
+
+    [Fact]
+    public void RetriesADeferredMigration_AndSucceedsOnceTheEnvironmentIsReady()
+    {
+        SeededDictionary("en");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context(withBundled: false));
+        Assert.False(Applied(state));
+        Assert.True(Directory.Exists(DataPath("en")));
+
+        BundledDictionary("vri-childers");
+        DataMigrations.Run(state, Context());
+
+        Assert.True(Applied(state));
+        Assert.False(Directory.Exists(DataPath("en")));
+    }
+
+    [Fact]
+    public void AThrowingMigrationIsNotRecordedAndDoesNotBlockTheOthers()
+    {
+        var state = new ApplicationState();
+        var ran = new List<string>();
+        var migrations = new[]
+        {
+            new DataMigrations.Migration("boom", "throws",
+                (_, _) => throw new InvalidOperationException("nope")),
+            new DataMigrations.Migration("after", "runs anyway", (_, notes) =>
+            {
+                ran.Add("after");
+                notes.Add("after ran");
+                return DataMigrations.Outcome.Done;
+            }),
+        };
+
+        var notes = DataMigrations.Run(state, Context(), migrations);
+
+        Assert.Contains("after", ran);
+        Assert.DoesNotContain("boom", state.AppliedDataMigrations);
+        Assert.Contains("after", state.AppliedDataMigrations);
+        Assert.Contains(notes, n => n.Contains("FAILED") && n.Contains("nope"));
     }
 
     [Fact]
@@ -160,27 +251,29 @@ public class DataMigrationsTests : IDisposable
         DataMigrations.Run(state, Context());
         var idsAfterFirst = state.AppliedDataMigrations.ToList();
 
-        // A second pass must not re-record the id (and, re-created here, must not act again either).
+        // Re-created here: a second pass must neither re-record nor act again.
         SeededDictionary("en");
         var notes = DataMigrations.Run(state, Context());
 
         Assert.Equal(idsAfterFirst, state.AppliedDataMigrations);
         Assert.Empty(notes);
-        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "en")));
+        Assert.True(Directory.Exists(DataPath("en")));
     }
+
+    // ===== idempotency and edge cases =====
 
     [Fact]
     public void IsIdempotent_WhenTheRecordIsLostButTheWorkIsDone()
     {
-        // A data directory restored from backup, or a state file rolled back, can present an already-migrated
-        // tree with no record of it. Re-running must be harmless rather than destructive.
+        // A data directory restored from backup, or a state file rolled back, can present an
+        // already-migrated tree with no record of it. Re-running must be harmless.
         SeededDictionary("vri-childers");
         BundledDictionary("vri-childers");
         var state = new ApplicationState();
 
         DataMigrations.Run(state, Context());
 
-        Assert.True(Directory.Exists(Path.Combine(_data, "dictionaries", "vri-childers")));
+        Assert.True(Directory.Exists(DataPath("vri-childers")));
         Assert.True(Applied(state));
     }
 
@@ -193,6 +286,18 @@ public class DataMigrationsTests : IDisposable
 
         Assert.True(Applied(state));
         Assert.Contains(notes, n => n.Contains("nothing to do"));
+    }
+
+    [Fact]
+    public void ToleratesANullMigrationList()
+    {
+        // A hand-edited state file can null the property out.
+        var state = new ApplicationState { AppliedDataMigrations = null! };
+
+        DataMigrations.Run(state, Context());
+
+        Assert.NotNull(state.AppliedDataMigrations);
+        Assert.True(Applied(state));
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/DataMigrationsTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DataMigrationsTests.cs
@@ -9,8 +9,9 @@ using Xunit;
 namespace CST.Avalonia.Tests.Services;
 
 // #564: #522 renamed the bundled dictionary ids (en -> vri-childers, hi -> vri-hindi) but nothing removed
-// the superseded directories, and seeding only writes what is MISSING - so an install carried over from
-// beta 5 held both generations and the Settings Dictionary tab listed every entry twice.
+// the superseded directories, and seeding only writes what is MISSING - so an install that already had
+// them keeps both generations and the Settings Dictionary tab lists every entry twice. The affected
+// installs are development/source builds from 2026-07-01..07-27; no released build ever seeded en/hi.
 //
 // This migration DELETES user-visible content, so the guards matter far more than the happy path: most of
 // these tests pin the cases where it must decline to act.
@@ -138,6 +139,9 @@ public class DataMigrationsTests : IDisposable
 
         Assert.True(File.Exists(Path.Combine(DataPath("en"), "my-glossary.txt")));
         Assert.Contains(notes, n => n.Contains("my-glossary.txt") && n.Contains("does not ship"));
+        // Declining is not finishing: recording it would freeze the duplicate listing in permanently, even
+        // after the user removes the glossary.
+        Assert.False(Applied(state));
     }
 
     [Fact]
@@ -153,6 +157,7 @@ public class DataMigrationsTests : IDisposable
 
         Assert.True(Directory.Exists(DataPath("en")));
         Assert.Contains(notes, n => n.Contains("differs from the shipped copy"));
+        Assert.False(Applied(state));
     }
 
     [Fact]
@@ -166,6 +171,7 @@ public class DataMigrationsTests : IDisposable
 
         Assert.True(Directory.Exists(DataPath("en")));
         Assert.Contains(notes, n => n.Contains("does not ship"));
+        Assert.False(Applied(state));
     }
 
     [Fact]
@@ -180,6 +186,7 @@ public class DataMigrationsTests : IDisposable
 
         Assert.True(Directory.Exists(DataPath("en")));
         Assert.Contains(notes, n => n.Contains("subdirectory"));
+        Assert.False(Applied(state));
     }
 
     // ===== runner contract: retry vs record =====
@@ -306,5 +313,87 @@ public class DataMigrationsTests : IDisposable
         var ids = DataMigrations.All.Select(m => m.Id).ToList();
         Assert.Equal(ids.Count, ids.Distinct(StringComparer.Ordinal).Count());
         Assert.All(ids, id => Assert.False(string.IsNullOrWhiteSpace(id)));
+    }
+
+    [Fact]
+    public void CleansUpOnALaterLaunch_OnceTheReasonForKeepingIsGone()
+    {
+        // The point of not recording a decline: the user removes their added file, and the next launch
+        // finishes the job instead of the duplicate listing being frozen in forever.
+        SeededDictionary("en");
+        var glossary = Path.Combine(DataPath("en"), "my-glossary.txt");
+        File.WriteAllText(glossary, "my own notes");
+        BundledDictionary("vri-childers");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context());
+        Assert.True(Directory.Exists(DataPath("en")));
+        Assert.False(Applied(state));
+
+        File.Delete(glossary);
+        DataMigrations.Run(state, Context());
+
+        Assert.False(Directory.Exists(DataPath("en")));
+        Assert.True(Applied(state));
+    }
+
+    [Theory]
+    [InlineData(".DS_Store")]
+    [InlineData("Thumbs.db")]
+    [InlineData("desktop.ini")]
+    public void RemovesRetiredId_DespiteOperatingSystemJunkFiles(string junk)
+    {
+        // A dictionaries folder that was ever browsed in Finder or Explorer picks these up. Treating them
+        // as user content would make the migration a permanent no-op on exactly the developer installs it
+        // targets.
+        SeededDictionary("en");
+        File.WriteAllText(Path.Combine(DataPath("en"), junk), "junk");
+        BundledDictionary("vri-childers");
+        var state = new ApplicationState();
+
+        DataMigrations.Run(state, Context());
+
+        Assert.False(Directory.Exists(DataPath("en")));
+        Assert.True(Applied(state));
+    }
+
+    [Fact]
+    public void ADeferredMigrationDoesNotBlockLaterOnes()
+    {
+        var state = new ApplicationState();
+        var migrations = new[]
+        {
+            new DataMigrations.Migration("defers", "not ready", (_, notes) =>
+            {
+                notes.Add("deferred on purpose");
+                return DataMigrations.Outcome.Retry;
+            }),
+            new DataMigrations.Migration("after", "runs anyway", (_, notes) =>
+            {
+                notes.Add("after ran");
+                return DataMigrations.Outcome.Done;
+            }),
+        };
+
+        DataMigrations.Run(state, Context(), migrations);
+
+        Assert.DoesNotContain("defers", state.AppliedDataMigrations);
+        Assert.Contains("after", state.AppliedDataMigrations);
+    }
+
+    [Fact]
+    public void FailureNotesCarryTheSharedMarkerTheLoggerKeysOff()
+    {
+        // App.RunDataMigrationsAsync raises these to Error by matching DataMigrations.FailureMarker.
+        var state = new ApplicationState();
+        var migrations = new[]
+        {
+            new DataMigrations.Migration("boom", "throws",
+                (_, _) => throw new InvalidOperationException("nope")),
+        };
+
+        var notes = DataMigrations.Run(state, Context(), migrations);
+
+        Assert.Contains(notes, n => n.Contains(DataMigrations.FailureMarker, StringComparison.Ordinal));
     }
 }

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -606,9 +606,10 @@ public partial class App : Application
     }
 
     /// <summary>
-    // #564: apply any pending user-data migrations and persist the record of what ran. Failures are
-    // logged and left unrecorded so they retry next launch; they never block startup.
-    private static void RunDataMigrations(IApplicationStateService stateService)
+    /// #564: apply any pending user-data migrations and persist the record of what ran. A migration that
+    /// fails or defers is left unrecorded so it retries next launch; nothing here blocks startup.
+    /// </summary>
+    private static async Task RunDataMigrationsAsync(IApplicationStateService stateService)
     {
         try
         {
@@ -618,12 +619,27 @@ public partial class App : Application
                 BundledDictionariesDirectory = BundledResourceLocator.Resolve("dictionaries"),
             };
 
-            var notes = DataMigrations.Run(stateService.Current, context);
-            foreach (var note in notes)
-                Log.Information("Data migration: {Note}", note);
+            // Mutate state on the UI thread. ApplicationStateService's snapshot-free serialization rests on
+            // "all mutations happen on the UI thread" (STATE-2), and this runs on the startup background
+            // task - so without the hop, the 60-second save timer can serialize AppliedDataMigrations while
+            // the runner is still adding to it. Migrations themselves are I/O, but they are brief and this
+            // already runs before the window is interactive. (#564)
+            IReadOnlyList<string> notes = Array.Empty<string>();
+            await Dispatcher.UIThread.InvokeAsync(() => notes = DataMigrations.Run(stateService.Current, context));
 
-            // Only dirty the state when something was actually recorded, so a clean install does not
-            // rewrite the state file on every launch just to say nothing happened.
+            foreach (var note in notes)
+            {
+                // A failure is worth more than an Information line: it means a migration will be retried
+                // and may keep failing, which nobody will notice buried among ordinary startup chatter.
+                if (note.Contains("FAILED", StringComparison.Ordinal))
+                    Log.Error("Data migration: {Note}", note);
+                else
+                    Log.Information("Data migration: {Note}", note);
+            }
+
+            // Any note at all means the runner touched the record (applied an id) or has something worth
+            // persisting a retry for, so dirty the state. A clean install still produces the "nothing to
+            // do" note, which is what gets the id written down the first time.
             if (notes.Count > 0)
                 stateService.MarkDirty();
         }
@@ -648,11 +664,15 @@ public partial class App : Application
                 
                 await stateService.LoadStateAsync();
 
-                // #564: migrate the user DATA directory before anything reads it. Runs here rather
-                // than inside a service so ordering is explicit: DictionaryService seeds on
-                // construction, and a migration that needed the seeded result would be too late on
-                // the very launch that matters (the first one after an upgrade).
-                RunDataMigrations(stateService);
+                // #564: migrate the user DATA directory, in one explicit place rather than scattered
+                // through the services that own each part of it.
+                //
+                // Do NOT read an ordering guarantee into this position. DictionaryService is already
+                // constructed (and has already seeded) by the time this runs - it is resolved during
+                // layout creation, well before this startup task - so this is not "before anything reads
+                // the data". A migration must therefore be safe to run against a data directory that is
+                // already live, and must not depend on running before or after any particular service.
+                await RunDataMigrationsAsync(stateService);
 
                 // Manually handle initial state restoration without StateChanged events
                 await InitializeFromLoadedState(stateService.Current);

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -631,15 +631,16 @@ public partial class App : Application
             {
                 // A failure is worth more than an Information line: it means a migration will be retried
                 // and may keep failing, which nobody will notice buried among ordinary startup chatter.
-                if (note.Contains("FAILED", StringComparison.Ordinal))
+                if (note.Contains(DataMigrations.FailureMarker, StringComparison.Ordinal))
                     Log.Error("Data migration: {Note}", note);
                 else
                     Log.Information("Data migration: {Note}", note);
             }
 
-            // Any note at all means the runner touched the record (applied an id) or has something worth
-            // persisting a retry for, so dirty the state. A clean install still produces the "nothing to
-            // do" note, which is what gets the id written down the first time.
+            // Dirty the state whenever anything happened. Strictly this over-fires: a deferral or a failure
+            // records nothing, so those launches rewrite an unchanged file. That is one cheap write on a
+            // launch that already had something go wrong, and the alternative - inspecting the notes to
+            // guess whether an id was added - would couple this to the note wording again.
             if (notes.Count > 0)
                 stateService.MarkDirty();
         }

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -637,10 +637,12 @@ public partial class App : Application
                     Log.Information("Data migration: {Note}", note);
             }
 
-            // Dirty the state whenever anything happened. Strictly this over-fires: a deferral or a failure
-            // records nothing, so those launches rewrite an unchanged file. That is one cheap write on a
-            // launch that already had something go wrong, and the alternative - inspecting the notes to
-            // guess whether an id was added - would couple this to the note wording again.
+            // Dirty the state whenever anything happened. Strictly this over-fires: a deferral records
+            // nothing, so that launch rewrites an unchanged file. And for an install that deliberately
+            // keeps a retired directory - a glossary of its own in en/ - the deferral is the steady state,
+            // so that redundant write recurs every launch rather than being a one-off after something went
+            // wrong. One small file write at startup is not worth the alternative, which would mean
+            // inspecting the notes to guess whether an id was added and coupling this to their wording.
             if (notes.Count > 0)
                 stateService.MarkDirty();
         }

--- a/src/CST.Avalonia/Services/DataMigrations.cs
+++ b/src/CST.Avalonia/Services/DataMigrations.cs
@@ -44,9 +44,15 @@ public static class DataMigrations
         Done,
 
         /// <summary>
-        /// The environment was not in a state where the migration could decide safely - not a failure, and
-        /// not "nothing to do". Leave it UNRECORDED so it re-attempts next launch. Recording an environment
-        /// problem would forfeit the migration permanently on the strength of one bad launch.
+        /// Either the migration could not decide safely, or it decided AGAINST acting for a reason that
+        /// may later stop applying. Not a failure, and not "nothing to do". Leave it UNRECORDED so it
+        /// re-evaluates next launch.
+        ///
+        /// Both halves matter. Recording an environment problem would forfeit the migration permanently on
+        /// the strength of one bad launch; recording a deliberate decline would freeze that decision in
+        /// even after the reason disappeared - the user removes the file that blocked it, or a later
+        /// release ships content that now matches. A migration that declines should return this, not
+        /// <see cref="Done"/>.
         /// </summary>
         Retry,
     }
@@ -131,7 +137,7 @@ public static class DataMigrations
     /// enumerates directories, and each retired id carries the same displayName as its replacement, every
     /// affected install lists each dictionary twice. (#564)
     ///
-    /// Who is actually affected: builds from between 2026-07-01 (6f9548b, when seeding was introduced) and
+    /// Who is actually affected: builds from between 2026-07-01 (3ce8e63, when seeding was introduced) and
     /// 2026-07-27 (9e046cd, the rename). NO released build ever seeded en/hi - the rename landed the day
     /// before the beta 5 tag, and betas 1-4 shipped no bundled dictionaries at all. So this targets
     /// development and source installs, not upgraders from a release. An earlier version of this comment
@@ -238,7 +244,10 @@ public static class DataMigrations
 
             if (!FilesEqual(file, counterpart))
             {
-                reason = $"'{name}' differs from the shipped copy (edited in place?)";
+                // Deliberately does not accuse the user: an install seeded before 3dd483e (2026-07-05,
+                // a one-line fix to the English dictionary) holds the older bytes through no action of
+                // theirs, and seeding is write-if-missing so it kept them.
+                reason = $"'{name}' differs from the shipped copy (edited, or seeded by an older build)";
                 return false;
             }
         }

--- a/src/CST.Avalonia/Services/DataMigrations.cs
+++ b/src/CST.Avalonia/Services/DataMigrations.cs
@@ -10,23 +10,23 @@ namespace CST.Avalonia.Services;
 /// One-time migrations of the user DATA directory (dictionaries, downloaded assets, indexes).
 ///
 /// Distinct from <see cref="ApplicationStateValidator.Migrate"/>, which upgrades the shape of the state
-/// FILE and is deliberately pure. These reshape what sits on disk around it, so they do I/O — but they
+/// FILE and is deliberately pure. These reshape what sits on disk around it, so they do I/O - but they
 /// stay free of DI and of app services so they remain directly unit-testable against a temp directory.
 ///
 /// Applied migrations are recorded by id in <see cref="ApplicationState.AppliedDataMigrations"/>, so each
 /// runs exactly once. Ids are permanent: renaming one re-runs it on every existing install.
 ///
-/// **Write every migration to be idempotent anyway.** The recorded id is the primary guard, but a
+/// <b>Write every migration to be idempotent anyway.</b> The recorded id is the primary guard, but a
 /// migration can also meet a half-finished state from an interrupted run, or a data directory restored
 /// from backup while the state file moved on. Belt and braces is cheap here; a destructive migration that
 /// assumes it is running on a pristine "before" state is not.
 /// </summary>
 public static class DataMigrations
 {
-    /// <summary>Inputs a migration may act on. No services, no DI — everything is a plain path.</summary>
+    /// <summary>Inputs a migration may act on. No services, no DI - everything is a plain path.</summary>
     public sealed class Context
     {
-        /// <summary>The user data root (…/CSTReader).</summary>
+        /// <summary>The user data root (.../CSTReader).</summary>
         public required string DataDirectory { get; init; }
 
         /// <summary>
@@ -37,7 +37,21 @@ public static class DataMigrations
         public string? BundledDictionariesDirectory { get; init; }
     }
 
-    public sealed record Migration(string Id, string Description, Action<Context, List<string>> Apply);
+    /// <summary>What the runner should do with a migration once it returns.</summary>
+    public enum Outcome
+    {
+        /// <summary>Work is done, or provably unnecessary. Record it; never run again.</summary>
+        Done,
+
+        /// <summary>
+        /// The environment was not in a state where the migration could decide safely - not a failure, and
+        /// not "nothing to do". Leave it UNRECORDED so it re-attempts next launch. Recording an environment
+        /// problem would forfeit the migration permanently on the strength of one bad launch.
+        /// </summary>
+        Retry,
+    }
+
+    public sealed record Migration(string Id, string Description, Func<Context, List<string>, Outcome> Apply);
 
     /// <summary>Ordered. Append new migrations; never renumber or rename existing ids.</summary>
     public static readonly IReadOnlyList<Migration> All = new List<Migration>
@@ -49,17 +63,24 @@ public static class DataMigrations
 
     /// <summary>
     /// Apply any migrations not yet recorded in <paramref name="state"/>, in order. Returns human-readable
-    /// notes for logging. A failing migration is recorded as failed and does NOT block the others, and is
-    /// NOT marked applied — so it will be retried next launch rather than silently skipped forever.
+    /// notes for logging.
+    ///
+    /// A migration returning <see cref="Outcome.Retry"/>, or throwing, is NOT recorded and re-attempts next
+    /// launch rather than being silently skipped forever. A throwing migration does not block the others.
     /// </summary>
-    public static IReadOnlyList<string> Run(ApplicationState state, Context context)
+    public static IReadOnlyList<string> Run(ApplicationState state, Context context) =>
+        Run(state, context, All);
+
+    // Overload taking the migration list so tests can drive the runner itself - the failure and retry paths
+    // are part of the contract and are not reachable through the fixed static list.
+    internal static IReadOnlyList<string> Run(ApplicationState state, Context context, IEnumerable<Migration> migrations)
     {
         var notes = new List<string>();
         if (state == null) return notes;
 
         var applied = state.AppliedDataMigrations ??= new List<string>();
 
-        foreach (var migration in All)
+        foreach (var migration in migrations)
         {
             if (applied.Contains(migration.Id, StringComparer.Ordinal))
                 continue;
@@ -67,11 +88,21 @@ public static class DataMigrations
             try
             {
                 var before = notes.Count;
-                migration.Apply(context, notes);
+                var outcome = migration.Apply(context, notes);
+
+                if (outcome == Outcome.Retry)
+                {
+                    if (notes.Count == before)
+                        notes.Add($"migration {migration.Id}: deferred, will retry next launch");
+                    continue;
+                }
+
                 applied.Add(migration.Id);
 
                 // Only announce migrations that actually did something; a no-op on a clean install is the
-                // common case and does not deserve a line in everyone's log.
+                // common case and does not deserve a line in everyone's log. This note is also what makes
+                // notes.Count > 0 on a clean install, which is what gets the record persisted at all - do
+                // not make it conditional.
                 if (notes.Count == before)
                     notes.Add($"migration {migration.Id}: nothing to do");
             }
@@ -87,30 +118,37 @@ public static class DataMigrations
     // ===== migrations =====
 
     /// <summary>
-    /// #522 renamed the bundled dictionary ids (en → vri-childers, hi → vri-hindi) but nothing removed the
+    /// #522 renamed the bundled dictionary ids (en to vri-childers, hi to vri-hindi) but nothing removed the
     /// superseded directories from an existing install, and seeding only ever writes what is MISSING. So an
     /// install carried over from beta 5 ends up with both generations on disk. Because
     /// <c>DictionaryService.AvailableLanguages</c> enumerates directories, and each retired id carries the
     /// same displayName as its replacement, every affected user sees each dictionary listed twice. (#564)
     ///
-    /// Deliberately keyed off the BUNDLED dictionaries, not the seeded ones. On the first launch after
-    /// upgrading, the replacement has not been seeded into the data directory yet — migrations run before
-    /// DictionaryService is constructed — so a check against the data directory would find no replacement,
-    /// do nothing, and leave the duplicates visible for that whole session.
+    /// Keyed off the BUNDLED dictionaries rather than the seeded copy in the data directory. Both happen to
+    /// be present by the time this runs today - DictionaryService is constructed during layout creation,
+    /// well before the state load this hangs off - but that ordering is an accident of DI resolution and not
+    /// something a destructive migration should depend on. What the app SHIPS is the stable fact.
+    ///
+    /// Downgrade note: beta 5 re-seeds en/hi from its own bundle, and its serializer drops the unknown
+    /// appliedDataMigrations property when it next saves - so downgrade-then-upgrade usually erases the
+    /// record and this simply runs again. If beta 5 never rewrites the state file, the duplicates return
+    /// and stay.
     /// </summary>
-    private static void RetireEnHiDictionaryIds(Context context, List<string> notes)
+    private static Outcome RetireEnHiDictionaryIds(Context context, List<string> notes)
     {
         var retired = new (string Old, string New)[] { ("en", "vri-childers"), ("hi", "vri-hindi") };
 
-        var dictionaries = Path.Combine(context.DataDirectory, "dictionaries");
-        if (!Directory.Exists(dictionaries)) return;
-
-        // Without sight of the bundled dictionaries we cannot tell "superseded" from "the only copy".
+        // Without sight of the bundled dictionaries we cannot tell "superseded" from "the only copy". That
+        // is an environment problem (an odd install layout, an unreadable ancestor), not a decision - so
+        // retry rather than record, or one bad launch forfeits the cleanup permanently.
         if (context.BundledDictionariesDirectory is not { } bundled || !Directory.Exists(bundled))
         {
-            notes.Add("retire-en-hi: bundled dictionaries not found; leaving the data directory alone");
-            return;
+            notes.Add("retire-en-hi: bundled dictionaries not found; deferring (will retry next launch)");
+            return Outcome.Retry;
         }
+
+        var dictionaries = Path.Combine(context.DataDirectory, "dictionaries");
+        if (!Directory.Exists(dictionaries)) return Outcome.Done;
 
         foreach (var (oldId, newId) in retired)
         {
@@ -118,33 +156,82 @@ public static class DataMigrations
             if (!Directory.Exists(oldDir)) continue;
 
             // The app must actually ship the replacement, or removing the old one loses the dictionary.
-            if (!Directory.Exists(Path.Combine(bundled, newId)))
+            var replacement = Path.Combine(bundled, newId);
+            if (!Directory.Exists(replacement))
             {
-                notes.Add($"retire-en-hi: '{oldId}' kept — the app does not ship '{newId}'");
+                notes.Add($"retire-en-hi: '{oldId}' kept - the app does not ship '{newId}'");
                 continue;
             }
 
-            // Only remove what we put there. Anything else means the user (or a future drop-in source) has
-            // added files, and a rename cleanup has no business deleting those.
-            var unexpected = Directory.EnumerateFiles(oldDir)
-                .Select(Path.GetFileName)
-                .Where(name => !IsSeededFileName(name))
-                .ToList();
-            if (unexpected.Count > 0 || Directory.EnumerateDirectories(oldDir).Any())
+            if (RedundantAgainst(oldDir, replacement, out var reason))
             {
-                notes.Add($"retire-en-hi: '{oldId}' kept — it holds files we did not seed ({string.Join(", ", unexpected)})");
-                continue;
+                Directory.Delete(oldDir, recursive: true);
+                notes.Add($"retire-en-hi: removed superseded dictionary id '{oldId}' (replaced by '{newId}')");
             }
-
-            Directory.Delete(oldDir, recursive: true);
-            notes.Add($"retire-en-hi: removed superseded dictionary id '{oldId}' (replaced by '{newId}')");
+            else
+            {
+                notes.Add($"retire-en-hi: '{oldId}' kept - {reason}");
+            }
         }
+
+        return Outcome.Done;
     }
 
-    // The only files seeding ever writes into a bundled dictionary directory: the flat-file dictionary
-    // itself and the app-owned source.json metadata.
-    private static bool IsSeededFileName(string? name) =>
-        name is not null &&
-        (name.EndsWith(".txt", StringComparison.OrdinalIgnoreCase) ||
-         string.Equals(name, "source.json", StringComparison.OrdinalIgnoreCase));
+    /// <summary>
+    /// True only when every file in <paramref name="oldDir"/> is provably reproduced by
+    /// <paramref name="replacement"/>, so deleting it cannot lose anything.
+    ///
+    /// Name-matching alone is not enough, and an earlier draft got this wrong by treating any *.txt as
+    /// "ours". Two ways that loses real data:
+    ///   - the loader merges EVERY *.txt in a dictionary directory, so a user's own glossary dropped into
+    ///     en/ is live content, not leftovers;
+    ///   - seeding is write-if-missing precisely so an existing install's data is never clobbered, so a
+    ///     user-EDITED dictionary file keeps its edits - and the shipped replacement does not have them.
+    /// Requiring byte equality against what the app ships covers both: anything added or changed fails the
+    /// comparison and the directory is kept.
+    ///
+    /// source.json is exempt because it is app-owned metadata that seeding already refreshes from the
+    /// bundle whenever it differs (see <see cref="DictionaryService.SeedDictionaries"/>), so a difference
+    /// there is ours, not the user's.
+    /// </summary>
+    private static bool RedundantAgainst(string oldDir, string replacement, out string reason)
+    {
+        if (Directory.EnumerateDirectories(oldDir).Any())
+        {
+            reason = "it holds a subdirectory we did not create";
+            return false;
+        }
+
+        foreach (var file in Directory.EnumerateFiles(oldDir))
+        {
+            var name = Path.GetFileName(file);
+
+            if (string.Equals(name, "source.json", StringComparison.OrdinalIgnoreCase))
+                continue;   // app-owned metadata, refreshed from the bundle anyway
+
+            var counterpart = Path.Combine(replacement, name);
+            if (!File.Exists(counterpart))
+            {
+                reason = $"it holds '{name}', which the app does not ship";
+                return false;
+            }
+
+            if (!FilesEqual(file, counterpart))
+            {
+                reason = $"'{name}' differs from the shipped copy (edited in place?)";
+                return false;
+            }
+        }
+
+        reason = "";
+        return true;
+    }
+
+    private static bool FilesEqual(string a, string b)
+    {
+        var fa = new FileInfo(a);
+        var fb = new FileInfo(b);
+        if (!fa.Exists || !fb.Exists || fa.Length != fb.Length) return false;
+        return File.ReadAllBytes(a).AsSpan().SequenceEqual(File.ReadAllBytes(b));
+    }
 }

--- a/src/CST.Avalonia/Services/DataMigrations.cs
+++ b/src/CST.Avalonia/Services/DataMigrations.cs
@@ -51,6 +51,13 @@ public static class DataMigrations
         Retry,
     }
 
+    /// <summary>
+    /// Marks a note describing a migration that threw. The startup logger keys its Error level off this,
+    /// so it lives here rather than being spelled out at both ends - a reworded note would otherwise
+    /// silently demote failures back to Information.
+    /// </summary>
+    public const string FailureMarker = "FAILED";
+
     public sealed record Migration(string Id, string Description, Func<Context, List<string>, Outcome> Apply);
 
     /// <summary>Ordered. Append new migrations; never renumber or rename existing ids.</summary>
@@ -108,7 +115,7 @@ public static class DataMigrations
             }
             catch (Exception ex)
             {
-                notes.Add($"migration {migration.Id} FAILED (will retry next launch): {ex.Message}");
+                notes.Add($"migration {migration.Id} {FailureMarker} (will retry next launch): {ex.Message}");
             }
         }
 
@@ -119,20 +126,21 @@ public static class DataMigrations
 
     /// <summary>
     /// #522 renamed the bundled dictionary ids (en to vri-childers, hi to vri-hindi) but nothing removed the
-    /// superseded directories from an existing install, and seeding only ever writes what is MISSING. So an
-    /// install carried over from beta 5 ends up with both generations on disk. Because
-    /// <c>DictionaryService.AvailableLanguages</c> enumerates directories, and each retired id carries the
-    /// same displayName as its replacement, every affected user sees each dictionary listed twice. (#564)
+    /// superseded directories from an install that already had them, and seeding only ever writes what is
+    /// MISSING - so both generations end up on disk. Because <c>DictionaryService.AvailableLanguages</c>
+    /// enumerates directories, and each retired id carries the same displayName as its replacement, every
+    /// affected install lists each dictionary twice. (#564)
+    ///
+    /// Who is actually affected: builds from between 2026-07-01 (6f9548b, when seeding was introduced) and
+    /// 2026-07-27 (9e046cd, the rename). NO released build ever seeded en/hi - the rename landed the day
+    /// before the beta 5 tag, and betas 1-4 shipped no bundled dictionaries at all. So this targets
+    /// development and source installs, not upgraders from a release. An earlier version of this comment
+    /// claimed beta 5 was the source, which git disproves.
     ///
     /// Keyed off the BUNDLED dictionaries rather than the seeded copy in the data directory. Both happen to
     /// be present by the time this runs today - DictionaryService is constructed during layout creation,
     /// well before the state load this hangs off - but that ordering is an accident of DI resolution and not
     /// something a destructive migration should depend on. What the app SHIPS is the stable fact.
-    ///
-    /// Downgrade note: beta 5 re-seeds en/hi from its own bundle, and its serializer drops the unknown
-    /// appliedDataMigrations property when it next saves - so downgrade-then-upgrade usually erases the
-    /// record and this simply runs again. If beta 5 never rewrites the state file, the duplicates return
-    /// and stay.
     /// </summary>
     private static Outcome RetireEnHiDictionaryIds(Context context, List<string> notes)
     {
@@ -150,6 +158,8 @@ public static class DataMigrations
         var dictionaries = Path.Combine(context.DataDirectory, "dictionaries");
         if (!Directory.Exists(dictionaries)) return Outcome.Done;
 
+        var kept = false;
+
         foreach (var (oldId, newId) in retired)
         {
             var oldDir = Path.Combine(dictionaries, oldId);
@@ -160,6 +170,7 @@ public static class DataMigrations
             if (!Directory.Exists(replacement))
             {
                 notes.Add($"retire-en-hi: '{oldId}' kept - the app does not ship '{newId}'");
+                kept = true;
                 continue;
             }
 
@@ -171,10 +182,16 @@ public static class DataMigrations
             else
             {
                 notes.Add($"retire-en-hi: '{oldId}' kept - {reason}");
+                kept = true;
             }
         }
 
-        return Outcome.Done;
+        // A directory we declined to remove is NOT a finished job. Recording Done here would freeze that
+        // decision forever: the duplicate listing would persist for the life of the install even after the
+        // reason disappeared - the user deletes their added glossary, or a later release ships bytes that
+        // match again. Re-evaluating costs one directory-existence check per launch, and every precondition
+        // is re-read from disk each time, so the retry can never act on a stale decision.
+        return kept ? Outcome.Retry : Outcome.Done;
     }
 
     /// <summary>
@@ -209,6 +226,9 @@ public static class DataMigrations
             if (string.Equals(name, "source.json", StringComparison.OrdinalIgnoreCase))
                 continue;   // app-owned metadata, refreshed from the bundle anyway
 
+            if (IsOperatingSystemJunk(name))
+                continue;   // see below - not content, and not a reason to keep a superseded directory
+
             var counterpart = Path.Combine(replacement, name);
             if (!File.Exists(counterpart))
             {
@@ -226,6 +246,21 @@ public static class DataMigrations
         reason = "";
         return true;
     }
+
+    /// <summary>
+    /// Files the operating system drops into any folder a user browses. They are not content, and treating
+    /// them as "something we did not ship" would make the migration decline permanently on precisely the
+    /// machines it targets - a developer install whose dictionaries folder was ever opened in Finder picks
+    /// up a .DS_Store and would then never be cleaned up.
+    ///
+    /// Only these exact names, and they are deleted along with the directory rather than preserved: the
+    /// OS regenerates them on demand and they carry nothing the user would miss.
+    /// </summary>
+    private static bool IsOperatingSystemJunk(string name) =>
+        string.Equals(name, ".DS_Store", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, "Thumbs.db", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, "desktop.ini", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, ".localized", StringComparison.OrdinalIgnoreCase);
 
     private static bool FilesEqual(string a, string b)
     {

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -131,11 +131,37 @@ public sealed class DictionaryService : IDictionaryService
             // (dpd-cst-subset, dppn) now live under this same root so all dictionaries share one directory,
             // and they hold .db files — without this filter they'd be reported as flat-file dictionaries and
             // the loader would try to parse SQLite as headword/definition line pairs.
-            return Directory.EnumerateDirectories(_dictionariesDirectory)
-                .Where(dir => Directory.EnumerateFiles(dir, "*.txt").Any())
-                .Select(dir => Path.GetFileName(dir))
-                .OrderBy(name => name, StringComparer.Ordinal)
-                .ToList();
+            try
+            {
+                return Directory.EnumerateDirectories(_dictionariesDirectory)
+                    .Where(dir => HasFlatFileDictionary(dir))
+                    .Select(dir => Path.GetFileName(dir))
+                    .OrderBy(name => name, StringComparer.Ordinal)
+                    .ToList();
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // A directory vanished mid-enumeration. Data migrations delete retired dictionary ids on a
+                // background thread while the registry, the local API and the dictionary panel can all be
+                // reading this property, so the window is small but real. Reporting "no dictionaries" for
+                // one call is recoverable - every caller re-reads - whereas letting it escape surfaces as a
+                // failure in whatever happened to be asking. (#564)
+                return Array.Empty<string>();
+            }
+        }
+    }
+
+    // Same "is this a flat-file dictionary?" test as above, with the same tolerance for a directory being
+    // removed underneath us mid-enumeration.
+    private static bool HasFlatFileDictionary(string dir)
+    {
+        try
+        {
+            return Directory.EnumerateFiles(dir, "*.txt").Any();
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return false;
         }
     }
 

--- a/src/CST.Avalonia/Services/DictionaryService.cs
+++ b/src/CST.Avalonia/Services/DictionaryService.cs
@@ -141,11 +141,12 @@ public sealed class DictionaryService : IDictionaryService
             }
             catch (DirectoryNotFoundException)
             {
-                // A directory vanished mid-enumeration. Data migrations delete retired dictionary ids on a
-                // background thread while the registry, the local API and the dictionary panel can all be
-                // reading this property, so the window is small but real. Reporting "no dictionaries" for
-                // one call is recoverable - every caller re-reads - whereas letting it escape surfaces as a
-                // failure in whatever happened to be asking. (#564)
+                // A directory vanished mid-enumeration. Data migrations delete retired dictionary ids at
+                // startup, and while that now runs on the UI thread, this property is read off it too - the
+                // source registry is a lazily-resolved singleton and the local dictionary API serves
+                // requests on its own threads. The window is small but real. Reporting "no dictionaries" for
+                // one call is recoverable, since every caller re-reads, whereas letting it escape surfaces
+                // as a failure in whatever happened to be asking. (#564)
                 return Array.Empty<string>();
             }
         }


### PR DESCRIPTION
Follow-up to #569, **already merged** — so the version this fixes is on `main`. Two review passes; both sets of findings addressed.

## Pass 1 — the data-loss bug

The guard accepted any `*.txt` as "one of ours", but seeding never wrote "any .txt" — only the two named dictionaries plus `source.json`. Two ways that lost real data:

- **`DictionaryService` merges EVERY `*.txt`** in a dictionary directory, so a glossary dropped into `en/` is live content the app is reading.
- **Seeding is write-if-missing** precisely so an install's data is never clobbered — so a user-*edited* dictionary keeps its edits, which the shipped replacement doesn't have.

Redundancy is now decided by **byte equality against what the app ships**. A retired directory is removed only when every file in it is reproduced exactly by the bundled replacement; anything added or changed keeps the directory. Verified on a real install: `en/` kept because of a planted `my-glossary.txt`, byte-identical `hi/` cleaned up. **The merged version would have deleted the glossary.**

Also from pass 1: `Retry` outcome so an environment failure isn't recorded; enumeration race in `AvailableLanguages` guarded; state mutation moved onto the UI thread (STATE-2); orphaned `/// <summary>` repaired; FAILED notes raised to `Error`; internal `Run` overload so the failure/retry paths are testable.

## Pass 2 — a declined cleanup was frozen forever

Any "kept" verdict returned `Done`, recording the migration and never re-evaluating — so the duplicate listing would persist for the life of the install even after the reason disappeared. Declining now returns `Retry`. Cost is one directory-existence check per launch, and every precondition is re-read from disk, so a retry can't act on a stale decision.

Two realistic triggers made that permanence worse than theoretical:

- **OS junk** — a `.DS_Store`, `Thumbs.db` or `desktop.ini` in a folder that was ever browsed failed the "app doesn't ship this" check and permanently blocked cleanup on exactly the installs this targets. Those names are now exempt and removed with the directory.
- **Stale shipped content** — `3dd483e` (2026-07-05) changed one line of the English dictionary; an install seeded just before that keeps the older bytes and fails the comparison. Now recoverable rather than permanent.

## The affected-cohort claim was wrong

`git ls-tree v5.0.0-beta.5` shows beta 5 shipping `vri-childers`/`vri-hindi` **only** — the rename (`9e046cd`) landed 07-27, the day before the 07-28 tag, and betas 1–4 bundled no dictionaries at all.

**No released build ever seeded `en`/`hi`.** The installs holding both generations are development and source builds from 2026-07-01…07-27 — not upgraders from a release, as the comment, the tests and #569's description all claimed. The downgrade note went further and described an impossible mechanism ("beta 5 re-seeds en/hi from its own bundle" — beta 5 has no `en`/`hi` to re-seed); removed rather than reworded.

In practice that makes this migration close to a no-op today: the maintainer's own dev VM is the known affected install. Its value is the mechanism and the guards, for when users do start running builds between releases.

Also corrected: the new `DictionaryService` comment justified its catch by saying migrations delete "on a background thread" — when this same change had just moved them to the UI thread. The catch is still warranted (lazily-resolved singleton; local API reads off-UI-thread), so the reasoning is fixed rather than the code.

## Tests

10 → 21, weighted toward refusals rather than the happy path.

Pass 2 found the permanence contract entirely unpinned: none of the "keeps" tests asserted whether the id was recorded, so either behaviour would have passed. All four now assert it, plus a decline cleaned up on a later launch once the added file is gone, the three junk filenames, a deferral not blocking later migrations, and failure notes carrying the shared marker.

**1036/1036 pass.**
