### PR TITLE
Book text zoom: Cmd/Ctrl +/-/0, persisted per script (#572)

### DIFF
--- a/src/CST.Avalonia.Tests/Input/ZoomKeysTests.cs
+++ b/src/CST.Avalonia.Tests/Input/ZoomKeysTests.cs
@@ -1,0 +1,152 @@
+using Avalonia.Input;
+using CST.Avalonia.Input;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Input;
+
+// #572: which keystrokes count as book zoom. Matching on Avalonia's Key alone is not safe here, because on
+// macOS Key is derived from the character the ACTIVE INPUT SOURCE produces. With a Devanagari or other
+// Indic layout active — entirely normal for a Pāli reader — the "=" key does not produce '=', the character
+// lookup misses, and Avalonia's QWERTY fallback reports it as OemMinus. Matching Key only would make Cmd+
+// silently dead for exactly the users most likely to be affected. PhysicalKey is layout-independent, so
+// both are consulted. (fable review)
+public class ZoomKeysTests
+{
+    private const KeyModifiers Cmd = KeyModifiers.Meta;
+
+    private static KeyEventArgs Press(Key key, PhysicalKey physical, KeyModifiers modifiers) =>
+        new() { Key = key, PhysicalKey = physical, KeyModifiers = modifiers };
+
+    // ---- The ordinary ASCII-layout cases ----------------------------------------------------------
+
+    [Theory]
+    [InlineData(Key.OemPlus, PhysicalKey.Equal)]            // unshifted "=", what Cmd++ really delivers
+    [InlineData(Key.Add, PhysicalKey.NumPadAdd)]            // numeric keypad
+    public void ZoomIn_Spellings(Key key, PhysicalKey physical)
+    {
+        Assert.Equal(ZoomCommand.In, ZoomKeys.Match(Press(key, physical, Cmd), Cmd));
+        // "+" is Shift+"=" on most layouts, so the shifted form must resolve identically.
+        Assert.Equal(ZoomCommand.In, ZoomKeys.Match(Press(key, physical, Cmd | KeyModifiers.Shift), Cmd));
+    }
+
+    [Theory]
+    [InlineData(Key.OemMinus, PhysicalKey.Minus)]
+    [InlineData(Key.Subtract, PhysicalKey.NumPadSubtract)]
+    public void ZoomOut_Spellings(Key key, PhysicalKey physical)
+    {
+        Assert.Equal(ZoomCommand.Out, ZoomKeys.Match(Press(key, physical, Cmd), Cmd));
+        Assert.Equal(ZoomCommand.Out, ZoomKeys.Match(Press(key, physical, Cmd | KeyModifiers.Shift), Cmd));
+    }
+
+    [Theory]
+    [InlineData(Key.D0, PhysicalKey.Digit0)]
+    [InlineData(Key.NumPad0, PhysicalKey.NumPad0)]
+    public void Reset_Spellings(Key key, PhysicalKey physical)
+    {
+        Assert.Equal(ZoomCommand.Reset, ZoomKeys.Match(Press(key, physical, Cmd), Cmd));
+    }
+
+    // ---- The non-Latin input source case, which is the reason this class exists -------------------
+
+    [Fact]
+    public void IndicLayout_EqualsKeyReportedAsOemMinus_StillZoomsIn()
+    {
+        // Avalonia's QWERTY fallback maps the physical "=" key to OemMinus when the layout produces a
+        // non-ASCII character. Matching on Key alone would zoom OUT here, or (since the shifted form is
+        // unbound) do nothing at all. PhysicalKey.Equal has to win.
+        var e = Press(Key.OemMinus, PhysicalKey.Equal, Cmd | KeyModifiers.Shift);
+        Assert.Equal(ZoomCommand.In, ZoomKeys.Match(e, Cmd));
+    }
+
+    [Fact]
+    public void IndicLayout_RealMinusKey_StillZoomsOut()
+    {
+        // The same fallback reports a genuine "-" as OemMinus too. This must NOT be captured by the
+        // physical-Equal rule above — the two cases are distinguished only by PhysicalKey.
+        var e = Press(Key.OemMinus, PhysicalKey.Minus, Cmd);
+        Assert.Equal(ZoomCommand.Out, ZoomKeys.Match(e, Cmd));
+    }
+
+    [Fact]
+    public void UnknownKeyOnAKnownPhysicalKey_StillResolves()
+    {
+        // A layout we have never seen produces some other character on the "=" key.
+        Assert.Equal(ZoomCommand.In, ZoomKeys.Match(Press(Key.OemQuestion, PhysicalKey.Equal, Cmd), Cmd));
+    }
+
+    // ---- Non-matches ------------------------------------------------------------------------------
+
+    [Fact]
+    public void WithoutTheCommandModifier_NothingMatches()
+    {
+        Assert.Null(ZoomKeys.Match(Press(Key.OemPlus, PhysicalKey.Equal, KeyModifiers.None), Cmd));
+        Assert.Null(ZoomKeys.Match(Press(Key.OemPlus, PhysicalKey.Equal, KeyModifiers.Shift), Cmd));
+    }
+
+    [Fact]
+    public void WithAlt_NothingMatches()
+    {
+        // Keeps this off system and app combos built on Alt.
+        Assert.Null(ZoomKeys.Match(Press(Key.OemPlus, PhysicalKey.Equal, Cmd | KeyModifiers.Alt), Cmd));
+    }
+
+    [Theory]
+    [InlineData(Key.D1, PhysicalKey.Digit1)]
+    [InlineData(Key.O, PhysicalKey.O)]
+    [InlineData(Key.F, PhysicalKey.F)]
+    [InlineData(Key.D, PhysicalKey.D)]
+    public void OtherShortcutKeys_AreNotZoom(Key key, PhysicalKey physical)
+    {
+        // Zoom is matched AFTER the letter-shortcut list in both window handlers, but it must not claim
+        // those keys even if the order ever changed.
+        Assert.Null(ZoomKeys.Match(Press(key, physical, Cmd), Cmd));
+    }
+
+    [Fact]
+    public void TheWindowsCommandModifierWorksToo()
+    {
+        var e = Press(Key.OemPlus, PhysicalKey.Equal, KeyModifiers.Control);
+        Assert.Equal(ZoomCommand.In, ZoomKeys.Match(e, KeyModifiers.Control));
+        // ...and the wrong modifier for the platform does not match.
+        Assert.Null(ZoomKeys.Match(e, KeyModifiers.Meta));
+    }
+
+    // ---- The macOS menu-equivalent exclusion ------------------------------------------------------
+
+    [Theory]
+    [InlineData(Key.OemPlus, PhysicalKey.Equal)]
+    [InlineData(Key.OemMinus, PhysicalKey.Minus)]
+    [InlineData(Key.D0, PhysicalKey.Digit0)]
+    public void MenuEquivalents_AreExcluded_SoTheyCannotFireTwice(Key key, PhysicalKey physical)
+    {
+        // macOS resolves ⌘=, ⌘- and ⌘0 through the View menu's key equivalents. The window handler must
+        // skip exactly those, or one press would zoom two steps.
+        Assert.True(ZoomKeys.IsMacMenuEquivalent(Press(key, physical, Cmd)));
+    }
+
+    [Theory]
+    [InlineData(Key.Add, PhysicalKey.NumPadAdd)]
+    [InlineData(Key.Subtract, PhysicalKey.NumPadSubtract)]
+    [InlineData(Key.NumPad0, PhysicalKey.NumPad0)]
+    public void NumpadSpellings_AreNotMenuEquivalents(Key key, PhysicalKey physical)
+    {
+        // A NativeMenuItem carries one gesture, so these have no menu route and the handler must take them.
+        Assert.False(ZoomKeys.IsMacMenuEquivalent(Press(key, physical, Cmd)));
+    }
+
+    [Fact]
+    public void ShiftedPlus_IsNotAMenuEquivalent()
+    {
+        // ⌘⇧= is the spelling most people actually press for "⌘+", and the menu cannot declare it. macOS
+        // matches key equivalents shift-sensitively, so the menu will not fire — the handler must.
+        Assert.False(ZoomKeys.IsMacMenuEquivalent(Press(Key.OemPlus, PhysicalKey.Equal, Cmd | KeyModifiers.Shift)));
+    }
+
+    [Fact]
+    public void MenuEquivalentExclusion_HoldsUnderANonLatinLayout()
+    {
+        // The Indic-fallback "=" (Key reported as OemMinus) is still the plain ⌘= the menu owns, so it must
+        // be excluded here even though Match() would classify it as zoom-in.
+        Assert.True(ZoomKeys.IsMacMenuEquivalent(Press(Key.OemMinus, PhysicalKey.Equal, Cmd)));
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/BookZoomServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/BookZoomServiceTests.cs
@@ -1,0 +1,314 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Conversion;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+// #572: book-text zoom is the ONLY stored size control for book content — #574 flattened the stylesheets to
+// one shared ladder and #42 was narrowed to font faces, so nothing else sizes the text. That makes the
+// arithmetic here load-bearing: a wrong CEF level silently renders every book at the wrong size, and a
+// clamping hole can render it at zero.
+public class BookZoomServiceTests
+{
+    private static (BookZoomService svc, Mock<ISettingsService> settings) Create()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings.SetupGet(s => s.Settings).Returns(new Settings());
+        return (new BookZoomService(settings.Object), settings);
+    }
+
+    // ---- Defaults and round-tripping -------------------------------------------------------------
+
+    [Fact]
+    public void DefaultZoom_IsExactlyOne_ForEveryScript()
+    {
+        var (svc, _) = Create();
+        // 1.0 must mean "the shipped stylesheet ladder, untouched". Anything else and a fresh install
+        // renders at a size nobody chose.
+        foreach (var script in System.Enum.GetValues<Script>())
+            Assert.Equal(1.0, svc.GetZoom(script));
+    }
+
+    [Fact]
+    public void Zoom_SurvivesAJsonRoundTrip()
+    {
+        // The issue flagged that ApplicationState's serializer uses WhenWritingDefault, which would drop a
+        // value. Zoom lives in Settings instead, whose serializer does not — this pins that difference,
+        // because a silently dropped zoom would reset the user's calibration on every restart.
+        var settings = new Settings();
+        settings.FontSettings.ScriptFonts["Devanagari"].BookZoom = 1.25;
+
+        var json = JsonSerializer.Serialize(settings);
+        var back = JsonSerializer.Deserialize<Settings>(json)!;
+
+        Assert.Equal(1.25, back.FontSettings.ScriptFonts["Devanagari"].BookZoom);
+        Assert.Contains("BookZoom", json);
+    }
+
+    [Fact]
+    public void MissingBookZoomInJson_DeserializesToOne()
+    {
+        // Every settings.json written before this feature lacks the property. Those users must land on
+        // 100%, not 0% (a blank page) — which is what a bare `default(double)` would give.
+        var json = """{"FontSettings":{"ScriptFonts":{"Latin":{"FontFamily":"","FontSize":12}}}}""";
+        var back = JsonSerializer.Deserialize<Settings>(json)!;
+        Assert.Equal(1.0, back.FontSettings.ScriptFonts["Latin"].BookZoom);
+    }
+
+    // ---- Stepping ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void ZoomIn_ThenZoomOut_ReturnsToTheStartingRung()
+    {
+        var (svc, _) = Create();
+        var start = svc.GetZoom(Script.Latin);
+        svc.ZoomIn(Script.Latin);
+        Assert.NotEqual(start, svc.GetZoom(Script.Latin));
+        svc.ZoomOut(Script.Latin);
+        Assert.Equal(start, svc.GetZoom(Script.Latin));
+    }
+
+    [Fact]
+    public void Stepping_ClampsAtBothEnds_WithoutWrapping()
+    {
+        var (svc, _) = Create();
+        for (int i = 0; i < 50; i++) svc.ZoomIn(Script.Latin);
+        Assert.Equal(BookZoomService.MaxZoom, svc.GetZoom(Script.Latin));
+
+        for (int i = 0; i < 50; i++) svc.ZoomOut(Script.Latin);
+        Assert.Equal(BookZoomService.MinZoom, svc.GetZoom(Script.Latin));
+    }
+
+    [Fact]
+    public void EveryRung_IsReachableByStepping_AndTheLadderIsStrictlyAscending()
+    {
+        // A duplicated or out-of-order rung would make one press a no-op, which reads as a dead key.
+        var ladder = BookZoomService.ZoomLadder;
+        Assert.Equal(ladder.OrderBy(x => x).ToList(), ladder.ToList());
+        Assert.Equal(ladder.Distinct().Count(), ladder.Count);
+
+        var (svc, _) = Create();
+        for (int i = 0; i < 50; i++) svc.ZoomOut(Script.Latin);
+
+        var visited = new List<double> { svc.GetZoom(Script.Latin) };
+        for (int i = 0; i < ladder.Count; i++)
+        {
+            var next = svc.ZoomIn(Script.Latin);
+            if (next != visited[^1]) visited.Add(next);
+        }
+        Assert.Equal(ladder.ToList(), visited);
+    }
+
+    [Fact]
+    public void AnOffLadderStoredValue_StepsInTheRequestedDirection()
+    {
+        // A hand-edited settings file, or a value written by a build with a different ladder. Snapping to
+        // the NEAREST rung could move the text the opposite way from the key that was pressed.
+        var (svc, settings) = Create();
+        settings.Object.Settings.FontSettings.ScriptFonts["Latin"].BookZoom = 1.13;
+
+        Assert.True(svc.ZoomIn(Script.Latin) > 1.13);
+        settings.Object.Settings.FontSettings.ScriptFonts["Latin"].BookZoom = 1.13;
+        Assert.True(svc.ZoomOut(Script.Latin) < 1.13);
+    }
+
+    [Fact]
+    public void ResetZoom_ReturnsToOne_FromEitherDirection()
+    {
+        var (svc, _) = Create();
+        svc.ZoomIn(Script.Latin); svc.ZoomIn(Script.Latin);
+        Assert.Equal(1.0, svc.ResetZoom(Script.Latin));
+
+        svc.ZoomOut(Script.Latin); svc.ZoomOut(Script.Latin);
+        Assert.Equal(1.0, svc.ResetZoom(Script.Latin));
+    }
+
+    // ---- Per-script isolation ---------------------------------------------------------------------
+
+    [Fact]
+    public void ZoomIsPerScript_AndDoesNotLeakBetweenThem()
+    {
+        // The whole point of the per-script decision: zoom calibrates for the FACE a script resolves to, so
+        // a Devanagari adjustment must not follow the reader into a Latin book.
+        var (svc, _) = Create();
+        svc.ZoomIn(Script.Devanagari);
+        svc.ZoomIn(Script.Devanagari);
+
+        Assert.True(svc.GetZoom(Script.Devanagari) > 1.0);
+        Assert.Equal(1.0, svc.GetZoom(Script.Latin));
+    }
+
+    [Fact]
+    public void ChangingZoom_RaisesZoomChanged_ForThatScriptOnly()
+    {
+        var (svc, _) = Create();
+        var events = new List<BookZoomChangedEventArgs>();
+        svc.ZoomChanged += (_, e) => events.Add(e);
+
+        svc.ZoomIn(Script.Thai);
+
+        var evt = Assert.Single(events);
+        Assert.Equal(Script.Thai, evt.Script);
+        Assert.Equal(svc.GetZoom(Script.Thai), evt.Zoom);
+    }
+
+    [Fact]
+    public void SteppingAtTheCeiling_RaisesNothingAndSavesNothing()
+    {
+        // Holding Cmd+ at the top would otherwise fire an event and schedule a save per repeat, waking every
+        // open book to re-apply a value that did not change.
+        var (svc, settings) = Create();
+        for (int i = 0; i < 50; i++) svc.ZoomIn(Script.Latin);
+
+        settings.Invocations.Clear();
+        var events = 0;
+        svc.ZoomChanged += (_, _) => events++;
+
+        svc.ZoomIn(Script.Latin);
+
+        Assert.Equal(0, events);
+        Assert.DoesNotContain(settings.Invocations, i => i.Method.Name == nameof(ISettingsService.RequestSave));
+    }
+
+    [Fact]
+    public void ResetZoom_AlwaysNotifies_EvenWhenAlreadyAtOneHundredPercent()
+    {
+        // The browser's real zoom can differ from what we stored — a Ctrl+scroll that landed before the
+        // bridge script was injected, a failed injection, or a macOS trackpad pinch (page scale, which we
+        // do not manage). In all of those the stored value says 100% while the text is not, so an early
+        // return would make "Actual Size" a dead key precisely when it is needed. CEF's SetZoomLevel(0)
+        // also clears page scale, so this is the only thing that undoes a pinch. (fable review)
+        var (svc, settings) = Create();
+        Assert.Equal(1.0, svc.GetZoom(Script.Latin));   // already at the default
+
+        var events = new List<BookZoomChangedEventArgs>();
+        svc.ZoomChanged += (_, e) => events.Add(e);
+        settings.Invocations.Clear();
+
+        svc.ResetZoom(Script.Latin);
+
+        var evt = Assert.Single(events);
+        Assert.Equal(1.0, evt.Zoom);
+        // Notifies, but must NOT dirty the settings file — nothing actually changed.
+        Assert.DoesNotContain(settings.Invocations, i => i.Method.Name == nameof(ISettingsService.RequestSave));
+    }
+
+    [Fact]
+    public void ChangingZoom_RequestsADebouncedSave()
+    {
+        var (svc, settings) = Create();
+        svc.ZoomIn(Script.Latin);
+        // RequestSave, not SaveSettingsAsync: a burst of Cmd+ presses must coalesce into one write.
+        settings.Verify(s => s.RequestSave(), Times.Once);
+        settings.Verify(s => s.SaveSettingsAsync(), Times.Never);
+    }
+
+    [Fact]
+    public void AScriptMissingFromSettings_IsSeededRatherThanSilentlyIgnored()
+    {
+        // A settings file written before a script existed has no entry for it. Dropping the change would
+        // make that script permanently unzoomable, with no error.
+        var (svc, settings) = Create();
+        settings.Object.Settings.FontSettings.ScriptFonts.Remove("Thai");
+
+        var zoom = svc.ZoomIn(Script.Thai);
+
+        Assert.True(zoom > 1.0);
+        Assert.Equal(zoom, svc.GetZoom(Script.Thai));
+    }
+
+    // ---- Clamping ---------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0.0)]        // what a WhenWritingDefault serializer hands back for an omitted double
+    [InlineData(-1.0)]
+    [InlineData(double.NaN)]
+    public void NonsenseStoredValues_ReadBackAsOneHundredPercent(double stored)
+    {
+        // A zoom of 0 would set a CEF level of -infinity and blank the book entirely.
+        var (svc, settings) = Create();
+        settings.Object.Settings.FontSettings.ScriptFonts["Latin"].BookZoom = stored;
+        Assert.Equal(1.0, svc.GetZoom(Script.Latin));
+    }
+
+    [Theory]
+    [InlineData(99.0)]
+    [InlineData(0.001)]
+    public void OutOfRangeStoredValues_AreClampedIntoTheLadder(double stored)
+    {
+        var (svc, settings) = Create();
+        settings.Object.Settings.FontSettings.ScriptFonts["Latin"].BookZoom = stored;
+        Assert.InRange(svc.GetZoom(Script.Latin), BookZoomService.MinZoom, BookZoomService.MaxZoom);
+    }
+
+    // ---- CEF level conversion ---------------------------------------------------------------------
+
+    [Fact]
+    public void OneHundredPercent_IsCefLevelZero()
+    {
+        // Chromium's scale is logarithmic with 1.0 at level 0. Passing the raw factor instead would make
+        // 125% render at 1.2^1.25 = ~245%.
+        Assert.Equal(0.0, BookZoomService.ToCefZoomLevel(1.0), 10);
+    }
+
+    [Fact]
+    public void CefLevelConversion_RoundTrips_ForEveryRung()
+    {
+        foreach (var rung in BookZoomService.ZoomLadder)
+        {
+            var level = BookZoomService.ToCefZoomLevel(rung);
+            Assert.Equal(rung, BookZoomService.FromCefZoomLevel(level), 10);
+        }
+    }
+
+    [Fact]
+    public void CefLevel_MatchesChromiumsOwnStepOf1Point2()
+    {
+        // Chromium defines factor = 1.2^level, so a factor of exactly 1.2 must be level 1.
+        Assert.Equal(1.0, BookZoomService.ToCefZoomLevel(1.2), 10);
+        Assert.Equal(-1.0, BookZoomService.ToCefZoomLevel(1.0 / 1.2), 10);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(double.NaN)]
+    public void CefLevelConversion_DoesNotProduceInfinityOrNaN_ForBadInput(double bad)
+    {
+        var level = BookZoomService.ToCefZoomLevel(bad);
+        Assert.False(double.IsNaN(level) || double.IsInfinity(level));
+        Assert.Equal(0.0, level, 10);   // falls back to 100%
+    }
+
+    // ---- Readout ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void IsZoomed_IsFalseAtOneHundredPercent_AndTrueOffIt()
+    {
+        var (svc, _) = Create();
+        Assert.False(svc.IsZoomed(Script.Latin));
+        svc.ZoomIn(Script.Latin);
+        Assert.True(svc.IsZoomed(Script.Latin));
+        svc.ResetZoom(Script.Latin);
+        Assert.False(svc.IsZoomed(Script.Latin));
+    }
+
+    [Fact]
+    public void FormatZoom_RendersWholePercentages()
+    {
+        var (svc, settings) = Create();
+        Assert.Equal("100%", svc.FormatZoom(Script.Latin));
+
+        settings.Object.Settings.FontSettings.ScriptFonts["Latin"].BookZoom = 1.25;
+        Assert.Equal("125%", svc.FormatZoom(Script.Latin));
+
+        // 0.67 must not render as "67.000000001%" or similar under any locale.
+        settings.Object.Settings.FontSettings.ScriptFonts["Latin"].BookZoom = 0.67;
+        Assert.Equal("67%", svc.FormatZoom(Script.Latin));
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/CefBrowserAccessTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CefBrowserAccessTests.cs
@@ -1,0 +1,80 @@
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+// #572: book zoom reaches CefBrowserHost through two reflection hops into non-public members of
+// WebViewControl and CefGlue. Reflection into a third-party package's internals breaks SILENTLY on an
+// upgrade - the shortcut simply stops doing anything, with no exception and nothing obviously wrong.
+//
+// These tests exist to convert that into a build failure. If a WebViewControl or CefGlue bump renames or
+// re-scopes either member, this goes red and names the member, instead of the feature quietly dying in the
+// field. Nothing here needs a live browser: resolution is static.
+public class CefBrowserAccessTests
+{
+    [Fact]
+    public void ReflectionChain_StillResolves_AgainstTheCurrentPackages()
+    {
+        Assert.True(
+            CefBrowserAccess.IsAvailable,
+            $"The CEF reflection chain no longer resolves. Unresolved: '{CefBrowserAccess.MissingMembers}'. " +
+            "A WebViewControl/CefGlue upgrade has most likely renamed or re-scoped these members. Book zoom " +
+            "(#572) is inert until the chain in CefBrowserAccess is updated to match.");
+    }
+
+    [Fact]
+    public void MissingMembers_IsEmpty_WhenChainResolves()
+    {
+        // Guards the diagnostic itself: a MissingMembers that stays empty while IsAvailable is false would
+        // make the failure above unactionable.
+        if (CefBrowserAccess.IsAvailable)
+            Assert.Equal("", CefBrowserAccess.MissingMembers);
+        else
+            Assert.NotEqual("", CefBrowserAccess.MissingMembers);
+    }
+
+    // Names alone are not enough. If a package bump keeps both property names but changes either TYPE, the
+    // `is not BaseCefBrowser` / `is not CefBrowser` pattern checks in TryGetBrowserHost fall through to null
+    // on every call — the feature dies silently while the name-only assertions above stay green. (fable review)
+    [Fact]
+    public void WebViewUnderlyingBrowser_IsStillAssignableToBaseCefBrowser()
+    {
+        var type = CefBrowserAccess.WebViewBrowserPropertyType;
+        Assert.NotNull(type);
+        Assert.True(
+            typeof(Xilium.CefGlue.Common.BaseCefBrowser).IsAssignableFrom(type),
+            $"WebView.UnderlyingBrowser is now '{type}', which does not derive from BaseCefBrowser. " +
+            "TryGetBrowserHost's type check will return null forever until CefBrowserAccess is updated.");
+    }
+
+    [Fact]
+    public void BaseCefBrowserUnderlyingBrowser_IsStillCefBrowser()
+    {
+        var type = CefBrowserAccess.BaseBrowserPropertyType;
+        Assert.NotNull(type);
+        Assert.True(
+            typeof(Xilium.CefGlue.CefBrowser).IsAssignableFrom(type),
+            $"BaseCefBrowser.UnderlyingBrowser is now '{type}', not a CefBrowser. Book zoom is inert until " +
+            "CefBrowserAccess is updated to match.");
+    }
+
+    [Fact]
+    public void CefBrowser_StillExposesGetHost_Publicly()
+    {
+        // The third hop is public API rather than reflection, so a rename here is a compile error in
+        // CefBrowserAccess — but only while something still calls it. Pinned so the contract is documented
+        // in one place with the other two.
+        var getHost = typeof(Xilium.CefGlue.CefBrowser).GetMethod("GetHost", System.Type.EmptyTypes);
+        Assert.NotNull(getHost);
+        Assert.True(getHost!.IsPublic);
+        Assert.Equal(typeof(Xilium.CefGlue.CefBrowserHost), getHost.ReturnType);
+    }
+
+    [Fact]
+    public void TryGetBrowserHost_ReturnsNull_ForNullWebView()
+    {
+        // The call sites treat null as "zoom unavailable, do nothing". Anything thrown here would surface as
+        // a crash on a keystroke.
+        Assert.Null(CefBrowserAccess.TryGetBrowserHost(null, Serilog.Log.Logger));
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -432,7 +432,13 @@ public partial class App : Application
         try
         {
             Log.Information("InitializeFontsAsync() started");
-            
+
+            // Book zoom (#572) reaches CEF through two reflection hops into non-public members of
+            // WebViewControl/CefGlue. A package upgrade breaks that silently — the shortcut just stops
+            // working — so report resolvability once, here, where it lands in the log next to the other
+            // font/text startup lines. CefBrowserAccessTests fails the build for the same cause.
+            CefBrowserAccess.Probe(Log.Logger);
+
             var fontService = ServiceProvider?.GetRequiredService<IFontService>();
             if (fontService != null)
             {
@@ -1180,6 +1186,10 @@ public partial class App : Application
         services.AddSingleton<IScriptService, ScriptService>();
         services.AddSingleton<ISettingsService, SettingsService>();
         services.AddSingleton<IFontService, FontService>();
+        // Per-script book-text zoom (#572). Separate from IFontService: that owns app chrome fonts, this
+        // owns book content size, and #574 made zoom the only per-script size control there is.
+        services.AddSingleton<IBookZoomService>(sp =>
+            new BookZoomService(sp.GetRequiredService<ISettingsService>()));
         services.AddSingleton<IApplicationStateService, ApplicationStateService>();
         services.AddSingleton<ChapterListsService>();
         // Recently-opened-books (MRU) list backing the File → Open Recent menu (#44).
@@ -1384,9 +1394,43 @@ public partial class App : Application
     ///
     /// macOS is excluded deliberately: a binding here plus the system menu's accelerator would fire twice.
     /// </summary>
+    /// <summary>
+    /// Applies a book-zoom keystroke to <paramref name="window"/>'s active book, if it is one.
+    /// Returns true when handled. (#572)
+    /// </summary>
+    private bool ApplyZoomKey(KeyEventArgs e, Window window)
+    {
+        var command = ZoomKeys.Match(e, PlatformGesture.CommandModifier);
+        if (command == null) return false;
+
+        Log.Debug("*** FLOATING WINDOW ZOOM SHORTCUT: {Command} (key={Key}, physical={Physical}) ***",
+            command, e.Key, e.PhysicalKey);
+        e.Handled = true;
+
+        var book = FindActiveBookInFloatingWindow(window)?.BookDisplayControl;
+        switch (command)
+        {
+            case ZoomCommand.In: book?.ZoomIn(); break;
+            case ZoomCommand.Out: book?.ZoomOut(); break;
+            default: book?.ResetZoom(); break;
+        }
+        return true;
+    }
+
     public void RegisterFloatingWindowShortcuts(Window window)
     {
-        if (OperatingSystem.IsMacOS()) return;
+        // #572, fable review: on macOS the floating window's NativeMenu declares ⌘=, ⌘- and ⌘0, but a menu
+        // item carries one gesture each — so ⌘⇧= (what most people press for "⌘+") and the numpad keys were
+        // dead outside the WebView. Register exactly the spellings the menu does not, so nothing double-fires.
+        if (OperatingSystem.IsMacOS())
+        {
+            window.AddHandler(InputElement.KeyDownEvent, (object? s, KeyEventArgs e) =>
+            {
+                if (ZoomKeys.IsMacMenuEquivalent(e)) return;   // the View menu owns ⌘=, ⌘- and ⌘0
+                if (ApplyZoomKey(e, window)) return;
+            }, global::Avalonia.Interactivity.RoutingStrategies.Bubble);
+            return;
+        }
 
         try
         {
@@ -1412,6 +1456,7 @@ public partial class App : Application
                 (PlatformGesture.Parse("o"),        () => SimpleTabbedWindow.RevealSelectBookPanel()),
                 (PlatformGesture.Parse("p"),        () => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.Print()),
                 (PlatformGesture.Parse("shift+p"),  () => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.PrintSelection()),
+                // #572 zoom is matched separately below, by physical key as well as produced character.
                 (PlatformGesture.Parse("OemComma"), () => _ = ShowSettingsWindow()),
             };
 
@@ -1426,6 +1471,8 @@ public partial class App : Application
                     invoke();
                     return;
                 }
+
+                ApplyZoomKey(e, window);   // #572, after the gesture list so it cannot shadow a letter
             }, global::Avalonia.Interactivity.RoutingStrategies.Bubble);
 
             Log.Information("Registered {Count} shortcuts for floating window: {WindowTitle}",
@@ -1492,10 +1539,25 @@ public partial class App : Application
             };
             _dictionaryMenuItems.Add(dictionaryItem);
 
+            // #572: book zoom, mirroring the main window's View menu. macOS shows the menu bar of the
+            // ACTIVE window, so without these three a floated book would have dead zoom keys — the same
+            // hole #448 found for Cmd+D/Cmd+F. Only the "+" spelling can be advertised in a menu; the
+            // keyboard handler above also takes shift+OemPlus and the numpad keys.
+            var zoomInItem = new NativeMenuItem { Header = "Zoom In", Gesture = PlatformGesture.Parse("OemPlus") };
+            zoomInItem.Click += (s, e) => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.ZoomIn();
+            var zoomOutItem = new NativeMenuItem { Header = "Zoom Out", Gesture = PlatformGesture.Parse("OemMinus") };
+            zoomOutItem.Click += (s, e) => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.ZoomOut();
+            var zoomResetItem = new NativeMenuItem { Header = "Actual Size", Gesture = PlatformGesture.Parse("D0") };
+            zoomResetItem.Click += (s, e) => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.ResetZoom();
+
             var viewMenu = new NativeMenu();
             viewMenu.Add(selectBookItem);
             viewMenu.Add(searchItem);
             viewMenu.Add(dictionaryItem);
+            viewMenu.Add(new NativeMenuItemSeparator());
+            viewMenu.Add(zoomInItem);
+            viewMenu.Add(zoomOutItem);
+            viewMenu.Add(zoomResetItem);
 
             // Tools menu: Go To... + View Source (floating windows are book-centric)
             var goToItem = new NativeMenuItem { Header = "Go To...", Gesture = PlatformGesture.Parse("G") };

--- a/src/CST.Avalonia/Input/ZoomKeys.cs
+++ b/src/CST.Avalonia/Input/ZoomKeys.cs
@@ -1,0 +1,70 @@
+using Avalonia.Input;
+
+namespace CST.Avalonia.Input;
+
+public enum ZoomCommand { In, Out, Reset }
+
+/// <summary>
+/// Recognises the book-zoom keystrokes. (#572)
+///
+/// <para>
+/// Matching by <see cref="KeyGesture"/> alone is not safe for this app's users. Avalonia derives
+/// <see cref="Key"/> on macOS from the character the active input source <i>produces</i>: with an ASCII
+/// layout the "=" key yields <see cref="Key.OemPlus"/> and everything works. With a Devanagari or other
+/// Indic input source active — entirely normal for a Pāli reader — the character lookup misses and Avalonia
+/// falls back to a QWERTY table that maps the physical "=" key to <see cref="Key.OemMinus"/>. So ⌘⇧= would
+/// silently do nothing, while the menu's ⌘= kept working through macOS's own ASCII-layout fallback. The
+/// symptom is a dead key for exactly the users most likely to have such a layout active. (fable review)
+/// </para>
+///
+/// <para>
+/// <see cref="PhysicalKey"/> is layout-independent, so it is checked as well. Both are consulted rather than
+/// physical-only: a layout that deliberately relocates these characters should still work by what it
+/// produces, and remapped-keyboard users expect the printed legend to win.
+/// </para>
+/// </summary>
+public static class ZoomKeys
+{
+    /// <summary>
+    /// Returns the zoom command for <paramref name="e"/>, or null when it is not a zoom keystroke.
+    /// <paramref name="commandModifier"/> is the platform's command modifier (⌘ on macOS, Ctrl elsewhere).
+    /// </summary>
+    public static ZoomCommand? Match(KeyEventArgs e, KeyModifiers commandModifier)
+    {
+        if (!e.KeyModifiers.HasFlag(commandModifier)) return null;
+        // Alt+Cmd+= is not ours; excluding it keeps this off any system or app combo built on Alt.
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Alt)) return null;
+
+        // Shift is deliberately NOT tested: "+" is Shift+"=" on most layouts, so both the shifted and
+        // unshifted forms of each key must resolve to the same command.
+        return (e.Key, e.PhysicalKey) switch
+        {
+            (Key.OemPlus or Key.Add, _) => ZoomCommand.In,
+            (_, PhysicalKey.Equal or PhysicalKey.NumPadAdd) => ZoomCommand.In,
+
+            (Key.OemMinus or Key.Subtract, _) => ZoomCommand.Out,
+            (_, PhysicalKey.Minus or PhysicalKey.NumPadSubtract) => ZoomCommand.Out,
+
+            (Key.D0 or Key.NumPad0, _) => ZoomCommand.Reset,
+            (_, PhysicalKey.Digit0 or PhysicalKey.NumPad0) => ZoomCommand.Reset,
+
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// True for the three spellings a macOS NativeMenu item already declares — unshifted main-row
+    /// <c>=</c>, <c>-</c> and <c>0</c>.
+    ///
+    /// <para>
+    /// macOS resolves menu key equivalents itself, and it does so against an ASCII-capable layout, so those
+    /// three keep working whatever input source is active. A window handler must therefore skip exactly
+    /// them, or a single ⌘= would zoom twice. Everything else — the shifted forms and the numpad — a menu
+    /// item cannot express, since it carries one gesture each.
+    /// </para>
+    /// </summary>
+    public static bool IsMacMenuEquivalent(KeyEventArgs e) =>
+        !e.KeyModifiers.HasFlag(KeyModifiers.Shift) &&
+        (e.PhysicalKey is PhysicalKey.Equal or PhysicalKey.Minus or PhysicalKey.Digit0
+         || e.Key is Key.OemPlus or Key.OemMinus or Key.D0);
+}

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -149,5 +149,32 @@ namespace CST.Avalonia.Models
     {
         public string FontFamily { get; set; } = "";
         public int FontSize { get; set; } = 12;
+
+        /// <summary>
+        /// Book-text zoom for this script, as a multiplier on the stylesheet's own sizes. 1.0 renders the
+        /// shipped ladder exactly (body 12pt / chapter 18pt / book 21pt / nikaya 24pt). (#572)
+        ///
+        /// <para>
+        /// NOT a multiplier on <see cref="FontSize"/> above, despite sharing this class. <see cref="FontSize"/>
+        /// sizes app <i>chrome</i> for this script — the book tree, search results, the dictionary pane — and
+        /// zoom never touches any of those. Zoom applies only to book content, through Chromium's own
+        /// browser-level zoom, so it scales every stylesheet class proportionally including headings.
+        /// </para>
+        ///
+        /// <para>
+        /// It lives here because zoom is per script for the same reason the face is: #574 flattened the
+        /// stylesheets to one shared size ladder, so zoom became the only per-script size control, and it is
+        /// calibration for whatever face this script resolves to. Switching a book's script therefore has to
+        /// switch face and zoom together — keeping them in one record is what makes that a single lookup.
+        /// </para>
+        ///
+        /// <para>
+        /// Persisted through <c>SettingsService</c>, whose serializer does not set
+        /// <c>WhenWritingDefault</c> — so unlike <c>ApplicationState</c>, a 1.0 here survives a round-trip
+        /// rather than being silently omitted. Values are clamped on read regardless; see
+        /// <c>BookZoomService</c>.
+        /// </para>
+        /// </summary>
+        public double BookZoom { get; set; } = 1.0;
     }
 }

--- a/src/CST.Avalonia/Services/BookZoomService.cs
+++ b/src/CST.Avalonia/Services/BookZoomService.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Conversion;
+using Serilog;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>Raised when a script's book zoom changes, so every open book in that script can re-apply it.</summary>
+public class BookZoomChangedEventArgs : EventArgs
+{
+    public BookZoomChangedEventArgs(Script script, double zoom) { Script = script; Zoom = zoom; }
+    public Script Script { get; }
+    public double Zoom { get; }
+}
+
+public interface IBookZoomService
+{
+    /// <summary>The stored zoom for a script, clamped to the supported range. 1.0 when nothing is stored.</summary>
+    double GetZoom(Script script);
+
+    /// <summary>Steps up the ladder. Returns the new zoom (unchanged at the ceiling).</summary>
+    double ZoomIn(Script script);
+
+    /// <summary>Steps down the ladder. Returns the new zoom (unchanged at the floor).</summary>
+    double ZoomOut(Script script);
+
+    /// <summary>Returns to 1.0 — the shipped stylesheet sizes exactly.</summary>
+    double ResetZoom(Script script);
+
+    /// <summary>True when this script is not at 100%, i.e. the readout should show something.</summary>
+    bool IsZoomed(Script script);
+
+    /// <summary>"125%" — for menus and the Settings readout.</summary>
+    string FormatZoom(Script script);
+
+    event EventHandler<BookZoomChangedEventArgs>? ZoomChanged;
+}
+
+/// <summary>
+/// Owns per-script book-text zoom. (#572)
+///
+/// <para>
+/// Zoom is the <b>only</b> stored size control for book text. #574 flattened all 14 stylesheets to one shared
+/// ladder, and #42 was narrowed to font <i>face</i> selection, so there is deliberately no user-editable base
+/// size — the two were redundant, and a live control beats typing a number into a dialog for a judgment that
+/// can only be made by eye. Effective size is <c>shippedXslSize × zoom[script]</c>.
+/// </para>
+///
+/// <para>
+/// Per <i>script</i> rather than per tab or global: the stylesheet ladder is now identical across scripts, so
+/// the only thing zoom compensates for is the metrics of whatever face that script resolves to — which is
+/// exactly what the face setting is scoped to. A book switching script therefore picks up that script's zoom
+/// along with its face.
+/// </para>
+///
+/// <para>
+/// This service is the model only. Pushing a level into a browser is <c>BookDisplayView</c>'s job, since that
+/// is what owns a WebView; this type never touches CEF.
+/// </para>
+/// </summary>
+public class BookZoomService : IBookZoomService
+{
+    /// <summary>
+    /// The zoom ladder. Chromium's own ladder trimmed at both ends: a reader has no use for 25% (illegible)
+    /// or 500% (a few words per screen), and every extra rung is one more press to cross. Kept at 10% steps
+    /// through the 90–110 range because that is where face calibration actually happens — the coarser 25%
+    /// jumps higher up are fine for "I want it bigger" but useless for "does this face look right".
+    /// </summary>
+    private static readonly double[] Ladder =
+        { 0.50, 0.67, 0.75, 0.80, 0.90, 1.00, 1.10, 1.25, 1.50, 1.75, 2.00, 2.50, 3.00 };
+
+    public static double MinZoom => Ladder[0];
+    public static double MaxZoom => Ladder[^1];
+    public const double DefaultZoom = 1.0;
+
+    // Two ladder rungs can sit 0.05 apart, so the tolerance for "already on this rung" has to be well below
+    // that. Also absorbs the float error from a JSON round-trip of 0.67.
+    private const double Epsilon = 0.001;
+
+    private readonly ISettingsService _settingsService;
+    private readonly ILogger _logger;
+
+    public BookZoomService(ISettingsService settingsService, ILogger? logger = null)
+    {
+        _settingsService = settingsService;
+        _logger = logger ?? Log.ForContext<BookZoomService>();
+    }
+
+    public event EventHandler<BookZoomChangedEventArgs>? ZoomChanged;
+
+    public double GetZoom(Script script)
+    {
+        var settings = _settingsService.Settings.FontSettings;
+        if (settings.TryGetFont(script, out var setting) && setting != null)
+            return Clamp(setting.BookZoom);
+
+        // A script absent from the dictionary is normal for a settings file written before this script
+        // existed, and for any key the FontSettings constructor does not seed.
+        return DefaultZoom;
+    }
+
+    public double ZoomIn(Script script) => Step(script, +1);
+
+    public double ZoomOut(Script script) => Step(script, -1);
+
+    /// <summary>
+    /// Returns to 1.0 — and always notifies, even when the stored value was already 1.0.
+    ///
+    /// That "pointless" notification is the whole value of the command. The browser's real zoom can drift
+    /// away from what we stored: a Ctrl+scroll that landed before the bridge script was injected, a failed
+    /// injection, or a macOS trackpad pinch (page-scale, which we deliberately do not manage). In every one
+    /// of those states the text is not at 100% while the setting says it is, and an early return would make
+    /// "Actual Size" a dead key exactly when the user needs it. CEF's SetZoomLevel(0) additionally resets
+    /// page scale, so this is also the only thing that undoes a pinch. (fable review)
+    /// </summary>
+    public double ResetZoom(Script script) => SetZoom(script, DefaultZoom, alwaysNotify: true);
+
+    public bool IsZoomed(Script script) => Math.Abs(GetZoom(script) - DefaultZoom) > Epsilon;
+
+    public string FormatZoom(Script script) =>
+        (GetZoom(script) * 100).ToString("0", CultureInfo.InvariantCulture) + "%";
+
+    /// <summary>
+    /// Moves <paramref name="direction"/> rungs from the current value. When the stored value is between
+    /// rungs — a hand-edited settings file, or a value from a future build with a different ladder — this
+    /// snaps to the next rung in the direction of travel rather than to the nearest, so a press always moves
+    /// and always moves the way the user asked.
+    /// </summary>
+    private double Step(Script script, int direction)
+    {
+        var current = GetZoom(script);
+
+        double target = direction > 0
+            ? Ladder.FirstOrDefault(r => r > current + Epsilon, Ladder[^1])
+            : Ladder.LastOrDefault(r => r < current - Epsilon, Ladder[0]);
+
+        return SetZoom(script, target);
+    }
+
+    private double SetZoom(Script script, double zoom, bool alwaysNotify = false)
+    {
+        zoom = Clamp(zoom);
+        var settings = _settingsService.Settings.FontSettings;
+
+        if (!settings.TryGetFont(script, out var setting) || setting == null)
+        {
+            // Seed the entry rather than dropping the change: a script missing from the dictionary would
+            // otherwise be permanently unzoomable, and silently so.
+            setting = new ScriptFontSetting();
+            settings.ScriptFonts[ScriptKeys.Of(script)] = setting;
+        }
+
+        var unchanged = Math.Abs(setting.BookZoom - zoom) <= Epsilon;
+        if (unchanged && !alwaysNotify)
+        {
+            // Already there — at a ladder end this is every repeat press. Returning early keeps it from
+            // scheduling a save and waking every open book for nothing.
+            return zoom;
+        }
+
+        if (!unchanged)
+        {
+            setting.BookZoom = zoom;
+            _settingsService.RequestSave();   // debounced: a burst of Cmd+ presses coalesces into one write
+        }
+
+        _logger.Information("Book zoom for {Script} set to {Zoom:P0}", script, zoom);
+        ZoomChanged?.Invoke(this, new BookZoomChangedEventArgs(script, zoom));
+        return zoom;
+    }
+
+    private static double Clamp(double zoom)
+    {
+        // Covers a hand-edited settings file and, importantly, 0.0 — which is what a serializer configured
+        // with WhenWritingDefault would hand back for an omitted double. Settings does not use that setting
+        // today, but a zoom of 0 would blank the text entirely, so it is not worth depending on.
+        if (double.IsNaN(zoom) || zoom <= 0) return DefaultZoom;
+        return Math.Clamp(zoom, MinZoom, MaxZoom);
+    }
+
+    /// <summary>
+    /// Chromium expresses zoom logarithmically: <c>factor = 1.2^level</c>, so level 0 is 100%. This is what
+    /// <c>CefBrowserHost.SetZoomLevel</c> takes — passing it a raw factor would set 125% to 1.2^1.25 ≈ 245%.
+    /// </summary>
+    public static double ToCefZoomLevel(double zoomFactor)
+    {
+        if (double.IsNaN(zoomFactor) || zoomFactor <= 0) zoomFactor = DefaultZoom;
+        return Math.Log(zoomFactor) / Math.Log(1.2);
+    }
+
+    /// <summary>Inverse of <see cref="ToCefZoomLevel"/>, for reading a level back out of a browser.</summary>
+    public static double FromCefZoomLevel(double zoomLevel) => Math.Pow(1.2, zoomLevel);
+
+    /// <summary>The ladder, exposed for tests and for a Settings readout that wants to show the steps.</summary>
+    public static IReadOnlyList<double> ZoomLadder => Ladder;
+}

--- a/src/CST.Avalonia/Services/CefBrowserAccess.cs
+++ b/src/CST.Avalonia/Services/CefBrowserAccess.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Serilog;
+using WebViewControl;
+using Xilium.CefGlue;
+using Xilium.CefGlue.Common;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Reaches the underlying <see cref="CefBrowserHost"/> behind a <see cref="WebView"/>. (#572)
+///
+/// <para>
+/// Most of CEF's browser-level API — zoom, find-in-page, print-to-PDF — has no equivalent on
+/// <c>WebViewControl.WebView</c>, which exposes navigation, script execution and little else. Getting at it
+/// takes two hops, and only the first two are non-public:
+/// </para>
+/// <list type="number">
+///   <item><c>WebView.UnderlyingBrowser</c> — <b>internal</b> getter, returns WebViewControl's own
+///   <c>ChromiumBrowser</c>. That type is internal too, but it derives from the public
+///   <see cref="BaseCefBrowser"/>, so the value can be typed once retrieved.</item>
+///   <item><c>BaseCefBrowser.UnderlyingBrowser</c> — <b>protected</b> getter, returns <see cref="CefBrowser"/>.</item>
+///   <item><c>CefBrowser.GetHost()</c> — public from here on.</item>
+/// </list>
+///
+/// <para>
+/// This is the first place in the codebase to reflect into CEF internals. (An earlier note claimed #112's
+/// printing work had already mapped this chain; it had not — printing shipped <c>window.print()</c> through
+/// JavaScript and never touched the browser object.) Because both hops bind to non-public members of a
+/// third-party package, a WebViewControl or CefGlue upgrade can break them silently, so:
+/// </para>
+/// <list type="bullet">
+///   <item>every failure degrades to a null return and a log line, never an exception at a call site;</item>
+///   <item><see cref="Probe"/> reports resolvability once at startup, so a broken chain shows up in the log
+///   rather than as a mysteriously dead keyboard shortcut;</item>
+///   <item><c>CefBrowserAccessTests</c> asserts both members still resolve, so a package bump fails the
+///   build rather than the feature.</item>
+/// </list>
+/// </summary>
+public static class CefBrowserAccess
+{
+    private const BindingFlags NonPublicInstance = BindingFlags.Instance | BindingFlags.NonPublic;
+
+    // Resolved once. Nullable rather than throwing: a null here must disable the feature, not break startup.
+    private static readonly PropertyInfo? WebViewUnderlyingBrowser =
+        typeof(WebView).GetProperty("UnderlyingBrowser", NonPublicInstance);
+
+    private static readonly PropertyInfo? BaseBrowserUnderlyingBrowser =
+        typeof(BaseCefBrowser).GetProperty("UnderlyingBrowser", NonPublicInstance);
+
+    /// <summary>
+    /// True when both non-public hops resolved. False means any CEF-level feature must disable itself.
+    /// </summary>
+    public static bool IsAvailable => WebViewUnderlyingBrowser != null && BaseBrowserUnderlyingBrowser != null;
+
+    /// <summary>
+    /// Names of the members that failed to resolve, for logging. Empty when <see cref="IsAvailable"/>.
+    /// </summary>
+    public static string MissingMembers => string.Join(", ", new[]
+    {
+        WebViewUnderlyingBrowser == null ? "WebView.UnderlyingBrowser" : null,
+        BaseBrowserUnderlyingBrowser == null ? "BaseCefBrowser.UnderlyingBrowser" : null,
+    }.Where(m => m != null));
+
+    /// <summary>
+    /// The resolved property types, for the tests to pin. Names surviving an upgrade is not enough: if
+    /// either property keeps its name but changes type, the <c>is not</c> checks in
+    /// <see cref="TryGetBrowserHost"/> return null forever and the feature dies silently — the exact
+    /// failure the tests exist to catch. (fable review)
+    /// </summary>
+    internal static Type? WebViewBrowserPropertyType => WebViewUnderlyingBrowser?.PropertyType;
+    internal static Type? BaseBrowserPropertyType => BaseBrowserUnderlyingBrowser?.PropertyType;
+
+    /// <summary>
+    /// Logs whether the reflection chain resolved. Call once during startup so a package upgrade that breaks
+    /// it is visible in the log instead of presenting as a silently dead shortcut.
+    /// </summary>
+    public static void Probe(ILogger logger)
+    {
+        if (IsAvailable)
+            logger.Information("CEF browser access available (WebView.UnderlyingBrowser + BaseCefBrowser.UnderlyingBrowser resolved)");
+        else
+            logger.Warning("CEF browser access UNAVAILABLE - unresolved: {Missing}. Book zoom (#572) will be inert; " +
+                           "a WebViewControl/CefGlue upgrade most likely renamed or re-scoped these members", MissingMembers);
+    }
+
+    /// <summary>
+    /// Returns the browser host for <paramref name="webView"/>, or null when the chain is unavailable or the
+    /// browser is not yet created. Never throws.
+    /// </summary>
+    public static CefBrowserHost? TryGetBrowserHost(WebView? webView, ILogger logger)
+    {
+        if (webView == null || !IsAvailable) return null;
+
+        try
+        {
+            // Not just an optimisation: before initialization UnderlyingBrowser is null, and asking a
+            // half-built browser for its host is exactly the sort of thing that crashes CEF rather than
+            // returning null.
+            if (!webView.IsBrowserInitialized) return null;
+
+            if (WebViewUnderlyingBrowser!.GetValue(webView) is not BaseCefBrowser chromium)
+                return null;
+
+            if (BaseBrowserUnderlyingBrowser!.GetValue(chromium) is not CefBrowser browser)
+                return null;
+
+            return browser.GetHost();
+        }
+        catch (Exception ex)
+        {
+            logger.Error("Failed to reach the CEF browser host | {Details}", ex.Message);
+            return null;
+        }
+    }
+}

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -118,6 +118,9 @@ public partial class BookDisplayView : UserControl
         this.AttachedToVisualTree += OnAttachedToVisualTree;
         this.DetachedFromVisualTree += OnDetachedFromVisualTree;
 
+        // Zoom is stored per script and applies to book text only, so every book view listens. (#572)
+        SubscribeToZoomChanges();
+
         // Try to create WebView browser
         TryCreateWebView();
     }
@@ -304,6 +307,11 @@ public partial class BookDisplayView : UserControl
     public void Shutdown()
     {
         _isShutDown = true;
+        // Released here rather than on detach: the zoom subscription is on a singleton, so leaving it
+        // attached would root this View (and its rendered DOM) for the session — the same leak shape BOOK-1
+        // describes for the browser itself. Detach is the recycled tab-switch/float path and must NOT
+        // unsubscribe, or a re-attached tab would stop following zoom changes. (#572)
+        UnsubscribeFromZoomChanges();
         DisposeWebView();
     }
 
@@ -637,6 +645,202 @@ public partial class BookDisplayView : UserControl
             token.Above, token.Below, token.Fraction);
         ScrollToPositionToken(token);
     }
+
+    #region Book text zoom (#572)
+
+    // Zoom is stored per script by BookZoomService and pushed into Chromium's own browser-level zoom, which
+    // scales every stylesheet class proportionally — including the heading ladder — for free. That is why
+    // this uses CefBrowserHost.SetZoomLevel rather than injecting CSS: #574 left the stylesheets with
+    // absolute pt sizes on ~15 classes, and CSS would have to override every one of them.
+    private IBookZoomService? _bookZoomService;
+    private EventHandler<BookZoomChangedEventArgs>? _zoomChangedHandler;
+    private System.Timers.Timer? _zoomSettleTimer = null;
+    private ReadingPositionToken? _zoomRestoreToken = null;
+    // Marks a zoom BURST in progress, exactly as _resizeInProgress does for a drag. Holding Cmd+ forwards
+    // auto-repeat, and the ~200ms status tick keeps re-capturing _lastPositionToken throughout — against a
+    // cache the in-page resize handler rebuilds ~100ms after each step. So by the second step the rolling
+    // token already describes the DRIFTED position, and re-snapshotting per step would commit that drift.
+    // Snapshot once, on the first step, while the token is still pre-zoom. (fable review)
+    private bool _zoomInProgress = false;
+    // Bumped on every completed navigation. A deferred scroll restoration records the generation that armed
+    // it, so one belonging to a superseded document can be recognised and dropped. -1 means none pending.
+    private int _navGeneration = 0;
+    private int _deferredScrollGeneration = -1;
+
+    /// <summary>
+    /// Subscribes this view to zoom changes for its script. Called once from the constructor.
+    ///
+    /// The subscription is on a singleton service, so it roots this View until released — the same leak
+    /// shape the FontService subscription had. <see cref="UnsubscribeFromZoomChanges"/> runs from the
+    /// existing shutdown path.
+    /// </summary>
+    private void SubscribeToZoomChanges()
+    {
+        _bookZoomService = App.ServiceProvider?.GetService(typeof(IBookZoomService)) as IBookZoomService;
+        if (_bookZoomService == null)
+        {
+            _logger.Debug("Book zoom service unavailable - zoom will not apply to this view");
+            return;
+        }
+
+        _zoomChangedHandler = (_, args) =>
+        {
+            // Zoom is per script, so a change fires for every open book; only those showing that script care.
+            if (_viewModel == null || _viewModel.BookScript != args.Script) return;
+            Dispatcher.UIThread.Post(() => ApplyZoom(args.Zoom, preservePosition: true));
+        };
+        _bookZoomService.ZoomChanged += _zoomChangedHandler;
+    }
+
+    private void UnsubscribeFromZoomChanges()
+    {
+        if (_bookZoomService != null && _zoomChangedHandler != null)
+            _bookZoomService.ZoomChanged -= _zoomChangedHandler;
+        _zoomChangedHandler = null;
+
+        _zoomSettleTimer?.Stop();
+        _zoomSettleTimer?.Dispose();
+        _zoomSettleTimer = null;
+    }
+
+    /// <summary>
+    /// Pushes this script's stored zoom into the browser without touching the reading position.
+    ///
+    /// Called from <c>OnNavigationCompleted</c>, which covers every route that produces a fresh browser:
+    /// first load, a script change (which reloads), and the float/unfloat cycle that disposes and recreates
+    /// the WebView. Chromium also keeps its own per-origin zoom inside the request context, and all books
+    /// share an origin — so without setting it explicitly on every load, a zoom set while reading one script
+    /// would leak into the next book regardless of its script. Setting it unconditionally here overwrites
+    /// whatever Chromium remembered, which is why this runs even when the value is 1.0.
+    /// </summary>
+    /// <returns>
+    /// True when a zoom other than 100% was applied, i.e. the document is about to reflow. The caller uses
+    /// this to defer resolving any scroll target until the new layout exists.
+    /// </returns>
+    private bool ApplyStoredZoomOnLoad()
+    {
+        if (_bookZoomService == null || _viewModel == null) return false;
+
+        var zoom = _bookZoomService.GetZoom(_viewModel.BookScript);
+        ApplyZoom(zoom, preservePosition: false);
+        return Math.Abs(zoom - 1.0) > 0.001;
+    }
+
+    /// <summary>
+    /// Sets the browser's zoom level.
+    ///
+    /// <paramref name="preservePosition"/> is false on a fresh load — there is no position to keep yet, and
+    /// the saved-anchor restoration in <c>ExecutePendingRestoration</c> owns where the page lands. It is true
+    /// for a live zoom change, where the reflow would otherwise move the text out from under the reader.
+    /// </summary>
+    private void ApplyZoom(double zoom, bool preservePosition)
+    {
+        if (_isShutDown || _webView == null || !_isBrowserInitialized) return;
+
+        var host = CefBrowserAccess.TryGetBrowserHost(_webView, _logger);
+        if (host == null)
+        {
+            // Either the reflection chain broke on a package upgrade (CefBrowserAccess.Probe says so at
+            // startup) or the browser is mid-teardown. Neither is worth an exception on a keystroke.
+            _logger.Debug("Zoom skipped - no browser host available");
+            return;
+        }
+
+        // Snapshot BEFORE the reflow, and only on the FIRST step of a burst. The rolling token is refreshed
+        // by the ~200ms status tick, so it is at most one tick stale but still pre-reflow — the best
+        // available, because a zoom's resize event only arrives after layout has already moved. Re-taking it
+        // on later steps would capture the drift instead. (Same two-part discipline as the resize path.)
+        if (preservePosition && !_zoomInProgress && _anchorCacheBuilt && this.IsVisible)
+        {
+            _zoomInProgress = true;
+            _zoomRestoreToken = _lastPositionToken;
+            _logger.Debug("Zoom started - snapshotted reading position (above={Above}, below={Below}, frac={Frac})",
+                _zoomRestoreToken?.Above, _zoomRestoreToken?.Below, _zoomRestoreToken?.Fraction);
+        }
+
+        try
+        {
+            var level = BookZoomService.ToCefZoomLevel(zoom);
+            host.SetZoomLevel(level);
+            _logger.Information("Applied book zoom {Zoom:P0} (CEF level {Level:0.###}) to {Script}",
+                zoom, level, _viewModel?.BookScript);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Failed to set zoom level | {Details}", ex.Message);
+            _zoomRestoreToken = null;
+            _zoomInProgress = false;   // or the burst flag would latch and suppress the next real snapshot
+            return;
+        }
+
+        if (preservePosition) StartZoomSettle();
+    }
+
+    /// <summary>
+    /// Restores the reading position once the zoom reflow has settled.
+    ///
+    /// The delay has to outlast the in-page resize handler's own 100ms debounce, because a browser zoom
+    /// fires <c>resize</c> and that handler rebuilds the anchor cache — restoring against the stale cache
+    /// would scroll to pre-zoom pixel positions. Same constant as the resize path, for the same reason.
+    /// A repeated press re-arms the timer, so holding Cmd+ restores once at the end rather than fighting
+    /// each intermediate step.
+    /// </summary>
+    private void StartZoomSettle()
+    {
+        if (_zoomSettleTimer == null)
+        {
+            _zoomSettleTimer = new System.Timers.Timer(ResizeSettleMs) { AutoReset = false };
+            _zoomSettleTimer.Elapsed += (_, __) => Dispatcher.UIThread.Post(RestoreAfterZoom);
+        }
+        _zoomSettleTimer.Stop();
+        _zoomSettleTimer.Start();
+    }
+
+    private void RestoreAfterZoom()
+    {
+        // Another zoom step landed while this was queued (or the user simply paused mid-burst) — the burst
+        // is still running, so keep the original pre-zoom snapshot and let the real settle restore it.
+        // Returning WITHOUT clearing _zoomInProgress is the point: it is what stops the next step
+        // re-snapshotting the drifted token. (Mirrors RestoreAfterResize.)
+        if (_zoomSettleTimer?.Enabled == true) return;
+
+        _zoomInProgress = false;
+        if (_isShutDown) return;
+
+        var token = _zoomRestoreToken;
+        _zoomRestoreToken = null;
+        if (token == null || !this.IsVisible) return;
+
+        _logger.Debug("Zoom settled - restoring reading position (above={Above}, below={Below}, frac={Frac})",
+            token.Above, token.Below, token.Fraction);
+        ScrollToPositionToken(token);
+    }
+
+    /// <summary>Zoom in one step. Public so the menu items and keyboard shortcuts can drive it.</summary>
+    public void ZoomIn() => StepZoom(s => s.ZoomIn(_viewModel!.BookScript), "in");
+
+    /// <summary>Zoom out one step.</summary>
+    public void ZoomOut() => StepZoom(s => s.ZoomOut(_viewModel!.BookScript), "out");
+
+    /// <summary>Back to 100% — the shipped stylesheet sizes exactly.</summary>
+    public void ResetZoom() => StepZoom(s => s.ResetZoom(_viewModel!.BookScript), "reset");
+
+    private void StepZoom(Func<IBookZoomService, double> step, string what)
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() => StepZoom(step, what));
+            return;
+        }
+        if (_bookZoomService == null || _viewModel == null || _isShutDown) return;
+
+        // The service persists and raises ZoomChanged; this view applies it through that event like any
+        // other, so a second tab showing the same script updates by exactly the same route.
+        var zoom = step(_bookZoomService);
+        _logger.Debug("Zoom {What} requested for {Script} - now {Zoom:P0}", what, _viewModel.BookScript, zoom);
+    }
+
+    #endregion
 
 
     private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -1610,6 +1814,9 @@ public partial class BookDisplayView : UserControl
                 // Mark browser as initialized for scroll tracking
                 _isBrowserInitialized = true;
 
