### PR TITLE
#578: the surface B provider layer — Anthropic Messages + OpenAI-compatible

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Tests.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// The Anthropic adapter against recorded SSE. No network, no key, no spend — the wire format is replayed
+/// verbatim, so these pin the parts of the contract a live smoke test would not reach: the failure taxonomy,
+/// a stream that dies mid-answer, and the request shape. (#578)
+/// </summary>
+public class AnthropicMessagesProviderTests
+{
+    private static AnthropicMessagesProvider Provider(
+        StubHttpMessageHandler handler, string? key = "sk-test", string? baseUrl = null, TimeSpan? idle = null) =>
+        new(new HttpClient(handler), new AnthropicOptions(key, baseUrl),
+            NullLogger<AnthropicMessagesProvider>.Instance, idle);
+
+    private static ChatRequest Request(string? system = null) =>
+        new("claude-opus-5", 1024, system, new[] { new ChatMessage(ChatRole.User, "Explain this passage.") });
+
+    private static async Task<List<ChatDelta>> CollectAsync(
+        IChatProvider provider, ChatRequest? request = null, CancellationToken ct = default)
+    {
+        var deltas = new List<ChatDelta>();
+        await foreach (var delta in provider.StreamAsync(request ?? Request(), ct))
+            deltas.Add(delta);
+        return deltas;
+    }
+
+    private static string Text(IEnumerable<ChatDelta> deltas) =>
+        string.Concat(deltas.Where(d => d.Kind == ChatDeltaKind.Text).Select(d => d.Text));
+
+    private static string Reasoning(IEnumerable<ChatDelta> deltas) =>
+        string.Concat(deltas.Where(d => d.Kind == ChatDeltaKind.Reasoning).Select(d => d.Text));
+
+    private const string HappyStream = """
+        event: message_start
+        data: {"type":"message_start","message":{"usage":{"input_tokens":412}}}
+
+        event: content_block_start
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Heedfulness "}}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"is the path."}}
+
+        event: message_delta
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":37}}
+
+        event: message_stop
+        data: {"type":"message_stop"}
+
+        """;
+
+    [Fact]
+    public async Task Streams_text_deltas_in_order()
+    {
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(HappyStream)));
+
+        Assert.Equal("Heedfulness is the path.", Text(deltas));
+        Assert.DoesNotContain(deltas, d => d.Kind == ChatDeltaKind.Error);
+    }
+
+    [Fact]
+    public async Task Reports_usage_from_both_ends_of_the_stream()
+    {
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(HappyStream)));
+        var usage = deltas.Where(d => d.Kind == ChatDeltaKind.Usage).Select(d => d.Usage!).ToList();
+
+        Assert.Contains(usage, u => u.InputTokens == 412);
+        Assert.Contains(usage, u => u.OutputTokens == 37);
+    }
+
+    [Fact]
+    public async Task Thinking_deltas_are_segregated_from_the_answer()
+    {
+        const string stream = """
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"The compound is a dvanda."}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"It means X."}}
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("It means X.", Text(deltas));
+        Assert.Equal("The compound is a dvanda.", Reasoning(deltas));
+    }
+
+    [Fact]
+    public async Task Request_carries_max_tokens_and_no_sampling_parameters()
+    {
+        // max_tokens is required by the API; temperature/top_p/top_k are REJECTED with a 400 by current models.
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        await CollectAsync(Provider(handler), Request(system: "You are a Pali reading assistant."));
+
+        using var body = JsonDocument.Parse(handler.LastRequestBody);
+        var root = body.RootElement;
+
+        Assert.Equal(1024, root.GetProperty("max_tokens").GetInt32());
+        Assert.True(root.GetProperty("stream").GetBoolean());
+        Assert.Equal("You are a Pali reading assistant.", root.GetProperty("system").GetString());
+        Assert.False(root.TryGetProperty("temperature", out _));
+        Assert.False(root.TryGetProperty("top_p", out _));
+        Assert.False(root.TryGetProperty("top_k", out _));
+    }
+
+    [Fact]
+    public async Task Request_carries_the_api_key_and_version_headers()
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        await CollectAsync(Provider(handler));
+
+        Assert.Equal("sk-test", handler.LastRequest!.Headers.GetValues("x-api-key").Single());
+        Assert.Equal("2023-06-01", handler.LastRequest.Headers.GetValues("anthropic-version").Single());
+    }
+
+    [Fact]
+    public async Task A_missing_key_fails_before_any_request_is_made()
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler, key: null)));
+
+        Assert.Equal(AiErrorKind.NotConfigured, error.Error.Kind);
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Theory]
+    [InlineData(null, "https://api.anthropic.com/v1/messages")]
+    [InlineData("https://api.anthropic.com", "https://api.anthropic.com/v1/messages")]
+    [InlineData("https://gateway.example.com/anthropic", "https://gateway.example.com/anthropic/messages")]
+    [InlineData("https://gateway.example.com/v1/messages", "https://gateway.example.com/v1/messages")]
+    public async Task Resolves_the_endpoint_from_assorted_base_urls(string? baseUrl, string expected)
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        await CollectAsync(Provider(handler, baseUrl: baseUrl));
+
+        Assert.Equal(expected, handler.RequestedUrls.Single().ToString());
+    }
+
+    [Fact]
+    public async Task Unauthorized_maps_to_its_own_kind_and_does_not_echo_the_provider_prose()
+    {
+        // The body quotes request material back; none of it may reach the error we surface or log.
+        const string body = """
+            {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key for prompt 'Explain Dhp 21: appamado amatapadam'"}}
+            """;
+        var handler = StubHttpMessageHandler.Error(HttpStatusCode.Unauthorized, body);
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler)));
+
+        Assert.Equal(AiErrorKind.Unauthorized, error.Error.Kind);
+        Assert.Equal("authentication_error", error.Error.ProviderCode);
+        Assert.DoesNotContain("appamado", error.Error.Message);
+        Assert.DoesNotContain("Explain Dhp", error.Error.Message);
+    }
+
+    [Fact]
+    public async Task Rate_limiting_carries_the_retry_after_delay()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.TooManyRequests,
+            """{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}""",
+            retryAfter: "30");
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler)));
+
+        Assert.Equal(AiErrorKind.RateLimited, error.Error.Kind);
+        Assert.Equal(TimeSpan.FromSeconds(30), error.Error.RetryAfter);
+    }
+
+    [Fact]
+    public async Task A_context_overflow_is_distinguished_from_other_bad_requests()
+    {
+        // Anthropic has no machine-readable code for this — the prose is the only signal.
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            """{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 1200000 tokens > 1000000"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler)));
+
+        Assert.Equal(AiErrorKind.ContextTooLong, error.Error.Kind);
+    }
+
+    [Fact]
+    public async Task An_ordinary_bad_request_stays_a_provider_error()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            """{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: must be >= 1"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler)));
+
+        Assert.Equal(AiErrorKind.Provider, error.Error.Kind);
+    }
+
+    [Fact]
+    public async Task An_error_event_mid_stream_keeps_the_text_already_streamed()
+    {
+        const string stream = """
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Heedfulness "}}
+
+            event: error
+            data: {"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("Heedfulness ", Text(deltas));
+        var error = Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!;
+        Assert.Equal(AiErrorKind.Provider, error.Kind);
+        Assert.Equal("overloaded_error", error.ProviderCode);
+    }
+
+    [Fact]
+    public async Task A_dropped_connection_mid_stream_keeps_the_partial_answer()
+    {
+        const string stream = """
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Heedfulness is "}}
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.SseThenDrop(stream)));
+
+        Assert.Equal("Heedfulness is ", Text(deltas));
+        var error = Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!;
+        Assert.Equal(AiErrorKind.Network, error.Kind);
+    }
+
+    [Fact]
+    public async Task A_malformed_event_is_skipped_rather_than_ending_a_healthy_stream()
+    {
+        const string stream = """
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Heed"}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"trunc
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"fulness"}}
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("Heedfulness", Text(deltas));
+        Assert.DoesNotContain(deltas, d => d.Kind == ChatDeltaKind.Error);
+    }
+
+    [Fact]
+    public async Task Cancellation_throws_rather_than_reporting_an_error_delta()
+    {
+        using var cts = new CancellationTokenSource();
+        var provider = Provider(StubHttpMessageHandler.Hangs());
+
+        var pump = Task.Run(async () => await CollectAsync(provider, ct: cts.Token));
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pump);
+    }
+
+    [Fact]
+    public async Task A_silent_stream_is_abandoned_by_the_idle_timeout()
+    {
+        var provider = Provider(StubHttpMessageHandler.Hangs(), idle: TimeSpan.FromMilliseconds(150));
+
+        var deltas = await CollectAsync(provider);
+
+        var error = Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!;
+        Assert.Equal(AiErrorKind.Network, error.Kind);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
@@ -21,9 +21,10 @@ namespace CST.Avalonia.Tests.Services.Ai;
 public class AnthropicMessagesProviderTests
 {
     private static AnthropicMessagesProvider Provider(
-        StubHttpMessageHandler handler, string? key = "sk-test", string? baseUrl = null, TimeSpan? idle = null) =>
-        new(new HttpClient(handler), new AnthropicOptions(key, baseUrl),
-            NullLogger<AnthropicMessagesProvider>.Instance, idle);
+        StubHttpMessageHandler handler, string? key = "sk-test", string? baseUrl = null,
+        TimeSpan? idle = null, TimeSpan? firstEvent = null) =>
+        new(new HttpClient(handler) { Timeout = Timeout.InfiniteTimeSpan }, new AnthropicOptions(key, baseUrl),
+            NullLogger<AnthropicMessagesProvider>.Instance, idle, firstEvent);
 
     private static ChatRequest Request(string? system = null) =>
         new("claude-opus-5", 1024, system, new[] { new ChatMessage(ChatRole.User, "Explain this passage.") });
@@ -279,13 +280,80 @@ public class AnthropicMessagesProviderTests
     }
 
     [Fact]
-    public async Task A_silent_stream_is_abandoned_by_the_idle_timeout()
+    public async Task A_stream_that_never_starts_is_abandoned_by_the_first_event_timeout()
     {
-        var provider = Provider(StubHttpMessageHandler.Hangs(), idle: TimeSpan.FromMilliseconds(150));
+        // Time-to-first-token has its own, longer window than the between-lines idle timeout: a local runner
+        // evaluating a large injected passage can legitimately sit silent for minutes before saying anything.
+        var provider = Provider(
+            StubHttpMessageHandler.Hangs(),
+            idle: TimeSpan.FromMinutes(5),
+            firstEvent: TimeSpan.FromMilliseconds(150));
 
         var deltas = await CollectAsync(provider);
 
         var error = Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!;
         Assert.Equal(AiErrorKind.Network, error.Kind);
+    }
+
+    [Fact]
+    public async Task A_200_carrying_no_events_is_reported_rather_than_answered_blank()
+    {
+        // The wrong-endpoint case: something answers 200 with a page that is not a stream. Saying nothing would
+        // leave the user unable to tell a misconfiguration from a model that declined to speak.
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse("<html>not an api</html>")));
+
+        var error = Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!;
+        Assert.Equal(AiErrorKind.Provider, error.Kind);
+    }
+
+    [Fact]
+    public async Task A_chunk_of_an_unexpected_json_shape_does_not_crash_the_stream()
+    {
+        // `data: null` parses successfully and then faults on the first property read; a `delta` that is a
+        // string rather than an object faults the same way. Both must be skipped, not thrown out of the
+        // iterator as an unclassified crash mid-answer. (A numeric `type` is NOT in this fixture: it falls
+        // back to the SSE event name, which is the right behaviour rather than a skip.)
+        const string stream = """
+            event: ping
+            data: null
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","delta":"not-an-object"}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Survived."}}
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("Survived.", Text(deltas));
+        Assert.DoesNotContain(deltas, d => d.Kind == ChatDeltaKind.Error);
+    }
+
+    [Fact]
+    public async Task A_provider_code_that_is_not_token_shaped_is_dropped_rather_than_logged()
+    {
+        // A wrong endpoint can put anything in `type`, including echoed request material.
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            """{"type":"error","error":{"type":"rejected while handling 'Explain Dhp 21: appamado amatapadam'"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler)));
+
+        Assert.Null(error.Error.ProviderCode);
+        Assert.DoesNotContain("appamado", error.Error.Message);
+    }
+
+    [Fact]
+    public void A_client_with_a_finite_timeout_is_refused_at_construction()
+    {
+        // A finite HttpClient.Timeout truncates a long stream and reports it as a cancellation — close to
+        // undiagnosable from a bug report, so it fails loudly here instead.
+        var http = new HttpClient(StubHttpMessageHandler.Sse(HappyStream)) { Timeout = TimeSpan.FromSeconds(100) };
+
+        Assert.Throws<ArgumentException>(() =>
+            new AnthropicMessagesProvider(
+                http, new AnthropicOptions("sk-test"), NullLogger<AnthropicMessagesProvider>.Instance));
     }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
@@ -144,7 +144,7 @@ public class AnthropicMessagesProviderTests
     [Theory]
     [InlineData(null, "https://api.anthropic.com/v1/messages")]
     [InlineData("https://api.anthropic.com", "https://api.anthropic.com/v1/messages")]
-    [InlineData("https://gateway.example.com/anthropic", "https://gateway.example.com/anthropic/messages")]
+    [InlineData("https://gateway.example.com/anthropic", "https://gateway.example.com/anthropic/v1/messages")]
     [InlineData("https://gateway.example.com/v1/messages", "https://gateway.example.com/v1/messages")]
     public async Task Resolves_the_endpoint_from_assorted_base_urls(string? baseUrl, string expected)
     {

--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
@@ -439,12 +439,58 @@ public class OpenAiCompatibleProviderTests
     [Theory]
     [InlineData("https://host/v1?api-version=2024-01", "https://host/v1/chat/completions?api-version=2024-01")]
     [InlineData("https://HOST/V1/CHAT/COMPLETIONS", "https://host/V1/CHAT/COMPLETIONS")]
-    [InlineData("https://host/mychat/completions", "https://host/mychat/completions/chat/completions")]
+    [InlineData("https://host/mychat/completions", "https://host/mychat/completions/v1/chat/completions")]
+    [InlineData("https://openrouter.ai/api", "https://openrouter.ai/api/v1/chat/completions")]
     public async Task Endpoint_resolution_survives_the_awkward_base_urls(string baseUrl, string expected)
     {
         var handler = StubHttpMessageHandler.Sse(HappyStream);
         await CollectAsync(Provider(handler, baseUrl: baseUrl));
 
         Assert.Equal(expected, handler.RequestedUrls.Single().ToString());
+    }
+
+    [Fact]
+    public void A_client_with_a_finite_timeout_is_refused_at_construction()
+    {
+        // Pinned on BOTH adapters: a finite HttpClient.Timeout truncates a long stream and reports it as a
+        // cancellation, and #583's DI wiring is the place most likely to hand one over by accident.
+        var http = new HttpClient(StubHttpMessageHandler.Sse(HappyStream)) { Timeout = TimeSpan.FromSeconds(100) };
+
+        Assert.Throws<ArgumentException>(() =>
+            new OpenAiCompatibleProvider(
+                http, new OpenAiCompatibleOptions("https://x.example/v1"),
+                NullLogger<OpenAiCompatibleProvider>.Instance));
+    }
+
+    [Fact]
+    public async Task An_overlong_provider_code_is_dropped_rather_than_logged()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            "{\"error\":{\"code\":\"" + new string('c', 200) + "\"}}");
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler)));
+
+        Assert.Null(error.Error.ProviderCode);
+    }
+
+    [Fact]
+    public async Task Held_back_think_text_is_flushed_before_an_error_delta_not_after()
+    {
+        // A partial tag is in hand when the failure lands; releasing it after the error would put answer text
+        // beyond a delta the contract says is terminal.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"Answer <th"}}]}
+
+            data: {"error":{"code":"server_error"}}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("Answer <th", Text(deltas));
+        Assert.Equal(ChatDeltaKind.Error, deltas[^1].Kind);
     }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
@@ -439,8 +439,20 @@ public class OpenAiCompatibleProviderTests
     [Theory]
     [InlineData("https://host/v1?api-version=2024-01", "https://host/v1/chat/completions?api-version=2024-01")]
     [InlineData("https://HOST/V1/CHAT/COMPLETIONS", "https://host/V1/CHAT/COMPLETIONS")]
-    [InlineData("https://host/mychat/completions", "https://host/mychat/completions/v1/chat/completions")]
+    [InlineData("https://host/mychat/completions", "https://host/mychat/completions/chat/completions")]
+    // A single unversioned segment is the docs URL with /v1 dropped — rescue it.
     [InlineData("https://openrouter.ai/api", "https://openrouter.ai/api/v1/chat/completions")]
+    [InlineData("https://api.groq.com/openai", "https://api.groq.com/openai/v1/chat/completions")]
+    // …but a LONGER path is somebody's documented base and must be taken at its word. These are all real:
+    // Gemini's OpenAI-compat base, Azure classic deployments, and a Cloudflare AI Gateway path.
+    [InlineData("https://generativelanguage.googleapis.com/v1beta/openai/",
+        "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions")]
+    [InlineData("https://r.openai.azure.com/openai/deployments/gpt?api-version=2024-02-01",
+        "https://r.openai.azure.com/openai/deployments/gpt/chat/completions?api-version=2024-02-01")]
+    [InlineData("https://gateway.ai.cloudflare.com/v1/acct/gw/compat",
+        "https://gateway.ai.cloudflare.com/v1/acct/gw/compat/chat/completions")]
+    // A version segment need not be bare digits.
+    [InlineData("https://host/v1beta", "https://host/v1beta/chat/completions")]
     public async Task Endpoint_resolution_survives_the_awkward_base_urls(string baseUrl, string expected)
     {
         var handler = StubHttpMessageHandler.Sse(HappyStream);

--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
@@ -24,9 +24,10 @@ public class OpenAiCompatibleProviderTests
         StubHttpMessageHandler handler,
         string? baseUrl = "https://api.deepseek.com/v1",
         string? key = "sk-test",
-        TimeSpan? idle = null) =>
-        new(new HttpClient(handler), new OpenAiCompatibleOptions(baseUrl, key),
-            NullLogger<OpenAiCompatibleProvider>.Instance, idle);
+        TimeSpan? idle = null,
+        TimeSpan? firstEvent = null) =>
+        new(new HttpClient(handler) { Timeout = Timeout.InfiniteTimeSpan }, new OpenAiCompatibleOptions(baseUrl, key),
+            NullLogger<OpenAiCompatibleProvider>.Instance, idle, firstEvent);
 
     private static ChatRequest Request(string? system = null) =>
         new("deepseek-chat", 1024, system, new[] { new ChatMessage(ChatRole.User, "Explain this passage.") });
