### PR TITLE
Report the passage window's real extent (#602)

### DIFF
--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -122,7 +122,7 @@ Design rules, each load-bearing:
   `PassageResult.NextCursor`, which is wrong: that cursor means the window ended before the end of the BOOK
   FILE, not before the end of the requested paragraph, so on the real corpus it is set for nearly every request
   and the badge would always fire. A fidelity signal that always fires is one users learn to ignore. The bundle
-  reports only what is known — `WindowMayExtendPastReference` — and a true paragraph-scoped trim signal needs
+  reports `ParagraphsCovered`, measured from where the window actually ended (#602), and a trim signal needs
   support from the passage reader.
 - **A failed fetch is loud.** The passage tool reports "book not available", "reference not found" and
   unsupported reference kinds all as empty text with the reason in `NormalizedReference` — the field the app
@@ -277,14 +277,17 @@ answer about three paragraphs. Three fences:
 4. **A trimmed passage gets a visible "partial passage" badge**, driven by `BudgetReport`. A *translation*
    labelled as of a passage that was silently truncated is a fidelity failure specific to this corpus.
 
-> **Fence 4 was not delivered as written — 2026-08-11 (#580/#582).** There is **no truncation flag** to drive
-> the badge. The obvious candidate, `PassageResult.NextCursor`, is non-null whenever the window ends before the
-> end of the *book file* rather than before the end of the requested reference, so on the real corpus it is set
-> for almost every request — a badge driven by it would fire always, and a fidelity signal that always fires is
-> one users learn to ignore. What ships instead is the weaker true statement, `WindowMayExtendPastReference`,
-> told to the model in the scope declaration (fence 1) and to the user as a notice. **A genuine
-> paragraph-scoped trim badge needs the passage reader to report whether the window covered the reference** —
-> unbuilt work, not an oversight in #582.
+> **Fence 4, and how it was finally driveable — 2026-08-11 (#580 → #602).** #580 could not implement this. The
+> obvious signal, `PassageResult.NextCursor`, is non-null whenever the window ends before the end of the *book
+> file* rather than the requested paragraph, so on the real corpus it is set for almost every request — a badge
+> driven by it would have fired always, and a fidelity signal that always fires is one users learn to ignore.
+> What shipped instead was the weaker true statement `WindowMayExtendPastReference`.
+>
+> That understatement then hid a real bug (#602): a Translate window on Dhp 21 covered **25 paragraphs** while
+> the citation read "paragraph 21", and the notice said only that the window "may extend past" it. The passage
+> reader now reports the paragraph in effect where the window **ended**, so `BudgetReport.ParagraphsCovered` is
+> measured rather than guessed — the citation names a range, the notice states the count, and the badge this
+> fence asks for is at last driveable from a signal that means something.
 
 Free-form follow-up on the Explain preset is the leak in the dam — keep it, but these are its seatbelts.
 
@@ -579,3 +582,16 @@ and #582 surfaced its notice, which is true and reads like a rounding caveat rat
 answer covers twenty-nine paragraphs nobody asked about. §6 names truthful output over a *narrower* scope than
 assumed as the characteristic failure; this is that failure mirrored, and the app-rendered citation makes it
 worse rather than better. Fixing it also unblocks §6's fence 4, since the missing capability is the same one.
+
+**2026-08-11 (#602, the window's real extent)** — the passage reader now reports the paragraph in effect where
+the window **ended**, not only where it began. Three consequences: `normalizedReference` names a range
+("paragraphs 21-45 (kn2)") whenever the window spans more than one paragraph; `BudgetReport.ParagraphsCovered`
+replaces the always-true `WindowMayExtendPastReference` with a measured count; and §6's fence 4 becomes
+implementable.
+
+**Reporting the extent is not the same as fixing it, and the rest is a product decision.** The Dhp 21 window
+still covers 25 paragraphs — the citation and the notice are now honest about it, which stops the app
+*misrepresenting* the answer, but a reader who asks to translate one verse still gets twenty-five. The remaining
+options in #602 (clamp the window to the cited reference; budget in paragraphs rather than characters) change
+what "translate this" *means*, and trade surrounding context against focus differently per preset. That is
+fsnow's call, not something to settle in an implementation commit.

--- a/src/CST.Avalonia.Tests/Integration/ContextPreviewEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/ContextPreviewEndpointTests.cs
@@ -60,7 +60,7 @@ public class ContextPreviewEndpointTests
                 Citation: new CitationRef(request.BookId, "D\u012Bghanik\u0101ya", "paragraph 5 (dn1)",
                     Array.Empty<CST.Search.SnippetPageRef>()),
                 Provenance: new Provenance("test", null),
-                Budget: new BudgetReport(Array.Empty<BundlePart>(), 42, WindowMayExtendPastReference: true)));
+                Budget: new BudgetReport(Array.Empty<BundlePart>(), 42, ParagraphsCovered: 3)));
         }
     }
 
