### PR TITLE
Fix reading-position drift when zooming with two books open (#572)

### DIFF
--- a/src/CST.Avalonia.Tests/Views/ZoomReflowTimingTests.cs
+++ b/src/CST.Avalonia.Tests/Views/ZoomReflowTimingTests.cs
@@ -1,0 +1,42 @@
+using CST.Avalonia.Views;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Views;
+
+// #572: the post-zoom position restore waits for the CACHE_BUILT that the in-page anchor-cache rebuild
+// emits. Its correctness rests on ONE ordering property, which is otherwise invisible — it lives in the gap
+// between a C# constant and a delay interpolated into an injected JavaScript string, with nothing in
+// between to enforce it.
+//
+// The property: the in-page rebuild debounce must outlast the C# burst settle. The rebuild timer starts at
+// the renderer's last resize, which necessarily postdates the last SetZoomLevel arriving — so if the
+// debounce is the longer of the two, CACHE_BUILT can never arrive before the restore is waiting for it.
+//
+// An earlier revision had these the other way round (150 vs 250) and compensated with a build counter to
+// detect an already-arrived signal. That was unsound: a build could START before the zoom and have its
+// title reach C# after the counter was captured, satisfying the check while reflecting the OLD layout.
+// Ordering the delays removes the hole instead of testing for it — but only while this holds.
+public class ZoomReflowTimingTests
+{
+    [Fact]
+    public void AnchorRebuildDebounce_OutlastsTheZoomSettle()
+    {
+        Assert.True(
+            BookDisplayView.AnchorRebuildDebounceMs > BookDisplayView.ResizeSettleMs,
+            $"AnchorRebuildDebounceMs ({BookDisplayView.AnchorRebuildDebounceMs}ms) must be greater than " +
+            $"ResizeSettleMs ({BookDisplayView.ResizeSettleMs}ms). The post-zoom restore waits for the " +
+            "CACHE_BUILT emitted by the in-page rebuild; if the rebuild can finish first, that signal " +
+            "arrives with nothing waiting for it and the restore falls through to the backstop — restoring " +
+            "against a layout that may still be reflowing, which is the reading-position drift of #571/#572.");
+    }
+
+    [Fact]
+    public void TheOrderingHasUsefulMargin()
+    {
+        // Not just greater — greater by enough that ordinary scheduling jitter cannot invert it. A margin
+        // this small would be a coincidence rather than a design.
+        Assert.True(
+            BookDisplayView.AnchorRebuildDebounceMs - BookDisplayView.ResizeSettleMs >= 25,
+            "The gap between the rebuild debounce and the zoom settle is too small to survive timer jitter.");
+    }
+}

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -52,7 +52,15 @@ public partial class BookDisplayView : UserControl
     private System.Timers.Timer? _resizeSettleTimer = null;
     private bool _resizeInProgress = false;
     private double _lastKnownWidth = 0, _lastKnownHeight = 0;
-    private const int ResizeSettleMs = 250;   // > the injected JS resize handler's 100ms cache rebuild
+    internal const int ResizeSettleMs = 250;   // debounce for a resize/zoom gesture, before restoring
+    /// <summary>
+    /// Trailing-edge debounce for the in-page anchor-cache rebuild, injected into the JS.
+    ///
+    /// MUST stay greater than <see cref="ResizeSettleMs"/>. The zoom restore waits for the CACHE_BUILT this
+    /// rebuild emits, and the ordering guarantee — that the signal cannot arrive before the restore is
+    /// waiting for it — rests entirely on this being the longer of the two. (fable review)
+    /// </summary>
+    internal const int AnchorRebuildDebounceMs = 300;
     private readonly string _tabId = $"tab_{DateTime.Now.Ticks}_{Guid.NewGuid().ToString("N")[..8]}";
     private string? _tempHtmlFilePath;   // the temp HTML file this View last loaded from; deleted on dispose (BOOK-8)
 
@@ -657,15 +665,26 @@ public partial class BookDisplayView : UserControl
     private System.Timers.Timer? _zoomSettleTimer = null;
     private ReadingPositionToken? _zoomRestoreToken = null;
     // Marks a zoom BURST in progress, exactly as _resizeInProgress does for a drag. Holding Cmd+ forwards
-    // auto-repeat, and the ~200ms status tick keeps re-capturing _lastPositionToken throughout — against a
-    // cache the in-page resize handler rebuilds ~100ms after each step. So by the second step the rolling
-    // token already describes the DRIFTED position, and re-snapshotting per step would commit that drift.
-    // Snapshot once, on the first step, while the token is still pre-zoom. (fable review)
+    // auto-repeat, and the ~200ms status tick keeps re-capturing _lastPositionToken throughout — so by the
+    // second step the rolling token already describes the DRIFTED position, and re-snapshotting per step
+    // would commit that drift. Snapshot once, on the first step, while the token is still pre-zoom.
+    // (fable review)
     private bool _zoomInProgress = false;
     // Bumped on every completed navigation. A deferred scroll restoration records the generation that armed
     // it, so one belonging to a superseded document can be recognised and dropped. -1 means none pending.
     private int _navGeneration = 0;
     private int _deferredScrollGeneration = -1;
+    // 1 while a finished zoom burst is waiting for the reflow to land before restoring the position.
+    private int _zoomAwaitingCacheBuilt = 0;
+    // Identifies the current await. DispatcherTimer.RunOnce cannot be cancelled, so a backstop from a
+    // superseded burst stays in flight; stamping it lets the stale one recognise itself and do nothing.
+    private int _zoomAwaitGeneration = 0;
+    // The navigation the current await belongs to, so a restore cannot be applied to a replaced document.
+    private int _zoomAwaitNavGeneration = -1;
+    // Backstop only. The real trigger is CACHE_BUILT; this bounds the wait if the page never reports one
+    // (the same failure the anchor-cache watchdog exists for). Generous, because firing early is the very
+    // bug this replaced — a late restore is merely visible, an early one is wrong.
+    private const int ZoomReflowBackstopMs = 1500;
 
     /// <summary>
     /// Subscribes this view to zoom changes for its script. Called once from the constructor.
@@ -701,6 +720,11 @@ public partial class BookDisplayView : UserControl
         _zoomSettleTimer?.Stop();
         _zoomSettleTimer?.Dispose();
         _zoomSettleTimer = null;
+
+        // Clear the await so a CACHE_BUILT or backstop arriving after shutdown cannot try to scroll a
+        // disposed browser. RestoreZoomTokenNow also checks _isShutDown; this makes it two locks on one door.
+        CancelPendingZoomAwait();
+        _zoomRestoreToken = null;
     }
 
     /// <summary>