+                // #572: a new document supersedes any deferred scroll restoration armed by the previous one.
+                Interlocked.Increment(ref _navGeneration);
+
                 // Signal the ViewModel that initialization is complete and navigation can be enabled
                 _viewModel.CompleteInitialization();
 
@@ -1622,6 +1829,11 @@ public partial class BookDisplayView : UserControl
                 // Set up JavaScript bridge after content loads
                 SetupJavaScriptBridge();
 
+                // BEFORE the anchor cache is built: zoom reflows the text, so a cache built at the old zoom
+                // would hold pixel positions that are wrong the moment this applies. The build itself waits
+                // for fonts.ready plus a paint frame, which also covers the relayout this triggers. (#572)
+                var zoomWillReflow = ApplyStoredZoomOnLoad();
+
                 // Build the anchor position cache — UNCONDITIONALLY, because this navigation just gave
                 // the page a fresh JS context (any previous window.cstAnchorCache is gone, whatever
                 // _anchorCacheBuilt claims). No fixed "let it settle" delay: the build itself waits for
@@ -1632,7 +1844,9 @@ public partial class BookDisplayView : UserControl
 
                 // The document is ready — execute any queued restoration (saved anchor or saved
                 // search hit) NOW, from the one signal that knows the DOM exists. (BOOK-7)