@@ -191,7 +191,7 @@ public class ContextPreviewEndpointTests
         Assert.Equal("s0101m.mul.xml", root.GetProperty("citation").GetProperty("bookId").GetString());
         Assert.Equal("paragraph 5 (dn1)", root.GetProperty("citation").GetProperty("normalizedReference").GetString());
         Assert.Equal("what is this about?", root.GetProperty("userQuestion").GetString());
-        Assert.True(root.GetProperty("budget").GetProperty("windowMayExtendPastReference").GetBoolean());
+        Assert.Equal(3, root.GetProperty("budget").GetProperty("paragraphsCovered").GetInt32());
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -121,7 +121,7 @@ public class AiChatOrchestratorTests
                 Provenance: new Provenance("test", null),
                 Budget: new BudgetReport(
                     new[] { new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window") },
-                    100, WindowMayExtendPastReference: false)));
+                    100, ParagraphsCovered: 1)));
         }
     }
 

--- a/src/CST.Avalonia.Tests/Services/Ai/AiContextBundlerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiContextBundlerTests.cs
@@ -118,7 +118,9 @@ public class AiContextBundlerTests : IDisposable
         var bundle = await Bundler().BuildAsync(Request());
 
         Assert.Equal(BookId, bundle.Citation.BookId);
-        Assert.Equal("paragraph 5 (dn1)", bundle.Citation.NormalizedReference);
+        // A RANGE, because the 1600-character Explain window genuinely runs from paragraph 5 into 6. Naming
+        // only the first would understate what the answer beside it was actually written from. (#602)
+        Assert.Equal("paragraphs 5-6 (dn1)", bundle.Citation.NormalizedReference);
         Assert.Contains(bundle.Citation.Pages, p => p.Edition == PageEdition.Vri && p.Number == 1);
     }
 
@@ -272,14 +274,28 @@ public class AiContextBundlerTests : IDisposable
     }
 
     [Fact]
-    public async Task The_window_reports_that_it_may_extend_past_the_cited_reference()
+    public async Task The_window_reports_how_many_paragraphs_it_actually_covers()
     {
-        // The reader takes a character budget from the reference and flows on into what follows, so the text can
-        // carry more than the citation names. That is what is actually known — there is deliberately no
-        // "was truncated" flag, since NextCursor means end-of-FILE, not end-of-paragraph.
+        // Measured, not guessed: Explain's 1600-character budget overflows paragraph 5's verse into 6. It is the
+        // NUMBER, not a "may extend" hedge, that lets a caller tell "the paragraph you asked for" from "thirty
+        // verses across three chapters" — which is the failure that prompted this. (#602)
+        var bundle = await Bundler().BuildAsync(Request(AiTask.Explain));
+
+        Assert.Equal(2, bundle.Budget.ParagraphsCovered);
+        Assert.True(bundle.Budget.WindowExtendsPastReference);
+    }
+
+    [Fact]
+    public async Task A_window_contained_in_one_paragraph_says_so_rather_than_hedging()
+    {
+        // The other side of the boundary: word-by-word's 600-character budget stays inside paragraph 5's verse.
+        // Reporting 1 here is what makes AI_SURFACE_B.md §6's partial-passage badge implementable at all — its
+        // predecessor was derived from NextCursor and so was set on essentially every request.
         var bundle = await Bundler().BuildAsync(Request(AiTask.WordByWord));
 
-        Assert.True(bundle.Budget.WindowMayExtendPastReference);
+        Assert.Equal(1, bundle.Budget.ParagraphsCovered);
+        Assert.False(bundle.Budget.WindowExtendsPastReference);
+        Assert.Equal("paragraph 5 (dn1)", bundle.Citation.NormalizedReference);
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
@@ -48,7 +48,7 @@ public class PromptBuilderTests : IDisposable
         IReadOnlyList<LemmaEntry>? lemmas = null,
         IReadOnlyList<BundlePart>? parts = null,
         IReadOnlyList<ApparatusNote>? notes = null,
-        bool windowMayExtendPastReference = true,
+        int? paragraphsCovered = 3,
         string? userQuestion = null,
         string outputLanguage = "English",
         CommentaryLevel level = CommentaryLevel.Mula)