@@ -746,6 +770,20 @@ public partial class BookDisplayView : UserControl
             return;
         }
 
+        if (preservePosition)
+        {
+            // A press arriving while the PREVIOUS burst is still waiting for its reflow signal is a
+            // continuation of that burst, not a new one — the user simply hesitated. Cancelling the pending
+            // await and resuming keeps the original pre-zoom token. Without this the await would be consumed
+            // mid-burst (restoring a half-zoomed position and nulling the token), and the real final restore
+            // would then find nothing to restore. (fable review)
+            if (CancelPendingZoomAwait())
+            {
+                _zoomInProgress = true;
+                _logger.Debug("Zoom resumed before the previous burst's reflow landed - keeping the original snapshot");
+            }
+        }
+
         // Snapshot BEFORE the reflow, and only on the FIRST step of a burst. The rolling token is refreshed
         // by the ~200ms status tick, so it is at most one tick stale but still pre-reflow — the best
         // available, because a zoom's resize event only arrives after layout has already moved. Re-taking it
@@ -779,11 +817,10 @@ public partial class BookDisplayView : UserControl
     /// <summary>
     /// Restores the reading position once the zoom reflow has settled.
     ///
-    /// The delay has to outlast the in-page resize handler's own 100ms debounce, because a browser zoom
-    /// fires <c>resize</c> and that handler rebuilds the anchor cache — restoring against the stale cache
-    /// would scroll to pre-zoom pixel positions. Same constant as the resize path, for the same reason.
-    /// A repeated press re-arms the timer, so holding Cmd+ restores once at the end rather than fighting
-    /// each intermediate step.
+    /// This detects only that the KEYPRESSES have stopped; it does not mean the reflow has landed, which is
+    /// why <see cref="RestoreAfterZoom"/> then waits for CACHE_BUILT rather than restoring here. A repeated
+    /// press re-arms the timer, so holding Cmd+ restores once at the end rather than fighting each
+    /// intermediate step.
     /// </summary>
     private void StartZoomSettle()
     {
@@ -807,11 +844,88 @@ public partial class BookDisplayView : UserControl
         _zoomInProgress = false;
         if (_isShutDown) return;
 
+        if (_zoomRestoreToken == null || !this.IsVisible)
+        {
+            _zoomRestoreToken = null;
+            return;
+        }
+
+        // The burst has ended, but that does NOT mean the reflow has landed. SetZoomLevel is a
+        // browser→renderer IPC round trip, so the keypresses stopping tells us nothing about whether the
+        // renderer has finished laying out at the new zoom. Restoring on a fixed delay computes the scroll
+        // target against whatever layout happens to exist at that moment — which is the old one whenever
+        // the renderer is slow.
+        //
+        // "Slow" is not hypothetical: with a second book open in a floating window, BOTH browsers reflow on
+        // every step, and a fast zoom in and out reliably lost the position on the focused book while the
+        // single-book case looked fine. Same open-loop weakness the load path had; this is the same fix.
+        //
+        // The zoom's own resize event drives the (debounced) anchor-cache rebuild in the page, and build()
+        // emits CACHE_BUILT only after reading real positions — so that signal means layout has genuinely
+        // settled at the new zoom. Wait for it, with a backstop in case it never comes.
+        //
+        // Ordering is correct BY CONSTRUCTION rather than by luck: the in-page debounce
+        // (AnchorRebuildDebounceMs) is deliberately longer than this settle (ResizeSettleMs), and its timer
+        // starts from the renderer's last resize — which necessarily postdates the last SetZoomLevel
+        // arriving. So the CACHE_BUILT that proves the reflow landed can never precede the await being
+        // armed here. An earlier revision instead compared a build counter to detect a signal that had
+        // already arrived; that was unsound, because a build could START before the zoom and have its title
+        // reach C# after, satisfying the counter while reflecting the OLD layout. Making the two delays
+        // ordered removes the hole rather than testing for it. (fable review)
+        var awaitGeneration = Interlocked.Increment(ref _zoomAwaitGeneration);
+        Volatile.Write(ref _zoomAwaitNavGeneration, Volatile.Read(ref _navGeneration));
+        Interlocked.Exchange(ref _zoomAwaitingCacheBuilt, 1);
+
+        _logger.Debug("Zoom burst ended - awaiting CACHE_BUILT before restoring (above={Above}, below={Below}, frac={Frac})",
+            _zoomRestoreToken.Above, _zoomRestoreToken.Below, _zoomRestoreToken.Fraction);
+
+        // Stamped with the await it belongs to: an uncancellable RunOnce from a PREVIOUS burst would
+        // otherwise still be in flight and could consume a later burst's await early — restoring against an
+        // unsettled layout, which is the very bug this waiting exists to prevent. (fable review)
+        DispatcherTimer.RunOnce(() => RestoreZoomTokenNow(awaitGeneration),
+            TimeSpan.FromMilliseconds(ZoomReflowBackstopMs));
+    }
+
+    /// <summary>
+    /// Cancels a pending post-zoom await, returning true if one was actually pending. Bumping the
+    /// generation is what neutralises the backstop timer already in flight for it.
+    /// </summary>
+    private bool CancelPendingZoomAwait()
+    {
+        if (Interlocked.Exchange(ref _zoomAwaitingCacheBuilt, 0) == 0) return false;
+        Interlocked.Increment(ref _zoomAwaitGeneration);
+        return true;
+    }
+
+    /// <summary>
+    /// Performs the post-zoom position restore exactly once, for the await identified by
+    /// <paramref name="awaitGeneration"/> — whichever of the CACHE_BUILT signal or the backstop reaches it
+    /// first. A stale caller (a backstop from a superseded burst, or a signal belonging to a document that
+    /// has since been replaced) is dropped.
+    /// </summary>
+    private void RestoreZoomTokenNow(int awaitGeneration)
+    {
+        if (Volatile.Read(ref _zoomAwaitGeneration) != awaitGeneration) return;
+
+        // A navigation since the await was armed means this token describes a document that no longer
+        // exists. Anchor names are stable across scripts, so the scroll would SUCCEED rather than no-op —
+        // landing the new document at the old position and fighting ExecutePendingRestoration. (fable review)
+        if (Volatile.Read(ref _navGeneration) != Volatile.Read(ref _zoomAwaitNavGeneration))
+        {
+            _logger.Debug("Dropping post-zoom restore - the document was replaced while waiting");
+            Interlocked.Exchange(ref _zoomAwaitingCacheBuilt, 0);
+            _zoomRestoreToken = null;
+            return;
+        }
+
+        // Interlocked: the signal and the backstop can both arrive, and only the first may act.
+        if (Interlocked.Exchange(ref _zoomAwaitingCacheBuilt, 0) == 0) return;
+
         var token = _zoomRestoreToken;
         _zoomRestoreToken = null;
-        if (token == null || !this.IsVisible) return;
+        if (token == null || _isShutDown || !this.IsVisible) return;
 
-        _logger.Debug("Zoom settled - restoring reading position (above={Above}, below={Below}, frac={Frac})",
+        _logger.Debug("Zoom reflow settled - restoring reading position (above={Above}, below={Below}, frac={Frac})",
             token.Above, token.Below, token.Fraction);
         ScrollToPositionToken(token);
     }
@@ -1759,11 +1873,29 @@ public partial class BookDisplayView : UserControl
                         cstBuildWhenReady();
                     }}
 