-                ExecutePendingRestoration();
+                // When a non-default zoom was just applied the scroll half waits for the reflow, or the
+                // target is computed against the pre-zoom layout. (#572, fable review)
+                ExecutePendingRestoration(zoomWillReflow ? ResizeSettleMs : 0);
             });
         }
     }
@@ -1687,7 +1901,20 @@ public partial class BookDisplayView : UserControl
     // mirroring InitializeAsync's #36 preference for the exact hit over its paragraph anchor.
     // Replaces three racing fixed-delay attempts (1000/500/300 ms) that silently no-opped when the
     // browser wasn't ready, leaving the book at the top on slow loads. (BOOK-7)
-    private void ExecutePendingRestoration()
+    /// <summary>
+    /// <paramref name="delayScrollMs"/> defers only the SCROLL half. (#572)
+    ///
+    /// A load-time zoom other than 100% reflows the document asynchronously — Chromium applies
+    /// <c>SetZoomLevel</c> over browser→renderer IPC, while the restoration scripts go out over a different
+    /// channel — so resolving a scroll target immediately can compute it against the pre-zoom layout and
+    /// land the reader somewhere else. Unlike a live zoom there is no rolling token yet to restore from, so
+    /// nothing would correct it. Every relaunch of a book in a zoomed script hits this. (fable review)
+    ///
+    /// The visibility half is deliberately NOT deferred: a fresh render shows all notes, so delaying
+    /// <see cref="ApplyFootnotesVisibility"/> would flash them for the length of the delay in exactly the
+    /// case we are trying to improve.
+    /// </summary>
+    private void ExecutePendingRestoration(int delayScrollMs = 0)
     {
         if (_viewModel == null || _webView == null || !_isBrowserInitialized)
             return;
@@ -1696,6 +1923,54 @@ public partial class BookDisplayView : UserControl
         // toggle state on every load/reload before the hit/anchor restoration branches below.
         ApplyFootnotesVisibility(_viewModel.ShowFootnotes);
         ApplySearchTermsVisibility(_viewModel.ShowSearchTerms);
+
+        if (delayScrollMs > 0)
+        {
+            // The pending intents are deliberately NOT taken yet — TakePending* consumes them, so reading
+            // them here and acting later would lose them if anything ran in between.
+            //
+            // Tagged with the current navigation. The primary trigger is the CACHE_BUILT signal (see
+            // OnTitleChanged); this timer is only a backstop for the case where the build never reports —
+            // the same failure the anchor-cache watchdog exists for. Whichever fires first wins, because
+            // RunDeferredScrollRestoration clears the tag atomically.
+            var generation = Volatile.Read(ref _navGeneration);
+            Volatile.Write(ref _deferredScrollGeneration, generation);
+            _logger.Debug("Deferring scroll restoration for the load-time zoom reflow (nav {Generation})", generation);
+
+            DispatcherTimer.RunOnce(RunDeferredScrollRestoration, TimeSpan.FromMilliseconds(delayScrollMs * 4));
+            return;
+        }
+
+        ExecutePendingScrollRestoration();
+    }
+
+    /// <summary>
+    /// Runs a deferred scroll restoration exactly once, and only for the navigation that armed it. (#572)
+    ///
+    /// <para>
+    /// The generation check is what stops a stale deferral from firing into a newer document. Without it, a
+    /// script change landing inside the deferral window would let the old timer consume the intents the new
+    /// navigation had just queued — the new load would then find them already taken and fall back to a
+    /// coarser position, which is worse than the race the deferral was added to fix. (fable review)
+    /// </para>
+    /// </summary>
+    private void RunDeferredScrollRestoration()
+    {
+        var generation = Volatile.Read(ref _navGeneration);
+        // Interlocked, not a plain compare-then-write: the CACHE_BUILT signal and the backstop timer can
+        // both arrive, and only the first may act.
+        if (Interlocked.CompareExchange(ref _deferredScrollGeneration, -1, generation) != generation)
+            return;
+
+        if (_isShutDown) return;
+        _logger.Debug("Zoom reflow settled - running deferred scroll restoration (nav {Generation})", generation);
+        ExecutePendingScrollRestoration();
+    }
+
+    private void ExecutePendingScrollRestoration()
+    {
+        if (_viewModel == null || _webView == null || !_isBrowserInitialized)
+            return;
 
         var pendingHit = _viewModel.TakePendingHitNavigation();
         var pendingToken = _viewModel.TakePendingPositionToken();
@@ -1876,6 +2151,14 @@ public partial class BookDisplayView : UserControl
                 {
                     _anchorCacheBuilt = true;
                     _anchorCacheBuildInFlight = false;
+
+                    // #572: a load-time zoom deferred its scroll restoration until the reflow landed. This
+                    // is that signal — build() runs after fonts.ready plus a paint frame, so a CACHE_BUILT
+                    // for the CURRENT navigation means layout has settled at the new zoom. Signal-driven
+                    // rather than a fixed delay, because the reflow's duration is a renderer-side IPC round
+                    // trip that nothing here bounds. (fable review)
+                    if (Volatile.Read(ref _deferredScrollGeneration) == Volatile.Read(ref _navGeneration))
+                        Dispatcher.UIThread.Post(RunDeferredScrollRestoration);
                     // Surface the resolved page NOW instead of waiting for the next scroll tick
                     // (≤200ms) plus its 200ms pre-lock delay. Same lock discipline as
                     // OnScrollPositionCheck: skip (don't block) if JS work is in progress —
@@ -2064,6 +2347,35 @@ public partial class BookDisplayView : UserControl
             catch (Exception ex)
             {
                 _logger.Error("Error processing copy request from JavaScript | {Details}", ex.Message);
+            }
+        }
+        // #572: zoom requested from inside the book WebView, where Chromium would otherwise apply its own
+        // script-blind, per-origin zoom. One branch for all three because they differ only in the action.
+        else if (title != null &&
+                 (title.StartsWith("CST_ZOOM_IN:") || title.StartsWith("CST_ZOOM_OUT:") || title.StartsWith("CST_ZOOM_RESET:")))
+        {
+            try
+            {
+                var parts = title.Split('|');
+                var messageTabId = parts.Length > 1 && parts[1].StartsWith("TAB:") ? parts[1].Substring(4) : "";
+
+                if (messageTabId == _tabId)
+                {
+                    var command = parts[0];
+                    _logger.Debug("*** ZOOM REQUESTED FROM JAVASCRIPT: {Command} ***", command);
+                    // Runs on the CEF thread. StepZoom marshals itself, but posting here keeps this branch
+                    // consistent with its neighbours and keeps the service call off the CEF thread. (BOOK-2)
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (command.StartsWith("CST_ZOOM_IN")) ZoomIn();
+                        else if (command.StartsWith("CST_ZOOM_OUT")) ZoomOut();
+                        else ResetZoom();
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Error processing zoom request from JavaScript | {Details}", ex.Message);
             }
         }
         // Check for select all request from JavaScript
@@ -2378,6 +2690,41 @@ public partial class BookDisplayView : UserControl
                                     return false;
                                 }
 
+                                // #572: Cmd/Ctrl + plus/minus/0 (book zoom). Required for the same reason as
+                                // Go To and Look Up below, not a special case: while CEF holds focus,
+                                // Avalonia never sees the keystroke at all, so the window-level handlers and
+                                // the native menu are both unreachable from inside a book.
+                                //
+                                // It is NOT here to suppress a Chromium built-in. This is an alloy build, so
+                                // the keyboard zoom accelerators (which live in Chromium's chrome layer) are
+                                // absent — which is exactly why #572 reports Cmd+plus doing nothing on macOS
+                                // today, and why the only accidental zoom anyone found was Ctrl+*scroll*.
+                                // The wheel handler further down is the one that does suppress a real
+                                // built-in. preventDefault here is cheap hygiene, not the mechanism.
+                                // (Corrected after fable review; the earlier note claimed the opposite and
+                                // would have misdirected anyone optimising this later.)
+                                //
+                                // Key spellings, all of which reach here: '=' is the unshifted main-row key
+                                // (what Cmd++ actually produces), '+' is the shifted one and the numpad's,
+                                // '-'/'_' likewise, and '0' covers both main row and numpad.
+                                if ((event.metaKey || event.ctrlKey) && !event.altKey) {
+                                    var zoomCmd = null;
+                                    if (event.key === '=' || event.key === '+') { zoomCmd = 'CST_ZOOM_IN'; }
+                                    else if (event.key === '-' || event.key === '_') { zoomCmd = 'CST_ZOOM_OUT'; }
+                                    else if (event.key === '0') { zoomCmd = 'CST_ZOOM_RESET'; }
+
+                                    if (zoomCmd !== null) {
+                                        window.cstLogger.log('DEBUG', 'Zoom shortcut detected in JavaScript: ' + zoomCmd);
+                                        event.preventDefault();
+                                        event.stopPropagation();
+                                        // Auto-repeat IS forwarded, unlike the modal shortcuts above: holding
+                                        // Cmd+ to run the text up several steps is the expected behaviour of a
+                                        // zoom key, and the ladder plus the settle debounce already bound it.
+                                        document.title = zoomCmd + ':|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                                        return false;
+                                    }
+                                }
+
                                 // #443: Cmd+G / Ctrl+G (Go To) - when this WebView has focus, CEF holds the
                                 // native focus so the window's focus resolution comes back empty and the
                                 // native-menu Go To falls back to the first split's book. Forward it like
@@ -2463,6 +2810,44 @@ public partial class BookDisplayView : UserControl
                                     return false;
                                 }
                             }, true); // Use capture phase to intercept before other handlers
