### PR TITLE
Find in Page: Cmd/Ctrl+F in the current book (#570)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/CefBrowserAccessTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CefBrowserAccessTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using CST.Avalonia.Services;
 using Xunit;
 
@@ -68,6 +69,87 @@ public class CefBrowserAccessTests
         Assert.NotNull(getHost);
         Assert.True(getHost!.IsPublic);
         Assert.Equal(typeof(Xilium.CefGlue.CefBrowserHost), getHost.ReturnType);
+    }
+
+    // ---- Find in Page (#570) -------------------------------------------------------------------
+    // Find reaches CEF through the same chain, plus three API surfaces of its own. All three are ordinary
+    // public API rather than reflection, so a rename is a compile error — but the FindHandler PROPERTY is
+    // the extension point the whole feature hangs on, and a change to its accessibility or type would be a
+    // silent behaviour loss rather than a build break.
+
+    [Fact]
+    public void BaseCefBrowser_StillExposesASettableFindHandler()
+    {
+        var prop = typeof(Xilium.CefGlue.Common.BaseCefBrowser)
+            .GetProperty("FindHandler", System.Reflection.BindingFlags.Instance |
+                                        System.Reflection.BindingFlags.Public |
+                                        System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(prop);
+        Assert.True(prop!.SetMethod?.IsPublic == true,
+            "BaseCefBrowser.FindHandler no longer has a public setter. Find in Page attaches its result " +
+            "handler through it; without that, searches still run but no match counts ever arrive.");
+        Assert.True(typeof(Xilium.CefGlue.Common.Handlers.FindHandler).IsAssignableFrom(prop.PropertyType),
+            $"BaseCefBrowser.FindHandler is now '{prop.PropertyType}'.");
+    }
+
+    [Fact]
+    public void FindHandler_IsStillSubclassable()
+    {
+        // CstFindHandler derives from it and overrides OnFindResult. A sealed class or a non-virtual
+        // callback would break find with no compile error at the call sites.
+        var t = typeof(Xilium.CefGlue.Common.Handlers.FindHandler);
+        Assert.True(t.IsPublic);
+        Assert.False(t.IsSealed);
+
+        // It is ABSTRACT with a PROTECTED parameterless constructor — subclassable, which is the whole
+        // requirement, but not directly instantiable. (GetConstructor's default overload only returns
+        // public ones, which is why the accessibility has to be asked for explicitly.)
+        var ctor = t.GetConstructor(
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public |
+            System.Reflection.BindingFlags.NonPublic,
+            binder: null, System.Type.EmptyTypes, modifiers: null);
+        Assert.NotNull(ctor);
+        Assert.True(ctor!.IsPublic || ctor.IsFamily,
+            "Handlers.FindHandler's parameterless constructor is no longer reachable from a subclass, " +
+            "so CstFindHandler cannot derive from it.");
+
+        // OnFindResult is declared on the BASE, Xilium.CefGlue.CefFindHandler, and reflection does not
+        // return non-public members of base classes — so it has to be looked up where it lives.
+        Assert.True(typeof(Xilium.CefGlue.CefFindHandler).IsAssignableFrom(t),
+            $"Handlers.FindHandler no longer derives from CefFindHandler (base is '{t.BaseType}').");
+
+        var onFindResult = typeof(Xilium.CefGlue.CefFindHandler)
+            .GetMethod("OnFindResult", System.Reflection.BindingFlags.Instance |
+                                       System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(onFindResult);
+        Assert.True(onFindResult!.IsVirtual, "CefFindHandler.OnFindResult is no longer overridable.");
+
+        // The callback's shape, which CstFindHandler overrides literally.
+        Assert.Equal(
+            new[] { "CefBrowser", "Int32", "Int32", "CefRectangle", "Int32", "Boolean" },
+            onFindResult.GetParameters().Select(p => p.ParameterType.Name).ToArray());
+    }
+
+    [Fact]
+    public void CefBrowserHost_StillExposesFindAndStopFinding_WithTheExpectedShape()
+    {
+        // Pinned because the shape HAS changed before: CEF 120 dropped the leading `identifier` argument
+        // that older versions' Find took. A future bump doing something similar would otherwise surface as
+        // a confusing compile error far from here.
+        var find = typeof(Xilium.CefGlue.CefBrowserHost).GetMethod("Find",
+            new[] { typeof(string), typeof(bool), typeof(bool), typeof(bool) });
+        Assert.NotNull(find);
+        Assert.True(find!.IsPublic);
+
+        var stop = typeof(Xilium.CefGlue.CefBrowserHost).GetMethod("StopFinding", new[] { typeof(bool) });
+        Assert.NotNull(stop);
+        Assert.True(stop!.IsPublic);
+    }
+
+    [Fact]
+    public void TryGetChromiumBrowser_ReturnsNull_ForNullWebView()
+    {
+        Assert.Null(CefBrowserAccess.TryGetChromiumBrowser(null, Serilog.Log.Logger));
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/FindResultAccumulatorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/FindResultAccumulatorTests.cs
@@ -1,0 +1,125 @@
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+// #570: Chromium reports one find across SEVERAL replies that carry different information, and folding
+// them into "3 of 47" has already been wrong once in this feature — it displayed 0/47 for a search that
+// had genuinely selected match 1, which then made Next look as though it skipped to 2. These tests exist
+// because that logic used to live in view code-behind where nothing could reach it.
+//
+// The two rules under test:
+//   * an ordinal of 0 means "this reply says nothing about the active match", NOT "no match is active"
+//   * only the reply with finalUpdate carries an authoritative total
+public class FindResultAccumulatorTests
+{
+    // The realistic shape of one search's replies: partial counts while scanning, the ordinal arriving in
+    // its own reply, then a final total that says nothing about the ordinal.
+    private static FindResultAccumulator AfterATypicalSearch(int id = 1, int total = 47, int ordinal = 1)
+    {
+        var a = new FindResultAccumulator();
+        a.Accept(id, count: 3, activeMatchOrdinal: 0, finalUpdate: false);
+        a.Accept(id, count: 0, activeMatchOrdinal: ordinal, finalUpdate: false);
+        a.Accept(id, count: total, activeMatchOrdinal: 0, finalUpdate: true);
+        return a;
+    }
+
+    [Fact]
+    public void TheActiveOrdinalSurvivesAFinalReplyThatDoesNotMentionIt()
+    {
+        // The original bug, pinned exactly: the final reply carries ordinal 0, and reading it literally
+        // rendered "0/47" for a search sitting on match 1.
+        var a = AfterATypicalSearch();
+        Assert.Equal("1/47", a.Format());
+    }
+
+    [Fact]
+    public void PartialCountsAreNotDisplayedAsTheTotal()
+    {
+        // Rendering intermediate counts makes the number tick visibly upward after every keystroke.
+        var a = new FindResultAccumulator();
+        a.Accept(1, count: 3, activeMatchOrdinal: 1, finalUpdate: false);
+        Assert.Equal(0, a.Count);
+        a.Accept(1, count: 47, activeMatchOrdinal: 0, finalUpdate: true);
+        Assert.Equal(47, a.Count);
+    }
+
+    [Fact]
+    public void NoMatchesRendersZeroOfZero()
+    {
+        var a = new FindResultAccumulator();
+        a.Accept(1, count: 0, activeMatchOrdinal: 0, finalUpdate: true);
+        Assert.Equal("0/0", a.Format());
+    }
+
+    [Fact]
+    public void ATotalWithNoOrdinalYetShowsTheFirstMatch_NotZero()
+    {
+        // Chromium selects the first match on a new search; if the total lands before the reply naming the
+        // ordinal, showing 0 would be both wrong and a visible flicker before it corrected.
+        var a = new FindResultAccumulator();
+        a.Accept(1, count: 12, activeMatchOrdinal: 0, finalUpdate: true);
+        Assert.Equal("1/12", a.Format());
+    }
+
+    [Fact]
+    public void TheOrdinalNeverExceedsTheCount_AcrossANormalNavigation()
+    {
+        var a = AfterATypicalSearch(total: 3);
+        a.Accept(1, count: 0, activeMatchOrdinal: 2, finalUpdate: false);
+        Assert.Equal("2/3", a.Format());
+        a.Accept(1, count: 0, activeMatchOrdinal: 3, finalUpdate: false);
+        Assert.Equal("3/3", a.Format());
+    }
+
+    // ---- Stale replies from a superseded search ---------------------------------------------------
+
+    [Fact]
+    public void ALateReplyFromAPreviousSearchIsRejected()
+    {
+        // The scenario that produced a phantom count: type a query in a big book, then keep typing. The
+        // earlier search's final reply can arrive after the newer search has started. Installing its total
+        // would show a count belonging to a query the user has already moved on from.
+        var a = AfterATypicalSearch(id: 5, total: 94);
+
+        a.Reset();                                                   // new search begins
+        a.Accept(6, count: 2, activeMatchOrdinal: 1, finalUpdate: true);
+        Assert.Equal("1/2", a.Format());
+
+        var accepted = a.Accept(5, count: 94, activeMatchOrdinal: 40, finalUpdate: true);   // late, stale
+        Assert.False(accepted);
+        Assert.Equal("1/2", a.Format());
+    }
+
+    [Fact]
+    public void ResetDoesNotForgetTheIdentifierHighWaterMark()
+    {
+        // Reset clears the displayed numbers but must keep the newest id, or the very next stale reply
+        // would be indistinguishable from a fresh one.
+        var a = AfterATypicalSearch(id: 9);
+        a.Reset();
+        Assert.False(a.Accept(8, count: 500, activeMatchOrdinal: 1, finalUpdate: true));
+        Assert.Equal(0, a.Count);
+    }
+
+    [Fact]
+    public void RepliesCarryingTheSameIdentifierAreStillAccepted()
+    {
+        // All replies for one search share an id, so the staleness test must be "older than", not
+        // "different from" — otherwise a single search would only ever register its first reply.
+        var a = new FindResultAccumulator();
+        Assert.True(a.Accept(3, count: 0, activeMatchOrdinal: 1, finalUpdate: false));
+        Assert.True(a.Accept(3, count: 9, activeMatchOrdinal: 0, finalUpdate: true));
+        Assert.Equal("1/9", a.Format());
+    }
+
+    [Fact]
+    public void ResetClearsWhatIsDisplayed()
+    {
+        var a = AfterATypicalSearch();
+        a.Reset();
+        Assert.Equal(0, a.Count);
+        Assert.Equal(0, a.Ordinal);
+        Assert.Equal("", a.Format());   // nothing known again, not "no matches"
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1461,7 +1461,9 @@ public partial class App : Application
                 (PlatformGesture.Parse("e"),        () => OnViewSourceFromFloatingWindow(window, source2010: false)),
                 (PlatformGesture.Parse("shift+e"),  () => OnViewSourceFromFloatingWindow(window, source2010: true)),
                 (PlatformGesture.Parse("d"),        () => _ = SimpleTabbedWindow.LookUpInDictionaryAsync(FindActiveBookInFloatingWindow(window))),
-                (PlatformGesture.Parse("f"),        () => _ = SimpleTabbedWindow.SearchForSelectionAsync(FindActiveBookInFloatingWindow(window))),
+                // #570: F is Find in Page; Search for Selection moves to Shift+F.
+                (PlatformGesture.Parse("f"),        () => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.ShowFindBar()),
+                (PlatformGesture.Parse("shift+f"),  () => _ = SimpleTabbedWindow.SearchForSelectionAsync(FindActiveBookInFloatingWindow(window))),
                 (PlatformGesture.Parse("w"),        () => OnCloseTabFromFloatingWindow(window)),
                 (PlatformGesture.Parse("o"),        () => SimpleTabbedWindow.RevealSelectBookPanel()),
                 (PlatformGesture.Parse("p"),        () => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.Print()),
@@ -1590,13 +1592,18 @@ public partial class App : Application
             var lookUpItem = new NativeMenuItem { Header = "Look Up in Dictionary", Gesture = PlatformGesture.Parse("D") };
             lookUpItem.Click += async (s, e) =>
                 await SimpleTabbedWindow.LookUpInDictionaryAsync(FindActiveBookInFloatingWindow(window));
-            var searchSelectionItem = new NativeMenuItem { Header = "Search for Selection", Gesture = PlatformGesture.Parse("F") };
+            // #570: Find in Page on the floated book. macOS shows the ACTIVE window's menu bar, so without
+            // this the key would be dead in a floating window — the hole #448 found for Cmd+D/Cmd+F.
+            var findInPageItem = new NativeMenuItem { Header = "Find in Page…", Gesture = PlatformGesture.Parse("F") };
+            findInPageItem.Click += (s2, e2) => FindActiveBookInFloatingWindow(window)?.BookDisplayControl?.ShowFindBar();
+            var searchSelectionItem = new NativeMenuItem { Header = "Search for Selection", Gesture = PlatformGesture.Parse("Shift+F") };
             searchSelectionItem.Click += async (s, e) =>
                 await SimpleTabbedWindow.SearchForSelectionAsync(FindActiveBookInFloatingWindow(window));
 
             var toolsMenu = new NativeMenu();
             toolsMenu.Add(goToItem);
             toolsMenu.Add(lookUpItem);
+            toolsMenu.Add(findInPageItem);
             toolsMenu.Add(searchSelectionItem);
             toolsMenu.Add(viewSource1957Item);
             toolsMenu.Add(viewSource2010Item);

--- a/src/CST.Avalonia/Input/WebViewShortcutRelay.cs
+++ b/src/CST.Avalonia/Input/WebViewShortcutRelay.cs
@@ -32,9 +32,19 @@ public static class WebViewShortcutRelay
     /// JavaScript to inject once the page has loaded. <paramref name="viewId"/> identifies the view in the
     /// messages it pushes back.
     ///
-    /// <paramref name="includeFind"/> controls Ctrl/Cmd+F. The PDF viewer passes false: Chromium's
-    /// find-in-page is the one shortcut users genuinely want there, and intercepting it would trade that
-    /// away for "Search for Selection" with no selection - a straight downgrade. (fable review)
+    /// <paramref name="includeFind"/> controls Ctrl/Cmd+SHIFT+F (Search for Selection), and also whether
+    /// plain Ctrl/Cmd+F is swallowed. The PDF viewer passes false, so neither is claimed there and the
+    /// keystroke reaches Chromium's own PDF find.
+    ///
+    /// Note that find finds nothing in practice: the source PDFs are page SCANS with no text layer. Leaving
+    /// the key unclaimed is still the right default — it is the standard behaviour for a PDF, and it would
+    /// start working for free if those documents ever gained OCR text — but do not read this as protecting
+    /// a capability that currently exists. (Confirmed by the maintainer, 2026-08-11.)
+    ///
+    /// #570 moved Search for Selection from Cmd+F to Cmd+Shift+F, because Cmd+F is now Find in Page. Plain
+    /// Cmd+F is deliberately NOT relayed from these views: find-in-page applies to book text, and none of
+    /// the relaying views (Welcome, the dictionary meaning pane, the PDF viewer) is a book. Leaving it
+    /// unclaimed means Chromium's own find still works in the PDF viewer, where it is genuinely useful.
     /// </summary>
     public static string BuildScript(string viewId, bool includeFind = true) => @"
         (function() {
@@ -54,9 +64,20 @@ public static class WebViewShortcutRelay
 
                 // Deliberately NOT forwarded: e/g/p and shift variants are book commands, and w is
                 // handled per-view where a closable tab exists.
+                // #570: plain Cmd/Ctrl+F. These views have no book, so find-in-page has nothing to act
+                // on — but on macOS an unconsumed key equivalent bubbles to AppKit, where the native menu's
+                // Find in Page item would fire and open the find bar on whichever book happens to be active
+                // BEHIND this view. Swallowing it here is the honest no-op. The PDF viewer opts out
+                // (includeFind false) because Chromium's own find genuinely works there and is wanted.
+                if (k === 'f' && !event.shiftKey && " + (includeFind ? "true" : "false") + @") {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    return;
+                }
+
                 if (k === 'o' && !event.shiftKey) { name = 'SELECT_BOOK'; }
                 else if (k === 'd' && !event.shiftKey) { name = 'DICTIONARY'; }
-                else if (k === 'f' && !event.shiftKey && " + (includeFind ? "true" : "false") + @") { name = 'SEARCH'; }
+                else if (k === 'f' && event.shiftKey && " + (includeFind ? "true" : "false") + @") { name = 'SEARCH'; }
                 else if (k === ',') { name = 'SETTINGS'; }
 
                 if (name === null) { return; }

--- a/src/CST.Avalonia/Services/CefBrowserAccess.cs
+++ b/src/CST.Avalonia/Services/CefBrowserAccess.cs
@@ -86,23 +86,45 @@ public static class CefBrowserAccess
     }
 
     /// <summary>
-    /// Returns the browser host for <paramref name="webView"/>, or null when the chain is unavailable or the
-    /// browser is not yet created. Never throws.
+    /// Hop 1 only: the <see cref="BaseCefBrowser"/> behind a <see cref="WebView"/>.
+    ///
+    /// <para>
+    /// Needed on its own because some CEF features are configured on the browser rather than the host —
+    /// notably <c>BaseCefBrowser.FindHandler</c>, which find-in-page (#570) must set to receive match
+    /// counts. That property is a public setter on a public type, so only this first hop is reflection.
+    /// </para>
     /// </summary>
-    public static CefBrowserHost? TryGetBrowserHost(WebView? webView, ILogger logger)
+    public static BaseCefBrowser? TryGetChromiumBrowser(WebView? webView, ILogger logger)
     {
         if (webView == null || !IsAvailable) return null;
 
         try
         {
             // Not just an optimisation: before initialization UnderlyingBrowser is null, and asking a
-            // half-built browser for its host is exactly the sort of thing that crashes CEF rather than
+            // half-built browser for anything is the sort of thing that crashes CEF rather than
             // returning null.
             if (!webView.IsBrowserInitialized) return null;
 
-            if (WebViewUnderlyingBrowser!.GetValue(webView) is not BaseCefBrowser chromium)
-                return null;
+            return WebViewUnderlyingBrowser!.GetValue(webView) as BaseCefBrowser;
+        }
+        catch (Exception ex)
+        {
+            logger.Error("Failed to reach the Chromium browser | {Details}", ex.Message);
+            return null;
+        }
+    }
 
+    /// <summary>
+    /// Returns the browser host for <paramref name="webView"/>, or null when the chain is unavailable or the
+    /// browser is not yet created. Never throws.
+    /// </summary>
+    public static CefBrowserHost? TryGetBrowserHost(WebView? webView, ILogger logger)
+    {
+        var chromium = TryGetChromiumBrowser(webView, logger);
+        if (chromium == null) return null;
+
+        try
+        {
             if (BaseBrowserUnderlyingBrowser!.GetValue(chromium) is not CefBrowser browser)
                 return null;
 

--- a/src/CST.Avalonia/Services/CstFindHandler.cs
+++ b/src/CST.Avalonia/Services/CstFindHandler.cs
@@ -1,0 +1,80 @@
+using System;
+using Avalonia.Threading;
+using Xilium.CefGlue;
+using Xilium.CefGlue.Common.Handlers;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>Result of a find-in-page pass: how many matches, and which one is active.</summary>
+public class FindResultEventArgs : EventArgs
+{
+    public FindResultEventArgs(int identifier, int count, int activeMatchOrdinal, CefRectangle selectionRect, bool finalUpdate)
+    {
+        Identifier = identifier;
+        Count = count;
+        ActiveMatchOrdinal = activeMatchOrdinal;
+        SelectionRect = selectionRect;
+        FinalUpdate = finalUpdate;
+    }
+
+    /// <summary>
+    /// Chromium's request id for this search. Increases across searches, so a reply carrying an id below
+    /// the newest one seen belongs to a search that has already been superseded and must be discarded —
+    /// otherwise a late final from the previous query installs its total against the current one.
+    /// </summary>
+    public int Identifier { get; }
+
+    /// <summary>Total matches found. Rises as Chromium scans; only trustworthy once <see cref="FinalUpdate"/>.</summary>
+    public int Count { get; }
+
+    /// <summary>1-based index of the highlighted match, or 0 when there is none.</summary>
+    public int ActiveMatchOrdinal { get; }
+
+    /// <summary>
+    /// Where the active match sits in the viewport. Not currently read — it was needed by an overlay find
+    /// bar, which turned out not to render over this WebView, so the bar is docked instead. Kept because it
+    /// is the only positional information Chromium offers about a match.
+    /// </summary>
+    public CefRectangle SelectionRect { get; }
+
+    /// <summary>True on the last callback for this search. Earlier ones are partial.</summary>
+    public bool FinalUpdate { get; }
+}
+
+/// <summary>
+/// Receives Chromium's find-in-page results for one book. (#570)
+///
+/// <para>
+/// Attached via <c>BaseCefBrowser.FindHandler</c>, which is a public setter on a public type — so unlike
+/// reaching the browser itself, no reflection is involved here. <see cref="CefBrowserAccess"/> handles the
+/// one reflection hop needed to get the browser.
+/// </para>
+///
+/// <para>
+/// <b>Callbacks arrive on a CEF thread</b>, so everything is marshalled to the UI thread before the event is
+/// raised. Subscribers touch view state and must not have to know that.
+/// </para>
+///
+/// <para>
+/// Chromium reports <b>incrementally</b> while it is still scanning the document, so <c>count</c> climbs
+/// across several callbacks for a single search and only the one with <c>finalUpdate</c> set is
+/// authoritative. Consumers that render the count without honouring that flag show a number visibly ticking
+/// upward after every keystroke.
+/// </para>
+/// </summary>
+public class CstFindHandler : FindHandler
+{
+    private readonly Action<FindResultEventArgs> _onResult;
+
+    public CstFindHandler(Action<FindResultEventArgs> onResult) => _onResult = onResult;
+
+    protected override void OnFindResult(CefBrowser browser, int identifier, int count,
+        CefRectangle selectionRect, int activeMatchOrdinal, bool finalUpdate)
+    {
+        // CEF 120's Find() no longer takes an identifier, so we cannot correlate against one we issued —
+        // but Chromium still reports one, and it increases across searches, which is enough to recognise a
+        // reply from a search that has since been superseded. (fable review)
+        var args = new FindResultEventArgs(identifier, count, activeMatchOrdinal, selectionRect, finalUpdate);
+        Dispatcher.UIThread.Post(() => _onResult(args));
+    }
+}

--- a/src/CST.Avalonia/Services/FindResultAccumulator.cs
+++ b/src/CST.Avalonia/Services/FindResultAccumulator.cs
@@ -1,0 +1,81 @@
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Turns Chromium's stream of find replies into the "3 of 47" a user sees. (#570)
+///
+/// <para>
+/// This exists as its own class because a single reply does not carry both numbers, and getting that wrong
+/// is invisible until someone reads the counter carefully. Chromium reports a search across several
+/// replies: some know which match is active, a later one knows the authoritative total but says nothing
+/// meaningful about the active match. Reading either value straight off the final reply produced "0/47"
+/// for a search that had genuinely selected match 1 — which then made Next look as though it skipped to 2.
+/// </para>
+///
+/// <para>
+/// It is also pure and UI-free so it can be tested. The logic previously lived inline in the view, where
+/// the one part of this feature that had already been wrong once was the only part with no test.
+/// </para>
+/// </summary>
+public class FindResultAccumulator
+{
+    private int _count;
+    private int _ordinal;
+    private int _newestIdentifier;
+    private bool _hasTotal;
+
+    /// <summary>Total matches, or 0 before any authoritative reply has arrived.</summary>
+    public int Count => _count;
+
+    /// <summary>1-based index of the active match, or 0 if not yet reported.</summary>
+    public int Ordinal => _ordinal;
+
+    /// <summary>Forget everything. Call when a NEW search starts or the query is cleared.</summary>
+    public void Reset()
+    {
+        _count = 0;
+        _ordinal = 0;
+        _hasTotal = false;
+        // _newestIdentifier is deliberately NOT reset: Chromium's request ids keep climbing across
+        // searches, so remembering the high-water mark is what lets a late reply from the PREVIOUS
+        // search be recognised and dropped.
+    }
+
+    /// <summary>
+    /// Folds one reply in. Returns false ONLY when the reply is stale and was discarded — it says nothing
+    /// about whether there is yet anything worth displaying, which is <see cref="Format"/>'s business.
+    /// </summary>
+    public bool Accept(int identifier, int count, int activeMatchOrdinal, bool finalUpdate)
+    {
+        // Replies from a superseded search are worthless and actively harmful: a late final from search N
+        // arriving after search N+1 started would install N's total against N+1's query. Chromium's request
+        // identifiers increase, so anything below the newest is stale.
+        if (identifier < _newestIdentifier) return false;
+        _newestIdentifier = identifier;
+
+        // Ordinal 0 means "this reply says nothing about the active match", NOT "no match is active" — so
+        // keep the last real one rather than overwriting with a non-answer.
+        if (activeMatchOrdinal > 0) _ordinal = activeMatchOrdinal;
+
+        // The count climbs while Chromium is still scanning, so only the final reply's total can be
+        // trusted; rendering the intermediate ones makes the number visibly tick upward as you type.
+        if (finalUpdate)
+        {
+            _count = count;
+            _hasTotal = true;
+        }
+
+        return true;
+    }
+
+    /// <summary>The counter text: "" before anything is known, "0/0" for no matches, else "3/47".</summary>
+    public string Format()
+    {
+        // No authoritative total yet. Showing a partial count here is what makes the number tick visibly
+        // upward as the user types.
+        if (!_hasTotal) return "";
+        if (_count == 0) return "0/0";
+        // A total with no ordinal yet means the first match is selected but the reply saying so has not
+        // arrived; showing 1 is both true and avoids a visible 0 flashing before it corrects.
+        return $"{(_ordinal > 0 ? _ordinal : 1)}/{_count}";
+    }
+}

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml
@@ -203,6 +203,71 @@
                          Width="100" Height="16" Margin="8,0"/>
         </Grid>
 
+        <!-- #570: Find in Page.
+
+             Docked above the book, NOT floated over it. An overlay was tried first and does not work: an
+             Avalonia sibling cannot paint above this WebView's surface. Measured, with the bar correctly
+             laid out and still invisible —
+                 IsVisible=true EffectivelyVisible=true Bounds=729,8,377,36 Opacity=1 ZIndex=0
+             The ZIndex="-1000" on the WebView below is someone else having hit the same wall. Do not retry
+             an overlay here without first changing how the browser is hosted.
+
+             Docking shifts the book down ~44px when the bar opens. That does not reflow the text — only a
+             WIDTH change rewraps it (see OnViewResized) — so the reading position survives, which is the
+             property that actually governed this choice.
+
+             No options: no whole-word or regex (CEF's find offers neither), and no Match Case. That last
+             one is not a simplification but a consequence — Chromium's find is ICU string search where the
+             flag selects collation strength, so case-insensitive and diacritic-insensitive are the same
+             switch. A toggle would therefore trade one kind of wrong answer for another rather than
+             offering precision. See the call site in the code-behind for which way it is set and why.
+             Query, position, next/previous, close. -->
+        <Border x:Name="findBar"
+                DockPanel.Dock="Top"
+                IsVisible="False"
+                Padding="8,5"
+                Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                BorderThickness="0,0,0,1">
+            <!-- Right-aligned so the controls sit near the scrollbar and the book's left margin stays
+                 clean, but the Border itself stretches so the strip reads as chrome rather than a
+                 floating island. -->
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                        <TextBox x:Name="findQueryBox"
+                                 Width="200"
+                                 MinHeight="26"
+                                 Padding="6,2"
+                                 VerticalContentAlignment="Center"
+                                 Watermark="Find in page"
+                                 ToolTip.Tip="Find in this book. Enter for next, Shift+Enter for previous, Escape to close."/>
+
+                        <!-- Fixed width so the bar does not resize as the count changes from "" to
+                             "3 of 47" — a jittering overlay over settled text reads as a glitch. -->
+                        <TextBlock x:Name="findCountText"
+                                   Width="72"
+                                   Margin="8,0,4,0"
+                                   VerticalAlignment="Center"
+                                   TextAlignment="Right"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+
+                        <Button x:Name="findPrevButton"
+                                Margin="2,0,0,0" Padding="6,2" MinWidth="0"
+                                ToolTip.Tip="Previous match (Shift+Enter)">
+                            <TextBlock Text="&#x2227;"/>
+                        </Button>
+                        <Button x:Name="findNextButton"
+                                Margin="2,0,0,0" Padding="6,2" MinWidth="0"
+                                ToolTip.Tip="Next match (Enter)">
+                            <TextBlock Text="&#x2228;"/>
+                        </Button>
+                        <Button x:Name="findCloseButton"
+                                Margin="6,0,0,0" Padding="6,2" MinWidth="0"
+                                ToolTip.Tip="Close (Escape)">
+                            <TextBlock Text="&#x2715;"/>
+                        </Button>
+                    </StackPanel>
+                </Border>
+
         <!-- Main Browser Control -->
         <Border DockPanel.Dock="Top" BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="1">
             <Panel>
@@ -237,6 +302,7 @@
                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
                     </StackPanel>
                 </ScrollViewer>
+
             </Panel>
         </Border>
     </DockPanel>

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -129,6 +129,9 @@ public partial class BookDisplayView : UserControl
         // Zoom is stored per script and applies to book text only, so every book view listens. (#572)
         SubscribeToZoomChanges();
 
+        // #570: wire the find bar's controls. The bar itself stays hidden until Cmd/Ctrl+F.
+        SetupFindBar();
+
         // Try to create WebView browser
         TryCreateWebView();
     }
@@ -320,6 +323,9 @@ public partial class BookDisplayView : UserControl
         // describes for the browser itself. Detach is the recycled tab-switch/float path and must NOT
         // unsubscribe, or a re-attached tab would stop following zoom changes. (#572)
         UnsubscribeFromZoomChanges();
+        // #570: drop the find handler's reference back into this view before the browser goes away.
+        _findHandler = null;
+        _findHandlerAttached = false;
         DisposeWebView();
     }
 
@@ -956,6 +962,241 @@ public partial class BookDisplayView : UserControl
 
     #endregion
 
+    #region Find in Page (#570)
+
+    // Chromium's own find, reached through CefBrowserAccess. Highlighting of every match with the active
+    // one distinct, auto-scroll, wrap-around and match counts all come free.
+    //
+    // Matching is a literal substring, case-insensitive, with no folding and no script conversion. That is
+    // deliberate: the corpus capitalises programmatically at sentence starts rather than semantically, so
+    // case carries nothing searchable; and a reader working across scripts copies text out of the book
+    // rather than typing it, so the query already arrives in the right form. Converting it would risk
+    // corrupting a query that was correct.
+    private Border? _findBar;
+    private TextBox? _findQueryBox;
+    private TextBlock? _findCountText;
+    private CstFindHandler? _findHandler;
+    private bool _findHandlerAttached;
+    // Folding Chromium's multi-reply result stream into one counter. Extracted so it can be unit tested:
+    // it is the part of this feature that has already been wrong once. (fable review)
+    private readonly FindResultAccumulator _findResults = new();
+    // Identifies a ShowFindBar call across its await, so an orphaned one cannot clobber a newer one.
+    private int _findOpenGeneration;
+
+    private void SetupFindBar()
+    {
+        _findBar = this.FindControl<Border>("findBar");
+        _findQueryBox = this.FindControl<TextBox>("findQueryBox");
+        _findCountText = this.FindControl<TextBlock>("findCountText");
+
+        if (_findQueryBox != null)
+        {
+            // Incremental: each keystroke restarts the search (findNext: false), which is how Chromium
+            // narrows as you type and keeps the count live.
+            _findQueryBox.TextChanged += (_, _) => RunFind(forward: true, findNext: false);
+            _findQueryBox.KeyDown += OnFindQueryKeyDown;
+        }
+
+        var prev = this.FindControl<Button>("findPrevButton");
+        var next = this.FindControl<Button>("findNextButton");
+        var close = this.FindControl<Button>("findCloseButton");
+        if (prev != null) prev.Click += (_, _) => RunFind(forward: false, findNext: true);
+        if (next != null) next.Click += (_, _) => RunFind(forward: true, findNext: true);
+        if (close != null) close.Click += (_, _) => HideFindBar();
+    }
+
+    private void OnFindQueryKeyDown(object? sender, KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Enter:
+                // Shift+Enter reverses — the standard find-bar idiom. findNext: true advances within the
+                // existing search rather than restarting it.
+                RunFind(forward: !e.KeyModifiers.HasFlag(KeyModifiers.Shift), findNext: true);
+                e.Handled = true;
+                break;
+            case Key.Escape:
+                HideFindBar();
+                e.Handled = true;
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Opens the find bar and focuses it. Prefills from the book's current selection, which makes ⌘F and
+    /// ⌘⇧F symmetrical — the same selection, searched here or across the corpus.
+    /// </summary>
+    public async void ShowFindBar()
+    {
+        if (!Dispatcher.UIThread.CheckAccess()) { Dispatcher.UIThread.Post(ShowFindBar); return; }
+        if (_isShutDown || _findBar == null || _findQueryBox == null) return;
+
+        if (!CefBrowserAccess.IsAvailable)
+        {
+            // The reflection chain broke on a package upgrade. Opening a bar that cannot search would be
+            // worse than not opening one; Probe has already said so in the startup log.
+            _logger.Warning("Find in Page unavailable - CEF browser access did not resolve");
+            return;
+        }
+
+        AttachFindHandler();
+
+        // The selection round-trip can take up to 700ms, and _lookupSelectionTcs is a SHARED field (⌘D
+        // uses it too). A second ⌘F — or a ⌘D — replaces it, so this call's TCS never completes and it
+        // sleeps out the full timeout before resuming. By then the user may have typed a query, which the
+        // tail below would then select-all and the next keystroke would wipe. Stamp the call and let the
+        // orphan recognise itself. (fable review)
+        var generation = ++_findOpenGeneration;
+
+        var selection = await GetWebViewSelectionAsync();
+
+        // Re-check everything that could have changed across the await: a newer open superseded this one,
+        // or the tab was closed while it was outstanding.
+        if (generation != _findOpenGeneration || _isShutDown || _findBar == null || _findQueryBox == null)
+            return;
+
+        if (!string.IsNullOrWhiteSpace(selection))
+        {
+            // First line only: a multi-line selection as a query matches nothing and reads as broken.
+            var firstLine = selection.Split('\n')[0].Trim();
+            if (firstLine.Length > 0) _findQueryBox.Text = firstLine;
+        }
+
+        _findBar.IsVisible = true;
+        _findQueryBox.Focus();
+        _findQueryBox.SelectAll();
+        // Re-run whatever is in the box: reopening on a remembered query should light its matches again,
+        // rather than showing an empty count beside text that looks searched.
+        RunFind(forward: true, findNext: false);
+    }
+
+    /// <summary>Closes the bar, clears Chromium's highlighting, and returns focus to the book.</summary>
+    public void HideFindBar()
+    {
+        if (!Dispatcher.UIThread.CheckAccess()) { Dispatcher.UIThread.Post(HideFindBar); return; }
+        if (_findBar == null || !_findBar.IsVisible) return;
+
+        _findBar.IsVisible = false;
+        if (_findCountText != null) _findCountText.Text = "";
+
+        // clearSelection: FALSE — keep the match selected as the bar closes. Chromium's own find bar does
+        // the same, and it matters more here than in a browser: the motivating request for this feature was
+        // finding your way back to a place in the text, so discarding the selection at the moment the user
+        // closes the bar would throw away the answer they just asked for. (fable review)
+        StopFinding(clearSelection: false);
+
+        // The query is deliberately left in the box: reopening find in this tab continues where it left
+        // off, per tab, which is what every shipped find bar does.
+        _webView?.Focus();
+    }
+
+    /// <summary>
+    /// Clears the active search and its highlighting. Safe when nothing is searching.
+    ///
+    /// <para>
+    /// <paramref name="clearSelection"/> false keeps the found text selected. Closing the bar passes false,
+    /// so the match stays visible as your place in the text; clearing the query passes true, because the
+    /// selection then belongs to a search the user has explicitly abandoned.
+    /// </para>
+    /// </summary>
+    private void StopFinding(bool clearSelection)
+    {
+        var host = CefBrowserAccess.TryGetBrowserHost(_webView, _logger);
+        if (host == null) return;
+        try { host.StopFinding(clearSelection); }
+        catch (Exception ex) { _logger.Error("StopFinding failed | {Details}", ex.Message); }
+    }
+
+    private void RunFind(bool forward, bool findNext)
+    {
+        if (_isShutDown || _findBar == null || !_findBar.IsVisible) return;
+
+        var query = _findQueryBox?.Text ?? "";
+        if (string.IsNullOrEmpty(query))
+        {
+            // Emptying the box must clear the highlighting too, or the previous search's matches stay lit
+            // with no query on screen to explain them.
+            _findResults.Reset();
+            if (_findCountText != null) _findCountText.Text = "";
+            // true here: the query was deliberately cleared, so the old match is not the user's place any
+            // more — leaving it selected would be leftover state from a search they abandoned.
+            StopFinding(clearSelection: true);
+            return;
+        }
+
+        var host = CefBrowserAccess.TryGetBrowserHost(_webView, _logger);
+        if (host == null) return;
+
+        // findNext false means a NEW search rather than a step within the current one, so any accumulated
+        // position is stale.
+        if (!findNext) _findResults.Reset();
+
+        try
+        {
+            // matchCase: false — case-insensitive, with a known and accepted cost.
+            //
+            // This flag is not really about case. Chromium's find is ICU string search and it selects the
+            // collation STRENGTH: false is PRIMARY, which folds case AND combining marks together; true is
+            // TERTIARY, which respects both. There is no case-insensitive-but-diacritic-sensitive setting —
+            // it is one knob, so the two properties cannot be chosen independently.
+            //
+            // Choosing false therefore accepts diacritic folding: "ekaṃ" also matches "ekam" in Latin, and
+            // in Myanmar the niggahita is ignored so the search widens to "eka" (294 hits in DN3 rather
+            // than 94). Choosing true instead would miss sentence-initial capitals — measured at ~8% of
+            // "ekaṃ" occurrences across the 217 books, since the corpus capitalises programmatically at
+            // sentence starts rather than semantically.
+            //
+            // Case-insensitive was judged the better trade for shipping: the missed capitals are invisible
+            // to the user, whereas an over-wide match is at least visible and still contains what was
+            // sought. Getting BOTH requires matching in JavaScript over the DOM (CSS Custom Highlight API,
+            // no DOM mutation) — understood, deliberately deferred, and worth revisiting if the folding
+            // proves to matter in use.
+            host.Find(query, forward, matchCase: false, findNext: findNext);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Find failed | {Details}", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Attaches the result handler to this browser. Cleared on navigation and re-attached on demand:
+    /// float/unfloat disposes and rebuilds the WebView, so a one-shot attach would silently stop reporting
+    /// counts after the first float.
+    /// </summary>
+    private void AttachFindHandler()
+    {
+        if (_findHandlerAttached || _isShutDown) return;
+
+        var browser = CefBrowserAccess.TryGetChromiumBrowser(_webView, _logger);
+        if (browser == null) return;
+
+        _findHandler ??= new CstFindHandler(OnFindResult);
+        browser.FindHandler = _findHandler;   // public setter on a public type - no reflection here
+        _findHandlerAttached = true;
+        _logger.Debug("Find handler attached");
+    }
+
+    private void OnFindResult(FindResultEventArgs e)
+    {
+        if (_isShutDown || _findBar == null || !_findBar.IsVisible) return;
+
+        // A reply for a query that no longer exists must not paint a count. StopFinding self-posts to the
+        // CEF UI thread, so the previous search's final reply can still arrive AFTER the box was emptied
+        // and the highlighting cleared — leaving "1/94" beside an empty box with nothing highlighted, and
+        // nothing further to correct it. (fable review)
+        if (string.IsNullOrEmpty(_findQueryBox?.Text)) return;
+
+        // Accept returns false only for a reply belonging to a superseded search. Whether there is yet
+        // anything worth showing is Format's business — it returns "" until an authoritative total exists.
+        if (!_findResults.Accept(e.Identifier, e.Count, e.ActiveMatchOrdinal, e.FinalUpdate)) return;
+
+        var text = _findResults.Format();
+        if (_findCountText != null && text.Length > 0) _findCountText.Text = text;
+    }
+
+    #endregion
+
 
     private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
@@ -1128,19 +1369,19 @@ public partial class BookDisplayView : UserControl
             // It happens BEFORE the lock is acquired, so it does not block other UI operations.
             await Task.Delay(200);
 
-            _logger.Debug("OnScrollPositionCheck attempting to acquire JS lock");
+            // No lock-lifecycle logging here, unlike the other JS callers: this runs on the ~200ms status
+            // tick, per book view, so six Debug lines per tick was 89% of an entire Debug-level log — about
+            // 60 lines a second with two books open, which buried everything else. The failure branch below
+            // is kept, because a lock that cannot be acquired is the only outcome worth knowing about.
             if (await _jsExecutionLock.WaitAsync(0))
             {
-                _logger.Debug("OnScrollPositionCheck acquired JS lock successfully");
                 try
                 {
                     UpdateScrollBasedStatus();
                 }
                 finally
                 {
-                    _logger.Debug("OnScrollPositionCheck releasing JS lock");
                     _jsExecutionLock.Release();
-                    _logger.Debug("OnScrollPositionCheck released JS lock");
                 }
             }
             else
@@ -1154,8 +1395,6 @@ public partial class BookDisplayView : UserControl
     {
         try
         {
-            _logger.Debug("UpdateScrollBasedStatus called - anchorCacheBuilt: {AnchorCacheBuilt}", _anchorCacheBuilt);
-
             if (!_anchorCacheBuilt || _webView == null)
             {
                 _logger.Debug("UpdateScrollBasedStatus skipped - anchorCacheBuilt: {AnchorCacheBuilt}, browser: {HasBrowser}", _anchorCacheBuilt, _webView != null);
@@ -1163,7 +1402,6 @@ public partial class BookDisplayView : UserControl
             }
 
             // Try to get scroll position and status in a single JavaScript call
-            _logger.Debug("Executing JavaScript for status update");
             var script = $@"
                 (function() {{
                 try {{
@@ -1949,6 +2187,13 @@ public partial class BookDisplayView : UserControl
                 // #572: a new document supersedes any deferred scroll restoration armed by the previous one.
                 Interlocked.Increment(ref _navGeneration);
 
+                // #570: this is a different document, so any search in flight is meaningless and the
+                // handler must be re-attached (a script change reloads; float/unfloat rebuilds the browser
+                // entirely). Hiding rather than re-running is deliberate — after a script change the query
+                // is in the previous script and would silently match nothing.
+                _findHandlerAttached = false;
+                HideFindBar();
+
                 // Signal the ViewModel that initialization is complete and navigation can be enabled
                 _viewModel.CompleteInitialization();
 
@@ -2663,6 +2908,24 @@ public partial class BookDisplayView : UserControl
             }
         }
         // #28: Search for Selection requested from JavaScript (⌘/Ctrl+F while this book's WebView has focus).
+        // #570: Cmd/Ctrl+F from inside the book WebView.
+        else if (title != null && title.StartsWith("CST_FIND_IN_PAGE:"))
+        {
+            try
+            {
+                var parts = title.Split('|');
+                var messageTabId = parts.Length > 1 && parts[1].StartsWith("TAB:") ? parts[1].Substring(4) : "";
+                if (messageTabId == _tabId)
+                {
+                    _logger.Debug("*** FIND IN PAGE REQUESTED FROM JAVASCRIPT ***");
+                    Dispatcher.UIThread.Post(ShowFindBar);   // runs on the CEF thread (BOOK-2)
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Error processing find-in-page request from JavaScript | {Details}", ex.Message);
+            }
+        }
         else if (title != null && title.StartsWith("CST_SEARCH_SELECTION_REQUESTED:"))
         {
             try
@@ -2901,12 +3164,28 @@ public partial class BookDisplayView : UserControl
 
                                 // #28: Cmd+F / Ctrl+F (Search for Selection). preventDefault also suppresses
                                 // Chromium's own find bar, which would otherwise open over the book.
-                                if ((event.key === 'f' || event.key === 'F') && !event.shiftKey && (event.metaKey || event.ctrlKey)) {
+                                // #570: Cmd/Ctrl+SHIFT+F is now Search for Selection (corpus-wide). Plain
+                                // Cmd/Ctrl+F was rebound to Find in Page below — the browser-universal
+                                // meaning, what CST4 used it for, and what the request asked for.
+                                if ((event.key === 'f' || event.key === 'F') && event.shiftKey && (event.metaKey || event.ctrlKey)) {
                                     event.preventDefault();
                                     event.stopPropagation();
                                     if (event.repeat) return false;
                                     window.cstLogger.log('DEBUG', 'Search for Selection shortcut detected in JavaScript');
                                     document.title = 'CST_SEARCH_SELECTION_REQUESTED:|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                                    return false;
+                                }
+
+                                // #570: Cmd/Ctrl+F -> Find in Page for THIS book. Must be captured here:
+                                // while CEF holds focus Avalonia never sees the keystroke, and Chromium
+                                // would otherwise open its own find bar, which we do not control and which
+                                // would sit outside the app's chrome entirely.
+                                if ((event.key === 'f' || event.key === 'F') && !event.shiftKey && (event.metaKey || event.ctrlKey)) {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                    if (event.repeat) return false;
+                                    window.cstLogger.log('DEBUG', 'Find in Page shortcut detected in JavaScript');
+                                    document.title = 'CST_FIND_IN_PAGE:|TAB:{_tabId}|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
                                     return false;
                                 }
 

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -58,7 +58,8 @@
                 <NativeMenu>
                     <NativeMenuItem Header="Go To..." Click="OnGoToMenuItemClick" Gesture="{input:CommandGesture g}" />
                     <NativeMenuItem Header="Look Up in Dictionary" Click="OnLookUpInDictionaryClick" Gesture="{input:CommandGesture d}" />
-                    <NativeMenuItem Header="Search for Selection" Click="OnSearchForSelectionClick" Gesture="{input:CommandGesture f}" />
+                    <NativeMenuItem Header="Find in Page…" Click="OnFindInPageClick" Gesture="{input:CommandGesture f}" />
+                    <NativeMenuItem Header="Search for Selection" Click="OnSearchForSelectionClick" Gesture="{input:CommandGesture shift+f}" />
                     <NativeMenuItem Header="View Source (1957 ed.)" Click="OnViewSource1957Click" Gesture="{input:CommandGesture e}" />
                     <NativeMenuItem Header="View Source (2010 ed.)" Click="OnViewSource2010Click" Gesture="{input:CommandGesture shift+e}" />
                 </NativeMenu>

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -769,7 +769,10 @@ public partial class SimpleTabbedWindow : Window
             (PlatformGesture.Parse("w"),       () => OnCloseTabClick(this, EventArgs.Empty)),
             (PlatformGesture.Parse("g"),       () => OnGoToMenuItemClick(this, EventArgs.Empty)),
             (PlatformGesture.Parse("d"),       () => OnLookUpInDictionaryClick(this, EventArgs.Empty)),
-            (PlatformGesture.Parse("f"),       () => OnSearchForSelectionClick(this, EventArgs.Empty)),
+            // #570: F is now Find in Page (browser-universal, and what CST4 used it for). Search for
+            // Selection, which held F, moves to Shift+F.
+            (PlatformGesture.Parse("f"),       () => OnFindInPageClick(this, EventArgs.Empty)),
+            (PlatformGesture.Parse("shift+f"), () => OnSearchForSelectionClick(this, EventArgs.Empty)),
             (PlatformGesture.Parse("e"),       () => OnViewSource1957Click(this, EventArgs.Empty)),
             (PlatformGesture.Parse("shift+e"), () => OnViewSource2010Click(this, EventArgs.Empty)),
             // #572 book zoom is NOT in this list — it is matched separately below, by physical key as well
@@ -924,6 +927,20 @@ public partial class SimpleTabbedWindow : Window
     private void OnZoomOutClick(object? sender, EventArgs e) => InvokeZoom(b => b.ZoomOut(), "Zoom Out");
 
     private void OnZoomResetClick(object? sender, EventArgs e) => InvokeZoom(b => b.ResetZoom(), "Actual Size");
+
+    // #570: open Find in Page on the active book. No active book means nothing to search, and doing
+    // nothing is the honest answer — find has no meaning without a document.
+    private void OnFindInPageClick(object? sender, EventArgs e)
+    {
+        var book = FindActiveBookInThisWindow();
+        if (book?.BookDisplayControl == null)
+        {
+            _logger.Debug("Find in Page: no active book in window {WindowTitle}", this.Title);
+            return;
+        }
+        _logger.Information("Find in Page (Cmd+F) from window: {WindowTitle}", this.Title);
+        book.BookDisplayControl.ShowFindBar();
+    }
 
     private void InvokeZoom(Action<BookDisplayView> action, string what)
     {


### PR DESCRIPTION
Restores the in-book find that CST 4.1 had. Requested by a beta tester who had been using the corpus-wide search as a substitute, and who had built a copy-a-line-then-search ritual around its absence.

## What it does

**⌘/Ctrl+F** opens a find bar for the current book. Type to search incrementally, Enter / Shift+Enter for next and previous, Escape to close. **Search for Selection moves to ⌘/Ctrl+Shift+F** — ⌘F is what CST4 used, what every browser uses, and what the request asked for. The two now read as *find here* and *search everywhere* on adjacent shortcuts.

Uses **Chromium's own find**, reached through the `CefBrowserAccess` established by #572 for zoom. Highlighting of every match, auto-scroll, wrap-around, the scrollbar tickmarks and the match counts all come free. The only new access is the `FindHandler` attach point, which is a public setter on a public type rather than reflection.

Bound across all four routes — the Windows/Linux window handler, macOS NativeMenu items, floating windows, and the in-book JS capture for when CEF holds focus — plus the relay used by the bookless views.

## The bar is docked, not floated

An overlay was built first and **does not work**: Avalonia content cannot paint above this WebView's surface. Measured, with the bar correctly laid out and still invisible:

```
IsVisible=true  EffectivelyVisible=true  Bounds=729,8,377,36  Opacity=1  ZIndex=0
```

The `ZIndex="-1000"` already sitting on the WebView is someone else having hit the same wall. That finding is written into the XAML with the evidence, so it isn't rediscovered.

Docking shifts the book ~44px when the bar opens. It does **not** reflow the text — only a width change rewraps — so the reading position survives, which is the property that governed the choice.

## Matching, and one consequence worth stating plainly

Chromium's find is **ICU string search**, and `matchCase` selects the collation **strength**, not merely case. `false` is PRIMARY, which folds case *and combining marks* together; `true` is TERTIARY, which respects both. **There is no case-insensitive-but-diacritic-sensitive setting** — it is one knob.

So case-insensitivity costs diacritic exactness. Searching `ekaṃ` in DN3:

| | result |
|---|---|
| Latin | also matches `ekam` — 94 hits |
| Myanmar | niggahita ignored, search widens to `eka` — 294 hits |

The alternative was measured rather than guessed: with `matchCase: true`, a lowercase query misses sentence-initial capitals — **~8% of `ekaṃ` occurrences across the 217 books**, since the corpus capitalises programmatically at sentence starts rather than semantically. Case-insensitive was judged the better trade for shipping.

**This is not ours to fix.** The maintainer reproduced the identical `ekaṃ` behaviour in **Brave against the tipitaka.org web version** — it is how Chromium find behaves for anyone reading Pāli in any Chromium browser. Getting both properties requires matching in JavaScript over the DOM (CSS Custom Highlight API, no DOM mutation), which is understood and deliberately deferred — and would put our find *ahead of* the website rather than merely at parity.

## Review

Fable-reviewed; four defects found and fixed.

- **A late reply from a superseded search could paint a phantom count.** Empty the box in a large book and the previous search's final reply arrives *after* the highlighting was cleared, leaving `1/94` beside an empty box with nothing to correct it. Chromium still reports a request identifier even though CEF 120's `Find` no longer takes one — enough to recognise and drop stale replies. I had commented that the identifier was safe to ignore, which was wrong.
- **Two rapid ⌘F presses** orphaned the first call's 700 ms selection round-trip (its `TaskCompletionSource` is shared with ⌘D), which then resumed and select-all'd whatever had been typed meanwhile.
- **Escape discarded the match selection**, undercutting the issue's own motivation — the request was about finding your place again. Closing now keeps it; clearing the query still discards it.
- **On macOS, ⌘F in the Welcome or Dictionary pane** fell through to the native menu and opened find on whichever book was active behind it.

It also **verified** that `Find` and `StopFinding` both self-post to the CEF UI thread, so the `GetZoomLevel`-style silent no-op flagged for this issue does not apply.

## FindResultAccumulator

The reply-folding logic is extracted as a pure, tested class. Chromium reports one search across several replies carrying *different* information: some know which match is active, a later one knows the authoritative total but says nothing meaningful about the active match.

This is the part of the feature that was **already wrong once** — it displayed `0/47` for a search sitting on match 1, which made Next look as though it skipped to 2 — and it was the only part with no coverage, because it lived in view code-behind. Writing the tests immediately surfaced a design smell: `Accept`'s return value was conflating "not stale" with "worth rendering".

## Testing

Full suite **1219 passed, 0 failed**, including 9 new accumulator tests and 5 new API-shape tripwires that fail the build if a package bump moves the find members.

Smoke-tested by the maintainer.

**Unverified: the Windows routing column.** Exactly-one-route-fires is proven from source for the macOS cells; the in-WebView capture and the bubble handler on Windows want a pass on the ARM64 VM, as the zoom work did.

The PDF viewer deliberately does not claim ⌘F, so Chromium's own find still gets it — though it finds nothing in practice, since the source PDFs are page scans with no text layer. It would begin working for free if those ever gained OCR text.

Closes #570.