@@ -309,5 +310,141 @@ public class OpenAiCompatibleProviderTests
         cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pump);
+    }
+
+    [Fact]
+    public async Task A_numeric_error_code_does_not_crash_the_stream()
+    {
+        // OpenRouter reports mid-stream failures with a NUMERIC code. Reading it as a string throws
+        // InvalidOperationException straight out of the iterator — an unclassified crash where the contract
+        // promises an Error delta.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"Heed"}}]}
+
+            data: {"error":{"code":403,"message":"moderation"}}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("Heed", Text(deltas));
+        var error = Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!;
+        Assert.Equal("403", error.ProviderCode);
+    }
+
+    [Fact]
+    public async Task Nothing_is_appended_to_the_answer_after_an_error_delta()
+    {
+        // A gateway can report a failure and keep streaming. The Error delta is terminal by contract.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"Heed"}}]}
+
+            data: {"error":{"code":"server_error"}}
+
+            data: {"choices":[{"delta":{"content":" MORE"}}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("Heed", Text(deltas));
+        Assert.Equal(ChatDeltaKind.Error, deltas[^1].Kind);
+    }
+
+    [Fact]
+    public async Task A_chunk_of_an_unexpected_json_shape_does_not_crash_the_stream()
+    {
+        const string stream = """
+            data: null
+
+            data: {"choices":"not-an-array"}
+
+            data: {"choices":[{"delta":{"content":"Survived."}}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("Survived.", Text(deltas));
+        Assert.DoesNotContain(deltas, d => d.Kind == ChatDeltaKind.Error);
+    }
+
+    [Fact]
+    public async Task A_200_carrying_no_events_is_reported_rather_than_answered_blank()
+    {
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse("<html>not an api</html>")));
+
+        var error = Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!;
+        Assert.Equal(AiErrorKind.Provider, error.Kind);
+    }
+
+    [Fact]
+    public async Task A_stream_that_begins_inside_a_think_block_is_still_segregated()
+    {
+        // Some runner chat templates pre-fill the opening <think> into the prompt, so the model's output starts
+        // inside the block and only the closing tag is ever streamed.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"weighing options</think>The answer."}}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("The answer.", Text(deltas));
+        Assert.Equal("weighing options", Reasoning(deltas));
+    }
+
+    [Fact]
+    public async Task An_unclosed_think_block_is_flushed_as_reasoning_not_as_the_answer()
+    {
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"<think>still musing"}}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("", Text(deltas));
+        Assert.Equal("still musing", Reasoning(deltas));
+    }
+
+    [Fact]
+    public async Task Pali_diacritics_split_across_a_read_boundary_survive_intact()
+    {
+        // The corpus is full of multi-byte characters; a UTF-8 sequence straddling a buffer boundary must not
+        // be mangled into replacement characters.
+        var text = string.Concat(System.Linq.Enumerable.Repeat("appamado amatapadam thana ", 400))
+            .Replace("appamado", "appam\u0101do").Replace("amatapadam", "amatapada\u1E41")
+            .Replace("thana", "\u1E6Dh\u0101na");
+        var stream =
+            "data: {\"choices\":[{\"delta\":{\"content\":\"" + text + "\"}}]}\n\n" +
+            "data: [DONE]\n\n";
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal(text, Text(deltas));
+        Assert.DoesNotContain("\uFFFD", Text(deltas));
+    }
+
+    [Theory]
+    [InlineData("https://host/v1?api-version=2024-01", "https://host/v1/chat/completions?api-version=2024-01")]
+    [InlineData("https://HOST/V1/CHAT/COMPLETIONS", "https://host/V1/CHAT/COMPLETIONS")]
+    [InlineData("https://host/mychat/completions", "https://host/mychat/completions/chat/completions")]
+    public async Task Endpoint_resolution_survives_the_awkward_base_urls(string baseUrl, string expected)
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        await CollectAsync(Provider(handler, baseUrl: baseUrl));
+
+        Assert.Equal(expected, handler.RequestedUrls.Single().ToString());
     }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
@@ -505,4 +505,28 @@ public class OpenAiCompatibleProviderTests
         Assert.Equal("Answer <th", Text(deltas));
         Assert.Equal(ChatDeltaKind.Error, deltas[^1].Kind);
     }
+
+    [Fact]
+    public async Task Reasoning_on_the_undocumented_field_name_is_also_segregated()
+    {
+        // Captured from a live Ollama serving gpt-oss over its OpenAI-compatible surface: the reasoning arrives
+        // on `reasoning`, not the `reasoning_content` DeepSeek documents. Parsing only the documented name
+        // dropped the whole reasoning stream, which showed up as usage reporting 80 output tokens beside a
+        // one-line answer. OpenRouter uses the same short name.
+        const string stream = """
+            data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"The"}}]}
+
+            data: {"choices":[{"index":0,"delta":{"content":"","reasoning":" user asks."}}]}
+
+            data: {"choices":[{"index":0,"delta":{"content":"Appamada is heedfulness."}}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("Appamada is heedfulness.", Text(deltas));
+        Assert.Equal("The user asks.", Reasoning(deltas));
+    }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Tests.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// The OpenAI-compatible adapter — the one that has to serve DeepSeek, OpenRouter, Ollama and LM Studio from a
+/// single implementation. Most of these pin per-provider quirks rather than the happy path: reasoning that
+/// arrives on two different channels, and the base-URL forms users actually paste. (#578)
+/// </summary>
+public class OpenAiCompatibleProviderTests
+{
+    private static OpenAiCompatibleProvider Provider(
+        StubHttpMessageHandler handler,
+        string? baseUrl = "https://api.deepseek.com/v1",
+        string? key = "sk-test",
+        TimeSpan? idle = null) =>
+        new(new HttpClient(handler), new OpenAiCompatibleOptions(baseUrl, key),
+            NullLogger<OpenAiCompatibleProvider>.Instance, idle);
+
+    private static ChatRequest Request(string? system = null) =>
+        new("deepseek-chat", 1024, system, new[] { new ChatMessage(ChatRole.User, "Explain this passage.") });
+
+    private static async Task<List<ChatDelta>> CollectAsync(
+        IChatProvider provider, ChatRequest? request = null, CancellationToken ct = default)
+    {
+        var deltas = new List<ChatDelta>();
+        await foreach (var delta in provider.StreamAsync(request ?? Request(), ct))
+            deltas.Add(delta);
+        return deltas;
+    }
+
+    private static string Text(IEnumerable<ChatDelta> deltas) =>
+        string.Concat(deltas.Where(d => d.Kind == ChatDeltaKind.Text).Select(d => d.Text));
+
+    private static string Reasoning(IEnumerable<ChatDelta> deltas) =>
+        string.Concat(deltas.Where(d => d.Kind == ChatDeltaKind.Reasoning).Select(d => d.Text));
+
+    private const string HappyStream = """
+        data: {"choices":[{"delta":{"content":"Heedfulness "}}]}
+
+        data: {"choices":[{"delta":{"content":"is the path."}}]}
+
+        data: {"usage":{"prompt_tokens":412,"completion_tokens":37},"choices":[]}
+
+        data: [DONE]
+
+        """;
+
+    [Fact]
+    public async Task Streams_text_deltas_in_order()
+    {
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(HappyStream)));
+
+        Assert.Equal("Heedfulness is the path.", Text(deltas));
+    }
+
+    [Fact]
+    public async Task Reports_usage_from_the_final_chunk()
+    {
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(HappyStream)));
+        var usage = Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Usage).Usage!;
+
+        Assert.Equal(412, usage.InputTokens);
+        Assert.Equal(37, usage.OutputTokens);
+    }
+
+    [Fact]
+    public async Task Structured_reasoning_never_reaches_the_answer_channel()
+    {
+        // DeepSeek's reasoning models stream reasoning_content alongside content on the same connection.
+        const string stream = """
+            data: {"choices":[{"delta":{"reasoning_content":"The user wants a gloss. "}}]}
+
+            data: {"choices":[{"delta":{"reasoning_content":"Check the compound."}}]}
+
+            data: {"choices":[{"delta":{"content":"It means heedfulness."}}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("It means heedfulness.", Text(deltas));
+        Assert.Equal("The user wants a gloss. Check the compound.", Reasoning(deltas));
+    }
+
+    [Fact]
+    public async Task Inline_think_tags_are_stripped_out_of_the_answer()
+    {
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"<think>weighing options</think>The answer."}}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("The answer.", Text(deltas));
+        Assert.Equal("weighing options", Reasoning(deltas));
+    }
+
+    [Fact]
+    public async Task A_think_tag_split_across_chunks_is_still_stripped()
+    {
+        // The hard case: the tag straddles a delta boundary, so no per-chunk replace can see it whole.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"<thi"}}]}
+
+            data: {"choices":[{"delta":{"content":"nk>hidden</thi"}}]}
+
+            data: {"choices":[{"delta":{"content":"nk>Visible."}}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("Visible.", Text(deltas));
+        Assert.Equal("hidden", Reasoning(deltas));
+    }
+
+    [Fact]
+    public async Task Text_that_merely_looks_like_the_start_of_a_tag_is_not_swallowed()
+    {
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"a < b and c <th"}}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("a < b and c <th", Text(deltas));
+    }
+
+    [Fact]
+    public async Task The_system_prompt_becomes_a_leading_message()
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        await CollectAsync(Provider(handler), Request(system: "You are a Pali reading assistant."));
+
+        using var body = JsonDocument.Parse(handler.LastRequestBody);
+        var messages = body.RootElement.GetProperty("messages");
+
+        Assert.Equal("system", messages[0].GetProperty("role").GetString());
+        Assert.Equal("You are a Pali reading assistant.", messages[0].GetProperty("content").GetString());
+        Assert.Equal("user", messages[1].GetProperty("role").GetString());
+    }
+
+    [Fact]
+    public async Task An_api_key_is_sent_when_configured()
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        await CollectAsync(Provider(handler));
+
+        Assert.Equal("Bearer", handler.LastRequest!.Headers.Authorization!.Scheme);
+        Assert.Equal("sk-test", handler.LastRequest.Headers.Authorization.Parameter);
+    }
+
+    [Fact]
+    public async Task An_empty_key_is_a_valid_configuration_for_a_local_runner()
+    {
+        // Ollama and LM Studio accept anonymous requests; requiring a key would block the fully-local option.
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+
+        var deltas = await CollectAsync(Provider(handler, baseUrl: "http://localhost:11434/v1", key: ""));
+
+        Assert.Null(handler.LastRequest!.Headers.Authorization);
+        Assert.Equal("Heedfulness is the path.", Text(deltas));
+    }
+
+    [Theory]
+    [InlineData("https://api.deepseek.com", "https://api.deepseek.com/v1/chat/completions")]
+    [InlineData("https://api.deepseek.com/v1", "https://api.deepseek.com/v1/chat/completions")]
+    [InlineData("https://api.deepseek.com/v1/", "https://api.deepseek.com/v1/chat/completions")]
+    [InlineData("http://localhost:11434/v1", "http://localhost:11434/v1/chat/completions")]
+    [InlineData("https://openrouter.ai/api/v1", "https://openrouter.ai/api/v1/chat/completions")]
+    [InlineData("https://x.example/v1/chat/completions", "https://x.example/v1/chat/completions")]
+    public async Task Resolves_the_endpoint_from_the_base_url_forms_users_actually_paste(
+        string baseUrl, string expected)
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        await CollectAsync(Provider(handler, baseUrl: baseUrl));
+
+        Assert.Equal(expected, handler.RequestedUrls.Single().ToString());
+    }
+
+    [Fact]
+    public async Task A_missing_endpoint_fails_before_any_request_is_made()
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler, baseUrl: null)));
+
+        Assert.Equal(AiErrorKind.NotConfigured, error.Error.Kind);
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task A_non_http_endpoint_is_rejected_as_misconfiguration()
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+
+        var error = await Assert.ThrowsAsync<AiException>(
+            () => CollectAsync(Provider(handler, baseUrl: "file:///etc/passwd")));
+
+        Assert.Equal(AiErrorKind.NotConfigured, error.Error.Kind);
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task Unauthorized_maps_to_its_own_kind_and_does_not_echo_the_provider_prose()
+    {
+        const string body = """
+            {"error":{"code":"invalid_api_key","message":"bad key while handling 'Explain Dhp 21: appamado'"}}
+            """;
+        var handler = StubHttpMessageHandler.Error(HttpStatusCode.Unauthorized, body);
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler)));
+
+        Assert.Equal(AiErrorKind.Unauthorized, error.Error.Kind);
+        Assert.Equal("invalid_api_key", error.Error.ProviderCode);
+        Assert.DoesNotContain("appamado", error.Error.Message);
+    }
+
+    [Fact]
+    public async Task A_context_overflow_is_recognised_from_its_code()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            """{"error":{"code":"context_length_exceeded","message":"too long"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler)));
+
+        Assert.Equal(AiErrorKind.ContextTooLong, error.Error.Kind);
+    }
+
+    [Fact]
+    public async Task Rate_limiting_carries_the_retry_after_delay()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.TooManyRequests,
+            """{"error":{"code":"rate_limit_exceeded"}}""",
+            retryAfter: "12");
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler)));
+
+        Assert.Equal(AiErrorKind.RateLimited, error.Error.Kind);
+        Assert.Equal(TimeSpan.FromSeconds(12), error.Error.RetryAfter);
+    }
+
+    [Fact]
+    public async Task An_error_delivered_as_a_200_chunk_still_surfaces()
+    {
+        // Some gateways answer 200 and put the failure in the stream.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"Heed"}}]}
+
+            data: {"error":{"code":"server_error","message":"upstream exploded"}}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("Heed", Text(deltas));
+        var error = Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!;
+        Assert.Equal("server_error", error.ProviderCode);
+        Assert.DoesNotContain("exploded", error.Message);
+    }
+
+    [Fact]
+    public async Task A_dropped_connection_mid_stream_keeps_the_partial_answer()
+    {
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"Heedfulness is "}}]}
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.SseThenDrop(stream)));
+
+        Assert.Equal("Heedfulness is ", Text(deltas));
+        Assert.Equal(AiErrorKind.Network, Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!.Kind);
+    }
+
+    [Fact]
+    public async Task Cancellation_throws_rather_than_reporting_an_error_delta()
+    {
+        using var cts = new CancellationTokenSource();
+        var provider = Provider(StubHttpMessageHandler.Hangs());
+
+        var pump = Task.Run(async () => await CollectAsync(provider, ct: cts.Token));
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pump);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/ThinkTagFilterTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ThinkTagFilterTests.cs
@@ -93,6 +93,21 @@ public class ThinkTagFilterTests
     }
 
     [Fact]