+
+                            // #571/#572: Ctrl+scroll. This is the gesture a Windows user already found by
+                            // accident — it applied Chromium's own layout zoom, which reflowed the text and
+                            // lost their place, because nothing on the C# side ever knew it happened. A beta
+                            // tester built a copy-a-line-then-search ritual around exactly that (#570).
+                            //
+                            // Routing it here makes it the same operation as Cmd/Ctrl+plus: it steps the
+                            // per-script ladder, persists, and restores the reading position after the
+                            // reflow. preventDefault is what stops Chromium's parallel, script-blind zoom.
+                            //
+                            // macOS is excluded (cstZoomOnWheel is false there). Trackpad pinch arrives as
+                            // ctrl+wheel too, and pinch on macOS today is page-scale magnification that
+                            // preserves position and does not rewrap — a different, working behaviour that
+                            // this issue was not asked to replace.
+                            if ({_zoomOnWheel}) {
+                                // Trackpads emit a stream of small deltas where a mouse wheel emits one
+                                // notch of ~100, so stepping per event would race up the ladder on a
+                                // trackpad. Accumulate and step on threshold to make both feel the same.
+                                window.__cstWheelAcc = 0;
+                                document.addEventListener('wheel', function(event) {
+                                    if (!event.ctrlKey) { return; }
+                                    event.preventDefault();      // suppress Chromium's own zoom
+                                    event.stopPropagation();
+
+                                    window.__cstWheelAcc += event.deltaY;
+                                    if (Math.abs(window.__cstWheelAcc) < 50) { return; }
+                                    // deltaY is negative scrolling up/away, which is the zoom-IN direction.
+                                    var cmd = window.__cstWheelAcc < 0 ? 'CST_ZOOM_IN' : 'CST_ZOOM_OUT';
+                                    window.__cstWheelAcc = 0;
+                                    document.title = cmd + ':|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                                // passive:false is required to preventDefault a wheel event, and it has a
+                                // known cost: a non-passive document-level wheel listener makes Chromium
+                                // wait on the main thread before every scroll, not just ctrl+scroll. That is
+                                // a scroll-latency tax on the largest books, on the platforms where this is
+                                // enabled. Unavoidable while the interception is conditional — the decision
+                                // to cancel can only be made in the handler. (fable review)
+                                }, { capture: true, passive: false });
+                            }
                             
                             window.cstLogger.log('DEBUG', 'Keyboard capture initialized');
                         }