-                    // Rebuild cache when window is resized
+                    // Rebuild the cache once the resizing STOPS. (#572)
+                    //
+                    // This used to schedule an unconditional setTimeout(build, 100) on every resize event,
+                    // with no clearTimeout — so a burst of resizes queued one full rebuild each. A zoom
+                    // burst of ten steps meant ten complete rebuilds of a 1000+ anchor cache, and a window
+                    // drag was worse. Measured in the log as CACHE_BUILT firing six-plus times per burst,
+                    // ~150ms apart, still arriving well after the burst had ended.
+                    //
+                    // That made CACHE_BUILT useless as a 'layout has settled' signal — it only ever meant
+                    // 'a build queued 100ms ago just finished', which could easily predate the last resize.
+                    // The zoom restore waits on that signal, so it was restoring against a layout that was
+                    // still reflowing, and the position drifted. Debouncing makes the signal mean what its
+                    // name says, and removes the redundant rebuilds. (#434, #321)
+                    // The delay is deliberately LONGER than the C# zoom settle (ResizeSettleMs, 250ms), and
+                    // this timer starts from the renderer's last resize — which necessarily postdates the
+                    // last SetZoomLevel arriving. That ordering is what lets the zoom restore simply wait
+                    // for CACHE_BUILT: the signal can never arrive before something is waiting for it, so
+                    // no counter or already-arrived check is needed. Keep the two in step if either moves.
                     window.addEventListener('resize', function() {{
-                        setTimeout(function() {{
-                            window.cstAnchorCache.build();
-                        }}, 100); // Small delay to let text reflow
+                        clearTimeout(window.__cstResizeRebuildTimer);
+                        window.__cstResizeRebuildTimer = setTimeout(function() {{
+                            window.cstAnchorCache.build();   // emits CACHE_BUILT when the anchors are populated
+                        }}, {AnchorRebuildDebounceMs});
                     }});
                 }})();
             ";