@@ -56,7 +56,7 @@ public class PromptBuilderTests : IDisposable
         var pages = new[] { new SnippetPageRef(PageEdition.Vri, 1, 17) };
         var result = new PassageResult(
             "s0502m.mul.xml", "paragraph 21 (dhp)", passage, pages, 21, "dhp", null,
-            windowMayExtendPastReference ? 4200 : null,
+            paragraphsCovered > 1 ? 4200 : null,
             notes?.Count ?? 0, notes ?? Array.Empty<ApparatusNote>());
 
         return new AiContextBundle(
@@ -67,7 +67,7 @@ public class PromptBuilderTests : IDisposable
             new Provenance("6.0.0-test", null),
             new BudgetReport(
                 parts ?? new[] { new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window") },
-                500, windowMayExtendPastReference));
+                500, paragraphsCovered));
     }
 
     [Fact]
@@ -79,16 +79,16 @@ public class PromptBuilderTests : IDisposable
 
         Assert.Contains("Dhammapadapāḷi", prompt.System);
         Assert.Contains("paragraph 21 (dhp)", prompt.System);
-        Assert.Contains("may run on past the end of the cited reference", prompt.System);
+        Assert.Contains("covering 3 numbered paragraphs", prompt.System);
     }
 
     [Fact]
     public void A_window_that_reached_the_end_of_the_file_says_so_instead()
     {
-        var prompt = _builder.Build(Bundle(windowMayExtendPastReference: false));
+        var prompt = _builder.Build(Bundle(paragraphsCovered: 1));
 
-        Assert.Contains("running to the end of the book file", prompt.System);
-        Assert.DoesNotContain("may run on past", prompt.System);
+        Assert.Contains("exactly the paragraph named", prompt.System);
+        Assert.DoesNotContain("numbered paragraphs", prompt.System);
     }
 
     [Fact]
@@ -334,7 +334,7 @@ public class PromptBuilderTests : IDisposable
                 new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window"),
                 new BundlePart(BundlePartNames.Lemmas, BundlePartState.Unavailable, "asset not installed"),
             },
-            windowMayExtendPastReference: false));
+            paragraphsCovered: 1));
 
         Assert.Empty(prompt.Notices);
     }
@@ -346,7 +346,7 @@ public class PromptBuilderTests : IDisposable
         // nag about a missing download on a perfectly good bundle.
         var prompt = _builder.Build(Bundle(
             parts: new[] { new BundlePart(BundlePartNames.Apparatus, BundlePartState.Empty, "none") },
-            windowMayExtendPastReference: false));
+            paragraphsCovered: 1));
 
         Assert.Empty(prompt.Notices);
     }