@@ -2634,6 +3019,12 @@ public partial class BookDisplayView : UserControl
 
                 // Replace tab ID placeholder with actual tab ID value
                 script = script.Replace("{_tabId}", _tabId);
+                // #571/#572: Ctrl+scroll drives our per-script zoom on Windows/Linux only. On macOS the same
+                // ctrl+wheel event is what a trackpad pinch produces, and pinch there is page-scale
+                // magnification that keeps the reading position and does not rewrap — working behaviour this
+                // change was not asked to replace. Substituted as a JS literal the same way {_tabId} is: the
+                // script is a verbatim string, so it cannot be interpolated in place.
+                script = script.Replace("{_zoomOnWheel}", OperatingSystem.IsMacOS() ? "false" : "true");
 
                 _webView.ExecuteScript(script);
             }

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -41,6 +41,15 @@
                     <NativeMenuItem Header="Select a Book" />
                     <NativeMenuItem Header="Search" />
                     <NativeMenuItem Header="Dictionary" />
+                    <NativeMenuItemSeparator />
+                    <!-- #572 book zoom. The menu carries the discoverability: a beta tester asked for a way
+                         to enlarge the text and, finding none, invented a copy-a-line-then-search ritual
+                         instead (#570). Only the "+" spelling is advertised here - the keyboard handlers
+                         additionally accept shift+OemPlus and the numpad keys, which a menu cannot show.
+                         Zoom is stored per script and applies to book text only, never app chrome. -->
+                    <NativeMenuItem Header="Zoom In" Click="OnZoomInClick" Gesture="{input:CommandGesture OemPlus}" />
+                    <NativeMenuItem Header="Zoom Out" Click="OnZoomOutClick" Gesture="{input:CommandGesture OemMinus}" />
+                    <NativeMenuItem Header="Actual Size" Click="OnZoomResetClick" Gesture="{input:CommandGesture D0}" />
                 </NativeMenu>
             </NativeMenuItem>
 

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -706,8 +706,47 @@ public partial class SimpleTabbedWindow : Window
     /// This covers focus anywhere in Avalonia's own controls. When a book WebView holds focus, CEF takes
     /// the keystroke before Avalonia sees it - that case is handled by the JS capture in BookDisplayView.
     /// </summary>
+    /// <summary>
+    /// macOS-only: the zoom key spellings a NativeMenu cannot advertise. (#572, fable review)
+    ///
+    /// The View menu declares ⌘=, ⌘- and ⌘0, and on macOS those key equivalents are the only route while
+    /// focus is outside a book (the window-level handlers below all return early there, because a binding
+    /// plus the system menu would fire twice). But a menu item carries exactly one gesture, so ⌘⇧= — which
+    /// is what most people actually press for "⌘+" — and the numpad keys did nothing anywhere except
+    /// inside a book, where the JS capture accepts every spelling. Windows accepts them all everywhere.
+    ///
+    /// No double-fire risk: these are precisely the spellings the menu does NOT register, and with focus in
+    /// the WebView CEF consumes the keystroke before Avalonia sees it.
+    /// </summary>
+    private void RegisterMacZoomKeyBindings()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        AddHandler(KeyDownEvent, (object? s, KeyEventArgs e) =>
+        {
+            // Skip what the View menu already claims, or ⌘= would zoom twice.
+            if (ZoomKeys.IsMacMenuEquivalent(e)) return;
+
+            var command = ZoomKeys.Match(e, PlatformGesture.CommandModifier);
+            if (command == null) return;
+
+            _logger.Debug("*** MAC ZOOM SHORTCUT: {Command} (key={Key}, physical={Physical}) ***",
+                command, e.Key, e.PhysicalKey);
+            e.Handled = true;
+            switch (command)
+            {
+                case ZoomCommand.In: OnZoomInClick(this, EventArgs.Empty); break;
+                case ZoomCommand.Out: OnZoomOutClick(this, EventArgs.Empty); break;
+                default: OnZoomResetClick(this, EventArgs.Empty); break;
+            }
+        }, RoutingStrategies.Bubble);
+
+        _logger.Information("Registered macOS zoom key spellings the View menu cannot declare (shifted + numpad)");
+    }
+
     private void RegisterMenuShortcutKeyBindings()
     {
+        RegisterMacZoomKeyBindings();
         if (OperatingSystem.IsMacOS()) return;
 
         // A bubbling AddHandler, NOT KeyBindings. Measured on Windows: with a ComboBox dropdown open the
@@ -733,6 +772,9 @@ public partial class SimpleTabbedWindow : Window
             (PlatformGesture.Parse("f"),       () => OnSearchForSelectionClick(this, EventArgs.Empty)),
             (PlatformGesture.Parse("e"),       () => OnViewSource1957Click(this, EventArgs.Empty)),
             (PlatformGesture.Parse("shift+e"), () => OnViewSource2010Click(this, EventArgs.Empty)),
+            // #572 book zoom is NOT in this list — it is matched separately below, by physical key as well
+            // as by produced character, because a non-Latin input source makes the KeyGesture route
+            // unreliable. See ZoomKeys.
             // #564: the Window menu's Minimize item declares this gesture, and a NativeMenuBar gesture
             // dispatches nothing off macOS - so without this entry the menu would advertise a dead shortcut.
             (PlatformGesture.Parse("m"), () => WindowState = global::Avalonia.Controls.WindowState.Minimized),
@@ -757,6 +799,20 @@ public partial class SimpleTabbedWindow : Window
                 e.Handled = true;
                 invoke();
                 return;
+            }
+
+            // #572 zoom, after the gesture list so it can never shadow a letter shortcut.
+            var zoom = ZoomKeys.Match(e, PlatformGesture.CommandModifier);
+            if (zoom == null) return;
+
+            _logger.Debug("*** MAIN WINDOW ZOOM SHORTCUT: {Command} (key={Key}, physical={Physical}) ***",
+                zoom, e.Key, e.PhysicalKey);
+            e.Handled = true;
+            switch (zoom)
+            {
+                case ZoomCommand.In: OnZoomInClick(this, EventArgs.Empty); break;
+                case ZoomCommand.Out: OnZoomOutClick(this, EventArgs.Empty); break;
+                default: OnZoomResetClick(this, EventArgs.Empty); break;
             }
         }, RoutingStrategies.Bubble);
 
