### PR TITLE
Surface B: presets, system prompt, and the grounding contract (#582)

### DIFF
--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -1,6 +1,8 @@
 # Surface B — the in-app model, v1 by context injection (Planned)
 
-**Status:** Planned. Not started.
+**Status:** In progress. Shipped: B1 (#578, provider layer), B3 (#580, context bundler), B4 (#582, presets and
+the grounding contract), plus the reader-state read path and `POST /v1/ai/context-preview` (#593). No AI feature
+is user-visible yet — the orchestrator (B5, #583) is what first connects a prompt to a provider.
 **Parent:** [AI_INTEGRATION.md](AI_INTEGRATION.md) — the design of record for the A–E surface map. §11.1 there
 states the decided model-access *policy*; this document is the *implementation plan* for B.
 **Tracker:** epic #186 → children #578–#587 (filed 2026-08-09; the per-item numbers are in §12).
@@ -319,6 +321,27 @@ conversion is safe to enable per model tier.
 v1.1 conversion proviso: **validate that marked content is actually convertible** (pure Pāli character set)
 and leave it Latin otherwise — models will occasionally mark English or emit malformed diacritics.
 
+### The marker is `[[…]]` — decided 2026-08-11 (#582)
+
+Two constraints. It must not occur in the corpus, and it must not occur in ordinary answer prose in **any**
+language a user might set as their answer language.
+
+A survey of all 217 XML books found **zero** occurrences of `[[`, `]]`, `«`, `»`, `⟦`, `⟧`, `{`, `}`, `|`, `~`
+and `¶`; `^` appears 3 times, `` ` `` 6 times, `§` 53 times. So corpus collision eliminates none of the leading
+candidates. (Incidentally: braces being absent from the source confirms that the ones around inline notes are
+added by the passage renderer.)
+
+The **second** constraint is what decides it. `«…»` is out: it is the standard quotation mark in Russian and
+French, so a user answering in either would have every ordinary quotation read as marked Pāli — a v1.1
+conversion bug seeded in v1. `⟦…⟧` is collision-free but measures a weak model's *Unicode fidelity* rather than
+its instruction-following, which inverts what B9 is trying to learn. `[[…]]` is emittable by any model, absent
+from the corpus, and claimed by no language's punctuation.
+
+**Unbalanced markers are stripped anyway and counted, never rendered.** A literal `[[` on screen is a visible
+defect in the answer for a rule the user never asked about; the imbalance is real signal about the model, so it
+is recorded for B9 rather than silently repaired. Marker fragments split across stream deltas are handled by a
+hold-back filter — the same hazard as the think-tag filter, and the same failure if ignored.
+
 ---
 
 ## 10. Failure, privacy, and terminology
@@ -484,3 +507,28 @@ path in the selection pipeline and an exclusion from the v1.1 script conversion,
 is the one supported script that does not round-trip. That non-round-tripping is rare enough in practice not to
 earn a code path; removed from §3.1, §9 and the §12 table, and deliberately kept out of #581. Work items filed
 as #578–#587 under epic #186; issue numbers added to §12.
+
+**2026-08-11 (#582, the prompt layer)** — three decisions worth keeping, all forced by evidence rather than
+argument:
+
+- **The Pāli-quote marker is `[[…]]`** — see §9. Decided by a corpus survey plus one constraint the plan had
+  not stated: the marker must not collide with ordinary answer prose in any language a user may select, which
+  is what eliminates the guillemets.
+- **The template engine is substitution-only** — no conditionals, no loops. These templates are user-editable
+  (B7), and control flow would make them a small programming language whose breakage we would then have to
+  diagnose. The cost is that a placeholder cannot be omitted when it has nothing to say, so every value renders
+  as a self-describing sentence instead: "the reader has not selected anything", "the word-analysis data is not
+  installed". That turns out to be the better prompt, and it is the mechanism that makes the plan's
+  "degrade visibly, never silently" requirement fall out of the design rather than rest on discipline.
+- **The provisions inventory is derived from the template's own placeholders.** Found by reading a dumped
+  prompt, not by a test: the inventory said `apparatus — given` on presets whose template never rendered the
+  apparatus, so the model was told it had been given something it could not see. Deriving the inventory from
+  what the template actually uses makes the two agree by construction, including after a user edit.
+
+**A live run against `gpt-oss:120b-cloud` was worth more than the third code review.** The fences held —
+cross-corpus refusal, scope naming, no invented references — but the model **mistranslated the verse it was
+looking at** (Case 2 in [PALI_FIDELITY_CASES.md](../../testing/PALI_FIDELITY_CASES.md)) and left inline Pāli
+unmarked while marking block quotes. The marker failure was fixed by naming the competing convention —
+"use the markers instead of italics, an italicised word is a word left behind in Latin" — where merely stating
+the requirement had not worked. The mistranslation was not fixable by prompting and is exactly the evidence
+#584's fidelity advisory exists to carry.

--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -265,6 +265,15 @@ answer about three paragraphs. Three fences:
 4. **A trimmed passage gets a visible "partial passage" badge**, driven by `BudgetReport`. A *translation*
    labelled as of a passage that was silently truncated is a fidelity failure specific to this corpus.
 
+> **Fence 4 was not delivered as written — 2026-08-11 (#580/#582).** There is **no truncation flag** to drive
+> the badge. The obvious candidate, `PassageResult.NextCursor`, is non-null whenever the window ends before the
+> end of the *book file* rather than before the end of the requested reference, so on the real corpus it is set
+> for almost every request — a badge driven by it would fire always, and a fidelity signal that always fires is
+> one users learn to ignore. What ships instead is the weaker true statement, `WindowMayExtendPastReference`,
+> told to the model in the scope declaration (fence 1) and to the user as a notice. **A genuine
+> paragraph-scoped trim badge needs the passage reader to report whether the window covered the reference** —
+> unbuilt work, not an oversight in #582.
+
 Free-form follow-up on the Explain preset is the leak in the dam — keep it, but these are its seatbelts.
 
 ---

--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -230,6 +230,16 @@ public interface IChatProvider
   `reasoning_content` delta field, or inline think-tags). An adapter that naively concatenates deltas will
   render chain-of-thought into the answer panel. Skip or segregate reasoning fields, and defensively strip
   think-tags.
+- **`max_tokens` is not an answer budget — deferred rather than guessed (2026-08-11, fsnow).** An earlier cut of
+  #582 sized a cap per preset from the expected length of each answer. That is the wrong quantity to predict:
+  on a reasoning model the cap covers reasoning *and* answer, and reasoning volume varies by an order of
+  magnitude between models — `minimax-m3` needed 3,177 completion tokens to translate a two-line verse against
+  a 2,400 budget (#601). **The per-preset table remains, with every entry unset**, as the seam #584/#585 fills
+  in from Settings; today the OpenAI-compatible adapter *omits* the field and the Anthropic adapter — where it
+  is required — sends the largest value valid across every current Claude model. That is **64K, not 128K**:
+  Opus 5, Sonnet 5 and the Opus 4.x family all allow 128K, but **Haiku 4.5 caps at 64K**, and the model id is
+  whatever the user typed into Settings. Cost is controlled by reporting what each call spent (§10), not by a
+  truncation the user never sees.
 - **`HttpClient`'s 100 s default timeout will kill long generations.** Use `Timeout.InfiniteTimeSpan` with
   per-request cancellation, plus an adapter-level *idle* timeout.
 - **Mid-stream network drop is distinct from cancellation** — partial text is already on screen. Keep the

--- a/docs/testing/PALI_FIDELITY_CASES.md
+++ b/docs/testing/PALI_FIDELITY_CASES.md
@@ -61,6 +61,7 @@ the failure mode is real.
 | Date | Model | Harness | Grounded | Verdict | Note |
 |---|---|---|---|---|---|
 | 2026-08-10 | `gpt-oss:120b` | Ollama OpenAI-compat, surface B provider layer (#578) | No | **FAIL** | Answered *"means heedlessness or negligence, especially the lack of mindful vigilance in practice"* — fluent, confident, and inverted. Spent 56 reasoning deltas reaching it. |
+| 2026-08-11 | `gpt-oss:120b-cloud` | Same, with the #582 prompt layer over a #580 bundle | Yes | **PASS** (incidental) | Glossed it *"(heedfulness, diligence)"* and correctly contrasted it with *pamāda*. **Not a clean re-run:** the request was an Explain preset on Dhp 21, not the Case 1 prompt, so the term was glossed in passing rather than asked about. Suggestive, not conclusive. |
 
 **Reasoning volume is not accuracy.** The failing run above produced substantially more reasoning than answer.
 Worth remembering when the panel in #586 decides how much weight to give a visible reasoning pane.
@@ -70,6 +71,62 @@ Worth remembering when the panel in #586 decides how much weight to give a visib
 Re-run this case **grounded** once #580 can inject Dhp 21 and the dictionary entry. If the same model then
 answers correctly, that is the strongest available evidence for the injection-first design — and if it still
 inverts the term with the passage in front of it, that is a much more serious finding about the model.
+
+The 2026-08-11 row is the first evidence in that direction, but it is not the experiment: the term was glossed
+in passing during an Explain request rather than asked about directly. **The clean paired run — Case 1's own
+prompt, ungrounded and grounded, same model, same day — is still owed.**
+
+---
+
+## Case 2 — Dhp 21, second half: rendering the passage that is on screen
+
+| | |
+|---|---|
+| **Prompt** | Explain or translate Dhp 21 with the verse supplied: `Appamādo amatapadaṃ, pamādo maccuno padaṃ; appamattā na mīyanti, ye pamattā yathā matā.` |
+| **Correct** | Heedfulness is the path to the deathless (*amata*), heedlessness the path to death (*maccu*); the heedful do not die, those who are heedless are **as if already dead**. |
+| **Authority** | The corpus itself, plus morphology settled by any bundled dictionary: *maccu* = death; *mīyanti* = they die (√mar); *matā* = dead (pp. of √mar); *yathā matā* = "like dead people". |
+| **Failure signature** | Any of: rendering *maccuno padaṃ* as something other than death; rendering *mīyanti* as a verb of decline rather than dying; reading *matā* as from *maññati* ("think") rather than *marati* ("die"). |
+| **Why it discriminates** | The whole verse turns on one root appearing four times (*amata*, *maccu*, *mīyanti*, *matā*). A model that loses the root loses the verse — and it does so **with the text in front of it**, which is what makes this a grounding case rather than a recall case. |
+
+### Observations
+
+| Date | Model | Harness | Grounded | Verdict | Note |
+|---|---|---|---|---|---|
+| 2026-08-11 | `gpt-oss:120b-cloud` | Ollama OpenAI-compat, #582 prompt layer over a #580 bundle | Yes | **FAIL** | Three of the four: *maccuno padaṃ* became *"the path of the samsaric (world-bound) condition"*; *amatapadaṃ* became *"the unsurpassed (or 'immortal') foot-path"*; and the second line became *"those who are heedful never decline; those who are negligent, as they think, decline"* — reading *matā* as *maññati* and losing *mīyanti* entirely. It got *appamāda* itself right (Case 1) while mistranslating the line that defines it. |
+| 2026-08-11 | `gpt-oss:120b-cloud` | Same, second run (prompt revised for Case 3) | Yes | **FAIL** | Reproduced: *"the path of macca (the world of becoming)"*, *"the heedful do not fall away"*, *"those who are heedless, as they think, are lost."* Same three errors, different wording — and it invented a lemma, *macca*, for *maccuno*. |
+
+**The grounded/ungrounded distinction does not save a model from its own morphology.** This failure happened with
+the verse supplied verbatim, so it is not a recall failure — which makes it a sharper instrument than Case 1 for
+separating models, and a direct argument for the fidelity advisory in #584.
+
+---
+
+## Case 3 — marker discipline: does the model mark *inline* Pāli?
+
+| | |
+|---|---|
+| **Prompt** | Any preset. The system prompt (#582) instructs wrapping every span of quoted Pāli in `[[…]]`, explicitly "including single words and words inside lists or tables". |
+| **Correct** | Every Pāli span marked, including single terms in running prose; nothing else marked. |
+| **Failure signature** | Block quotations marked but inline terms left unmarked — typically rendered with markdown emphasis instead. Also: marking English, marking a translation, or leaving markers unbalanced. |
+| **Why it matters** | This is not a fidelity case; it is the **feasibility** case for v1.1. Answer prose and quoted Pāli are separate axes (AI_SURFACE_B.md §9), and script conversion can only be enabled for models that mark reliably. Unmarked inline terms are the failure mode that matters most, because those are exactly the words a Burmese-script reader wants converted. |
+
+### Observations
+
+| Date | Model | Harness | Grounded | Verdict | Note |
+|---|---|---|---|---|---|
+| 2026-08-11 | `gpt-oss:120b-cloud` | #582 prompt layer, first live run | Yes | **PARTIAL** | Marked both block-quoted verse lines correctly and balanced every marker — but rendered every inline term (*appamāda*, *pamāda*, *amatapadaṃ*) in markdown italics instead. Enabling conversion for this model would convert the verse and leave the vocabulary in Latin, which is the worse half. |
+| 2026-08-11 | `gpt-oss:120b-cloud` | Same, after the system prompt was revised | Yes | **PASS** | Every inline term marked — `[[appamāda]]`, `[[macca]]` — and every marker balanced. It also wrapped some markers in italics (`*[[…]]*`), which is harmless: the marked span itself stays clean, so conversion is unaffected. |
+
+**The wording fix, and what it says about instruction design.** The original instruction already said "including
+single words"; the model followed the markdown-emphasis convention anyway. What changed its behaviour was
+**naming the competing convention and giving the consequence**: *"Use the markers instead of italics or bold.
+Italicising a Pāli word is the usual convention in writing about these texts, and here it is the wrong one …
+an italicised word is a word left behind in Latin."* Plus an inline example beside the block one.
+
+The generalisable point for #582 and #587: when a model has a strong prior convention for a task, an instruction
+that merely states the requirement loses to it. An instruction that *names the prior* and says what it costs
+wins. Worth trying before concluding that a model cannot follow a formatting contract — and worth re-checking
+per model, since this is one data point.
 
 ---
 

--- a/docs/testing/PALI_FIDELITY_CASES.md
+++ b/docs/testing/PALI_FIDELITY_CASES.md
@@ -31,6 +31,56 @@ Two rules follow:
   passes grounded is direct evidence for that bet; the same verdict without the grounding state is nearly
   worthless.
 
+## The model matrix
+
+**The target audience is frontier models** (AI_INTEGRATION.md §11.1), and this file's verdicts are only
+meaningful against a matrix that includes them. What is listed here is the *sub-frontier* half — cheap to run,
+and the half that actually decides two open questions: whether #584's advisory has evidence behind it, and
+whether the lemma injection #580 kept "for grammar and word-by-word only" earns its place, since §4 records
+that **the interesting cell is the sub-frontier one**.
+
+### Ollama cloud, free tier (probed 2026-08-11, fsnow's account)
+
+Ollama's cloud catalogue is much larger than any one account can reach; most of it is subscription-gated. These
+are the models that actually answer on a free account, largest first:
+
+| Model tag | Parameters | Context |
+|---|---|---|
+| `nemotron-3-ultra:cloud` | 550B | 262K |
+| `minimax-m3:cloud` | MoE (not reported) | 524K |
+| `nemotron-3-super:cloud` | 120B | 262K |
+| `gpt-oss:120b-cloud` | 117B | 131K |
+| `gemma4:cloud` (= `gemma4:31b-cloud`) | 32.7B | 262K |
+| `nemotron-3-nano:30b-cloud` | 32B | 262K |
+| `gpt-oss:20b-cloud` | 20.9B | 131K |
+
+**Gated behind a paid plan**, so not available for routine runs: `glm-5.2`, `glm-5.1`, `deepseek-v4-flash`,
+`deepseek-v4-pro`, `kimi-k2.6`, `kimi-k2.7-code`, `minimax-m2.7`, `qwen3.5` (both cloud tags),
+`mistral-large-3:675b`. `kimi-k3` needs a plan *and* extra usage on top.
+
+> **`gpt-oss:120b` is not the best available and should stop being the default probe.** It is fourth of seven by
+> size, and it is only the one appearing in the observations below because it was the model at hand
+> (fsnow: *"you are testing with that one only because I am familiar with it… not because it is the best
+> available"*). **`nemotron-3-ultra:cloud` is 550B and free.** Re-running the case set across the tiers above is
+> the standing next step for #587 — a single-model column is not a matrix, and a failure observed on one
+> mid-tier model tells you about that model, not about the tier.
+
+### First cross-model observation (2026-08-11)
+
+The same Explain request, on the same passage, run across three of the tiers:
+
+| Model | Scope refusal | Marker discipline | Incidental glossing |
+|---|---|---|---|
+| `nemotron-3-ultra:cloud` | correct | correct, inline included | correct — *amatapadaṃ* as "the deathless state/path", *pamāda* as "heedlessness" |
+| `minimax-m3:cloud` | correct | correct, inline included | no glosses volunteered |
+| `gpt-oss:120b-cloud` | correct | correct after the prompt fix (Case 3) | **wrong** — "the unsurpassed foot-path", "the samsaric condition" |
+
+The fences from AI_SURFACE_B.md §6 held on every tier, which is the more reassuring half of this result. **Case 2
+was not re-tested**: neither larger model volunteered a full translation, so its failure signature had nothing
+to fire on. Running Case 2 properly needs the Translate preset, not Explain.
+
+---
+
 ## Adding a case
 
 A case earns its place when it has:

--- a/docs/testing/PALI_FIDELITY_CASES.md
+++ b/docs/testing/PALI_FIDELITY_CASES.md
@@ -65,19 +65,66 @@ are the models that actually answer on a free account, largest first:
 > the standing next step for #587 — a single-model column is not a matrix, and a failure observed on one
 > mid-tier model tells you about that model, not about the tier.
 
-### First cross-model observation (2026-08-11)
+### Screening run — 2026-08-11
 
-The same Explain request, on the same passage, run across three of the tiers:
+All seven free-tier models, run **serially** (the account runs one cloud model at a time), on two items: Case 1
+ungrounded with no system prompt, and Case 2 grounded through the real Translate preset.
 
-| Model | Scope refusal | Marker discipline | Incidental glossing |
+| Model | Case 1 (ungrounded) | Case 2 (grounded translation) | Keep? |
 |---|---|---|---|
-| `nemotron-3-ultra:cloud` | correct | correct, inline included | correct — *amatapadaṃ* as "the deathless state/path", *pamāda* as "heedlessness" |
-| `minimax-m3:cloud` | correct | correct, inline included | no glosses volunteered |
-| `gpt-oss:120b-cloud` | correct | correct after the prompt fix (Case 3) | **wrong** — "the unsurpassed foot-path", "the samsaric condition" |
+| `nemotron-3-ultra:cloud` | PASS | **PASS** — all four lines | **yes** |
+| `nemotron-3-super:cloud` | PASS | **PASS** — all four lines | **yes**, with a caveat below |
+| `gemma4:cloud` | PASS | **PASS** — all four lines, concise | **yes** |
+| `minimax-m3:cloud` | PASS | **PASS** — all four lines | **yes**, budget-hungry (#601) |
+| `gpt-oss:120b-cloud` | PASS | **FAIL** — *matā* as "as they think" | no, for translation |
+| `nemotron-3-nano:30b-cloud` | PASS | **FAIL** — *matā* as "as a mother" | no |
+| `gpt-oss:20b-cloud` | **FAIL** — glossed *appamāda* as "failing or stumbling… to make a mistake" | **FAIL** — "free of pride… leads to annihilation"; "as mothers" | no |
 
-The fences from AI_SURFACE_B.md §6 held on every tier, which is the more reassuring half of this result. **Case 2
-was not re-tested**: neither larger model volunteered a full translation, so its failure signature had nothing
-to fire on. Running Case 2 properly needs the Translate preset, not Explain.
+**The shortlist is the top four.** `nemotron-3-ultra`, `nemotron-3-super`, `gemma4` and `minimax-m3` all render
+Dhp 21 correctly, mark inline Pāli, refuse cross-corpus questions, and handle the apparatus note sensibly.
+`gemma4` is the surprise: at 32.7B it matches the 550B model on this verse and is the cheapest capable option.
+
+**Set aside for Pāli work:** `gpt-oss:20b` is not usable — it fails the most basic vocabulary question in the
+canon. `nemotron-3-nano` and `gpt-oss:120b` both read the verse's key word wrongly (Case 4 below). Keep them
+only as *deliberately weak* cells, where the question is what a poor model does with good context.
+
+> **Encoding caveat on `nemotron-3-super`.** Its output contained mojibake where the niggahita should be —
+> `amatapada??` rather than `amatapadaṃ` — while the same model rendered other diacritics correctly. This
+> matters beyond cosmetics: **a mangled diacritic inside the quote markers cannot be script-converted**, which
+> is exactly what §9's v1.1 proviso ("validate that marked content is actually convertible") was written for.
+> Worth re-checking before this model is relied on, and worth being the first real test of that validator.
+
+### One reading of these results
+
+Every model passed the *ungrounded* vocabulary question except the smallest — but three then mistranslated the
+verse **with the verse in front of them**. Recall and reading are different capabilities, and surface B depends
+on the second. A matrix built only from "does it know what this word means" would have rated four of these
+models as fine.
+
+---
+
+## Case 4 — vowel length: `matā` (dead) read as `mātā` (mother)
+
+| | |
+|---|---|
+| **Prompt** | Translate Dhp 21 with the verse supplied. |
+| **Correct** | `ye pamattā yathā matā` — "those who are heedless are as if dead". *matā* is the past participle of *marati*, to die. |
+| **Authority** | The corpus. *matā* (short *a*) is "dead"; *mātā* (long *ā*) is "mother". **Vowel length is phonemic in Pāli** — they are different words, not spellings. The verse settles it independently: the same root supplies *amata*, *maccu* and *mīyanti* in the two lines around it, and "as a mother" is not a reading the sentence supports. |
+| **Failure signature** | "as a mother", "like a mother", "as mothers" — or any reading of *matā* not derived from *marati*, including *maññati* ("think"). |
+| **Why it discriminates** | Two of seven models made this exact error **independently**, and the four larger ones did not. It is mechanically checkable, it is invisible to a reader without Pāli, and it needs no judgement to score. It also probes the one thing romanized Pāli most needs from a model: that a macron is information, not decoration. |
+
+### Observations
+
+| Date | Model | Grounded | Verdict | Note |
+|---|---|---|---|---|
+| 2026-08-11 | `nemotron-3-nano:30b-cloud` | Yes | **FAIL** | "those who are heedless — as a mother —", then offered both "as a mother (does)" and "like a mother" as the ambiguity. It reported the line as ambiguous, which the prompt asks for — but between two readings that are both wrong. |
+| 2026-08-11 | `gpt-oss:20b-cloud` | Yes | **FAIL** | "those who are attached are as mothers". Also lost the rest of the verse entirely. |
+| 2026-08-11 | `gpt-oss:120b-cloud` | Yes | **FAIL** | Different error, same word: "as they think", reading *matā* from *maññati*. Reproduced across three runs. |
+| 2026-08-11 | `nemotron-3-ultra`, `nemotron-3-super`, `gemma4`, `minimax-m3` | Yes | **PASS** | All four: "as if dead" / "as the dead" / "like the dead". |
+
+**A model that volunteers an ambiguity note for the wrong pair of readings is more dangerous than one that just
+gets it wrong**, because the hedging reads as care. Worth remembering when #586 decides how much authority the
+panel's presentation lends an answer.
 
 ---
 

--- a/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
@@ -121,6 +121,20 @@ public class AnthropicMessagesProviderTests
     }
 
     [Fact]
+    public async Task An_unset_cap_becomes_the_ceiling_every_current_model_accepts()
+    {
+        // The API requires the field, so null cannot mean "omit" here. 64K rather than 128K because the model
+        // id is whatever the user typed: Opus 5, Sonnet 5 and the Opus 4.x family all allow 128K, but Haiku 4.5
+        // caps at 64K, and this adapter cannot tell which one it is talking to.
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        await CollectAsync(Provider(handler), Request() with { MaxTokens = null });
+
+        using var body = JsonDocument.Parse(handler.LastRequestBody);
+
+        Assert.Equal(AiLimits.UniversalMaxTokens, body.RootElement.GetProperty("max_tokens").GetInt32());
+    }
+
+    [Fact]
     public async Task Request_carries_the_api_key_and_version_headers()
     {
         var handler = StubHttpMessageHandler.Sse(HappyStream);

--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
@@ -59,6 +59,20 @@ public class OpenAiCompatibleProviderTests
         """;
 
     [Fact]
+    public async Task An_unset_cap_omits_max_tokens_entirely()
+    {
+        // Unlike Anthropic, the field is optional here — so "no cap" is expressed by absence rather than by a
+        // number we invented. That matters most on a reasoning model, where a cap covers reasoning as well as
+        // the answer and can consume the whole budget before a word is written (#601).
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        await CollectAsync(Provider(handler), Request() with { MaxTokens = null });
+
+        using var body = JsonDocument.Parse(handler.LastRequestBody);
+
+        Assert.False(body.RootElement.TryGetProperty("max_tokens", out _));
+    }
+
+    [Fact]
     public async Task Streams_text_deltas_in_order()
     {
         var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(HappyStream)));

--- a/src/CST.Avalonia.Tests/Services/Ai/PaliQuoteFilterTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PaliQuoteFilterTests.cs
@@ -1,0 +1,125 @@
+using System.Linq;
+using System.Text;
+using CST.Avalonia.Services.Ai;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// The Pāli-quote marker and its v1 reader. (#582)
+///
+/// <para>The marker is instructed from v1 and only stripped from v1 — so what has to hold now is that no
+/// fragment of it ever reaches the panel, on any chunking, and that marker discipline is COUNTED rather than
+/// quietly repaired, since those counts are what #587 uses to decide whether script conversion is safe to turn
+/// on for a given model.</para>
+/// </summary>
+public class PaliQuoteFilterTests
+{
+    /// <summary>Feed a string one character at a time — the worst chunking a provider can produce.</summary>
+    private static (string Text, PaliQuoteFilter Filter) FeedByCharacter(string input)
+    {
+        var filter = new PaliQuoteFilter();
+        var output = new StringBuilder();
+        foreach (var c in input) output.Append(filter.Feed(c.ToString()));
+        output.Append(filter.Flush());
+        return (output.ToString(), filter);
+    }
+
+    [Fact]
+    public void Strips_markers_and_keeps_what_they_wrapped()
+    {
+        Assert.Equal(
+            "the phrase appamādo amatapadaṃ opens the chapter",
+            PaliQuoteMarkers.Strip("the phrase [[appamādo amatapadaṃ]] opens the chapter"));
+    }
+
+    [Fact]
+    public void A_marker_split_across_deltas_never_leaks_a_bracket()
+    {
+        // The whole difficulty: a delta can end between the two brackets. A naive per-chunk Replace both misses
+        // the marker and puts its first half on screen.
+        var filter = new PaliQuoteFilter();
+        var output = filter.Feed("the phrase [") + filter.Feed("[appamādo]") + filter.Feed("] opens it");
+        output += filter.Flush();
+
+        Assert.Equal("the phrase appamādo opens it", output);
+        Assert.Equal(1, filter.Quotes);
+        Assert.Equal(0, filter.UnbalancedMarkers);
+    }
+
+    [Fact]
+    public void Character_by_character_streaming_produces_the_same_text()
+    {
+        var (text, filter) = FeedByCharacter("a [[eko]] b [[dve]] c");
+
+        Assert.Equal("a eko b dve c", text);
+        Assert.Equal(2, filter.Quotes);
+    }
+
+    [Fact]
+    public void An_unclosed_quote_is_stripped_anyway_and_counted()
+    {
+        // Leaving a literal "[[" on screen is a visible defect in the answer, for a rule the user never asked
+        // about — so it goes. The imbalance is real signal about the model, so it is recorded rather than lost.
+        var (text, filter) = FeedByCharacter("he said [[appamādo and stopped");
+
+        Assert.Equal("he said appamādo and stopped", text);
+        Assert.Equal(0, filter.Quotes);
+        Assert.Equal(1, filter.UnbalancedMarkers);
+    }
+
+    [Fact]
+    public void A_stray_closer_is_stripped_anyway_and_counted()
+    {
+        var (text, filter) = FeedByCharacter("nothing opened ]] here");
+
+        Assert.Equal("nothing opened  here", text);
+        Assert.Equal(1, filter.UnbalancedMarkers);
+    }
+
+    [Fact]
+    public void A_single_bracket_in_ordinary_prose_survives()
+    {
+        // Held back while it might grow into a marker, then released as the ordinary text it was.
+        var (text, _) = FeedByCharacter("see note [3] and [4]");
+
+        Assert.Equal("see note [3] and [4]", text);
+    }
+
+    [Fact]
+    public void A_stream_severed_mid_marker_flushes_the_fragment_rather_than_swallowing_it()
+    {
+        var filter = new PaliQuoteFilter();
+        var output = filter.Feed("truncated [");
+        output += filter.Flush();
+
+        Assert.Equal("truncated [", output);
+    }
+
+    [Fact]
+    public void Text_with_no_markers_passes_through_unchanged()
+    {
+        var (text, filter) = FeedByCharacter("an ordinary answer with no Pali quoted at all");
+
+        Assert.Equal("an ordinary answer with no Pali quoted at all", text);
+        Assert.Equal(0, filter.Quotes);
+        Assert.Equal(0, filter.UnbalancedMarkers);
+    }
+
+    [Fact]
+    public void The_marker_does_not_occur_in_the_system_prompt_it_instructs()
+    {
+        // The system prompt has to SHOW the marker to teach it, which means the prompt is itself a place the
+        // marker appears. Guard the one thing that would actually break: the markers must arrive via the
+        // {{paliOpen}}/{{paliClose}} placeholders, so the constant and the instruction cannot drift apart.
+        var store = new PromptTemplateStore(
+            System.IO.Path.Combine(System.IO.Path.GetTempPath(), "cst-no-such-dir"),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<PromptTemplateStore>.Instance);
+
+        var text = store.GetDefault(PromptTemplateNames.System);
+
+        Assert.DoesNotContain(PaliQuoteMarkers.Open, text);
+        Assert.Contains("{{" + PromptPlaceholders.PaliOpen + "}}", text);
+        Assert.Contains("{{" + PromptPlaceholders.PaliClose + "}}", text);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/PaliQuoteFilterTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PaliQuoteFilterTests.cs
@@ -78,6 +78,59 @@ public class PaliQuoteFilterTests
     }
 
     [Fact]
+    public void Doubled_markers_do_not_put_a_literal_bracket_on_screen()
+    {
+        // Found by adversarial review. [[…]] is wikitext link syntax, so a model with a lot of wiki in its
+        // training set will double the markers — and the earlier version, which hunted only for a CLOSER while
+        // inside a quote, passed the second opener through as content and rendered "[[appamāda" at the user.
+        var (text, filter) = FeedByCharacter("[[[[appamāda]]]]");
+
+        Assert.Equal("appamāda", text);
+        Assert.Equal(1, filter.Quotes);
+        Assert.Equal(2, filter.UnbalancedMarkers);
+    }
+
+    [Fact]
+    public void Nested_markers_are_flattened_rather_than_rendered()
+    {
+        var (text, filter) = FeedByCharacter("[[a [[b]] c]]");
+
+        Assert.Equal("a b c", text);
+        Assert.DoesNotContain("[", text);
+        Assert.DoesNotContain("]", text);
+        Assert.Equal(2, filter.UnbalancedMarkers);
+    }
+
+    [Fact]
+    public void No_input_can_put_a_marker_fragment_on_screen()
+    {
+        // The class's central promise, asserted over the shapes a confused model actually produces rather than
+        // over one hand-picked case.
+        var inputs = new[]
+        {
+            "[[a]]", "[[[[a]]]]", "[[a [[b]] c]]", "]]a[[", "[[a", "a]]", "[[]]", "[[[a]]]",
+            "a [[b]] c ]] d [[ e", "[[a]] [[b", "]]]]", "[[[[",
+        };
+
+        foreach (var input in inputs)
+        {
+            var (text, _) = FeedByCharacter(input);
+
+            Assert.DoesNotContain(PaliQuoteMarkers.Open, text);
+            Assert.DoesNotContain(PaliQuoteMarkers.Close, text);
+        }
+    }
+
+    [Fact]
+    public void An_empty_delta_is_harmless()
+    {
+        var filter = new PaliQuoteFilter();
+
+        Assert.Equal(string.Empty, filter.Feed(string.Empty));
+        Assert.Equal("a", filter.Feed("a") + filter.Flush());
+    }
+
+    [Fact]
     public void A_single_bracket_in_ordinary_prose_survives()
     {
         // Held back while it might grow into a marker, then released as the ordinary text it was.

--- a/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
@@ -140,14 +140,20 @@ public class PromptBuilderTests : IDisposable
     }
 
     [Fact]
-    public void Every_preset_gets_an_output_budget_and_word_by_word_gets_the_largest()
+    public void No_preset_imposes_an_output_cap()
     {
-        // One entry per word plus a running translation is far more output than an explanation of a window four
-        // times the length; a cap sized for prose truncates it mid-list.
-        var budgets = Enum.GetValues<AiTask>().ToDictionary(t => t, t => _builder.Build(Bundle(t)).MaxOutputTokens);
+        // The cap is deliberately unset: it would have to predict output length, and on a reasoning model it
+        // cannot — reasoning and answer share the budget, so the cap truncates mid-answer or yields a blank
+        // panel (#601). The per-preset table survives as the seam #584/#585 fills in from Settings.
+        foreach (var task in Enum.GetValues<AiTask>())
+            Assert.Null(_builder.Build(Bundle(task)).MaxOutputTokens);
+    }
 
-        Assert.All(budgets.Values, b => Assert.True(b > 0));
-        Assert.Equal(budgets.Values.Max(), budgets[AiTask.WordByWord]);
+    [Fact]
+    public void A_task_with_no_budget_entry_fails_loudly_rather_than_rendering()
+    {
+        // What the all-null table still buys at runtime: membership says the task is renderable at all.
+        Assert.Throws<ArgumentOutOfRangeException>(() => _builder.Build(Bundle((AiTask)999)));
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
@@ -1,0 +1,356 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CST;
+using CST.Avalonia.Services.Ai;
+using CST.Navigation;
+using CST.Search;
+using CST.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Bundle to prompt. (#582)
+///
+/// <para>What is actually under test is the grounding contract: that the prompt states its own scope, that an
+/// absent part says it is absent rather than rendering as an empty heading, and that the same facts reach the
+/// user through <see cref="RenderedPrompt.Notices"/>. A degradation the model is warned about and the user is
+/// not is still silent from where the user is sitting.</para>
+/// </summary>
+public class PromptBuilderTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly PromptTemplateStore _store;
+    private readonly PromptBuilder _builder;
+
+    public PromptBuilderTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cst-prompt-build-" + Guid.NewGuid().ToString("N"));
+        _store = new PromptTemplateStore(_dir, NullLogger<PromptTemplateStore>.Instance);
+        _builder = new PromptBuilder(_store);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+    }
+
+    private static AiContextBundle Bundle(
+        AiTask task = AiTask.Explain,
+        string passage = "appamādo amatapadaṃ, pamādo maccuno padaṃ.",
+        SelectionContext? selection = null,
+        IReadOnlyList<LemmaEntry>? lemmas = null,
+        IReadOnlyList<BundlePart>? parts = null,
+        IReadOnlyList<ApparatusNote>? notes = null,
+        bool windowMayExtendPastReference = true,
+        string? userQuestion = null,
+        string outputLanguage = "English",
+        CommentaryLevel level = CommentaryLevel.Mula)
+    {
+        var pages = new[] { new SnippetPageRef(PageEdition.Vri, 1, 17) };
+        var result = new PassageResult(
+            "s0502m.mul.xml", "paragraph 21 (dhp)", passage, pages, 21, "dhp", null,
+            windowMayExtendPastReference ? 4200 : null,
+            notes?.Count ?? 0, notes ?? Array.Empty<ApparatusNote>());
+
+        return new AiContextBundle(
+            task, outputLanguage, userQuestion, result, selection,
+            lemmas ?? Array.Empty<LemmaEntry>(),
+            new BookContext("s0502m.mul.xml", "Dhammapadapāḷi", Pitaka.Sutta, level),
+            new CitationRef("s0502m.mul.xml", "Dhammapadapāḷi", "paragraph 21 (dhp)", pages),
+            new Provenance("6.0.0-test", null),
+            new BudgetReport(
+                parts ?? new[] { new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window") },
+                500, windowMayExtendPastReference));
+    }
+
+    [Fact]
+    public void The_system_prompt_states_the_scope_from_bundle_data()
+    {
+        // The fence against injection's characteristic failure: a truthful answer over a narrower scope than the
+        // user assumed. The model is told what the excerpt IS before it is told what to do with it.
+        var prompt = _builder.Build(Bundle());
+
+        Assert.Contains("Dhammapadapāḷi", prompt.System);
+        Assert.Contains("paragraph 21 (dhp)", prompt.System);
+        Assert.Contains("may run on past the end of the cited reference", prompt.System);
+    }
+
+    [Fact]
+    public void A_window_that_reached_the_end_of_the_file_says_so_instead()
+    {
+        var prompt = _builder.Build(Bundle(windowMayExtendPastReference: false));
+
+        Assert.Contains("running to the end of the book file", prompt.System);
+        Assert.DoesNotContain("may run on past", prompt.System);
+    }
+
+    [Fact]
+    public void The_answer_language_reaches_the_prompt()
+    {
+        var prompt = _builder.Build(Bundle(outputLanguage: "Burmese"));
+
+        Assert.Contains("Write in Burmese", prompt.System);
+    }
+
+    [Fact]
+    public void The_quote_markers_come_from_the_constant_not_from_the_template_text()
+    {
+        var prompt = _builder.Build(Bundle());
+
+        Assert.Contains(PaliQuoteMarkers.Open + "appamādo amatapadaṃ" + PaliQuoteMarkers.Close, prompt.System);
+    }
+
+    [Fact]
+    public void The_user_turn_carries_the_passage_and_the_citation()
+    {
+        var prompt = _builder.Build(Bundle());
+
+        Assert.Contains("appamādo amatapadaṃ", prompt.UserContent);
+        Assert.Contains("paragraph 21 (dhp)", prompt.UserContent);
+        Assert.Contains("VRI vol. 1 p. 17", prompt.UserContent);
+    }
+
+    [Fact]
+    public void The_commentary_level_is_stated_so_a_tika_is_not_read_as_the_canonical_text()
+    {
+        var prompt = _builder.Build(Bundle(level: CommentaryLevel.Tika));
+
+        Assert.Contains("ṭīkā", prompt.UserContent);
+        Assert.Contains("Sutta piṭaka", prompt.UserContent);
+    }
+
+    [Fact]
+    public void No_placeholder_survives_into_a_rendered_prompt()
+    {
+        // A literal "{{lemmas}}" reaching the model reads as a section that should have been filled and was not.
+        foreach (var task in Enum.GetValues<AiTask>())
+        {
+            var prompt = _builder.Build(Bundle(task));
+
+            Assert.DoesNotContain("{{", prompt.System);
+            Assert.DoesNotContain("{{", prompt.UserContent);
+        }
+    }
+
+    [Fact]
+    public void Every_preset_gets_an_output_budget_and_word_by_word_gets_the_largest()
+    {
+        // One entry per word plus a running translation is far more output than an explanation of a window four
+        // times the length; a cap sized for prose truncates it mid-list.
+        var budgets = Enum.GetValues<AiTask>().ToDictionary(t => t, t => _builder.Build(Bundle(t)).MaxOutputTokens);
+
+        Assert.All(budgets.Values, b => Assert.True(b > 0));
+        Assert.Equal(budgets.Values.Max(), budgets[AiTask.WordByWord]);
+    }
+
+    [Fact]
+    public void An_absent_selection_is_a_sentence_not_an_empty_heading()
+    {
+        var prompt = _builder.Build(Bundle());
+
+        Assert.Contains("has not selected anything", prompt.UserContent);
+    }
+
+    [Fact]
+    public void A_selection_the_window_does_not_contain_warns_the_model_and_the_user()
+    {
+        var prompt = _builder.Build(Bundle(
+            selection: new SelectionContext("dhammā manopubbaṅgamā", FoundInWindow: false)));
+
+        Assert.Contains("was not found in the passage above", prompt.UserContent);
+        Assert.Contains(prompt.Notices, n => n.Contains("not found in the passage window"));
+    }
+
+    [Fact]
+    public void A_missing_lemma_asset_is_named_as_a_missing_download_not_as_a_fact_about_the_words()
+    {
+        // The plan requires the lemma presets to degrade VISIBLY. The distinction carried here is the one that
+        // matters: "we could not look this up" versus "these words have no analysis".
+        var prompt = _builder.Build(Bundle(
+            AiTask.Grammar,
+            parts: new[]
+            {
+                new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window"),
+                new BundlePart(BundlePartNames.Lemmas, BundlePartState.Unavailable, "the DPD-lemma asset is not installed"),
+            }));
+
+        Assert.Contains("not installed", prompt.UserContent);
+        Assert.Contains("say that the analysis was unavailable", prompt.UserContent);
+        Assert.Contains(prompt.Notices, n => n.Contains("word analysis") && n.Contains("not installed"));
+    }
+
+    [Fact]
+    public void An_empty_lemma_result_reads_as_a_gap_in_the_lookup_rather_than_a_missing_asset()
+    {
+        var prompt = _builder.Build(Bundle(
+            AiTask.Grammar,
+            parts: new[]
+            {
+                new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window"),
+                new BundlePart(BundlePartNames.Lemmas, BundlePartState.Included, "0 candidate lemma(s)"),
+            }));
+
+        Assert.Contains("gap in the lookup", prompt.UserContent);
+        Assert.DoesNotContain("not installed", prompt.UserContent);
+    }
+
+    [Fact]
+    public void Lemmas_render_as_a_table_and_a_pipe_in_a_gloss_does_not_break_a_row()
+    {
+        var prompt = _builder.Build(Bundle(
+            AiTask.WordByWord,
+            lemmas: new[]
+            {
+                new LemmaEntry("appamādo", "appamāda", "masc", "heedfulness"),
+                new LemmaEntry("padaṃ", "pada", "nt", "foot | word | state"),
+            }));
+
+        Assert.Contains("| appamādo | appamāda | masc | heedfulness |", prompt.UserContent);
+        Assert.Contains(@"foot \| word \| state", prompt.UserContent);
+    }
+
+    [Fact]
+    public void A_trimmed_lemma_list_tells_the_model_that_absence_means_nothing()
+    {
+        var prompt = _builder.Build(Bundle(
+            AiTask.WordByWord,
+            lemmas: new[] { new LemmaEntry("appamādo", "appamāda", "masc", null) },
+            parts: new[]
+            {
+                new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window"),
+                new BundlePart(BundlePartNames.Lemmas, BundlePartState.TrimmedForBudget, "60 of 140 words"),
+            }));
+
+        Assert.Contains("no conclusion follows from their absence", prompt.UserContent);
+        Assert.Contains(prompt.Notices, n => n.Contains("cut to fit"));
+    }
+
+    [Fact]
+    public void Apparatus_notes_are_labelled_as_evidence_about_the_text_not_as_the_text()
+    {
+        var prompt = _builder.Build(Bundle(
+            AiTask.Translate,
+            notes: new[] { new ApparatusNote(12, "appamādo", "appamādā", "sī, syā") }));
+
+        Assert.Contains("reading *appamādā* in sī, syā", prompt.UserContent);
+        Assert.Contains("evidence about the text, not part of it", prompt.UserContent);
+    }
+
+    [Fact]
+    public void A_window_with_no_apparatus_says_so_rather_than_leaving_the_section_blank()
+    {
+        var prompt = _builder.Build(Bundle(AiTask.Translate));
+
+        Assert.Contains("no print notes in this window", prompt.UserContent);
+    }
+
+    [Fact]
+    public void The_users_question_lands_verbatim_and_last()
+    {
+        var prompt = _builder.Build(Bundle(userQuestion: "why the instrumental here?"));
+
+        Assert.Contains("why the instrumental here?", prompt.UserContent);
+        Assert.EndsWith("why the instrumental here?", prompt.UserContent.TrimEnd());
+    }
+
+    [Fact]
+    public void No_question_leaves_no_empty_heading_behind()
+    {
+        var prompt = _builder.Build(Bundle());
+
+        Assert.DoesNotContain("The reader asks", prompt.UserContent);
+    }
+
+    [Fact]
+    public void The_provisions_inventory_names_what_was_and_was_not_gathered()
+    {
+        var prompt = _builder.Build(Bundle(
+            parts: new[]
+            {
+                new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window"),
+                new BundlePart(BundlePartNames.Apparatus, BundlePartState.Empty, "no apparatus in this window"),
+            }));
+
+        Assert.Contains("**passage** — given", prompt.UserContent);
+        Assert.Contains("**apparatus** — nothing to give", prompt.UserContent);
+    }
+
+    [Fact]
+    public void The_inventory_cannot_claim_a_part_the_template_never_shows()
+    {
+        // Found by reading a dumped prompt rather than by a test: the inventory said "apparatus — given" while
+        // only the translate template rendered the notes, so on every other preset the model was told it had
+        // been given something it could not see. Deriving the inventory from the template's own placeholders
+        // makes the two agree by construction, including after a user edit.
+        _store.Save(PromptTemplateNames.Explain, "{{citation}}\n{{passage}}\n{{provisions}}");
+
+        var prompt = _builder.Build(Bundle(
+            parts: new[]
+            {
+                new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window"),
+                new BundlePart(BundlePartNames.Apparatus, BundlePartState.Included, "3 print note(s)"),
+            }));
+
+        Assert.Contains("**passage** — given", prompt.UserContent);
+        Assert.DoesNotContain("apparatus", prompt.UserContent);
+    }
+
+    [Fact]
+    public void A_degradation_in_a_part_the_preset_does_not_use_is_not_reported_to_the_user()
+    {
+        // An Explain answer is not worse for the word-analysis download being absent — it never asked for one.
+        _store.Save(PromptTemplateNames.Explain, "{{citation}}\n{{passage}}\n{{provisions}}");
+
+        var prompt = _builder.Build(Bundle(
+            parts: new[]
+            {
+                new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window"),
+                new BundlePart(BundlePartNames.Lemmas, BundlePartState.Unavailable, "asset not installed"),
+            },
+            windowMayExtendPastReference: false));
+
+        Assert.Empty(prompt.Notices);
+    }
+
+    [Fact]
+    public void An_empty_part_is_not_reported_to_the_user_as_a_problem()
+    {
+        // "Nothing to give" is healthy — most windows outside mūla texts carry no apparatus. A notice here would
+        // nag about a missing download on a perfectly good bundle.
+        var prompt = _builder.Build(Bundle(
+            parts: new[] { new BundlePart(BundlePartNames.Apparatus, BundlePartState.Empty, "none") },
+            windowMayExtendPastReference: false));
+
+        Assert.Empty(prompt.Notices);
+    }
+
+    [Fact]
+    public void A_rejected_prompt_edit_is_reported_to_the_user_who_made_it()
+    {
+        // The one degradation the model cannot be told about: the template that would have carried the news is
+        // the one that failed to load. Without a notice the user reads answers from a prompt they think they
+        // replaced.
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path.Combine(_dir, "explain.md"), "just do it");
+
+        var prompt = _builder.Build(Bundle());
+
+        Assert.Contains(prompt.Notices, n => n.Contains("explain") && n.Contains("not used"));
+        Assert.Contains("appamādo amatapadaṃ", prompt.UserContent);   // the built-in still ran
+    }
+
+    [Fact]
+    public void A_valid_prompt_edit_is_used_and_reported_as_nothing()
+    {
+        _store.Save(PromptTemplateNames.Explain, "MY TEMPLATE\n{{citation}}\n{{passage}}");
+
+        var prompt = _builder.Build(Bundle(windowMayExtendPastReference: false));
+
+        Assert.StartsWith("MY TEMPLATE", prompt.UserContent);
+        Assert.Empty(prompt.Notices);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
@@ -38,6 +38,9 @@ public class PromptBuilderTests : IDisposable
         if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
     }
 
+    /// <summary>The smallest override that validates: every required placeholder, no prose.</summary>
+    private const string Minimal = "{{citation}}\n{{passage}}\n{{selection}}\n{{userQuestion}}";
+
     private static AiContextBundle Bundle(
         AiTask task = AiTask.Explain,
         string passage = "appamādo amatapadaṃ, pamādo maccuno padaṃ.",
@@ -199,6 +202,20 @@ public class PromptBuilderTests : IDisposable
     }
 
     [Fact]
+    public void A_preset_that_gathers_no_lemmas_says_so_rather_than_reporting_an_empty_lookup()
+    {
+        // Reachable by adding {{lemmas}} to a preset that does not gather them — the bundler records a lemmas
+        // part only for Grammar and WordByWord. Saying "the lookup returned no candidates" here would describe
+        // a lookup that never ran, which is the same class of false diagnostic as an empty section.
+        _store.Save(PromptTemplateNames.Explain, Minimal + "\n{{lemmas}}");
+
+        var prompt = _builder.Build(Bundle());
+
+        Assert.Contains("this preset does not use it", prompt.UserContent);
+        Assert.DoesNotContain("gap in the lookup", prompt.UserContent);
+    }
+
+    [Fact]
     public void Lemmas_render_as_a_table_and_a_pipe_in_a_gloss_does_not_break_a_row()
     {
         var prompt = _builder.Build(Bundle(
@@ -286,7 +303,7 @@ public class PromptBuilderTests : IDisposable
         // only the translate template rendered the notes, so on every other preset the model was told it had
         // been given something it could not see. Deriving the inventory from the template's own placeholders
         // makes the two agree by construction, including after a user edit.
-        _store.Save(PromptTemplateNames.Explain, "{{citation}}\n{{passage}}\n{{provisions}}");
+        _store.Save(PromptTemplateNames.Explain, Minimal + "\n{{provisions}}");
 
         var prompt = _builder.Build(Bundle(
             parts: new[]
@@ -303,7 +320,7 @@ public class PromptBuilderTests : IDisposable
     public void A_degradation_in_a_part_the_preset_does_not_use_is_not_reported_to_the_user()
     {
         // An Explain answer is not worse for the word-analysis download being absent — it never asked for one.
-        _store.Save(PromptTemplateNames.Explain, "{{citation}}\n{{passage}}\n{{provisions}}");
+        _store.Save(PromptTemplateNames.Explain, Minimal + "\n{{provisions}}");
 
         var prompt = _builder.Build(Bundle(
             parts: new[]
@@ -346,7 +363,7 @@ public class PromptBuilderTests : IDisposable
     [Fact]
     public void A_valid_prompt_edit_is_used_and_reported_as_nothing()
     {
-        _store.Save(PromptTemplateNames.Explain, "MY TEMPLATE\n{{citation}}\n{{passage}}");
+        _store.Save(PromptTemplateNames.Explain, "MY TEMPLATE\n" + Minimal);
 
         var prompt = _builder.Build(Bundle(windowMayExtendPastReference: false));
 

--- a/src/CST.Avalonia.Tests/Services/Ai/PromptTemplateStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptTemplateStoreTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.IO;
+using System.Linq;
+using CST.Avalonia.Services.Ai;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// The prompt-template store: built-in defaults as embedded resources, user overrides on disk. (#582)
+///
+/// <para>The shipped templates are asserted here too. They are data, so nothing about them is checked at
+/// compile time — a mistyped placeholder in a resource file would otherwise first show up as a literal brace
+/// pair in a request the user paid for.</para>
+/// </summary>
+public class PromptTemplateStoreTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly PromptTemplateStore _store;
+
+    public PromptTemplateStoreTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cst-prompts-" + Guid.NewGuid().ToString("N"));
+        _store = new PromptTemplateStore(_dir, NullLogger<PromptTemplateStore>.Instance);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+    }
+
+    [Theory]
+    [InlineData(PromptTemplateNames.System)]
+    [InlineData(PromptTemplateNames.Explain)]
+    [InlineData(PromptTemplateNames.Translate)]
+    [InlineData(PromptTemplateNames.Grammar)]
+    [InlineData(PromptTemplateNames.WordByWord)]
+    public void Every_shipped_template_passes_the_validation_it_imposes_on_the_user(string name)
+    {
+        // If a built-in cannot meet the bar we hold user edits to, either the template or the bar is wrong.
+        Assert.Empty(PromptTemplateStore.Validate(name, _store.GetDefault(name)));
+    }
+
+    [Fact]
+    public void Every_task_has_a_template_and_every_template_a_default()
+    {
+        foreach (var task in Enum.GetValues<AiTask>())
+        {
+            var name = PromptTemplateNames.ForTask(task);
+            Assert.Contains(name, PromptTemplateNames.All);
+            Assert.False(string.IsNullOrWhiteSpace(_store.GetDefault(name)));
+        }
+    }
+
+    [Fact]
+    public void A_valid_override_replaces_the_built_in()
+    {
+        var text = "My own instructions.\n\n{{citation}}\n\n{{passage}}";
+        _store.Save(PromptTemplateNames.Explain, text);
+
+        var template = _store.Get(PromptTemplateNames.Explain);
+
+        Assert.Equal(text, template.Text);
+        Assert.True(template.IsUserEdited);
+    }
+
+    [Fact]
+    public void Reset_goes_back_to_the_built_in()
+    {
+        _store.Save(PromptTemplateNames.Explain, "{{citation}} {{passage}}");
+        _store.Reset(PromptTemplateNames.Explain);
+
+        var template = _store.Get(PromptTemplateNames.Explain);
+
+        Assert.False(template.IsUserEdited);
+        Assert.Equal(_store.GetDefault(PromptTemplateNames.Explain), template.Text);
+    }
+
+    [Fact]
+    public void Reset_on_an_untouched_template_is_not_an_error()
+    {
+        _store.Reset(PromptTemplateNames.Translate);
+
+        Assert.False(_store.Get(PromptTemplateNames.Translate).IsUserEdited);
+    }
+
+    [Fact]
+    public void Save_refuses_a_template_that_drops_the_passage()
+    {
+        // The failure this guards is silent and total: the model is asked to explain a passage it was never
+        // given, and answers anyway.
+        var error = Assert.Throws<PromptTemplateException>(
+            () => _store.Save(PromptTemplateNames.Explain, "Explain it. {{citation}}"));
+
+        Assert.Contains("{{passage}}", error.Problems.Single());
+    }
+
+    [Fact]
+    public void Save_refuses_an_unknown_placeholder()
+    {
+        // Left in, it would reach the model as a literal "{{glosses}}" — which reads to the model as a section
+        // that should have been filled and was not.
+        var error = Assert.Throws<PromptTemplateException>(
+            () => _store.Save(PromptTemplateNames.Explain, "{{citation}} {{passage}} {{glosses}}"));
+
+        Assert.Contains("{{glosses}}", error.Problems.Single());
+    }
+
+    [Fact]
+    public void Save_refuses_a_system_prompt_that_drops_the_marking_instruction()
+    {
+        var error = Assert.Throws<PromptTemplateException>(
+            () => _store.Save(PromptTemplateNames.System, "Answer in {{outputLanguage}} about {{scope}}."));
+
+        Assert.Equal(2, error.Problems.Count);
+        Assert.Contains(error.Problems, p => p.Contains("{{paliOpen}}"));
+        Assert.Contains(error.Problems, p => p.Contains("{{paliClose}}"));
+    }
+
+    [Fact]
+    public void Validation_reports_every_problem_at_once()
+    {
+        var problems = PromptTemplateStore.Validate(PromptTemplateNames.Grammar, "{{nope}} {{alsoNope}}");
+
+        // Two unknown placeholders and three missing required ones — an editor that showed these one per save
+        // would be a chore to use.
+        Assert.Equal(5, problems.Count);
+    }
+
+    [Fact]
+    public void An_invalid_override_on_disk_falls_back_to_the_built_in_and_says_why()
+    {
+        // Reachable by hand-editing the file, which is the documented way to edit these until #585 ships a UI.
+        // Falling back silently would leave the user reading answers from a prompt they believe they replaced.
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path.Combine(_dir, "explain.md"), "no placeholders here at all");
+
+        var template = _store.Get(PromptTemplateNames.Explain);
+
+        Assert.False(template.IsUserEdited);
+        Assert.Equal(_store.GetDefault(PromptTemplateNames.Explain), template.Text);
+        Assert.Equal(2, _store.RejectedOverrides[PromptTemplateNames.Explain].Count);
+    }
+
+    [Fact]
+    public void An_empty_override_is_rejected_rather_than_sent_as_an_empty_prompt()
+    {
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path.Combine(_dir, "system.md"), "   \n\n  ");
+
+        var template = _store.Get(PromptTemplateNames.System);
+
+        Assert.False(template.IsUserEdited);
+        Assert.Contains("empty", _store.RejectedOverrides[PromptTemplateNames.System].Single());
+    }
+
+    [Fact]
+    public void A_rejection_clears_once_the_override_is_fixed()
+    {
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path.Combine(_dir, "explain.md"), "broken");
+        _store.Get(PromptTemplateNames.Explain);
+        Assert.True(_store.RejectedOverrides.ContainsKey(PromptTemplateNames.Explain));
+
+        _store.Save(PromptTemplateNames.Explain, "{{citation}} {{passage}}");
+        _store.Get(PromptTemplateNames.Explain);
+
+        Assert.False(_store.RejectedOverrides.ContainsKey(PromptTemplateNames.Explain));
+    }
+
+    [Fact]
+    public void Spaces_inside_a_placeholder_are_tolerated()
+    {
+        // "{{ passage }}" is the obvious thing to type and would otherwise fail as a MISSING required
+        // placeholder — a message pointing at the one thing the user did include.
+        Assert.Empty(PromptTemplateStore.Validate(PromptTemplateNames.Explain, "{{ citation }} {{ passage }}"));
+    }
+
+    [Fact]
+    public void An_unknown_template_name_is_a_programming_error_not_a_fallback()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _store.GetDefault("summarize"));
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/PromptTemplateStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptTemplateStoreTests.cs
@@ -25,6 +25,9 @@ public class PromptTemplateStoreTests : IDisposable
         _store = new PromptTemplateStore(_dir, NullLogger<PromptTemplateStore>.Instance);
     }
 
+    /// <summary>The smallest override that passes validation for the Explain preset.</summary>
+    private const string ExplainMinimum = "{{citation}} {{passage}} {{selection}} {{userQuestion}}";
+
     public void Dispose()
     {
         if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
@@ -56,7 +59,7 @@ public class PromptTemplateStoreTests : IDisposable
     [Fact]
     public void A_valid_override_replaces_the_built_in()
     {
-        var text = "My own instructions.\n\n{{citation}}\n\n{{passage}}";
+        var text = "My own instructions.\n\n{{citation}}\n\n{{passage}}\n{{selection}}\n{{userQuestion}}";
         _store.Save(PromptTemplateNames.Explain, text);
 
         var template = _store.Get(PromptTemplateNames.Explain);
@@ -68,7 +71,7 @@ public class PromptTemplateStoreTests : IDisposable
     [Fact]
     public void Reset_goes_back_to_the_built_in()
     {
-        _store.Save(PromptTemplateNames.Explain, "{{citation}} {{passage}}");
+        _store.Save(PromptTemplateNames.Explain, ExplainMinimum);
         _store.Reset(PromptTemplateNames.Explain);
 
         var template = _store.Get(PromptTemplateNames.Explain);
@@ -91,7 +94,8 @@ public class PromptTemplateStoreTests : IDisposable
         // The failure this guards is silent and total: the model is asked to explain a passage it was never
         // given, and answers anyway.
         var error = Assert.Throws<PromptTemplateException>(
-            () => _store.Save(PromptTemplateNames.Explain, "Explain it. {{citation}}"));
+            () => _store.Save(PromptTemplateNames.Explain,
+                "Explain it. {{citation}} {{selection}} {{userQuestion}}"));
 
         Assert.Contains("{{passage}}", error.Problems.Single());
     }
@@ -102,7 +106,8 @@ public class PromptTemplateStoreTests : IDisposable
         // Left in, it would reach the model as a literal "{{glosses}}" — which reads to the model as a section
         // that should have been filled and was not.
         var error = Assert.Throws<PromptTemplateException>(
-            () => _store.Save(PromptTemplateNames.Explain, "{{citation}} {{passage}} {{glosses}}"));
+            () => _store.Save(PromptTemplateNames.Explain,
+                "{{citation}} {{passage}} {{selection}} {{userQuestion}} {{glosses}}"));
 
         Assert.Contains("{{glosses}}", error.Problems.Single());
     }
@@ -123,9 +128,9 @@ public class PromptTemplateStoreTests : IDisposable
     {
         var problems = PromptTemplateStore.Validate(PromptTemplateNames.Grammar, "{{nope}} {{alsoNope}}");
 
-        // Two unknown placeholders and three missing required ones — an editor that showed these one per save
+        // Two unknown placeholders and five missing required ones — an editor that showed these one per save
         // would be a chore to use.
-        Assert.Equal(5, problems.Count);
+        Assert.Equal(7, problems.Count);
     }
 
     [Fact]
@@ -140,7 +145,7 @@ public class PromptTemplateStoreTests : IDisposable
 
         Assert.False(template.IsUserEdited);
         Assert.Equal(_store.GetDefault(PromptTemplateNames.Explain), template.Text);
-        Assert.Equal(2, _store.RejectedOverrides[PromptTemplateNames.Explain].Count);
+        Assert.Equal(4, _store.RejectedOverrides[PromptTemplateNames.Explain].Count);
     }
 
     [Fact]
@@ -163,9 +168,64 @@ public class PromptTemplateStoreTests : IDisposable
         _store.Get(PromptTemplateNames.Explain);
         Assert.True(_store.RejectedOverrides.ContainsKey(PromptTemplateNames.Explain));
 
-        _store.Save(PromptTemplateNames.Explain, "{{citation}} {{passage}}");
+        _store.Save(PromptTemplateNames.Explain, ExplainMinimum);
         _store.Get(PromptTemplateNames.Explain);
 
+        Assert.False(_store.RejectedOverrides.ContainsKey(PromptTemplateNames.Explain));
+    }
+
+    [Theory]
+    [InlineData("{{citation}} {{passage}} {{selection}} {{userQuestion}} {{user_question}}")]
+    [InlineData("{{citation}} {{passage}} {{selection}} {{userQuestion}} {{2lemmas}}")]
+    [InlineData("{{citation}} {{passage}} {{selection}} {{userQuestion}} {{word-by-word}}")]
+    [InlineData("{{citation}} {{passage}} {{selection}} {{userQuestion}} {{pass age}}")]
+    [InlineData("{{citation}} {{passage}} {{selection}} {{userQuestion}} {{passage")]
+    public void A_near_miss_placeholder_is_caught_rather_than_sent_as_literal_braces(string text)
+    {
+        // Found by adversarial review. These do not match the identifier grammar, so the unknown-NAME check
+        // cannot see them at all — and without a second pass they sail through validation and reach the model
+        // as literal braces, which is the precise outcome that check exists to prevent.
+        var problems = PromptTemplateStore.Validate(PromptTemplateNames.Explain, text);
+
+        Assert.Contains(problems, p => p.Contains("not a valid placeholder"));
+    }
+
+    [Fact]
+    public void Save_refuses_a_template_that_drops_the_readers_own_selection_or_question()
+    {
+        // The one silence this design promises not to permit. The user selects a phrase, types a question, and
+        // gets an answer that saw neither — worse than the equivalent for the passage, because they WATCHED
+        // themselves supply the input.
+        var error = Assert.Throws<PromptTemplateException>(
+            () => _store.Save(PromptTemplateNames.Explain, "{{citation}} {{passage}}"));
+
+        Assert.Contains(error.Problems, p => p.Contains("{{selection}}"));
+        Assert.Contains(error.Problems, p => p.Contains("{{userQuestion}}"));
+    }
+
+    [Fact]
+    public void Reset_refuses_a_name_that_would_escape_the_override_directory()
+    {
+        // Trusted callers today; #585 puts a Settings control in front of it.
+        Assert.Throws<ArgumentOutOfRangeException>(() => _store.Reset("../../notes"));
+    }
+
+    [Fact]
+    public void Concurrent_reads_do_not_corrupt_the_rejection_map()
+    {
+        // The store is a DI singleton and Get mutates on EVERY call, including the no-override path. #583's
+        // orchestrator plus a surface-C agent hitting the API is concurrent Build by construction.
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path.Combine(_dir, "grammar.md"), "broken");
+
+        System.Threading.Tasks.Parallel.For(0, 200, _ =>
+        {
+            _store.Get(PromptTemplateNames.Explain);
+            _store.Get(PromptTemplateNames.Grammar);
+            _ = _store.RejectedOverrides.Count;
+        });
+
+        Assert.True(_store.RejectedOverrides.ContainsKey(PromptTemplateNames.Grammar));
         Assert.False(_store.RejectedOverrides.ContainsKey(PromptTemplateNames.Explain));
     }
 
@@ -174,7 +234,9 @@ public class PromptTemplateStoreTests : IDisposable
     {
         // "{{ passage }}" is the obvious thing to type and would otherwise fail as a MISSING required
         // placeholder — a message pointing at the one thing the user did include.
-        Assert.Empty(PromptTemplateStore.Validate(PromptTemplateNames.Explain, "{{ citation }} {{ passage }}"));
+        Assert.Empty(PromptTemplateStore.Validate(
+            PromptTemplateNames.Explain,
+            "{{ citation }} {{ passage }} {{ selection }} {{ userQuestion }}"));
     }
 
     [Fact]

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1219,6 +1219,12 @@ public partial class App : Application
             sp.GetService<ILemmaSearchService>(),
             typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown",
             sp.GetRequiredService<ILogger<Services.Ai.AiContextBundler>>()));
+
+        // The prompt layer (#582). Singleton so a rejected user override is reported once rather than
+        // re-discovered per request; the store re-reads the override FILE on every Get, so an edit made outside
+        // the app takes effect on the next invocation without a restart.
+        services.AddSingleton<Services.Ai.IPromptTemplateStore, Services.Ai.PromptTemplateStore>();
+        services.AddSingleton<Services.Ai.IPromptBuilder, Services.Ai.PromptBuilder>();
         services.AddSingleton<ILemmaReportService, LemmaReportService>();
 
         // Surface-C tool wrappers (exposed over the local API). (#186)

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -55,6 +55,10 @@
     <EmbeddedResource Include="Resources\welcome-content.html" />
     <EmbeddedResource Include="Resources\buddha-transparent.png" />
     <EmbeddedResource Include="Resources\LocalApi\llms.txt" />
+    <!-- Surface B prompt templates (#582). Embedded so they cannot go missing from an installed app; the user's
+         edits live beside settings.json and override these at load. Wildcard so adding a preset needs no csproj
+         edit — PromptTemplateNames.All is the list that matters, and a name there with no resource fails loudly. -->
+    <EmbeddedResource Include="Resources\Ai\*.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CST.Avalonia/Resources/Ai/explain.md
+++ b/src/CST.Avalonia/Resources/Ai/explain.md
@@ -1,0 +1,27 @@
+{{book}}
+{{citation}}
+
+## Passage
+
+{{passage}}
+
+## Selection
+
+{{selection}}
+
+## Print apparatus for this window
+
+{{apparatus}}
+
+## What you were and were not given
+
+{{provisions}}
+
+---
+
+Explain this passage: what it says, and what a reader needs in order to follow it. Draw out the terms that carry
+weight, and note anything in the wording that a translator would have to make a decision about.
+
+If a selection is given, centre the explanation on it and use the rest of the passage as its context.
+
+{{userQuestion}}

--- a/src/CST.Avalonia/Resources/Ai/grammar.md
+++ b/src/CST.Avalonia/Resources/Ai/grammar.md
@@ -1,0 +1,40 @@
+{{book}}
+{{citation}}
+
+## Passage
+
+{{passage}}
+
+## Selection
+
+{{selection}}
+
+## Word analysis gathered for this request
+
+{{lemmas}}
+
+## Print apparatus for this window
+
+{{apparatus}}
+
+## What you were and were not given
+
+{{provisions}}
+
+---
+
+Explain the grammar of this Pāli.
+
+- Work through the sentence: how it is built, what governs what, and where each clause begins and ends.
+- For the words that carry the construction, give the stem and the form — case and number for nouns and
+  adjectives, person, number, tense and voice for verbs, and the members and type of any compound.
+- Where the form is ambiguous — a genitive that could be a dative, an aorist that could be a participle — say so
+  and say which reading the sentence supports.
+- Explain sandhi where it obscures what a word actually is.
+
+The word analysis above is a candidate list, not an answer: a form can resolve to several stems, and the list was
+built before anything read this sentence. Choose what fits the syntax, and say when you are overriding it.
+
+If a selection is given, analyse the selection and use the rest of the passage as its context.
+
+{{userQuestion}}

--- a/src/CST.Avalonia/Resources/Ai/system.md
+++ b/src/CST.Avalonia/Resources/Ai/system.md
@@ -53,7 +53,8 @@ from Pāli.
 ## Writing the answer
 
 - Write in {{outputLanguage}}. Quoted Pāli stays Pāli.
-- Call them "Pāli texts", "the Tipiṭaka", "the canon", or "VRI texts"; say "the tradition" or "the commentarial
-  tradition" where you mean those.
+- When you name these texts collectively, or the tradition they come from, call them "Pāli texts", "the
+  Tipiṭaka", "the canon", or "VRI texts", and say "the tradition" or "the commentarial tradition". Use those
+  terms in whatever language you are writing in, in place of whatever that language's default phrase would be.
 - Be concrete. Show the reader what is in the passage rather than summarizing it from a distance.
 - No preamble about what you are about to do. Answer.

--- a/src/CST.Avalonia/Resources/Ai/system.md
+++ b/src/CST.Avalonia/Resources/Ai/system.md
@@ -1,0 +1,59 @@
+You are a Pāli reading assistant built into CST Reader, a reader for the Chaṭṭha Saṅgāyana Tipiṭaka published by
+the Vipassana Research Institute (VRI). You are helping someone who has a passage open in front of them.
+
+## What you are working from
+
+Everything you know about this text is in the message that follows. **You are not reading the book. You are
+reading an excerpt of it.** Your scope is:
+
+{{scope}}
+
+Treat that as the whole of what you can speak to with authority.
+
+## Grounding
+
+- Answer from the passage you were given. Where you draw on general knowledge of Pāli or of the commentarial
+  tradition, say so, so the reader can tell the two apart.
+- **Name your scope when it matters.** If the question reaches past the excerpt — a whole sutta, a whole vagga,
+  a text as a whole — say plainly what you actually saw before you answer it.
+- **If the passage does not contain the answer, say so.** That is a complete and useful answer. Do not close the
+  gap from memory.
+- **Never invent a reference.** Do not produce paragraph, page, or volume numbers, or sutta titles, that are not
+  in what you were given. The reader renders the citation itself, from its own data, beside your answer — you do
+  not need to supply one, and one you supply cannot be checked.
+- **Nothing supplied to you is authoritative.** Any word analysis in that message was gathered by a heuristic before
+  anything had read the passage; it can be wrong, and it can be for a different sense of the word than this
+  passage uses. Prefer the reading the passage itself supports. And **absence is not evidence**: a word with no
+  entry was missed by the heuristic, not found to be undefined or unimportant.
+
+## Questions this passage cannot answer
+
+Some questions need the whole corpus rather than one passage: where else a phrase occurs, how often a term
+appears, who a person is, what a parallel passage says elsewhere. You do not have the corpus and you cannot
+search it.
+
+Say so, and point the reader at the tools beside you — the Search panel covers every book in the collection, and
+the dictionary looks up Pāli words directly. Do not answer such a question from memory instead. An answer
+assembled from recollection is precisely where invented references come from.
+
+## Quoting Pāli
+
+Wrap every span of Pāli you quote in {{paliOpen}} and {{paliClose}} — every time, including a single word in the
+middle of a sentence:
+
+> the term {{paliOpen}}appamāda{{paliClose}} is defined by the line {{paliOpen}}appamādo amatapadaṃ{{paliClose}}
+
+**Use the markers instead of italics or bold.** Italicising a Pāli word is the usual convention in writing about
+these texts, and here it is the wrong one: the reader renders what the markers contain in the script its user
+actually reads, so an italicised word is a word left behind in Latin.
+
+Mark the Pāli and nothing else — not the prose around it, not your translation of it, not English words borrowed
+from Pāli.
+
+## Writing the answer
+
+- Write in {{outputLanguage}}. Quoted Pāli stays Pāli.
+- Call them "Pāli texts", "the Tipiṭaka", "the canon", or "VRI texts"; say "the tradition" or "the commentarial
+  tradition" where you mean those.
+- Be concrete. Show the reader what is in the passage rather than summarizing it from a distance.
+- No preamble about what you are about to do. Answer.

--- a/src/CST.Avalonia/Resources/Ai/translate.md
+++ b/src/CST.Avalonia/Resources/Ai/translate.md
@@ -1,0 +1,35 @@
+{{book}}
+{{citation}}
+
+## Passage
+
+{{passage}}
+
+## Selection
+
+{{selection}}
+
+## Print apparatus for this window
+
+{{apparatus}}
+
+## What you were and were not given
+
+{{provisions}}
+
+---
+
+Translate this passage.
+
+- Translate what is here, sentence by sentence, in the order it appears. Do not summarize and do not paraphrase
+  past what the Pāli says.
+- Where a term has no clean equivalent, give your rendering and then the Pāli in brackets rather than choosing a
+  familiar English word that carries the wrong sense.
+- Where the syntax is genuinely ambiguous, translate the reading you judge best and say in one line what the
+  other reading would be. Do not silently pick one.
+- The print apparatus records variant readings from the printed editions. Where a variant would change the
+  translation, say so and say which reading you followed.
+
+If a selection is given, translate the selection and use the rest of the passage only as context.
+
+{{userQuestion}}

--- a/src/CST.Avalonia/Resources/Ai/translate.md
+++ b/src/CST.Avalonia/Resources/Ai/translate.md
@@ -23,8 +23,8 @@ Translate this passage.
 
 - Translate what is here, sentence by sentence, in the order it appears. Do not summarize and do not paraphrase
   past what the Pāli says.
-- Where a term has no clean equivalent, give your rendering and then the Pāli in brackets rather than choosing a
-  familiar English word that carries the wrong sense.
+- Where a term has no clean equivalent, give your rendering and then the Pāli in parentheses — marked as Pāli,
+  like every other Pāli word — rather than choosing a familiar English word that carries the wrong sense.
 - Where the syntax is genuinely ambiguous, translate the reading you judge best and say in one line what the
   other reading would be. Do not silently pick one.
 - The print apparatus records variant readings from the printed editions. Where a variant would change the

--- a/src/CST.Avalonia/Resources/Ai/word-by-word.md
+++ b/src/CST.Avalonia/Resources/Ai/word-by-word.md
@@ -27,7 +27,7 @@ Give a word-by-word reading of this Pāli.
 
 Take the words in the order they appear in the text. For each one:
 
-- the word as it appears, quoted;
+- the word as it appears in the text, wrapped in the Pāli markers;
 - its stem;
 - its form — case and number, or person, number, tense and voice;
 - what it means here, in this sentence.

--- a/src/CST.Avalonia/Resources/Ai/word-by-word.md
+++ b/src/CST.Avalonia/Resources/Ai/word-by-word.md
@@ -1,0 +1,50 @@
+{{book}}
+{{citation}}
+
+## Passage
+
+{{passage}}
+
+## Selection
+
+{{selection}}
+
+## Word analysis gathered for this request
+
+{{lemmas}}
+
+## Print apparatus for this window
+
+{{apparatus}}
+
+## What you were and were not given
+
+{{provisions}}
+
+---
+
+Give a word-by-word reading of this Pāli.
+
+Take the words in the order they appear in the text. For each one:
+
+- the word as it appears, quoted;
+- its stem;
+- its form — case and number, or person, number, tense and voice;
+- what it means here, in this sentence.
+
+Then give a single running translation of the whole.
+
+Rules:
+
+- Split compounds into their members and analyse each member, then say what the compound means as a whole.
+- Where sandhi has fused two words, separate them and say so.
+- Where a form could be read more than one way, give the reading this sentence supports and note the other in a
+  few words.
+- Say what the word means **here**. A dictionary range of senses is not a reading of this passage.
+
+The word analysis above is a candidate list, not an answer: it was built before anything read this sentence, and
+a word missing from it is a gap in the lookup, not a word without a meaning.
+
+If a selection is given, work through the selection and use the rest of the passage as its context.
+
+{{userQuestion}}

--- a/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
@@ -134,7 +134,8 @@ public sealed class AnthropicMessagesProvider : IChatProvider
         {
             json.WriteStartObject();
             json.WriteString("model", request.Model);
-            json.WriteNumber("max_tokens", request.MaxTokens);   // required by the API
+            // Required by the API, so a null request cap becomes the universal ceiling rather than an omission.
+            json.WriteNumber("max_tokens", request.MaxTokens ?? AiLimits.UniversalMaxTokens);
             json.WriteBoolean("stream", true);
 
             if (!string.IsNullOrEmpty(request.System))

--- a/src/CST.Avalonia/Services/Ai/ChatContracts.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatContracts.cs
@@ -3,6 +3,24 @@ using System.Collections.Generic;
 
 namespace CST.Avalonia.Services.Ai;
 
+/// <summary>Ceilings that are facts about the provider APIs rather than choices of ours.</summary>
+public static class AiLimits
+{
+    /// <summary>
+    /// The largest <c>max_tokens</c> valid across every current Claude model, used where the Anthropic API
+    /// requires a number and the caller did not choose one.
+    ///
+    /// <para><b>Why 64K and not 128K.</b> Opus 5, Sonnet 5, Fable 5 and the Opus 4.x family all cap output at
+    /// 128K, but <b>Haiku 4.5 caps at 64K</b> — and the model id here is whatever the user typed into Settings,
+    /// so the adapter cannot know which it is. 64K is the largest value that cannot 400 on any of them. A user
+    /// who wants the full 128K on a large model can say so once #584 carries per-model limits.</para>
+    ///
+    /// <para>This is a runaway guard, not a size estimate. Streaming is what keeps a cap this high safe: a
+    /// non-streaming request anywhere near it would hit the HTTP timeout first, and both adapters stream.</para>
+    /// </summary>
+    public const int UniversalMaxTokens = 64_000;
+}
+
 /// <summary>Who authored a turn. There is no System role — the system prompt is its own request field.</summary>
 public enum ChatRole
 {
@@ -18,12 +36,21 @@ public sealed record ChatMessage(ChatRole Role, string Content);
 /// translate this into their own wire format, so nothing provider-specific leaks into the caller.
 /// </summary>
 /// <param name="Model">Provider-specific model id, verbatim as the user configured it.</param>
-/// <param name="MaxTokens">Output cap. Required — the Anthropic API rejects a request without one.</param>
+/// <param name="MaxTokens">
+/// Output cap, or null for "do not specify one". <b>Null is the ordinary case</b>: an answer-shaped cap has to
+/// predict output length, and on a reasoning model it cannot — reasoning tokens count against the same budget,
+/// so the cap silently truncates or produces an empty answer (#601). Cost is better controlled by showing the
+/// user what each call spent (AI_SURFACE_B.md §10) than by a limit they never see.
+///
+/// <para>The two adapters differ because the wire formats do: the OpenAI-compatible shape omits the field
+/// entirely, which is the honest expression of "no limit"; the Anthropic Messages API <b>requires</b> a number,
+/// so that adapter substitutes <see cref="AiLimits.UniversalMaxTokens"/>.</para>
+/// </param>
 /// <param name="System">System prompt, or null. Anthropic carries it in a top-level field; the
 /// OpenAI-compatible shape carries it as a leading message, which the adapter handles.</param>
 public sealed record ChatRequest(
     string Model,
-    int MaxTokens,
+    int? MaxTokens,
     string? System,
     IReadOnlyList<ChatMessage> Messages);
 

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -155,7 +155,9 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
         {
             json.WriteStartObject();
             json.WriteString("model", request.Model);
-            json.WriteNumber("max_tokens", request.MaxTokens);
+            // Optional here, unlike Anthropic — omitting it is the honest expression of "no cap", and it lets
+            // a reasoning model spend what it needs on reasoning without starving the answer (#601).
+            if (request.MaxTokens is { } maxTokens) json.WriteNumber("max_tokens", maxTokens);
             json.WriteBoolean("stream", true);
 
             // Ask for usage on the final chunk. Providers that do not know the option ignore it.

--- a/src/CST.Avalonia/Services/Ai/PaliQuoteMarkers.cs
+++ b/src/CST.Avalonia/Services/Ai/PaliQuoteMarkers.cs
@@ -45,10 +45,11 @@ public static class PaliQuoteMarkers
 /// still be the first half of a marker.
 ///
 /// <para><b>Unbalanced markers are stripped anyway, and counted.</b> A model that opens a quote and never closes
-/// it should not put a literal <c>[[</c> on screen — a visible defect in the answer for a rule the user never
-/// asked about. But the imbalance is real signal about that model's marker discipline, so
-/// <see cref="UnbalancedMarkers"/> records it for #587 rather than discarding it silently. <see cref="Quotes"/>
-/// counts the properly closed ones, which is the other half of the same measurement.</para>
+/// it — or that doubles or nests the markers, which wikitext-trained models do — should not put a literal
+/// <c>[[</c> on screen. That is a visible defect in the answer for a rule the user never asked about. But the
+/// imbalance is real signal about that model's marker discipline, so <see cref="UnbalancedMarkers"/> records it
+/// for #587 rather than discarding it silently. <see cref="Quotes"/> counts the properly closed ones, which is
+/// the other half of the same measurement.</para>
 ///
 /// <para><b>What this deliberately does not do:</b> it does not preserve span boundaries. v1 renders the Pāli
 /// verbatim, so it needs only removal; v1.1's converter needs the spans themselves and should read them from the
@@ -81,26 +82,27 @@ public sealed class PaliQuoteFilter
         {
             var marker = _inside ? PaliQuoteMarkers.Close : PaliQuoteMarkers.Open;
 
-            // Outside a quote a stray closer is still a marker: strip it, count the imbalance, and carry on.
-            // Leaving it in would render "]]" at the user, which is the one outcome worse than losing the span.
-            if (!_inside)
+            // A marker that cannot be the one we are hunting for is still a marker, and rendering it is the one
+            // outcome worse than losing the span. So whichever comes first wins: outside a quote a stray CLOSER
+            // is stripped and counted; inside one a second OPENER is stripped and counted, and the quote stays
+            // open. The second case is not hypothetical — [[…]] is wikitext link syntax, so a model that has
+            // seen a lot of it will double or nest the markers, and without this "[[[[appamāda]]]]" put a
+            // literal "[[" on screen.
+            var other = _inside ? PaliQuoteMarkers.Open : PaliQuoteMarkers.Close;
+            var mine = buffer.IndexOf(marker, position, StringComparison.Ordinal);
+            var theirs = buffer.IndexOf(other, position, StringComparison.Ordinal);
+            if (theirs >= 0 && (mine < 0 || theirs < mine))
             {
-                var open = buffer.IndexOf(PaliQuoteMarkers.Open, position, StringComparison.Ordinal);
-                var stray = buffer.IndexOf(PaliQuoteMarkers.Close, position, StringComparison.Ordinal);
-                if (stray >= 0 && (open < 0 || stray < open))
-                {
-                    output.Append(buffer, position, stray - position);
-                    position = stray + PaliQuoteMarkers.Close.Length;
-                    UnbalancedMarkers++;
-                    continue;
-                }
+                output.Append(buffer, position, theirs - position);
+                position = theirs + other.Length;
+                UnbalancedMarkers++;
+                continue;
             }
 
-            var hit = buffer.IndexOf(marker, position, StringComparison.Ordinal);
-            if (hit >= 0)
+            if (mine >= 0)
             {
-                output.Append(buffer, position, hit - position);
-                position = hit + marker.Length;
+                output.Append(buffer, position, mine - position);
+                position = mine + marker.Length;
                 if (_inside) Quotes++;
                 _inside = !_inside;
                 continue;

--- a/src/CST.Avalonia/Services/Ai/PaliQuoteMarkers.cs
+++ b/src/CST.Avalonia/Services/Ai/PaliQuoteMarkers.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Text;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>
+/// The marker a model wraps quoted Pāli in, and the v1 reader that strips it back out. (#582, AI_SURFACE_B.md §9)
+///
+/// <para><b>Why this ships in v1 when v1 does nothing with it.</b> Answer prose and quoted Pāli are two axes:
+/// the user picks the answer language, and separately (from v1.1) the script the Pāli is rendered in. Converting
+/// a whole answer would mangle the prose around the quotes, so the model has to tell us which spans are Pāli.
+/// v1 renders those spans verbatim in Latin — but the <i>instruction</i> is in the system prompt from day one,
+/// because if it arrived in v1.1 the prompt shape would change after #587 had already baselined, and we would
+/// have learned nothing about per-model marker discipline in the meantime. That discipline is exactly the
+/// evidence that decides whether conversion is safe to enable for a given model tier.</para>
+///
+/// <para><b>Why <c>[[…]]</c>.</b> Two constraints. It must not occur in the corpus, and it must not occur in
+/// ordinary answer prose in any language the user might pick. A survey of all 217 XML books found zero
+/// occurrences of <c>[[</c>, <c>]]</c>, <c>«</c>, <c>»</c>, <c>⟦</c>, <c>⟧</c>, <c>{</c> and <c>}</c> — so corpus
+/// collision rules none of them out. (The braces the passage reader puts around inline notes are added by the
+/// renderer, not present in the source.) Prose collision rules out the guillemets: <c>« »</c> is the standard
+/// quotation mark in Russian and French, so a user who sets either as their answer language would have every
+/// ordinary quotation read as marked Pāli. The exotic bracket pair <c>⟦ ⟧</c> is collision-free but tests a weak
+/// model's Unicode fidelity rather than its instruction-following, which inverts what #587 is trying to measure.
+/// <c>[[…]]</c> is emittable by any model, absent from the corpus, and claimed by no language's punctuation.</para>
+/// </summary>
+public static class PaliQuoteMarkers
+{
+    public const string Open = "[[";
+    public const string Close = "]]";
+
+    /// <summary>
+    /// Strip markers from a complete string. For streamed text use <see cref="PaliQuoteFilter"/> instead — a
+    /// delta can end between the two brackets, and this would leak the half.
+    /// </summary>
+    public static string Strip(string text)
+    {
+        var filter = new PaliQuoteFilter();
+        return filter.Feed(text) + filter.Flush();
+    }
+}
+
+/// <summary>
+/// Removes <see cref="PaliQuoteMarkers"/> from streamed answer text, holding back a trailing bracket that could
+/// still be the first half of a marker.
+///
+/// <para><b>Unbalanced markers are stripped anyway, and counted.</b> A model that opens a quote and never closes
+/// it should not put a literal <c>[[</c> on screen — a visible defect in the answer for a rule the user never
+/// asked about. But the imbalance is real signal about that model's marker discipline, so
+/// <see cref="UnbalancedMarkers"/> records it for #587 rather than discarding it silently. <see cref="Quotes"/>
+/// counts the properly closed ones, which is the other half of the same measurement.</para>
+///
+/// <para><b>What this deliberately does not do:</b> it does not preserve span boundaries. v1 renders the Pāli
+/// verbatim, so it needs only removal; v1.1's converter needs the spans themselves and should read them from the
+/// accumulated answer rather than from this filter, because a span can straddle any number of deltas and
+/// buffering one to completion would stall the stream mid-sentence.</para>
+/// </summary>
+public sealed class PaliQuoteFilter
+{
+    private string _held = string.Empty;
+    private bool _inside;
+
+    /// <summary>Properly opened and closed quotes seen so far.</summary>
+    public int Quotes { get; private set; }
+
+    /// <summary>Markers that had no partner — an opener never closed, or a closer with nothing open.</summary>
+    public int UnbalancedMarkers { get; private set; }
+
+    /// <summary>Feed one delta of answer text; returns what should be rendered.</summary>
+    public string Feed(string chunk)
+    {
+        if (string.IsNullOrEmpty(chunk) && _held.Length == 0) return string.Empty;
+
+        var buffer = _held + chunk;
+        _held = string.Empty;
+
+        var output = new StringBuilder();
+        var position = 0;
+
+        while (position < buffer.Length)
+        {
+            var marker = _inside ? PaliQuoteMarkers.Close : PaliQuoteMarkers.Open;
+
+            // Outside a quote a stray closer is still a marker: strip it, count the imbalance, and carry on.
+            // Leaving it in would render "]]" at the user, which is the one outcome worse than losing the span.
+            if (!_inside)
+            {
+                var open = buffer.IndexOf(PaliQuoteMarkers.Open, position, StringComparison.Ordinal);
+                var stray = buffer.IndexOf(PaliQuoteMarkers.Close, position, StringComparison.Ordinal);
+                if (stray >= 0 && (open < 0 || stray < open))
+                {
+                    output.Append(buffer, position, stray - position);
+                    position = stray + PaliQuoteMarkers.Close.Length;
+                    UnbalancedMarkers++;
+                    continue;
+                }
+            }
+
+            var hit = buffer.IndexOf(marker, position, StringComparison.Ordinal);
+            if (hit >= 0)
+            {
+                output.Append(buffer, position, hit - position);
+                position = hit + marker.Length;
+                if (_inside) Quotes++;
+                _inside = !_inside;
+                continue;
+            }
+
+            // No complete marker ahead. A single trailing bracket could still become one on the next delta, so
+            // it waits. Both markers begin with a bracket and end with the same character, so this is one char
+            // either way — but it has to be checked against both, or a "]" held while outside would be released
+            // as text and its partner never recognised.
+            var hold = Math.Max(
+                TrailingMarkerPrefix(buffer, position, PaliQuoteMarkers.Open),
+                TrailingMarkerPrefix(buffer, position, PaliQuoteMarkers.Close));
+
+            var holdFrom = buffer.Length - hold;
+            output.Append(buffer, position, holdFrom - position);
+            _held = buffer[holdFrom..];
+            position = buffer.Length;
+        }
+
+        return output.ToString();
+    }
+
+    /// <summary>
+    /// End of stream. A held bracket was never going to complete a marker, so it was ordinary text; an
+    /// unclosed quote is counted as unbalanced now that no closer can arrive.
+    /// </summary>
+    public string Flush()
+    {
+        var tail = _held;
+        _held = string.Empty;
+        if (_inside)
+        {
+            UnbalancedMarkers++;
+            _inside = false;
+        }
+        return tail;
+    }
+
+    /// <summary>How much of the buffer's tail is a proper prefix of <paramref name="marker"/>.</summary>
+    private static int TrailingMarkerPrefix(string buffer, int from, string marker)
+    {
+        var max = Math.Min(marker.Length - 1, buffer.Length - from);
+        for (var length = max; length > 0; length--)
+        {
+            if (string.CompareOrdinal(buffer, buffer.Length - length, marker, 0, length) == 0)
+                return length;
+        }
+        return 0;
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
@@ -54,8 +54,13 @@ public sealed class PromptBuilder : IPromptBuilder
     /// <summary>
     /// Output cap per preset. Sized to the shape of the answer rather than uniformly: a word-by-word reading of
     /// a 600-character window is one entry per word plus a running translation, which is far more output than an
-    /// explanation of a passage four times the length. The failure mode of setting these too low is an answer
-    /// truncated mid-list, so they are generous — but the user is paying, so not unboundedly.
+    /// explanation of the 1600-character window Explain gets. The failure mode of setting these too low is an
+    /// answer truncated mid-list, so they lean high — but the user is paying, so not unboundedly.
+    ///
+    /// <para><b>These are estimates and #587 should check them.</b> A full 600-character window is roughly 90
+    /// words; at an entry apiece plus compound splits plus a running translation, word-by-word could plausibly
+    /// run past 3000 and truncate exactly where it hurts most. There is no local tokenizer to size this against,
+    /// so the number is reasoning, not measurement.</para>
     /// </summary>
     private static readonly Dictionary<AiTask, int> OutputBudget = new()
     {
@@ -72,7 +77,8 @@ public sealed class PromptBuilder : IPromptBuilder
     public RenderedPrompt Build(AiContextBundle bundle)
     {
         if (!OutputBudget.TryGetValue(bundle.Task, out var maxTokens))
-            throw new ArgumentOutOfRangeException(nameof(bundle), bundle.Task, "No output budget for this task.");
+            throw new ArgumentOutOfRangeException(
+                $"{nameof(bundle)}.{nameof(bundle.Task)}", bundle.Task, "No output budget for this task.");
 
         var presetName = PromptTemplateNames.ForTask(bundle.Task);
         var system = _templates.Get(PromptTemplateNames.System);
@@ -80,7 +86,9 @@ public sealed class PromptBuilder : IPromptBuilder
 
         // Which parts the inventory may claim is decided by what the preset actually renders, so the two cannot
         // disagree — including after a user edit. Both templates are scanned because either may carry it.
-        var shown = PlaceholdersUsed(system.Text + preset.Text);
+        // Scanned with a separator: "{{" ending the system template and "apparatus}}" opening the preset are
+        // each harmless alone, but concatenated they synthesize a placeholder neither template contains.
+        var shown = PlaceholdersUsed(system.Text + "\n" + preset.Text);
         var values = BuildValues(bundle, shown);
 
         return new RenderedPrompt(
@@ -168,7 +176,10 @@ public sealed class PromptBuilder : IPromptBuilder
         var extent = bundle.Budget.WindowMayExtendPastReference
             ? "It is a reading window starting there — not the whole text, and it may run on past the end of the "
               + "cited reference into what follows it."
-            : "It is a reading window starting there and running to the end of the book file — not the whole text.";
+            // Not "not the whole text": a short book read from the start IS wholly in the window, and telling
+            // the model otherwise buys hedging on an answer that did not need it.
+            : "It is a reading window starting there and running to the end of the book file, which may be less "
+              + "than the whole text.";
 
         return $"an excerpt from {where}. {extent}";
     }
@@ -252,10 +263,21 @@ public sealed class PromptBuilder : IPromptBuilder
                  + "the words could not be analysed.";
         }
 
+        // Order matters. Candidates in hand are reported as candidates whatever the budget report says about
+        // them — the DATA is the ground truth here, and a bookkeeping mismatch must not hide real analysis.
         if (bundle.Lemmas.Count == 0)
         {
+            // No part at all means no lookup was ATTEMPTED — the bundler gathers lemmas only for the
+            // grammatical presets. Reachable through a user override that adds {{lemmas}} to Explain, and
+            // "the lookup returned no candidates" there would describe a lookup that never ran.
+            if (part is null)
+                return "No word analysis was gathered for this request — this preset does not use it.";
+
+            var why = part.State == BundlePartState.TrimmedForBudget
+                ? " The list was also cut to fit the budget."
+                : string.Empty;
             return "The lookup returned no candidates for the words in this passage. That is a gap in the "
-                 + "lookup, not a statement about the words.";
+                 + "lookup, not a statement about the words." + why;
         }
 
         var table = new StringBuilder();
@@ -264,7 +286,7 @@ public sealed class PromptBuilder : IPromptBuilder
         foreach (var entry in bundle.Lemmas)
         {
             table.AppendLine(
-                $"| {entry.Form} | {entry.Lemma} | {entry.PartOfSpeech ?? "—"} | {Cell(entry.Gloss)} |");
+                $"| {Cell(entry.Form)} | {Cell(entry.Lemma)} | {Cell(entry.PartOfSpeech)} | {Cell(entry.Gloss)} |");
         }
 
         if (part is { State: BundlePartState.TrimmedForBudget })
@@ -278,7 +300,11 @@ public sealed class PromptBuilder : IPromptBuilder
         return table.ToString().TrimEnd();
     }
 
-    /// <summary>A pipe in a gloss would break the row it sits in; a newline would break the table.</summary>
+    /// <summary>
+    /// A pipe in a cell would break the row it sits in; a newline would break the table. Applied to every field,
+    /// not just the gloss: the stem and part-of-speech come from the separately versioned DPD asset, which this
+    /// code should not assume will stay pipe-free.
+    /// </summary>
     private static string Cell(string? value) =>
         string.IsNullOrWhiteSpace(value)
             ? "—"

--- a/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
@@ -11,7 +11,9 @@ namespace CST.Avalonia.Services.Ai;
 /// <summary>A prompt ready to send, plus what the panel should tell the user about how it was assembled.</summary>
 /// <param name="System">The shared system prompt, rendered.</param>
 /// <param name="UserContent">The single user turn: the context blocks and the preset's instruction.</param>
-/// <param name="MaxOutputTokens">Output cap for this preset. Required by the Anthropic API and sane everywhere.</param>
+/// <param name="MaxOutputTokens">Output cap for this preset, or null for "do not specify one" — the current
+/// default for every preset. See <see cref="PromptBuilder"/> for why, and <see cref="ChatRequest.MaxTokens"/>
+/// for what each adapter does with a null.</param>
 /// <param name="Notices">
 /// Degradations worth showing beside the answer — a missing asset, a trimmed part, a selection the window does
 /// not contain, a prompt edit that was rejected. The prompt states these to the MODEL; these state them to the
@@ -20,7 +22,7 @@ namespace CST.Avalonia.Services.Ai;
 public sealed record RenderedPrompt(
     string System,
     string UserContent,
-    int MaxOutputTokens,
+    int? MaxOutputTokens,
     IReadOnlyList<string> Notices);
 
 /// <summary>Turns a context bundle into a prompt. See <see cref="PromptBuilder"/>.</summary>
@@ -52,22 +54,28 @@ public interface IPromptBuilder
 public sealed class PromptBuilder : IPromptBuilder
 {
     /// <summary>
-    /// Output cap per preset. Sized to the shape of the answer rather than uniformly: a word-by-word reading of
-    /// a 600-character window is one entry per word plus a running translation, which is far more output than an
-    /// explanation of the 1600-character window Explain gets. The failure mode of setting these too low is an
-    /// answer truncated mid-list, so they lean high — but the user is paying, so not unboundedly.
+    /// Per-preset output cap — <b>the seam, deliberately unfilled</b>. Every entry is currently null, meaning
+    /// "do not specify a cap"; the table survives so #584/#585 can expose the cap per model in Settings without
+    /// reintroducing the concept (fsnow, 2026-08-11: <i>"that leaves a placeholder in case we want to expose
+    /// that in the model settings"</i>).
     ///
-    /// <para><b>These are estimates and #587 should check them.</b> A full 600-character window is roughly 90
-    /// words; at an entry apiece plus compound splits plus a running translation, word-by-word could plausibly
-    /// run past 3000 and truncate exactly where it hurts most. There is no local tokenizer to size this against,
-    /// so the number is reasoning, not measurement.</para>
+    /// <para><b>Why the values are gone.</b> An earlier version sized each preset to the expected length of its
+    /// answer — 1500 for Explain, 3000 for word-by-word. That is the wrong quantity to predict. On a reasoning
+    /// model the cap covers reasoning AND answer, and reasoning volume varies by an order of magnitude between
+    /// models: <c>minimax-m3</c> needed 3,177 completion tokens to translate a two-line verse, against a
+    /// budget of 2,400 (#601). The failure it buys is the worst-shaped one available — a translation cut off
+    /// mid-verse, or a blank panel, on a request the user already paid for. Cost is controlled by reporting
+    /// what each call spent (AI_SURFACE_B.md §10), not by a silent truncation.</para>
+    ///
+    /// <para>The table still earns its place at runtime: membership is what says a task is renderable at all,
+    /// so an <see cref="AiTask"/> added without a budget entry fails loudly here rather than silently.</para>
     /// </summary>
-    private static readonly Dictionary<AiTask, int> OutputBudget = new()
+    private static readonly Dictionary<AiTask, int?> OutputBudget = new()
     {
-        [AiTask.Explain] = 1500,
-        [AiTask.Translate] = 2400,
-        [AiTask.Grammar] = 1500,
-        [AiTask.WordByWord] = 3000,
+        [AiTask.Explain] = null,
+        [AiTask.Translate] = null,
+        [AiTask.Grammar] = null,
+        [AiTask.WordByWord] = null,
     };
 
     private readonly IPromptTemplateStore _templates;

--- a/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
@@ -1,0 +1,395 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CST;
+using CST.Navigation;
+using CST.Search;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>A prompt ready to send, plus what the panel should tell the user about how it was assembled.</summary>
+/// <param name="System">The shared system prompt, rendered.</param>
+/// <param name="UserContent">The single user turn: the context blocks and the preset's instruction.</param>
+/// <param name="MaxOutputTokens">Output cap for this preset. Required by the Anthropic API and sane everywhere.</param>
+/// <param name="Notices">
+/// Degradations worth showing beside the answer — a missing asset, a trimmed part, a selection the window does
+/// not contain, a prompt edit that was rejected. The prompt states these to the MODEL; these state them to the
+/// USER, which is the half that keeps "degrade visibly" honest. Empty on a clean build.
+/// </param>
+public sealed record RenderedPrompt(
+    string System,
+    string UserContent,
+    int MaxOutputTokens,
+    IReadOnlyList<string> Notices);
+
+/// <summary>Turns a context bundle into a prompt. See <see cref="PromptBuilder"/>.</summary>
+public interface IPromptBuilder
+{
+    RenderedPrompt Build(AiContextBundle bundle);
+}
+
+/// <summary>
+/// Renders the shared system prompt and the preset's instruction template against a context bundle. (#582)
+///
+/// <para><b>The division of labour.</b> #580's bundler decides WHAT to gather; this decides how it is said. The
+/// split is what lets a bundle be asserted against the real corpus with no model in sight, and it is why the
+/// templates can be user-editable without any of the gathering logic being exposed.</para>
+///
+/// <para><b>Every placeholder renders to a sentence, never to nothing.</b> The template engine has no
+/// conditionals (see <see cref="PromptPlaceholders"/>), so an absent selection or a missing lemma asset must
+/// still produce text — and the text says what is absent and why. That is the mechanism behind the plan's
+/// requirement that the lemma presets "degrade visibly, never silently": a model told the analysis was
+/// unavailable answers differently from one handed an empty heading, and differently again from one that was
+/// never told. The same facts reach the user through <see cref="RenderedPrompt.Notices"/>.</para>
+///
+/// <para><b>The scope statement is the load-bearing one.</b> Injection's characteristic failure is not
+/// hallucination but a truthful answer over a silently narrower scope than the user assumed — "explain this
+/// sutta" answered confidently from three paragraphs. The system prompt therefore opens by stating what the
+/// excerpt actually is, and the citation the app renders beside the answer comes from the same bundle data.
+/// (AI_SURFACE_B.md §6)</para>
+/// </summary>
+public sealed class PromptBuilder : IPromptBuilder
+{
+    /// <summary>
+    /// Output cap per preset. Sized to the shape of the answer rather than uniformly: a word-by-word reading of
+    /// a 600-character window is one entry per word plus a running translation, which is far more output than an
+    /// explanation of a passage four times the length. The failure mode of setting these too low is an answer
+    /// truncated mid-list, so they are generous — but the user is paying, so not unboundedly.
+    /// </summary>
+    private static readonly Dictionary<AiTask, int> OutputBudget = new()
+    {
+        [AiTask.Explain] = 1500,
+        [AiTask.Translate] = 2400,
+        [AiTask.Grammar] = 1500,
+        [AiTask.WordByWord] = 3000,
+    };
+
+    private readonly IPromptTemplateStore _templates;
+
+    public PromptBuilder(IPromptTemplateStore templates) => _templates = templates;
+
+    public RenderedPrompt Build(AiContextBundle bundle)
+    {
+        if (!OutputBudget.TryGetValue(bundle.Task, out var maxTokens))
+            throw new ArgumentOutOfRangeException(nameof(bundle), bundle.Task, "No output budget for this task.");
+
+        var presetName = PromptTemplateNames.ForTask(bundle.Task);
+        var system = _templates.Get(PromptTemplateNames.System);
+        var preset = _templates.Get(presetName);
+
+        // Which parts the inventory may claim is decided by what the preset actually renders, so the two cannot
+        // disagree — including after a user edit. Both templates are scanned because either may carry it.
+        var shown = PlaceholdersUsed(system.Text + preset.Text);
+        var values = BuildValues(bundle, shown);
+
+        return new RenderedPrompt(
+            Render(system.Text, values),
+            Render(preset.Text, values),
+            maxTokens,
+            BuildNotices(bundle, shown, PromptTemplateNames.System, presetName));
+    }
+
+    /// <summary>The placeholder names a template refers to.</summary>
+    private static IReadOnlySet<string> PlaceholdersUsed(string template) =>
+        PromptTemplateStore.PlaceholderPattern.Matches(template)
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The placeholder that shows a gathered part. A part with no entry here — or whose placeholder the template
+    /// does not use — is not something the model was shown, so the inventory must not claim it was.
+    /// </summary>
+    private static readonly Dictionary<string, string> PartPlaceholder = new(StringComparer.Ordinal)
+    {
+        [BundlePartNames.Passage] = PromptPlaceholders.Passage,
+        [BundlePartNames.Selection] = PromptPlaceholders.Selection,
+        [BundlePartNames.Lemmas] = PromptPlaceholders.Lemmas,
+        [BundlePartNames.Apparatus] = PromptPlaceholders.Apparatus,
+    };
+
+    /// <summary>
+    /// How a part is named to the USER. The internal part names are the prompt's and the budget report's
+    /// vocabulary, not a reader's — "the lemmas was cut" is neither English nor meaningful to someone who has
+    /// never heard the bundle described.
+    /// </summary>
+    private static string PartLabel(string partName) => partName switch
+    {
+        BundlePartNames.Passage => "passage",
+        BundlePartNames.Selection => "selection",
+        BundlePartNames.Lemmas => "word analysis",
+        BundlePartNames.Apparatus => "print apparatus",
+        _ => partName,
+    };
+
+    private static bool IsShown(BundlePart part, IReadOnlySet<string> shown) =>
+        PartPlaceholder.TryGetValue(part.Name, out var placeholder) && shown.Contains(placeholder);
+
+    /// <summary>
+    /// Substitute <c>{{name}}</c>. A placeholder with no value renders as empty — unreachable through
+    /// <see cref="PromptTemplateStore"/>, which rejects unknown names before a template is ever used, and
+    /// deliberately not an exception here so that a validation gap degrades to a gap in the prompt rather than
+    /// to an AI panel that cannot open.
+    /// </summary>
+    internal static string Render(string template, IReadOnlyDictionary<string, string> values) =>
+        PromptTemplateStore.PlaceholderPattern.Replace(
+            template,
+            match => values.TryGetValue(match.Groups[1].Value, out var value) ? value : string.Empty);
+
+    private static Dictionary<string, string> BuildValues(
+        AiContextBundle bundle, IReadOnlySet<string> shown) => new(StringComparer.Ordinal)
+    {
+        [PromptPlaceholders.OutputLanguage] = bundle.OutputLanguage,
+        [PromptPlaceholders.Scope] = Scope(bundle),
+        [PromptPlaceholders.PaliOpen] = PaliQuoteMarkers.Open,
+        [PromptPlaceholders.PaliClose] = PaliQuoteMarkers.Close,
+
+        [PromptPlaceholders.Passage] = bundle.Passage.Text.Trim(),
+        [PromptPlaceholders.Citation] = Citation(bundle.Citation),
+        [PromptPlaceholders.Book] = Book(bundle.Book),
+        [PromptPlaceholders.Selection] = Selection(bundle.Selection),
+        [PromptPlaceholders.Lemmas] = Lemmas(bundle),
+        [PromptPlaceholders.Apparatus] = Apparatus(bundle.Passage.Notes),
+        [PromptPlaceholders.UserQuestion] = UserQuestion(bundle.UserQuestion),
+        [PromptPlaceholders.Provisions] = Provisions(bundle.Budget, shown),
+    };
+
+    /// <summary>
+    /// What the excerpt actually is. Says the two things the model cannot work out for itself: that this is a
+    /// window rather than the text, and whether it runs on past the reference the citation names.
+    /// </summary>
+    private static string Scope(AiContextBundle bundle)
+    {
+        var where = $"{bundle.Citation.BookName}, at {bundle.Citation.NormalizedReference}";
+
+        // NextCursor being set means the window stopped before the end of the book FILE — not before the end of
+        // the paragraph — so all that can honestly be said is that it may carry text past the reference. See
+        // BudgetReport for why there is no truncation flag to report instead.
+        var extent = bundle.Budget.WindowMayExtendPastReference
+            ? "It is a reading window starting there — not the whole text, and it may run on past the end of the "
+              + "cited reference into what follows it."
+            : "It is a reading window starting there and running to the end of the book file — not the whole text.";
+
+        return $"an excerpt from {where}. {extent}";
+    }
+
+    private static string Citation(CitationRef citation)
+    {
+        var pages = citation.Pages.Count == 0
+            ? string.Empty
+            : " — " + string.Join(", ", citation.Pages.Select(PageRef));
+
+        return $"**Reference:** {citation.BookName}, {citation.NormalizedReference}{pages}";
+    }
+
+    private static string PageRef(SnippetPageRef page)
+    {
+        var edition = page.Edition switch
+        {
+            PageEdition.Vri => "VRI",
+            PageEdition.Myanmar => "Myanmar",
+            PageEdition.Pts => "PTS",
+            PageEdition.Thai => "Thai",
+            _ => "other",
+        };
+        return page.Volume > 0
+            ? $"{edition} vol. {page.Volume} p. {page.Number}"
+            : $"{edition} p. {page.Number}";
+    }
+
+    /// <summary>
+    /// Where the passage sits in the canon. Cheap, and it forecloses a category error a model would otherwise
+    /// have no way to avoid: a ṭīkā glossed as the word of the Buddha reads perfectly plausibly.
+    /// </summary>
+    private static string Book(BookContext book)
+    {
+        var pitaka = book.Pitaka switch
+        {
+            Pitaka.Vinaya => "Vinaya piṭaka",
+            Pitaka.Sutta => "Sutta piṭaka",
+            Pitaka.Abhidhamma => "Abhidhamma piṭaka",
+            _ => "outside the three piṭakas",
+        };
+
+        var level = book.CommentaryLevel switch
+        {
+            CommentaryLevel.Mula => "mūla — the canonical text itself",
+            CommentaryLevel.Atthakatha => "aṭṭhakathā — commentary on a canonical text",
+            CommentaryLevel.Tika => "ṭīkā — sub-commentary, commenting on an aṭṭhakathā",
+            _ => "an ancillary text",
+        };
+
+        return $"**Text:** {book.Name}\n**Place in the canon:** {pitaka}; {level}";
+    }
+
+    private static string Selection(SelectionContext? selection)
+    {
+        if (selection is null)
+            return "The reader has not selected anything. Treat the whole passage as being in view.";
+
+        // A selection the window does not contain means the surrounding text may not support what is being asked
+        // about — worth telling the model, since it is the difference between "explain this in context" and
+        // "explain this, and be aware the context you have may be the wrong context".
+        var note = selection.FoundInWindow
+            ? string.Empty
+            : "\n\n(This selection was not found in the passage above. The reader may have scrolled, or the "
+              + "selection may lie outside the window. Treat the surrounding text with corresponding caution.)";
+
+        return $"The reader has selected:\n\n> {selection.Text}{note}";
+    }
+
+    private static string Lemmas(AiContextBundle bundle)
+    {
+        // Distinguish "the asset is missing" from "the asset is here and matched nothing". Both leave the
+        // section empty; only the first is a thing the user can fix, and conflating them would have the model
+        // reporting a download problem as a fact about the Pāli.
+        var part = bundle.Budget.Parts.FirstOrDefault(p => p.Name == BundlePartNames.Lemmas);
+
+        if (part is { State: BundlePartState.Unavailable })
+        {
+            return "No word analysis is available for this request — the word-analysis data is not installed. "
+                 + "Work from the passage alone, and say that the analysis was unavailable rather than implying "
+                 + "the words could not be analysed.";
+        }
+
+        if (bundle.Lemmas.Count == 0)
+        {
+            return "The lookup returned no candidates for the words in this passage. That is a gap in the "
+                 + "lookup, not a statement about the words.";
+        }
+
+        var table = new StringBuilder();
+        table.AppendLine("| form in the text | stem | part of speech | gloss |");
+        table.AppendLine("|---|---|---|---|");
+        foreach (var entry in bundle.Lemmas)
+        {
+            table.AppendLine(
+                $"| {entry.Form} | {entry.Lemma} | {entry.PartOfSpeech ?? "—"} | {Cell(entry.Gloss)} |");
+        }
+
+        if (part is { State: BundlePartState.TrimmedForBudget })
+        {
+            table.AppendLine();
+            table.AppendLine(
+                "(This list was cut to fit the budget. Words missing from it were not analysed, and no "
+                + "conclusion follows from their absence.)");
+        }
+
+        return table.ToString().TrimEnd();
+    }
+
+    /// <summary>A pipe in a gloss would break the row it sits in; a newline would break the table.</summary>
+    private static string Cell(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? "—"
+            : value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ").Trim();
+
+    private static string Apparatus(IReadOnlyList<ApparatusNote> notes)
+    {
+        if (notes.Count == 0)
+            return "There are no print notes in this window.";
+
+        var text = new StringBuilder();
+        foreach (var note in notes)
+        {
+            var reading = string.IsNullOrWhiteSpace(note.Reading) ? null : note.Reading!.Trim();
+            var sigla = string.IsNullOrWhiteSpace(note.Sigla) ? null : note.Sigla!.Trim();
+
+            var suffix = (reading, sigla) switch
+            {
+                (not null, not null) => $" — reading *{reading}* in {sigla}",
+                (not null, null) => $" — reading *{reading}*",
+                (null, not null) => $" — in {sigla}",
+                _ => string.Empty,
+            };
+
+            text.AppendLine($"- {note.Text.Trim()}{suffix}");
+        }
+
+        text.AppendLine();
+        text.AppendLine(
+            "These are footnotes from the printed editions, recording variant readings. They are evidence about "
+            + "the text, not part of it.");
+
+        return text.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// The user's own question, verbatim and last, where it carries most weight.
+    ///
+    /// <para><b>Deliberately not length-capped.</b> A cap would silently discard part of what the user asked, to
+    /// prevent an over-long request that the provider already reports precisely — <c>AiErrorKind.ContextTooLong</c>
+    /// exists for it, and an explicit error the user can act on beats a truncation they cannot see.</para>
+    /// </summary>
+    private static string UserQuestion(string? question) =>
+        string.IsNullOrWhiteSpace(question)
+            ? string.Empty
+            : $"## The reader asks\n\n{question.Trim()}";
+
+    /// <summary>
+    /// An inventory of what was gathered, in the prompt, so the model can qualify its answer instead of reading
+    /// an empty section as an absence in the text.
+    /// </summary>
+    private static string Provisions(BudgetReport budget, IReadOnlySet<string> shown)
+    {
+        var parts = budget.Parts.Where(p => IsShown(p, shown)).ToList();
+        if (parts.Count == 0) return "(no parts were recorded for this request)";
+
+        var lines = parts.Select(part =>
+        {
+            var state = part.State switch
+            {
+                BundlePartState.Included => "given",
+                BundlePartState.TrimmedForBudget => "given, but cut to fit the budget",
+                BundlePartState.Unavailable => "NOT AVAILABLE",
+                BundlePartState.Empty => "nothing to give",
+                _ => part.State.ToString(),
+            };
+            var detail = string.IsNullOrWhiteSpace(part.Detail) ? string.Empty : $" ({part.Detail})";
+            return $"- **{part.Name}** — {state}{detail}";
+        });
+
+        return string.Join("\n", lines);
+    }
+
+    /// <summary>
+    /// The same facts the prompt tells the model, told to the user. A degradation the model is warned about and
+    /// the user is not is still a silent one from where the user is sitting.
+    /// </summary>
+    private IReadOnlyList<string> BuildNotices(
+        AiContextBundle bundle, IReadOnlySet<string> shown, params string[] templateNames)
+    {
+        var notices = new List<string>();
+
+        // A prompt edit that was found and rejected is the one degradation the model cannot be told about — the
+        // template carrying the news is the one that failed to load. Telling the user is the only channel left,
+        // and without it they read answers produced by a prompt they believe they replaced.
+        foreach (var name in templateNames)
+        {
+            if (_templates.RejectedOverrides.TryGetValue(name, out var problems))
+            {
+                notices.Add(
+                    $"Your edited '{name}' prompt was not used ({string.Join("; ", problems)}). "
+                    + "The built-in prompt was used instead.");
+            }
+        }
+
+        // Only parts this prompt would actually have shown. Reporting a missing word-analysis asset beside an
+        // Explain answer, which never asks for one, is a nag about something that did not affect the answer.
+        foreach (var part in bundle.Budget.Parts.Where(p => IsShown(p, shown)))
+        {
+            if (part.State == BundlePartState.Unavailable)
+                notices.Add($"The {PartLabel(part.Name)} could not be gathered: {part.Detail ?? "not available"}.");
+            else if (part.State == BundlePartState.TrimmedForBudget)
+                notices.Add($"The {PartLabel(part.Name)} was cut to fit the request budget.");
+        }
+
+        if (bundle.Selection is { FoundInWindow: false })
+            notices.Add("The selected text was not found in the passage window the model was given.");
+
+        if (bundle.Budget.WindowMayExtendPastReference)
+            notices.Add("The passage window may extend past the end of the cited reference.");
+
+        return notices;
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/PromptTemplates.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptTemplates.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using CST.Avalonia.Constants;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>
+/// The names of the prompt templates. Strings rather than an enum because they are also FILE NAMES for the user
+/// override, and an enum would put a rename one refactor away from orphaning everyone's edits.
+/// </summary>
+public static class PromptTemplateNames
+{
+    /// <summary>The shared system prompt — the grounding contract. Sent with every preset.</summary>
+    public const string System = "system";
+
+    public const string Explain = "explain";
+    public const string Translate = "translate";
+    public const string Grammar = "grammar";
+    public const string WordByWord = "word-by-word";
+
+    public static IReadOnlyList<string> All { get; } =
+        new[] { System, Explain, Translate, Grammar, WordByWord };
+
+    /// <summary>The instruction template for a preset.</summary>
+    public static string ForTask(AiTask task) => task switch
+    {
+        AiTask.Explain => Explain,
+        AiTask.Translate => Translate,
+        AiTask.Grammar => Grammar,
+        AiTask.WordByWord => WordByWord,
+        _ => throw new ArgumentOutOfRangeException(nameof(task), task, "No prompt template for this task."),
+    };
+}
+
+/// <summary>
+/// The values a template may substitute. <b>Substitution only — no conditionals, no loops, no expressions.</b>
+///
+/// <para>That is a deliberate ceiling, because these templates are user-editable (#585) and a template language
+/// with control flow is a small programming language the user can break in ways we then have to diagnose. The
+/// cost is that a placeholder cannot be omitted when it has nothing to say — so instead every value renders as
+/// something self-describing, and "the user selected nothing" is a sentence rather than an empty slot. That
+/// turns out to be the better prompt anyway: a model told the selection is absent behaves differently from one
+/// handed a blank.</para>
+/// </summary>
+public static class PromptPlaceholders
+{
+    public const string OutputLanguage = "outputLanguage";
+    public const string Scope = "scope";
+    public const string PaliOpen = "paliOpen";
+    public const string PaliClose = "paliClose";
+
+    public const string Passage = "passage";
+    public const string Citation = "citation";
+    public const string Book = "book";
+    public const string Selection = "selection";
+    public const string Lemmas = "lemmas";
+    public const string Apparatus = "apparatus";
+    public const string UserQuestion = "userQuestion";
+    public const string Provisions = "provisions";
+
+    /// <summary>Every placeholder any template may use. An unknown one is a template error, not an empty string.</summary>
+    public static IReadOnlySet<string> Known { get; } = new HashSet<string>(StringComparer.Ordinal)
+    {
+        OutputLanguage, Scope, PaliOpen, PaliClose,
+        Passage, Citation, Book, Selection, Lemmas, Apparatus, UserQuestion, Provisions,
+    };
+
+    /// <summary>
+    /// What a template cannot do without. These are the load-bearing ones: a preset template that has lost
+    /// <c>{{passage}}</c> asks the model to explain nothing, and one that has lost <c>{{citation}}</c> invites an
+    /// answer with no scope attached — the exact failure AI_SURFACE_B.md §6 is written against. The system
+    /// template's requirements carry the marking instruction and the answer language.
+    /// </summary>
+    public static IReadOnlyDictionary<string, IReadOnlyList<string>> Required { get; } =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+        {
+            [PromptTemplateNames.System] = new[] { OutputLanguage, Scope, PaliOpen, PaliClose },
+            [PromptTemplateNames.Explain] = new[] { Passage, Citation },
+            [PromptTemplateNames.Translate] = new[] { Passage, Citation },
+            [PromptTemplateNames.Grammar] = new[] { Passage, Citation, Lemmas },
+            [PromptTemplateNames.WordByWord] = new[] { Passage, Citation, Lemmas },
+        };
+}
+
+/// <summary>A template and where it came from.</summary>
+/// <param name="IsUserEdited">True when a valid user override was loaded. Drives "reset to default" in Settings.</param>
+public sealed record PromptTemplate(string Name, string Text, bool IsUserEdited);
+
+/// <summary>Thrown when a template cannot be used. Carries the reasons so an editor can show them.</summary>
+public sealed class PromptTemplateException : Exception
+{
+    public PromptTemplateException(string name, IReadOnlyList<string> problems)
+        : base($"Prompt template '{name}' is not usable: {string.Join("; ", problems)}")
+    {
+        TemplateName = name;
+        Problems = problems;
+    }
+
+    public string TemplateName { get; }
+    public IReadOnlyList<string> Problems { get; }
+}
+
+/// <summary>Reads the prompt templates, preferring a valid user override to the built-in default.</summary>
+public interface IPromptTemplateStore
+{
+    /// <summary>The template in force. Never throws for a bad override — see <see cref="PromptTemplateStore"/>.</summary>
+    PromptTemplate Get(string name);
+
+    /// <summary>The built-in text, whatever the user has done to their copy.</summary>
+    string GetDefault(string name);
+
+    /// <summary>Validate and persist a user override. Throws <see cref="PromptTemplateException"/> if invalid.</summary>
+    void Save(string name, string text);
+
+    /// <summary>Discard the user override and go back to the built-in.</summary>
+    void Reset(string name);
+
+    /// <summary>
+    /// Overrides that were found but rejected, by template name — so Settings can say WHICH edit was ignored
+    /// and why, rather than leaving the user with a template they believe is in force and is not.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<string>> RejectedOverrides { get; }
+}
+
+/// <summary>
+/// Prompt templates as data: built-in defaults are embedded resources, and the user may override any of them
+/// with a file in <c>&lt;app data&gt;/ai-templates/</c>. (#582, AI_SURFACE_B.md §4)
+///
+/// <para><b>A bad override falls back rather than throwing.</b> An unusable template is a configuration mistake,
+/// and taking the AI panel out of service for one would be a bad trade — but falling back SILENTLY would be
+/// worse than either, because the user would go on believing their edit was in force while reading answers
+/// produced by a different prompt. So: fall back, log, and record the reasons in
+/// <see cref="RejectedOverrides"/> for Settings to surface. <see cref="Save"/> validates up front, so the
+/// ordinary path is that a bad edit is refused at the point of editing and never reaches disk.</para>
+///
+/// <para><b>Validation is placeholder-shaped, not prose-shaped.</b> An unknown <c>{{placeholder}}</c> is
+/// rejected because it would otherwise reach the model as a literal brace pair, and a missing REQUIRED one is
+/// rejected because it silently removes the passage, the citation, or the marking instruction from the prompt.
+/// What the user writes AROUND the placeholders is theirs — including instructions we would not have written.
+/// The grounding contract is defended by making its inputs non-removable, not by policing wording.</para>
+/// </summary>
+public sealed class PromptTemplateStore : IPromptTemplateStore
+{
+    /// <summary>Matches <c>{{name}}</c>, tolerating inner spaces so <c>{{ passage }}</c> is not a mystery failure.</summary>
+    internal static readonly Regex PlaceholderPattern = new(@"\{\{\s*([A-Za-z][A-Za-z0-9]*)\s*\}\}", RegexOptions.Compiled);
+
+    private readonly string _overrideDirectory;
+    private readonly ILogger<PromptTemplateStore> _logger;
+    private readonly Dictionary<string, IReadOnlyList<string>> _rejected = new(StringComparer.Ordinal);
+
+    public PromptTemplateStore(ILogger<PromptTemplateStore> logger)
+        : this(Path.Combine(AppConstants.DataDirectory, "ai-templates"), logger)
+    {
+    }
+
+    /// <summary>Test seam: point the store at a temp directory instead of the user's real one.</summary>
+    internal PromptTemplateStore(string overrideDirectory, ILogger<PromptTemplateStore> logger)
+    {
+        _overrideDirectory = overrideDirectory;
+        _logger = logger;
+    }
+
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> RejectedOverrides => _rejected;
+
+    public PromptTemplate Get(string name)
+    {
+        var builtIn = GetDefault(name);
+
+        var path = OverridePath(name);
+        string text;
+        try
+        {
+            if (!File.Exists(path))
+            {
+                _rejected.Remove(name);
+                return new PromptTemplate(name, builtIn, IsUserEdited: false);
+            }
+
+            text = File.ReadAllText(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogWarning(ex, "Could not read the prompt template override at {Path}; using the built-in", path);
+            _rejected[name] = new[] { "the override file could not be read" };
+            return new PromptTemplate(name, builtIn, IsUserEdited: false);
+        }
+
+        var problems = Validate(name, text);
+        if (problems.Count > 0)
+        {
+            _logger.LogWarning(
+                "Prompt template override '{Name}' is not usable ({Problems}); using the built-in",
+                name, string.Join("; ", problems));
+            _rejected[name] = problems;
+            return new PromptTemplate(name, builtIn, IsUserEdited: false);
+        }
+
+        _rejected.Remove(name);
+        return new PromptTemplate(name, text, IsUserEdited: true);
+    }
+
+    public string GetDefault(string name)
+    {
+        if (!PromptTemplateNames.All.Contains(name))
+            throw new ArgumentOutOfRangeException(nameof(name), name, "Not a prompt template name.");
+
+        // Missing means a build problem — the resource is embedded from this same project — so it fails loudly
+        // rather than degrading to an empty prompt, which would produce confident answers about nothing.
+        return ReadResource($"Ai.{name}.md")
+               ?? throw new PromptTemplateException(name, new[] { "the built-in template resource is missing" });
+    }
+
+    public void Save(string name, string text)
+    {
+        var problems = Validate(name, text);
+        if (problems.Count > 0) throw new PromptTemplateException(name, problems);
+
+        Directory.CreateDirectory(_overrideDirectory);
+        File.WriteAllText(OverridePath(name), text, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        _rejected.Remove(name);
+        _logger.LogInformation("Saved a user override for prompt template '{Name}'", name);
+    }
+
+    public void Reset(string name)
+    {
+        var path = OverridePath(name);
+        if (File.Exists(path)) File.Delete(path);
+        _rejected.Remove(name);
+        _logger.LogInformation("Reset prompt template '{Name}' to the built-in default", name);
+    }
+
+    /// <summary>Everything wrong with a template, all at once — an editor showing one error at a time is a chore.</summary>
+    internal static IReadOnlyList<string> Validate(string name, string text)
+    {
+        if (!PromptTemplateNames.All.Contains(name))
+            throw new ArgumentOutOfRangeException(nameof(name), name, "Not a prompt template name.");
+
+        var problems = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            problems.Add("the template is empty");
+            return problems;
+        }
+
+        var used = PlaceholderPattern.Matches(text)
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var unknown in used.Where(u => !PromptPlaceholders.Known.Contains(u)).OrderBy(u => u, StringComparer.Ordinal))
+            problems.Add($"{{{{{unknown}}}}} is not a placeholder this template can use");
+
+        foreach (var required in PromptPlaceholders.Required[name].Where(r => !used.Contains(r)))
+            problems.Add($"{{{{{required}}}}} is required and is missing");
+
+        return problems;
+    }
+
+    private string OverridePath(string name) => Path.Combine(_overrideDirectory, name + ".md");
+
+    private static string? ReadResource(string endsWith)
+    {
+        var assembly = typeof(PromptTemplateStore).Assembly;
+        var resource = assembly.GetManifestResourceNames()
+            .FirstOrDefault(n => n.EndsWith(endsWith, StringComparison.OrdinalIgnoreCase));
+        if (resource is null) return null;
+
+        using var stream = assembly.GetManifestResourceStream(resource);
+        if (stream is null) return null;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/PromptTemplates.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptTemplates.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -72,19 +73,27 @@ public static class PromptPlaceholders
     };
 
     /// <summary>
-    /// What a template cannot do without. These are the load-bearing ones: a preset template that has lost
-    /// <c>{{passage}}</c> asks the model to explain nothing, and one that has lost <c>{{citation}}</c> invites an
-    /// answer with no scope attached — the exact failure AI_SURFACE_B.md §6 is written against. The system
-    /// template's requirements carry the marking instruction and the answer language.
+    /// What a template cannot do without. Two kinds, both load-bearing.
+    ///
+    /// <para><b>The grounding contract's inputs.</b> A preset template that has lost <c>{{passage}}</c> asks the
+    /// model to explain nothing; one that has lost <c>{{citation}}</c> invites an answer with no scope attached —
+    /// the exact failure AI_SURFACE_B.md §6 is written against. The system template's requirements carry the
+    /// marking instruction and the answer language.</para>
+    ///
+    /// <para><b>The user's own inputs.</b> <c>{{selection}}</c> and <c>{{userQuestion}}</c> are required for the
+    /// same reason, and arguably a stronger one: an override that drops them validates cleanly, and the user then
+    /// selects a phrase, types a question, and gets an answer that saw neither — with nothing to indicate it.
+    /// That is the one silence this design promises not to permit, and it is worse than the equivalent for the
+    /// passage because the user WATCHED themselves supply the input.</para>
     /// </summary>
     public static IReadOnlyDictionary<string, IReadOnlyList<string>> Required { get; } =
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
         {
             [PromptTemplateNames.System] = new[] { OutputLanguage, Scope, PaliOpen, PaliClose },
-            [PromptTemplateNames.Explain] = new[] { Passage, Citation },
-            [PromptTemplateNames.Translate] = new[] { Passage, Citation },
-            [PromptTemplateNames.Grammar] = new[] { Passage, Citation, Lemmas },
-            [PromptTemplateNames.WordByWord] = new[] { Passage, Citation, Lemmas },
+            [PromptTemplateNames.Explain] = new[] { Passage, Citation, Selection, UserQuestion },
+            [PromptTemplateNames.Translate] = new[] { Passage, Citation, Selection, UserQuestion },
+            [PromptTemplateNames.Grammar] = new[] { Passage, Citation, Lemmas, Selection, UserQuestion },
+            [PromptTemplateNames.WordByWord] = new[] { Passage, Citation, Lemmas, Selection, UserQuestion },
         };
 }
 
@@ -152,7 +161,11 @@ public sealed class PromptTemplateStore : IPromptTemplateStore
 
     private readonly string _overrideDirectory;
     private readonly ILogger<PromptTemplateStore> _logger;
-    private readonly Dictionary<string, IReadOnlyList<string>> _rejected = new(StringComparer.Ordinal);
+    // Concurrent because this is a DI SINGLETON and Get mutates on every call, including the no-override path.
+    // #583's orchestrator and the surface-C endpoints can both be building a prompt at once — a user driving the
+    // panel while an MCP agent hits the API is the ordinary cold-agent test setup, not an exotic one — and a
+    // plain Dictionary under concurrent write corrupts or throws from deep inside prompt assembly.
+    private readonly ConcurrentDictionary<string, IReadOnlyList<string>> _rejected = new(StringComparer.Ordinal);
 
     public PromptTemplateStore(ILogger<PromptTemplateStore> logger)
         : this(Path.Combine(AppConstants.DataDirectory, "ai-templates"), logger)
@@ -166,7 +179,9 @@ public sealed class PromptTemplateStore : IPromptTemplateStore
         _logger = logger;
     }
 
-    public IReadOnlyDictionary<string, IReadOnlyList<string>> RejectedOverrides => _rejected;
+    /// <summary>A snapshot. Handing out the live map would let a caller enumerate it mid-write.</summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> RejectedOverrides =>
+        new Dictionary<string, IReadOnlyList<string>>(_rejected, StringComparer.Ordinal);
 
     public PromptTemplate Get(string name)
     {
@@ -178,7 +193,7 @@ public sealed class PromptTemplateStore : IPromptTemplateStore
         {
             if (!File.Exists(path))
             {
-                _rejected.Remove(name);
+                _rejected.TryRemove(name, out _);
                 return new PromptTemplate(name, builtIn, IsUserEdited: false);
             }
 
@@ -201,14 +216,13 @@ public sealed class PromptTemplateStore : IPromptTemplateStore
             return new PromptTemplate(name, builtIn, IsUserEdited: false);
         }
 
-        _rejected.Remove(name);
+        _rejected.TryRemove(name, out _);
         return new PromptTemplate(name, text, IsUserEdited: true);
     }
 
     public string GetDefault(string name)
     {
-        if (!PromptTemplateNames.All.Contains(name))
-            throw new ArgumentOutOfRangeException(nameof(name), name, "Not a prompt template name.");
+        EnsureKnown(name);
 
         // Missing means a build problem — the resource is embedded from this same project — so it fails loudly
         // rather than degrading to an empty prompt, which would produce confident answers about nothing.
@@ -223,23 +237,26 @@ public sealed class PromptTemplateStore : IPromptTemplateStore
 
         Directory.CreateDirectory(_overrideDirectory);
         File.WriteAllText(OverridePath(name), text, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-        _rejected.Remove(name);
+        _rejected.TryRemove(name, out _);
         _logger.LogInformation("Saved a user override for prompt template '{Name}'", name);
     }
 
     public void Reset(string name)
     {
+        // Validated like Get and Save. Without this Reset("../../notes") deletes an arbitrary .md — harmless
+        // while every caller is trusted, and not once #585 puts a Settings control in front of it.
+        EnsureKnown(name);
+
         var path = OverridePath(name);
         if (File.Exists(path)) File.Delete(path);
-        _rejected.Remove(name);
+        _rejected.TryRemove(name, out _);
         _logger.LogInformation("Reset prompt template '{Name}' to the built-in default", name);
     }
 
     /// <summary>Everything wrong with a template, all at once — an editor showing one error at a time is a chore.</summary>
     internal static IReadOnlyList<string> Validate(string name, string text)
     {
-        if (!PromptTemplateNames.All.Contains(name))
-            throw new ArgumentOutOfRangeException(nameof(name), name, "Not a prompt template name.");
+        EnsureKnown(name);
 
         var problems = new List<string>();
 
@@ -259,7 +276,25 @@ public sealed class PromptTemplateStore : IPromptTemplateStore
         foreach (var required in PromptPlaceholders.Required[name].Where(r => !used.Contains(r)))
             problems.Add($"{{{{{required}}}}} is required and is missing");
 
+        // Anything brace-shaped the identifier grammar could not see. {{user_question}}, {{word-by-word}},
+        // {{2lemmas}}, {{ pass age }} and an unclosed {{passage all fail to match, so without this pass they are
+        // INVISIBLE to the unknown-name check above and reach the model as literal braces — the precise outcome
+        // that check exists to prevent, arriving through the one door it does not cover.
+        var residue = PlaceholderPattern.Replace(text, string.Empty);
+        if (residue.Contains("{{", StringComparison.Ordinal) || residue.Contains("}}", StringComparison.Ordinal))
+        {
+            problems.Add(
+                "there is a '{{' or '}}' that is not a valid placeholder — check for a typo, a space, or a "
+                + "missing brace");
+        }
+
         return problems;
+    }
+
+    private static void EnsureKnown(string name)
+    {
+        if (!PromptTemplateNames.All.Contains(name))
+            throw new ArgumentOutOfRangeException(nameof(name), name, "Not a prompt template name.");
     }
 
     private string OverridePath(string name) => Path.Combine(_overrideDirectory, name + ".md");


### PR DESCRIPTION
Closes #582. Part of epic #186. Plan: [`AI_SURFACE_B.md`](https://github.com/fsnow/cst/blob/main/docs/features/planned/AI_SURFACE_B.md) §4, §6, §9.

#580 decided *what* to gather. This decides *how it is said*, and what the model is told about the difference.

## What's here

- **`Resources/Ai/*.md`** — the shared system prompt and one instruction template per preset, embedded.
- **`PromptTemplateStore`** — built-in defaults, user override in `<app data>/ai-templates/`, validate/save/reset.
- **`PromptBuilder`** — `AiContextBundle` → `RenderedPrompt(System, UserContent, MaxOutputTokens, Notices)`.
- **`PaliQuoteMarkers` / `PaliQuoteFilter`** — the marker contract and its streaming-safe v1 reader.

`#583` composes the `ChatRequest`: this layer deliberately knows nothing about the configured model.

## The grounding contract

The system prompt carries §6's fences, because injection's characteristic failure is not hallucination but a **truthful answer over a silently narrower scope than the user assumed**. It opens by stating what the excerpt actually is, instructs the model to name its scope, refuses cross-corpus questions toward the reader's own search rather than letting it improvise from training data, and states that nothing injected is authoritative and that **absence is not evidence**.

## Two design calls worth a look

**The template engine is substitution-only** — no conditionals, no loops. These are user-editable (#585), and control flow makes them a small programming language whose breakage we then diagnose. The cost is that a placeholder can't be omitted when it has nothing to say, so every value renders as a self-describing sentence instead. That's what makes *"degrade visibly, never silently"* fall out of the design rather than rest on discipline: a missing word-analysis asset says so, in the prompt **and** in a user-facing notice, instead of leaving a blank heading the model reads as an absence in the text.

**A bad override falls back to the built-in, loudly.** Silent fallback would leave the user reading answers from a prompt they believe they replaced — so the reasons are recorded and surfaced as a notice.

## The marker is `[[…]]`

Instructed from v1 though v1 only strips it, so #587 baselines on the final prompt shape. A survey of all 217 books found **zero** occurrences of every candidate (`[[`, `«`, `⟦`, `{`, `|`, `¶`), so corpus collision decided nothing. Prose collision did: `« »` is the standard quotation mark in Russian and French, and a user answering in either would have every ordinary quotation read as marked Pāli. `⟦…⟧` would measure a weak model's Unicode fidelity rather than its instruction-following, which inverts what #587 is trying to learn.

Unbalanced markers are stripped anyway and **counted** — a literal `[[` on screen is a defect for a rule the user never asked about, but the imbalance is signal for #587.

## What the live run found that review didn't

One call to `gpt-oss:120b-cloud` through the #578 provider layer:

- **Reading a dumped prompt** (not a test) caught the inventory claiming `apparatus — given` on presets whose template never rendered it — the model told it had been given something it couldn't see. The inventory now derives from the template's own placeholders, so the two agree by construction, including after a user edit.
- **Every fence held** — cross-corpus refusal, scope naming, no invented references, house terminology.
- **Marker discipline failed on inline terms**: block quotes marked, `*appamāda*` in italics. Fixed by *naming the competing convention* — "an italicised word is a word left behind in Latin" — where stating the requirement had not worked. Verified by a second run.
- **It mistranslated the verse in front of it** — `maccuno padaṃ` as "the samsaric condition", `yathā matā` read from *maññati* rather than *marati*. Not fixable by prompting; filed as **case 2** in `PALI_FIDELITY_CASES.md`, which is exactly the evidence #584's fidelity advisory exists to carry. Case 1's open follow-up also gets its first (incidental) grounded observation.

## Testing

53 new tests; **1257/1257** pass. Every shipped template is asserted against the same validation user edits face — they're data, so nothing about them is checked at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)