+    public void The_guarantee_survives_three_way_chunkings_too()
+    {
+        // Two boundaries can force held text to be re-held rather than resolved, which two-way splits never
+        // exercise.
+        const string stream = "musing</think>The answer.";
+        for (var i = 1; i < stream.Length - 1; i++)
+        for (var j = i + 1; j < stream.Length; j++)
+        {
+            var (visible, _) = Run(stream[..i], stream[i..j], stream[j..]);
+            Assert.DoesNotContain("<", visible);
+            Assert.EndsWith("The answer.", visible);
+        }
+    }
+
+    [Fact]
     public void Text_already_emitted_is_not_retroactively_reclassified()
     {
         // Once visible text has been returned it cannot be recalled, so a later stray close tag must not move

--- a/src/CST.Avalonia.Tests/Services/Ai/ThinkTagFilterTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ThinkTagFilterTests.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CST.Avalonia.Services.Ai;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Direct tests for the think-tag filter. It is the fiddliest class in the provider layer — a small state
+/// machine over arbitrarily-chunked text — and exercising it only through SSE fixtures is both coarse and
+/// awkward. Two real defects (a split closing tag, and stale visible-text tracking within a chunk) survived
+/// provider-level coverage and would have been caught here. (#578)
+/// </summary>
+public class ThinkTagFilterTests
+{
+    /// <summary>Feed chunks in order and return the concatenated channels, flush included.</summary>
+    private static (string Visible, string Reasoning) Run(params string[] chunks)
+    {
+        var filter = new ThinkTagFilter();
+        var visible = new StringBuilder();
+        var reasoning = new StringBuilder();
+
+        foreach (var chunk in chunks)
+        {
+            var (v, r) = filter.Feed(chunk);
+            visible.Append(v);
+            reasoning.Append(r);
+        }
+
+        var (tailVisible, tailReasoning) = filter.Flush();
+        visible.Append(tailVisible);
+        reasoning.Append(tailReasoning);
+
+        return (visible.ToString(), reasoning.ToString());
+    }
+
+    /// <summary>Every way of cutting a string into n pieces is a legitimate delta boundary.</summary>
+    private static IEnumerable<string[]> EverySplit(string text)
+    {
+        for (var i = 1; i < text.Length; i++)
+            yield return new[] { text[..i], text[i..] };
+    }
+
+    [Fact]
+    public void Passes_ordinary_text_through_untouched()
+    {
+        Assert.Equal(("Heedfulness is the path.", ""), Run("Heedfulness ", "is the path."));
+    }
+
+    [Fact]
+    public void Separates_a_complete_think_block()
+    {
+        Assert.Equal(("The answer.", "musing"), Run("<think>musing</think>The answer."));
+    }
+
+    [Fact]
+    public void Separates_correctly_no_matter_where_the_chunks_fall()
+    {
+        // The whole difficulty of the class: a tag can straddle any boundary.
+        const string stream = "before<think>hidden</think>after";
+        foreach (var split in EverySplit(stream))
+            Assert.Equal(("beforeafter", "hidden"), Run(split));
+    }
+
+    [Fact]
+    public void A_stream_that_begins_inside_a_block_is_still_separated()
+    {
+        // Some runner chat templates pre-fill the opening tag into the prompt, so the model's output starts
+        // inside the block and only the closing tag is ever streamed.
+        Assert.Equal(("The answer.", "musing"), Run("musing</think>The answer."));
+    }
+
+    [Fact]
+    public void No_tag_or_fragment_ever_reaches_the_answer_however_a_closing_tag_is_split()
+    {
+        // The regression that provider-level coverage missed: holding back only prefixes of the tag being
+        // hunted meant a partial "</thi" was released as answer text, after which "nk>" could never be
+        // recognised — so a mangled tag rendered in the middle of the answer.
+        //
+        // Note what is NOT promised. When the stream begins inside a block, text before the closing tag has
+        // already been returned to the caller by the time the tag arrives, so it cannot be reclassified; only
+        // the single-delta case (below) gets it right. Buffering to fix that would stall the opening of every
+        // normal answer to serve a rare one. The guarantee is narrower and absolute: the tag never renders.
+        const string stream = "musing</think>The answer.";
+        foreach (var split in EverySplit(stream))
+        {
+            var (visible, _) = Run(split);
+            Assert.DoesNotContain("<", visible);
+            Assert.DoesNotContain("thi", visible, System.StringComparison.OrdinalIgnoreCase);
+            Assert.EndsWith("The answer.", visible);
+        }
+    }
+
+    [Fact]
+    public void Text_already_emitted_is_not_retroactively_reclassified()
+    {
+        // Once visible text has been returned it cannot be recalled, so a later stray close tag must not move
+        // it — but the tag itself is still suppressed rather than rendered.
+        Assert.Equal(("Hello done", ""), Run("Hello ", "done</think>"));
+    }
+
+    [Fact]
+    public void Text_emitted_earlier_in_the_same_chunk_also_counts_as_emitted()
+    {
+        // The subtle case: `Hello` and `done` are returned in the SAME delta, so `done` is just as
+        // un-retractable as text from a previous chunk and must stay visible.
+        Assert.Equal(("Hellodone!", "plan"), Run("Hello<think>plan</think>done</think>!"));
+    }
+
+    [Fact]
+    public void An_unclosed_block_is_flushed_as_reasoning()
+    {
+        Assert.Equal(("", "still musing"), Run("<think>still musing"));
+    }
+
+    [Fact]
+    public void A_held_back_partial_tag_is_released_as_text_at_the_end_of_the_stream()
+    {
+        Assert.Equal(("a < b and c <th", ""), Run("a < b and c <th"));
+    }
+
+    [Fact]
+    public void Text_that_only_resembles_a_tag_is_not_swallowed()
+    {
+        Assert.Equal(("<thinker> and <thing>", ""), Run("<thinker>", " and <thing>"));
+    }
+
+    [Fact]
+    public void Tag_matching_is_case_insensitive()
+    {
+        Assert.Equal(("after", "hidden"), Run("<THINK>hidden</Think>after"));
+    }
+
+    [Fact]
+    public void Repeated_blocks_alternate_correctly()
+    {
+        Assert.Equal(("ac", "b1b2"), Run("<think>b1</think>a<think>b2</think>c"));
+    }
+
+    [Fact]
+    public void A_pathological_run_of_angle_brackets_loses_no_characters()
+    {
+        var chunks = Enumerable.Repeat("<", 50).ToArray();
+        var (visible, reasoning) = Run(chunks);
+
+        Assert.Equal(new string('<', 50), visible);
+        Assert.Equal("", reasoning);
+    }
+
+    [Fact]
+    public void Held_text_never_grows_without_bound()
+    {
+        // Only a possible partial tag may be held, so the buffer is bounded by the longer tag's length.
+        var filter = new ThinkTagFilter();
+        var emitted = 0;
+        for (var i = 0; i < 200; i++)
+            emitted += filter.Feed("</thin").Visible.Length;
+
+        var flushed = filter.Flush().Visible.Length;
+        Assert.Equal(200 * "</thin".Length, emitted + flushed);
+    }
+}

--- a/src/CST.Avalonia.Tests/TestSupport/StubHttpMessageHandler.cs
+++ b/src/CST.Avalonia.Tests/TestSupport/StubHttpMessageHandler.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CST.Avalonia.Tests.TestSupport;
+
+/// <summary>
+/// Replays a canned HTTP response so the chat providers can be tested against recorded wire traffic — no
+/// network, no API key, no spend. Also captures the outgoing request, which is half the point: the request
+/// SHAPE is part of the providers' contract (Anthropic requires <c>max_tokens</c> and rejects sampling
+/// parameters), and a shape regression is invisible from the response side.
+/// </summary>
+internal sealed class StubHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+
+    internal StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) => _respond = respond;
+
+    /// <summary>The last request the handler saw, with its body already read.</summary>
+    internal HttpRequestMessage? LastRequest { get; private set; }
+
+    /// <summary>Body of the last request, as sent.</summary>
+    internal string LastRequestBody { get; private set; } = string.Empty;
+
+    /// <summary>Every request URL the handler saw, in order.</summary>
+    internal List<Uri> RequestedUrls { get; } = new();
+
+    /// <summary>Replay an SSE body with a 200.</summary>
+    internal static StubHttpMessageHandler Sse(string body) =>
+        new(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(body)))
+            {
+                Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/event-stream") },
+            },
+        });
+
+    /// <summary>Replay an SSE body that dies part-way through, as a dropped connection does.</summary>
+    internal static StubHttpMessageHandler SseThenDrop(string body) =>
+        new(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(new DroppingStream(Encoding.UTF8.GetBytes(body))),
+        });
+
+    /// <summary>Replay a stream that never produces anything and never completes, until cancelled.</summary>
+    internal static StubHttpMessageHandler Hangs() =>
+        new(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(new HangingStream()),
+        });
+
+    /// <summary>Replay an error status with a JSON body.</summary>
+    internal static StubHttpMessageHandler Error(HttpStatusCode status, string json, string? retryAfter = null)
+    {
+        return new StubHttpMessageHandler(_ =>
+        {
+            var response = new HttpResponseMessage(status)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            };
+            if (retryAfter is not null)
+                response.Headers.TryAddWithoutValidation("Retry-After", retryAfter);
+            return response;
+        });
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        RequestedUrls.Add(request.RequestUri!);
+        if (request.Content is not null)
+            LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+
+        return _respond(request);
+    }
+
+    /// <summary>Yields its bytes, then faults exactly as a severed connection does.</summary>
+    private sealed class DroppingStream : Stream
+    {
+        private readonly byte[] _payload;
+        private int _position;
+
+        internal DroppingStream(byte[] payload) => _payload = payload;
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_position >= _payload.Length)
+                throw new IOException("The connection was closed by the peer.");
+
+            var take = Math.Min(count, _payload.Length - _position);
+            Array.Copy(_payload, _position, buffer, offset, take);
+            _position += take;
+            return take;
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (_position >= _payload.Length)
+                throw new IOException("The connection was closed by the peer.");
+
+            var take = Math.Min(buffer.Length, _payload.Length - _position);
+            _payload.AsSpan(_position, take).CopyTo(buffer.Span);
+            _position += take;
+            return ValueTask.FromResult(take);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _payload.Length;
+        public override long Position { get => _position; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>Accepts the connection and then says nothing — the case an idle timeout exists to catch.</summary>
+    private sealed class HangingStream : Stream
+    {
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return 0;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Thread.Sleep(Timeout.Infinite);
+            return 0;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/AiHttp.cs
+++ b/src/CST.Avalonia/Services/Ai/AiHttp.cs
@@ -1,24 +1,56 @@
 using System;
 using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace CST.Avalonia.Services.Ai;
 
 /// <summary>Shared HTTP plumbing for the chat providers.</summary>
 internal static class AiHttp
 {
+    /// <summary>Plenty for classification; a provider that sends more is not telling us anything we use.</summary>
+    private const int MaxErrorBodyBytes = 8 * 1024;
+
+    /// <summary>Provider codes are short tokens. Anything longer is not a code, whatever the provider calls it.</summary>
+    private const int MaxProviderCodeLength = 64;
+
     /// <summary>
-    /// An <see cref="HttpClient"/> configured for streaming.
+    /// An <see cref="HttpClient"/> configured for streaming. <b>Providers must be given a client built here</b>
+    /// (see <see cref="EnsureStreamable"/>).
     ///
     /// <para><b>The infinite timeout is deliberate and load-bearing.</b> <see cref="HttpClient.Timeout"/> is a
     /// deadline for the whole request including the response body, so on a streamed response the default 100
     /// seconds silently truncates any generation that runs longer — which for a translation at high effort is
-    /// routine. Liveness is enforced instead by <see cref="SseReader"/>'s idle timeout, which is the property we
-    /// actually want: kill a stream that has stopped producing, not one that is merely long.</para>
+    /// routine. Worse, it surfaces as a <see cref="TaskCanceledException"/> with the caller's token NOT
+    /// cancelled, so it is indistinguishable from the user pressing stop. Liveness is enforced instead by
+    /// <see cref="SseReader"/>'s idle timeout, which is the property we actually want: kill a stream that has
+    /// stopped producing, not one that is merely long.</para>
     /// </summary>
     internal static HttpClient CreateClient() =>
         new() { Timeout = System.Threading.Timeout.InfiniteTimeSpan };
+
+    /// <summary>
+    /// Guard the invariant above at construction, because a finite timeout does not fail loudly — it truncates a
+    /// long answer and reports it as a cancellation, which is close to undiagnosable from a bug report.
+    /// </summary>
+    internal static HttpClient EnsureStreamable(HttpClient http)
+    {
+        if (http.Timeout != System.Threading.Timeout.InfiniteTimeSpan)
+        {
+            throw new ArgumentException(
+                "A chat provider needs an HttpClient with an infinite timeout (see AiHttp.CreateClient): a finite " +
+                "HttpClient.Timeout truncates long streamed responses and reports it as a cancellation. " +
+                "Liveness is enforced by the SSE reader's idle timeout instead.",
+                nameof(http));
+        }
+
+        return http;
+    }
 
     /// <summary>
     /// Resolve the request URL from a user-supplied base URL.
@@ -26,16 +58,17 @@ internal static class AiHttp
     /// <para>Users paste whatever their provider's docs showed them, and the variants are all legitimate:
     /// <c>https://api.deepseek.com</c>, <c>https://api.deepseek.com/v1</c>,
     /// <c>http://localhost:11434/v1</c>, <c>https://openrouter.ai/api/v1</c>. Getting this wrong produces a 404
-    /// that looks like a broken provider rather than a mistyped setting, so be forgiving here:
-    /// a bare host gains the version segment, a base that already carries one does not, and a URL that already
-    /// names the endpoint is left alone.</para>
+    /// that looks like a broken provider rather than a mistyped setting, so be forgiving: a bare host gains the
+    /// version segment, a base that already carries one does not, and a URL that already names the endpoint is
+    /// left alone. Any query string is preserved — Azure-style bases carry <c>?api-version=</c>, and appending
+    /// the path as raw text would bury it inside the query.</para>
     /// </summary>
     /// <param name="baseUrl">The configured base URL.</param>
     /// <param name="versionedPath">Path to use when the base URL is a bare host, e.g. <c>v1/chat/completions</c>.</param>
     /// <param name="path">Path to use when the base URL already carries a path, e.g. <c>chat/completions</c>.</param>
     internal static Uri ResolveEndpoint(string baseUrl, string versionedPath, string path)
     {
-        var trimmed = (baseUrl ?? string.Empty).Trim().TrimEnd('/');
+        var trimmed = (baseUrl ?? string.Empty).Trim();
         if (trimmed.Length == 0 || !Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ||
             (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
         {
@@ -44,26 +77,35 @@ internal static class AiHttp
                 "The endpoint URL is not a valid http(s) address."));
         }
 
-        if (trimmed.EndsWith("/" + path, StringComparison.OrdinalIgnoreCase))
-            return uri;
+        var builder = new UriBuilder(uri);
+        var existing = builder.Path.Trim('/');
 
-        var hasPath = uri.AbsolutePath.Trim('/').Length > 0;
-        return new Uri(trimmed + "/" + (hasPath ? path : versionedPath));
+        if (existing.EndsWith(path, StringComparison.OrdinalIgnoreCase) &&
+            (existing.Length == path.Length || existing[^(path.Length + 1)] == '/'))
+        {
+            return builder.Uri;   // already names the endpoint
+        }
+
+        var suffix = existing.Length == 0 ? versionedPath : path;
+        builder.Path = existing.Length == 0 ? suffix : existing + "/" + suffix;
+        return builder.Uri;
     }
 
     /// <summary>The provider's requested backoff, when it sent one. Seconds and HTTP-date forms are both legal.</summary>
     internal static TimeSpan? RetryAfter(HttpResponseMessage response)
     {
         var header = response.Headers.RetryAfter;
-        if (header is null) return null;
-        if (header.Delta is { } delta) return delta;
-        if (header.Date is { } date)
+        if (header is not null)
         {
-            var wait = date - DateTimeOffset.UtcNow;
-            return wait > TimeSpan.Zero ? wait : TimeSpan.Zero;
+            if (header.Delta is { } delta) return delta;
+            if (header.Date is { } date)
+            {
+                var wait = date - DateTimeOffset.UtcNow;
+                return wait > TimeSpan.Zero ? wait : TimeSpan.Zero;
+            }
         }
 
-        // HttpClient only surfaces a parsed header; a malformed one lands in the raw collection.
+        // A header HttpClient could not parse stays in the raw collection.
         if (response.Headers.TryGetValues("retry-after", out var raw))
         {
             foreach (var value in raw)
@@ -77,6 +119,61 @@ internal static class AiHttp
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Clamp a provider-supplied error code to something genuinely safe to log.
+    ///
+    /// <para>The rest of the design keeps provider prose out of logs and out of <see cref="AiError.Message"/>,
+    /// but <c>error.type</c> / <c>error.code</c> are provider-controlled strings and "OpenAI-compatible" means an
+    /// arbitrary user-pasted endpoint — including, on a mistyped setting, an entirely different server. Nothing
+    /// stops such a server putting a paragraph of echoed request material where a short token belongs, and that
+    /// paragraph would land in the log. A length cap plus a token charset makes the "bounded vocabulary" claim
+    /// true instead of merely intended.</para>
+    /// </summary>
+    internal static string? SanitizeProviderCode(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+
+        var code = raw.Trim();
+        if (code.Length > MaxProviderCodeLength) return null;
+        return code.All(c => char.IsAsciiLetterOrDigit(c) || c is '_' or '-' or '.' or ':') ? code : null;
+    }
+
+    /// <summary>
+    /// Read at most <see cref="MaxErrorBodyBytes"/> of an error body, for classification only.
+    ///
+    /// <para>Bounded because the client runs without a timeout: a server that sends error headers and then stalls
+    /// the body would otherwise hang until the user cancels, and a very large body would be buffered whole. The
+    /// content is never logged or retained — see <see cref="AiError"/>.</para>
+    /// </summary>
+    internal static async Task<string> ReadBoundedBodyAsync(
+        HttpContent content, TimeSpan timeout, CancellationToken ct)
+    {
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        deadline.CancelAfter(timeout);
+
+        try
+        {
+            await using var stream = await content.ReadAsStreamAsync(deadline.Token).ConfigureAwait(false);
+            var buffer = new byte[MaxErrorBodyBytes];
+            var filled = 0;
+
+            while (filled < buffer.Length)
+            {
+                var read = await stream
+                    .ReadAsync(buffer.AsMemory(filled, buffer.Length - filled), deadline.Token)
+                    .ConfigureAwait(false);
+                if (read == 0) break;
+                filled += read;
+            }
+
+            return Encoding.UTF8.GetString(buffer, 0, filled);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            return string.Empty;   // no body is simply no extra information; the status already classified it
+        }
     }
 
     /// <summary>Map a status code to its kind, before any provider-specific refinement.</summary>
@@ -98,4 +195,9 @@ internal static class AiHttp
             "The request was longer than the model's context window. Try a smaller passage or fewer glosses.",
         _ => $"The provider rejected the request (HTTP {(int)status}).",
     };
+
+    /// <summary>The error for a 200 that carried nothing a provider stream could possibly be made of.</summary>
+    internal static AiError EmptyResponse() => new(
+        AiErrorKind.Provider,
+        "The provider accepted the request but returned no response. Check the endpoint URL and the model name.");
 }

--- a/src/CST.Avalonia/Services/Ai/AiHttp.cs
+++ b/src/CST.Avalonia/Services/Ai/AiHttp.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>Shared HTTP plumbing for the chat providers.</summary>
+internal static class AiHttp
+{
+    /// <summary>
+    /// An <see cref="HttpClient"/> configured for streaming.
+    ///
+    /// <para><b>The infinite timeout is deliberate and load-bearing.</b> <see cref="HttpClient.Timeout"/> is a
+    /// deadline for the whole request including the response body, so on a streamed response the default 100
+    /// seconds silently truncates any generation that runs longer — which for a translation at high effort is
+    /// routine. Liveness is enforced instead by <see cref="SseReader"/>'s idle timeout, which is the property we
+    /// actually want: kill a stream that has stopped producing, not one that is merely long.</para>
+    /// </summary>
+    internal static HttpClient CreateClient() =>
+        new() { Timeout = System.Threading.Timeout.InfiniteTimeSpan };
+
+    /// <summary>
+    /// Resolve the request URL from a user-supplied base URL.
+    ///
+    /// <para>Users paste whatever their provider's docs showed them, and the variants are all legitimate:
+    /// <c>https://api.deepseek.com</c>, <c>https://api.deepseek.com/v1</c>,
+    /// <c>http://localhost:11434/v1</c>, <c>https://openrouter.ai/api/v1</c>. Getting this wrong produces a 404
+    /// that looks like a broken provider rather than a mistyped setting, so be forgiving here:
+    /// a bare host gains the version segment, a base that already carries one does not, and a URL that already
+    /// names the endpoint is left alone.</para>
+    /// </summary>
+    /// <param name="baseUrl">The configured base URL.</param>
+    /// <param name="versionedPath">Path to use when the base URL is a bare host, e.g. <c>v1/chat/completions</c>.</param>
+    /// <param name="path">Path to use when the base URL already carries a path, e.g. <c>chat/completions</c>.</param>
+    internal static Uri ResolveEndpoint(string baseUrl, string versionedPath, string path)
+    {
+        var trimmed = (baseUrl ?? string.Empty).Trim().TrimEnd('/');
+        if (trimmed.Length == 0 || !Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new AiException(new AiError(
+                AiErrorKind.NotConfigured,
+                "The endpoint URL is not a valid http(s) address."));
+        }
+
+        if (trimmed.EndsWith("/" + path, StringComparison.OrdinalIgnoreCase))
+            return uri;
+
+        var hasPath = uri.AbsolutePath.Trim('/').Length > 0;
+        return new Uri(trimmed + "/" + (hasPath ? path : versionedPath));
+    }
+
+    /// <summary>The provider's requested backoff, when it sent one. Seconds and HTTP-date forms are both legal.</summary>
+    internal static TimeSpan? RetryAfter(HttpResponseMessage response)
+    {
+        var header = response.Headers.RetryAfter;
+        if (header is null) return null;
+        if (header.Delta is { } delta) return delta;
+        if (header.Date is { } date)
+        {
+            var wait = date - DateTimeOffset.UtcNow;
+            return wait > TimeSpan.Zero ? wait : TimeSpan.Zero;
+        }
+
+        // HttpClient only surfaces a parsed header; a malformed one lands in the raw collection.
+        if (response.Headers.TryGetValues("retry-after", out var raw))
+        {
+            foreach (var value in raw)
+            {
+                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds) &&
+                    seconds >= 0)
+                {
+                    return TimeSpan.FromSeconds(seconds);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Map a status code to its kind, before any provider-specific refinement.</summary>
+    internal static AiErrorKind KindFor(HttpStatusCode status) => status switch
+    {
+        HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => AiErrorKind.Unauthorized,
+        HttpStatusCode.TooManyRequests => AiErrorKind.RateLimited,
+        _ => AiErrorKind.Provider,
+    };
+
+    /// <summary>The user-facing sentence for a kind. Never contains provider text — see <see cref="AiError"/>.</summary>
+    internal static string MessageFor(AiErrorKind kind, HttpStatusCode status) => kind switch
+    {
+        AiErrorKind.Unauthorized =>
+            "The provider rejected the API key. Check the key and that it has access to this model.",
+        AiErrorKind.RateLimited =>
+            "The provider is rate-limiting this key. Wait a moment and try again.",
+        AiErrorKind.ContextTooLong =>
+            "The request was longer than the model's context window. Try a smaller passage or fewer glosses.",
+        _ => $"The provider rejected the request (HTTP {(int)status}).",
+    };
+}

--- a/src/CST.Avalonia/Services/Ai/AiHttp.cs
+++ b/src/CST.Avalonia/Services/Ai/AiHttp.cs
@@ -10,6 +10,28 @@ using System.Threading.Tasks;
 
 namespace CST.Avalonia.Services.Ai;
 
+/// <summary>
+/// Which convention a provider's documented "base URL" follows — they differ, and guessing wrong turns a
+/// correctly-pasted setting into a 404.
+/// </summary>
+internal enum BaseUrlConvention
+{
+    /// <summary>
+    /// The base URL already carries the version segment: <c>OPENAI_BASE_URL=https://api.openai.com/v1</c>. The
+    /// documented value is the string you append <c>/chat/completions</c> to, so a pathed base is taken at its
+    /// word — Gemini's <c>/v1beta/openai</c>, Azure's <c>/openai/deployments/{d}</c> and Cloudflare's gateway
+    /// paths are all correct as given and must not be second-guessed.
+    /// </summary>
+    IncludesVersion,
+
+    /// <summary>
+    /// The base URL excludes the version segment: Anthropic's own SDK takes <c>https://api.anthropic.com</c> and
+    /// appends <c>/v1/messages</c> itself, so a gateway mounted at <c>/anthropic</c> serves
+    /// <c>/anthropic/v1/messages</c>.
+    /// </summary>
+    ExcludesVersion,
+}
+
 /// <summary>Shared HTTP plumbing for the chat providers.</summary>
 internal static class AiHttp
 {
@@ -56,17 +78,25 @@ internal static class AiHttp
     /// Resolve the request URL from a user-supplied base URL.
     ///
     /// <para>Users paste whatever their provider's docs showed them, and the variants are all legitimate:
-    /// <c>https://api.deepseek.com</c>, <c>https://api.deepseek.com/v1</c>,
-    /// <c>http://localhost:11434/v1</c>, <c>https://openrouter.ai/api/v1</c>. Getting this wrong produces a 404
-    /// that looks like a broken provider rather than a mistyped setting, so be forgiving: a bare host gains the
-    /// version segment, a base that already carries one does not, and a URL that already names the endpoint is
-    /// left alone. Any query string is preserved — Azure-style bases carry <c>?api-version=</c>, and appending
-    /// the path as raw text would bury it inside the query.</para>
+    /// <c>https://api.deepseek.com</c>, <c>https://api.deepseek.com/v1</c>, <c>http://localhost:11434/v1</c>,
+    /// <c>https://openrouter.ai/api/v1</c>. Getting this wrong produces a 404 that looks like a broken provider
+    /// rather than a mistyped setting, so: a bare host gains the version segment, a base that already carries one
+    /// does not, and a URL that already names the endpoint is left alone. Any query string is preserved — Azure
+    /// bases carry <c>?api-version=</c>, and appending the path as text would bury it inside the query.</para>
+    ///
+    /// <para><b>The one guess, and its limit.</b> A single-segment path with no version — <c>openrouter.ai/api</c>,
+    /// <c>api.groq.com/openai</c> — is the docs' URL with the <c>/v1</c> dropped, so under
+    /// <see cref="BaseUrlConvention.IncludesVersion"/> the version is added back. That rescue stops at ONE
+    /// segment on purpose: a longer path is somebody's documented base (Gemini's <c>/v1beta/openai</c>, Azure's
+    /// <c>/openai/deployments/{id}</c>, a Cloudflare gateway path), and rescuing a typo is not worth 404-ing a
+    /// setting that was pasted correctly.</para>
     /// </summary>
     /// <param name="baseUrl">The configured base URL.</param>
-    /// <param name="versionedPath">Path to use when the base URL is a bare host, e.g. <c>v1/chat/completions</c>.</param>
-    /// <param name="path">Path to use when the base URL already carries a path, e.g. <c>chat/completions</c>.</param>
-    internal static Uri ResolveEndpoint(string baseUrl, string versionedPath, string path)
+    /// <param name="versionedPath">Path used when the version segment must be added, e.g. <c>v1/chat/completions</c>.</param>
+    /// <param name="path">Path used when the base already carries the version, e.g. <c>chat/completions</c>.</param>
+    /// <param name="convention">Which convention the provider's own documentation follows.</param>
+    internal static Uri ResolveEndpoint(
+        string baseUrl, string versionedPath, string path, BaseUrlConvention convention)
     {
         var trimmed = (baseUrl ?? string.Empty).Trim();
         if (trimmed.Length == 0 || !Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ||
@@ -86,20 +116,26 @@ internal static class AiHttp
             return builder.Uri;   // already names the endpoint
         }
 
-        // Does the base already carry a version segment? The OpenAI convention is that a "base URL" ends in
-        // one (OPENAI_BASE_URL=https://api.openai.com/v1), so a path WITHOUT one is a mount point that still
-        // needs it — `https://openrouter.ai/api` is the docs' URL with the `/v1` dropped, and appending only
-        // `chat/completions` there yields a 404 that reads as a broken provider rather than a mistyped setting.
-        var lastSegment = existing.Length == 0
-            ? string.Empty
-            : existing[(existing.LastIndexOf('/') + 1)..];
-        var versioned = lastSegment.Length > 1 && (lastSegment[0] is 'v' or 'V') &&
-                        lastSegment[1..].All(char.IsAsciiDigit);
+        var segments = existing.Length == 0 ? Array.Empty<string>() : existing.Split('/');
+        var addVersion = segments.Length switch
+        {
+            0 => true,                                   // bare host always needs the version segment
+            _ when IsVersionSegment(segments[^1]) => false,   // already versioned
+            _ => convention == BaseUrlConvention.ExcludesVersion || segments.Length == 1,
+        };
 
-        var suffix = versioned ? path : versionedPath;
+        var suffix = addVersion ? versionedPath : path;
         builder.Path = existing.Length == 0 ? suffix : existing + "/" + suffix;
         return builder.Uri;
     }
+
+    /// <summary>
+    /// A path segment that names an API version — <c>v1</c>, <c>v2</c>, and also <c>v1beta</c> / <c>v1.0</c>,
+    /// which Gemini and others use. A leading <c>v</c> followed by a digit is the whole test; anything more
+    /// elaborate would start rejecting real version segments.
+    /// </summary>
+    private static bool IsVersionSegment(string segment) =>
+        segment.Length > 1 && segment[0] is 'v' or 'V' && char.IsAsciiDigit(segment[1]);
 
     /// <summary>The provider's requested backoff, when it sent one. Seconds and HTTP-date forms are both legal.</summary>
     internal static TimeSpan? RetryAfter(HttpResponseMessage response)

--- a/src/CST.Avalonia/Services/Ai/AiHttp.cs
+++ b/src/CST.Avalonia/Services/Ai/AiHttp.cs
@@ -86,7 +86,17 @@ internal static class AiHttp
             return builder.Uri;   // already names the endpoint
         }
 
-        var suffix = existing.Length == 0 ? versionedPath : path;
+        // Does the base already carry a version segment? The OpenAI convention is that a "base URL" ends in
+        // one (OPENAI_BASE_URL=https://api.openai.com/v1), so a path WITHOUT one is a mount point that still
+        // needs it — `https://openrouter.ai/api` is the docs' URL with the `/v1` dropped, and appending only
+        // `chat/completions` there yields a 404 that reads as a broken provider rather than a mistyped setting.
+        var lastSegment = existing.Length == 0
+            ? string.Empty
+            : existing[(existing.LastIndexOf('/') + 1)..];
+        var versioned = lastSegment.Length > 1 && (lastSegment[0] is 'v' or 'V') &&
+                        lastSegment[1..].All(char.IsAsciiDigit);
+
+        var suffix = versioned ? path : versionedPath;
         builder.Path = existing.Length == 0 ? suffix : existing + "/" + suffix;
         return builder.Uri;
     }

--- a/src/CST.Avalonia/Services/Ai/AiJson.cs
+++ b/src/CST.Avalonia/Services/Ai/AiJson.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>
+/// Shape-safe accessors for provider JSON.
+///
+/// <para><b>Why these exist rather than plain <c>GetString()</c>.</b> A provider's payload is untrusted input,
+/// and <see cref="JsonElement"/> throws <see cref="System.InvalidOperationException"/> the moment a value is not
+/// the kind you assumed — <c>GetString()</c> on a number, or <c>TryGetProperty</c> on a root that is not an
+/// object. Inside a streaming iterator that exception escapes to the consumer as an unclassified crash
+/// mid-answer, which is exactly the outcome the Error-delta contract exists to prevent. Real traffic hits this:
+/// OpenRouter reports mid-stream failures with a NUMERIC <c>code</c>, and a bare <c>data: null</c> chunk parses
+/// successfully and then faults on the first property read.</para>
+/// </summary>
+internal static class AiJson
+{
+    /// <summary>True when the element is an object and can safely be probed for properties.</summary>
+    internal static bool IsObject(JsonElement element) => element.ValueKind == JsonValueKind.Object;
+
+    /// <summary>A string property, or null if absent or of any other kind.</summary>
+    internal static string? String(JsonElement element, string name) =>
+        IsObject(element) && element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    /// <summary>An int property, or null if absent or not a number that fits.</summary>
+    internal static int? Int(JsonElement element, string name) =>
+        IsObject(element) && element.TryGetProperty(name, out var value) &&
+        value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var number)
+            ? number
+            : null;
+
+    /// <summary>An object property, or null if absent or of another kind.</summary>
+    internal static JsonElement? Object(JsonElement element, string name) =>
+        IsObject(element) && element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.Object
+            ? value
+            : null;
+
+    /// <summary>An array property, or null if absent or of another kind.</summary>
+    internal static JsonElement? Array(JsonElement element, string name) =>
+        IsObject(element) && element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.Array
+            ? value
+            : null;
+
+    /// <summary>
+    /// An error code, which providers spell as either a string or a number — OpenRouter uses the HTTP status as
+    /// a bare number. Numbers are rendered invariantly so the result is always a short token.
+    /// </summary>
+    internal static string? Code(JsonElement element, string name)
+    {
+        if (!IsObject(element) || !element.TryGetProperty(name, out var value)) return null;
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Number => value.TryGetInt64(out var number)
+                ? number.ToString(CultureInfo.InvariantCulture)
+                : value.GetRawText(),
+            _ => null,
+        };
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
@@ -65,7 +65,8 @@ public sealed class AnthropicMessagesProvider : IChatProvider
         var endpoint = AiHttp.ResolveEndpoint(
             string.IsNullOrWhiteSpace(_options.BaseUrl) ? AnthropicOptions.DefaultBaseUrl : _options.BaseUrl!,
             versionedPath: "v1/messages",
-            path: "messages");
+            path: "messages",
+            convention: BaseUrlConvention.ExcludesVersion);
 
         using var message = new HttpRequestMessage(HttpMethod.Post, endpoint)
         {

--- a/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>Configuration for <see cref="AnthropicMessagesProvider"/>.</summary>
+/// <param name="ApiKey">Required — Anthropic has no anonymous access.</param>
+/// <param name="BaseUrl">Override for a proxy or gateway; defaults to the public API.</param>
+public sealed record AnthropicOptions(string? ApiKey, string? BaseUrl = null)
+{
+    internal const string DefaultBaseUrl = "https://api.anthropic.com";
+}
+
+/// <summary>
+/// The Anthropic Messages API (<c>POST /v1/messages</c>, SSE). Claude-first is the standing default for
+/// surface B — see AI_INTEGRATION.md §11.1. (#578)
+///
+/// <para><b>Two request-shape rules that are easy to get wrong.</b> <c>max_tokens</c> is REQUIRED — omitting it
+/// is a 400, not a default. And current Claude models REJECT <c>temperature</c>/<c>top_p</c>/<c>top_k</c> with a
+/// 400, so this adapter deliberately has no sampling knobs to send and the Settings UI must not offer any.</para>
+/// </summary>
+public sealed class AnthropicMessagesProvider : IChatProvider
+{
+    private const string AnthropicVersion = "2023-06-01";
+
+    private readonly HttpClient _http;
+    private readonly AnthropicOptions _options;
+    private readonly ILogger<AnthropicMessagesProvider> _logger;
+    private readonly TimeSpan _idleTimeout;
+
+    public AnthropicMessagesProvider(
+        HttpClient http,
+        AnthropicOptions options,
+        ILogger<AnthropicMessagesProvider> logger,
+        TimeSpan? idleTimeout = null)
+    {
+        _http = http;
+        _options = options;
+        _logger = logger;
+        _idleTimeout = idleTimeout ?? SseReader.DefaultIdleTimeout;
+    }
+
+    public string Id => "anthropic";
+
+    public async IAsyncEnumerable<ChatDelta> StreamAsync(
+        ChatRequest request,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options.ApiKey))
+            throw new AiException(new AiError(AiErrorKind.NotConfigured, "No Anthropic API key is configured."));
+        if (string.IsNullOrWhiteSpace(request.Model))
+            throw new AiException(new AiError(AiErrorKind.NotConfigured, "No model is configured."));
+
+        var endpoint = AiHttp.ResolveEndpoint(
+            string.IsNullOrWhiteSpace(_options.BaseUrl) ? AnthropicOptions.DefaultBaseUrl : _options.BaseUrl!,
+            versionedPath: "v1/messages",
+            path: "messages");
+
+        using var message = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new StringContent(BuildBody(request), Encoding.UTF8, "application/json"),
+        };
+        message.Headers.TryAddWithoutValidation("x-api-key", _options.ApiKey);
+        message.Headers.TryAddWithoutValidation("anthropic-version", AnthropicVersion);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _http
+                .SendAsync(message, HttpCompletionOption.ResponseHeadersRead, ct)
+                .ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new AiException(new AiError(
+                AiErrorKind.Network, "Could not reach the Anthropic API. Check your network connection."), ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+                throw new AiException(await ClassifyAsync(response, ct).ConfigureAwait(false));
+
+            var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+
+            await foreach (var sse in SseReader.ReadAsync(stream, _idleTimeout, ct).ConfigureAwait(false))
+            {
+                if (sse.Failure is { } failure)
+                {
+                    _logger.LogWarning("Anthropic stream ended early: {Kind}", failure.Kind);
+                    yield return ChatDelta.ForError(failure);
+                    yield break;
+                }
+
+                foreach (var delta in Interpret(sse))
+                {
+                    yield return delta;
+                    if (delta.Kind == ChatDeltaKind.Error)
+                        yield break;
+                }
+            }
+        }
+    }
+
+    private static string BuildBody(ChatRequest request)
+    {
+        var buffer = new MemoryStream();
+        using (var json = new Utf8JsonWriter(buffer))
+        {
+            json.WriteStartObject();
+            json.WriteString("model", request.Model);
+            json.WriteNumber("max_tokens", request.MaxTokens);   // required by the API
+            json.WriteBoolean("stream", true);
+
+            if (!string.IsNullOrEmpty(request.System))
+                json.WriteString("system", request.System);
+
+            json.WriteStartArray("messages");
+            foreach (var turn in request.Messages)
+            {
+                json.WriteStartObject();
+                json.WriteString("role", turn.Role == ChatRole.Assistant ? "assistant" : "user");
+                json.WriteString("content", turn.Content);
+                json.WriteEndObject();
+            }
+            json.WriteEndArray();
+
+            // No temperature / top_p / top_k: current Claude models reject them with a 400.
+            json.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    /// <summary>Translate one SSE event into zero or more deltas.</summary>
+    private static IEnumerable<ChatDelta> Interpret(SseEvent sse)
+    {
+        JsonElement root;
+        try
+        {
+            using var document = JsonDocument.Parse(sse.Data);
+            root = document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            // A single malformed event is not worth abandoning a good stream over; the terminator or the next
+            // event will carry us forward. (A truncated FINAL event just ends the stream.)
+            yield break;
+        }
+
+        var type = root.TryGetProperty("type", out var typeElement) ? typeElement.GetString() : sse.Name;
+
+        switch (type)
+        {
+            case "content_block_delta":
+                if (root.TryGetProperty("delta", out var delta))
+                {
+                    var deltaType = delta.TryGetProperty("type", out var dt) ? dt.GetString() : null;
+                    if (deltaType == "text_delta" && delta.TryGetProperty("text", out var text))
+                    {
+                        var value = text.GetString();
+                        if (!string.IsNullOrEmpty(value)) yield return ChatDelta.ForText(value);
+                    }
+                    else if (deltaType == "thinking_delta" && delta.TryGetProperty("thinking", out var thinking))
+                    {
+                        var value = thinking.GetString();
+                        if (!string.IsNullOrEmpty(value)) yield return ChatDelta.ForReasoning(value);
+                    }
+                }
+                break;
+
+            case "message_start":
+                if (root.TryGetProperty("message", out var start) &&
+                    start.TryGetProperty("usage", out var startUsage))
+                {
+                    yield return ChatDelta.ForUsage(new ChatUsage(
+                        InputTokens: ReadInt(startUsage, "input_tokens"),
+                        OutputTokens: ReadInt(startUsage, "output_tokens")));
+                }
+                break;
+
+            case "message_delta":
+                if (root.TryGetProperty("usage", out var endUsage))
+                {
+                    yield return ChatDelta.ForUsage(new ChatUsage(
+                        InputTokens: ReadInt(endUsage, "input_tokens"),
+                        OutputTokens: ReadInt(endUsage, "output_tokens")));
+                }
+                break;
+
+            case "error":
+                // The API can report a failure mid-stream (overloaded, and other transient states). The caller
+                // already has partial text on screen, so this is an Error delta rather than an exception.
+                var code = root.TryGetProperty("error", out var error) &&
+                           error.TryGetProperty("type", out var errorType)
+                    ? errorType.GetString()
+                    : null;
+                yield return ChatDelta.ForError(new AiError(
+                    AiErrorKind.Provider,
+                    "The model stopped part-way through: the provider reported an error.",
+                    ProviderCode: code));
+                break;
+
+            // message_stop / content_block_start / content_block_stop / ping carry nothing we need.
+        }
+    }
+
+    private static int? ReadInt(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.TryGetInt32(out var number) ? number : null;
+
+    /// <summary>
+    /// Classify a non-2xx response. The body IS read — it is the only way to tell a context-window overflow from
+    /// any other 400 — but only the short <c>error.type</c> token escapes into the log or the returned error. The
+    /// prose in <c>error.message</c> commonly quotes the offending request back, which here means corpus text and
+    /// the user's own question, so it is used for classification and then dropped.
+    /// </summary>
+    private async Task<AiError> ClassifyAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var kind = AiHttp.KindFor(response.StatusCode);
+        string? code = null;
+
+        try
+        {
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            using var document = JsonDocument.Parse(body);
+            if (document.RootElement.TryGetProperty("error", out var error))
+            {
+                code = error.TryGetProperty("type", out var type) ? type.GetString() : null;
+
+                if (kind == AiErrorKind.Provider &&
+                    (int)response.StatusCode == 400 &&
+                    error.TryGetProperty("message", out var messageElement) &&
+                    LooksLikeContextOverflow(messageElement.GetString()))
+                {
+                    kind = AiErrorKind.ContextTooLong;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException or HttpRequestException or IOException)
+        {
+            // An unparseable body tells us nothing extra; the status code already classified it.
+        }
+
+        _logger.LogWarning(
+            "Anthropic request failed: HTTP {Status} {Code}", (int)response.StatusCode, code ?? "(no code)");
+
+        return new AiError(
+            kind,
+            AiHttp.MessageFor(kind, response.StatusCode),
+            StatusCode: (int)response.StatusCode,
+            ProviderCode: code,
+            RetryAfter: AiHttp.RetryAfter(response));
+    }
+
+    /// <summary>
+    /// Anthropic has no machine-readable code for a context overflow — it is an <c>invalid_request_error</c>
+    /// like any other — so the prose is the only signal available. Matched, never retained.
+    /// </summary>
+    private static bool LooksLikeContextOverflow(string? message) =>
+        message is not null &&
+        (message.Contains("prompt is too long", StringComparison.OrdinalIgnoreCase) ||
+         message.Contains("exceed the context", StringComparison.OrdinalIgnoreCase) ||
+         message.Contains("context window", StringComparison.OrdinalIgnoreCase));
+}

--- a/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
@@ -35,17 +35,20 @@ public sealed class AnthropicMessagesProvider : IChatProvider
     private readonly AnthropicOptions _options;
     private readonly ILogger<AnthropicMessagesProvider> _logger;
     private readonly TimeSpan _idleTimeout;
+    private readonly TimeSpan _firstEventTimeout;
 
     public AnthropicMessagesProvider(
         HttpClient http,
         AnthropicOptions options,
         ILogger<AnthropicMessagesProvider> logger,
-        TimeSpan? idleTimeout = null)
+        TimeSpan? idleTimeout = null,
+        TimeSpan? firstEventTimeout = null)
     {
-        _http = http;
+        _http = AiHttp.EnsureStreamable(http);
         _options = options;
         _logger = logger;
         _idleTimeout = idleTimeout ?? SseReader.DefaultIdleTimeout;
+        _firstEventTimeout = firstEventTimeout ?? SseReader.DefaultFirstEventTimeout;
     }
 
     public string Id => "anthropic";
@@ -90,8 +93,10 @@ public sealed class AnthropicMessagesProvider : IChatProvider
                 throw new AiException(await ClassifyAsync(response, ct).ConfigureAwait(false));
 
             var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            var produced = false;
 
-            await foreach (var sse in SseReader.ReadAsync(stream, _idleTimeout, ct).ConfigureAwait(false))
+            await foreach (var sse in SseReader.ReadAsync(stream, _idleTimeout, _firstEventTimeout, ct)
+                               .ConfigureAwait(false))
             {
                 if (sse.Failure is { } failure)
                 {
@@ -100,12 +105,23 @@ public sealed class AnthropicMessagesProvider : IChatProvider
                     yield break;
                 }
 
+                produced = true;
+
                 foreach (var delta in Interpret(sse))
                 {
                     yield return delta;
                     if (delta.Kind == ChatDeltaKind.Error)
                         yield break;
                 }
+            }
+
+            // A 200 that carried no events at all is not success. The usual cause is an endpoint that is not the
+            // API — a proxy or portal answering 200 with HTML — and reporting nothing would leave the user with
+            // a blank answer and no way to tell a misconfiguration from a model that declined to speak.
+            if (!produced)
+            {
+                _logger.LogWarning("Anthropic returned a 200 with no stream events");
+                yield return ChatDelta.ForError(AiHttp.EmptyResponse());
             }
         }
     }
@@ -140,7 +156,11 @@ public sealed class AnthropicMessagesProvider : IChatProvider
         return Encoding.UTF8.GetString(buffer.ToArray());
     }
 
-    /// <summary>Translate one SSE event into zero or more deltas.</summary>
+    /// <summary>
+    /// Translate one SSE event into zero or more deltas. Every property read goes through <see cref="AiJson"/>:
+    /// a provider payload is untrusted input, and a raw <c>GetString()</c> on an unexpected kind throws out of
+    /// this iterator as an unclassified crash mid-answer.
+    /// </summary>
     private static IEnumerable<ChatDelta> Interpret(SseEvent sse)
     {
         JsonElement root;
@@ -156,65 +176,55 @@ public sealed class AnthropicMessagesProvider : IChatProvider
             yield break;
         }
 
-        var type = root.TryGetProperty("type", out var typeElement) ? typeElement.GetString() : sse.Name;
+        if (!AiJson.IsObject(root))
+            yield break;   // e.g. a bare `data: null` keep-alive — parses fine, has no properties
+
+        var type = AiJson.String(root, "type") ?? sse.Name;
 
         switch (type)
         {
             case "content_block_delta":
-                if (root.TryGetProperty("delta", out var delta))
+                if (AiJson.Object(root, "delta") is { } delta)
                 {
-                    var deltaType = delta.TryGetProperty("type", out var dt) ? dt.GetString() : null;
-                    if (deltaType == "text_delta" && delta.TryGetProperty("text", out var text))
+                    switch (AiJson.String(delta, "type"))
                     {
-                        var value = text.GetString();
-                        if (!string.IsNullOrEmpty(value)) yield return ChatDelta.ForText(value);
-                    }
-                    else if (deltaType == "thinking_delta" && delta.TryGetProperty("thinking", out var thinking))
-                    {
-                        var value = thinking.GetString();
-                        if (!string.IsNullOrEmpty(value)) yield return ChatDelta.ForReasoning(value);
+                        case "text_delta" when AiJson.String(delta, "text") is { Length: > 0 } text:
+                            yield return ChatDelta.ForText(text);
+                            break;
+                        case "thinking_delta" when AiJson.String(delta, "thinking") is { Length: > 0 } thinking:
+                            yield return ChatDelta.ForReasoning(thinking);
+                            break;
                     }
                 }
                 break;
 
             case "message_start":
-                if (root.TryGetProperty("message", out var start) &&
-                    start.TryGetProperty("usage", out var startUsage))
-                {
-                    yield return ChatDelta.ForUsage(new ChatUsage(
-                        InputTokens: ReadInt(startUsage, "input_tokens"),
-                        OutputTokens: ReadInt(startUsage, "output_tokens")));
-                }
+                if (AiJson.Object(root, "message") is { } start && AiJson.Object(start, "usage") is { } startUsage)
+                    yield return UsageDelta(startUsage);
                 break;
 
             case "message_delta":
-                if (root.TryGetProperty("usage", out var endUsage))
-                {
-                    yield return ChatDelta.ForUsage(new ChatUsage(
-                        InputTokens: ReadInt(endUsage, "input_tokens"),
-                        OutputTokens: ReadInt(endUsage, "output_tokens")));
-                }
+                if (AiJson.Object(root, "usage") is { } endUsage)
+                    yield return UsageDelta(endUsage);
                 break;
 
             case "error":
                 // The API can report a failure mid-stream (overloaded, and other transient states). The caller
                 // already has partial text on screen, so this is an Error delta rather than an exception.
-                var code = root.TryGetProperty("error", out var error) &&
-                           error.TryGetProperty("type", out var errorType)
-                    ? errorType.GetString()
-                    : null;
                 yield return ChatDelta.ForError(new AiError(
                     AiErrorKind.Provider,
                     "The model stopped part-way through: the provider reported an error.",
-                    ProviderCode: code));
+                    ProviderCode: AiHttp.SanitizeProviderCode(
+                        AiJson.Object(root, "error") is { } error ? AiJson.Code(error, "type") : null)));
                 break;
 
             // message_stop / content_block_start / content_block_stop / ping carry nothing we need.
         }
     }
 