@@ -857,6 +913,28 @@ public partial class SimpleTabbedWindow : Window
             return;
         }
         book.BookDisplayControl.Print();
+    }
+
+    // #572: book-text zoom. Acts on the active book only — zoom is stored per script, so the change then
+    // propagates through BookZoomService.ZoomChanged to every other open book showing that same script.
+    // "No active book" is a genuine state (an empty window, or focus in the tree), and doing nothing is the
+    // honest answer: zoom has no meaning without a book, and the chrome deliberately never scales.
+    private void OnZoomInClick(object? sender, EventArgs e) => InvokeZoom(b => b.ZoomIn(), "Zoom In");
+
+    private void OnZoomOutClick(object? sender, EventArgs e) => InvokeZoom(b => b.ZoomOut(), "Zoom Out");
+
+    private void OnZoomResetClick(object? sender, EventArgs e) => InvokeZoom(b => b.ResetZoom(), "Actual Size");
+
+    private void InvokeZoom(Action<BookDisplayView> action, string what)
+    {
+        var book = FindActiveBookInThisWindow();
+        if (book?.BookDisplayControl == null)
+        {
+            _logger.Debug("{What}: no active book in window {WindowTitle}", what, this.Title);
+            return;
+        }
+        _logger.Information("{What} from window: {WindowTitle}", what, this.Title);
+        action(book.BookDisplayControl);
     }
 
     // #112: print the current selection in the active book (falls back to whole-book when nothing is selected).


