### PR TITLE
Surface B: the selection pipeline (#581)

### DIFF
--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -1,7 +1,8 @@
 # Surface B — the in-app model, v1 by context injection (Planned)
 
-**Status:** In progress. Shipped: B1 (#578, provider layer), B3 (#580, context bundler), B4 (#582, presets and
-the grounding contract), B5 (#583, orchestrator), plus the reader-state read path and
+**Status:** In progress. Shipped: B1 (#578, provider layer), B3 (#580, context bundler), B3a (#581, selection
+pipeline), B4 (#582, presets and the grounding contract), B5 (#583, orchestrator), plus the reader-state read
+path and
 `POST /v1/ai/context-preview` (#593). **The chain now runs end to end** — a live Translate turn against the real
 corpus and a real model works — but nothing is user-visible until the Settings UI (B7, #585) and the panel
 (B8, #586) exist.
@@ -595,3 +596,21 @@ still covers 25 paragraphs — the citation and the notice are now honest about 
 options in #602 (clamp the window to the cited reference; budget in paragraphs rather than characters) change
 what "translate this" *means*, and trade surrounding context against focus differently per preset. That is
 fsnow's call, not something to settle in an implementation commit.
+
+**2026-08-11 (#581, the selection pipeline)** — the selection is the one bundler input scraped from the DOM, and
+it now gets handling to match.
+
+- **Conversion moved into a pure, testable pipeline.** The display script is known only to the reader, so
+  `ReaderStateService` still supplies it, but the rules live in one place. Splitting them would let the two
+  sides of the window comparison drift, which is precisely how a locator starts reporting false misses.
+- **Three selection states, not two.** "Nothing selected" and "we could not read the selection" were the same
+  null. They are different: the first means the whole passage is legitimately in view; the second means the
+  words the user highlighted were dropped. Only the second is worth telling them about — and it is exactly the
+  state that otherwise reaches the user as *"the AI ignored my selection"*. The channel already distinguished
+  them (`GetWebViewSelectionAsync` returns `""` for nothing and `null` for a failed or timed-out round trip);
+  the pipeline stops throwing that away.
+- **Composition (NFC) is cheap insurance behind a measured risk.** A corpus survey found the Devanagari source
+  already NFC, and `ScriptConverter` emits composed Latin, so in the ordinary path both sides of the comparison
+  agree. But a decomposed selection is *ordinally* unequal (`a`+U+0304 ≠ U+0101), and the symptom would be a
+  bundle reporting "selection not found in the passage window" — a false diagnostic from the component whose
+  whole job is faithful diagnostics.

--- a/src/CST.Avalonia.Tests/Services/Ai/AiContextBundlerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiContextBundlerTests.cs
@@ -151,6 +151,20 @@ public class AiContextBundlerTests : IDisposable
     }
 
     [Fact]
+    public async Task A_selection_the_reader_could_not_read_is_recorded_as_unavailable()
+    {
+        // Not the same as no selection: this is the state that otherwise reaches the user as "the AI ignored
+        // my selection". (#581)
+        var bundle = await Bundler().BuildAsync(
+            new AiContextRequest(AiTask.Explain, BookId, "English",
+                new NavigationReference.Paragraph(5), SelectionUnavailable: true));
+
+        Assert.Equal(SelectionState.Unavailable, bundle.Selection!.State);
+        Assert.Null(bundle.Selection.Text);
+        Assert.Equal(BundlePartState.Unavailable, Part(bundle, BundlePartNames.Selection).State);
+    }
+
+    [Fact]
     public async Task A_missing_lemma_asset_reads_as_unavailable_not_as_a_budget_problem()
     {
         // The distinction is the point: conflating them sends whoever is debugging a thin grammar answer to

--- a/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
@@ -168,10 +168,23 @@ public class PromptBuilderTests : IDisposable
     public void A_selection_the_window_does_not_contain_warns_the_model_and_the_user()
     {
         var prompt = _builder.Build(Bundle(
-            selection: new SelectionContext("dhammā manopubbaṅgamā", FoundInWindow: false)));
+            selection: new SelectionContext("dhammā manopubbaṅgamā", SelectionState.NotFoundInWindow)));
 
         Assert.Contains("was not found in the passage above", prompt.UserContent);
         Assert.Contains(prompt.Notices, n => n.Contains("not found in the passage window"));
+    }
+
+    [Fact]
+    public void A_selection_that_could_not_be_read_is_distinguished_from_none()
+    {
+        // The two were the same null before #581. The difference is an answer about the whole passage
+        // (correct) versus one that quietly dropped the words the user highlighted.
+        var prompt = _builder.Build(Bundle(
+            selection: new SelectionContext(null, SelectionState.Unavailable)));
+
+        Assert.Contains("could not be read", prompt.UserContent);
+        Assert.DoesNotContain("has not selected anything", prompt.UserContent);
+        Assert.Contains(prompt.Notices, n => n.Contains("could not be read"));
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/SelectionPipelineTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/SelectionPipelineTests.cs
@@ -1,0 +1,116 @@
+using System.Text;
+using CST.Avalonia.Services.Ai;
+using CST.Conversion;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// The selection pipeline. (#581, AI_SURFACE_B.md §3.1)
+///
+/// <para>The selection is the one bundler input scraped from the DOM: it arrives in the user's display script,
+/// through a <c>document.title</c> round trip, with a timeout. Each of those is a way for the words the user
+/// highlighted to be silently dropped, and each has a case here.</para>
+/// </summary>
+public class SelectionPipelineTests
+{
+    // Devanagari for "appamādo amatapadaṃ" — the opening of Dhp 21.
+    private const string Devanagari = "अप्पमादो अमतपदं";
+    private const string Latin = "appamādo amatapadaṃ";
+
+    private const string Window =
+        "Appamādo amatapadaṃ, pamādo maccuno padaṃ;\nappamattā na mīyanti, ye pamattā yathā matā.";
+
+    [Fact]
+    public void A_non_latin_selection_is_converted()
+    {
+        // Not a refinement. Unconverted, every dictionary and lemma lookup misses and the window match fails,
+        // which makes the two grammatical presets work for Latin-script readers only — the opposite of the
+        // reader who prompted surface B.
+        Assert.Equal(Latin, SelectionPipeline.Normalize(Devanagari, Script.Devanagari));
+    }
+
+    [Fact]
+    public void A_converted_selection_is_found_in_the_window()
+    {
+        // The end-to-end point of conversion: a Devanagari reader's selection locates in a Latin passage.
+        var normalized = SelectionPipeline.Normalize(Devanagari, Script.Devanagari)!;
+
+        Assert.True(SelectionPipeline.IsWithin(normalized, Window));
+    }
+
+    [Fact]
+    public void A_decomposed_selection_still_matches_a_composed_window()
+    {
+        // ScriptConverter emits composed Latin, so both sides normally agree — but a decomposed selection
+        // (a + U+0304 rather than U+0101) is ORDINALLY unequal, and the symptom would be a bundle reporting
+        // "selection not found in the passage window": a false diagnostic from the component whose whole job is
+        // faithful diagnostics.
+        var decomposed = Latin.Normalize(NormalizationForm.FormD);
+        Assert.NotEqual(Latin, decomposed);          // the failure this guards is real
+
+        var normalized = SelectionPipeline.Normalize(decomposed, Script.Latin)!;
+
+        Assert.Equal(Latin, normalized);
+        Assert.True(SelectionPipeline.IsWithin(normalized, Window));
+    }
+
+    [Fact]
+    public void A_selection_straddling_a_line_break_matches_across_it()
+    {
+        // Selecting across a paragraph or line boundary drags the break in with it. The window renders that
+        // break differently from the DOM, so an un-collapsed comparison misses on a selection that is plainly
+        // present.
+        var straddling = "  maccuno   padaṃ;\n  appamattā \t na mīyanti  ";
+
+        var normalized = SelectionPipeline.Normalize(straddling, Script.Latin)!;
+
+        Assert.Equal("maccuno padaṃ; appamattā na mīyanti", normalized);
+        Assert.True(SelectionPipeline.IsWithin(normalized, Window));
+    }
+
+    [Fact]
+    public void Matching_ignores_case_because_the_corpus_capitalises_programmatically()
+    {
+        // "Appamādo" heads the window; the same word mid-sentence is lowercase. A reader selecting one and the
+        // renderer showing the other must not count as a miss.
+        var normalized = SelectionPipeline.Normalize("APPAMĀDO AMATAPADAṂ", Script.Latin)!;
+
+        Assert.True(SelectionPipeline.IsWithin(normalized, Window));
+    }
+
+    [Fact]
+    public void A_selection_absent_from_the_window_is_reported_as_absent()
+    {
+        var normalized = SelectionPipeline.Normalize("dhammā manopubbaṅgamā", Script.Latin)!;
+
+        Assert.False(SelectionPipeline.IsWithin(normalized, Window));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\n\t ")]
+    public void Nothing_selected_normalizes_to_nothing(string? raw)
+    {
+        // The caller distinguishes this from "could not read the selection"; the pipeline's job is only to say
+        // there is no usable text.
+        Assert.Null(SelectionPipeline.Normalize(raw, Script.Latin));
+    }
+
+    [Fact]
+    public void Normalizing_is_idempotent()
+    {
+        // The bundler re-runs it rather than trusting its caller, which is only safe if it is.
+        var once = SelectionPipeline.Normalize(Devanagari, Script.Devanagari)!;
+
+        Assert.Equal(once, SelectionPipeline.Normalize(once, Script.Latin));
+    }
+
+    [Fact]
+    public void An_empty_window_matches_nothing_rather_than_everything()
+    {
+        Assert.False(SelectionPipeline.IsWithin("appamādo", string.Empty));
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -154,7 +154,7 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
             bundle = await _bundler.BuildAsync(
                 new AiContextRequest(
                     request.Task, request.BookId, language, request.Reference,
-                    request.SelectionText, request.UserQuestion),
+                    request.SelectionText, request.UserQuestion, request.SelectionUnavailable),
                 token).ConfigureAwait(false);
 
             prompt = _prompts.Build(bundle);

--- a/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
+++ b/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
@@ -144,7 +144,7 @@ public sealed class AiContextBundler : IAiContextBundler
             passage.NoteCount > 0 ? BundlePartState.Included : BundlePartState.Empty,
             passage.NoteCount > 0 ? $"{passage.NoteCount} print note(s)" : "no apparatus in this window"));
 
-        var selection = BuildSelection(request.SelectionText, passage.Text, parts);
+        var selection = BuildSelection(request, passage.Text, parts);
         var lemmas = GatherLemmas(request.Task, selection?.Text ?? passage.Text, parts);
 
         var bookName = ScriptConverter.Convert(book.LongNavPath, Script.Devanagari, Script.Latin);
@@ -176,23 +176,42 @@ public sealed class AiContextBundler : IAiContextBundler
     }
 
     /// <summary>
-    /// Normalize the selection and locate it in the window. A selection the window does not contain is still
-    /// passed to the model — it is what the user pointed at — but the mismatch is recorded rather than hidden,
-    /// because it means the surrounding passage may not support what is being asked about.
+    /// Locate the selection in the window, and record what became of it.
+    ///
+    /// <para>A selection the window does not contain is still passed to the model — it is what the user pointed
+    /// at — but the mismatch is recorded rather than hidden, because it means the surrounding passage may not
+    /// support what is being asked about.</para>
+    ///
+    /// <para><b>Three outcomes, not two.</b> "Nothing selected" and "we could not tell what was selected" were
+    /// the same null before #581. They are not the same thing: the first means the whole passage is legitimately
+    /// in view, the second means the words the user highlighted were dropped on the floor. Only the second is
+    /// something to tell them about. (§3.1)</para>
     /// </summary>
-    private static SelectionContext? BuildSelection(string? raw, string windowText, List<BundlePart> parts)
+    private static SelectionContext? BuildSelection(
+        AiContextRequest request, string windowText, List<BundlePart> parts)
     {
-        if (string.IsNullOrWhiteSpace(raw)) return null;
+        if (request.SelectionUnavailable)
+        {
+            parts.Add(new BundlePart(
+                BundlePartNames.Selection,
+                BundlePartState.Unavailable,
+                "the reader could not read the selection (the page was not ready, or the request timed out)"));
+            return new SelectionContext(null, SelectionState.Unavailable);
+        }
 
-        var text = Whitespace.Replace(raw.Trim(), " ");
-        var found = Whitespace.Replace(windowText, " ").Contains(text, StringComparison.OrdinalIgnoreCase);
+        // Already Latin, composed and whitespace-collapsed by SelectionPipeline.Normalize; run it again rather
+        // than trust the caller, since it is idempotent and the alternative is a silent locator miss.
+        var text = SelectionPipeline.Normalize(request.SelectionText, Script.Latin);
+        if (text is null) return null;
+
+        var found = SelectionPipeline.IsWithin(text, windowText);
 
         parts.Add(new BundlePart(
             BundlePartNames.Selection,
             BundlePartState.Included,
             found ? null : "selection not found in the passage window"));
 
-        return new SelectionContext(text, found);
+        return new SelectionContext(text, found ? SelectionState.Located : SelectionState.NotFoundInWindow);
     }
 
     /// <summary>

--- a/src/CST.Avalonia/Services/Ai/AiTurn.cs
+++ b/src/CST.Avalonia/Services/Ai/AiTurn.cs
@@ -8,12 +8,17 @@ namespace CST.Avalonia.Services.Ai;
 /// </summary>
 /// <param name="Reference">Where in the book. Null reads from the START of the book, so a caller that does not
 /// know the reading position must refuse rather than pass null (see <see cref="ReaderStateService"/>).</param>
+/// <param name="SelectionText">Already through <c>SelectionPipeline.Normalize</c>. Null means nothing was
+/// selected.</param>
+/// <param name="SelectionUnavailable">The reader could not read the selection — see
+/// <see cref="SelectionState.Unavailable"/>. Distinct from a null <paramref name="SelectionText"/>.</param>
 public sealed record AiTurnRequest(
     AiTask Task,
     string BookId,
     NavigationReference? Reference = null,
     string? SelectionText = null,
-    string? UserQuestion = null);
+    string? UserQuestion = null,
+    bool SelectionUnavailable = false);
 
 /// <summary>What kind of thing a <see cref="AiTurnEvent"/> carries.</summary>
 public enum AiTurnEventKind

--- a/src/CST.Avalonia/Services/Ai/ContextBundle.cs
+++ b/src/CST.Avalonia/Services/Ai/ContextBundle.cs
@@ -21,9 +21,13 @@ public enum AiTask
 /// </summary>
 /// <param name="BookId">The open book's file name, as <c>Book.FileName</c> spells it.</param>
 /// <param name="Reference">Where in the book. Null reads from the start.</param>
-/// <param name="SelectionText">The user's selection, ALREADY normalized to Latin script by the selection
-/// pipeline (#581). This type does not convert: a raw display-script selection passed here would silently fail
-/// every dictionary and lemma lookup, which is the failure #581 exists to prevent.</param>
+/// <param name="SelectionText">The user's selection, ALREADY put through <c>SelectionPipeline.Normalize</c> —
+/// Latin script, composed, whitespace-collapsed. This type does not convert: a raw display-script selection
+/// passed here would silently fail every dictionary and lemma lookup, which is the failure #581 exists to
+/// prevent. Null means nothing was selected.</param>
+/// <param name="SelectionUnavailable">The reader could not determine the selection at all. Distinct from a null
+/// <paramref name="SelectionText"/>, which means the user genuinely selected nothing — see
+/// <see cref="SelectionState.Unavailable"/>.</param>
 /// <param name="OutputLanguage">Language the ANSWER should be in — a separate axis from the script of quoted
 /// Pāli. Not optional: translate into what?</param>
 /// <param name="UserQuestion">Free-form question, where the preset allows one.</param>
@@ -33,14 +37,39 @@ public sealed record AiContextRequest(
     string OutputLanguage,
     CST.Navigation.NavigationReference? Reference = null,
     string? SelectionText = null,
-    string? UserQuestion = null);
+    string? UserQuestion = null,
+    bool SelectionUnavailable = false);
 
-/// <summary>The user's selection, once the selection pipeline has normalized it.</summary>
-/// <param name="Text">Latin-script, whitespace-normalized.</param>
-/// <param name="FoundInWindow">Whether the selection was located within the fetched passage window. False
-/// means the model is being shown a selection the surrounding passage may not contain — worth knowing, and
-/// recorded in the budget report rather than silently ignored.</param>
-public sealed record SelectionContext(string Text, bool FoundInWindow);
+/// <summary>What became of the user's selection.</summary>
+public enum SelectionState
+{
+    /// <summary>Converted, normalized, and found in the passage window.</summary>
+    Located,
+
+    /// <summary>
+    /// Converted and normalized, but not present in the window. The model is still shown it — it is what the
+    /// user pointed at — but the surrounding passage may not support what is being asked about.
+    /// </summary>
+    NotFoundInWindow,
+
+    /// <summary>
+    /// The reader could not say what was selected — the WebView was not ready, or the round trip through the
+    /// <c>document.title</c> channel timed out. <b>Deliberately distinct from "nothing was selected"</b>: those
+    /// two were the same null before #581, and the difference is the difference between an answer about the
+    /// whole passage (correct) and an answer that quietly ignored the words the user highlighted (which the
+    /// user experiences as "the AI ignored my selection").
+    /// </summary>
+    Unavailable,
+}
+
+/// <summary>The user's selection, once the selection pipeline has been through it.</summary>
+/// <param name="Text">Latin-script, composed, whitespace-collapsed. Null when <see cref="State"/> is
+/// <see cref="SelectionState.Unavailable"/> — there is no text to carry.</param>
+public sealed record SelectionContext(string? Text, SelectionState State)
+{
+    /// <summary>Whether the selection was located within the fetched passage window.</summary>
+    public bool FoundInWindow => State == SelectionState.Located;
+}
 
 /// <summary>A word's stem and grammatical analysis, from the optional DPD-lemma asset.</summary>
 public sealed record LemmaEntry(

--- a/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
@@ -250,10 +250,18 @@ public sealed class PromptBuilder : IPromptBuilder
         if (selection is null)
             return "The reader has not selected anything. Treat the whole passage as being in view.";
 
-        // A selection the window does not contain means the surrounding text may not support what is being asked
-        // about — worth telling the model, since it is the difference between "explain this in context" and
-        // "explain this, and be aware the context you have may be the wrong context".
-        var note = selection.FoundInWindow
+        // Distinct from "nothing selected": the user may well have highlighted something we failed to read, so
+        // the model is told the difference rather than being allowed to assume the passage is all there was.
+        if (selection.State == SelectionState.Unavailable)
+        {
+            return "The reader may have selected something, but it could not be read. Answer about the passage "
+                 + "as a whole, and say that you were not able to see a selection.";
+        }
+
+        // A selection the window does not contain means the surrounding text may not support what is being
+        // asked about — the difference between "explain this in context" and "explain this, and be aware the
+        // context you have may be the wrong context".
+        var note = selection.State == SelectionState.Located
             ? string.Empty
             : "\n\n(This selection was not found in the passage above. The reader may have scrolled, or the "
               + "selection may lie outside the window. Treat the surrounding text with corresponding caution.)";
@@ -422,8 +430,16 @@ public sealed class PromptBuilder : IPromptBuilder
                 notices.Add($"The {PartLabel(part.Name)} was cut to fit the request budget.");
         }
 
-        if (bundle.Selection is { FoundInWindow: false })
-            notices.Add("The selected text was not found in the passage window the model was given.");
+        switch (bundle.Selection?.State)
+        {
+            case SelectionState.NotFoundInWindow:
+                notices.Add("The selected text was not found in the passage window the model was given.");
+                break;
+            case SelectionState.Unavailable:
+                // The one the user most needs: otherwise this reads as "the AI ignored my selection".
+                notices.Add("Your selection could not be read, so the answer covers the whole passage.");
+                break;
+        }
 
         // Says the number. "May extend past the reference" was true of almost every request and read like a
         // rounding caveat; "covers 29 paragraphs" is a fact the reader can act on. (#602)

--- a/src/CST.Avalonia/Services/Ai/ReaderState.cs
+++ b/src/CST.Avalonia/Services/Ai/ReaderState.cs
@@ -34,12 +34,17 @@ public enum ReaderStateProblem
 /// <summary>What the user is looking at: the book, where in it, and what (if anything) they have selected.</summary>
 /// <param name="BookId">The open book's file name — what the bundler and the passage tool key on.</param>
 /// <param name="Paragraph">The paragraph the viewport is on.</param>
-/// <param name="SelectionText">The user's selection, if any, <b>already converted to Latin</b> — see
-/// <see cref="ReaderStateService"/>.</param>
+/// <param name="SelectionText">The user's selection, already through <c>SelectionPipeline.Normalize</c> —
+/// Latin, composed, whitespace-collapsed. Null means <i>nothing was selected</i>.</param>
+/// <param name="SelectionUnavailable">The selection could not be read at all — the WebView was not ready, or
+/// the <c>document.title</c> round trip timed out. <b>Not the same as a null
+/// <paramref name="SelectionText"/></b>: conflating them is what makes a dropped selection look to the user
+/// like "the AI ignored my selection". (#581)</param>
 public sealed record ReaderState(
     string BookId,
     int Paragraph,
-    string? SelectionText);
+    string? SelectionText,
+    bool SelectionUnavailable = false);
 
 /// <summary>Success or a named refusal. Never a partial answer.</summary>
 public readonly record struct ReaderStateResult(ReaderState? State, ReaderStateProblem? Problem)
@@ -101,8 +106,9 @@ public sealed class ReaderStateService : IReaderStateService
 
         ct.ThrowIfCancellationRequested();
 
-        var selection = await ReadSelectionAsync(document);
-        return ReaderStateResult.Ok(result.State with { SelectionText = selection });
+        var (selection, unavailable) = await ReadSelectionAsync(document);
+        return ReaderStateResult.Ok(
+            result.State with { SelectionText = selection, SelectionUnavailable = unavailable });
     }
 
     private (ReaderStateResult Result, BookDisplayViewModel? Document) ReadActiveBook()
@@ -152,18 +158,23 @@ public sealed class ReaderStateService : IReaderStateService
     }
 
     /// <summary>