-    private static int? ReadInt(JsonElement element, string name) =>
-        element.TryGetProperty(name, out var value) && value.TryGetInt32(out var number) ? number : null;
+    private static ChatDelta UsageDelta(JsonElement usage) => ChatDelta.ForUsage(new ChatUsage(
+        InputTokens: AiJson.Int(usage, "input_tokens"),
+        OutputTokens: AiJson.Int(usage, "output_tokens")));
 
     /// <summary>
     /// Classify a non-2xx response. The body IS read — it is the only way to tell a context-window overflow from
@@ -227,26 +237,31 @@ public sealed class AnthropicMessagesProvider : IChatProvider
         var kind = AiHttp.KindFor(response.StatusCode);
         string? code = null;
 
-        try
-        {
-            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            using var document = JsonDocument.Parse(body);
-            if (document.RootElement.TryGetProperty("error", out var error))
-            {
-                code = error.TryGetProperty("type", out var type) ? type.GetString() : null;
+        var body = await AiHttp
+            .ReadBoundedBodyAsync(response.Content, TimeSpan.FromSeconds(10), ct)
+            .ConfigureAwait(false);
 
-                if (kind == AiErrorKind.Provider &&
-                    (int)response.StatusCode == 400 &&
-                    error.TryGetProperty("message", out var messageElement) &&
-                    LooksLikeContextOverflow(messageElement.GetString()))
+        if (body.Length > 0)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(body);
+                if (AiJson.Object(document.RootElement, "error") is { } error)
                 {
-                    kind = AiErrorKind.ContextTooLong;
+                    code = AiHttp.SanitizeProviderCode(AiJson.Code(error, "type"));
+
+                    if (kind == AiErrorKind.Provider &&
+                        (int)response.StatusCode == 400 &&
+                        LooksLikeContextOverflow(AiJson.String(error, "message")))
+                    {
+                        kind = AiErrorKind.ContextTooLong;
+                    }
                 }
             }
-        }
-        catch (Exception ex) when (ex is JsonException or InvalidOperationException or HttpRequestException or IOException)
-        {
-            // An unparseable body tells us nothing extra; the status code already classified it.
+            catch (JsonException)
+            {
+                // An unparseable body tells us nothing extra; the status code already classified it.
+            }
         }
 
         _logger.LogWarning(

--- a/src/CST.Avalonia/Services/Ai/ChatContracts.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatContracts.cs
@@ -40,7 +40,12 @@ public enum ChatDeltaKind
     /// </summary>
     Reasoning,
 
-    /// <summary>Token accounting. May arrive more than once; later values supersede earlier ones.</summary>
+    /// <summary>
+    /// Token accounting. May arrive more than once, and <b>must be merged per field, not wholesale</b>: the
+    /// Anthropic stream reports the two halves separately (input at the start, output at the end), so a consumer
+    /// that lets a later value supersede an earlier one erases the input count. A null field means "not reported
+    /// in this delta", never zero.
+    /// </summary>
     Usage,
 
     /// <summary>
@@ -98,8 +103,10 @@ public enum AiErrorKind
 /// <para><b>Nothing here echoes request material.</b> <see cref="Message"/> is composed by us, never lifted from
 /// the provider's error body: those bodies routinely quote the offending request back, which for surface B means
 /// corpus text and the user's own question. <see cref="ProviderCode"/> carries only the provider's short
-/// machine-readable token (<c>rate_limit_error</c>, <c>context_length_exceeded</c>) — bounded vocabulary, safe to
-/// log and genuinely useful when diagnosing.</para>
+/// machine-readable token (<c>rate_limit_error</c>, <c>context_length_exceeded</c>) — genuinely useful when
+/// diagnosing, and safe to log because it is clamped by <c>AiHttp.SanitizeProviderCode</c> to a token-shaped
+/// value. That clamp is what makes the claim true rather than merely intended: the field is provider-controlled,
+/// and "OpenAI-compatible" means an arbitrary user-pasted endpoint that could put anything there.</para>
 /// </summary>
 public sealed record AiError(
     AiErrorKind Kind,

--- a/src/CST.Avalonia/Services/Ai/ChatContracts.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatContracts.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>Who authored a turn. There is no System role — the system prompt is its own request field.</summary>
+public enum ChatRole
+{
+    User,
+    Assistant,
+}
+
+/// <summary>One turn of the conversation sent to the model.</summary>
+public sealed record ChatMessage(ChatRole Role, string Content);
+
+/// <summary>
+/// A request to a model, in the shape surface B needs and nothing more. Deliberately narrow: the two adapters
+/// translate this into their own wire format, so nothing provider-specific leaks into the caller.
+/// </summary>
+/// <param name="Model">Provider-specific model id, verbatim as the user configured it.</param>
+/// <param name="MaxTokens">Output cap. Required — the Anthropic API rejects a request without one.</param>
+/// <param name="System">System prompt, or null. Anthropic carries it in a top-level field; the
+/// OpenAI-compatible shape carries it as a leading message, which the adapter handles.</param>
+public sealed record ChatRequest(
+    string Model,
+    int MaxTokens,
+    string? System,
+    IReadOnlyList<ChatMessage> Messages);
+
+/// <summary>What a <see cref="ChatDelta"/> carries.</summary>
+public enum ChatDeltaKind
+{
+    /// <summary>Answer text. The only kind a caller must render.</summary>
+    Text,
+
+    /// <summary>
+    /// Model reasoning, segregated rather than dropped so a caller may show it deliberately. Never mix it into
+    /// the answer: DeepSeek's reasoning models stream this alongside the answer over the same OpenAI-compatible
+    /// surface, and a naive concatenation renders chain-of-thought at the user.
+    /// </summary>
+    Reasoning,
+
+    /// <summary>Token accounting. May arrive more than once; later values supersede earlier ones.</summary>
+    Usage,
+
+    /// <summary>
+    /// The stream ended early. Emitted INSTEAD of throwing, because by this point the caller is already showing
+    /// partial text and losing it would be worse than showing it with an error appended. A pre-stream failure
+    /// throws <see cref="AiException"/> instead — see <see cref="IChatProvider.StreamAsync"/>.
+    /// </summary>
+    Error,
+}
+
+/// <summary>One increment of a streamed response.</summary>
+public sealed record ChatDelta(
+    ChatDeltaKind Kind,
+    string? Text = null,
+    ChatUsage? Usage = null,
+    AiError? Error = null)
+{
+    public static ChatDelta ForText(string text) => new(ChatDeltaKind.Text, Text: text);
+    public static ChatDelta ForReasoning(string text) => new(ChatDeltaKind.Reasoning, Text: text);
+    public static ChatDelta ForUsage(ChatUsage usage) => new(ChatDeltaKind.Usage, Usage: usage);
+    public static ChatDelta ForError(AiError error) => new(ChatDeltaKind.Error, Error: error);
+}
+
+/// <summary>Token counts as the provider reported them. Null where a provider does not report that half.</summary>
+public sealed record ChatUsage(int? InputTokens, int? OutputTokens);
+
+/// <summary>
+/// The normalized failure set. Callers switch on this rather than on HTTP status codes or provider-specific
+/// error bodies, so the UI has one vocabulary regardless of which provider is configured.
+/// </summary>
+public enum AiErrorKind
+{
+    /// <summary>No model, endpoint, or (where required) key. Detected before any request is made.</summary>
+    NotConfigured,
+
+    /// <summary>Could not reach the provider, or the stream died mid-flight. Distinct from cancellation.</summary>
+    Network,
+
+    /// <summary>401/403 — the key is missing, wrong, or lacks access to the model.</summary>
+    Unauthorized,
+
+    /// <summary>429. <see cref="AiError.RetryAfter"/> is set when the provider said how long to wait.</summary>
+    RateLimited,
+
+    /// <summary>The request exceeded the model's context window. Actionable: the caller can trim and retry.</summary>
+    ContextTooLong,
+
+    /// <summary>Anything else the provider rejected or failed on.</summary>
+    Provider,
+}
+
+/// <summary>
+/// A provider failure, normalized.
+///
+/// <para><b>Nothing here echoes request material.</b> <see cref="Message"/> is composed by us, never lifted from
+/// the provider's error body: those bodies routinely quote the offending request back, which for surface B means
+/// corpus text and the user's own question. <see cref="ProviderCode"/> carries only the provider's short
+/// machine-readable token (<c>rate_limit_error</c>, <c>context_length_exceeded</c>) — bounded vocabulary, safe to
+/// log and genuinely useful when diagnosing.</para>
+/// </summary>
+public sealed record AiError(
+    AiErrorKind Kind,
+    string Message,
+    int? StatusCode = null,
+    string? ProviderCode = null,
+    TimeSpan? RetryAfter = null);
+
+/// <summary>
+/// Thrown for a failure that occurs BEFORE any content has been streamed, where there is no partial answer to
+/// preserve and throwing is the more ergonomic contract. Once text is flowing the provider yields
+/// <see cref="ChatDeltaKind.Error"/> instead.
+/// </summary>
+public sealed class AiException : Exception
+{
+    public AiException(AiError error) : base(error.Message) => Error = error;
+
+    public AiException(AiError error, Exception inner) : base(error.Message, inner) => Error = error;
+
+    public AiError Error { get; }
+}

--- a/src/CST.Avalonia/Services/Ai/IChatProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/IChatProvider.cs
@@ -16,11 +16,18 @@ public interface IChatProvider
     /// <summary>
     /// Stream a response. Deltas arrive as they are produced; the enumerable completes when the model stops.
     ///
-    /// <para><b>Failure has two shapes, deliberately.</b> A failure before any content — unreachable host, 401,
-    /// a request the provider rejected outright — throws <see cref="AiException"/>, because there is nothing on
-    /// screen yet and an exception is the cleaner contract. A failure once deltas have started yields a
-    /// <see cref="ChatDeltaKind.Error"/> delta and completes normally, so the caller keeps the partial answer it
-    /// has already shown the user.</para>
+    /// <para><b>Failure has two shapes, and the boundary is the HTTP response — not the first delta.</b> A
+    /// failure while establishing the response — unreachable host, 401, a request the provider rejected
+    /// outright — throws <see cref="AiException"/>, because nothing can be on screen yet. Once a successful
+    /// response has been accepted, every failure yields a <see cref="ChatDeltaKind.Error"/> delta and the
+    /// enumerable completes normally, so the caller keeps whatever partial answer it has already shown.</para>
+    ///
+    /// <para><b>A caller must therefore handle an Error delta arriving with no preceding text.</b> A stream can
+    /// fail after the response is accepted but before it produces anything — a first event that is an error, a
+    /// connection dropped immediately after the headers, a provider that accepts and then goes silent, or a 200
+    /// carrying no events at all. That is not the same as "there is a partial answer to preserve".</para>
+    ///
+    /// <para>An <see cref="ChatDeltaKind.Error"/> delta is terminal: no further deltas follow it.</para>
     ///
     /// <para>Cancellation via <paramref name="ct"/> is neither: it throws
     /// <see cref="System.OperationCanceledException"/> like any other .NET async method, and is never reported as

--- a/src/CST.Avalonia/Services/Ai/IChatProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/IChatProvider.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>
+/// A streaming chat model, behind one interface so surface B does not care which provider is configured.
+/// Implemented twice: <see cref="AnthropicMessagesProvider"/> and <see cref="OpenAiCompatibleProvider"/>.
+/// (#578, AI_SURFACE_B.md §5)
+/// </summary>
+public interface IChatProvider
+{
+    /// <summary>A short id for logs and settings, e.g. <c>anthropic</c> / <c>openai-compatible</c>.</summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Stream a response. Deltas arrive as they are produced; the enumerable completes when the model stops.
+    ///
+    /// <para><b>Failure has two shapes, deliberately.</b> A failure before any content — unreachable host, 401,
+    /// a request the provider rejected outright — throws <see cref="AiException"/>, because there is nothing on
+    /// screen yet and an exception is the cleaner contract. A failure once deltas have started yields a
+    /// <see cref="ChatDeltaKind.Error"/> delta and completes normally, so the caller keeps the partial answer it
+    /// has already shown the user.</para>
+    ///
+    /// <para>Cancellation via <paramref name="ct"/> is neither: it throws
+    /// <see cref="System.OperationCanceledException"/> like any other .NET async method, and is never reported as
+    /// an <see cref="AiError"/>. An idle stream that stops producing without being cancelled IS an error, and
+    /// surfaces as <see cref="AiErrorKind.Network"/>.</para>
+    /// </summary>
+    IAsyncEnumerable<ChatDelta> StreamAsync(ChatRequest request, CancellationToken ct = default);
+}

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -63,7 +63,8 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
             throw new AiException(new AiError(AiErrorKind.NotConfigured, "No model is configured."));
 
         var endpoint = AiHttp.ResolveEndpoint(
-            _options.BaseUrl!, versionedPath: "v1/chat/completions", path: "chat/completions");
+            _options.BaseUrl!, versionedPath: "v1/chat/completions", path: "chat/completions",
+            convention: BaseUrlConvention.IncludesVersion);
 
         using var message = new HttpRequestMessage(HttpMethod.Post, endpoint)
         {

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -35,17 +35,20 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
     private readonly OpenAiCompatibleOptions _options;
     private readonly ILogger<OpenAiCompatibleProvider> _logger;
     private readonly TimeSpan _idleTimeout;
+    private readonly TimeSpan _firstEventTimeout;
 
     public OpenAiCompatibleProvider(
         HttpClient http,
         OpenAiCompatibleOptions options,
         ILogger<OpenAiCompatibleProvider> logger,
-        TimeSpan? idleTimeout = null)
+        TimeSpan? idleTimeout = null,
+        TimeSpan? firstEventTimeout = null)
     {
-        _http = http;
+        _http = AiHttp.EnsureStreamable(http);
         _options = options;
         _logger = logger;
         _idleTimeout = idleTimeout ?? SseReader.DefaultIdleTimeout;
+        _firstEventTimeout = firstEventTimeout ?? SseReader.DefaultFirstEventTimeout;
     }
 
     public string Id => "openai-compatible";
@@ -90,8 +93,10 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
 
             var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
             var think = new ThinkTagFilter();
+            var produced = false;
 
-            await foreach (var sse in SseReader.ReadAsync(stream, _idleTimeout, ct).ConfigureAwait(false))
+            await foreach (var sse in SseReader.ReadAsync(stream, _idleTimeout, _firstEventTimeout, ct)
+                               .ConfigureAwait(false))
             {
                 if (sse.Failure is { } failure)
                 {
@@ -101,22 +106,45 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
                     yield break;
                 }
 
+                produced = true;
+
                 if (sse.Data == "[DONE]")
                     break;
 
                 foreach (var delta in Interpret(sse, think))
+                {
+                    // An Error delta is terminal by contract (see ChatDeltaKind.Error) — a gateway that keeps
+                    // streaming after reporting a failure must not have that content appended to the answer.
+                    // Held-back think-tag text is flushed FIRST so it cannot arrive after the error.
+                    if (delta.Kind == ChatDeltaKind.Error)
+                    {
+                        foreach (var tail in FlushThink(think)) yield return tail;
+                        yield return delta;
+                        yield break;
+                    }
+
                     yield return delta;
+                }
             }
 
             foreach (var tail in FlushThink(think)) yield return tail;
+
+            // A 200 that carried no events at all is not success. The usual cause is an endpoint that is not the
+            // API — a proxy or portal answering 200 with HTML — and reporting nothing would leave the user with
+            // a blank answer and no way to tell a misconfiguration from a model that declined to speak.
+            if (!produced)
+            {
+                _logger.LogWarning("OpenAI-compatible endpoint returned a 200 with no stream events");
+                yield return ChatDelta.ForError(AiHttp.EmptyResponse());
+            }
         }
     }
 
     private static IEnumerable<ChatDelta> FlushThink(ThinkTagFilter think)
     {
         var (visible, reasoning) = think.Flush();
-        if (visible.Length > 0) yield return ChatDelta.ForText(visible);
         if (reasoning.Length > 0) yield return ChatDelta.ForReasoning(reasoning);
+        if (visible.Length > 0) yield return ChatDelta.ForText(visible);
     }
 
     private static string BuildBody(ChatRequest request)
