### PR TITLE
Surface B: key storage — common seam and macOS Keychain (#579)

### DIFF
--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -2,7 +2,7 @@
 
 **Status:** In progress. Shipped: B1 (#578, provider layer), B3 (#580, context bundler), B3a (#581, selection
 pipeline), B4 (#582, presets and the grounding contract), B5 (#583, orchestrator), B6 (#584, model registry),
-B9 (#587, evaluation harness), plus the reader-state read path and
+B9 (#587, evaluation harness), B2 (#579, key storage — **macOS only**), plus the reader-state read path and
 `POST /v1/ai/context-preview` (#593). **The chain now runs end to end** — a live Translate turn against the real
 corpus and a real model works — but nothing is user-visible until the Settings UI (B7, #585) and the panel
 (B8, #586) exist.
@@ -656,3 +656,28 @@ prompt, but the term the scorer would COUNT is one CLAUDE.md forbids appearing a
 Committing it to make the check fire would break that rule in order to test a convention — not a trade an
 implementation gets to make. The list is data (`cases.json` → `terminology.discouraged`), so populating it
 locally arms the gate with no code change.
+
+**2026-08-12 (#579, key storage — macOS half)** — Keychain via Security.framework, plus the common seam. The
+DPAPI half is deliberately not attempted from here: it cannot be exercised under `dotnet test` on a Mac, and
+shipping an untested credential store would be worse than reporting the truth.
+
+- **The modern `SecItem*` API, not the far simpler `SecKeychain*` one.** The legacy calls would be a third of
+  the code, but they have been deprecated since 10.10 — and a credential store is precisely the component that
+  must not stop working on an OS release.
+- **The `kSec*` keys are read with `dlsym`.** Their underlying string values are stable in practice and
+  undocumented in principle; loading the real symbols costs a few lines and removes a dependency on something
+  Apple never promised. Any missing symbol reports the store unavailable rather than building a half-populated
+  query that fails obscurely at every call site.
+- **Nothing is cached.** A cache goes stale the moment the user changes the key in Settings, and the lookup
+  costs microseconds — the wrong side of that trade is the one where the app keeps using a credential the user
+  has already replaced.
+- **"No key entered" and "nowhere to store one" are different problems with different fixes**, so the resolver
+  says which. Sending a Windows user to Settings to add a key would send them to a screen that cannot help.
+- **Platform behaviour is defined, not left to accident.** Windows and Linux report unavailable with a reason,
+  and both say that *an endpoint needing no API key still works* — the local-runner configuration is unaffected,
+  which keeps the privacy-first path open on every platform.
+
+The acceptance test asserts the key never appears in log output at any level — across store, read and delete,
+and against the **structured** log values as well as the formatted message, since a leak through a log property
+is just as public and the easier one to introduce by accident. Every test uses a unique service name, so
+running the suite can never read, overwrite or delete a developer's own stored key.

--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -664,6 +664,18 @@ shipping an untested credential store would be worse than reporting the truth.
 - **The modern `SecItem*` API, not the far simpler `SecKeychain*` one.** The legacy calls would be a third of
   the code, but they have been deprecated since 10.10 — and a credential store is precisely the component that
   must not stop working on an OS release.
+- **It targets the file-based (login) keychain, checked against Apple's docs rather than assumed.** `SecItem`
+  routes to the data-protection keychain only when the query carries `kSecUseDataProtectionKeychain` or
+  `kSecAttrSynchronizable` ([TN3137](https://developer.apple.com/documentation/technotes/tn3137-on-mac-keychains));
+  with neither, it talks to the file-based one. That is the right target while development is `dotnet run`,
+  because the data-protection keychain is only available to code carrying an entitlement and its access groups
+  come from code signing — an unsigned development build and the signed `.app` would not share a key. Revisiting
+  is **#609**.
+- **No `kSecAttrAccessible`, and that is a correction.** The first cut passed
+  `kSecAttrAccessibleAfterFirstUnlock` with a comment claiming it kept the key off a powered-down machine. It
+  does not: accessibility classes are the data-protection keychain's access model, the file-based keychain uses
+  ACLs, and the attribute was accepted and silently ignored. Inert code that *looks* like a security control is
+  worse than none, because it stops anyone asking the question again.
 - **The `kSec*` keys are read with `dlsym`.** Their underlying string values are stable in practice and
   undocumented in principle; loading the real symbols costs a few lines and removes a dependency on something
   Apple never promised. Any missing symbol reports the store unavailable rather than building a half-populated

--- a/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Key storage. (#579, AI_SURFACE_B.md §6)
+///
+/// <para>Every test uses a <b>unique service name</b>, so the suite can never read, overwrite or delete the key
+/// a developer has actually stored. Sharing the real one would make running the tests a way to lose a
+/// credential.</para>
+///
+/// <para>The Keychain tests no-op off macOS rather than failing: this lands macOS-first by design, and a red
+/// suite on Windows would say "broken" where the truth is "not built yet".</para>
+/// </summary>
+public class AiCredentialStoreTests : IDisposable
+{
+    /// <summary>Captures everything written at every level, so a leak has nowhere to hide.</summary>
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        internal readonly List<string> Lines = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Lines.Add(formatter(state, exception));
+            // The formatted message is not the only channel — a structured sink writes the raw values too.
+            if (state is IEnumerable<KeyValuePair<string, object?>> pairs)
+                Lines.AddRange(pairs.Select(p => $"{p.Key}={p.Value}"));
+        }
+    }
+
+    private const string Secret = "sk-ant-do-not-log-me-4f9a2c";
+
+    private readonly string _service = "CST Reader test " + Guid.NewGuid().ToString("N");
+    private readonly CapturingLogger<AiCredentialStore> _log = new();
+    private readonly AiCredentialStore _store;
+
+    public AiCredentialStoreTests() => _store = new AiCredentialStore(_log, _service);
+
+    public void Dispose()
+    {
+        if (_store.IsAvailable)
+            foreach (var provider in Enum.GetValues<ChatProviderKind>())
+                _store.DeleteApiKey(provider);
+    }
+
+    // ---- The acceptance test ------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_key_never_appears_in_log_output_at_any_level()
+    {
+        // §6's stated acceptance criterion. Asserted across store, read AND delete, and against the structured
+        // values as well as the formatted message — a leak through a log property would be just as public, and
+        // is the easier one to introduce by accident.
+        if (!_store.IsAvailable) return;
+
+        _store.SetApiKey(ChatProviderKind.Anthropic, Secret);
+        _store.GetApiKey(ChatProviderKind.Anthropic);
+        _store.DeleteApiKey(ChatProviderKind.Anthropic);
+
+        Assert.NotEmpty(_log.Lines);   // the logger really was wired, so absence means absence
+        foreach (var line in _log.Lines)
+        {
+            Assert.DoesNotContain(Secret, line, StringComparison.Ordinal);
+            // Not even a fragment: a logged prefix narrows a guess, and a logged length narrows it further.
+            Assert.DoesNotContain(Secret[..12], line, StringComparison.Ordinal);
+            Assert.DoesNotContain(Secret.Length.ToString(), line, StringComparison.Ordinal);
+        }
+    }
+
+    // ---- Round trip ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_stored_key_comes_back()
+    {
+        if (!_store.IsAvailable) return;
+
+        Assert.True(_store.SetApiKey(ChatProviderKind.Anthropic, Secret));
+        Assert.Equal(Secret, _store.GetApiKey(ChatProviderKind.Anthropic));
+    }
+
+    [Fact]
+    public void Storing_twice_replaces_rather_than_failing()
+    {
+        // SecItemAdd refuses a duplicate, so the second write must update in place. Delete-then-add would leave
+        // a window with no key at all if the add failed.
+        if (!_store.IsAvailable) return;
+
+        _store.SetApiKey(ChatProviderKind.Anthropic, Secret);
+        Assert.True(_store.SetApiKey(ChatProviderKind.Anthropic, "sk-ant-second-value"));
+
+        Assert.Equal("sk-ant-second-value", _store.GetApiKey(ChatProviderKind.Anthropic));
+    }
+
+    [Fact]
+    public void Providers_keep_separate_keys()
+    {
+        // The ordinary case for someone comparing a hosted model against a local one.
+        if (!_store.IsAvailable) return;
+
+        _store.SetApiKey(ChatProviderKind.Anthropic, "sk-ant-aaa");
+        _store.SetApiKey(ChatProviderKind.OpenAiCompatible, "sk-oai-bbb");
+
+        Assert.Equal("sk-ant-aaa", _store.GetApiKey(ChatProviderKind.Anthropic));
+        Assert.Equal("sk-oai-bbb", _store.GetApiKey(ChatProviderKind.OpenAiCompatible));
+    }
+
+    [Fact]
+    public void A_key_that_was_never_stored_reads_as_null()
+    {
+        if (!_store.IsAvailable) return;
+
+        Assert.Null(_store.GetApiKey(ChatProviderKind.Anthropic));
+    }
+
+    [Fact]
+    public void Deleting_a_key_that_is_not_there_is_success_not_failure()
+    {
+        // Idempotent: Settings should be able to offer "forget this key" without first checking.
+        if (!_store.IsAvailable) return;
+
+        Assert.True(_store.DeleteApiKey(ChatProviderKind.Anthropic));
+    }
+
+    [Fact]
+    public void A_deleted_key_is_gone()
+    {
+        if (!_store.IsAvailable) return;
+
+        _store.SetApiKey(ChatProviderKind.Anthropic, Secret);
+        Assert.True(_store.DeleteApiKey(ChatProviderKind.Anthropic));
+
+        Assert.Null(_store.GetApiKey(ChatProviderKind.Anthropic));
+    }
+
+    [Fact]
+    public void A_key_with_diacritics_and_whitespace_survives_the_round_trip()
+    {
+        // UTF-8 through CFData, and the trim on the way in: a key pasted from a web page routinely arrives with
+        // a trailing newline, and storing that verbatim produces a 401 nobody can explain.
+        if (!_store.IsAvailable) return;
+
+        _store.SetApiKey(ChatProviderKind.Anthropic, "  sk-ānt-ṃixed-42\n");
+
+        Assert.Equal("sk-ānt-ṃixed-42", _store.GetApiKey(ChatProviderKind.Anthropic));
+    }
+
+    [Fact]
+    public void An_empty_key_is_refused_rather_than_stored()
+    {
+        if (!_store.IsAvailable) return;
+
+        Assert.False(_store.SetApiKey(ChatProviderKind.Anthropic, "   "));
+        Assert.Null(_store.GetApiKey(ChatProviderKind.Anthropic));
+    }
+
+    // ---- Platform behaviour -------------------------------------------------------------------------------
+
+    [Fact]
+    public void Availability_matches_the_platform_this_ships_for()
+    {
+        // macOS-first is deliberate. Windows reports unavailable because DPAPI is unbuilt, not because it
+        // cannot work — and saying so beats shipping an implementation no one could test from here.
+        if (OperatingSystem.IsMacOS())
+        {
+            Assert.True(_store.IsAvailable);
+            Assert.Null(_store.Unavailable);
+        }
+        else
+        {
+            Assert.False(_store.IsAvailable);
+            Assert.False(string.IsNullOrWhiteSpace(_store.Unavailable));
+        }
+    }
+
+    [Fact]
+    public void An_unavailable_platform_explains_that_a_keyless_endpoint_still_works()
+    {
+        // The privacy-first configuration — a local runner on loopback — needs no key at all, so "no secure
+        // storage" must not read as "no assistant".
+        if (OperatingSystem.IsMacOS()) return;
+
+        Assert.Contains("no API key still works", _store.Unavailable);
+    }
+
+    [Fact]
+    public void Each_provider_gets_its_own_account_name()
+    {
+        Assert.NotEqual(
+            AiCredentialStore.AccountFor(ChatProviderKind.Anthropic),
+            AiCredentialStore.AccountFor(ChatProviderKind.OpenAiCompatible));
+    }
+
+    [Fact]
+    public void The_service_name_is_stable()
+    {
+        // Changing it orphans every key already stored, silently: the user is simply told they have not
+        // configured one. Pinned so that only a deliberate edit can do it.
+        Assert.Equal("CST Reader — AI provider", AiCredentialStore.ServiceName);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -21,13 +21,22 @@ public class ChatProviderResolverTests
     {
         private readonly string? _key;
 
-        internal FixedKey(string? key) => _key = key;
+        internal FixedKey(string? key, string? unavailable = null)
+        {
+            _key = key;
+            Unavailable = unavailable;
+        }
 
+        public bool IsAvailable => Unavailable is null;
+        public string? Unavailable { get; }
         public string? GetApiKey(ChatProviderKind provider) => _key;
+        public bool SetApiKey(ChatProviderKind provider, string apiKey) => throw new NotSupportedException();
+        public bool DeleteApiKey(ChatProviderKind provider) => throw new NotSupportedException();
     }
 
     private static ChatProviderResolver Resolver(
-        Action<ChatSettings> configure, string? apiKey = null, bool aiEnabled = true)
+        Action<ChatSettings> configure, string? apiKey = null, bool aiEnabled = true,
+        string? storageUnavailable = null)
     {
         var settings = new Settings();
         settings.Ai.Enabled = aiEnabled;
@@ -39,7 +48,7 @@ public class ChatProviderResolverTests
 
         return new ChatProviderResolver(
             service.Object,
-            apiKey is null ? null : new FixedKey(apiKey),
+            apiKey is null && storageUnavailable is null ? null : new FixedKey(apiKey, storageUnavailable),
             NullLoggerFactory.Instance,
             new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan });
     }
@@ -63,6 +72,21 @@ public class ChatProviderResolverTests
 
         Assert.Null(resolver.Resolve(out var problem));
         Assert.Contains("API key", problem);
+    }
+
+    [Fact]
+    public void A_platform_with_nowhere_to_store_a_key_says_that_rather_than_send_the_user_to_settings()
+    {
+        // Two different problems with two different fixes. "You have not entered a key" is solved in Settings;
+        // "this build cannot store one" is not solved there at all, and sending the user there to fix it wastes
+        // their time on a screen that cannot help. (#579)
+        var resolver = Resolver(
+            c => { c.Provider = "anthropic"; c.Model = "claude-opus-5"; },
+            storageUnavailable: "Secure key storage is not available in this build on Windows yet.");
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.Contains("not available in this build", problem);
+        Assert.DoesNotContain("Add one in Settings", problem);
     }
 
     [Fact]

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1235,6 +1235,11 @@ public partial class App : Application
             sp.GetRequiredService<ILoggerFactory>()));
         services.AddSingleton<Services.Ai.IAiChatOrchestrator, Services.Ai.AiChatOrchestrator>();
 
+        // Key storage (#579). Registered unconditionally: the store itself reports whether the platform has
+        // anywhere safe to put a key, which is what lets the resolver explain the difference between "no key
+        // entered" and "this build cannot store one".
+        services.AddSingleton<Services.Ai.IAiCredentialStore, Services.Ai.Credentials.AiCredentialStore>();
+
         // The fidelity advisory (#584). Data only — Settings (#585) and the panel (#586) surface it.
         services.AddSingleton<Services.Ai.IModelRegistry, Services.Ai.ModelRegistry>();
         services.AddSingleton<ILemmaReportService, LemmaReportService>();

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -25,8 +25,20 @@ public enum ChatProviderKind
 /// </summary>
 public interface IAiCredentialStore
 {
+    /// <summary>Whether this platform has somewhere safe to put a key at all.</summary>
+    bool IsAvailable { get; }
+
+    /// <summary>Why not, phrased for the user to read. Null when storage is available.</summary>
+    string? Unavailable { get; }
+
     /// <summary>The stored key for a provider, or null when none is stored.</summary>
     string? GetApiKey(ChatProviderKind provider);
+
+    /// <summary>Store or replace a provider's key. False when the platform cannot.</summary>
+    bool SetApiKey(ChatProviderKind provider, string apiKey);
+
+    /// <summary>Forget a provider's key. Forgetting one never stored counts as success.</summary>
+    bool DeleteApiKey(ChatProviderKind provider);
 }
 
 /// <summary>
@@ -128,7 +140,11 @@ public sealed class ChatProviderResolver : IChatProviderResolver
         switch (kind)
         {
             case ChatProviderKind.Anthropic when string.IsNullOrWhiteSpace(apiKey):
-                problem = "No API key is stored for Claude. Add one in Settings.";
+                // Two different problems with two different fixes: "you have not entered a key" is solved in
+                // Settings; "this build cannot store one" is not solved there at all, and telling the user to
+                // go and add one would send them somewhere that cannot help. (#579)
+                problem = _credentials?.Unavailable
+                          ?? "No API key is stored for Claude. Add one in Settings.";
                 return null;
 
             case ChatProviderKind.Anthropic:

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
@@ -1,0 +1,117 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Ai.Credentials;
+
+/// <summary>
+/// Where surface B's API keys live: the OS credential store, never a file we write. (#579, AI_SURFACE_B.md §6)
+///
+/// <para><b>Never <c>settings.json</c>.</b> That file is hand-edited, screenshotted, attached to bug reports and
+/// synced between machines. A key in it is a key in every one of those places, and unlike a wrong port number
+/// there is no way to notice after the fact.</para>
+///
+/// <para><b>Read lazily, on the request that needs it.</b> Nothing here runs at startup, so a user who never
+/// turns surface B on never triggers a Keychain access. That is the same class of mistake as the Chromium Safe
+/// Storage prompt this app already works around: a permission dialog on launch, for a feature the user has not
+/// asked for, teaches them to click through prompts.</para>
+///
+/// <para><b>Nothing is cached.</b> A cache would go stale the moment the user changes the key in Settings, and
+/// the lookup costs microseconds — the wrong side of that trade is the one where the app keeps using a
+/// credential the user has already replaced.</para>
+///
+/// <para><b>Nothing is ever logged.</b> Not the value, not a prefix, not its length. Outcomes only.</para>
+/// </summary>
+public sealed class AiCredentialStore : IAiCredentialStore
+{
+    /// <summary>
+    /// The Keychain service name. Stable and app-scoped: changing it would orphan every key already stored,
+    /// with no error — the user would simply be told they had not configured one.
+    /// </summary>
+    internal const string ServiceName = "CST Reader — AI provider";
+
+    private readonly ILogger<AiCredentialStore> _logger;
+    private readonly string _service;
+
+    public AiCredentialStore(ILogger<AiCredentialStore> logger) : this(logger, ServiceName) { }
+
+    /// <summary>
+    /// Test seam: a distinct service name, so a test can never overwrite or delete the developer's own stored
+    /// key. Sharing the real name would make running the suite a way to lose a credential.
+    /// </summary>
+    internal AiCredentialStore(ILogger<AiCredentialStore> logger, string service)
+    {
+        _logger = logger;
+        _service = service;
+    }
+
+    /// <summary>
+    /// Whether this platform has somewhere safe to put a key.
+    ///
+    /// <para><b>Linux is deliberately false</b> rather than accidentally unhandled. Secret Service / libsecret
+    /// is the right answer there and is unbuilt while Linux is unshipped; until then a key-requiring provider
+    /// reports itself unconfigured, which is honest. A local endpoint that needs no key is unaffected, so the
+    /// privacy-first configuration still works on Linux.</para>
+    ///
+    /// <para><b>Windows is false only because DPAPI is unbuilt</b> (#579 is landing macOS-first). It needs a
+    /// Windows target to develop against — it cannot be exercised under <c>dotnet test</c> on a Mac — so
+    /// shipping an untested implementation would be worse than reporting the truth.</para>
+    /// </summary>
+    public bool IsAvailable => OperatingSystem.IsMacOS() && MacOsKeychain.IsAvailable;
+
+    /// <summary>Why there is nowhere to store a key, for the message the user actually reads. Null when fine.</summary>
+    public string? Unavailable =>
+        IsAvailable ? null
+        : OperatingSystem.IsWindows()
+            ? "Secure key storage is not available in this build on Windows yet. "
+              + "An endpoint that needs no API key still works."
+        : OperatingSystem.IsMacOS()
+            ? "The macOS Keychain could not be reached, so no API key can be stored."
+        : "Secure key storage is not available on this platform. "
+          + "An endpoint that needs no API key still works.";
+
+    public string? GetApiKey(ChatProviderKind provider)
+    {
+        if (!IsAvailable) return null;
+
+        var key = MacOsKeychain.Find(_service, AccountFor(provider));
+
+        // The OUTCOME, never the value — and not its length either, which narrows a guess.
+        _logger.LogDebug("Credential lookup for {Provider}: {Result}",
+            provider, key is null ? "none stored" : "found");
+
+        return key;
+    }
+
+    /// <summary>Store or replace the key for a provider. Returns false when the platform cannot.</summary>
+    public bool SetApiKey(ChatProviderKind provider, string apiKey)
+    {
+        if (!IsAvailable || string.IsNullOrWhiteSpace(apiKey)) return false;
+
+        var saved = MacOsKeychain.Save(_service, AccountFor(provider), apiKey.Trim());
+        _logger.LogInformation("Stored an API key for {Provider}: {Result}",
+            provider, saved ? "ok" : "failed");
+        return saved;
+    }
+
+    /// <summary>Forget the key for a provider. Forgetting one that was never stored counts as success.</summary>
+    public bool DeleteApiKey(ChatProviderKind provider)
+    {
+        if (!IsAvailable) return false;
+
+        var deleted = MacOsKeychain.Delete(_service, AccountFor(provider));
+        _logger.LogInformation("Removed the API key for {Provider}: {Result}",
+            provider, deleted ? "ok" : "failed");
+        return deleted;
+    }
+
+    /// <summary>
+    /// One item per provider, so a user can keep a Claude key and an OpenAI-compatible key at once — which is
+    /// the ordinary case for someone comparing a hosted model against a local one.
+    /// </summary>
+    internal static string AccountFor(ChatProviderKind provider) => provider switch
+    {
+        ChatProviderKind.Anthropic => "anthropic",
+        ChatProviderKind.OpenAiCompatible => "openai-compatible",
+        _ => provider.ToString().ToLowerInvariant(),
+    };
+}

--- a/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
@@ -16,6 +16,11 @@ namespace CST.Avalonia.Services.Ai.Credentials;
 /// and undocumented in principle. Loading the real symbols costs a few lines and removes a dependency on
 /// something Apple never promised.</para>
 ///
+/// <para><b>Minimum macOS, from the SDK headers rather than memory.</b> The four functions are
+/// <c>API_AVAILABLE(macos(10.6))</c>, but the binding constraint is <c>kSecClassGenericPassword</c> at
+/// <b>10.7</b> — so this code needs 10.7, comfortably under the app's 10.15 floor. Worth stating because the
+/// gap is one release wide and easy to mis-remember as 10.6 throughout.</para>
+///
 /// <para><b>This targets the FILE-BASED (login) keychain, deliberately.</b> <c>SecItem</c> routes to the
 /// data-protection keychain only when the query carries <c>kSecUseDataProtectionKeychain</c> or
 /// <c>kSecAttrSynchronizable</c>; with neither, it talks to the file-based one

--- a/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
@@ -16,6 +16,19 @@ namespace CST.Avalonia.Services.Ai.Credentials;
 /// and undocumented in principle. Loading the real symbols costs a few lines and removes a dependency on
 /// something Apple never promised.</para>
 ///
+/// <para><b>This targets the FILE-BASED (login) keychain, deliberately.</b> <c>SecItem</c> routes to the
+/// data-protection keychain only when the query carries <c>kSecUseDataProtectionKeychain</c> or
+/// <c>kSecAttrSynchronizable</c>; with neither, it talks to the file-based one
+/// (Apple, TN3137 / DTS "On Mac Keychains"). That is the right target here because the data-protection keychain
+/// "is only available to code that can carry an entitlement", and its access groups are determined by code
+/// signing — so a plain <c>dotnet run</c> development build could not reach a key the signed <c>.app</c> stored,
+/// or the reverse. Apple does say the file-based implementation is on the road to deprecation; revisiting is
+/// tracked separately.</para>
+///
+/// <para><b>Hence no <c>kSecAttrAccessible</c>.</b> Accessibility classes are the data-protection keychain's
+/// access model; the file-based keychain uses ACLs instead, and the attribute is accepted and ignored there.
+/// Passing it would read like a protection this code does not actually provide.</para>
+///
 /// <para><b>Nothing here logs.</b> Not the value, not a prefix, not a length — the caller reports outcomes.</para>
 /// </summary>
 internal static class MacOsKeychain
@@ -86,7 +99,7 @@ internal static class MacOsKeychain
     private sealed record Constants(
         IntPtr Class, IntPtr GenericPassword, IntPtr Service, IntPtr Account,
         IntPtr ValueData, IntPtr ReturnData, IntPtr MatchLimit, IntPtr MatchLimitOne,
-        IntPtr Accessible, IntPtr AfterFirstUnlock, IntPtr True);
+        IntPtr True);
 
     private static Constants? LoadConstants()
     {
@@ -113,11 +126,6 @@ internal static class MacOsKeychain
             Deref(security, "kSecReturnData"),
             Deref(security, "kSecMatchLimit"),
             Deref(security, "kSecMatchLimitOne"),
-            Deref(security, "kSecAttrAccessible"),
-            // Not ...WhenUnlocked: surface B can be invoked from a session that is unlocked but whose keychain
-            // state we do not control, and AfterFirstUnlock is the weakest accessibility that still keeps the
-            // key off a locked, powered-down machine.
-            Deref(security, "kSecAttrAccessibleAfterFirstUnlock"),
             Deref(cf, "kCFBooleanTrue"));
 
         // Any missing symbol means the assumptions here no longer hold; report unavailable rather than build a
@@ -126,7 +134,7 @@ internal static class MacOsKeychain
                  {
                      constants.Class, constants.GenericPassword, constants.Service, constants.Account,
                      constants.ValueData, constants.ReturnData, constants.MatchLimit, constants.MatchLimitOne,
-                     constants.Accessible, constants.AfterFirstUnlock, constants.True,
+                     constants.True,
                  })
         {
             if (value == IntPtr.Zero) return null;
@@ -199,8 +207,8 @@ internal static class MacOsKeychain
             var accountRef = strings.Add(account);
 
             attributes = CreateDictionary(
-                new[] { k.Class, k.Service, k.Account, k.ValueData, k.Accessible },
-                new[] { k.GenericPassword, serviceRef, accountRef, data, k.AfterFirstUnlock });
+                new[] { k.Class, k.Service, k.Account, k.ValueData },
+                new[] { k.GenericPassword, serviceRef, accountRef, data });
             if (attributes == IntPtr.Zero) return false;
 
             var status = SecItemAdd(attributes, IntPtr.Zero);

--- a/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace CST.Avalonia.Services.Ai.Credentials;
+
+/// <summary>
+/// Generic-password items in the macOS Keychain, via Security.framework. (#579)
+///
+/// <para><b>The modern <c>SecItem*</c> API, not the far simpler <c>SecKeychain*</c> one.</b> The legacy calls
+/// would be a third of this code, but they have been deprecated since 10.10; a credential store is exactly the
+/// component that must not stop working on an OS release, and this one has to outlive several.</para>
+///
+/// <para><b>The <c>kSec*</c> keys are read with <c>dlsym</c> rather than hardcoded.</b> They are
+/// <c>CFStringRef</c> globals whose underlying string values ("svce", "acct", "v_Data") are stable in practice
+/// and undocumented in principle. Loading the real symbols costs a few lines and removes a dependency on
+/// something Apple never promised.</para>
+///
+/// <para><b>Nothing here logs.</b> Not the value, not a prefix, not a length — the caller reports outcomes.</para>
+/// </summary>
+internal static class MacOsKeychain
+{
+    private const string SecurityFramework =
+        "/System/Library/Frameworks/Security.framework/Security";
+    private const string CoreFoundation =
+        "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+
+    private const int ErrSecSuccess = 0;
+    private const int ErrSecItemNotFound = -25300;
+    private const int ErrSecDuplicateItem = -25299;
+
+    // ---- CoreFoundation ------------------------------------------------------------------------------------
+
+    [DllImport(CoreFoundation)]
+    private static extern void CFRelease(IntPtr cf);
+
+    [DllImport(CoreFoundation)]
+    private static extern IntPtr CFStringCreateWithBytes(
+        IntPtr alloc, byte[] bytes, long numBytes, uint encoding, [MarshalAs(UnmanagedType.I1)] bool isExternal);
+
+    [DllImport(CoreFoundation)]
+    private static extern IntPtr CFDataCreate(IntPtr alloc, byte[] bytes, long length);
+
+    [DllImport(CoreFoundation)]
+    private static extern IntPtr CFDataGetBytePtr(IntPtr data);
+
+    [DllImport(CoreFoundation)]
+    private static extern long CFDataGetLength(IntPtr data);
+
+    [DllImport(CoreFoundation)]
+    private static extern IntPtr CFDictionaryCreate(
+        IntPtr alloc, IntPtr[] keys, IntPtr[] values, long numValues,
+        IntPtr keyCallBacks, IntPtr valueCallBacks);
+
+    [DllImport(CoreFoundation)]
+    private static extern IntPtr CFBooleanGetTypeID();   // forces the library to load before dlopen
+
+    private const uint KCFStringEncodingUtf8 = 0x08000100;
+
+    // ---- Security ------------------------------------------------------------------------------------------
+
+    [DllImport(SecurityFramework)]
+    private static extern int SecItemAdd(IntPtr attributes, IntPtr result);
+
+    [DllImport(SecurityFramework)]
+    private static extern int SecItemCopyMatching(IntPtr query, out IntPtr result);
+
+    [DllImport(SecurityFramework)]
+    private static extern int SecItemUpdate(IntPtr query, IntPtr attributesToUpdate);
+
+    [DllImport(SecurityFramework)]
+    private static extern int SecItemDelete(IntPtr query);
+
+    // ---- Constant lookup -----------------------------------------------------------------------------------
+
+    [DllImport("libdl")]
+    private static extern IntPtr dlopen(string path, int mode);
+
+    [DllImport("libdl")]
+    private static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+    private const int RtldNow = 2;
+
+    private static readonly Lazy<Constants?> Symbols = new(LoadConstants);
+
+    private sealed record Constants(
+        IntPtr Class, IntPtr GenericPassword, IntPtr Service, IntPtr Account,
+        IntPtr ValueData, IntPtr ReturnData, IntPtr MatchLimit, IntPtr MatchLimitOne,
+        IntPtr Accessible, IntPtr AfterFirstUnlock, IntPtr True);
+
+    private static Constants? LoadConstants()
+    {
+        if (!OperatingSystem.IsMacOS()) return null;
+
+        var security = dlopen(SecurityFramework, RtldNow);
+        var cf = dlopen(CoreFoundation, RtldNow);
+        if (security == IntPtr.Zero || cf == IntPtr.Zero) return null;
+
+        // Each symbol is a POINTER TO a CFStringRef, so it needs one dereference. Reading the symbol address
+        // itself would hand SecItem* a pointer to a pointer and every call would fail with a type error.
+        IntPtr Deref(IntPtr handle, string symbol)
+        {
+            var address = dlsym(handle, symbol);
+            return address == IntPtr.Zero ? IntPtr.Zero : Marshal.ReadIntPtr(address);
+        }
+
+        var constants = new Constants(
+            Deref(security, "kSecClass"),
+            Deref(security, "kSecClassGenericPassword"),
+            Deref(security, "kSecAttrService"),
+            Deref(security, "kSecAttrAccount"),
+            Deref(security, "kSecValueData"),
+            Deref(security, "kSecReturnData"),
+            Deref(security, "kSecMatchLimit"),
+            Deref(security, "kSecMatchLimitOne"),
+            Deref(security, "kSecAttrAccessible"),
+            // Not ...WhenUnlocked: surface B can be invoked from a session that is unlocked but whose keychain
+            // state we do not control, and AfterFirstUnlock is the weakest accessibility that still keeps the
+            // key off a locked, powered-down machine.
+            Deref(security, "kSecAttrAccessibleAfterFirstUnlock"),
+            Deref(cf, "kCFBooleanTrue"));
+
+        // Any missing symbol means the assumptions here no longer hold; report unavailable rather than build a
+        // half-populated query that would fail obscurely at every call site.
+        foreach (var value in new[]
+                 {
+                     constants.Class, constants.GenericPassword, constants.Service, constants.Account,
+                     constants.ValueData, constants.ReturnData, constants.MatchLimit, constants.MatchLimitOne,
+                     constants.Accessible, constants.AfterFirstUnlock, constants.True,
+                 })
+        {
+            if (value == IntPtr.Zero) return null;
+        }
+
+        return constants;
+    }
+
+    internal static bool IsAvailable => OperatingSystem.IsMacOS() && Symbols.Value is not null;
+
+    // ---- Operations ----------------------------------------------------------------------------------------
+
+    /// <summary>The stored secret, or null when there is no item (or the platform is unavailable).</summary>
+    internal static string? Find(string service, string account)
+    {
+        if (Symbols.Value is not { } k) return null;
+
+        var query = IntPtr.Zero;
+        var result = IntPtr.Zero;
+        var strings = new StringHandles();
+        try
+        {
+            query = CreateDictionary(
+                new[] { k.Class, k.Service, k.Account, k.ReturnData, k.MatchLimit },
+                new[]
+                {
+                    k.GenericPassword,
+                    strings.Add(service),
+                    strings.Add(account),
+                    k.True,
+                    k.MatchLimitOne,
+                });
+            if (query == IntPtr.Zero) return null;
+
+            var status = SecItemCopyMatching(query, out result);
+            if (status != ErrSecSuccess || result == IntPtr.Zero) return null;
+
+            var length = CFDataGetLength(result);
+            if (length <= 0) return null;
+
+            var bytes = new byte[length];
+            Marshal.Copy(CFDataGetBytePtr(result), bytes, 0, (int)length);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        finally
+        {
+            if (result != IntPtr.Zero) CFRelease(result);
+            if (query != IntPtr.Zero) CFRelease(query);
+            strings.Dispose();
+        }
+    }
+
+    /// <summary>Store or replace a secret. Returns false when the platform cannot.</summary>
+    internal static bool Save(string service, string account, string secret)
+    {
+        if (Symbols.Value is not { } k) return false;
+
+        var attributes = IntPtr.Zero;
+        var query = IntPtr.Zero;
+        var update = IntPtr.Zero;
+        var strings = new StringHandles();
+        var data = IntPtr.Zero;
+        try
+        {
+            var secretBytes = Encoding.UTF8.GetBytes(secret);
+            data = CFDataCreate(IntPtr.Zero, secretBytes, secretBytes.Length);
+            if (data == IntPtr.Zero) return false;
+
+            var serviceRef = strings.Add(service);
+            var accountRef = strings.Add(account);
+
+            attributes = CreateDictionary(
+                new[] { k.Class, k.Service, k.Account, k.ValueData, k.Accessible },
+                new[] { k.GenericPassword, serviceRef, accountRef, data, k.AfterFirstUnlock });
+            if (attributes == IntPtr.Zero) return false;
+
+            var status = SecItemAdd(attributes, IntPtr.Zero);
+            if (status == ErrSecSuccess) return true;
+            if (status != ErrSecDuplicateItem) return false;
+
+            // Already present: SecItemAdd will not overwrite, so update in place. Delete-then-add would leave a
+            // window with no key at all if the add failed.
+            query = CreateDictionary(
+                new[] { k.Class, k.Service, k.Account },
+                new[] { k.GenericPassword, serviceRef, accountRef });
+            update = CreateDictionary(new[] { k.ValueData }, new[] { data });
+            if (query == IntPtr.Zero || update == IntPtr.Zero) return false;
+
+            return SecItemUpdate(query, update) == ErrSecSuccess;
+        }
+        finally
+        {
+            if (update != IntPtr.Zero) CFRelease(update);
+            if (query != IntPtr.Zero) CFRelease(query);
+            if (attributes != IntPtr.Zero) CFRelease(attributes);
+            if (data != IntPtr.Zero) CFRelease(data);
+            strings.Dispose();
+        }
+    }
+
+    /// <summary>Remove a secret. Removing one that is not there counts as success.</summary>
+    internal static bool Delete(string service, string account)
+    {
+        if (Symbols.Value is not { } k) return false;
+
+        var query = IntPtr.Zero;
+        var strings = new StringHandles();
+        try
+        {
+            query = CreateDictionary(
+                new[] { k.Class, k.Service, k.Account },
+                new[] { k.GenericPassword, strings.Add(service), strings.Add(account) });
+            if (query == IntPtr.Zero) return false;
+
+            var status = SecItemDelete(query);
+            return status is ErrSecSuccess or ErrSecItemNotFound;
+        }
+        finally
+        {
+            if (query != IntPtr.Zero) CFRelease(query);
+            strings.Dispose();
+        }
+    }
+
+    // ---- Helpers -------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A CFDictionary with the standard callbacks. Passing null callbacks means CoreFoundation neither retains
+    /// nor releases the members, so ownership stays with the caller — which is what the explicit
+    /// <c>CFRelease</c>s in every <c>finally</c> above are managing.
+    /// </summary>
+    private static IntPtr CreateDictionary(IntPtr[] keys, IntPtr[] values)
+    {
+        foreach (var value in values)
+            if (value == IntPtr.Zero)
+                return IntPtr.Zero;
+
+        return CFDictionaryCreate(IntPtr.Zero, keys, values, keys.Length, IntPtr.Zero, IntPtr.Zero);
+    }
+
+    /// <summary>Tracks the CFStrings a call creates so every one of them is released exactly once.</summary>
+    private sealed class StringHandles : IDisposable
+    {
+        private readonly System.Collections.Generic.List<IntPtr> _handles = new();
+
+        internal IntPtr Add(string value)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value);
+            var handle = CFStringCreateWithBytes(
+                IntPtr.Zero, bytes, bytes.Length, KCFStringEncodingUtf8, false);
+            if (handle != IntPtr.Zero) _handles.Add(handle);
+            return handle;
+        }
+
+        public void Dispose()
+        {
+            foreach (var handle in _handles) CFRelease(handle);
+            _handles.Clear();
+        }
+    }
+}


### PR DESCRIPTION
Refs #579. Part of epic #186. Plan: [`AI_SURFACE_B.md`](https://github.com/fsnow/cst/blob/main/docs/features/planned/AI_SURFACE_B.md) §6.

**The macOS half plus the common seam, as asked. The Windows DPAPI half stays open** — it needs a Windows target to develop against and cannot be exercised under `dotnet test` on a Mac, so shipping an untested credential store would be worse than reporting the truth.

## Implementation

**The modern `SecItem*` API, not the far simpler `SecKeychain*` one.** The legacy calls would be a third of this code, but they've been deprecated since 10.10 — and a credential store is precisely the component that must not stop working on an OS release.

**The `kSec*` keys are read with `dlsym` rather than hardcoded.** They're `CFStringRef` globals whose underlying values (`"svce"`, `"acct"`, `"v_Data"`) are stable in practice and undocumented in principle. Loading the real symbols costs a few lines and removes a dependency on something Apple never promised. Any missing symbol reports the store unavailable rather than building a half-populated query that fails obscurely at every call site.

**Storing twice updates in place.** `SecItemAdd` refuses a duplicate; delete-then-add would leave a window with no key at all if the add failed.

**Nothing is cached.** A cache goes stale the moment the user changes the key in Settings, and the lookup costs microseconds — the wrong side of that trade is the one where the app keeps using a credential the user already replaced.

## Two problems that look alike and aren't

"You have not entered a key" is solved in Settings. "This build cannot store one" is not solved there at all — sending a Windows user to Settings to fix it wastes their time on a screen that cannot help. The resolver now distinguishes them.

Both unavailable messages say **an endpoint needing no API key still works**, so "no secure storage" never reads as "no assistant" — the local-runner configuration stays open on every platform, which is the privacy-first path.

## Testing

**The acceptance test** asserts the key never appears in log output at any level — across store, read *and* delete, and against the **structured log values** as well as the formatted message, since a leak through a log property is just as public and is the easier one to introduce by accident. It also asserts the logger captured *something*, so absence means absence rather than a mis-wired test.

**The round trips run against the real Keychain**, so the P/Invoke is verified rather than assumed — including UTF-8 with diacritics, and the trim that stops a key pasted with a trailing newline producing a 401 nobody can explain.

**Every test uses a unique service name**, so running the suite can never read, overwrite or delete a developer's own stored key. I verified afterwards that no test items were left behind and that the real service was never touched.

Off macOS the Keychain tests no-op rather than fail: a red suite on Windows would say "broken" where the truth is "not built yet".

**1392/1392** pass.

## Still open on #579

- Windows DPAPI (`ProtectedData`, CurrentUser scope) — needs Merlin or Placid.
- Linux is deliberately unaddressed while unshipped, but the behaviour is now *defined* rather than an accidental gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)