### PR TITLE
Surface B: detect a turn cut off at the output limit (#601)

### DIFF
--- a/docs/features/planned/AI_SURFACE_B.md
+++ b/docs/features/planned/AI_SURFACE_B.md
@@ -243,6 +243,13 @@ public interface IChatProvider
   Opus 5, Sonnet 5 and the Opus 4.x family all allow 128K, but **Haiku 4.5 caps at 64K**, and the model id is
   whatever the user typed into Settings. Cost is controlled by reporting what each call spent (§10), not by a
   truncation the user never sees.
+- **A cap we do not set can still be hit, so truncation is detected rather than assumed away** (`length` on the
+  OpenAI-compatible shape, `max_tokens` on Anthropic's → `AiErrorKind.Truncated`). Omitting the field hands the
+  ceiling to the endpoint, not to nobody; and the Anthropic adapter always sends one because the API requires
+  it. The dangerous case is not the blank panel but the **half-written answer**: a stream cut off mid-verse ends
+  exactly as a complete one does, so without this the app renders a partial translation under a citation and
+  nothing distinguishes it from a finished one. Reported *after* the usage it explains — an `Error` delta is
+  terminal, and on both wire formats the token counts arrive with or behind the finish reason.
 - **`HttpClient`'s 100 s default timeout will kill long generations.** Use `Timeout.InfiniteTimeSpan` with
   per-request cancellation, plus an adapter-level *idle* timeout.
 - **Mid-stream network drop is distinct from cancellation** — partial text is already on screen. Keep the
@@ -571,6 +578,10 @@ the requirement had not worked. The mistranslation was not fixable by prompting 
 - **An empty answer is a named failure** (`AiErrorKind.EmptyAnswer`). A model can end a turn having produced
   only reasoning (#601), and #578 is *right* to segregate reasoning from answer — which is exactly what makes
   this failure invisible, leaving the caller a well-formed, successful, blank turn.
+- **Truncation is measured where the provider reports it, and worded here.** `AiErrorKind.Truncated` says *that*
+  the output limit was hit; only the orchestrator knows what the user got for it, so it composes one of three
+  messages — cut off mid-answer, all budget spent reasoning, or nothing produced at all. Three situations, three
+  fixes. `EmptyAnswer` remains the fallback for endpoints that report no finish reason at all.
 - **`ChatSettings` and `IChatProviderResolver` are the seam** for B2/B7. The key is deliberately absent from
   settings.json — it belongs in the OS credential store (#579) — and a key is required for Anthropic but *not*
   for OpenAI-compatible, because the motivating deployment is a local runner on loopback with no credential.

--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -348,6 +348,83 @@ public class AiChatOrchestratorTests
         Assert.Equal(AiErrorKind.EmptyAnswer, events[^1].Error!.Kind);
     }
 
+    // ---- Truncation (#601) ---------------------------------------------------------------------------------
+
+    private static FakeProvider TruncatedAfter(params ChatDelta[] deltas) =>
+        new(deltas.Append(ChatDelta.ForError(new AiError(
+            AiErrorKind.Truncated, "The model reached its output limit and stopped before finishing.",
+            ProviderCode: "length"))));
+
+    [Fact]
+    public async Task A_truncated_answer_keeps_its_text_and_says_it_is_incomplete()
+    {
+        // THE case this exists for. Without it a half-finished translation renders under a citation exactly like
+        // a finished one — the stream ends the same way either way — and nothing on screen says otherwise.
+        var events = await CollectAsync(Orchestrator(TruncatedAfter(
+            ChatDelta.ForText("Heedfulness is the path to the deathless; heedlessness is"))));
+
+        var error = events[^1].Error!;
+        Assert.Equal(AiErrorKind.Truncated, error.Kind);
+        Assert.Contains("incomplete", error.Message);
+        Assert.Equal("Heedfulness is the path to the deathless; heedlessness is", TextOf(events));
+        Assert.DoesNotContain(events, e => e.Kind == AiTurnEventKind.Completed);
+    }
+
+    [Fact]
+    public async Task A_turn_truncated_before_any_answer_names_the_reasoning_as_the_cause()
+    {
+        // #601's original observation: minimax-m3 spent 3,177 completion tokens reasoning about a two-line verse
+        // and never wrote the translation. "Raise the limit" is the actionable advice; a retry is not.
+        var events = await CollectAsync(Orchestrator(TruncatedAfter(ChatDelta.ForReasoning("Thinking..."))));
+
+        var error = events[^1].Error!;
+        Assert.Equal(AiErrorKind.Truncated, error.Kind);
+        Assert.Contains("reasoning", error.Message);
+        Assert.Contains("higher output limit", error.Message);
+    }
+
+    [Fact]
+    public async Task A_turn_truncated_before_anything_at_all_says_so_plainly()
+    {
+        var error = (await CollectAsync(Orchestrator(TruncatedAfter())))[^1].Error!;
+
+        Assert.Equal(AiErrorKind.Truncated, error.Kind);
+        Assert.DoesNotContain("reasoning", error.Message);
+    }
+
+    [Fact]
+    public async Task Truncation_does_not_report_itself_as_an_empty_answer()
+    {
+        // Both describe a blank panel, but only one of them KNOWS why. Measured beats inferred: EmptyAnswer must
+        // not shadow a truncation the provider actually observed.
+        var events = await CollectAsync(Orchestrator(TruncatedAfter(ChatDelta.ForReasoning("Thinking..."))));
+
+        Assert.DoesNotContain(
+            events, e => e.Kind == AiTurnEventKind.Error && e.Error!.Kind == AiErrorKind.EmptyAnswer);
+    }
+
+    [Fact]
+    public async Task A_truncated_turn_still_reports_what_it_spent()
+    {
+        // The whole point of a cap being hit is that the user paid for the tokens. Reporting the failure without
+        // the number would hide the one fact that explains it.
+        var events = await CollectAsync(Orchestrator(TruncatedAfter(
+            ChatDelta.ForText("Heedfulness"),
+            ChatDelta.ForUsage(new ChatUsage(412, 3177)))));
+
+        Assert.Equal(3177, events.Single(e => e.Kind == AiTurnEventKind.Usage).Usage!.OutputTokens);
+        Assert.Equal(AiErrorKind.Truncated, events[^1].Error!.Kind);
+    }
+
+    [Fact]
+    public async Task The_provider_code_survives_onto_the_reported_error()
+    {
+        // The message is rewritten here; the machine-readable token from the provider must not be lost with it.
+        var error = (await CollectAsync(Orchestrator(TruncatedAfter(ChatDelta.ForText("x")))))[^1].Error!;
+
+        Assert.Equal("length", error.ProviderCode);
+    }
+
     // ---- Cancellation and cancel-and-replace --------------------------------------------------------------
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
@@ -84,6 +84,84 @@ public class AnthropicMessagesProviderTests
         Assert.Contains(usage, u => u.OutputTokens == 37);
     }
 
+    // ---- Truncation (#601) ---------------------------------------------------------------------------------
+
+    private const string TruncatedStream = """
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Heedfulness is the"}}
+
+        event: message_delta
+        data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":1024}}
+
+        event: message_stop
+        data: {"type":"message_stop"}
+
+        """;
+
+    [Fact]
+    public async Task A_turn_that_hit_max_tokens_is_reported_as_truncated()
+    {
+        // max_tokens is REQUIRED here, so unlike the OpenAI-compatible shape this adapter always sends a cap —
+        // which makes a capped ending a permanent possibility rather than an endpoint-dependent one. (#601)
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(TruncatedStream)));
+
+        Assert.Equal(AiErrorKind.Truncated, deltas[^1].Error!.Kind);
+        Assert.Equal("Heedfulness is the", Text(deltas));
+    }
+
+    [Fact]
+    public async Task The_output_count_in_the_same_event_is_not_lost_to_the_error()
+    {
+        // stop_reason and the final output_tokens share one message_delta payload, and an Error delta is
+        // terminal — so reporting from inside that event would drop the count it arrived with.
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(TruncatedStream)));
+
+        var usage = deltas.FindIndex(d => d.Kind == ChatDeltaKind.Usage);
+        var error = deltas.FindIndex(d => d.Kind == ChatDeltaKind.Error);
+
+        Assert.True(usage >= 0, "usage was dropped");
+        Assert.True(usage < error, "the terminal error preceded the usage it explains");
+        Assert.Equal(1024, deltas[usage].Usage!.OutputTokens);
+    }
+
+    [Fact]
+    public async Task An_ordinary_end_turn_is_not_truncation()
+    {
+        // HappyStream ends with stop_reason "end_turn" — the common case, which must stay clean.
+        Assert.DoesNotContain(
+            await CollectAsync(Provider(StubHttpMessageHandler.Sse(HappyStream))),
+            d => d.Kind == ChatDeltaKind.Error);
+    }
+
+    [Fact]
+    public async Task A_stop_sequence_ending_is_not_truncation()
+    {
+        var stream = TruncatedStream.Replace("max_tokens", "stop_sequence");
+
+        Assert.DoesNotContain(
+            await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream))), d => d.Kind == ChatDeltaKind.Error);
+    }
+
+    [Fact]
+    public async Task A_mid_stream_api_error_still_wins_over_a_later_truncation()
+    {
+        const string stream = """
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Heedful"}}
+
+            event: error
+            data: {"type":"error","error":{"type":"overloaded_error"}}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":9}}
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal(AiErrorKind.Provider, Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!.Kind);
+    }
+
     [Fact]
     public async Task Thinking_deltas_are_segregated_from_the_answer()
     {

--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
@@ -90,6 +90,163 @@ public class OpenAiCompatibleProviderTests
         Assert.Equal(37, usage.OutputTokens);
     }
 
+    // ---- Truncation (#601) ---------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The real shape of a capped turn: content, then a chunk whose delta is empty and whose finish_reason says
+    /// why, then the usage chunk, then the terminator. Note the order — the reason is NOT last.
+    /// </summary>
+    private const string TruncatedStream = """
+        data: {"choices":[{"delta":{"content":"Heedfulness is the path to the"}}]}
+
+        data: {"choices":[{"delta":{},"finish_reason":"length"}]}
+
+        data: {"usage":{"prompt_tokens":412,"completion_tokens":3177},"choices":[]}
+
+        data: [DONE]
+
+        """;
+
+    [Fact]
+    public async Task A_turn_cut_off_at_the_output_limit_is_reported_as_truncated()
+    {
+        // Otherwise this is SILENT: a stream that stops mid-sentence at the cap ends exactly as a complete one
+        // does, so the app would render half a translation under a citation and call it an answer. (#601)
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(TruncatedStream)));
+
+        Assert.Equal(AiErrorKind.Truncated, deltas[^1].Error!.Kind);
+        Assert.Equal("Heedfulness is the path to the", Text(deltas));
+    }
+
+    [Fact]
+    public async Task The_truncation_error_arrives_after_the_usage_it_explains()
+    {
+        // An Error delta is terminal by contract, and the token counts arrive in a chunk BEHIND the one carrying
+        // finish_reason. Reporting on the spot would discard the number that explains the truncation — which is
+        // also the number the user paid.
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(TruncatedStream)));
+
+        var usage = deltas.FindIndex(d => d.Kind == ChatDeltaKind.Usage);
+        var error = deltas.FindIndex(d => d.Kind == ChatDeltaKind.Error);
+
+        Assert.True(usage >= 0, "usage was dropped");
+        Assert.True(usage < error, "the terminal error preceded the usage it explains");
+        Assert.Equal(3177, deltas[usage].Usage!.OutputTokens);
+    }
+
+    [Fact]
+    public async Task A_normal_ending_is_not_reported_as_truncation()
+    {
+        // finish_reason is present on the last chunk of EVERY turn. Firing on anything but the cap would put an
+        // error under every well-formed answer.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"Heedfulness."},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.DoesNotContain(deltas, d => d.Kind == ChatDeltaKind.Error);
+        Assert.Equal("Heedfulness.", Text(deltas));
+    }
+
+    [Theory]
+    [InlineData("stop")]
+    [InlineData("content_filter")]
+    [InlineData("tool_calls")]
+    [InlineData("")]
+    public async Task Only_a_length_ending_counts_as_truncation(string finishReason)
+    {
+        var stream = $$"""
+            data: {"choices":[{"delta":{"content":"x"},"finish_reason":"{{finishReason}}"}]}
+
+            data: [DONE]
+
+            """;
+
+        Assert.DoesNotContain(
+            await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream))), d => d.Kind == ChatDeltaKind.Error);
+    }
+
+    [Fact]
+    public async Task A_gateway_reporting_the_anthropic_spelling_is_understood()
+    {
+        // "OpenAI-compatible" is an arbitrary user-pasted endpoint, and a gateway fronting Anthropic passes its
+        // max_tokens through unchanged. It can only mean the one thing.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"x"},"finish_reason":"max_tokens"}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal(AiErrorKind.Truncated, deltas[^1].Error!.Kind);
+        Assert.Equal("max_tokens", deltas[^1].Error!.ProviderCode);
+    }
+
+    [Fact]
+    public async Task Content_on_the_same_chunk_as_the_finish_reason_is_not_dropped()
+    {
+        // Not every provider sends the reason on a chunk of its own — some attach it to the final content delta.
+        // Losing that delta would truncate the answer further than the model did.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"the deathless"},"finish_reason":"length"}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("the deathless", Text(deltas));
+        Assert.Equal(AiErrorKind.Truncated, deltas[^1].Error!.Kind);
+    }
+
+    [Fact]
+    public async Task Held_back_think_tag_text_is_flushed_before_the_truncation_is_reported()
+    {
+        // An Error delta is terminal, so anything the think-tag filter is still holding has to come out first or
+        // it is lost — the same ordering rule the mid-stream error path follows.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"<think>weighing it up"}}]}
+
+            data: {"choices":[{"delta":{},"finish_reason":"length"}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal("weighing it up", Reasoning(deltas));
+        Assert.Equal(ChatDeltaKind.Error, deltas[^1].Kind);
+    }
+
+    [Fact]
+    public async Task A_mid_stream_provider_error_still_wins_over_a_later_truncation()
+    {
+        // The error delta is terminal where it occurs; the truncation check must not append a second terminal
+        // event behind it.
+        const string stream = """
+            data: {"choices":[{"delta":{"content":"Heedful"}}]}
+
+            data: {"error":{"code":"server_error"}}
+
+            data: {"choices":[{"delta":{},"finish_reason":"length"}]}
+
+            data: [DONE]
+
+            """;
+
+        var deltas = await CollectAsync(Provider(StubHttpMessageHandler.Sse(stream)));
+
+        Assert.Equal(AiErrorKind.Provider, Assert.Single(deltas, d => d.Kind == ChatDeltaKind.Error).Error!.Kind);
+    }
+
     [Fact]
     public async Task Structured_reasoning_never_reaches_the_answer_channel()
     {

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -285,6 +285,11 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
 
         if (failure is not null)
         {
+            // The provider knows THAT the output limit was hit; only this loop knows what the user got for it.
+            // Those are three different problems with three different fixes, so they get three messages. (#601)
+            if (failure.Kind == AiErrorKind.Truncated)
+                failure = failure with { Message = TruncationMessage(sawText, sawReasoning) };
+
             _logger.LogInformation("AI turn failed: {Kind} ({Code})", failure.Kind, failure.ProviderCode ?? "-");
             yield return AiTurnEvent.ForError(failure);
             yield break;
@@ -311,6 +316,26 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
         yield return AiTurnEvent.ForCompleted(
             new PaliMarkerReport(markers.Quotes, markers.UnbalancedMarkers));
     }
+
+    /// <summary>
+    /// What to tell the user when the model stopped at its output limit (#601). The three cases are genuinely
+    /// different situations, and the difference is invisible to the provider that detected the truncation:
+    ///
+    /// <list type="bullet">
+    /// <item>Text was written — <b>the dangerous one</b>. Without this message a half-finished translation
+    /// renders under a citation exactly like a finished one, and nothing on screen says otherwise.</item>
+    /// <item>Reasoning but no answer — #601's original case. The work was done and never written down; the fix
+    /// is a bigger budget or a lighter-reasoning model, not a retry.</item>
+    /// <item>Neither — the cap is small enough that nothing could be produced at all.</item>
+    /// </list>
+    /// </summary>
+    private static string TruncationMessage(bool sawText, bool sawReasoning) =>
+        sawText
+            ? "This answer is incomplete: the model reached its output limit and stopped part-way through."
+            : sawReasoning
+                ? "The model spent its whole output limit on reasoning and never wrote an answer. "
+                  + "Try a higher output limit, or a model that reasons less."
+                : "The model reached its output limit before writing anything.";
 
     /// <summary>Cancelling a source another turn already disposed is a benign race, not an error.</summary>
     private static void TryCancel(CancellationTokenSource source)

--- a/src/CST.Avalonia/Services/Ai/AiHttp.cs
+++ b/src/CST.Avalonia/Services/Ai/AiHttp.cs
@@ -246,4 +246,14 @@ internal static class AiHttp
     internal static AiError EmptyResponse() => new(
         AiErrorKind.Provider,
         "The provider accepted the request but returned no response. Check the endpoint URL and the model name.");
+
+    /// <summary>
+    /// The error for a turn the model ended at its output limit (#601). The wording here is the generic one:
+    /// the orchestrator replaces it once it knows whether any answer text was written, because "cut off
+    /// mid-answer" and "spent the whole budget reasoning" want different advice.
+    /// </summary>
+    internal static AiError Truncated(string providerCode) => new(
+        AiErrorKind.Truncated,
+        "The model reached its output limit and stopped before finishing.",
+        ProviderCode: providerCode);
 }

--- a/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
@@ -94,6 +94,7 @@ public sealed class AnthropicMessagesProvider : IChatProvider
                 throw new AiException(await ClassifyAsync(response, ct).ConfigureAwait(false));
 
             var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            var finish = new FinishState();
             var produced = false;
 
             await foreach (var sse in SseReader.ReadAsync(stream, _idleTimeout, _firstEventTimeout, ct)
@@ -108,7 +109,7 @@ public sealed class AnthropicMessagesProvider : IChatProvider
 
                 produced = true;
 
-                foreach (var delta in Interpret(sse))
+                foreach (var delta in Interpret(sse, finish))
                 {
                     yield return delta;
                     if (delta.Kind == ChatDeltaKind.Error)
@@ -124,7 +125,24 @@ public sealed class AnthropicMessagesProvider : IChatProvider
                 _logger.LogWarning("Anthropic returned a 200 with no stream events");
                 yield return ChatDelta.ForError(AiHttp.EmptyResponse());
             }
+            else if (finish.Truncated)
+            {
+                // Emitted after the loop, not from the `message_delta` that reported it. That event carries the
+                // final output-token count in the same payload, and an Error delta is terminal by contract — so
+                // reporting on the spot would cost the user the one number that explains the truncation.
+                _logger.LogInformation("Anthropic turn ended at max_tokens");
+                yield return ChatDelta.ForError(AiHttp.Truncated("max_tokens"));
+            }
         }
+    }
+
+    /// <summary>
+    /// How the turn ended, carried out of <see cref="Interpret"/>. Mutable because <c>stop_reason</c> arrives
+    /// mid-stream and is acted on after it.
+    /// </summary>
+    private sealed class FinishState
+    {
+        internal bool Truncated;
     }
 
     private static string BuildBody(ChatRequest request)
@@ -163,7 +181,7 @@ public sealed class AnthropicMessagesProvider : IChatProvider
     /// a provider payload is untrusted input, and a raw <c>GetString()</c> on an unexpected kind throws out of
     /// this iterator as an unclassified crash mid-answer.
     /// </summary>
-    private static IEnumerable<ChatDelta> Interpret(SseEvent sse)
+    private static IEnumerable<ChatDelta> Interpret(SseEvent sse, FinishState finish)
     {
         JsonElement root;
         try
@@ -206,6 +224,14 @@ public sealed class AnthropicMessagesProvider : IChatProvider
                 break;
 
             case "message_delta":
+                // `stop_reason` and the final output-token count arrive together in this one event. Recorded
+                // rather than reported here — see the emission site in StreamAsync. (#601)
+                if (AiJson.Object(root, "delta") is { } end &&
+                    string.Equals(AiJson.String(end, "stop_reason"), "max_tokens", StringComparison.Ordinal))
+                {
+                    finish.Truncated = true;
+                }
+
                 if (AiJson.Object(root, "usage") is { } endUsage)
                     yield return UsageDelta(endUsage);
                 break;

--- a/src/CST.Avalonia/Services/Ai/ChatContracts.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatContracts.cs
@@ -135,6 +135,21 @@ public enum AiErrorKind
     /// </summary>
     EmptyAnswer,
 
+    /// <summary>
+    /// The model hit its output limit and stopped before finishing — <c>finish_reason: "length"</c> on the
+    /// OpenAI-compatible shape, <c>stop_reason: "max_tokens"</c> on Anthropic's. (#601)
+    ///
+    /// <para><b>Distinct from <see cref="EmptyAnswer"/> because it is measured rather than inferred, and because
+    /// it catches the case that would otherwise be SILENT.</b> A turn cut off after writing half a translation
+    /// ends its stream in exactly the same way a complete one does: the app would render a partial answer under
+    /// a citation, indistinguishable from a finished one. An answer that stops mid-verse and says so is a much
+    /// smaller problem than one that stops mid-verse and does not.</para>
+    ///
+    /// <para>Both are kept because not every OpenAI-compatible gateway reports a finish reason. Where one is
+    /// reported this is what fires; where none is, <see cref="EmptyAnswer"/> still catches the total case.</para>
+    /// </summary>
+    Truncated,
+
     /// <summary>Anything else the provider rejected or failed on.</summary>
     Provider,
 }

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -94,6 +94,7 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
 
             var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
             var think = new ThinkTagFilter();
+            var finish = new FinishState();
             var produced = false;
 
             await foreach (var sse in SseReader.ReadAsync(stream, _idleTimeout, _firstEventTimeout, ct)
@@ -112,7 +113,7 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
                 if (sse.Data == "[DONE]")
                     break;
 
-                foreach (var delta in Interpret(sse, think))
+                foreach (var delta in Interpret(sse, think, finish))
                 {
                     // An Error delta is terminal by contract (see ChatDeltaKind.Error) — a gateway that keeps
                     // streaming after reporting a failure must not have that content appended to the answer.
@@ -138,7 +139,26 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
                 _logger.LogWarning("OpenAI-compatible endpoint returned a 200 with no stream events");
                 yield return ChatDelta.ForError(AiHttp.EmptyResponse());
             }
+            else if (finish.Truncated)
+            {
+                // Deliberately AFTER the loop rather than at the chunk that reported it. The finish-reason chunk
+                // is not the last one: with `include_usage` the token counts arrive in a further chunk behind it,
+                // and an Error delta is terminal by contract — emitting it on the spot would discard exactly the
+                // number the user needs, which is what this turn cost them for a half-written answer.
+                _logger.LogInformation("OpenAI-compatible turn ended at the output limit ({Reason})", finish.Reason);
+                yield return ChatDelta.ForError(AiHttp.Truncated(finish.Reason!));
+            }
         }
+    }
+
+    /// <summary>
+    /// How the turn ended, carried out of <see cref="Interpret"/>. Mutable because the finish reason arrives
+    /// mid-stream and is acted on after it.
+    /// </summary>
+    private sealed class FinishState
+    {
+        internal bool Truncated;
+        internal string? Reason;
     }
 
     private static IEnumerable<ChatDelta> FlushThink(ThinkTagFilter think)
@@ -194,7 +214,7 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
     /// this iterator as an unclassified crash mid-answer. OpenRouter reporting a NUMERIC <c>error.code</c> is a
     /// real instance of exactly that.
     /// </summary>
-    private static IEnumerable<ChatDelta> Interpret(SseEvent sse, ThinkTagFilter think)
+    private static IEnumerable<ChatDelta> Interpret(SseEvent sse, ThinkTagFilter think, FinishState finish)
     {
         JsonElement root;
         try
@@ -221,26 +241,41 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
             yield break;
         }
 
-        if (AiJson.Array(root, "choices") is { } choices &&
-            choices.GetArrayLength() > 0 &&
-            AiJson.Object(choices[0], "delta") is { } delta)
+        // Not an early return: the final chunk carries `choices: []` alongside the usage read at the end of this
+        // method, so bailing out here would drop the token counts.
+        if (AiJson.Array(root, "choices") is { } choices && choices.GetArrayLength() > 0)
         {
-            // Structured reasoning — never merged into the answer. The field name is NOT standardised: DeepSeek
-            // documents `reasoning_content`, while Ollama's OpenAI-compat surface (and OpenRouter) use plain
-            // `reasoning`. Verified against a live Ollama serving gpt-oss: 73 of its deltas carried `reasoning`
-            // and none carried `reasoning_content`, so parsing only the documented name dropped the model's
-            // entire reasoning stream — leaving usage that says 80 output tokens next to a one-line answer.
-            if (AiJson.String(delta, "reasoning_content") is { Length: > 0 } reasoningContent)
-                yield return ChatDelta.ForReasoning(reasoningContent);
-            else if (AiJson.String(delta, "reasoning") is { Length: > 0 } reasoning)
-                yield return ChatDelta.ForReasoning(reasoning);
+            var choice = choices[0];
 
-            if (AiJson.String(delta, "content") is { Length: > 0 } content)
+            // finish_reason is a sibling of `delta`, not a member of it, and is null on every chunk but the last.
+            // Read outside the delta check because a provider may report it on a chunk carrying no delta at all —
+            // and inside the same chunk it can accompany the final content, which must still be yielded. (#601)
+            if (TruncationReason(AiJson.String(choice, "finish_reason")) is { } stopped)
             {
-                // Inline <think> tags are the other reasoning convention; strip them across chunk boundaries.
-                var (visible, inlineReasoning) = think.Feed(content);
-                if (inlineReasoning.Length > 0) yield return ChatDelta.ForReasoning(inlineReasoning);
-                if (visible.Length > 0) yield return ChatDelta.ForText(visible);
+                finish.Truncated = true;
+                finish.Reason = stopped;
+            }
+
+            if (AiJson.Object(choice, "delta") is { } delta)
+            {
+                // Structured reasoning — never merged into the answer. The field name is NOT standardised:
+                // DeepSeek documents `reasoning_content`, while Ollama's OpenAI-compat surface (and OpenRouter)
+                // use plain `reasoning`. Verified against a live Ollama serving gpt-oss: 73 of its deltas
+                // carried `reasoning` and none carried `reasoning_content`, so parsing only the documented name
+                // dropped the model's entire reasoning stream — leaving usage that says 80 output tokens next to
+                // a one-line answer.
+                if (AiJson.String(delta, "reasoning_content") is { Length: > 0 } reasoningContent)
+                    yield return ChatDelta.ForReasoning(reasoningContent);
+                else if (AiJson.String(delta, "reasoning") is { Length: > 0 } reasoning)
+                    yield return ChatDelta.ForReasoning(reasoning);
+
+                if (AiJson.String(delta, "content") is { Length: > 0 } content)
+                {
+                    // Inline <think> tags are the other reasoning convention; strip across chunk boundaries.
+                    var (visible, inlineReasoning) = think.Feed(content);
+                    if (inlineReasoning.Length > 0) yield return ChatDelta.ForReasoning(inlineReasoning);
+                    if (visible.Length > 0) yield return ChatDelta.ForText(visible);
+                }
             }
         }
 
@@ -251,6 +286,22 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
                 OutputTokens: AiJson.Int(usage, "completion_tokens")));
         }
     }
+
+    /// <summary>
+    /// The canonical finish reason when the model stopped at its output limit, or null for every other ending.
+    ///
+    /// <para>OpenAI spells it <c>length</c>; gateways fronting Anthropic pass its <c>max_tokens</c> through
+    /// unchanged, and both can only mean the one thing. Every other value — <c>stop</c>, <c>tool_calls</c>,
+    /// <c>content_filter</c> — is not this failure and must not be reported as one.</para>
+    ///
+    /// <para>The MATCHED CONSTANT is returned rather than the provider's own string, which is what makes it safe
+    /// to put in <see cref="AiError.ProviderCode"/> and thence into the log: the field is provider-controlled on
+    /// a user-pasted endpoint, and this narrows it to one of two literals we wrote.</para>
+    /// </summary>
+    private static string? TruncationReason(string? finishReason) =>
+        string.Equals(finishReason, "length", StringComparison.OrdinalIgnoreCase) ? "length"
+        : string.Equals(finishReason, "max_tokens", StringComparison.OrdinalIgnoreCase) ? "max_tokens"
+        : null;
 
     /// <summary>
     /// Classify a non-2xx response. As with the Anthropic adapter the body is read for classification only, and


### PR DESCRIPTION
Closes #601.

## The gap this closes

Deferring the per-preset output budget (#582) stopped us imposing a *wrong* cap — but it did not remove the cap. `MaxTokens: null` means two different things on the wire:

- **OpenAI-compatible** — the field is omitted. That is not "unlimited", it is **the endpoint's own default**. Generous on Ollama and the OpenAI API; anything at all on a user-pasted gateway.
- **Anthropic** — the API *requires* the field, so the adapter sends the universal 64K ceiling. A capped ending is a permanent possibility there, not an endpoint-dependent one.

So a turn can still end at a limit, and until now nothing noticed.

## Why the surviving half is the dangerous one

#601 opened on the blank panel: `minimax-m3` spent 3,177 completion tokens reasoning about a two-line verse and never wrote the translation. `AiErrorKind.EmptyAnswer` (#583) already names that, by inferring it from "no text arrived".

The case inference cannot reach is the **half-written answer**. A stream cut off mid-verse ends exactly as a complete one does — the app renders a partial translation under a citation and nothing on screen says otherwise. That is strictly worse than the blank panel, which at least announces itself.

## What changed

- **`AiErrorKind.Truncated`** — measured rather than inferred.
- **Both adapters read the finish reason.** `finish_reason: "length"` on the OpenAI-compatible shape (plus `"max_tokens"`, which gateways fronting Anthropic pass through unchanged), and `stop_reason: "max_tokens"` from Anthropic's `message_delta`.
- **Reported after the stream, not at the chunk that carried the reason.** An `Error` delta is terminal by contract, and on *both* wire formats the token counts arrive with or behind the finish reason — OpenAI's usage chunk sits behind it, Anthropic packs `stop_reason` and `output_tokens` into one payload. Emitting on the spot would discard the number that explains the truncation, which is also the number the user paid. Two tests pin the ordering.
- **The orchestrator words it.** The provider knows *that* the limit was hit; only the orchestrator knows what the user got for it, so it composes one of three messages — cut off mid-answer, whole budget spent reasoning, or nothing produced at all. Three situations, three fixes.
- **`EmptyAnswer` stays** as the fallback for endpoints that report no finish reason at all.

Also read outside the `delta` check, because a provider may report the reason on a chunk carrying no delta — and may attach it to the final content delta, which must still be yielded.

## Safety of the new `ProviderCode`

`finish_reason` is provider-controlled text on an arbitrary user-pasted endpoint, and it now reaches the log. The helper returns the **matched constant** rather than the provider's own string, narrowing it to one of two literals we wrote.

## Verification

**Mutation-checked**, not just green: disabling the emission fails exactly the seven detection tests and leaves the negative ones (`stop`, `content_filter`, `tool_calls`, `end_turn`, `stop_sequence`, empty) passing. That last group matters — `finish_reason` is present on the final chunk of *every* turn, so firing on anything but the cap would put an error under every well-formed answer.

Also pinned: think-tag text is flushed before the truncation is reported, and a mid-stream provider error still wins over a later truncation rather than appending a second terminal event.

**1414/1414 passing** (was 1392).

## Not in scope

Offering "raise the limit" as an actionable control is #585's per-model settings; the seam is already sitting unfilled in `PromptBuilder.OutputBudget`. Detection does not wait on it, and needs no UI work — any panel must already render `AiTurnEventKind.Error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)