@@ -157,6 +185,12 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
         return Encoding.UTF8.GetString(buffer.ToArray());
     }
 
+    /// <summary>
+    /// Translate one SSE chunk into zero or more deltas. Every property read goes through <see cref="AiJson"/>:
+    /// a provider payload is untrusted input, and a raw <c>GetString()</c> on an unexpected kind throws out of
+    /// this iterator as an unclassified crash mid-answer. OpenRouter reporting a NUMERIC <c>error.code</c> is a
+    /// real instance of exactly that.
+    /// </summary>
     private static IEnumerable<ChatDelta> Interpret(SseEvent sse, ThinkTagFilter think)
     {
         JsonElement root;
@@ -170,83 +204,76 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
             yield break;   // one bad chunk does not end an otherwise healthy stream
         }
 
+        if (!AiJson.IsObject(root))
+            yield break;
+
         // Some providers report an error as a normal 200 chunk rather than an HTTP status.
-        if (root.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.Object)
+        if (AiJson.Object(root, "error") is { } error)
         {
-            var code = error.TryGetProperty("code", out var codeElement) ? codeElement.GetString() : null;
-            code ??= error.TryGetProperty("type", out var typeElement) ? typeElement.GetString() : null;
             yield return ChatDelta.ForError(new AiError(
                 AiErrorKind.Provider,
                 "The model stopped part-way through: the provider reported an error.",
-                ProviderCode: code));
+                ProviderCode: AiHttp.SanitizeProviderCode(
+                    AiJson.Code(error, "code") ?? AiJson.Code(error, "type"))));
             yield break;
         }
 