-    /// Ask the WebView for the selection and convert it to Latin.
+    /// Ask the WebView for the selection and put it through <see cref="SelectionPipeline"/>.
     ///
-    /// <para><b>The conversion happens here because the display script is only known here.</b> The bundler's
-    /// <c>SelectionContext</c> documents its input as Latin and matches the selection against a Latin passage
-    /// window — hand it Devanagari and every bundle reports "selection not found", a false diagnostic from a
-    /// tool whose whole purpose is faithful diagnostics. (Richer normalization remains #581's job.)</para>
+    /// <para><b>The channel distinguishes two failures and so does this.</b>
+    /// <c>GetWebViewSelectionAsync</c> returns an empty string when the user genuinely selected nothing, and
+    /// <c>null</c> when it could not find out — the browser was not initialised, the script threw, or the
+    /// <c>document.title</c> round trip exceeded its 700 ms budget. Collapsing both to "no selection" is what
+    /// produces the report "the AI ignored my selection", so the distinction is carried upward. (#581)</para>
+    ///
+    /// <para><b>Conversion happens here because the display script is only known here</b>, and it is not a
+    /// refinement: hand the bundler Devanagari and every lookup misses and every window match fails, which makes
+    /// the two grammatical presets Latin-readers-only — the opposite of the user who prompted surface B.</para>
     ///
     /// <para>Run entirely on the UI thread: every other caller of the selection channel is a UI-thread command
     /// handler, it drives CEF, and it writes a single-slot completion source a concurrent Cmd+D would
     /// otherwise clobber.</para>
     /// </summary>