@@ -371,7 +371,7 @@ public class PromptBuilderTests : IDisposable
     {
         _store.Save(PromptTemplateNames.Explain, "MY TEMPLATE\n" + Minimal);
 
-        var prompt = _builder.Build(Bundle(windowMayExtendPastReference: false));
+        var prompt = _builder.Build(Bundle(paragraphsCovered: 1));
 
         Assert.StartsWith("MY TEMPLATE", prompt.UserContent);
         Assert.Empty(prompt.Notices);

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -179,9 +179,14 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
 <!--doc:reading-->
 - `POST /v1/passage` - a bounded, paged reading window (more context than a snippet, never a whole wall).
   Body: `{ bookId, paragraph?, bookCode?, cursor?, maxChars?, outputScript?, includeFootnotes? }`.
-  Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, noteCount, ... }` - `noteCount` is how
+  Returns `{ text, normalizedReference, pages, prevCursor, nextCursor, noteCount, paragraphNumber,
+  endParagraphNumber, ... }` - `noteCount` is how
   many `{...}` apparatus notes fall in the window (counted regardless of `includeFootnotes`; `>0` = apparatus
-  present here). Page by passing back the
+  present here). `normalizedReference` names a RANGE ("paragraphs 21-49 (kn2)") whenever the window spans more
+  than one paragraph, and `endParagraphNumber` is the paragraph in effect where it ended - CHECK IT BEFORE
+  CITING. `maxChars` is a character budget and is structurally blind, so on a verse text a modest budget covers
+  many paragraphs: 2400 characters of Dhammapada is roughly thirty verses across several chapters. Citing only
+  the opening paragraph of such a window misrepresents what you actually read. Page by passing back the
   integer `prevCursor` / `nextCursor` as `cursor` (see the cursor note above). A `cursor` (from occurrences or
   passage) reads the ENCLOSING SENTENCE: the window start is snapped back so you get the governing clause, not a
   mid-sentence fragment. `maxChars` is a SOFT budget - the window OVERSHOOTS to the next sentence boundary, so

--- a/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
+++ b/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
@@ -163,11 +163,10 @@ public sealed class AiContextBundler : IAiContextBundler
             Budget: new BudgetReport(
                 parts,
                 ApproximateTokens(passage.Text, lemmas),
-                // The window takes a character budget from the reference and flows on through whatever follows
-                // it, so unless it reached the end of the file it may carry text past the reference the citation
-                // names. That is a scope mismatch #582's prompt has to disclose, and it is all this layer can
-                // honestly say — see BudgetReport for why there is no "was truncated" flag.
-                WindowMayExtendPastReference: passage.NextCursor is not null));
+                // Measured, not guessed: the reader reports the paragraph in effect where the window ended, so
+                // this is the window's real span. The predecessor derived it from NextCursor and was therefore
+                // set on almost every request — see BudgetReport. (#602)
+                ParagraphsCovered: ParagraphsCovered(passage)));
 
         _logger.LogDebug(
             "Built {Task} bundle for {BookId}: {Lemmas} lemma(s), ~{Tokens} tokens",
@@ -237,6 +236,22 @@ public sealed class AiContextBundler : IAiContextBundler
             $"{lemmas.Count} candidate lemma(s) for {words.Count} word(s)"));
 
         return lemmas;
+    }
+
+    /// <summary>
+    /// How many numbered paragraphs the window spans. Null when the book carries no paragraph numbering at that
+    /// point, which is not the same as 1 — "unknown" must not be reported as "stayed put".
+    /// </summary>
+    private static int? ParagraphsCovered(PassageResult passage)
+    {
+        if (passage.ParagraphNumber is not int first) return null;
+        if (passage.EndParagraphNumber is not int last) return 1;
+
+        // Numbering restarts per sub-book in a Multi volume, so a raw subtraction across a sub-book boundary is
+        // meaningless — and can go negative. Refuse rather than report a number that looks measured and isn't.
+        if (passage.EndParagraphBookCode != passage.ParagraphBookCode) return null;
+
+        return last >= first ? last - first + 1 : null;
     }
 
     /// <summary>Distinct words worth resolving, longest first so the budget buys the substantial ones.</summary>

--- a/src/CST.Avalonia/Services/Ai/ContextBundle.cs
+++ b/src/CST.Avalonia/Services/Ai/ContextBundle.cs
@@ -107,20 +107,30 @@ public enum BundlePartState
 public sealed record BundlePart(string Name, BundlePartState State, string? Detail = null);
 
 /// <summary>
-/// What was included, what was cut, and what was missing.
+/// What was included, what was cut, and how far the window actually reached.
 ///
 /// <para><b>There is deliberately no "the passage was truncated" flag.</b> An earlier version derived one from
-/// <c>PassageResult.NextCursor</c>, which was wrong: that cursor is non-null whenever the window ends before
-/// the end of the BOOK FILE, not before the end of the requested paragraph. On the real corpus it is set for
-/// almost every request, so the badge it drove would have fired always — and a fidelity signal that always
-/// fires is one users learn to ignore, which is worse than not having it. Reporting a genuine paragraph-scoped
-/// trim needs the passage reader to say whether the window covered the reference; until it can,
-/// <see cref="WindowMayExtendPastReference"/> states only what is actually known.</para>
+/// <c>PassageResult.NextCursor</c>, which was wrong: that cursor is non-null whenever the window ends before the
+/// end of the BOOK FILE, not before the end of the requested paragraph. On the real corpus it is set for almost
+/// every request, so the badge it drove would have fired always — and a fidelity signal that always fires is one
+/// users learn to ignore.</para>
+///
+/// <para><see cref="ParagraphsCovered"/> replaced it, and unlike its predecessor it is <b>measured</b>: the
+/// passage reader now reports the paragraph in effect where the window ended, so this says how many paragraphs
+/// the returned text actually spans rather than guessing. That is what makes §6's partial-passage badge
+/// implementable at last, and what caught #602 — a Translate window budgeted at 2,400 characters covering
+/// roughly thirty Dhammapada verses beside a citation naming one.</para>
 /// </summary>
+/// <param name="ParagraphsCovered">How many numbered paragraphs the window spans; 1 when it stayed within the
+/// one asked for. Null when the book has no paragraph numbering at that point.</param>
 public sealed record BudgetReport(
     IReadOnlyList<BundlePart> Parts,
     int ApproximateTokens,
-    bool WindowMayExtendPastReference);
+    int? ParagraphsCovered)
+{
+    /// <summary>True when the window ran past the paragraph the citation names.</summary>
+    public bool WindowExtendsPastReference => ParagraphsCovered > 1;
+}
 
 /// <summary>Stable part names, so consumers match on a constant rather than a string literal.</summary>
 public static class BundlePartNames

--- a/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
@@ -178,16 +178,20 @@ public sealed class PromptBuilder : IPromptBuilder
     {
         var where = $"{bundle.Citation.BookName}, at {bundle.Citation.NormalizedReference}";
 
-        // NextCursor being set means the window stopped before the end of the book FILE — not before the end of
-        // the paragraph — so all that can honestly be said is that it may carry text past the reference. See
-        // BudgetReport for why there is no truncation flag to report instead.
-        var extent = bundle.Budget.WindowMayExtendPastReference
-            ? "It is a reading window starting there — not the whole text, and it may run on past the end of the "
-              + "cited reference into what follows it."
-            // Not "not the whole text": a short book read from the start IS wholly in the window, and telling
-            // the model otherwise buys hedging on an answer that did not need it.
-            : "It is a reading window starting there and running to the end of the book file, which may be less "
-              + "than the whole text.";
+        // How far the window ACTUALLY reached, measured rather than guessed (#602). Saying the number matters:
+        // the budget is in characters and structurally blind, so on a verse text a modest budget covers dozens
+        // of paragraphs, and a model told only "this may run on a little" will answer about all of them as
+        // though that were what was asked.
+        var extent = bundle.Budget.ParagraphsCovered switch
+        {
+            > 1 and int covered =>
+                $"It is a reading window covering {covered} numbered paragraphs — the whole of what follows is "
+                + "in view, so say which part of it you are answering about.",
+            1 => "It is exactly the paragraph named, and nothing after it.",
+            // Null means the book carries no paragraph numbering here — which is not the same as "one
+            // paragraph", and must not be reported as though it were.
+            _ => "It is a reading window starting there, not the whole text.",
+        };
 
         return $"an excerpt from {where}. {extent}";
     }
@@ -421,8 +425,14 @@ public sealed class PromptBuilder : IPromptBuilder
         if (bundle.Selection is { FoundInWindow: false })
             notices.Add("The selected text was not found in the passage window the model was given.");
 
-        if (bundle.Budget.WindowMayExtendPastReference)
-            notices.Add("The passage window may extend past the end of the cited reference.");
+        // Says the number. "May extend past the reference" was true of almost every request and read like a
+        // rounding caveat; "covers 29 paragraphs" is a fact the reader can act on. (#602)
+        if (bundle.Budget.ParagraphsCovered is > 1 and int covered)
+        {
+            notices.Add(
+                $"The passage window covers {covered} paragraphs, not just the one cited — the answer may range "
+                + "wider than you asked.");
+        }
 
         return notices;
     }

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -62,7 +62,8 @@ namespace CST.Avalonia.Services.Tools
 
             return new PassageResult(
                 BookId: request.BookId,
-                NormalizedReference: Describe(w.ParagraphNumber, w.ParagraphBookCode),
+                NormalizedReference: Describe(
+                    w.ParagraphNumber, w.ParagraphBookCode, w.EndParagraphNumber),
                 Text: w.Text,
                 Pages: w.Pages,
                 ParagraphNumber: w.ParagraphNumber,
@@ -70,7 +71,9 @@ namespace CST.Avalonia.Services.Tools
                 PrevCursor: w.PrevCursor,
                 NextCursor: w.NextCursor,
                 NoteCount: w.NoteCount,
-                Notes: w.Notes);
+                Notes: w.Notes,
+                EndParagraphNumber: w.EndParagraphNumber,
+                EndParagraphBookCode: w.EndParagraphBookCode);
         }
 
         private static int ResolveStart(NavigationReference? reference, BookMarkers markers) => reference switch
@@ -81,10 +84,24 @@ namespace CST.Avalonia.Services.Tools
             _ => -1   // Page / Chapter / RawAnchor: not resolved in the first cut
         };
 
-        private static string Describe(int? number, string? bookCode) =>
-            number is null ? "start of book"
-            : bookCode is null ? $"paragraph {number}"
-            : $"paragraph {number} ({bookCode})";
+        /// <summary>
+        /// A human-readable reference for the window — a RANGE when it spans more than one paragraph.
+        ///
+        /// <para>The window is budgeted in rendered characters and is structurally blind, so on a verse text a
+        /// modest budget covers many paragraphs: 2,400 characters of Dhammapada is ~30 verses across several
+        /// chapters. Naming only the first would understate that badly, and this string is what surface B
+        /// renders beside a generated answer as the app's own attestation of scope. (#602)</para>
+        /// </summary>
+        private static string Describe(int? number, string? bookCode, int? endNumber = null)
+        {
+            if (number is null) return "start of book";
+
+            var where = endNumber is int last && last != number
+                ? $"paragraphs {number}-{last}"
+                : $"paragraph {number}";
+
+            return bookCode is null ? where : $"{where} ({bookCode})";
+        }
 
         private static PassageResult Empty(PassageRequest request, string note) =>
             new(request.BookId, note, "", Array.Empty<SnippetPageRef>(), null, null, null, null, 0,

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -73,7 +73,17 @@ namespace CST.Search
             int paraStart = EnclosingParagraphStart(readStart, markers);
             int noteCount = TeiText.CountNotesIntersecting(xml, paraStart, readStart, end);
             var (num, code, pages) = markers.RefsAt(readStart);
-            return new PassageWindow(text, prev, next, num, code, pages, noteCount, notes);
+
+            // The reference in effect at the window's END. Without this a caller can only say where the window
+            // STARTED, so a character budget that runs on through many paragraphs is indistinguishable from one
+            // that covered exactly the paragraph asked for — and any citation built from the start alone
+            // understates the window's real extent. (#602)
+            //
+            // `end` is exclusive, so probe the last character actually included: at a paragraph boundary, `end`
+            // itself already sits in the NEXT paragraph and would overstate the span by one.
+            var (endNum, endCode, _) = markers.RefsAt(Math.Max(readStart, end - 1));
+
+            return new PassageWindow(text, prev, next, num, code, pages, noteCount, notes, endNum, endCode);
         }
 
         // Strip the {reading (sigla)} apparatus spans out of already-rendered text into structured notes
@@ -196,7 +206,9 @@ namespace CST.Search
         string? ParagraphBookCode,
         IReadOnlyList<SnippetPageRef> Pages,
         int NoteCount,
-        IReadOnlyList<ApparatusNote> Notes);
+        IReadOnlyList<ApparatusNote> Notes,
+        int? EndParagraphNumber = null,
+        string? EndParagraphBookCode = null);
 
     /// <summary>One apparatus note (a digitized print footnote — usually a variant reading) as structured data:
     /// its character <paramref name="Offset"/> into the returned brace-free <c>Text</c>, its full converted

--- a/src/CST.Core/Tools/PassageToolContracts.cs
+++ b/src/CST.Core/Tools/PassageToolContracts.cs
@@ -44,7 +44,12 @@ namespace CST.Tools
     /// A reading window: the text, the citation refs at its start, and cursors to page through. Pass a cursor
     /// back as <see cref="PassageRequest.Cursor"/> to continue; a null cursor means the book start/end.
     /// </summary>
-    /// <param name="NormalizedReference">Short human-readable reference at the window start (e.g. "paragraph 123 (an5)").</param>
+    /// <param name="NormalizedReference">Short human-readable reference for the window. Names a RANGE when the
+    /// window spans more than one paragraph (e.g. "paragraphs 21-49 (kn2)") — the character budget is
+    /// structurally blind, and on verse texts a modest budget covers many paragraphs, so a start-only reference
+    /// understates the extent of what was returned. (#602)</param>
+    /// <param name="EndParagraphNumber">The paragraph in effect at the window's END. Equal to
+    /// <see cref="PassageResult.ParagraphNumber"/> when the window stayed within one paragraph.</param>
     /// <param name="Text">The passage text in the requested script.</param>
     /// <param name="Pages">The per-edition page(s) at the window start, for citation.</param>
     /// <param name="NoteCount">How many print-edition apparatus notes (<c>{…}</c>) fall in this window. Counted
@@ -62,5 +67,7 @@ namespace CST.Tools
         int? PrevCursor,
         int? NextCursor,
         int NoteCount,
-        IReadOnlyList<ApparatusNote> Notes);
+        IReadOnlyList<ApparatusNote> Notes,
+        int? EndParagraphNumber = null,
+        string? EndParagraphBookCode = null);
 }


### PR DESCRIPTION
Closes #602. Found by running the #583 orchestrator end to end against the real corpus and a real model.

## The bug

A **Translate** turn on **Dhp 21** returned a good translation of **25 paragraphs** — through the end of chapter 2, all of chapter 3, into chapter 4 — beside a citation reading:

> **paragraph 21 (kn2)**

The model did nothing wrong; it translated the text it was given. The **citation** misrepresented — and the citation is the one thing on screen the app vouches for, rendered from its own data precisely so a garbled answer cannot forge one.

The window is budgeted in **characters** and is structurally blind. 2,400 characters of prose is a passage; a Dhammapada verse is ~80 characters.

## The fix

The passage reader now reports the paragraph in effect where the window **ended**, not only where it began — one extra `RefsAt` on a list it already holds. (`end` is exclusive, so it probes the last character actually included; probing `end` itself would overstate the span by one at every paragraph boundary.)

That measurement replaces a signal that never meant anything. `WindowMayExtendPastReference` was derived from `NextCursor`, which is non-null whenever the window stops before the end of the *book file* rather than the paragraph — set on essentially every request. `BudgetReport.ParagraphsCovered` is counted instead, and returns **null rather than a number** when the window crosses a Multi sub-book boundary, where numbering restarts and a subtraction would be meaningless.

On the exact case that exposed this, verified against the real corpus:

| | before | after |
|---|---|---|
| citation | `paragraph 21 (kn2)` | `paragraphs 21-45 (kn2)` |
| notice | "may extend past the end of the cited reference" | "covers **25 paragraphs**, not just the one cited — the answer may range wider than you asked" |
| scope, to the model | "may run on past the end of the cited reference" | "covering **25 numbered paragraphs** — say which part of it you are answering about" |

**This unblocks §6's fence 4** — the partial-passage badge #580 could not implement, for want of exactly this signal.

## Surface C gets it too

`/v1/passage` returns `endParagraphNumber` and a ranged `normalizedReference`, and `llms.txt` now tells agents to check it before citing. An agent citing the opening paragraph of a thirty-verse window has precisely the problem the panel had.

## What this deliberately does *not* do

**Reporting the extent is not the same as fixing it.** The window still covers 25 paragraphs — the app has stopped *misrepresenting* the answer, but a reader who asks to translate one verse still gets twenty-five.

The remaining options in #602 — clamp the window to the cited reference, or budget in paragraphs rather than characters — change what *"translate this"* means, and trade surrounding context against focus differently per preset. That's your call, not something to settle in an implementation commit.

**1318/1318** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)