-        if (root.TryGetProperty("choices", out var choices) &&
-            choices.ValueKind == JsonValueKind.Array &&
+        if (AiJson.Array(root, "choices") is { } choices &&
             choices.GetArrayLength() > 0 &&
-            choices[0].TryGetProperty("delta", out var delta))
+            AiJson.Object(choices[0], "delta") is { } delta)
         {
             // Structured reasoning (DeepSeek and others) — never merged into the answer.
-            if (delta.TryGetProperty("reasoning_content", out var reasoning) &&
-                reasoning.ValueKind == JsonValueKind.String)
-            {
-                var value = reasoning.GetString();
-                if (!string.IsNullOrEmpty(value)) yield return ChatDelta.ForReasoning(value);
-            }
+            if (AiJson.String(delta, "reasoning_content") is { Length: > 0 } reasoning)
+                yield return ChatDelta.ForReasoning(reasoning);
 
-            if (delta.TryGetProperty("content", out var content) && content.ValueKind == JsonValueKind.String)
+            if (AiJson.String(delta, "content") is { Length: > 0 } content)
             {
-                var value = content.GetString();
-                if (!string.IsNullOrEmpty(value))
-                {
-                    // Inline <think> tags are the other reasoning convention; strip them across chunk boundaries.
-                    var (visible, inlineReasoning) = think.Feed(value);
-                    if (inlineReasoning.Length > 0) yield return ChatDelta.ForReasoning(inlineReasoning);
-                    if (visible.Length > 0) yield return ChatDelta.ForText(visible);
-                }
+                // Inline <think> tags are the other reasoning convention; strip them across chunk boundaries.
+                var (visible, inlineReasoning) = think.Feed(content);
+                if (inlineReasoning.Length > 0) yield return ChatDelta.ForReasoning(inlineReasoning);
+                if (visible.Length > 0) yield return ChatDelta.ForText(visible);
             }
         }
 
-        if (root.TryGetProperty("usage", out var usage) && usage.ValueKind == JsonValueKind.Object)
+        if (AiJson.Object(root, "usage") is { } usage)
         {
             yield return ChatDelta.ForUsage(new ChatUsage(
-                InputTokens: ReadInt(usage, "prompt_tokens"),
-                OutputTokens: ReadInt(usage, "completion_tokens")));
+                InputTokens: AiJson.Int(usage, "prompt_tokens"),
+                OutputTokens: AiJson.Int(usage, "completion_tokens")));
         }
     }
 
-    private static int? ReadInt(JsonElement element, string name) =>
-        element.TryGetProperty(name, out var value) && value.TryGetInt32(out var number) ? number : null;
-
     /// <summary>