@@ -2159,6 +2291,16 @@ public partial class BookDisplayView : UserControl
                     // trip that nothing here bounds. (fable review)
                     if (Volatile.Read(ref _deferredScrollGeneration) == Volatile.Read(ref _navGeneration))
                         Dispatcher.UIThread.Post(RunDeferredScrollRestoration);
+
+                    // #572: same signal, for a LIVE zoom. A finished zoom burst waits here rather than on a
+                    // fixed delay, because the burst ending says nothing about whether the renderer has
+                    // finished reflowing — and restoring against a not-yet-reflowed layout is what lost the
+                    // position when a second book was open.
+                    if (Volatile.Read(ref _zoomAwaitingCacheBuilt) == 1)
+                    {
+                        var awaitGen = Volatile.Read(ref _zoomAwaitGeneration);
+                        Dispatcher.UIThread.Post(() => RestoreZoomTokenNow(awaitGen));
+                    }
                     // Surface the resolved page NOW instead of waiting for the next scroll tick
                     // (≤200ms) plus its 200ms pre-lock delay. Same lock discipline as
                     // OnScrollPositionCheck: skip (don't block) if JS work is in progress —


### PR DESCRIPTION
Follow-up to #591. Fixes a reading-position drift that only appeared with **two books open**.

## The repro

