### PR TITLE
Surface B: the evaluation harness (#587)

### DIFF
--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -2,7 +2,7 @@
 
 **Status:** In progress. Shipped: B1 (#578, provider layer), B3 (#580, context bundler), B3a (#581, selection
 pipeline), B4 (#582, presets and the grounding contract), B5 (#583, orchestrator), B6 (#584, model registry),
-plus the reader-state read path and
+B9 (#587, evaluation harness), plus the reader-state read path and
 `POST /v1/ai/context-preview` (#593). **The chain now runs end to end** — a live Translate turn against the real
 corpus and a real model works — but nothing is user-visible until the Settings UI (B7, #585) and the panel
 (B8, #586) exist.
@@ -632,3 +632,27 @@ rated differently.
   attached to everything is one nobody reads.
 - **Nothing is ever blocked** (AI_INTEGRATION.md §11.1). The interface returns a rating or advice; there is no
   member that can refuse a model, and a test asserts there is no boolean verdict on it.
+
+**2026-08-11 (#587, the evaluation harness)** — mechanical scorers plus a paid, opt-in runner.
+
+- **The scorers are unit-tested without a model or a network.** The live runs cost money, so what they spend it
+  on must be measurement whose behaviour is already pinned down; a scorer debugged against live output is
+  debugged at several dollars a mistake.
+- **The runner is silent unless `CST_AI_EVAL=1`.** A live call on every `dotnet test` would bill for a full
+  matrix whenever anyone touched an unrelated file.
+- **It scores the RAW answer**, so it calls the provider directly — the orchestrator strips quote markers by
+  design, and the markers are the measurement. Everything upstream (bundler, templates, prompt builder) is the
+  real thing, so what is scored is what the app would send.
+- **It reports; it never decides.** Tier changes are recorded by a person. A harness trusted to promote and
+  demote models would quietly become the definition of fidelity.
+
+The first run reproduced Case 4 mechanically and found a **new** failure: `gpt-oss:120b` answers the
+cross-corpus question with invented sutta references instead of declining — the hazard §6 is written against,
+observed rather than theorised. It also turned marker discipline into a number that says two models cannot
+share a script-conversion setting (`gemma4` 1 unmarked term across a 164-quote answer; `gpt-oss:120b` 16–37).
+
+**The terminology gate ships disarmed, deliberately.** The convention is stated positively in the system
+prompt, but the term the scorer would COUNT is one CLAUDE.md forbids appearing anywhere in this repo.
+Committing it to make the check fire would break that rule in order to test a convention — not a trade an
+implementation gets to make. The list is data (`cases.json` → `terminology.discouraged`), so populating it
+locally arms the gate with no code change.

--- a/docs/testing/PALI_FIDELITY_CASES.md
+++ b/docs/testing/PALI_FIDELITY_CASES.md
@@ -244,6 +244,57 @@ per model, since this is one data point.
 
 ---
 
+## The harness (#587)
+
+The scorers and the machine-readable case set live beside this file:
+
+- `docs/testing/ai-eval/cases.json` — the cases a machine re-runs. **This file stays the prose of record**: the
+  authoritative answer, why a case discriminates, and the dated per-model observations.
+- `AnswerScorer` — mechanical scoring for marker discipline, unmarked Pāli, ungrounded quotes, unsupported
+  references, terminology counts, and per-case failure signatures. Unit-tested without a model or a network,
+  because a scorer debugged against live output is debugged at several dollars a mistake.
+- `AiEvalHarness` — the paid runner. **Opt-in and silent by default**: nothing happens unless `CST_AI_EVAL=1`.
+
+```sh
+CST_AI_EVAL=1 CST_AI_EVAL_BASE_URL=http://localhost:11434/v1 \
+  dotnet test --filter "FullyQualifiedName~AiEvalHarness"
+```
+
+**The harness reports; it never decides.** Tier changes are a judgement recorded by a person, here and in
+`model-registry.json`. A harness trusted to promote and demote models would quietly become the definition of
+fidelity — the failure this file's organizing principle exists to avoid.
+
+### First harness run — 2026-08-11
+
+Two models, three cases. It reproduced Case 4 mechanically and found something new.
+
+| Model | Case | Result |
+|---|---|---|
+| `gemma4:cloud` | translate | 68 marked quotes, 0 unbalanced, 1 unmarked (*Nibbāna*) |
+| `gemma4:cloud` | cross-corpus refusal | **clean** |
+| `gemma4:cloud` | word-by-word | 164 marked quotes, 0 unbalanced, 1 unmarked (*Nibbāna*) |
+| `gpt-oss:120b-cloud` | translate | 9 quotes, **16 unmarked**, failure signature *"as they think"* matched |
+| `gpt-oss:120b-cloud` | cross-corpus refusal | **18 unmarked**, and it cited **MN/DN/SN/AN references** |
+| `gpt-oss:120b-cloud` | word-by-word | 71 quotes, **37 unmarked** |
+
+Two findings worth keeping:
+
+- **The marker-discipline gap is now a number.** `gemma4` leaves 1 term unmarked across a 164-quote answer;
+  `gpt-oss:120b` leaves 16–37. That is the measurement §9 needs to decide the v1.1 script-conversion rollout
+  per model, and it says these two models cannot share a setting.
+- **`gpt-oss:120b` fails the cross-corpus refusal** — asked where else *appamāda* is discussed, it answered with
+  sutta references rather than declining. That is the invented-citation hazard §6 is written against, observed
+  rather than theorised. It is a **new** case, not a re-run of an existing one.
+
+*Nibbāna* being flagged on `gemma4` is the scorer erring the way it was built to: an English-naturalized term
+carrying a diacritic. A small unmarked count of such terms is expected and is not a defect.
+
+One false positive was fixed by this run rather than by review: the scorer called *amataṃ padaṃ* an ungrounded
+quote, when it is the sī/syā **variant reading from the print apparatus** — which the Translate preset
+explicitly asks the model to cite. The apparatus is now part of the quotable corpus.
+
+---
+
 ## Related
 
 - **#587** — the evaluation harness that runs this set.

--- a/docs/testing/ai-eval/cases.json
+++ b/docs/testing/ai-eval/cases.json
@@ -1,0 +1,79 @@
+{
+  "_comment": [
+    "The surface-B evaluation set (#587). The B-side analog of LOCAL_API_COLD_TESTS.md's cold-agent loop.",
+    "These are the ONLY surface-B tests that spend money, so the runner is opt-in: it does nothing unless",
+    "CST_AI_EVAL=1 is set. See AiEvalHarness.",
+    "Cases mirror docs/testing/PALI_FIDELITY_CASES.md. That file is the prose of record — the authoritative",
+    "answer, why a case discriminates, and the dated per-model observations. This file is only what a machine",
+    "needs to re-run them.",
+    "Model list follows the one-per-family rule (fsnow, 2026-08-11): where two models of the same family are",
+    "both free and one is better, only the better one is run."
+  ],
+  "updated": "2026-08-11",
+
+  "terminology": {
+    "_comment": [
+      "DELIBERATELY EMPTY, and not an oversight. The house convention this scores is stated positively in the",
+      "system prompt ('call them Pali texts, the Tipitaka, the canon, VRI texts'); the term it exists to COUNT",
+      "is one CLAUDE.md forbids appearing anywhere in this repo. Committing it here to make the check fire",
+      "would break that rule to test a convention, which is not a trade an implementation gets to make.",
+      "Populate locally to run the terminology gate; the scorer is fully data-driven and needs no code change.",
+      "Counted, never rewritten: AI_SURFACE_B.md section 10 is explicit that string surgery on model prose",
+      "produces worse artifacts than the term it removes."
+    ],
+    "discouraged": []
+  },
+
+  "models": [
+    "nemotron-3-ultra:cloud",
+    "minimax-m3:cloud",
+    "gemma4:cloud",
+    "gpt-oss:120b-cloud"
+  ],
+
+  "cases": [
+    {
+      "id": "dhp21-translate",
+      "task": "translate",
+      "bookId": "s0502m.mul.xml",
+      "paragraph": 21,
+      "case": "PALI_FIDELITY_CASES.md case 2 and case 4",
+      "note": "Dhp 21 turns on one root appearing four times (amata, maccu, miyanti, mata). A model that loses the root loses the verse — with the text in front of it, so this is a reading failure, not a recall one.",
+      "failureSignatures": [
+        "as (a|the) mother",
+        "as mothers",
+        "like (a|the) mother",
+        "as they think",
+        "world of becoming",
+        "samsaric",
+        "do not (fall away|decline|go astray)",
+        "never (fall away|decline)"
+      ]
+    },
+    {
+      "id": "dhp21-explain-cross-corpus",
+      "task": "explain",
+      "bookId": "s0502m.mul.xml",
+      "paragraph": 21,
+      "userQuestion": "does this passage say where else appamada is discussed?",
+      "case": "AI_SURFACE_B.md section 6, cross-corpus refusal",
+      "note": "The passage cannot answer this. A correct response says so and points at the reader's own search; improvising from training data is the invented-citation hazard.",
+      "failureSignatures": [
+        "\\b(?:Dhp|Dhammapada)\\s+\\d+",
+        "\\b(?:MN|DN|SN|AN)\\s*\\d+"
+      ]
+    },
+    {
+      "id": "dhp21-wordbyword",
+      "task": "word-by-word",
+      "bookId": "s0502m.mul.xml",
+      "paragraph": 21,
+      "case": "PALI_FIDELITY_CASES.md case 3, marker discipline",
+      "note": "The densest inline-Pali task there is: every word is quoted. If a model marks inline Pali anywhere it will be here, and if it does not, v1.1 script conversion would leave its whole answer in Latin.",
+      "failureSignatures": [
+        "as (a|the) mother",
+        "as they think"
+      ]
+    }
+  ]
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/AiEvalHarness.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiEvalHarness.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Eval;
+using CST.Avalonia.Services.Tools;
+using CST.Navigation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Runs the fixed evaluation set across the model matrix and writes a scored report. (#587, AI_SURFACE_B.md §13)
+///
+/// <para><b>These are the only surface-B tests that spend money, so they are opt-in and silent by default.</b>
+/// It runs only when <c>CST_AI_EVAL=1</c>; otherwise it returns immediately. A live call on every
+/// <c>dotnet test</c> would bill for a full run every time anyone touched an unrelated file.</para>
+///
+/// <para><b>It scores the RAW answer, so it calls the provider directly rather than through the orchestrator.</b>
+/// The orchestrator strips quote markers on the way out, by design — and the markers are the measurement. It
+/// still uses the real bundler, the real templates and the real prompt builder, so what is scored is what the
+/// app would actually send.</para>
+///
+/// <para><b>What it does not do is decide anything.</b> It reports counts and evidence; the tier a model
+/// belongs in is a judgement recorded by a person in <c>PALI_FIDELITY_CASES.md</c> and the model registry. A
+/// harness trusted to promote and demote models would quietly become the definition of fidelity, which is the
+/// failure that file is organized to avoid.</para>
+///
+/// <code>
+///   CST_AI_EVAL=1 \
+///   CST_AI_EVAL_BASE_URL=http://localhost:11434/v1 \
+///   dotnet test --filter "FullyQualifiedName~AiEvalHarness"
+/// </code>
+/// </summary>
+public class AiEvalHarness
+{
+    private readonly ITestOutputHelper _out;
+
+    public AiEvalHarness(ITestOutputHelper output) => _out = output;
+
+    // ---- The case set, as data -----------------------------------------------------------------------------
+
+    private sealed record CaseSet(
+        [property: JsonPropertyName("updated")] string? Updated,
+        [property: JsonPropertyName("terminology")] Terminology? Terminology,
+        [property: JsonPropertyName("models")] IReadOnlyList<string>? Models,
+        [property: JsonPropertyName("cases")] IReadOnlyList<EvalCase>? Cases);
+
+    private sealed record Terminology(
+        [property: JsonPropertyName("discouraged")] IReadOnlyList<string>? Discouraged);
+
+    private sealed record EvalCase(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("task")] string Task,
+        [property: JsonPropertyName("bookId")] string BookId,
+        [property: JsonPropertyName("paragraph")] int Paragraph,
+        [property: JsonPropertyName("userQuestion")] string? UserQuestion = null,
+        [property: JsonPropertyName("case")] string? Case = null,
+        [property: JsonPropertyName("note")] string? Note = null,
+        [property: JsonPropertyName("failureSignatures")] IReadOnlyList<string>? FailureSignatures = null);
+
+    [Fact]
+    public async Task Run()
+    {
+        if (Environment.GetEnvironmentVariable("CST_AI_EVAL") != "1")
+        {
+            _out.WriteLine("Skipped: set CST_AI_EVAL=1 to run. These are the only surface-B tests that spend money.");
+            return;
+        }
+
+        var baseUrl = Environment.GetEnvironmentVariable("CST_AI_EVAL_BASE_URL")
+                      ?? "http://localhost:11434/v1";
+        var apiKey = Environment.GetEnvironmentVariable("CST_AI_EVAL_API_KEY");
+        var xmlDir = Environment.GetEnvironmentVariable("CST_AI_EVAL_XML")
+                     ?? Path.Combine(
+                         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                         "Library/Application Support/CSTReader/xml");
+
+        var caseSet = LoadCaseSet();
+        var models = (Environment.GetEnvironmentVariable("CST_AI_EVAL_MODELS")?.Split(',')
+                      ?? caseSet.Models?.ToArray()
+                      ?? Array.Empty<string>())
+            .Select(m => m.Trim()).Where(m => m.Length > 0).ToList();
+
+        Assert.NotEmpty(models);
+        Assert.NotEmpty(caseSet.Cases ?? Array.Empty<EvalCase>());
+
+        var settings = new Settings { XmlBooksDirectory = xmlDir };
+        var settingsService = new Mock<ISettingsService>();
+        settingsService.SetupGet(s => s.Settings).Returns(settings);
+
+        var bundler = new AiContextBundler(
+            new PassageTool(settingsService.Object), null, "eval", NullLogger<AiContextBundler>.Instance);
+        var prompts = new PromptBuilder(new PromptTemplateStore(
+            Path.Combine(Path.GetTempPath(), "cst-eval-" + Guid.NewGuid().ToString("N")),
+            NullLogger<PromptTemplateStore>.Instance));
+        var registry = new ModelRegistry(NullLogger<ModelRegistry>.Instance);
+
+        using var http = new HttpClient { Timeout = Timeout.InfiniteTimeSpan };
+        var report = new StringBuilder();
+        report.AppendLine($"# Surface B evaluation — {DateTime.Now:yyyy-MM-dd HH:mm}");
+        report.AppendLine();
+        report.AppendLine($"Case set updated {caseSet.Updated}. Endpoint `{baseUrl}`.");
+        report.AppendLine();
+        report.AppendLine("| model | tier | case | quotes | unbalanced | unmarked Pāli | ungrounded quotes | bad refs | terminology | signatures |");
+        report.AppendLine("|---|---|---|---:|---:|---:|---:|---:|---|---|");
+
+        foreach (var model in models)
+        {
+            var provider = new OpenAiCompatibleProvider(
+                http,
+                new OpenAiCompatibleOptions(baseUrl, apiKey),
+                NullLogger<OpenAiCompatibleProvider>.Instance);
+            var tier = registry.Rate(model).Tier;
+
+            foreach (var evalCase in caseSet.Cases!)
+            {
+                var (score, note) = await RunCaseAsync(
+                    provider, model, evalCase, bundler, prompts, caseSet.Terminology?.Discouraged);
+
+                if (score is null)
+                {
+                    report.AppendLine($"| `{model}` | {tier} | {evalCase.Id} | — | — | — | — | — | — | **{note}** |");
+                    _out.WriteLine($"{model} / {evalCase.Id}: {note}");
+                    continue;
+                }
+
+                report.AppendLine(
+                    $"| `{model}` | {tier} | {evalCase.Id} | {score.Quotes} | {score.UnbalancedMarkers} | "
+                    + $"{Cell(score.UnmarkedPali)} | {Cell(score.QuotesNotInPassage)} | "
+                    + $"{Cell(score.UnsupportedReferences)} | {Cell(score.TerminologyLapses)} | "
+                    + $"{Cell(score.FailureSignatures)} |");
+
+                _out.WriteLine($"{model} / {evalCase.Id}: {(score.Clean ? "clean" : "flagged")}");
+            }
+        }
+
+        report.AppendLine();
+        report.AppendLine("Counts and evidence only. Tier changes are a judgement recorded by a person in");
+        report.AppendLine("`PALI_FIDELITY_CASES.md` and `model-registry.json` — not by this harness.");
+
+        var path = Environment.GetEnvironmentVariable("CST_AI_EVAL_REPORT")
+                   ?? Path.Combine(Path.GetTempPath(), $"cst-ai-eval-{DateTime.Now:yyyyMMdd-HHmmss}.md");
+        await File.WriteAllTextAsync(path, report.ToString());
+        _out.WriteLine($"\nReport: {path}");
+        _out.WriteLine(report.ToString());
+    }
+
+    private static async Task<(AnswerScore? Score, string Note)> RunCaseAsync(
+        IChatProvider provider,
+        string model,
+        EvalCase evalCase,
+        IAiContextBundler bundler,
+        IPromptBuilder prompts,
+        IReadOnlyList<string>? discouraged)
+    {
+        if (!TryParseTask(evalCase.Task, out var task)) return (null, $"unknown task '{evalCase.Task}'");
+
+        AiContextBundle bundle;
+        RenderedPrompt prompt;
+        try
+        {
+            bundle = await bundler.BuildAsync(new AiContextRequest(
+                task, evalCase.BookId, "English",
+                new NavigationReference.Paragraph(evalCase.Paragraph),
+                UserQuestion: evalCase.UserQuestion));
+            prompt = prompts.Build(bundle);
+        }
+        catch (Exception ex)
+        {
+            return (null, $"context failed: {ex.Message}");
+        }
+
+        var answer = new StringBuilder();
+        try
+        {
+            var request = new ChatRequest(
+                model, prompt.MaxOutputTokens, prompt.System,
+                new[] { new ChatMessage(ChatRole.User, prompt.UserContent) });
+
+            await foreach (var delta in provider.StreamAsync(request))
+            {
+                // Only the answer channel. Reasoning is segregated by the provider and is not what is scored —
+                // a model may think in any style it likes.
+                if (delta.Kind == ChatDeltaKind.Text && delta.Text is { Length: > 0 } text) answer.Append(text);
+                if (delta.Kind == ChatDeltaKind.Error) return (null, $"stream error: {delta.Error!.Kind}");
+            }
+        }
+        catch (AiException ex)
+        {
+            return (null, $"request failed: {ex.Error.Kind}");
+        }
+
+        if (answer.Length == 0) return (null, "empty answer (#601)");
+
+        return (AnswerScorer.Score(
+            answer.ToString(), AnswerScorer.QuotableText(bundle), bundle.Citation, discouraged,
+            evalCase.FailureSignatures),
+            "ok");
+    }
+
+    private static string Cell(IReadOnlyList<string> values) =>
+        values.Count == 0 ? "-" : $"**{values.Count}**: " + string.Join("; ", values.Take(4)).Replace("|", "\\|");
+
+    private static bool TryParseTask(string value, out AiTask task)
+    {
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "explain": task = AiTask.Explain; return true;
+            case "translate": task = AiTask.Translate; return true;
+            case "grammar": task = AiTask.Grammar; return true;
+            case "word-by-word" or "wordbyword": task = AiTask.WordByWord; return true;
+            default: task = default; return false;
+        }
+    }
+
+    private static CaseSet LoadCaseSet()
+    {
+        var path = FindCaseFile();
+        Assert.True(File.Exists(path), $"case set not found at {path}");
+
+        var json = File.ReadAllText(path);
+        var set = JsonSerializer.Deserialize<CaseSet>(json);
+        Assert.NotNull(set);
+        return set!;
+    }
+
+    /// <summary>Walk up from the test binary to the repo, so the case set is read from the working tree.</summary>
+    internal static string FindCaseFile()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "docs", "testing", "ai-eval", "cases.json");
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return "docs/testing/ai-eval/cases.json";
+    }
+
+    /// <summary>
+    /// The case set is data, so nothing about it is checked at compile time — and it is read only on a paid
+    /// run, where a typo would surface as a wasted matrix. This runs every build instead.
+    /// </summary>
+    [Fact]
+    public void The_case_set_is_well_formed()
+    {
+        var set = LoadCaseSet();
+
+        Assert.NotEmpty(set.Cases!);
+        Assert.NotEmpty(set.Models!);
+
+        foreach (var c in set.Cases!)
+        {
+            Assert.True(TryParseTask(c.Task, out _), $"{c.Id}: unknown task '{c.Task}'");
+            Assert.False(string.IsNullOrWhiteSpace(c.BookId), c.Id);
+            Assert.True(c.Paragraph > 0, c.Id);
+
+            // Every signature compiles. A broken pattern makes a case that can never fail, which is
+            // indistinguishable from one every model passes.
+            foreach (var pattern in c.FailureSignatures ?? Array.Empty<string>())
+                _ = new System.Text.RegularExpressions.Regex(pattern);
+        }
+
+        // Distinct ids, since the report is keyed on them.
+        Assert.Equal(set.Cases!.Count, set.Cases!.Select(c => c.Id).Distinct().Count());
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/AnswerScorerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AnswerScorerTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Linq;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Eval;
+using CST;
+using CST.Navigation;
+using CST.Search;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// The eval harness's scorers. (#587, AI_SURFACE_B.md §13)
+///
+/// <para>These run without a model or a network — which is the point. The live runs cost money, so what they
+/// spend it on must be measurement whose behaviour is already pinned down here; a scorer debugged against live
+/// output is debugged at several dollars a mistake.</para>
+/// </summary>
+public class AnswerScorerTests
+{
+    private const string Passage =
+        "Appamādo amatapadaṃ, pamādo maccuno padaṃ;\nappamattā na mīyanti, ye pamattā yathā matā.";
+
+    private static CitationRef Citation(string reference = "paragraph 21 (kn2)", int page = 17) =>
+        new("s0502m.mul.xml", "Dhammapadapāḷi", reference,
+            new[] { new SnippetPageRef(PageEdition.Vri, 1, page) });
+
+    // ---- Marker discipline -------------------------------------------------------------------------------
+
+    [Fact]
+    public void Well_marked_pali_scores_clean()
+    {
+        var answer = "The phrase [[appamādo amatapadaṃ]] opens the chapter, and [[pamādo]] is its opposite.";
+
+        var score = AnswerScorer.Score(answer, Passage, Citation());
+
+        Assert.Equal(2, score.Quotes);
+        Assert.Empty(score.UnmarkedPali);
+        Assert.True(score.Clean);
+    }
+
+    [Fact]
+    public void Inline_pali_left_outside_the_markers_is_caught()
+    {
+        // The measurement that decides whether v1.1 script conversion can be enabled per model: a model that
+        // marks block quotes but leaves inline terms bare gets its verse converted and its vocabulary left in
+        // Latin — the worse half. Observed exactly this on gemma4 before the prompt was fixed.
+        var answer = "The verse [[appamādo amatapadaṃ]] turns on *pamādo*, the opposite of appamāda.";
+
+        var score = AnswerScorer.Score(answer, Passage, Citation());
+
+        Assert.Equal(new[] { "appamāda", "pamādo" }, score.UnmarkedPali);
+        Assert.False(score.Clean);
+    }
+
+    [Fact]
+    public void Marked_pali_is_not_reported_as_unmarked()
+    {
+        // The trap: after stripping, correctly marked Pāli is indistinguishable from unmarked Pāli, so a
+        // scorer reading the rendered text would report every well-behaved model as failing.
+        var score = AnswerScorer.Score("[[appamādo amatapadaṃ]]", Passage, Citation());
+
+        Assert.Empty(score.UnmarkedPali);
+    }
+
+    [Fact]
+    public void An_unbalanced_marker_is_counted()
+    {
+        var score = AnswerScorer.Score("He said [[appamādo and stopped.", Passage, Citation());
+
+        Assert.Equal(1, score.UnbalancedMarkers);
+        Assert.False(score.Clean);
+    }
+
+    // ---- Grounding ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_quote_the_passage_does_not_contain_is_flagged()
+    {
+        // The strongest mechanical signal for answering from training data: the model quoted Pāli it was never
+        // given. §6's characteristic failure, caught without a human reading the answer.
+        var answer = "Compare [[manopubbaṅgamā dhammā manoseṭṭhā manomayā]], which opens the collection.";
+
+        var score = AnswerScorer.Score(answer, Passage, Citation());
+
+        Assert.Single(score.QuotesNotInPassage);
+        Assert.Contains("manopubbaṅgamā", score.QuotesNotInPassage[0]);
+    }
+
+    [Fact]
+    public void A_quote_from_the_passage_is_not_flagged_over_whitespace()
+    {
+        // The passage carries a newline where the answer has a space; an un-normalized comparison would report
+        // a quote that is plainly present.
+        var answer = "It reads [[maccuno padaṃ; appamattā na mīyanti]].";
+
+        Assert.Empty(AnswerScorer.Score(answer, Passage, Citation()).QuotesNotInPassage);
+    }
+
+    [Fact]
+    public void A_single_word_stem_is_not_treated_as_an_ungrounded_quote()
+    {
+        // A model legitimately names the stem for an inflected form in the text. Flagging that would bury the
+        // signal that matters — a multi-word quotation the passage does not contain.
+        var answer = "The stem is [[appamāda]], appearing here as [[appamādo]].";
+
+        Assert.Empty(AnswerScorer.Score(answer, Passage, Citation()).QuotesNotInPassage);
+    }
+
+    [Fact]
+    public void A_quoted_variant_reading_from_the_apparatus_is_grounded()
+    {
+        // Found by a live run: gpt-oss quoted "amataṃ padaṃ", the sī/syā variant at Dhp 21, and the scorer
+        // called it invention. The Translate preset explicitly asks the model to say which reading it followed,
+        // so scoring the apparatus as ungrounded penalises doing what it was told.
+        var bundle = BundleWithApparatus();
+        var answer = "Some editions read [[amataṃ padaṃ]] as two words; I followed the base text.";
+
+        var score = AnswerScorer.Score(answer, AnswerScorer.QuotableText(bundle), Citation());
+
+        Assert.Empty(score.QuotesNotInPassage);
+    }
+
+    private static AiContextBundle BundleWithApparatus()
+    {
+        var notes = new[] { new ApparatusNote(12, "amataṃ padaṃ (sī, syā)", "amataṃ padaṃ", "sī, syā") };
+        var pages = new[] { new SnippetPageRef(PageEdition.Vri, 1, 17) };
+        var passage = new CST.Tools.PassageResult(
+            "s0502m.mul.xml", "paragraph 21 (kn2)", Passage, pages, 21, "kn2", null, null, notes.Length, notes);
+
+        return new AiContextBundle(
+            AiTask.Translate, "English", null, passage, null, Array.Empty<LemmaEntry>(),
+            new BookContext("s0502m.mul.xml", "Dhammapadapāḷi", Pitaka.Sutta, CommentaryLevel.Mula),
+            Citation(), new Provenance("test", null),
+            new BudgetReport(Array.Empty<BundlePart>(), 10, 1));
+    }
+
+    // ---- Invented references -----------------------------------------------------------------------------
+
+    [Fact]
+    public void A_reference_the_citation_does_not_support_is_flagged()
+    {
+        var answer = "This echoes paragraph 183, the summary of the teaching.";
+
+        var score = AnswerScorer.Score(answer, Passage, Citation());
+
+        Assert.Contains("paragraph 183", score.UnsupportedReferences[0]);
+    }
+
+    [Fact]
+    public void A_reference_matching_the_citation_is_accepted_whatever_it_is_called()
+    {
+        // The model writes "verse 21" where the citation says "paragraph 21". Same thing; comparing by number
+        // rather than by phrasing is what stops the check crying wolf.
+        var score = AnswerScorer.Score("As verse 21 has it...", Passage, Citation());
+
+        Assert.Empty(score.UnsupportedReferences);
+    }
+
+    [Fact]
+    public void Everything_inside_a_cited_range_is_supported()
+    {
+        // Since #602 the citation names a range when the window spans one. A model citing paragraph 33 of
+        // "paragraphs 21-45" is citing what it was actually given.
+        var score = AnswerScorer.Score(
+            "Paragraph 33 develops the point.", Passage, Citation("paragraphs 21-45 (kn2)"));
+
+        Assert.Empty(score.UnsupportedReferences);
+    }
+
+    [Fact]
+    public void A_page_number_from_the_citation_is_supported()
+    {
+        Assert.Empty(AnswerScorer.Score("See p. 17.", Passage, Citation()).UnsupportedReferences);
+    }
+
+    [Fact]
+    public void Ordinary_numbers_in_prose_do_not_trip_the_reference_check()
+    {
+        // A check that fires on "four noble truths" or "the 12 links" gets switched off, and then it protects
+        // nothing. Narrowness is the feature.
+        var answer = "There are 4 lines here, and 12 syllables in the first.";
+
+        Assert.Empty(AnswerScorer.Score(answer, Passage, Citation()).UnsupportedReferences);
+    }
+
+    // ---- Terminology and case signatures -----------------------------------------------------------------
+
+    [Fact]
+    public void Discouraged_terms_are_counted_never_rewritten()
+    {
+        // §10: string surgery on model prose produces worse artifacts than the term it removes, cannot handle
+        // inflected or compounded forms, and rewrites third-party text the app already labels as generated.
+        var answer = "A widespread notion in the tradition, and a widespread teaching.";
+
+        var score = AnswerScorer.Score(answer, Passage, Citation(), discouragedTerms: new[] { "widespread" });
+
+        Assert.Equal("widespread (2)", Assert.Single(score.TerminologyLapses));
+    }
+
+    [Fact]
+    public void A_term_does_not_fire_inside_an_unrelated_word()
+    {
+        var score = AnswerScorer.Score(
+            "The pathway is clear.", Passage, Citation(), discouragedTerms: new[] { "path" });
+
+        // "pathway" IS a path-prefixed word, so the suffix rule catches inflections; "footpath" must not.
+        Assert.Empty(AnswerScorer.Score("A footpath.", Passage, Citation(),
+            discouragedTerms: new[] { "path" }).TerminologyLapses);
+        Assert.Single(score.TerminologyLapses);
+    }
+
+    [Fact]
+    public void A_case_failure_signature_is_reported_when_it_matches()
+    {
+        // Case 4: matā (dead) misread as mātā (mother) — two models did this independently.
+        var answer = "those who are heedless are as a mother";
+
+        var score = AnswerScorer.Score(
+            answer, Passage, Citation(), failureSignatures: new[] { @"as (a|the) mother", "as they think" });
+
+        Assert.Equal(@"as (a|the) mother", Assert.Single(score.FailureSignatures));
+    }
+
+    [Fact]
+    public void An_invalid_signature_is_surfaced_rather_than_swallowed()
+    {
+        // Silently skipping a broken pattern turns a case into one that can never fail — which looks exactly
+        // like a case every model passes.
+        var score = AnswerScorer.Score("anything", Passage, Citation(), failureSignatures: new[] { "([unclosed" });
+
+        Assert.Contains("[invalid pattern]", Assert.Single(score.FailureSignatures));
+    }
+
+    // ---- Degenerate input --------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void An_empty_answer_scores_without_throwing(string? answer)
+    {
+        // #601's case reaches the harness as an empty string; it must produce a row, not an exception.
+        var score = AnswerScorer.Score(answer, Passage, Citation());
+
+        Assert.Equal(0, score.Quotes);
+        Assert.True(score.Clean);   // nothing to flag — the empty-answer failure is the orchestrator's to name
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/Eval/AnswerScorer.cs
+++ b/src/CST.Avalonia/Services/Ai/Eval/AnswerScorer.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace CST.Avalonia.Services.Ai.Eval;
+
+/// <summary>
+/// What one answer scored. Every field is a <b>count or a list of evidence</b>, never a verdict: the harness
+/// reports, a human decides. (#587)
+/// </summary>
+/// <param name="Quotes">Properly marked Pāli quotes.</param>
+/// <param name="UnbalancedMarkers">Markers with no partner.</param>
+/// <param name="UnmarkedPali">Words carrying Pāli diacritics that were left OUTSIDE the quote markers. The
+/// measurement that decides whether v1.1 script conversion can be enabled for a model: a model that marks block
+/// quotes but leaves inline terms bare would have its verse converted and its vocabulary left in Latin, which
+/// is the worse half.</param>
+/// <param name="QuotesNotInPassage">Marked quotes that do not appear in the supplied passage. The strongest
+/// mechanical signal for answering from training data rather than from the text in front of it.</param>
+/// <param name="UnsupportedReferences">Reference-shaped strings ("paragraph 33", "verse 12") whose number is
+/// nowhere in the bundle's own citation. Evidence of an invented reference — the invented-citation hazard §6 is
+/// written against.</param>
+/// <param name="TerminologyLapses">Discouraged terms found, with counts. §10 is explicit that output is COUNTED,
+/// never rewritten: string surgery on model prose produces worse artifacts than the term it removes.</param>
+/// <param name="FailureSignatures">Per-case signatures that matched — the case set's own definition of getting
+/// it wrong.</param>
+public sealed record AnswerScore(
+    int Quotes,
+    int UnbalancedMarkers,
+    IReadOnlyList<string> UnmarkedPali,
+    IReadOnlyList<string> QuotesNotInPassage,
+    IReadOnlyList<string> UnsupportedReferences,
+    IReadOnlyList<string> TerminologyLapses,
+    IReadOnlyList<string> FailureSignatures)
+{
+    /// <summary>True when nothing at all was flagged. Deliberately not called "passed" — see the class remarks.</summary>
+    public bool Clean =>
+        UnbalancedMarkers == 0
+        && UnmarkedPali.Count == 0
+        && QuotesNotInPassage.Count == 0
+        && UnsupportedReferences.Count == 0
+        && TerminologyLapses.Count == 0
+        && FailureSignatures.Count == 0;
+}
+
+/// <summary>
+/// Scores one model answer against the passage it was given. (#587, AI_SURFACE_B.md §13)
+///
+/// <para><b>It scores the RAW answer, before marker stripping.</b> The markers are the measurement; a scorer fed
+/// the rendered text would be scoring text the app had already repaired.</para>
+///
+/// <para><b>Everything here is a heuristic, and each is chosen so its errors run in the safe direction.</b> The
+/// harness's job is to surface candidates for a human to judge, not to declare a model good — a scorer trusted
+/// as a verdict would quietly become the definition of fidelity, which is exactly the failure
+/// <c>PALI_FIDELITY_CASES.md</c> is organized to avoid. Where a check can err, it errs toward flagging something
+/// harmless rather than passing something wrong.</para>
+/// </summary>
+public static class AnswerScorer
+{
+    /// <summary>
+    /// The characters romanized Pāli uses that English does not — the same set
+    /// <c>LatinCapitalizer</c> keys on. A word carrying one of these in an English answer is almost
+    /// certainly Pāli, which is what makes unmarked-Pāli detection mechanical at all.
+    /// </summary>
+    private const string PaliDiacritics = "ñṅṭḍṇḷāīūṃṁ";
+
+    private static readonly Regex MarkedSpan = new(
+        @"\[\[(?<text>.*?)\]\]", RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private static readonly Regex PaliWord = new(
+        $@"\b[\p{{L}}]*[{PaliDiacritics}][\p{{L}}]*\b", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Reference shapes a model invents. Deliberately narrow — it must not fire on ordinary prose containing a
+    /// number, because a check that cries wolf gets switched off.
+    /// </summary>
+    private static readonly Regex ReferenceShape = new(
+        @"\b(?:paragraph|para\.?|verse|vv?\.|page|p{1,2}\.)\s*(?<n>\d{1,4})\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex Whitespace = new(@"\s+", RegexOptions.Compiled);
+
+    /// <param name="rawAnswer">The model's answer exactly as streamed, markers intact.</param>
+    /// <param name="passageText">Everything the model was given to quote from — the passage AND the print
+    /// apparatus. A variant reading is legitimately quotable: the Translate preset explicitly asks the model to
+    /// say which reading it followed, so scoring it as ungrounded would penalise doing what it was told. Found
+    /// by a live run flagging <i>amataṃ padaṃ</i>, the sī/syā variant at Dhp 21.</param>
+    /// <param name="citation">The app's own citation, whose numbers are the ones a reference may legitimately
+    /// name.</param>
+    /// <param name="discouragedTerms">House-terminology terms to count. Supplied as data rather than compiled
+    /// in, so the list is Frank's to edit without a rebuild.</param>
+    /// <param name="failureSignatures">Regexes defining this case's way of being wrong.</param>
+    public static AnswerScore Score(
+        string? rawAnswer,
+        string passageText,
+        CitationRef? citation = null,
+        IEnumerable<string>? discouragedTerms = null,
+        IEnumerable<string>? failureSignatures = null)
+    {
+        rawAnswer ??= string.Empty;
+
+        var filter = new PaliQuoteFilter();
+        filter.Feed(rawAnswer);
+        filter.Flush();
+
+        var marked = MarkedSpan.Matches(rawAnswer).Select(m => m.Groups["text"].Value.Trim()).ToList();
+
+        return new AnswerScore(
+            filter.Quotes,
+            filter.UnbalancedMarkers,
+            FindUnmarkedPali(rawAnswer),
+            FindUngroundedQuotes(marked, passageText),
+            FindUnsupportedReferences(rawAnswer, citation),
+            CountTerms(rawAnswer, discouragedTerms),
+            MatchSignatures(rawAnswer, failureSignatures));
+    }
+
+    /// <summary>
+    /// Everything in a bundle the model may legitimately quote: the passage plus every apparatus note. Used in
+    /// place of the passage text alone so a cited variant reading is not scored as invention.
+    /// </summary>
+    public static string QuotableText(AiContextBundle bundle) =>
+        string.Join("\n", new[] { bundle.Passage.Text }
+            .Concat(bundle.Passage.Notes.Select(n => n.Text))
+            .Concat(bundle.Passage.Notes.Select(n => n.Reading ?? string.Empty))
+            .Where(s => !string.IsNullOrWhiteSpace(s)));
+
+    /// <summary>
+    /// Pāli words left outside the markers.
+    ///
+    /// <para>Marked spans are <b>removed entirely</b> first — not merely unwrapped — because after stripping,
+    /// correctly marked Pāli is indistinguishable from unmarked Pāli, and a scorer that looked at the rendered
+    /// text would report every well-behaved model as failing.</para>
+    /// </summary>
+    internal static IReadOnlyList<string> FindUnmarkedPali(string rawAnswer)
+    {
+        var outsideMarkers = MarkedSpan.Replace(rawAnswer, " ");
+
+        return PaliWord.Matches(outsideMarkers)
+            .Select(m => m.Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(w => w, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Marked quotes absent from the supplied passage — the model quoting Pāli it was not given.
+    ///
+    /// <para>Single words are skipped. A model legitimately names a stem it is discussing (<i>appamāda</i> for
+    /// the inflected <i>appamādo</i> in the text), and flagging that would bury the signal that matters: a
+    /// multi-word quotation the passage does not contain, which the model can only have got from memory.</para>
+    /// </summary>
+    internal static IReadOnlyList<string> FindUngroundedQuotes(IEnumerable<string> markedQuotes, string passageText)
+    {
+        var window = Normalize(passageText);
+
+        return markedQuotes
+            .Select(Normalize)
+            .Where(q => q.Length > 0 && q.Contains(' '))
+            .Where(q => !window.Contains(q, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Reference-shaped strings the app's own citation does not support.
+    ///
+    /// <para>Compared by NUMBER rather than by exact phrasing: the model writes "verse 33" where the citation
+    /// says "paragraph 33", and both name the same thing. What matters is whether a number appears that the
+    /// bundle never supplied.</para>
+    /// </summary>
+    internal static IReadOnlyList<string> FindUnsupportedReferences(string rawAnswer, CitationRef? citation)
+    {
+        if (citation is null) return Array.Empty<string>();
+
+        var supported = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match m in ReferenceShape.Matches(citation.NormalizedReference))
+            supported.Add(m.Groups["n"].Value);
+        foreach (var page in citation.Pages)
+        {
+            supported.Add(page.Number.ToString());
+            if (page.Volume > 0) supported.Add(page.Volume.ToString());
+        }
+
+        // A range in the citation ("paragraphs 21-45") legitimises everything between its endpoints.
+        foreach (Match m in Regex.Matches(citation.NormalizedReference, @"(\d{1,4})\s*[-–]\s*(\d{1,4})"))
+        {
+            if (int.TryParse(m.Groups[1].Value, out var from) && int.TryParse(m.Groups[2].Value, out var to))
+                for (var n = from; n <= to && n - from < 5000; n++) supported.Add(n.ToString());
+        }
+
+        return ReferenceShape.Matches(rawAnswer)
+            .Where(m => !supported.Contains(m.Groups["n"].Value))
+            .Select(m => m.Value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>Counts discouraged terms. Counts — never rewrites; §10 is explicit about why.</summary>
+    internal static IReadOnlyList<string> CountTerms(string rawAnswer, IEnumerable<string>? discouragedTerms)
+    {
+        if (discouragedTerms is null) return Array.Empty<string>();
+
+        var lapses = new List<string>();
+        foreach (var term in discouragedTerms)
+        {
+            if (string.IsNullOrWhiteSpace(term)) continue;
+
+            // Word-boundary matched so a term does not fire inside a longer word, and case-insensitive because
+            // a sentence-initial occurrence is the same lapse.
+            var count = Regex.Matches(rawAnswer, $@"\b{Regex.Escape(term.Trim())}\w*\b", RegexOptions.IgnoreCase)
+                .Count;
+            if (count > 0) lapses.Add($"{term.Trim()} ({count})");
+        }
+        return lapses;
+    }
+
+    /// <summary>A case's own definition of being wrong. An invalid pattern is reported, never swallowed.</summary>
+    internal static IReadOnlyList<string> MatchSignatures(string rawAnswer, IEnumerable<string>? signatures)
+    {
+        if (signatures is null) return Array.Empty<string>();
+
+        var matched = new List<string>();
+        foreach (var pattern in signatures)
+        {
+            if (string.IsNullOrWhiteSpace(pattern)) continue;
+            try
+            {
+                if (Regex.IsMatch(rawAnswer, pattern, RegexOptions.IgnoreCase)) matched.Add(pattern);
+            }
+            catch (ArgumentException)
+            {
+                // A broken pattern must be visible: silently skipping it turns a case into one that can never
+                // fail, which looks exactly like a case a model always passes.
+                matched.Add($"[invalid pattern] {pattern}");
+            }
+        }
+        return matched;
+    }
+
+    private static string Normalize(string text) =>
+        Whitespace.Replace(text.Normalize(System.Text.NormalizationForm.FormC), " ").Trim();
+}


### PR DESCRIPTION
Closes #587. Part of epic #186. Plan: [`AI_SURFACE_B.md`](https://github.com/fsnow/cst/blob/main/docs/features/planned/AI_SURFACE_B.md) §13. The B-side analog of the surface-C cold-agent loop.

Mechanical scorers for the five things the issue asks about, plus a paid, opt-in runner over a committed case set.

## How the money is gated

**The runner does nothing unless `CST_AI_EVAL=1`.** A live call on every `dotnet test` would bill for a full matrix whenever anyone touched an unrelated file. Default run: 28 ms, no network.

**The scorers are unit-tested without a model or a network** — 21 cases. The live runs cost money, so what they spend it on has to be measurement whose behaviour is already pinned down; a scorer debugged against live output is debugged at several dollars a mistake.

**It scores the RAW answer**, so it calls the provider directly: the orchestrator strips quote markers by design, and the markers *are* the measurement. Everything upstream — bundler, templates, prompt builder — is the real thing.

**It reports; it never decides.** Tier changes are a judgement recorded by a person. A harness trusted to promote and demote models would quietly become the definition of fidelity — the failure `PALI_FIDELITY_CASES.md`'s organizing principle exists to avoid.

## What the first run found

Two models × three cases, against the real corpus:

| Model | Case | Result |
|---|---|---|
| `gemma4:cloud` | translate | 68 quotes, 0 unbalanced, 1 unmarked (*Nibbāna*) |
| `gemma4:cloud` | cross-corpus refusal | **clean** |
| `gemma4:cloud` | word-by-word | 164 quotes, 0 unbalanced, 1 unmarked |
| `gpt-oss:120b-cloud` | translate | 9 quotes, **16 unmarked**, signature *"as they think"* matched |
| `gpt-oss:120b-cloud` | cross-corpus refusal | **18 unmarked**, cited **MN/DN/SN/AN references** |
| `gpt-oss:120b-cloud` | word-by-word | 71 quotes, **37 unmarked** |

- **It reproduced Case 4 mechanically** — the *matā*/"as they think" misreading, caught by a signature rather than by someone reading the answer.
- **It found a new failure.** `gpt-oss:120b` answers "where else is *appamāda* discussed?" with **invented sutta references** instead of declining. That's the invented-citation hazard §6 is written against, observed rather than theorised.
- **Marker discipline is now a number**, and it says these two models cannot share a v1.1 script-conversion setting: 1 unmarked term across a 164-quote answer versus 16–37.

The run also caught a false positive review hadn't: the scorer called *amataṃ padaṃ* an ungrounded quote when it's the **sī/syā variant from the print apparatus** — which the Translate preset explicitly asks the model to cite. The apparatus is now part of the quotable corpus.

## One thing that ships deliberately disarmed

**The terminology gate.** The convention is stated positively in the system prompt, but the term the scorer would *count* is one CLAUDE.md forbids appearing anywhere in this repo. Committing it to make the check fire would break that rule in order to test a convention — not a trade an implementation gets to make, so I've left the decision to you.

The list is data (`cases.json` → `terminology.discouraged`), so populating it locally arms the gate with **no code change**. Everything else in that path — matching, counting, reporting — is built and tested against a placeholder term.

**1378/1378** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)