-    /// Classify a non-2xx response. As with the Anthropic adapter the body is read for classification only:
-    /// <c>error.code</c> is a bounded token and is kept, while <c>error.message</c> can quote the request back
-    /// and is discarded.
+    /// Classify a non-2xx response. As with the Anthropic adapter the body is read for classification only, and
+    /// bounded: <c>error.code</c> is a short token and is kept (after sanitizing), while <c>error.message</c> can
+    /// quote the request back and is discarded.
     /// </summary>
     private async Task<AiError> ClassifyAsync(HttpResponseMessage response, CancellationToken ct)
     {
         var kind = AiHttp.KindFor(response.StatusCode);
         string? code = null;
 
-        try
-        {
-            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            using var document = JsonDocument.Parse(body);
-            if (document.RootElement.TryGetProperty("error", out var error) &&
-                error.ValueKind == JsonValueKind.Object)
-            {
-                code = error.TryGetProperty("code", out var codeElement) && codeElement.ValueKind == JsonValueKind.String
-                    ? codeElement.GetString()
-                    : null;
-                code ??= error.TryGetProperty("type", out var typeElement) ? typeElement.GetString() : null;
+        var body = await AiHttp
+            .ReadBoundedBodyAsync(response.Content, TimeSpan.FromSeconds(10), ct)
+            .ConfigureAwait(false);
 
-                if (string.Equals(code, "context_length_exceeded", StringComparison.OrdinalIgnoreCase))
-                    kind = AiErrorKind.ContextTooLong;
-            }
-        }
-        catch (Exception ex) when (ex is JsonException or InvalidOperationException or HttpRequestException or IOException)
+        if (body.Length > 0)
         {
+            try
+            {
+                using var document = JsonDocument.Parse(body);
+                if (AiJson.Object(document.RootElement, "error") is { } error)
+                {
+                    code = AiHttp.SanitizeProviderCode(
+                        AiJson.Code(error, "code") ?? AiJson.Code(error, "type"));
+
+                    if (string.Equals(code, "context_length_exceeded", StringComparison.OrdinalIgnoreCase))
+                        kind = AiErrorKind.ContextTooLong;
+                }
+            }
+            catch (JsonException)
+            {
+            }
         }
 
         _logger.LogWarning(

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -223,8 +223,14 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
             choices.GetArrayLength() > 0 &&
             AiJson.Object(choices[0], "delta") is { } delta)
         {
-            // Structured reasoning (DeepSeek and others) — never merged into the answer.
-            if (AiJson.String(delta, "reasoning_content") is { Length: > 0 } reasoning)
+            // Structured reasoning — never merged into the answer. The field name is NOT standardised: DeepSeek
+            // documents `reasoning_content`, while Ollama's OpenAI-compat surface (and OpenRouter) use plain
+            // `reasoning`. Verified against a live Ollama serving gpt-oss: 73 of its deltas carried `reasoning`
+            // and none carried `reasoning_content`, so parsing only the documented name dropped the model's
+            // entire reasoning stream — leaving usage that says 80 output tokens next to a one-line answer.
+            if (AiJson.String(delta, "reasoning_content") is { Length: > 0 } reasoningContent)
+                yield return ChatDelta.ForReasoning(reasoningContent);
+            else if (AiJson.String(delta, "reasoning") is { Length: > 0 } reasoning)
                 yield return ChatDelta.ForReasoning(reasoning);
 
             if (AiJson.String(delta, "content") is { Length: > 0 } content)

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>Configuration for <see cref="OpenAiCompatibleProvider"/>.</summary>
+/// <param name="BaseUrl">Required. This one field is what makes a single adapter serve DeepSeek, OpenRouter,
+/// Together, Ollama and LM Studio.</param>
+/// <param name="ApiKey">Optional — local runners (Ollama, LM Studio) accept anonymous requests, so an empty key
+/// is a valid configuration rather than a misconfiguration. A remote provider will answer 401 on its own.</param>
+public sealed record OpenAiCompatibleOptions(string? BaseUrl, string? ApiKey = null);
+
+/// <summary>
+/// The OpenAI-compatible Chat Completions shape (<c>POST {baseUrl}/chat/completions</c>, SSE). One adapter for
+/// every provider and local runner that speaks it — the BYO base URL is the whole point. (#578)
+///
+/// <para><b>Reasoning models need care here.</b> Providers serving reasoning models over this shape stream the
+/// reasoning in one of two ways: a separate <c>reasoning_content</c> delta field, or inline
+/// <c>&lt;think&gt;</c> tags inside ordinary <c>content</c>. Both are segregated onto
+/// <see cref="ChatDeltaKind.Reasoning"/>; concatenating deltas naively would render chain-of-thought at the
+/// user as though it were the answer.</para>
+/// </summary>
+public sealed class OpenAiCompatibleProvider : IChatProvider
+{
+    private readonly HttpClient _http;
+    private readonly OpenAiCompatibleOptions _options;
+    private readonly ILogger<OpenAiCompatibleProvider> _logger;
+    private readonly TimeSpan _idleTimeout;
+
+    public OpenAiCompatibleProvider(
+        HttpClient http,
+        OpenAiCompatibleOptions options,
+        ILogger<OpenAiCompatibleProvider> logger,
+        TimeSpan? idleTimeout = null)
+    {
+        _http = http;
+        _options = options;
+        _logger = logger;
+        _idleTimeout = idleTimeout ?? SseReader.DefaultIdleTimeout;
+    }
+
+    public string Id => "openai-compatible";
+
+    public async IAsyncEnumerable<ChatDelta> StreamAsync(
+        ChatRequest request,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options.BaseUrl))
+            throw new AiException(new AiError(AiErrorKind.NotConfigured, "No endpoint URL is configured."));
+        if (string.IsNullOrWhiteSpace(request.Model))
+            throw new AiException(new AiError(AiErrorKind.NotConfigured, "No model is configured."));
+
+        var endpoint = AiHttp.ResolveEndpoint(
+            _options.BaseUrl!, versionedPath: "v1/chat/completions", path: "chat/completions");
+
+        using var message = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new StringContent(BuildBody(request), Encoding.UTF8, "application/json"),
+        };
+        if (!string.IsNullOrWhiteSpace(_options.ApiKey))
+            message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.ApiKey);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _http
+                .SendAsync(message, HttpCompletionOption.ResponseHeadersRead, ct)
+                .ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new AiException(
+                new AiError(AiErrorKind.Network, "Could not reach the endpoint. Check the URL and your network."),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+                throw new AiException(await ClassifyAsync(response, ct).ConfigureAwait(false));
+
+            var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            var think = new ThinkTagFilter();
+
+            await foreach (var sse in SseReader.ReadAsync(stream, _idleTimeout, ct).ConfigureAwait(false))
+            {
+                if (sse.Failure is { } failure)
+                {
+                    _logger.LogWarning("OpenAI-compatible stream ended early: {Kind}", failure.Kind);
+                    foreach (var tail in FlushThink(think)) yield return tail;
+                    yield return ChatDelta.ForError(failure);
+                    yield break;
+                }
+
+                if (sse.Data == "[DONE]")
+                    break;
+
+                foreach (var delta in Interpret(sse, think))
+                    yield return delta;
+            }
+
+            foreach (var tail in FlushThink(think)) yield return tail;
+        }
+    }
+
+    private static IEnumerable<ChatDelta> FlushThink(ThinkTagFilter think)
+    {
+        var (visible, reasoning) = think.Flush();
+        if (visible.Length > 0) yield return ChatDelta.ForText(visible);
+        if (reasoning.Length > 0) yield return ChatDelta.ForReasoning(reasoning);
+    }
+
+    private static string BuildBody(ChatRequest request)
+    {
+        var buffer = new MemoryStream();
+        using (var json = new Utf8JsonWriter(buffer))
+        {
+            json.WriteStartObject();
+            json.WriteString("model", request.Model);
+            json.WriteNumber("max_tokens", request.MaxTokens);
+            json.WriteBoolean("stream", true);
+
+            // Ask for usage on the final chunk. Providers that do not know the option ignore it.
+            json.WriteStartObject("stream_options");
+            json.WriteBoolean("include_usage", true);
+            json.WriteEndObject();
+
+            json.WriteStartArray("messages");
+            if (!string.IsNullOrEmpty(request.System))
+            {
+                json.WriteStartObject();
+                json.WriteString("role", "system");
+                json.WriteString("content", request.System);
+                json.WriteEndObject();
+            }
+            foreach (var turn in request.Messages)
+            {
+                json.WriteStartObject();
+                json.WriteString("role", turn.Role == ChatRole.Assistant ? "assistant" : "user");
+                json.WriteString("content", turn.Content);
+                json.WriteEndObject();
+            }
+            json.WriteEndArray();
+
+            json.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    private static IEnumerable<ChatDelta> Interpret(SseEvent sse, ThinkTagFilter think)
+    {
+        JsonElement root;
+        try
+        {
+            using var document = JsonDocument.Parse(sse.Data);
+            root = document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            yield break;   // one bad chunk does not end an otherwise healthy stream
+        }
+
+        // Some providers report an error as a normal 200 chunk rather than an HTTP status.
+        if (root.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.Object)
+        {
+            var code = error.TryGetProperty("code", out var codeElement) ? codeElement.GetString() : null;
+            code ??= error.TryGetProperty("type", out var typeElement) ? typeElement.GetString() : null;
+            yield return ChatDelta.ForError(new AiError(
+                AiErrorKind.Provider,
+                "The model stopped part-way through: the provider reported an error.",
+                ProviderCode: code));
+            yield break;
+        }
+
+        if (root.TryGetProperty("choices", out var choices) &&
+            choices.ValueKind == JsonValueKind.Array &&
+            choices.GetArrayLength() > 0 &&
+            choices[0].TryGetProperty("delta", out var delta))
+        {
+            // Structured reasoning (DeepSeek and others) — never merged into the answer.
+            if (delta.TryGetProperty("reasoning_content", out var reasoning) &&
+                reasoning.ValueKind == JsonValueKind.String)
+            {
+                var value = reasoning.GetString();
+                if (!string.IsNullOrEmpty(value)) yield return ChatDelta.ForReasoning(value);
+            }
+
+            if (delta.TryGetProperty("content", out var content) && content.ValueKind == JsonValueKind.String)
+            {
+                var value = content.GetString();
+                if (!string.IsNullOrEmpty(value))
+                {
+                    // Inline <think> tags are the other reasoning convention; strip them across chunk boundaries.
+                    var (visible, inlineReasoning) = think.Feed(value);
+                    if (inlineReasoning.Length > 0) yield return ChatDelta.ForReasoning(inlineReasoning);
+                    if (visible.Length > 0) yield return ChatDelta.ForText(visible);
+                }
+            }
+        }
+
+        if (root.TryGetProperty("usage", out var usage) && usage.ValueKind == JsonValueKind.Object)
+        {
+            yield return ChatDelta.ForUsage(new ChatUsage(
+                InputTokens: ReadInt(usage, "prompt_tokens"),
+                OutputTokens: ReadInt(usage, "completion_tokens")));
+        }
+    }
+
+    private static int? ReadInt(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.TryGetInt32(out var number) ? number : null;
+
+    /// <summary>
+    /// Classify a non-2xx response. As with the Anthropic adapter the body is read for classification only:
+    /// <c>error.code</c> is a bounded token and is kept, while <c>error.message</c> can quote the request back
+    /// and is discarded.
+    /// </summary>
+    private async Task<AiError> ClassifyAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var kind = AiHttp.KindFor(response.StatusCode);
+        string? code = null;
+
+        try
+        {
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            using var document = JsonDocument.Parse(body);
+            if (document.RootElement.TryGetProperty("error", out var error) &&
+                error.ValueKind == JsonValueKind.Object)
+            {
+                code = error.TryGetProperty("code", out var codeElement) && codeElement.ValueKind == JsonValueKind.String
+                    ? codeElement.GetString()
+                    : null;
+                code ??= error.TryGetProperty("type", out var typeElement) ? typeElement.GetString() : null;
+
+                if (string.Equals(code, "context_length_exceeded", StringComparison.OrdinalIgnoreCase))
+                    kind = AiErrorKind.ContextTooLong;
+            }
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException or HttpRequestException or IOException)
+        {
+        }
+
+        _logger.LogWarning(
+            "OpenAI-compatible request failed: HTTP {Status} {Code}", (int)response.StatusCode, code ?? "(no code)");
+
+        return new AiError(
+            kind,
+            AiHttp.MessageFor(kind, response.StatusCode),
+            StatusCode: (int)response.StatusCode,
+            ProviderCode: code,
+            RetryAfter: AiHttp.RetryAfter(response));
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/SseReader.cs
+++ b/src/CST.Avalonia/Services/Ai/SseReader.cs
@@ -78,12 +78,11 @@ internal static class SseReader
 
             try
             {
-                line = await reader.ReadLineAsync(deadline.Token).ConfigureAwait(false);
-
-                // Until a DATA line has arrived we are still waiting on time-to-first-token, so each read keeps
-                // the long window. Rescheduling to the idle window here unconditionally would have flipped it on
-                // the first preamble comment, which is the same defect the sawAnyData pivot exists to close.
+                // Armed BEFORE the read, so the window in force always matches the pivot. Arming afterwards
+                // left one read carrying the previous line's verdict — harmless (always the more lenient of the
+                // two) but it made the timeout message name a window that had not applied.
                 deadline.CancelAfter(sawAnyData ? idleTimeout : firstEventTimeout);
+                line = await reader.ReadLineAsync(deadline.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {

--- a/src/CST.Avalonia/Services/Ai/SseReader.cs
+++ b/src/CST.Avalonia/Services/Ai/SseReader.cs
@@ -21,16 +21,28 @@ internal sealed record SseEvent(string? Name, string Data, AiError? Failure = nu
 /// Minimal Server-Sent Events reader, shared by both providers because both speak SSE and only differ in what
 /// the JSON payloads mean.
 ///
-/// <para><b>The idle timeout is the point of this class.</b> <see cref="System.Net.Http.HttpClient"/>'s own
+/// <para><b>The liveness timeouts are the point of this class.</b> <see cref="System.Net.Http.HttpClient"/>'s own
 /// timeout is a whole-request deadline, which is useless for a stream that is legitimately allowed to run for
-/// minutes — so the client is configured with an infinite timeout and liveness is enforced here instead, as a
-/// per-read deadline that resets on every byte. A provider that accepts the connection and then goes silent is
-/// otherwise indistinguishable from a slow answer, and would hang until the process exits.</para>
+/// minutes — so the client is configured with an infinite timeout and liveness is enforced here instead. A
+/// provider that accepts the connection and then goes silent is otherwise indistinguishable from a slow answer,
+/// and would hang until the process exits.</para>
 /// </summary>
 internal static class SseReader
 {
-    /// <summary>How long a stream may produce nothing at all before we call it dead.</summary>
+    /// <summary>
+    /// How long the stream may produce nothing between lines before we call it dead. Note this is per LINE, not
+    /// per byte: a line that trickles in over a long period is fine, and a stream that sends no newline at all
+    /// is not — which matches SSE, where nothing is actionable until a line completes.
+    /// </summary>
     internal static readonly TimeSpan DefaultIdleTimeout = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// A longer allowance for the FIRST line, which is the only one that includes the model's time-to-first-token.
+    /// A local runner doing prompt evaluation over an injected passage on modest hardware can legitimately sit
+    /// silent for minutes before emitting anything — folding that into the ordinary idle window would abandon the
+    /// fully-local path exactly when it is working hardest.
+    /// </summary>
+    internal static readonly TimeSpan DefaultFirstEventTimeout = TimeSpan.FromMinutes(10);
 
     /// <summary>
     /// Read events until the stream ends. Never throws for stream failures — an abnormal end arrives as a final
@@ -40,17 +52,24 @@ internal static class SseReader
     internal static async IAsyncEnumerable<SseEvent> ReadAsync(
         Stream stream,
         TimeSpan idleTimeout,
+        TimeSpan firstEventTimeout,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
 
-        // Linked so a real cancellation still propagates; CancelAfter is rescheduled on every successful read,
-        // which is what makes this an idle timeout rather than a total one.
-        using var idle = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        idle.CancelAfter(idleTimeout);
+        // Linked so a real cancellation still propagates; the deadline is rescheduled after every successful
+        // read, which is what makes this an idle timeout rather than a total one.
+        //
+        // Benign race: the timer can fire in the window between a read returning and the reschedule below. The
+        // token is then permanently cancelled and the next read reports an idle timeout even though data had just
+        // arrived. It needs the stream to go quiet for the whole window and then deliver a line within
+        // microseconds of expiry; the cost is one spurious "stopped responding" that a retry clears.
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        deadline.CancelAfter(firstEventTimeout);
 
         string? name = null;
         var data = new StringBuilder();
+        var sawAnyLine = false;
 
         while (true)
         {
@@ -59,8 +78,8 @@ internal static class SseReader
 
             try
             {
-                line = await reader.ReadLineAsync(idle.Token).ConfigureAwait(false);
-                idle.CancelAfter(idleTimeout);
+                line = await reader.ReadLineAsync(deadline.Token).ConfigureAwait(false);
+                deadline.CancelAfter(idleTimeout);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -68,10 +87,11 @@ internal static class SseReader
             }
             catch (OperationCanceledException)
             {
+                var window = sawAnyLine ? idleTimeout : firstEventTimeout;
                 line = null;
                 failure = new AiError(
                     AiErrorKind.Network,
-                    $"The model stopped responding (no data for {idleTimeout.TotalSeconds:0}s).");
+                    $"The model stopped responding (no data for {window.TotalSeconds:0}s).");
             }
             catch (Exception ex) when (ex is IOException or System.Net.Http.HttpRequestException)
             {
@@ -101,6 +121,8 @@ internal static class SseReader
                     yield return new SseEvent(name, data.ToString());
                 yield break;
             }
+
+            sawAnyLine = true;
 
             // Blank line dispatches the event being accumulated.
             if (line.Length == 0)

--- a/src/CST.Avalonia/Services/Ai/SseReader.cs
+++ b/src/CST.Avalonia/Services/Ai/SseReader.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>One dispatched Server-Sent Event, or the failure that ended the stream.</summary>
+/// <param name="Name">The <c>event:</c> field. Null when the stream omits it, as the OpenAI shape does.</param>
+/// <param name="Data">The accumulated <c>data:</c> field(s), newline-joined per the SSE spec.</param>
+/// <param name="Failure">Set only on the final element, when the stream ended abnormally.</param>
+internal sealed record SseEvent(string? Name, string Data, AiError? Failure = null)
+{
+    public static SseEvent Failed(AiError error) => new(null, string.Empty, error);
+}
+
+/// <summary>
+/// Minimal Server-Sent Events reader, shared by both providers because both speak SSE and only differ in what
+/// the JSON payloads mean.
+///
+/// <para><b>The idle timeout is the point of this class.</b> <see cref="System.Net.Http.HttpClient"/>'s own
+/// timeout is a whole-request deadline, which is useless for a stream that is legitimately allowed to run for
+/// minutes — so the client is configured with an infinite timeout and liveness is enforced here instead, as a
+/// per-read deadline that resets on every byte. A provider that accepts the connection and then goes silent is
+/// otherwise indistinguishable from a slow answer, and would hang until the process exits.</para>
+/// </summary>
+internal static class SseReader
+{
+    /// <summary>How long a stream may produce nothing at all before we call it dead.</summary>
+    internal static readonly TimeSpan DefaultIdleTimeout = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// Read events until the stream ends. Never throws for stream failures — an abnormal end arrives as a final
+    /// <see cref="SseEvent"/> carrying <see cref="SseEvent.Failure"/>, so callers can surface a partial answer
+    /// rather than losing it. Genuine cancellation via <paramref name="ct"/> DOES throw, as it should.
+    /// </summary>
+    internal static async IAsyncEnumerable<SseEvent> ReadAsync(
+        Stream stream,
+        TimeSpan idleTimeout,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+
+        // Linked so a real cancellation still propagates; CancelAfter is rescheduled on every successful read,
+        // which is what makes this an idle timeout rather than a total one.
+        using var idle = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        idle.CancelAfter(idleTimeout);
+
+        string? name = null;
+        var data = new StringBuilder();
+
+        while (true)
+        {
+            string? line;
+            AiError? failure = null;
+
+            try
+            {
+                line = await reader.ReadLineAsync(idle.Token).ConfigureAwait(false);
+                idle.CancelAfter(idleTimeout);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;  // the caller asked to stop — not a failure
+            }
+            catch (OperationCanceledException)
+            {
+                line = null;
+                failure = new AiError(
+                    AiErrorKind.Network,
+                    $"The model stopped responding (no data for {idleTimeout.TotalSeconds:0}s).");
+            }
+            catch (Exception ex) when (ex is IOException or System.Net.Http.HttpRequestException)
+            {
+                line = null;
+                failure = new AiError(AiErrorKind.Network, "The connection to the model was lost mid-response.");
+            }
+
+            if (failure is not null)
+            {
+                // Dispatch what was already buffered BEFORE reporting the failure. A severed connection
+                // routinely cuts the stream after a complete event but before the blank line that would have
+                // dispatched it; dropping that buffer would throw away text the user is entitled to keep, which
+                // is the whole reason a mid-stream failure is a delta rather than an exception. A genuinely
+                // half-written event is unparseable JSON and the provider skips it.
+                if (data.Length > 0)
+                    yield return new SseEvent(name, data.ToString());
+
+                yield return SseEvent.Failed(failure);
+                yield break;
+            }
+
+            // End of stream. A well-behaved provider has already sent its terminator; anything buffered here is
+            // a final event the stream never dispatched, so emit it rather than silently dropping content.
+            if (line is null)
+            {
+                if (data.Length > 0)
+                    yield return new SseEvent(name, data.ToString());
+                yield break;
+            }
+
+            // Blank line dispatches the event being accumulated.
+            if (line.Length == 0)
+            {
+                if (data.Length > 0)
+                    yield return new SseEvent(name, data.ToString());
+
+                name = null;
+                data.Clear();
+                continue;
+            }
+
+            if (line[0] == ':')
+                continue;  // comment / keep-alive
+
+            var colon = line.IndexOf(':');
+            var field = colon < 0 ? line : line[..colon];
+            var value = colon < 0 ? string.Empty : line[(colon + 1)..];
+            if (value.StartsWith(' '))
+                value = value[1..];
+
+            switch (field)
+            {
+                case "event":
+                    name = value;
+                    break;
+                case "data":
+                    if (data.Length > 0) data.Append('\n');
+                    data.Append(value);
+                    break;
+                // id / retry are part of SSE reconnection, which neither provider uses. Ignore.
+            }
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/SseReader.cs
+++ b/src/CST.Avalonia/Services/Ai/SseReader.cs
@@ -69,7 +69,7 @@ internal static class SseReader
 
         string? name = null;
         var data = new StringBuilder();
-        var sawAnyLine = false;
+        var sawAnyData = false;
 
         while (true)
         {
@@ -79,7 +79,11 @@ internal static class SseReader
             try
             {
                 line = await reader.ReadLineAsync(deadline.Token).ConfigureAwait(false);
-                deadline.CancelAfter(idleTimeout);
+
+                // Until a DATA line has arrived we are still waiting on time-to-first-token, so each read keeps
+                // the long window. Rescheduling to the idle window here unconditionally would have flipped it on
+                // the first preamble comment, which is the same defect the sawAnyData pivot exists to close.
+                deadline.CancelAfter(sawAnyData ? idleTimeout : firstEventTimeout);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -87,7 +91,7 @@ internal static class SseReader
             }
             catch (OperationCanceledException)
             {
-                var window = sawAnyLine ? idleTimeout : firstEventTimeout;
+                var window = sawAnyData ? idleTimeout : firstEventTimeout;
                 line = null;
                 failure = new AiError(
                     AiErrorKind.Network,
@@ -122,8 +126,6 @@ internal static class SseReader
                 yield break;
             }
 
-            sawAnyLine = true;
-
             // Blank line dispatches the event being accumulated.
             if (line.Length == 0)
             {
@@ -150,6 +152,12 @@ internal static class SseReader
                     name = value;
                     break;
                 case "data":
+                    // The pivot from the first-event window to the ordinary idle window is the first DATA line,
+                    // not merely the first line. A proxy that emits a preamble comment (OpenRouter sends
+                    // ": OPENROUTER PROCESSING") and then waits on a slow backend would otherwise collapse the
+                    // long time-to-first-token allowance to the short idle one — reintroducing exactly the
+                    // problem the two windows exist to separate.
+                    sawAnyData = true;
                     if (data.Length > 0) data.Append('\n');
                     data.Append(value);
                     break;

--- a/src/CST.Avalonia/Services/Ai/ThinkTagFilter.cs
+++ b/src/CST.Avalonia/Services/Ai/ThinkTagFilter.cs
@@ -21,7 +21,9 @@ namespace CST.Avalonia.Services.Ai;
 /// time the tag arrives, so it cannot be recalled; only when both fall in the same delta is it classified as
 /// reasoning. Fixing that properly would mean withholding output until a tag appears or the stream ends, which
 /// stalls the opening of every ordinary answer to serve a rare case. A literal <c>&lt;/think&gt;</c> written
-/// deliberately in answer prose is swallowed for the same reason — an accepted cost of the heuristic.</para>
+/// deliberately in answer prose is swallowed for the same reason — an accepted cost of the heuristic. And a
+/// stream SEVERED mid-tag flushes the fragment as text, since at end of input <c>"…&lt;/thi"</c> is
+/// indistinguishable from someone genuinely writing <c>"a &lt;th"</c>.</para>
 /// </summary>
 internal sealed class ThinkTagFilter
 {

--- a/src/CST.Avalonia/Services/Ai/ThinkTagFilter.cs
+++ b/src/CST.Avalonia/Services/Ai/ThinkTagFilter.cs
@@ -22,6 +22,7 @@ internal sealed class ThinkTagFilter
 
     private bool _inside;
     private string _held = string.Empty;
+    private bool _emittedVisible;
 
     /// <summary>Feed one content delta. Returns the text to show and the text to treat as reasoning.</summary>
     internal (string Visible, string Reasoning) Feed(string chunk)
@@ -37,6 +38,24 @@ internal sealed class ThinkTagFilter
         {
             var tag = _inside ? Close : Open;
             var sink = _inside ? reasoning : visible;
+
+            // A close tag arriving while we are NOT inside means the stream began mid-reasoning: some runner
+            // chat templates pre-fill the opening <think> into the prompt, so the model's output starts inside
+            // the block and only the closing tag is ever streamed. Without this the whole reasoning renders as
+            // the answer, followed by a literal </think> — the exact failure this filter exists to prevent.
+            if (!_inside)
+            {
+                var open = buffer.IndexOf(Open, position, StringComparison.OrdinalIgnoreCase);
+                var stray = buffer.IndexOf(Close, position, StringComparison.OrdinalIgnoreCase);
+                if (stray >= 0 && (open < 0 || stray < open))
+                {
+                    // Text before it is reasoning if nothing has reached the user yet. Once visible text HAS
+                    // been emitted we cannot retract it — but we can still refuse to render the tag itself.
+                    (_emittedVisible ? visible : reasoning).Append(buffer, position, stray - position);
+                    position = stray + Close.Length;
+                    continue;
+                }
+            }
 
             var hit = buffer.IndexOf(tag, position, StringComparison.OrdinalIgnoreCase);
             if (hit >= 0)
@@ -55,6 +74,7 @@ internal sealed class ThinkTagFilter
             position += rest;
         }
 
+        if (visible.Length > 0) _emittedVisible = true;
         return (visible.ToString(), reasoning.ToString());
     }
 

--- a/src/CST.Avalonia/Services/Ai/ThinkTagFilter.cs
+++ b/src/CST.Avalonia/Services/Ai/ThinkTagFilter.cs
@@ -14,6 +14,14 @@ namespace CST.Avalonia.Services.Ai;
 /// <c>"…done &lt;thi"</c> — so a naive per-chunk <c>Replace</c> both misses the tag and leaks its first half to
 /// the user. This holds back any trailing run that could still become a tag and re-examines it once more text
 /// arrives. <see cref="Flush"/> releases a held-back run that turned out to be ordinary text at end of stream.</para>
+///
+/// <para><b>What is guaranteed, and what is not.</b> Guaranteed: no tag, and no fragment of one, ever reaches
+/// the answer channel — on any chunking. NOT guaranteed: correct classification of text that precedes a closing
+/// tag when the stream <i>began</i> inside a block. That text has already been returned to the caller by the
+/// time the tag arrives, so it cannot be recalled; only when both fall in the same delta is it classified as
+/// reasoning. Fixing that properly would mean withholding output until a tag appears or the stream ends, which
+/// stalls the opening of every ordinary answer to serve a rare case. A literal <c>&lt;/think&gt;</c> written
+/// deliberately in answer prose is swallowed for the same reason — an accepted cost of the heuristic.</para>
 /// </summary>
 internal sealed class ThinkTagFilter
 {
@@ -49,9 +57,12 @@ internal sealed class ThinkTagFilter
                 var stray = buffer.IndexOf(Close, position, StringComparison.OrdinalIgnoreCase);
                 if (stray >= 0 && (open < 0 || stray < open))
                 {
-                    // Text before it is reasoning if nothing has reached the user yet. Once visible text HAS
+                    // Text before it is reasoning if nothing has reached the user yet. Once visible text has
                     // been emitted we cannot retract it — but we can still refuse to render the tag itself.
-                    (_emittedVisible ? visible : reasoning).Append(buffer, position, stray - position);
+                    // `visible.Length` matters as much as the flag: text appended earlier in THIS call is
+                    // returned in the same delta, so it is just as un-retractable as text from a prior one.
+                    var emitted = _emittedVisible || visible.Length > 0;
+                    (emitted ? visible : reasoning).Append(buffer, position, stray - position);
                     position = stray + Close.Length;
                     continue;
                 }
@@ -67,8 +78,20 @@ internal sealed class ThinkTagFilter
             }
 
             // No complete tag ahead. Anything that could still GROW into one has to wait for the next chunk.
+            //
+            // While OUTSIDE a block, BOTH tags matter. Holding back only prefixes of the tag we are hunting for
+            // is what let a split closing tag through: a stream that begins mid-reasoning ends "…options</thi",
+            // and if that tail is released as answer text the next chunk's "nk>" can never be recognised — the
+            // reasoning and the mangled tag both render as the answer, which is the failure this class exists
+            // to prevent, merely relocated to a chunk boundary.
+            var hold = _inside
+                ? LongestTagPrefixSuffix(buffer, position, Close)
+                : Math.Max(
+                    LongestTagPrefixSuffix(buffer, position, Open),
+                    LongestTagPrefixSuffix(buffer, position, Close));
+
             var rest = buffer.Length - position;
-            var holdFrom = buffer.Length - LongestTagPrefixSuffix(buffer, position, tag);
+            var holdFrom = buffer.Length - hold;
             sink.Append(buffer, position, holdFrom - position);
             _held = buffer[holdFrom..];
             position += rest;

--- a/src/CST.Avalonia/Services/Ai/ThinkTagFilter.cs
+++ b/src/CST.Avalonia/Services/Ai/ThinkTagFilter.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Text;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>
+/// Splits inline <c>&lt;think&gt;…&lt;/think&gt;</c> reasoning out of a streamed content channel.
+///
+/// <para>Some reasoning models served over the OpenAI-compatible shape do not use the structured
+/// <c>reasoning_content</c> field — they emit their reasoning inline, wrapped in think-tags, in the same
+/// <c>content</c> the answer arrives in. Without this the tags and everything between them render as answer text.</para>
+///
+/// <para><b>Tags split across chunk boundaries are the whole difficulty.</b> A delta can end mid-tag —
+/// <c>"…done &lt;thi"</c> — so a naive per-chunk <c>Replace</c> both misses the tag and leaks its first half to
+/// the user. This holds back any trailing run that could still become a tag and re-examines it once more text
+/// arrives. <see cref="Flush"/> releases a held-back run that turned out to be ordinary text at end of stream.</para>
+/// </summary>
+internal sealed class ThinkTagFilter
+{
+    private const string Open = "<think>";
+    private const string Close = "</think>";
+
+    private bool _inside;
+    private string _held = string.Empty;
+
+    /// <summary>Feed one content delta. Returns the text to show and the text to treat as reasoning.</summary>
+    internal (string Visible, string Reasoning) Feed(string chunk)
+    {
+        var buffer = _held + chunk;
+        _held = string.Empty;
+
+        var visible = new StringBuilder();
+        var reasoning = new StringBuilder();
+        var position = 0;
+
+        while (position < buffer.Length)
+        {
+            var tag = _inside ? Close : Open;
+            var sink = _inside ? reasoning : visible;
+
+            var hit = buffer.IndexOf(tag, position, StringComparison.OrdinalIgnoreCase);
+            if (hit >= 0)
+            {
+                sink.Append(buffer, position, hit - position);
+                position = hit + tag.Length;
+                _inside = !_inside;
+                continue;
+            }
+
+            // No complete tag ahead. Anything that could still GROW into one has to wait for the next chunk.
+            var rest = buffer.Length - position;
+            var holdFrom = buffer.Length - LongestTagPrefixSuffix(buffer, position, tag);
+            sink.Append(buffer, position, holdFrom - position);
+            _held = buffer[holdFrom..];
+            position += rest;
+        }
+
+        return (visible.ToString(), reasoning.ToString());
+    }
+
+    /// <summary>
+    /// End of stream: whatever is still held back was never going to complete a tag, so it is ordinary text.
+    /// Attributed to whichever channel was open at the time.
+    /// </summary>
+    internal (string Visible, string Reasoning) Flush()
+    {
+        var tail = _held;
+        _held = string.Empty;
+        if (tail.Length == 0) return (string.Empty, string.Empty);
+        return _inside ? (string.Empty, tail) : (tail, string.Empty);
+    }
+
+    /// <summary>
+    /// Length of the longest suffix of <paramref name="buffer"/> (at or after <paramref name="from"/>) that is a
+    /// proper prefix of <paramref name="tag"/> — i.e. how much text must be held back as a possible partial tag.
+    /// </summary>
+    private static int LongestTagPrefixSuffix(string buffer, int from, string tag)
+    {
+        var max = Math.Min(tag.Length - 1, buffer.Length - from);
+        for (var length = max; length > 0; length--)
+        {
+            if (string.Compare(buffer, buffer.Length - length, tag, 0, length, StringComparison.OrdinalIgnoreCase) == 0)
+                return length;
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
Closes #578. First code for surface B ([AI_SURFACE_B.md §5](https://github.com/fsnow/cst/blob/main/docs/features/planned/AI_SURFACE_B.md)). No wiring, no DI, no UI — this is the layer #583 will be built on.

One narrow `IChatProvider`, two streaming adapters over `HttpClient`, no SDK dependency, plus a shared SSE reader, a think-tag filter and HTTP helpers.

## The contract worth reviewing

**Failure has two shapes, and the boundary is the HTTP response — not the first delta.** A failure while establishing the response throws `AiException`; once a successful response is accepted, every failure yields a terminal `Error` delta and the enumerable completes, so the caller keeps whatever partial answer is already on screen. Cancellation is neither — it throws `OperationCanceledException` and is never an `AiError`. **A consumer must therefore handle an Error delta with nothing preceding it.**

## Two decisions for you rather than me

- **Providers refuse an `HttpClient` with a finite timeout**, throwing at construction. Deliberately harsh: a finite `HttpClient.Timeout` truncates a long generation and surfaces it as a `TaskCanceledException` with the caller's token *not* cancelled — indistinguishable from the user pressing stop. Silent wrong-answer beats loud error, so I made it loud. **#583/#585's DI wiring must configure the client explicitly or it fails on first resolve.**
- **The reasoning channel is populated but nothing consumes it.** #583 needs a deliberate call: collapsible pane, drop it, or account for it separately in usage.

## Reviewed three times, and it needed all three

Fable found a **blocking mid-stream crasher** in the first pass: provider JSON was parsed without shape guards, so `GetString()` on OpenRouter's *numeric* `error.code`, or `TryGetProperty` on a bare `data: null`, threw `InvalidOperationException` straight out of the iterator — an unclassified crash exactly where the contract promises an Error delta. I verified both empirically before fixing.

The second pass caught that **my own fix for the think-tag gap was incomplete in the same way the original was** — the split-across-chunks form survived. The third caught that **my endpoint typo-rescue had regressed correctly-pasted bases**: Gemini's own OpenAI-compat base (`.../v1beta/openai/`) got a second version segment appended and 404'd.

Also fixed across those passes: `Error` not terminal in the OpenAI adapter; `ProviderCode` documented as bounded-and-safe-to-log while being arbitrary provider-controlled text; a 200 with an empty or non-SSE body completing silently with zero deltas; time-to-first-token sharing the 120s idle window (a local runner evaluating a large passage would be killed mid-think on exactly the fully-local path); and docs that described behaviour the code didn't have.

## The live test found what three reviews couldn't

Run against a real Ollama serving `gpt-oss:120b-cloud`. **The reasoning field name is not standardised** — DeepSeek documents `reasoning_content`, Ollama and OpenRouter use plain `reasoning`. 73 deltas carried `reasoning`, none carried `reasoning_content`, so the adapter silently dropped the entire reasoning stream. No error; the only symptom was usage reporting 80 output tokens beside a seven-word answer. Not reachable from documentation — only from traffic.

The same run confirmed three things that were assumptions in the code: `stream_options.include_usage` is honoured, `max_tokens` is respected, and base-URL resolution reaches a real endpoint.

## Tests

**81 in the AI layer, full suite 1120/1120.** Recorded SSE replayed through a stub handler — no network, no key, no spend — weighted to failure paths: mid-stream drop, silent stream, malformed and unexpectedly-shaped chunks, cancellation, the error taxonomy, request shape, and Pāli diacritics split across a read boundary.

`ThinkTagFilter` has its own direct unit tests. Provider-level SSE fixtures are a coarse way to pin a character-level state machine, and two defects had already slipped through them — including one of mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)