### PR DESCRIPTION
Adds a deliberate way to resize book text on both platforms. Until now macOS had none at all, and Windows had only Chromium's undocumented Ctrl+scroll — which reflowed the text and lost the reader's place, because nothing on the C# side knew it had happened (#571). A beta tester built a copy-a-line-then-search ritual around exactly that (#570).

```
effective book text size = shippedXslSize × zoom[script]
```

## The model

Zoom is the **only** stored size control for book content. #574 flattened all 14 stylesheets to one ladder and #42 was narrowed to font *faces*, so there is deliberately no user-editable base size — the two were redundant, and a live control beats typing a number into a dialog for a judgement that can only be made by eye.

Stored **per script**: with the ladder now shared, the only thing zoom compensates for is the metrics of whatever face that script resolves to — the same axis the face setting uses. Switching a book's script switches face and zoom together.

**Book text only.** App chrome keeps following its own font settings.

## Mechanism

`CefBrowserHost.SetZoomLevel`, not CSS injection. It scales every absolute `pt` class proportionally for free — including the heading ladder — whereas CSS would mean overriding ~15 classes per stylesheet. Levels are logarithmic (`level = log(factor)/log(1.2)`).

Reaching it needs two reflection hops: `WebView.UnderlyingBrowser` (internal getter) then `BaseCefBrowser.UnderlyingBrowser` (protected); `GetHost()` is public from there. **This is the codebase's first reflection into CEF internals**, so `CefBrowserAccess` concentrates it in one place, degrades to a null return on every failure path, probes at startup so a break shows up in the log rather than as a mysteriously dead shortcut, and is pinned by tests that fail the *build* — including on property **type**, not just name — if a package bump breaks the chain. #570 needs the same access for find-in-page.