-    private static async Task<string?> ReadSelectionAsync(BookDisplayViewModel document)
+    private static async Task<(string? Text, bool Unavailable)> ReadSelectionAsync(BookDisplayViewModel document)
     {
         var raw = await Dispatcher.UIThread.InvokeAsync(async () =>
         {
@@ -171,9 +182,9 @@ public sealed class ReaderStateService : IReaderStateService
             return control is null ? null : await control.GetWebViewSelectionAsync();
         });
 
-        if (string.IsNullOrWhiteSpace(raw)) return null;
+        // null = could not read it; "" = read it, and there was nothing to read.
+        if (raw is null) return (null, true);
 
-        var script = document.BookScript;
-        return script == Script.Latin ? raw : ScriptConverter.Convert(raw, script, Script.Latin);
+        return (SelectionPipeline.Normalize(raw, document.BookScript), false);
     }
 }

--- a/src/CST.Avalonia/Services/Ai/SelectionPipeline.cs
+++ b/src/CST.Avalonia/Services/Ai/SelectionPipeline.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Text;
+using System.Text.RegularExpressions;
+using CST.Conversion;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>
+/// Turns what the WebView reports into something the rest of surface B can use. (#581, AI_SURFACE_B.md §3.1)
+///
+/// <para><b>The selection is the one bundler input genuinely scraped from the DOM.</b> Everything else comes
+/// from the tool layer, which owns its formats; this arrives in the user's display script, through a
+/// <c>document.title</c> round trip, with a timeout. So it gets the handling that deserves.</para>
+///
+/// <para><b>Two phases, because they run in different places.</b> <see cref="Normalize"/> needs the display
+/// script, which only the reader knows; <see cref="IsWithin"/> needs the passage window, which only the bundler
+/// has. Keeping them one class keeps the normalization rules in one place — the two sides of a comparison
+/// drifting apart is exactly how a locator starts reporting false misses.</para>
+/// </summary>
+public static class SelectionPipeline
+{
+    private static readonly Regex Whitespace = new(@"\s+", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Convert to Latin, compose, and collapse whitespace — the form every downstream comparison and lookup
+    /// assumes. Returns null when there is nothing usable.
+    ///
+    /// <para><b>Conversion is not a refinement.</b> A Burmese- or Devanagari-script reader selects text in that
+    /// script; unconverted, every dictionary and lemma lookup misses and the two presets that differentiate
+    /// this app work only for Latin-script readers — the opposite of the user who prompted the feature.</para>
+    ///
+    /// <para><b>Composition (NFC) is cheap insurance against a real failure.</b> `ScriptConverter` emits
+    /// composed Latin (ā is U+0101), and the passage text comes through the same converter, so in the ordinary
+    /// path both sides already agree. But a decomposed selection — a different input path, an OS that
+    /// normalizes on copy — is <i>ordinally unequal</i> to the composed form (a + U+0304 ≠ U+0101), and the
+    /// symptom would be a bundle reporting "selection not found in the passage window": a false diagnostic
+    /// from the one component whose job is faithful diagnostics.</para>
+    /// </summary>
+    public static string? Normalize(string? raw, Script sourceScript)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+
+        var latin = sourceScript == Script.Latin ? raw : ScriptConverter.Convert(raw, sourceScript, Script.Latin);
+
+        // Compose BEFORE collapsing whitespace: a combining mark is not whitespace, but normalizing after a
+        // regex pass means the regex ran over a different string than the one that ships.
+        latin = latin.Normalize(NormalizationForm.FormC);
+        latin = Whitespace.Replace(latin, " ").Trim();
+
+        return latin.Length == 0 ? null : latin;
+    }
+
+    /// <summary>
+    /// Whether a normalized selection appears in a passage window.
+    ///
+    /// <para>The window is normalized the same way here rather than at its source, because the window is the
+    /// tool layer's output and must not be silently rewritten on its way to the model — only the copy used for
+    /// this comparison is.</para>
+    ///
+    /// <para><b>Ordinal, case-insensitively.</b> Case-insensitive because the corpus capitalises
+    /// programmatically at sentence starts, so a selection lifted from mid-sentence and the same words at a
+    /// sentence head differ only in case. Ordinal rather than culture-aware because a culture-aware comparison
+    /// would fold characters Pāli distinguishes.</para>
+    /// </summary>
+    public static bool IsWithin(string normalizedSelection, string windowText)
+    {
+        if (string.IsNullOrEmpty(normalizedSelection) || string.IsNullOrEmpty(windowText)) return false;
+
+        var window = Whitespace.Replace(windowText.Normalize(NormalizationForm.FormC), " ");
+        return window.Contains(normalizedSelection, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -567,7 +567,10 @@ namespace CST.Avalonia.Services.LocalApi
                                 req.OutputLanguage ?? "English",
                                 new NavigationReference.Paragraph(reader.Paragraph),
                                 reader.SelectionText,
-                                req.UserQuestion),
+                                req.UserQuestion,
+                                // Carried, not collapsed: a selection the reader could not read is a different
+                                // state from no selection, and the preview exists to show the real input. (#581)
+                                reader.SelectionUnavailable),
                             ct);
 
                         return Results.Json(bundle);


