### PR TITLE
Surface B: the model registry and fidelity advisory (#584)

### DIFF
--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -1,8 +1,8 @@
 # Surface B — the in-app model, v1 by context injection (Planned)
 
 **Status:** In progress. Shipped: B1 (#578, provider layer), B3 (#580, context bundler), B3a (#581, selection
-pipeline), B4 (#582, presets and the grounding contract), B5 (#583, orchestrator), plus the reader-state read
-path and
+pipeline), B4 (#582, presets and the grounding contract), B5 (#583, orchestrator), B6 (#584, model registry),
+plus the reader-state read path and
 `POST /v1/ai/context-preview` (#593). **The chain now runs end to end** — a live Translate turn against the real
 corpus and a real model works — but nothing is user-visible until the Settings UI (B7, #585) and the panel
 (B8, #586) exist.
@@ -614,3 +614,21 @@ it now gets handling to match.
   agree. But a decomposed selection is *ordinally* unequal (`a`+U+0304 ≠ U+0101), and the symptom would be a
   bundle reporting "selection not found in the passage window" — a false diagnostic from the component whose
   whole job is faithful diagnostics.
+
+**2026-08-11 (#584, the model registry)** — the fidelity advisory's data, shipped as an embedded JSON resource
+with a lookup that normalizes the several spellings one model arrives in (vendor prefix, deployment suffix,
+dated snapshot) while never folding away **size**, since `gpt-oss:20b` and `gpt-oss:120b` are different models
+rated differently.
+
+- **`unrated` is not `discouraged`, and that distinction is the design.** Frontier models appear constantly; a
+  registry treating anything it had not heard of as suspect would have flagged half of today's good models a
+  year ago and would decay into noise the moment it stopped being updated — at which point users dismiss it,
+  including on the entries that matter. Unknown models get a mild "not evaluated"; the strong warning is
+  reserved for models with **evidence against them on this corpus**.
+- **Every non-recommended entry cites its evidence**, and a test enforces it. A registry that says a model is
+  not recommended for translating canonical text has to answer *why*, or it is an opinion with a version number.
+- **The advisory is scoped to translation.** Explaining or parsing a passage the model can see is a far smaller
+  fidelity surface than producing English a reader will take as the meaning of the Pāli — and an advisory
+  attached to everything is one nobody reads.
+- **Nothing is ever blocked** (AI_INTEGRATION.md §11.1). The interface returns a rating or advice; there is no
+  member that can refuse a model, and a test asserts there is no boolean verdict on it.

--- a/docs/testing/PALI_FIDELITY_CASES.md
+++ b/docs/testing/PALI_FIDELITY_CASES.md
@@ -61,9 +61,26 @@ are the models that actually answer on a free account, largest first:
 > **`gpt-oss:120b` is not the best available and should stop being the default probe.** It is fourth of seven by
 > size, and it is only the one appearing in the observations below because it was the model at hand
 > (fsnow: *"you are testing with that one only because I am familiar with it… not because it is the best
-> available"*). **`nemotron-3-ultra:cloud` is 550B and free.** Re-running the case set across the tiers above is
-> the standing next step for #587 — a single-model column is not a matrix, and a failure observed on one
-> mid-tier model tells you about that model, not about the tier.
+> available"*). **`nemotron-3-ultra:cloud` is 550B and free.**
+
+### One model per family — the run matrix
+
+**Rule (fsnow, 2026-08-11): where two models of the same family are both free here and one is better, only the
+better one is run.** Testing `nemotron-3-super` and `nemotron-3-nano` alongside `nemotron-3-ultra` spends quota
+re-measuring the same lineage's weaker members, and a family's floor tells you little that its ceiling does not.
+
+That reduces seven models to **four**:
+
+| Model | Family | Why this one |
+|---|---|---|
+| `nemotron-3-ultra:cloud` | nemotron-3 | Best of three free variants (550B vs 120B vs 30B) |
+| `minimax-m3:cloud` | minimax | Only free variant |
+| `gemma4:cloud` | gemma | Only free variant |
+| `gpt-oss:120b-cloud` | gpt-oss | Better of two free variants — and the matrix's deliberately weak cell |
+
+The observations below **keep** their `nemotron-3-super`, `nemotron-3-nano` and `gpt-oss:20b` rows: those were
+measured, the findings are real, and Case 4 rests on two of them independently. The rule governs what gets run
+*next*, not what has already been learned.
 
 ### Screening run — 2026-08-11
 

--- a/src/CST.Avalonia.Tests/Services/Ai/ModelRegistryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ModelRegistryTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Linq;
+using CST.Avalonia.Services.Ai;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// The fidelity advisory's data and lookup. (#584, AI_SURFACE_B.md §7)
+///
+/// <para>The shipped registry is asserted here as well as the matching rules: it is data, so nothing about it
+/// is checked at compile time, and an entry that silently fails to match is an advisory that never fires.</para>
+/// </summary>
+public class ModelRegistryTests
+{
+    private static readonly ModelRegistry Registry = new(NullLogger<ModelRegistry>.Instance);
+
+    // ---- Policy ------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("claude-opus-5")]
+    [InlineData("claude-fable-5")]
+    [InlineData("claude-sonnet-5")]
+    [InlineData("claude-opus-4-8")]
+    public void Claude_frontier_models_are_recommended(string id)
+    {
+        // Claude-first is the standing policy (AI_INTEGRATION.md §11.1), not a measurement.
+        Assert.Equal(ModelTier.Recommended, Registry.Rate(id).Tier);
+        Assert.Null(Registry.Advisory(AiTask.Translate, id));
+    }
+
+    [Fact]
+    public void An_unknown_model_is_unrated_rather_than_discouraged()
+    {
+        // The whole design. Frontier models appear constantly; a registry that treated anything it had not
+        // heard of as suspect would have flagged half of today's good models a year ago, and would decay into
+        // noise users learn to dismiss — including on the entries that matter.
+        var rating = Registry.Rate("some-model-released-next-tuesday");
+
+        Assert.Equal(ModelTier.Unrated, rating.Tier);
+        Assert.NotEqual(ModelTier.DiscouragedForTranslation, rating.Tier);
+    }
+
+    [Fact]
+    public void An_unrated_model_gets_a_softer_advisory_than_a_discouraged_one()
+    {
+        // "We have not tested this" and "this got it wrong" are different statements; conflating them is what
+        // turns advisories into noise.
+        var unrated = Registry.Advisory(AiTask.Translate, "some-model-released-next-tuesday")!;
+        var discouraged = Registry.Advisory(AiTask.Translate, "gpt-oss:20b")!;
+
+        Assert.Contains("has not been evaluated", unrated);
+        Assert.Contains("not recommended", discouraged);
+        Assert.NotEqual(unrated, discouraged);
+    }
+
+    [Fact]
+    public void A_discouraged_model_says_why_in_its_advisory()
+    {
+        // A registry that says a model is not recommended has to be able to answer why — otherwise it is an
+        // opinion with a version number.
+        var advisory = Registry.Advisory(AiTask.Translate, "gpt-oss:20b")!;
+
+        Assert.Contains("appamāda", advisory);
+        Assert.Contains("Check its output against the Pāli", advisory);
+    }
+
+    [Fact]
+    public void Every_non_recommended_entry_cites_evidence_or_says_it_is_untested()
+    {
+        // Guards the data, not the code: an entry demoting a model on no stated grounds is an opinion, and the
+        // one place that must not happen is the file that tells users which models to distrust.
+        foreach (var id in new[] { "gpt-oss:120b", "gpt-oss:20b", "nemotron-3-nano:30b" })
+        {
+            var rating = Registry.Rate(id);
+            Assert.Equal(ModelTier.DiscouragedForTranslation, rating.Tier);
+            Assert.False(string.IsNullOrWhiteSpace(rating.Note), id);
+            Assert.False(string.IsNullOrWhiteSpace(rating.Evidence), id);
+        }
+    }
+
+    [Fact]
+    public void The_advisory_is_scoped_to_translation()
+    {
+        // An advisory attached to everything is one nobody reads. Explaining a passage the model can see is a
+        // far smaller fidelity surface than producing English a reader takes as the meaning of the Pāli.
+        foreach (var task in new[] { AiTask.Explain, AiTask.Grammar, AiTask.WordByWord })
+            Assert.Null(Registry.Advisory(task, "gpt-oss:20b"));
+
+        Assert.NotNull(Registry.Advisory(AiTask.Translate, "gpt-oss:20b"));
+    }
+
+    [Fact]
+    public void Nothing_is_ever_blocked()
+    {
+        // Curate, advise, never block. The advisory is a string; there is no path that refuses a model, and a
+        // reader who wants a local model for privacy has a reason we do not get to override.
+        var discouraged = Registry.Rate("gpt-oss:20b");
+
+        Assert.Equal(ModelTier.DiscouragedForTranslation, discouraged.Tier);
+        Assert.NotNull(Registry.Advisory(AiTask.Translate, "gpt-oss:20b"));
+        // And no API exists to reject one: every member returns a rating or advice, never a verdict.
+        Assert.DoesNotContain(typeof(IModelRegistry).GetMethods(), m => m.ReturnType == typeof(bool));
+    }
+
+    // ---- Id matching -------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("gpt-oss:120b-cloud", "gpt-oss:120b")]
+    [InlineData("  GPT-OSS:120B-CLOUD  ", "gpt-oss:120b")]
+    [InlineData("anthropic/claude-opus-5", "claude-opus-5")]
+    [InlineData("gemma4:cloud", "gemma4")]
+    public void Ids_normalize_across_the_spellings_a_model_arrives_in(string typed, string expected)
+    {
+        // The same model reaches us several ways: an aggregator prefixes the vendor, Ollama suffixes the
+        // deployment. Neither changes which model it is.
+        Assert.Equal(expected, ModelRegistry.NormalizeId(typed));
+    }
+
+    [Fact]
+    public void Size_is_never_normalized_away()
+    {
+        // gpt-oss:20b and gpt-oss:120b are different models rated differently — folding them together would
+        // put the warning on the wrong one.
+        Assert.Equal(ModelTier.DiscouragedForTranslation, Registry.Rate("gpt-oss:20b").Tier);
+        Assert.NotEqual(Registry.Rate("gpt-oss:20b").Note, Registry.Rate("gpt-oss:120b").Note);
+    }
+
+    [Fact]
+    public void A_dated_snapshot_resolves_to_its_family()
+    {
+        Assert.Equal(ModelTier.Permitted, Registry.Rate("claude-haiku-4-5-20251001").Tier);
+    }
+
+    [Fact]
+    public void A_prefix_only_matches_at_a_separator()
+    {
+        // Otherwise "gpt-oss:120b" would swallow a hypothetical "gpt-oss:1200b" it says nothing about.
+        Assert.True(ModelRegistry.Matches("gpt-oss:120b", "gpt-oss:120b-turbo"));
+        Assert.False(ModelRegistry.Matches("gpt-oss:120b", "gpt-oss:1200b"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void A_missing_model_id_is_unrated_rather_than_an_error(string? id)
+    {
+        Assert.Equal(ModelTier.Unrated, Registry.Rate(id).Tier);
+    }
+
+    [Fact]
+    public void The_shipped_registry_actually_loaded()
+    {
+        // Without this, a broken resource would show up only as every model silently reporting unrated —
+        // an advisory that never fires looks exactly like a well-behaved one.
+        Assert.Equal(ModelTier.Recommended, Registry.Rate("claude-opus-5").Tier);
+        Assert.False(string.IsNullOrWhiteSpace(ModelRegistry.Updated));
+    }
+
+    [Theory]
+    [InlineData("recommended", ModelTier.Recommended)]
+    [InlineData("permitted", ModelTier.Permitted)]
+    [InlineData("discouraged-for-translation", ModelTier.DiscouragedForTranslation)]
+    public void Tier_names_in_the_data_match_the_enum(string name, ModelTier expected)
+    {
+        Assert.True(ModelRegistry.TryParseTier(name, out var tier));
+        Assert.Equal(expected, tier);
+    }
+
+    [Fact]
+    public void An_unknown_tier_name_is_refused_rather_than_guessed()
+    {
+        Assert.False(ModelRegistry.TryParseTier("banned", out _));
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1234,6 +1234,9 @@ public partial class App : Application
             sp.GetService<Services.Ai.IAiCredentialStore>(),
             sp.GetRequiredService<ILoggerFactory>()));
         services.AddSingleton<Services.Ai.IAiChatOrchestrator, Services.Ai.AiChatOrchestrator>();
+
+        // The fidelity advisory (#584). Data only — Settings (#585) and the panel (#586) surface it.
+        services.AddSingleton<Services.Ai.IModelRegistry, Services.Ai.ModelRegistry>();
         services.AddSingleton<ILemmaReportService, LemmaReportService>();
 
         // Surface-C tool wrappers (exposed over the local API). (#186)

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -59,6 +59,9 @@
          edits live beside settings.json and override these at load. Wildcard so adding a preset needs no csproj
          edit — PromptTemplateNames.All is the list that matters, and a name there with no resource fails loudly. -->
     <EmbeddedResource Include="Resources\Ai\*.md" />
+    <!-- The fidelity advisory's data (#584). Embedded so it ships with the app and cannot be edited into
+         something that silently mis-rates a model. -->
+    <EmbeddedResource Include="Resources\Ai\model-registry.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CST.Avalonia/Resources/Ai/model-registry.json
+++ b/src/CST.Avalonia/Resources/Ai/model-registry.json
@@ -1,0 +1,77 @@
+{
+  "_comment": [
+    "The fidelity advisory's data (#584). Policy is AI_INTEGRATION.md §11.1: CURATE, ADVISE, NEVER BLOCK.",
+    "A tier here is a claim about a model's fidelity on THIS corpus, so every non-recommended entry cites the",
+    "evidence for it in docs/testing/PALI_FIDELITY_CASES.md. An entry with no evidence is an opinion, and this",
+    "file is not for opinions.",
+    "Anything absent is 'unrated', which is NOT 'discouraged' — see ModelRegistry for why that distinction is",
+    "the whole design.",
+    "Where two models of the same family are both free to run and one is better, only the better one is",
+    "screened (fsnow, 2026-08-11) — a family's floor tells you little its ceiling does not. Entries already",
+    "measured stay: the rule governs what gets run next, not what has been learned.",
+    "Ids are matched after normalization (lowercase, vendor prefix and deployment suffix stripped) and may also",
+    "match as a dotted/dashed prefix, so a dated snapshot resolves to its family. Register FULL ids only: a",
+    "truncated one would swallow later releases it says nothing about."
+  ],
+  "updated": "2026-08-11",
+  "models": [
+    { "id": "claude-opus-5", "tier": "recommended" },
+    { "id": "claude-fable-5", "tier": "recommended" },
+    { "id": "claude-mythos-5", "tier": "recommended" },
+    { "id": "claude-opus-4-8", "tier": "recommended" },
+    { "id": "claude-opus-4-7", "tier": "recommended" },
+    { "id": "claude-opus-4-6", "tier": "recommended" },
+    { "id": "claude-sonnet-5", "tier": "recommended" },
+    { "id": "claude-sonnet-4-6", "tier": "recommended" },
+
+    {
+      "id": "claude-haiku-4-5",
+      "tier": "permitted",
+      "note": "Fast and cheap, and untested on the fidelity set. Fine for explaining; check translations."
+    },
+
+    {
+      "id": "nemotron-3-ultra",
+      "tier": "permitted",
+      "note": "Rendered all four lines of Dhp 21 correctly, including the deathless/death contrast.",
+      "evidence": "PALI_FIDELITY_CASES.md, screening run 2026-08-11"
+    },
+    {
+      "id": "nemotron-3-super",
+      "tier": "permitted",
+      "note": "Rendered Dhp 21 correctly, but emitted mojibake where the niggahita should be — a mangled diacritic inside the quote markers cannot be script-converted.",
+      "evidence": "PALI_FIDELITY_CASES.md, screening run 2026-08-11"
+    },
+    {
+      "id": "gemma4",
+      "tier": "permitted",
+      "note": "Matched the 550B model on Dhp 21 at 32.7B — the cheapest capable option screened.",
+      "evidence": "PALI_FIDELITY_CASES.md, screening run 2026-08-11"
+    },
+    {
+      "id": "minimax-m3",
+      "tier": "permitted",
+      "note": "Rendered Dhp 21 correctly. Reasons heavily — it spent 3,177 completion tokens on a two-line verse.",
+      "evidence": "PALI_FIDELITY_CASES.md, screening run 2026-08-11"
+    },
+
+    {
+      "id": "gpt-oss:120b",
+      "tier": "discouraged-for-translation",
+      "note": "Misread matā (dead) as if from maññati (think) in Dhp 21, across three separate runs.",
+      "evidence": "PALI_FIDELITY_CASES.md case 4"
+    },
+    {
+      "id": "nemotron-3-nano:30b",
+      "tier": "discouraged-for-translation",
+      "note": "Misread matā (dead) as mātā (mother) in Dhp 21 — and offered both wrong readings as an ambiguity note, which reads as care.",
+      "evidence": "PALI_FIDELITY_CASES.md case 4"
+    },
+    {
+      "id": "gpt-oss:20b",
+      "tier": "discouraged-for-translation",
+      "note": "Glossed appamāda as 'failing or stumbling… to make a mistake' — the most quoted word in the canon, inverted.",
+      "evidence": "PALI_FIDELITY_CASES.md cases 1 and 4"
+    }
+  ]
+}

--- a/src/CST.Avalonia/Services/Ai/ModelRegistry.cs
+++ b/src/CST.Avalonia/Services/Ai/ModelRegistry.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>
+/// How far a model is trusted on <b>this</b> corpus. Not a general quality ranking — a claim about Pāli
+/// fidelity, which is why every non-recommended entry cites evidence.
+/// </summary>
+public enum ModelTier
+{
+    /// <summary>
+    /// Not in the registry. <b>This is not a criticism</b> — see <see cref="ModelRegistry"/> for why the
+    /// distinction from <see cref="DiscouragedForTranslation"/> is the whole point.
+    /// </summary>
+    Unrated,
+
+    /// <summary>Trusted for translating canonical text. Claude-first, per AI_INTEGRATION.md §11.1.</summary>
+    Recommended,
+
+    /// <summary>Passed the fidelity set, or is untested but has no evidence against it.</summary>
+    Permitted,
+
+    /// <summary>Failed the fidelity set on the corpus itself. Advised against for translation — never blocked.</summary>
+    DiscouragedForTranslation,
+}
+
+/// <summary>What the registry knows about one model.</summary>
+/// <param name="Note">Why it sits where it does, in one sentence, for a human reading Settings.</param>
+/// <param name="Evidence">Where the claim comes from. Absent only for the recommended tier, which follows from
+/// the standing policy rather than from a measurement.</param>
+public sealed record ModelRating(ModelTier Tier, string? Note = null, string? Evidence = null);
+
+/// <summary>Rates a configured model, and says what (if anything) to warn about.</summary>
+public interface IModelRegistry
+{
+    /// <summary>The tier for a model id as the user typed it. Never throws; unknown ids are Unrated.</summary>
+    ModelRating Rate(string? modelId);
+
+    /// <summary>
+    /// The advisory to show for a task, or null when none is warranted. Only ever advice: the user's choice of
+    /// model is theirs, and a reader who wants a local model for privacy has a good reason we do not get to
+    /// override (AI_INTEGRATION.md §11.1 — curate, advise, never block).
+    /// </summary>
+    string? Advisory(AiTask task, string? modelId);
+}
+
+/// <summary>
+/// The fidelity advisory's data and lookup. (#584, AI_SURFACE_B.md §7)
+///
+/// <para><b>Why a registry at all.</b> Model quality is a fidelity feature here rather than a preference: this
+/// is a sacred-text corpus, and hallucination risk runs inverse to model quality times grounding. A model that
+/// inverts <i>appamāda</i> or reads <i>matā</i> as "mother" produces fluent, confident, wrong Pāli that a reader
+/// who came to this app <b>because they cannot yet read Pāli unaided</b> has no way to catch.</para>
+///
+/// <para><b>Unrated is not discouraged, and that is the whole design.</b> Frontier models appear constantly. A
+/// registry that treated anything it had not heard of as suspect would have flagged half of today's good models
+/// a year ago, and would decay into noise the moment it stopped being updated — at which point users learn to
+/// dismiss it, including on the entries that matter. So the default for an unknown model is a mild "not
+/// evaluated", and the strong warning is reserved for models with <b>evidence against them on this corpus</b>.</para>
+///
+/// <para><b>Every non-recommended entry cites its evidence.</b> A registry that says a model is not recommended
+/// for translating canonical text has to be able to answer <i>why</i> — otherwise it is an opinion with a
+/// version number.</para>
+/// </summary>
+public sealed class ModelRegistry : IModelRegistry
+{
+    private sealed record Entry(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("tier")] string Tier,
+        [property: JsonPropertyName("note")] string? Note = null,
+        [property: JsonPropertyName("evidence")] string? Evidence = null);
+
+    private sealed record Document(
+        [property: JsonPropertyName("updated")] string? Updated,
+        [property: JsonPropertyName("models")] IReadOnlyList<Entry>? Models);
+
+    private static readonly ModelRating UnratedRating = new(ModelTier.Unrated);
+
+    private readonly IReadOnlyList<(string Id, ModelRating Rating)> _entries;
+    private readonly ILogger<ModelRegistry> _logger;
+
+    public ModelRegistry(ILogger<ModelRegistry> logger)
+    {
+        _logger = logger;
+        _entries = Load(logger);
+    }
+
+    /// <summary>The date the shipped registry was last revised — worth showing beside an advisory.</summary>
+    public static string? Updated { get; private set; }
+
+    public ModelRating Rate(string? modelId)
+    {
+        var id = NormalizeId(modelId);
+        if (id is null) return UnratedRating;
+
+        foreach (var (entryId, rating) in _entries)
+            if (Matches(entryId, id))
+                return rating;
+
+        return UnratedRating;
+    }
+
+    public string? Advisory(AiTask task, string? modelId)
+    {
+        // Only translation carries an advisory. Explaining or parsing a passage the model can see is a far
+        // smaller fidelity surface than producing English that a reader will take as the meaning of the Pāli —
+        // and an advisory attached to everything is one nobody reads.
+        if (task != AiTask.Translate) return null;
+
+        var rating = Rate(modelId);
+        return rating.Tier switch
+        {
+            ModelTier.Recommended => null,
+
+            ModelTier.DiscouragedForTranslation =>
+                $"This model is not recommended for translating canonical text. {rating.Note} "
+                + "Check its output against the Pāli.",
+
+            ModelTier.Permitted =>
+                "This model is not in the recommended tier for translating canonical text. "
+                + "Check its output against the Pāli.",
+
+            // Deliberately softer, and deliberately says WHY it is softer: "we have not tested this" is a
+            // different statement from "this got it wrong", and conflating them is what makes advisories noise.
+            _ => "This model has not been evaluated on this corpus. Check its output against the Pāli.",
+        };
+    }
+
+    /// <summary>
+    /// Reduce a user-typed model id to the form the registry is keyed on.
+    ///
+    /// <para>Three things get stripped, each because the same model reaches us spelled several ways:
+    /// <b>case</b>; a leading <c>vendor/</c> segment, since an aggregator serves Claude as
+    /// <c>anthropic/claude-opus-5</c> and it is still Claude; and a trailing <c>-cloud</c> / <c>:cloud</c>
+    /// deployment suffix, which names where a model runs rather than which model it is.</para>
+    ///
+    /// <para><b>Size is never stripped.</b> <c>gpt-oss:20b</c> and <c>gpt-oss:120b</c> are different models and
+    /// are rated differently — folding them together would put a warning on the wrong one.</para>
+    /// </summary>
+    internal static string? NormalizeId(string? modelId)
+    {
+        if (string.IsNullOrWhiteSpace(modelId)) return null;
+
+        var id = modelId.Trim().ToLowerInvariant();
+
+        var slash = id.LastIndexOf('/');
+        if (slash >= 0 && slash < id.Length - 1) id = id[(slash + 1)..];
+
+        foreach (var suffix in new[] { "-cloud", ":cloud" })
+            if (id.EndsWith(suffix, StringComparison.Ordinal))
+                id = id[..^suffix.Length];
+
+        return id.Length == 0 ? null : id;
+    }
+
+    /// <summary>
+    /// Exact match, or the registered id as a prefix ending at a separator — so a dated snapshot
+    /// (<c>claude-haiku-4-5-20251001</c>) resolves to its family, while <c>gpt-oss:120b</c> can never match
+    /// <c>gpt-oss:1200b</c>. Registering a truncated id would defeat the boundary rule, which is why the data
+    /// file says to register full ids only.
+    /// </summary>
+    internal static bool Matches(string entryId, string normalizedId)
+    {
+        if (string.Equals(entryId, normalizedId, StringComparison.Ordinal)) return true;
+        if (!normalizedId.StartsWith(entryId, StringComparison.Ordinal)) return false;
+
+        var next = normalizedId[entryId.Length];
+        return next is '-' or ':' or '.' or '@';
+    }
+
+    private static IReadOnlyList<(string, ModelRating)> Load(ILogger<ModelRegistry> logger)
+    {
+        var json = ReadResource("Ai.model-registry.json");
+        if (json is null)
+        {
+            // Degrade to "everything is unrated" rather than failing: an absent registry must not take the
+            // assistant out of service, and unrated is the honest thing to say when we know nothing.
+            logger.LogError("The model registry resource is missing; every model will be reported as unrated");
+            return Array.Empty<(string, ModelRating)>();
+        }
+
+        Document? document;
+        try
+        {
+            document = JsonSerializer.Deserialize<Document>(json);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogError(ex, "The model registry could not be parsed; every model will be reported as unrated");
+            return Array.Empty<(string, ModelRating)>();
+        }
+
+        Updated = document?.Updated;
+
+        var entries = new List<(string, ModelRating)>();
+        foreach (var entry in document?.Models ?? Array.Empty<Entry>())
+        {
+            var id = NormalizeId(entry.Id);
+            if (id is null) continue;
+
+            if (!TryParseTier(entry.Tier, out var tier))
+            {
+                logger.LogWarning("Model registry entry '{Id}' has an unknown tier '{Tier}'; skipping",
+                    entry.Id, entry.Tier);
+                continue;
+            }
+
+            entries.Add((id, new ModelRating(tier, entry.Note, entry.Evidence)));
+        }
+
+        // Longest id first, so a more specific entry wins over a family prefix that would also match.
+        return entries.OrderByDescending(e => e.Item1.Length).ToList();
+    }
+
+    internal static bool TryParseTier(string? value, out ModelTier tier)
+    {
+        switch (value?.Trim().ToLowerInvariant())
+        {
+            case "recommended": tier = ModelTier.Recommended; return true;
+            case "permitted": tier = ModelTier.Permitted; return true;
+            case "discouraged-for-translation": tier = ModelTier.DiscouragedForTranslation; return true;
+            case "unrated": tier = ModelTier.Unrated; return true;
+            default: tier = ModelTier.Unrated; return false;
+        }
+    }
+
+    private static string? ReadResource(string endsWith)
+    {
+        var assembly = typeof(ModelRegistry).Assembly;
+        var name = assembly.GetManifestResourceNames()
+            .FirstOrDefault(n => n.EndsWith(endsWith, StringComparison.OrdinalIgnoreCase));
+        if (name is null) return null;
+
+        using var stream = assembly.GetManifestResourceStream(name);
+        if (stream is null) return null;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}


### PR DESCRIPTION
Closes #584. Part of epic #186. Plan: [`AI_SURFACE_B.md`](https://github.com/fsnow/cst/blob/main/docs/features/planned/AI_SURFACE_B.md) §7, under AI_INTEGRATION.md §11.1: **curate, advise, never block.**

Model quality is a fidelity feature here rather than a preference. This is a sacred-text corpus, and a model that inverts *appamāda* or reads *matā* as "mother" produces fluent, confident, wrong Pāli — which a reader who came to this app **because they cannot yet read Pāli unaided** has no way to catch.

## `unrated` is not `discouraged` — the whole design

Frontier models appear constantly. A registry that treated anything it had not heard of as suspect would have flagged half of today's good models a year ago, and would decay into noise the moment it stopped being updated — at which point users learn to dismiss it, **including on the entries that matter**.

So an unknown model gets a mild *"has not been evaluated on this corpus"*, and the strong warning is reserved for models with **evidence against them here**. A test asserts the two advisories differ.

## Every non-recommended entry cites its evidence

Enforced by a test, because this is the one file whose job is telling users which models to distrust — an entry demoting a model on no stated grounds is an opinion with a version number. The `discouraged-for-translation` entries come from the 2026-08-11 screening run and cite cases 1 and 4:

| Model | Why |
|---|---|
| `gpt-oss:120b` | Misread *matā* (dead) as if from *maññati* (think) in Dhp 21, across three runs |
| `nemotron-3-nano:30b` | Misread *matā* as *mātā* (mother) — and offered both wrong readings as an ambiguity note, which reads as care |
| `gpt-oss:20b` | Glossed *appamāda* as "failing or stumbling… to make a mistake" |

## Two scoping decisions

**The advisory fires only on translation.** Explaining or parsing a passage the model can see is a far smaller fidelity surface than producing English a reader takes as *the meaning of the Pāli* — and an advisory attached to everything is one nobody reads.

**Nothing is ever blocked.** The interface returns a rating or a sentence; no member can refuse a model, and a test asserts there's no boolean verdict on it. A reader who wants a local model for privacy has a reason we don't get to override.

## Id matching

Normalizes the several spellings one model arrives in — an aggregator's `anthropic/` prefix, Ollama's `-cloud` suffix, a dated snapshot resolving to its family — but **never folds away size**. `gpt-oss:20b` and `gpt-oss:120b` are different models rated differently; conflating them would put the warning on the wrong one. Prefix matching requires a separator boundary, so `gpt-oss:120b` can't swallow a hypothetical `gpt-oss:1200b`.

## Your family rule, recorded

Where two models of the same family are both free here and one is better, only the better one gets screened. That takes the run matrix from **seven models to four** — `nemotron-3-ultra`, `minimax-m3`, `gemma4`, `gpt-oss:120b` (the last as the deliberately weak cell). Entries already measured stay in the registry and the case observations: the rule governs what gets run *next*, not what has been learned. Recorded in both `PALI_FIDELITY_CASES.md` and the registry's own header.

**1357/1357** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)