## Bindings

Four routes, exactly one firing per keystroke: the Windows/Linux window handler, macOS NativeMenu View items, floating windows, and a JS keydown capture for when CEF holds focus.

Keystrokes are recognised by `ZoomKeys`, which matches on **`PhysicalKey` as well as `Key`** — see the review section for why that is not optional here. Every spelling resolves: unshifted `=` (what ⌘+ actually delivers), the shifted form, and the numpad. macOS additionally handles the spellings a NativeMenu item cannot advertise, since it carries one gesture each, while skipping the three the menu owns so nothing fires twice.

View menu gets Zoom In / Zoom Out / Actual Size in both window types. The menu is the discoverability: an undiscoverable feature gets worked around rather than found.

## Ctrl+scroll (#571)

Now routes through the same path on Windows/Linux — stepping the same ladder, persisting, and restoring the reading position. That is #571's fix *by construction* rather than a patch bolted onto Chromium's own zoom.

macOS is excluded: trackpad pinch arrives as ctrl+wheel there, and pinch is page-scale magnification that keeps position and does not rewrap — working behaviour this change was not asked to replace.

## Reading position

Preserved across the reflow using the #434 token, with the resize path's two-part discipline: snapshot **once** on the first step of a burst, restore after the reflow settles. Snapshotting per step would let the 200 ms status tick capture the already-drifted position mid-burst and commit it.

At load time the scroll half of the restoration waits for the **`CACHE_BUILT` signal** rather than a fixed delay, and carries a **navigation generation** so a deferral belonging to a superseded document cannot consume the next one's intents.

## Review

Fable-reviewed twice; seven defects found and fixed, none of which I would have caught alone.

**First pass:**

- **A burst-snapshot bug.** Holding ⌘+ re-snapshotted the reading position on every step, so the 200 ms status tick would capture the already-drifted position mid-burst and commit it — a bounded recurrence of the exact #571 symptom this feature exists to fix. My comment claimed it mirrored the resize path's guard; it had copied only the timer re-arm half.
- **⌘0 was a dead key** whenever the browser's real zoom had drifted from the stored value (a Ctrl+scroll landing before the bridge injects, or a macOS pinch). And CEF's `SetZoomLevel(0)` is the only thing that clears page scale, so the no-op was forfeiting the only way to undo a pinch.
- **A load-time ordering race**: a scroll target could be resolved against the pre-zoom layout, with no rolling token yet to correct it.
- **A macOS gap** where only the unshifted spellings worked outside a book.

**Second pass, on those fixes:**

- **Input-source dependence — the one that matters most here.** Avalonia derives `Key` on macOS from the character the *active input source* produces. With a Devanagari or other Indic layout active, the `=` key doesn't produce `=`, the lookup misses, and the QWERTY fallback reports `OemMinus`. ⌘⇧= would have been silently dead for exactly the readers most likely to have such a layout. Hence `ZoomKeys`, which consults `PhysicalKey` too, on both platforms.
- **A stale deferral across navigations**: a script change inside the deferral window would let the old timer consume the intents the new navigation had just queued, leaving it *worse* off than the race the deferral fixed. Now generation-tagged with an `Interlocked` claim.
- **The 250 ms was an open-loop guess** against a renderer IPC round-trip nothing in this codebase bounds. Now driven by the `CACHE_BUILT` signal — which fires after `fonts.ready` plus a paint frame, i.e. genuinely post-reflow — with the timer demoted to a backstop.

Both passes also **verified**: `SetZoomLevel` self-posts to the CEF UI thread, so calling it from the Avalonia thread is safe (`GetZoomLevel` does **not** — worth knowing for #570); exactly one route fires per keystroke in all five focus/platform combinations; and Chromium's per-origin zoom keys on the full file spec, so a book's zoom cannot leak into the Welcome page, dictionary pane or PDF viewer.

## Not included

The Settings readout and reset from the #572 decision record. It is specified to sit beside the per-script face, and #42 is rebuilding that panel; `IsZoomed`/`FormatZoom` exist for it.

## Testing

Full suite **1177 passed, 0 failed**. The injected bridge script was extracted and syntax-checked with `node --check` — it is a C# verbatim string, so a brace slip there would break the whole JS bridge silently.

**Needs a Windows pass on Merlin**, none of which is testable on macOS:
- that the zoom keys resolve on real hardware, including under a non-Latin input source (the `PhysicalKey` path)
- that `preventDefault` genuinely suppresses Chromium's ctrl+scroll layout zoom in this OSR build — the #571 acceptance case
- the View menu's gesture text, which may render literally as "Ctrl+OemPlus"

Closes #572. Fixes #571.