### PR DESCRIPTION
Closes #581. Part of epic #186. Plan: [`AI_SURFACE_B.md`](https://github.com/fsnow/cst/blob/main/docs/features/planned/AI_SURFACE_B.md) §3.1.

The selection is the one bundler input genuinely scraped from the DOM — it arrives in the user's display script, through a `document.title` round trip, with a 700 ms timeout. Each of those is a way for the words the user highlighted to be silently dropped.

## Three states, not two

**"Nothing selected" and "we could not read the selection" were the same `null`.** They are different things: the first means the whole passage is legitimately in view; the second means the highlighted words went on the floor. Only the second is worth telling the user about — and it's exactly the state that otherwise reaches them as *"the AI ignored my selection"*.

The channel already made the distinction — `GetWebViewSelectionAsync` returns `""` for nothing selected and `null` for a failed or timed-out round trip. We were discarding it one layer up. It now runs through `ReaderState`, the bundle, the prompt, the user-facing notices, and the context-preview endpoint.

## Conversion is a prerequisite, not a refinement

Unconverted, every dictionary and lemma lookup misses and the window match fails — which makes the two grammatical presets work for **Latin-script readers only**, the opposite of the reader who prompted surface B. It stays driven from `ReaderStateService` (the only place that knows the display script), but the rules now live in one class alongside the window-location rules. Splitting them would let the two sides of a comparison drift, which is exactly how a locator starts reporting false misses.

## NFC composition — measured, not assumed

I checked before adding it. A survey of the corpus found the Devanagari source **already NFC** (its only combining mark is the virama, U+094D, which has no composed form), and `ScriptConverter` emits **composed** Latin — so in the ordinary path both sides of the comparison already agree.

But a decomposed selection is *ordinally* unequal: `a` + U+0304 ≠ U+0101. The symptom would be a bundle reporting "selection not found in the passage window" — a false diagnostic from the component whose whole job is faithful diagnostics. The test asserts the inequality first, so the guard can't quietly become vacuous.

## Acceptance cases

All three the issue asks for: a **non-Latin selection** (Devanagari → Latin, then located in a Latin window), a selection **straddling a line break** (whitespace collapse, since the window renders breaks differently from the DOM), and the **null/timeout path**. Plus case-insensitivity, because the corpus capitalises programmatically at sentence starts.

**1332/1332** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)