### PR TITLE
Surface B: the orchestrator (#583)

### DIFF
--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -1,8 +1,10 @@
 # Surface B — the in-app model, v1 by context injection (Planned)
 
 **Status:** In progress. Shipped: B1 (#578, provider layer), B3 (#580, context bundler), B4 (#582, presets and
-the grounding contract), plus the reader-state read path and `POST /v1/ai/context-preview` (#593). No AI feature
-is user-visible yet — the orchestrator (B5, #583) is what first connects a prompt to a provider.
+the grounding contract), B5 (#583, orchestrator), plus the reader-state read path and
+`POST /v1/ai/context-preview` (#593). **The chain now runs end to end** — a live Translate turn against the real
+corpus and a real model works — but nothing is user-visible until the Settings UI (B7, #585) and the panel
+(B8, #586) exist.
 **Parent:** [AI_INTEGRATION.md](AI_INTEGRATION.md) — the design of record for the A–E surface map. §11.1 there
 states the decided model-access *policy*; this document is the *implementation plan* for B.
 **Tracker:** epic #186 → children #578–#587 (filed 2026-08-09; the per-item numbers are in §12).
@@ -551,3 +553,29 @@ unmarked while marking block quotes. The marker failure was fixed by naming the 
 "use the markers instead of italics, an italicised word is a word left behind in Latin" — where merely stating
 the requirement had not worked. The mistranslation was not fixable by prompting and is exactly the evidence
 #584's fidelity advisory exists to carry.
+
+**2026-08-11 (#583, the orchestrator)** — the pieces are now one feature. Decisions worth keeping:
+
+- **Nothing expected throws.** Not-configured, an unreadable passage, a dead network, a 401 — all arrive as a
+  terminal `Error` event. §10 requires the panel to render each as a sentence, and collapsing #578's two
+  failure shapes here spares every future caller from re-deriving that. #578's contract is unchanged: the
+  *provider* still throws before the response and yields an `Error` delta after it.
+- **A superseded turn ends quietly; the caller's own cancellation throws.** Being replaced is not a failure —
+  an error banner under an answer the reader abandoned would be both wrong and alarming — but a consumer that
+  cancels its own enumeration must not be told the turn succeeded. Two cancellation sources, two behaviours,
+  distinguished by which token fired.
+- **An empty answer is a named failure** (`AiErrorKind.EmptyAnswer`). A model can end a turn having produced
+  only reasoning (#601), and #578 is *right* to segregate reasoning from answer — which is exactly what makes
+  this failure invisible, leaving the caller a well-formed, successful, blank turn.
+- **`ChatSettings` and `IChatProviderResolver` are the seam** for B2/B7. The key is deliberately absent from
+  settings.json — it belongs in the OS credential store (#579) — and a key is required for Anthropic but *not*
+  for OpenAI-compatible, because the motivating deployment is a local runner on loopback with no credential.
+
+**A live end-to-end run found a scope bug the unit tests could not** — filed as **#602**. A Translate turn on
+Dhp 21 returned a good translation of roughly *thirty* verses, spanning into two later chapters, beside a
+citation reading "paragraph 21". The window is budgeted in **characters** and is structurally blind: 2,400
+characters of prose is a passage, but a Dhammapada verse is ~80 characters. `WindowMayExtendPastReference` fired
+and #582 surfaced its notice, which is true and reads like a rounding caveat rather than a warning that the
+answer covers twenty-nine paragraphs nobody asked about. §6 names truthful output over a *narrower* scope than
+assumed as the characteristic failure; this is that failure mirrored, and the app-rendered citation makes it
+worse rather than better. Fixing it also unblocks §6's fence 4, since the missing capability is the same one.

--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -1,0 +1,430 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using CST;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using CST.Navigation;
+using CST.Search;
+using CST.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// The orchestrator end to end, against a fake provider that echoes the assembled request back. (#583)
+///
+/// <para>What is actually under test is the contract a panel depends on: that no expected failure throws, that
+/// a superseded turn ends quietly while the caller's own cancellation does not, that usage survives a
+/// mid-stream failure, and that a turn which produced no answer is reported as one rather than as success.</para>
+/// </summary>
+public class AiChatOrchestratorTests
+{
+    // ---- Doubles ------------------------------------------------------------------------------------------
+
+    /// <summary>Records the request it was given and replays a scripted stream.</summary>
+    private sealed class FakeProvider : IChatProvider
+    {
+        private readonly IReadOnlyList<ChatDelta> _deltas;
+        private readonly AiException? _throwBeforeStreaming;
+        private readonly TaskCompletionSource? _blockAfterFirst;
+
+        internal FakeProvider(
+            IEnumerable<ChatDelta>? deltas = null,
+            AiException? throwBeforeStreaming = null,
+            TaskCompletionSource? blockAfterFirst = null)
+        {
+            _deltas = deltas?.ToList() ?? new List<ChatDelta> { ChatDelta.ForText("Heedfulness is the path.") };
+            _throwBeforeStreaming = throwBeforeStreaming;
+            _blockAfterFirst = blockAfterFirst;
+        }
+
+        public string Id => "fake";
+        internal ChatRequest? LastRequest { get; private set; }
+
+        // Blocking is ONE-SHOT per provider, not per stream. The supersede test resolves the same provider for
+        // both turns, so a per-stream block would park the replacement too and nothing would ever cancel it.
+        private bool _hasBlocked;
+
+        public async IAsyncEnumerable<ChatDelta> StreamAsync(
+            ChatRequest request, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            LastRequest = request;
+            if (_throwBeforeStreaming is not null) throw _throwBeforeStreaming;
+
+            var first = true;
+            foreach (var delta in _deltas)
+            {
+                yield return delta;
+
+                if (first && _blockAfterFirst is not null && !_hasBlocked)
+                {
+                    first = false;
+                    _hasBlocked = true;
+                    // Park until cancelled — lets a test supersede a turn that is genuinely mid-stream.
+                    _blockAfterFirst.TrySetResult();
+                    await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    private sealed class FixedResolver : IChatProviderResolver
+    {
+        private readonly ChatProviderResolution? _resolution;
+        private readonly string? _problem;
+
+        internal FixedResolver(IChatProvider? provider, string? problem = null)
+        {
+            _resolution = provider is null ? null : new ChatProviderResolution(provider, "test-model");
+            _problem = problem;
+        }
+
+        public ChatProviderResolution? Resolve(out string? problem)
+        {
+            problem = _problem;
+            return _resolution;
+        }
+    }
+
+    private sealed class StubBundler : IAiContextBundler
+    {
+        private readonly Exception? _throw;
+
+        internal StubBundler(Exception? toThrow = null) => _throw = toThrow;
+
+        internal AiContextRequest? LastRequest { get; private set; }
+
+        public Task<AiContextBundle> BuildAsync(AiContextRequest request, CancellationToken ct = default)
+        {
+            LastRequest = request;
+            if (_throw is not null) throw _throw;
+
+            var pages = Array.Empty<SnippetPageRef>();
+            var passage = new PassageResult(
+                request.BookId, "paragraph 21 (dhp)", "Appamādo amatapadaṃ.", pages, 21, "dhp", null, null, 0,
+                Array.Empty<ApparatusNote>());
+
+            return Task.FromResult(new AiContextBundle(
+                request.Task, request.OutputLanguage, request.UserQuestion, passage,
+                Selection: null,
+                Lemmas: Array.Empty<LemmaEntry>(),
+                Book: new BookContext(request.BookId, "Dhammapadapāḷi", Pitaka.Sutta, CommentaryLevel.Mula),
+                Citation: new CitationRef(request.BookId, "Dhammapadapāḷi", "paragraph 21 (dhp)", pages),
+                Provenance: new Provenance("test", null),
+                Budget: new BudgetReport(
+                    new[] { new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window") },
+                    100, WindowMayExtendPastReference: false)));
+        }
+    }
+
+    // ---- Fixture ------------------------------------------------------------------------------------------
+
+    private static ISettingsService Settings(string language = "English")
+    {
+        var settings = new Settings();
+        settings.Ai.Chat.AnswerLanguage = language;
+        var mock = new Mock<ISettingsService>();
+        mock.SetupGet(s => s.Settings).Returns(settings);
+        return mock.Object;
+    }
+
+    private static AiChatOrchestrator Orchestrator(
+        IChatProvider? provider = null,
+        string? notConfigured = null,
+        IAiContextBundler? bundler = null,
+        string language = "English")
+    {
+        // A store pointed at a directory that does not exist: no user override can be picked up, so every test
+        // runs against the shipped templates.
+        var templates = new PromptTemplateStore(
+            Path.Combine(Path.GetTempPath(), "cst-orch-" + Guid.NewGuid().ToString("N")),
+            NullLogger<PromptTemplateStore>.Instance);
+
+        return new AiChatOrchestrator(
+            new FixedResolver(provider, notConfigured),
+            bundler ?? new StubBundler(),
+            new PromptBuilder(templates),
+            Settings(language),
+            NullLogger<AiChatOrchestrator>.Instance);
+    }
+
+    private static AiTurnRequest Request(AiTask task = AiTask.Explain) =>
+        new(task, "s0502m.mul.xml", new NavigationReference.Paragraph(21));
+
+    private static async Task<List<AiTurnEvent>> CollectAsync(
+        IAiChatOrchestrator orchestrator, AiTurnRequest? request = null, CancellationToken ct = default)
+    {
+        var events = new List<AiTurnEvent>();
+        await foreach (var e in orchestrator.RunAsync(request ?? Request(), ct))
+            events.Add(e);
+        return events;
+    }
+
+    private static string TextOf(IEnumerable<AiTurnEvent> events) =>
+        string.Concat(events.Where(e => e.Kind == AiTurnEventKind.Text).Select(e => e.Text));
+
+    // ---- The happy path -----------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task A_turn_assembles_a_request_and_streams_an_answer()
+    {
+        var provider = new FakeProvider();
+
+        var events = await CollectAsync(Orchestrator(provider));
+
+        Assert.Equal(AiTurnEventKind.Started, events[0].Kind);
+        Assert.Equal(AiTurnEventKind.Completed, events[^1].Kind);
+        Assert.Equal("Heedfulness is the path.", TextOf(events));
+
+        // The assembled request is the thing worth asserting: the prompt layer's output reaches the wire.
+        var sent = provider.LastRequest!;
+        Assert.Equal("test-model", sent.Model);
+        Assert.Contains("Appamādo amatapadaṃ.", sent.Messages.Single().Content);
+        Assert.Contains("paragraph 21 (dhp)", sent.System);
+    }
+
+    [Fact]
+    public async Task The_citation_reaches_the_caller_before_any_text()
+    {
+        // The panel draws its chrome from this while the model is still thinking; arriving late would mean an
+        // answer rendered with no scope beside it.
+        var events = await CollectAsync(Orchestrator(new FakeProvider()));
+
+        var started = Assert.IsType<AiTurnContext>(events[0].Context);
+        Assert.Equal("paragraph 21 (dhp)", started.Citation.NormalizedReference);
+        Assert.Equal("Dhammapadapāḷi", started.Book.Name);
+    }
+
+    [Fact]
+    public async Task The_configured_answer_language_reaches_the_bundle()
+    {
+        var bundler = new StubBundler();
+
+        await CollectAsync(Orchestrator(new FakeProvider(), bundler: bundler, language: "Burmese"));
+
+        Assert.Equal("Burmese", bundler.LastRequest!.OutputLanguage);
+    }
+
+    [Fact]
+    public async Task Pali_markers_are_stripped_from_the_answer_and_counted()
+    {
+        // Split across deltas on purpose — the marker can straddle a chunk boundary, and the count is what
+        // #587 uses to decide whether script conversion is safe for a model.
+        var provider = new FakeProvider(new[]
+        {
+            ChatDelta.ForText("The phrase [" ),
+            ChatDelta.ForText("[appamādo]"),
+            ChatDelta.ForText("] opens it."),
+        });
+
+        var events = await CollectAsync(Orchestrator(provider));
+
+        Assert.Equal("The phrase appamādo opens it.", TextOf(events));
+        Assert.Equal(new PaliMarkerReport(1, 0), events[^1].Markers);
+    }
+
+    [Fact]
+    public async Task Reasoning_is_delivered_separately_from_the_answer()
+    {
+        var provider = new FakeProvider(new[]
+        {
+            ChatDelta.ForReasoning("Let me parse the compound."),
+            ChatDelta.ForText("It is a dvanda."),
+        });
+
+        var events = await CollectAsync(Orchestrator(provider));
+
+        Assert.Equal("It is a dvanda.", TextOf(events));
+        Assert.Equal("Let me parse the compound.",
+            events.Single(e => e.Kind == AiTurnEventKind.Reasoning).Text);
+    }
+
+    [Fact]
+    public async Task Usage_is_merged_per_field_across_the_stream()
+    {
+        // The Anthropic stream reports the halves at opposite ends of the turn, so a consumer that lets a later
+        // delta supersede an earlier one erases the input count.
+        var provider = new FakeProvider(new[]
+        {
+            ChatDelta.ForUsage(new ChatUsage(1200, null)),
+            ChatDelta.ForText("An answer."),
+            ChatDelta.ForUsage(new ChatUsage(null, 350)),
+        });
+
+        var events = await CollectAsync(Orchestrator(provider));
+
+        var usage = events.Single(e => e.Kind == AiTurnEventKind.Usage).Usage!;
+        Assert.Equal(1200, usage.InputTokens);
+        Assert.Equal(350, usage.OutputTokens);
+    }
+
+    // ---- Failures -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Not_configured_is_an_event_rather_than_an_exception()
+    {
+        // The panel has to render this as a sentence pointing at Settings — never a raw error. (§10)
+        var events = await CollectAsync(
+            Orchestrator(provider: null, notConfigured: "No API key is stored for Claude."));
+
+        var error = Assert.Single(events).Error!;
+        Assert.Equal(AiErrorKind.NotConfigured, error.Kind);
+        Assert.Contains("No API key", error.Message);
+    }
+
+    [Fact]
+    public async Task An_unassemblable_passage_fails_before_anything_leaves_the_machine()
+    {
+        var provider = new FakeProvider();
+
+        var events = await CollectAsync(Orchestrator(
+            provider, bundler: new StubBundler(new AiContextException("No passage text for 's0502m.mul.xml'."))));
+
+        var error = Assert.Single(events).Error!;
+        Assert.Equal(AiErrorKind.ContextUnavailable, error.Kind);
+        Assert.Null(provider.LastRequest);   // nothing was sent
+    }
+
+    [Fact]
+    public async Task A_pre_stream_provider_failure_becomes_a_terminal_error_event()
+    {
+        var provider = new FakeProvider(
+            throwBeforeStreaming: new AiException(new AiError(AiErrorKind.Unauthorized, "The API key was rejected.")));
+
+        var events = await CollectAsync(Orchestrator(provider));
+
+        Assert.Equal(AiErrorKind.Unauthorized, events[^1].Error!.Kind);
+        Assert.Equal(AiTurnEventKind.Started, events[0].Kind);   // the citation still rendered
+    }
+
+    [Fact]
+    public async Task A_mid_stream_failure_keeps_the_partial_answer_and_still_reports_usage()
+    {
+        // Losing the partial would be worse than showing it with an error under it — and the tokens were spent
+        // either way, so the user is owed the count.
+        var provider = new FakeProvider(new[]
+        {
+            ChatDelta.ForText("Heedfulness is "),
+            ChatDelta.ForUsage(new ChatUsage(900, 12)),
+            ChatDelta.ForError(new AiError(AiErrorKind.Network, "The stream ended unexpectedly.")),
+            ChatDelta.ForText("never reached"),
+        });
+
+        var events = await CollectAsync(Orchestrator(provider));
+
+        Assert.Equal("Heedfulness is ", TextOf(events));
+        Assert.Equal(900, events.Single(e => e.Kind == AiTurnEventKind.Usage).Usage!.InputTokens);
+        Assert.Equal(AiErrorKind.Network, events[^1].Error!.Kind);
+    }
+
+    [Fact]
+    public async Task A_turn_that_produced_only_reasoning_is_reported_as_an_empty_answer()
+    {
+        // #601: the model spends its whole budget thinking. The provider layer is correct to segregate
+        // reasoning, and that correctness is what would otherwise leave the caller a successful blank turn.
+        var provider = new FakeProvider(new[] { ChatDelta.ForReasoning("Thinking at length...") });
+
+        var events = await CollectAsync(Orchestrator(provider));
+
+        var error = events[^1].Error!;
+        Assert.Equal(AiErrorKind.EmptyAnswer, error.Kind);
+        Assert.Contains("reasoning", error.Message);
+        Assert.DoesNotContain(events, e => e.Kind == AiTurnEventKind.Completed);
+    }
+
+    [Fact]
+    public async Task A_wholly_empty_response_is_also_an_empty_answer()
+    {
+        var events = await CollectAsync(Orchestrator(new FakeProvider(Array.Empty<ChatDelta>())));
+
+        Assert.Equal(AiErrorKind.EmptyAnswer, events[^1].Error!.Kind);
+    }
+
+    // ---- Cancellation and cancel-and-replace --------------------------------------------------------------
+
+    [Fact]
+    public async Task Stopping_a_turn_ends_it_quietly_and_keeps_what_was_written()
+    {
+        // Stop is a user action, not a failure — an error banner under an answer they chose to halt would be
+        // both wrong and alarming.
+        var streaming = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var provider = new FakeProvider(
+            new[] { ChatDelta.ForText("Heedfulness is "), ChatDelta.ForText("never reached") },
+            blockAfterFirst: streaming);
+        var orchestrator = Orchestrator(provider);
+
+        var events = new List<AiTurnEvent>();
+        var run = Task.Run(async () =>
+        {
+            await foreach (var e in orchestrator.RunAsync(Request()))
+                events.Add(e);
+        });
+
+        await streaming.Task;
+        orchestrator.Stop();
+        await run;
+
+        Assert.Equal("Heedfulness is ", TextOf(events));
+        Assert.DoesNotContain(events, e => e.Kind == AiTurnEventKind.Error);
+        Assert.DoesNotContain(events, e => e.Kind == AiTurnEventKind.Completed);
+    }
+
+    [Fact]
+    public async Task A_second_turn_supersedes_the_first_rather_than_queueing_behind_it()
+    {
+        // Cancel-and-replace: a reader who re-asks wants the new answer, not to watch one they abandoned.
+        var streaming = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = new FakeProvider(
+            new[] { ChatDelta.ForText("first"), ChatDelta.ForText("never reached") },
+            blockAfterFirst: streaming);
+        var orchestrator = Orchestrator(first);
+
+        var firstEvents = new List<AiTurnEvent>();
+        var firstRun = Task.Run(async () =>
+        {
+            await foreach (var e in orchestrator.RunAsync(Request()))
+                firstEvents.Add(e);
+        });
+
+        await streaming.Task;
+
+        var secondEvents = await CollectAsync(orchestrator, Request(AiTask.Translate));
+        await firstRun;
+
+        Assert.Equal("first", TextOf(firstEvents));                       // partial, no error
+        Assert.DoesNotContain(firstEvents, e => e.Kind == AiTurnEventKind.Error);
+        Assert.Equal(AiTurnEventKind.Completed, secondEvents[^1].Kind);   // the replacement ran to completion
+    }
+
+    [Fact]
+    public async Task The_callers_own_cancellation_throws_as_any_async_method_would()
+    {
+        // Distinct from being superseded: a consumer that cancels its own enumeration must not be quietly told
+        // the turn ended normally.
+        var streaming = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var provider = new FakeProvider(
+            new[] { ChatDelta.ForText("partial"), ChatDelta.ForText("never reached") },
+            blockAfterFirst: streaming);
+        using var cts = new CancellationTokenSource();
+
+        var run = CollectAsync(Orchestrator(provider), ct: cts.Token);
+        await streaming.Task;
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run);
+    }
+
+    [Fact]
+    public void Stopping_with_no_turn_in_flight_is_harmless()
+    {
+        Orchestrator(new FakeProvider()).Stop();
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Net.Http;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Settings + a key in, a callable provider out — or a sentence explaining what is missing. (#583)
+///
+/// <para>The refusals carry the weight: every one of them is text a user reads in the panel, so the test is as
+/// much about whether the message names something they can act on as about the null.</para>
+/// </summary>
+public class ChatProviderResolverTests
+{
+    private sealed class FixedKey : IAiCredentialStore
+    {
+        private readonly string? _key;
+
+        internal FixedKey(string? key) => _key = key;
+
+        public string? GetApiKey(ChatProviderKind provider) => _key;
+    }
+
+    private static ChatProviderResolver Resolver(
+        Action<ChatSettings> configure, string? apiKey = null, bool aiEnabled = true)
+    {
+        var settings = new Settings();
+        settings.Ai.Enabled = aiEnabled;
+        settings.Ai.Chat.Enabled = true;
+        configure(settings.Ai.Chat);
+
+        var service = new Mock<ISettingsService>();
+        service.SetupGet(s => s.Settings).Returns(settings);
+
+        return new ChatProviderResolver(
+            service.Object,
+            apiKey is null ? null : new FixedKey(apiKey),
+            NullLoggerFactory.Instance,
+            new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan });
+    }
+
+    [Fact]
+    public void Anthropic_resolves_with_a_stored_key()
+    {
+        var resolver = Resolver(c => { c.Provider = "anthropic"; c.Model = " claude-opus-5 "; }, apiKey: "sk-ant-x");
+
+        var resolution = resolver.Resolve(out var problem);
+
+        Assert.Null(problem);
+        Assert.IsType<AnthropicMessagesProvider>(resolution!.Provider);
+        Assert.Equal("claude-opus-5", resolution.Model);   // trimmed, otherwise verbatim
+    }
+
+    [Fact]
+    public void Anthropic_without_a_key_says_so_rather_than_failing_at_the_wire()
+    {
+        var resolver = Resolver(c => { c.Provider = "anthropic"; c.Model = "claude-opus-5"; });
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.Contains("API key", problem);
+    }
+
+    [Fact]
+    public void An_openai_compatible_endpoint_needs_no_key()
+    {
+        // The motivating deployment: Ollama or LM Studio on loopback, which has no credential at all. Requiring
+        // one here would lock out the configuration surface B was built to serve.
+        var resolver = Resolver(c =>
+        {
+            c.Provider = "openai-compatible";
+            c.BaseUrl = "http://localhost:11434/v1";
+            c.Model = "gemma4:cloud";
+        });
+
+        var resolution = resolver.Resolve(out var problem);
+
+        Assert.Null(problem);
+        Assert.IsType<OpenAiCompatibleProvider>(resolution!.Provider);
+    }
+
+    [Fact]
+    public void An_openai_compatible_endpoint_without_a_base_url_is_refused()
+    {
+        // No default is possible: the base URL IS the provider.
+        var resolver = Resolver(c => { c.Provider = "openai-compatible"; c.Model = "deepseek-chat"; });
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.Contains("base URL", problem);
+    }
+
+    [Fact]
+    public void No_model_is_refused_before_anything_else_is_examined()
+    {
+        var resolver = Resolver(c => { c.Provider = "anthropic"; c.Model = null; }, apiKey: "sk-ant-x");
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.Contains("model", problem);
+    }
+
+    [Fact]
+    public void The_master_switch_being_off_is_reported_as_a_setting_not_a_fault()
+    {
+        var resolver = Resolver(
+            c => { c.Provider = "anthropic"; c.Model = "claude-opus-5"; }, apiKey: "sk-ant-x", aiEnabled: false);
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.Contains("turned off", problem);
+    }
+
+    [Fact]
+    public void An_unknown_provider_name_names_itself_in_the_message()
+    {
+        var resolver = Resolver(c => { c.Provider = "bedrock"; c.Model = "x"; }, apiKey: "k");
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.Contains("bedrock", problem);
+    }
+
+    [Theory]
+    [InlineData("anthropic", ChatProviderKind.Anthropic)]
+    [InlineData("Claude", ChatProviderKind.Anthropic)]
+    [InlineData("openai-compatible", ChatProviderKind.OpenAiCompatible)]
+    [InlineData("openai_compatible", ChatProviderKind.OpenAiCompatible)]
+    [InlineData("  OpenAI  ", ChatProviderKind.OpenAiCompatible)]
+    public void Provider_names_are_forgiving_because_the_field_is_hand_edited(string value, ChatProviderKind expected)
+    {
+        // Until #585 there is no UI: this string is typed into settings.json by hand.
+        Assert.True(ChatProviderResolver.TryParseKind(value, out var kind));
+        Assert.Equal(expected, kind);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("gpt")]
+    public void An_unrecognised_provider_name_does_not_silently_pick_one(string? value)
+    {
+        Assert.False(ChatProviderResolver.TryParseKind(value, out _));
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1225,6 +1225,15 @@ public partial class App : Application
         // the app takes effect on the next invocation without a restart.
         services.AddSingleton<Services.Ai.IPromptTemplateStore, Services.Ai.PromptTemplateStore>();
         services.AddSingleton<Services.Ai.IPromptBuilder, Services.Ai.PromptBuilder>();
+
+        // The orchestrator (#583). IAiCredentialStore is resolved with GetService because #579 has not landed:
+        // its absence is a supported configuration — a local runner on loopback needs no key — which the
+        // resolver reports rather than treating as a wiring error.
+        services.AddSingleton<Services.Ai.IChatProviderResolver>(sp => new Services.Ai.ChatProviderResolver(
+            sp.GetRequiredService<ISettingsService>(),
+            sp.GetService<Services.Ai.IAiCredentialStore>(),
+            sp.GetRequiredService<ILoggerFactory>()));
+        services.AddSingleton<Services.Ai.IAiChatOrchestrator, Services.Ai.AiChatOrchestrator>();
         services.AddSingleton<ILemmaReportService, LemmaReportService>();
 
         // Surface-C tool wrappers (exposed over the local API). (#186)

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -42,6 +42,9 @@ namespace CST.Avalonia.Models
 
         public LocalApiSettings LocalApi { get; set; } = new();
 
+        /// <summary>Surface B — the assistant inside the reader. Off until configured.</summary>
+        public ChatSettings Chat { get; set; } = new();
+
         /// <summary>The REST (/v1) surface runs only when the master and the local-API permission are both on.</summary>
         [JsonIgnore]
         public bool LocalApiEnabled => Enabled && LocalApi.Enabled;
@@ -63,6 +66,35 @@ namespace CST.Avalonia.Models
         /// already ticked. Unreachable through today's Settings UI, but #280 gives MCP its own toggle. (fable LOW-5)</summary>
         [JsonIgnore]
         public bool RemoteControlAllowed => ServerShouldRun && LocalApi.AllowRemoteControl;
+    }
+
+    /// <summary>
+    /// The in-app assistant (surface B). Everything here is user-visible configuration EXCEPT the API key,
+    /// which is deliberately absent: keys belong in the OS credential store (#579), never in a settings file
+    /// that gets pasted into bug reports. The UI that edits these is #585; until it exists they are hand-edited.
+    /// </summary>
+    public class ChatSettings
+    {
+        /// <summary>Effective only under the AI master switch, like every other surface-B/C permission.</summary>
+        public bool Enabled { get; set; } = false;
+
+        /// <summary><c>anthropic</c> or <c>openai-compatible</c>. Claude-first is the standing default.</summary>
+        public string Provider { get; set; } = "anthropic";
+
+        /// <summary>
+        /// Endpoint base URL. Optional for Anthropic (it has a real default); <b>required</b> for
+        /// OpenAI-compatible, where the base URL is what selects the provider.
+        /// </summary>
+        public string? BaseUrl { get; set; }
+
+        /// <summary>Model id, verbatim. Never validated against a list — see <c>ChatProviderResolution</c>.</summary>
+        public string? Model { get; set; }
+
+        /// <summary>
+        /// Language the ANSWER is written in — a separate axis from the script quoted Pāli is rendered in
+        /// (AI_SURFACE_B.md §9). Not optional in the bundle: "translate" has to mean translate into something.
+        /// </summary>
+        public string AnswerLanguage { get; set; } = "English";
     }
 
     /// <summary>Permissions for the loopback API server that exposes the corpus tools to agents (surface C).</summary>

--- a/src/CST.Avalonia/Models/SettingsValidator.cs
+++ b/src/CST.Avalonia/Models/SettingsValidator.cs
@@ -91,6 +91,7 @@ public static class SettingsValidator
         // again, and Settings is the only repair path. Repair like every other section. (#319 A7-2)
         if (settings.Ai == null) { settings.Ai = new AiSettings(); fixes.Add("ai settings were null; reset to default"); }
         if (settings.Ai.LocalApi == null) { settings.Ai.LocalApi = new LocalApiSettings(); fixes.Add("ai.localApi settings were null; reset to default"); }
+        if (settings.Ai.Chat == null) { settings.Ai.Chat = new ChatSettings(); fixes.Add("ai.chat settings were null; reset to default"); }
 
         // (The historical local-API Port/Token scrub is gone with those fields, removed in #280: the port is
         // ephemeral and the token per-session, both held only in local-api.json. A stale value left in an old

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>Runs one turn of the in-app assistant. See <see cref="AiChatOrchestrator"/>.</summary>
+public interface IAiChatOrchestrator
+{
+    /// <summary>
+    /// Run a turn, streaming events as they happen.
+    ///
+    /// <para><b>Nothing expected is thrown.</b> Not-configured, an unreadable passage, a dead network, a 401 —
+    /// all arrive as a terminal <see cref="AiTurnEventKind.Error"/> event. A panel has to render every one of
+    /// those as a sentence rather than an exception (AI_SURFACE_B.md §10), and collapsing the provider layer's
+    /// two failure shapes into one here is what spares every future caller from re-deriving that.</para>
+    ///
+    /// <para><b>Starting a turn cancels the one in flight</b> — cancel-and-replace, not queue. The replacement
+    /// happens when the new turn is first enumerated, not when this method returns, because an async iterator
+    /// runs no code until then.</para>
+    /// </summary>
+    IAsyncEnumerable<AiTurnEvent> RunAsync(AiTurnRequest request, CancellationToken ct = default);
+
+    /// <summary>Stop the turn in flight, if any. What the panel's stop control calls.</summary>
+    void Stop();
+}
+
+/// <summary>
+/// Bundle → prompt → provider → events. The layer that makes surface B a feature rather than four libraries.
+/// (#583, AI_SURFACE_B.md §5, §10)
+///
+/// <para><b>Cancel-and-replace, not queue.</b> Asking a second question supersedes the first: a reader who
+/// re-asks wants the new answer, and a queue would make them watch an answer they have already abandoned. A
+/// superseded turn ends QUIETLY — its partial text stands and no error is reported, because being replaced is
+/// not a failure. The caller's own token behaves the ordinary .NET way and throws, so a consumer that cancels
+/// its own enumeration is not silently told the turn succeeded.</para>
+///
+/// <para><b>An empty answer is reported as a failure.</b> A model can end a turn having produced only
+/// reasoning — the whole output budget spent thinking, nothing written down (#601). The provider layer is
+/// right to segregate reasoning from answer, and that correctness is exactly what makes this failure invisible:
+/// the caller gets a well-formed, successful, blank turn. So a turn that emitted no text is turned into a
+/// named error here, where it is still possible to say something useful about it.</para>
+///
+/// <para><b>What is never logged above Debug.</b> The prompt contains corpus text and the user's own question,
+/// and the answer contains both back again. Above Debug this logs only shapes and counts. (§10)</para>
+/// </summary>
+public sealed class AiChatOrchestrator : IAiChatOrchestrator
+{
+    private readonly IChatProviderResolver _resolver;
+    private readonly IAiContextBundler _bundler;
+    private readonly IPromptBuilder _prompts;
+    private readonly ISettingsService _settings;
+    private readonly ILogger<AiChatOrchestrator> _logger;
+
+    private readonly object _gate = new();
+    private CancellationTokenSource? _current;
+
+    public AiChatOrchestrator(
+        IChatProviderResolver resolver,
+        IAiContextBundler bundler,
+        IPromptBuilder prompts,
+        ISettingsService settings,
+        ILogger<AiChatOrchestrator> logger)
+    {
+        _resolver = resolver;
+        _bundler = bundler;
+        _prompts = prompts;
+        _settings = settings;
+        _logger = logger;
+    }
+
+    public void Stop()
+    {
+        CancellationTokenSource? running;
+        lock (_gate)
+        {
+            running = _current;
+            _current = null;
+        }
+
+        if (running is null) return;
+        _logger.LogDebug("Stopping the AI turn in flight");
+        TryCancel(running);
+    }
+
+    public async IAsyncEnumerable<AiTurnEvent> RunAsync(
+        AiTurnRequest request, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        // Supersede whatever is running. Each turn disposes only the source it owns (in the finally below), so
+        // this never disposes a source another iterator is still linked to.
+        var mine = new CancellationTokenSource();
+        CancellationTokenSource? superseded;
+        lock (_gate)
+        {
+            superseded = _current;
+            _current = mine;
+        }
+
+        if (superseded is not null)
+        {
+            _logger.LogDebug("Superseding the AI turn in flight");
+            TryCancel(superseded);
+        }
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, mine.Token);
+        var token = linked.Token;
+
+        try
+        {
+            await foreach (var turnEvent in RunCoreAsync(request, ct, token).ConfigureAwait(false))
+                yield return turnEvent;
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                if (ReferenceEquals(_current, mine)) _current = null;
+            }
+            mine.Dispose();
+        }
+    }
+
+    /// <param name="callerToken">The consumer's own token. Cancelling it must throw, as any .NET async method
+    /// would; cancelling only ours means superseded or stopped, which ends the turn quietly.</param>
+    /// <param name="token">The linked token actually passed downstream.</param>
+    private async IAsyncEnumerable<AiTurnEvent> RunCoreAsync(
+        AiTurnRequest request, CancellationToken callerToken, CancellationToken token)
+    {
+        var provider = _resolver.Resolve(out var problem);
+        if (provider is null)
+        {
+            // Never a raw error: the panel shows this sentence and points at Settings. (§10)
+            yield return AiTurnEvent.ForError(new AiError(
+                AiErrorKind.NotConfigured, problem ?? "The assistant is not configured yet."));
+            yield break;
+        }
+
+        var language = _settings.Settings.Ai.Chat.AnswerLanguage;
+        if (string.IsNullOrWhiteSpace(language)) language = "English";
+
+        // ---- Assemble. Everything here happens before a byte leaves the machine, so a failure is clean.
+        AiContextBundle? bundle = null;
+        RenderedPrompt? prompt = null;
+        AiError? assemblyFailure = null;
+        var superseded = false;
+
+        // `yield return` is illegal inside a catch clause, so every failure is captured and reported below.
+        try
+        {
+            bundle = await _bundler.BuildAsync(
+                new AiContextRequest(
+                    request.Task, request.BookId, language, request.Reference,
+                    request.SelectionText, request.UserQuestion),
+                token).ConfigureAwait(false);
+
+            prompt = _prompts.Build(bundle);
+        }
+        catch (OperationCanceledException) when (!callerToken.IsCancellationRequested)
+        {
+            superseded = true;
+        }
+        catch (AiContextException ex)
+        {
+            // Reachable on ordinary data, not only on bugs: a ranged paragraph anchor is not in the marker
+            // index, and a catalogued book whose XML never downloaded behaves the same way.
+            _logger.LogInformation("Could not assemble context for {Task} on {BookId}: {Reason}",
+                request.Task, request.BookId, ex.Message);
+            assemblyFailure = new AiError(AiErrorKind.ContextUnavailable, ex.Message);
+        }
+        catch (PromptTemplateException ex)
+        {
+            // Only reachable if a built-in template resource is missing from the build — a bad package, not a
+            // configuration mistake, so it says so rather than sending the user to Settings.
+            _logger.LogError(ex, "The prompt templates could not be loaded");
+            assemblyFailure = new AiError(
+                AiErrorKind.Provider, "The assistant's prompts could not be loaded. This build may be damaged.");
+        }
+
+        if (superseded) yield break;
+        if (assemblyFailure is not null)
+        {
+            yield return AiTurnEvent.ForError(assemblyFailure);
+            yield break;
+        }
+
+        // Content at Debug only — the prompt carries corpus text and the user's question. (§10)
+        _logger.LogDebug("AI turn prompt for {Task}:\n{System}\n---\n{User}",
+            request.Task, prompt.System, prompt.UserContent);
+        _logger.LogInformation(
+            "AI turn: {Task} on {BookId} via {Provider}/{Model}, ~{Tokens} context tokens, {Notices} notice(s)",
+            request.Task, request.BookId, provider.Provider.Id, provider.Model,
+            bundle.Budget.ApproximateTokens, prompt.Notices.Count);
+
+        yield return AiTurnEvent.ForStarted(new AiTurnContext(
+            bundle.Task, bundle.OutputLanguage, bundle.Citation, bundle.Book, prompt.Notices));
+
+        // ---- Stream.
+        var chat = new ChatRequest(
+            provider.Model,
+            prompt.MaxOutputTokens,
+            prompt.System,
+            new[] { new ChatMessage(ChatRole.User, prompt.UserContent) });
+
+        var markers = new PaliQuoteFilter();
+        int? inputTokens = null, outputTokens = null;
+        var sawText = false;
+        var sawReasoning = false;
+        AiError? failure = null;
+
+        // The manual enumerator is required, not stylistic: `yield return` is illegal inside a try that has a
+        // catch clause, and every failure below has to be turned into an event rather than propagated.
+        await using (var deltas = provider.Provider.StreamAsync(chat, token).GetAsyncEnumerator(token))
+        {
+            while (true)
+            {
+                ChatDelta delta;
+                try
+                {
+                    if (!await deltas.MoveNextAsync().ConfigureAwait(false)) break;
+                    delta = deltas.Current;
+                }
+                catch (OperationCanceledException) when (!callerToken.IsCancellationRequested)
+                {
+                    // Superseded or stopped. Keep whatever is on screen and end quietly — being replaced is
+                    // not a failure, and reporting one would put an error under an answer the user abandoned.
+                    _logger.LogDebug("AI turn ended early (superseded or stopped)");
+                    yield break;
+                }
+                catch (AiException ex)
+                {
+                    failure = ex.Error;
+                    break;
+                }
+
+                switch (delta.Kind)
+                {
+                    case ChatDeltaKind.Text when delta.Text is { Length: > 0 } text:
+                    {
+                        var visible = markers.Feed(text);
+                        if (visible.Length > 0)
+                        {
+                            sawText = true;
+                            yield return AiTurnEvent.ForText(visible);
+                        }
+                        break;
+                    }
+
+                    case ChatDeltaKind.Reasoning when delta.Text is { Length: > 0 } reasoning:
+                        sawReasoning = true;
+                        yield return AiTurnEvent.ForReasoning(reasoning);
+                        break;
+
+                    // Merged PER FIELD, never wholesale: the Anthropic stream reports the two halves at
+                    // opposite ends of the turn, so letting a later delta supersede an earlier one erases the
+                    // input count. A null field means "not reported in this delta", never zero.
+                    case ChatDeltaKind.Usage when delta.Usage is { } usage:
+                        inputTokens = usage.InputTokens ?? inputTokens;
+                        outputTokens = usage.OutputTokens ?? outputTokens;
+                        break;
+
+                    case ChatDeltaKind.Error when delta.Error is { } error:
+                        failure = error;
+                        break;
+                }
+
+                if (failure is not null) break;
+            }
+        }
+
+        var tail = markers.Flush();
+        if (tail.Length > 0)
+        {
+            sawText = true;
+            yield return AiTurnEvent.ForText(tail);
+        }
+
+        // Usage before the terminal event, and on the failure path too — a turn that died mid-stream still
+        // spent tokens, and the user is paying for those either way.
+        if (inputTokens is not null || outputTokens is not null)
+            yield return AiTurnEvent.ForUsage(new AiUsageReport(inputTokens, outputTokens));
+
+        if (failure is not null)
+        {
+            _logger.LogInformation("AI turn failed: {Kind} ({Code})", failure.Kind, failure.ProviderCode ?? "-");
+            yield return AiTurnEvent.ForError(failure);
+            yield break;
+        }
+
+        if (!sawText)
+        {
+            // See the class remarks: a well-formed turn that wrote nothing down. Naming the reasoning case
+            // separately matters because the fix differs — raise the cap, versus try a different model.
+            _logger.LogInformation(
+                "AI turn produced no answer text (reasoning seen: {Reasoning})", sawReasoning);
+            yield return AiTurnEvent.ForError(new AiError(
+                AiErrorKind.EmptyAnswer,
+                sawReasoning
+                    ? "The model spent its whole response on reasoning and never wrote an answer. "
+                      + "Try a higher output limit, or a different model."
+                    : "The model returned an empty response."));
+            yield break;
+        }
+
+        _logger.LogDebug("AI turn complete: {Quotes} marked quote(s), {Unbalanced} unbalanced",
+            markers.Quotes, markers.UnbalancedMarkers);
+
+        yield return AiTurnEvent.ForCompleted(
+            new PaliMarkerReport(markers.Quotes, markers.UnbalancedMarkers));
+    }
+
+    /// <summary>Cancelling a source another turn already disposed is a benign race, not an error.</summary>
+    private static void TryCancel(CancellationTokenSource source)
+    {
+        try { source.Cancel(); }
+        catch (ObjectDisposedException) { }
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/AiTurn.cs
+++ b/src/CST.Avalonia/Services/Ai/AiTurn.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using CST.Navigation;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>
+/// What the user asked for. The orchestrator's whole input — everything else it looks up.
+/// </summary>
+/// <param name="Reference">Where in the book. Null reads from the START of the book, so a caller that does not
+/// know the reading position must refuse rather than pass null (see <see cref="ReaderStateService"/>).</param>
+public sealed record AiTurnRequest(
+    AiTask Task,
+    string BookId,
+    NavigationReference? Reference = null,
+    string? SelectionText = null,
+    string? UserQuestion = null);
+
+/// <summary>What kind of thing a <see cref="AiTurnEvent"/> carries.</summary>
+public enum AiTurnEventKind
+{
+    /// <summary>
+    /// The context is assembled and the request is away. Carries the citation the app renders beside the
+    /// answer and any degradation notices. <b>Always the first event on a successful turn</b>, and it arrives
+    /// before any text — the panel can draw its chrome while the model is still thinking.
+    /// </summary>
+    Started,
+
+    /// <summary>Answer text, marker-stripped and ready to render.</summary>
+    Text,
+
+    /// <summary>Model reasoning, segregated. A caller may show it deliberately or drop it; never concatenate it
+    /// into the answer.</summary>
+    Reasoning,
+
+    /// <summary>Token accounting, merged across the stream. Emitted once, before the terminal event.</summary>
+    Usage,
+
+    /// <summary>
+    /// The turn failed. Terminal. Any <see cref="Text"/> already emitted stands — a mid-stream failure keeps
+    /// the partial answer rather than discarding it.
+    /// </summary>
+    Error,
+
+    /// <summary>The turn finished normally. Terminal.</summary>
+    Completed,
+}
+
+/// <summary>What the app renders beside the answer, and what it must tell the user about how it was built.</summary>
+/// <param name="Citation">Rendered by the app from bundle data, never parsed out of model output — which is
+/// what makes it impossible for a garbled answer to produce a false citation on screen.</param>
+/// <param name="Notices">Degradations worth showing: a missing asset, a trimmed part, a selection the window
+/// does not contain, a prompt edit that was rejected. Empty on a clean turn.</param>
+public sealed record AiTurnContext(
+    AiTask Task,
+    string OutputLanguage,
+    CitationRef Citation,
+    BookContext Book,
+    IReadOnlyList<string> Notices);
+
+/// <summary>
+/// How the model quoted Pāli, counted rather than merely repaired. (#587)
+/// </summary>
+/// <param name="Quotes">Properly opened and closed quotes.</param>
+/// <param name="UnbalancedMarkers">Markers with no partner. Stripped from the answer regardless — see
+/// <see cref="PaliQuoteFilter"/> — but recorded, because marker discipline is what decides whether script
+/// conversion can be enabled for a given model (AI_SURFACE_B.md §9).</param>
+public sealed record PaliMarkerReport(int Quotes, int UnbalancedMarkers);
+
+/// <summary>Tokens as the provider reported them. Null where a provider does not report that half.</summary>
+/// <remarks>
+/// There is no cost field. Neither wire format reports a price, so a figure here would have to come from a
+/// rate table — which is #584's registry, not this layer's to invent. §10's "show what the call cost" is
+/// satisfied by tokens until that lands.
+/// </remarks>
+public sealed record AiUsageReport(int? InputTokens, int? OutputTokens);
+
+/// <summary>One event in a turn. See <see cref="AiTurnEventKind"/> for which field each kind populates.</summary>
+public sealed record AiTurnEvent(
+    AiTurnEventKind Kind,
+    string? Text = null,
+    AiTurnContext? Context = null,
+    AiUsageReport? Usage = null,
+    AiError? Error = null,
+    PaliMarkerReport? Markers = null)
+{
+    public static AiTurnEvent ForStarted(AiTurnContext context) => new(AiTurnEventKind.Started, Context: context);
+    public static AiTurnEvent ForText(string text) => new(AiTurnEventKind.Text, Text: text);
+    public static AiTurnEvent ForReasoning(string text) => new(AiTurnEventKind.Reasoning, Text: text);
+    public static AiTurnEvent ForUsage(AiUsageReport usage) => new(AiTurnEventKind.Usage, Usage: usage);
+    public static AiTurnEvent ForError(AiError error) => new(AiTurnEventKind.Error, Error: error);
+
+    public static AiTurnEvent ForCompleted(PaliMarkerReport markers) =>
+        new(AiTurnEventKind.Completed, Markers: markers);
+}

--- a/src/CST.Avalonia/Services/Ai/ChatContracts.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatContracts.cs
@@ -120,6 +120,21 @@ public enum AiErrorKind
     /// <summary>The request exceeded the model's context window. Actionable: the caller can trim and retry.</summary>
     ContextTooLong,
 
+    /// <summary>
+    /// The app could not assemble what the model needs — no passage at the reference, a book whose XML never
+    /// downloaded. Distinct from every kind above because <b>nothing left the machine</b>: it is not the
+    /// provider's fault, no tokens were spent, and the fix is in the reader rather than in Settings. (#583)
+    /// </summary>
+    ContextUnavailable,
+
+    /// <summary>
+    /// The turn completed successfully and produced no answer. Usually the whole output budget went to
+    /// reasoning (#601). Named rather than folded into <see cref="Provider"/> because it is the one failure a
+    /// correct provider layer makes INVISIBLE — segregating reasoning from answer, exactly as it should, leaves
+    /// the caller a well-formed blank turn. (#583)
+    /// </summary>
+    EmptyAnswer,
+
     /// <summary>Anything else the provider rejected or failed on.</summary>
     Provider,
 }

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using CST.Avalonia.Models;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>Which wire format a configured endpoint speaks.</summary>
+public enum ChatProviderKind
+{
+    /// <summary>The Anthropic Messages API. The standing default (AI_INTEGRATION.md §11.1).</summary>
+    Anthropic,
+
+    /// <summary>The OpenAI-compatible Chat Completions shape — DeepSeek, OpenRouter, Ollama, LM Studio, …</summary>
+    OpenAiCompatible,
+}
+
+/// <summary>
+/// Where the API key lives. <b>Declared here, implemented by #579</b> (Keychain on macOS, DPAPI on Windows).
+///
+/// <para>Resolved with <c>GetService</c> rather than <c>GetRequiredService</c>, exactly as the optional
+/// DPD-lemma asset is: its absence is a supported configuration that the resolver reports, not a wiring error.
+/// That is what lets surface B run today against a local endpoint that needs no key at all.</para>
+/// </summary>
+public interface IAiCredentialStore
+{
+    /// <summary>The stored key for a provider, or null when none is stored.</summary>
+    string? GetApiKey(ChatProviderKind provider);
+}
+
+/// <summary>
+/// A configured provider, ready to call.
+/// </summary>
+/// <param name="Model">The model id, verbatim as the user typed it. Never validated against a list — the
+/// OpenAI-compatible shape serves arbitrary endpoints, so any list we shipped would be wrong within a month.</param>
+public sealed record ChatProviderResolution(IChatProvider Provider, string Model);
+
+/// <summary>Resolves the configured provider, or explains why there isn't one.</summary>
+public interface IChatProviderResolver
+{
+    /// <summary>
+    /// The configured provider, or null with <paramref name="problem"/> describing what the user must set.
+    /// Returns rather than throws: "not configured" is the ordinary state of a feature that ships off, and the
+    /// panel needs to render an explanation, not an exception (AI_SURFACE_B.md §10).
+    /// </summary>
+    ChatProviderResolution? Resolve(out string? problem);
+}
+
+/// <summary>
+/// Builds a provider from settings. (#583)
+///
+/// <para><b>What this deliberately does not own.</b> The API key comes from <see cref="IAiCredentialStore"/>
+/// (#579) and the UI that sets any of this is #585. What lives here is only the resolution: settings plus a key
+/// in, a callable provider out. That split is why the orchestrator can be built and tested before either of
+/// those exists.</para>
+///
+/// <para><b>A missing key is not always a misconfiguration.</b> The motivating deployment for the
+/// OpenAI-compatible adapter is a local runner — Ollama, LM Studio — reached over loopback with no credential
+/// at all. So the key is required for Anthropic and optional for OpenAI-compatible, and "no key" is reported as
+/// a problem only where it actually is one.</para>
+/// </summary>
+public sealed class ChatProviderResolver : IChatProviderResolver
+{
+    private readonly ISettingsService _settings;
+    private readonly IAiCredentialStore? _credentials;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly HttpClient _http;
+
+    public ChatProviderResolver(
+        ISettingsService settings,
+        IAiCredentialStore? credentials,
+        ILoggerFactory loggerFactory)
+        : this(settings, credentials, loggerFactory, CreateHttpClient())
+    {
+    }
+
+    /// <summary>Test seam: supply a client over a stub handler instead of reaching the network.</summary>
+    internal ChatProviderResolver(
+        ISettingsService settings,
+        IAiCredentialStore? credentials,
+        ILoggerFactory loggerFactory,
+        HttpClient http)
+    {
+        _settings = settings;
+        _credentials = credentials;
+        _loggerFactory = loggerFactory;
+        _http = http;
+    }
+
+    /// <summary>
+    /// One client for the app's lifetime, and it <b>must</b> have an infinite timeout — the providers reject a
+    /// finite one outright. <c>HttpClient</c>'s 100-second default would silently kill a long generation, which
+    /// is why the adapters carry their own idle and first-event timeouts instead: those bound the gap BETWEEN
+    /// events, which is the thing that actually indicates a dead stream, rather than the total duration, which
+    /// on a long answer indicates nothing at all.
+    ///
+    /// <para>Reused rather than created per turn because a fresh <c>HttpClient</c> per request exhausts sockets
+    /// under any real usage. The usual counter-argument — stale DNS on a long-lived client — is weak here: the
+    /// endpoint is a user-configured address in a desktop app, not a rotating service mesh.</para>
+    /// </summary>
+    private static HttpClient CreateHttpClient() => new() { Timeout = Timeout.InfiniteTimeSpan };
+
+    public ChatProviderResolution? Resolve(out string? problem)
+    {
+        var chat = _settings.Settings.Ai.Chat;
+
+        if (!_settings.Settings.Ai.Enabled || !chat.Enabled)
+        {
+            problem = "AI features are turned off. Turn them on in Settings to use the assistant.";
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(chat.Model))
+        {
+            problem = "No model is configured. Choose one in Settings.";
+            return null;
+        }
+
+        if (!TryParseKind(chat.Provider, out var kind))
+        {
+            problem = $"'{chat.Provider}' is not a provider this build knows how to talk to.";
+            return null;
+        }
+
+        var apiKey = _credentials?.GetApiKey(kind);
+
+        switch (kind)
+        {
+            case ChatProviderKind.Anthropic when string.IsNullOrWhiteSpace(apiKey):
+                problem = "No API key is stored for Claude. Add one in Settings.";
+                return null;
+
+            case ChatProviderKind.Anthropic:
+                problem = null;
+                return new ChatProviderResolution(
+                    new AnthropicMessagesProvider(
+                        _http,
+                        new AnthropicOptions(apiKey, NullIfBlank(chat.BaseUrl)),
+                        _loggerFactory.CreateLogger<AnthropicMessagesProvider>()),
+                    chat.Model!.Trim());
+
+            case ChatProviderKind.OpenAiCompatible when string.IsNullOrWhiteSpace(chat.BaseUrl):
+                // No default is possible here — the base URL IS the provider. This is the field that makes one
+                // adapter serve DeepSeek, OpenRouter, Ollama and LM Studio.
+                problem = "No endpoint address is configured. Enter the provider's base URL in Settings.";
+                return null;
+
+            case ChatProviderKind.OpenAiCompatible:
+                // A key is deliberately NOT required — a local runner on loopback has none.
+                problem = null;
+                return new ChatProviderResolution(
+                    new OpenAiCompatibleProvider(
+                        _http,
+                        new OpenAiCompatibleOptions(chat.BaseUrl!.Trim(), NullIfBlank(apiKey)),
+                        _loggerFactory.CreateLogger<OpenAiCompatibleProvider>()),
+                    chat.Model!.Trim());
+
+            default:
+                problem = $"'{chat.Provider}' is not a provider this build knows how to talk to.";
+                return null;
+        }
+    }
+
+    internal static bool TryParseKind(string? value, out ChatProviderKind kind)
+    {
+        switch (value?.Trim().ToLowerInvariant())
+        {
+            case "anthropic" or "claude":
+                kind = ChatProviderKind.Anthropic;
+                return true;
+            // Hyphen and underscore both, because this string is hand-edited in settings.json until #585.
+            case "openai-compatible" or "openai_compatible" or "openai":
+                kind = ChatProviderKind.OpenAiCompatible;
+                return true;
+            default:
+                kind = default;
+                return false;
+        }
+    }
+
+    private static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+}


### PR DESCRIPTION
Closes #583. Part of epic #186. Plan: [`AI_SURFACE_B.md`](https://github.com/fsnow/cst/blob/main/docs/features/planned/AI_SURFACE_B.md) §5, §10.

Bundle → prompt → provider → events. **The chain now runs end to end** — a live Translate turn against the real corpus and a real model works. Nothing is user-visible until Settings (#585) and the panel (#586).

## Three contracts a panel depends on

**Nothing expected throws.** Not-configured, an unreadable passage, a dead network, a 401 — all arrive as a terminal `Error` event. §10 requires each to render as a sentence rather than an exception, and collapsing #578's two failure shapes here spares every future caller from re-deriving the distinction. #578's own contract is unchanged underneath.

**A superseded turn ends quietly; the caller's own cancellation throws.** Being replaced is not a failure — an error banner under an answer the reader abandoned would be both wrong and alarming. But a consumer that cancels its *own* enumeration must not be told the turn succeeded. Two cancellation sources, two behaviours, distinguished by which token fired.

**An empty answer is a named failure** (`AiErrorKind.EmptyAnswer`). A model can end a turn having produced only reasoning (#601) — and #578 is *right* to segregate reasoning from answer, which is exactly what makes this invisible: the caller gets a well-formed, successful, blank turn.

## The seam for #579 and #585

`ChatSettings` (provider, base URL, model, answer language) and `IChatProviderResolver`. The **API key is deliberately absent from settings.json** — it belongs in the OS credential store (#579), not in a file that gets pasted into bug reports. A key is required for Anthropic and **not** for OpenAI-compatible, because the motivating deployment is a local runner on loopback with no credential at all; refusing there would lock out the configuration this adapter was built to serve.

## What the live run found that the tests couldn't

Running the whole chain against the real corpus and `gemma4:cloud`:

- **Marker discipline held** — 62 quotes, 0 unbalanced, all stripped correctly.
- **Usage merged correctly** across the stream (in=2599, out=2088).
- **A scope bug, filed as #602.** A Translate turn on **Dhp 21** returned a good translation of roughly **thirty verses**, running through the end of chapter 2, all of chapter 3, and into chapter 4 — beside a citation reading *"paragraph 21"*. The window is budgeted in **characters** and is structurally blind: 2,400 characters of prose is a passage, but a Dhammapada verse is ~80 characters. `WindowMayExtendPastReference` fired and #582 surfaced its notice, which is true and reads like a rounding caveat rather than a warning that the answer covers twenty-nine paragraphs nobody asked about.

  §6 names truthful output over a *narrower* scope than assumed as injection's characteristic failure. This is that failure mirrored — and the app-rendered citation makes it worse rather than better, since the citation is the one thing on screen the app vouches for. Fixing it also unblocks §6's fence 4.

## Testing

29 new tests; **1317/1317** pass. The orchestrator tests cover the acceptance criteria directly — a fake provider that echoes the assembled request back, cancellation, and cancel-and-replace.

One test-harness note worth recording: the cancellation tests deadlocked until the `TaskCompletionSource` got `RunContinuationsAsynchronously`. Without it the awaiting test continuation runs inline on the provider's own thread, inside the iterator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)