Two books, one in the main window and one floated, **both scrolled mid-book**. Zoom rapidly in and out — both lose their reading position. A single book looked fine, which is why #591 passed its smoke test.

## Root cause

The in-page anchor-cache rebuild was **never debounced**. It did `setTimeout(build, 100)` on *every* resize event with no `clearTimeout`, so each zoom step queued a full rebuild of a 1000+ anchor cache. From the Debug log, one burst:

```
13:51:51.357  Zoom burst ended - awaiting CACHE_BUILT
13:51:51.537  Anchor cache built     ← restore fires on THIS
13:51:51.733  Anchor cache built     ← but they keep coming
13:51:51.909  Anchor cache built
13:51:52.023  Anchor cache built
```

That matters because the post-zoom restore waits for `CACHE_BUILT` to know the reflow has landed. The signal didn't mean that — it meant *"a build queued 100 ms ago just finished"*, which could easily predate the last zoom step. The floated book restored 28 ms after its burst on a stale signal; the larger book never got one inside the 1500 ms backstop and restored on that instead. Both restored against layouts that were still moving.

A second browser is what pushed the reflow past the deadline, which is exactly why one book never showed it.

## The fix

**Debounce the rebuild** (trailing edge). `CACHE_BUILT` now fires once, after resizing stops, and means what its name says.

This is also a **pre-existing performance fix unrelated to zoom**: a window drag was rebuilding the entire anchor cache once per resize event. Zoom only made it visible by hammering the same path.

**The debounce (300 ms) is deliberately longer than the C# burst settle (250 ms).** Its timer starts from the renderer's last resize, which necessarily postdates the last `SetZoomLevel` arriving — so the signal can never reach C# before the restore is waiting for it.

An interim revision had these the other way round and compensated with a build counter to catch an already-arrived signal. Fable showed that was **unsound rather than merely awkward**: a build could *start* before the zoom and have its title reach C# *after* the capture, satisfying the counter while reflecting the old layout. Ordering the two delays removes the hole instead of testing for it. Since that invariant now spans a C# constant and a delay interpolated into an injected JavaScript string, with nothing between them to enforce it, a test asserts the ordering with margin and explains what breaks if it inverts.

## Three further defects, found in review

- **A stale backstop could fire into the next burst.** `DispatcherTimer.RunOnce` can't be cancelled, so a 1500 ms backstop from burst 1 stayed in flight; zooming again 0.3–1.5 s later let it consume burst 2's await ~50 ms after its keypresses stopped — reintroducing this very bug for the zoom-pause-zoom pattern. Awaits are now generation-stamped so a stale backstop recognises itself.
- **Resuming a burst mid-await lost the restore entirely.** A press arriving while the previous burst still waited re-snapshotted an already-drifted token; the old signal then restored it mid-burst and nulled the token, so the real final restore found nothing. A pending await is now treated as burst continuation and keeps the original pre-zoom snapshot.
- **A pending restore could scroll the wrong document.** Nothing cleared the await on navigation, so a script change inside the window let the new document's first `CACHE_BUILT` scroll it to the old token — and because anchor names are stable across scripts, it would *succeed* rather than no-op, fighting `ExecutePendingRestoration`. The await now carries its navigation generation.

## Checked and cleared

Fable specifically verified the debounce does **not** regress ordinary window resizing, which was the main risk since that listener is shared: the resize path snapshots pre-reflow and restores through the cache-free `ScrollToPositionToken`, so it never depended on the rebuild at all. The only visible effect is that status-bar page numbers hold during a drag rather than updating mid-drag.

## Testing

Full suite **1179 passed, 0 failed**. Both injected scripts re-extracted and syntax-checked with `node --check`.

Maintainer-verified on the original two-book repro and the wider smoke list.

Still outstanding, unchanged from #591: the **Windows pass on Merlin** — zoom key resolution including under a non-Latin input source, and Ctrl+scroll position retention (#571's acceptance case). Every constant here (250/300/1500) was tuned against macOS renderer timing, and three of the four defects above were timing windows, so a Windows zoom-burst pass with two windows is worth doing before release.

Refs #572, #571.
