### PR TITLE
Close the four book-font review findings (#613, #614, #615, #616)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/BookFontTests.cs
+++ b/src/CST.Avalonia.Tests/Services/BookFontTests.cs
@@ -279,7 +279,39 @@ public class BookFontTests
 
         var resolved = BookFontResolver.Resolve(settings.Object, Script.Latin);
         Assert.All(resolved, c => Assert.True(c >= 0x20 || c == '\t'));
+        // True for THESE inputs, which are all unpaired. A well-formed pair must survive — see below.
         Assert.DoesNotContain(resolved, char.IsSurrogate);
+    }
+
+    [Fact]
+    public void AWellFormedSurrogatePairIsKept_OnlyUnpairedHalvesAreDropped()
+    {
+        // char.IsSurrogate is true for BOTH halves of a valid pair, so testing it per-character dropped
+        // legitimate astral-plane names: U+1D400 MATHEMATICAL BOLD CAPITAL A + "Font" silently became
+        // "Font". A well-formed pair is legal XML and legal CSS; only an UNPAIRED half trips the XmlWriter
+        // behind XslCompiledTransform, which is the whole justification for dropping anything here. (#615)
+        var pair = char.ConvertFromUtf32(0x1D400);          // a valid pair, as two UTF-16 code units
+        var settings = SettingsMock();
+        settings.Object.Settings.FontSettings.ScriptFonts["Latin"].BookFontFamily = pair + "Font";
+
+        Assert.Contains(pair, BookFontResolver.Resolve(settings.Object, Script.Latin));
+    }
+
+    [Fact]
+    public void AHalfPairAdjacentToRealTextIsStillDropped()
+    {
+        // The cases the narrowed check must NOT start letting through: a high surrogate followed by an
+        // ordinary character rather than its low half, and a low surrogate with no high half before it.
+        var high = ((char)0xD835).ToString();
+        var low = ((char)0xDC00).ToString();
+
+        foreach (var stored in new[] { high + "Font", "Font" + low, high + "x" + low })
+        {
+            var settings = SettingsMock();
+            settings.Object.Settings.FontSettings.ScriptFonts["Latin"].BookFontFamily = stored;
+
+            Assert.DoesNotContain(BookFontResolver.Resolve(settings.Object, Script.Latin), char.IsSurrogate);
+        }
     }
 
     [Fact]
@@ -337,10 +369,61 @@ public class BookFontTests
     [Fact]
     public void AnUninstalledFontShowsTheDefaultLabel_WithoutErasingTheSavedValue()
     {
-        // Display-only fallback. The saved setting is untouched so the choice returns by itself once the
-        // font is reinstalled — the #67 rule, and the hook #573 will report through.
+        // The last-resort fallback, reached only if the caller hands over a list the saved face is not in.
+        // ApplyLoadedFonts no longer does that — see the missing-entry tests below — but a SelectedItem that
+        // is not an item of the ItemsSource renders BLANK, so this must never return the saved name blindly.
         var list = new List<string> { "Default", "Kohinoor Devanagari" };
         Assert.Equal("Default",
+            AppearanceSettingsViewModel.ResolveBookFontSelection(list, "A Font That Was Uninstalled"));
+    }
+
+    // ---- A saved face that is not installed (#614) ------------------------------------------------
+
+    [Fact]
+    public void ASavedFaceThatIsNotInstalledIsOfferedSoThePickerCanShowIt()
+    {
+        // The list used to hold installed faces only, so an uninstalled choice fell back to displaying
+        // "Default" while the renderer went on using the missing name — the picker and the book disagreed
+        // about what was configured, and nothing on screen said so.
+        var list = new List<string> { "Default", "Kohinoor Devanagari" };
+
+        Assert.Equal("A Font That Was Uninstalled",
+            AppearanceSettingsViewModel.SavedFaceMissingFrom(list, "A Font That Was Uninstalled"));
+    }
+
+    [Fact]
+    public void AnInstalledFaceIsNotOfferedTwice()
+    {
+        var list = new List<string> { "Default", "Kohinoor Devanagari" };
+
+        Assert.Null(AppearanceSettingsViewModel.SavedFaceMissingFrom(list, "Kohinoor Devanagari"));
+        // Same tolerance as the selection match: case and surrounding space are not a different font.
+        Assert.Null(AppearanceSettingsViewModel.SavedFaceMissingFrom(list, "  kohinoor devanagari "));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoSavedFaceAddsNothingToTheList(string? saved)
+    {
+        var list = new List<string> { "Default", "Kohinoor Devanagari" };
+
+        Assert.Null(AppearanceSettingsViewModel.SavedFaceMissingFrom(list, saved));
+    }
+
+    [Fact]
+    public void OnceOfferedTheSavedFaceIsWhatTheSelectionResolvesTo()
+    {
+        // The point of adding it: the selection now lands on the saved face instead of on "Default", which
+        // is what makes choosing "Default" an actual change rather than a no-op the setter discards.
+        var list = new List<string> { "Default", "Kohinoor Devanagari" };
+        var missing = AppearanceSettingsViewModel.SavedFaceMissingFrom(list, "A Font That Was Uninstalled")!;
+        list.Insert(1, missing);
+
+        Assert.Equal("A Font That Was Uninstalled",
+            AppearanceSettingsViewModel.ResolveBookFontSelection(list, "A Font That Was Uninstalled"));
+        Assert.NotEqual("Default",
             AppearanceSettingsViewModel.ResolveBookFontSelection(list, "A Font That Was Uninstalled"));
     }
 

--- a/src/CST.Avalonia.Tests/Services/RetireUserXslDirectoryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/RetireUserXslDirectoryTests.cs
@@ -143,13 +143,75 @@ public class RetireUserXslDirectoryTests : IDisposable
     }
 
     [Fact]
-    public void ItRecordsItselfSoItDoesNotRunAgain()
+    public void ItRecordsItselfExactlyOnce_EvenThoughItKeepsRunning()
     {
+        // Recorded on the first run so the log shows when it happened, and never duplicated afterwards.
+        // The record is history here, not a skip condition - see the re-appearance test below. (#616)
+        MakeXslDir();
+        var state = FreshState();
+        RunOnlyThisMigration(state, Context());
+        RunOnlyThisMigration(state, Context());
+
+        Assert.Single(state.AppliedDataMigrations!.Where(id => id == "2026-08-retire-user-xsl-directory"));
+    }
+
+    [Fact]
+    public void ADirectoryThatREAPPEARSAfterRetirementIsRetiredAgain()
+    {
+        // The defect: Beta 6 retires xsl/ and records the migration; a still-installed Beta 5 launched
+        // against the same data directory recreates it; a once-only migration then skips forever and the
+        // stale directory is back permanently - the exact thing this migration exists to remove. A tester
+        // running both betas is not an exotic case, it is the normal one. (#616)
+        MakeXslDir(3);
+        var state = FreshState();
+        RunOnlyThisMigration(state, Context());
+        Assert.False(Directory.Exists(Path.Combine(_data, "xsl")));
+
+        MakeXslDir(14);   // Beta 5 launches and writes its own copy back
+
+        var notes = RunOnlyThisMigration(state, Context());
+
+        Assert.False(Directory.Exists(Path.Combine(_data, "xsl")));
+        Assert.DoesNotContain(notes, n => n.Contains(DataMigrations.FailureMarker));
+        // Retired alongside the first, never over it - the earlier copy may hold the user's hand edits.
+        Assert.True(Directory.Exists(Path.Combine(_data, "xsl-retired")));
+        Assert.True(Directory.Exists(Path.Combine(_data, "xsl-retired-2")));
+        Assert.Equal(3, Directory.GetFiles(Path.Combine(_data, "xsl-retired")).Length);
+        Assert.Equal(14, Directory.GetFiles(Path.Combine(_data, "xsl-retired-2")).Length);
+    }
+
+    [Fact]
+    public void ARerunWithNothingToDoSaysNothing()
+    {
+        // A recurring migration must not add a line to every launch's log, or it stops being a log of
+        // things that happened. Only the first run is announced; later quiet runs are silent. (#616)
         MakeXslDir();
         var state = FreshState();
         RunOnlyThisMigration(state, Context());
 
-        Assert.Single(state.AppliedDataMigrations!.Where(id => id == "2026-08-retire-user-xsl-directory"));
+        Assert.Empty(RunOnlyThisMigration(state, Context()));
+    }
+
+    [Fact]
+    public void ItIsRegisteredAsRecurring()
+    {
+        // The flag is the whole fix; wiring the implementation without it restores the defect silently.
+        Assert.True(DataMigrations.All.Single(m => m.Id == "2026-08-retire-user-xsl-directory").Recurring);
+    }
+
+    [Fact]
+    public void AOnceOnlyMigrationStillRunsOnlyOnce()
+    {
+        // The flag must not have made every migration recurring.
+        var runs = 0;
+        var once = new DataMigrations.Migration(
+            "test-once-only", "counts its runs", (_, _) => { runs++; return DataMigrations.Outcome.Done; });
+        var state = FreshState();
+
+        DataMigrations.Run(state, Context(), new[] { once });
+        DataMigrations.Run(state, Context(), new[] { once });
+
+        Assert.Equal(1, runs);
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/ViewModels/BookFaceRenderDecisionTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/BookFaceRenderDecisionTests.cs
@@ -1,0 +1,116 @@
+using CST.Avalonia.ViewModels;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// The two decisions behind re-rendering a book when its face changes. (#613)
+///
+/// <para>
+/// The bug these replace could not be reached through either decision alone, which is why it survived
+/// review: the font event compared the new face against what was rendered and against what was on its way,
+/// and both comparisons were correct in isolation. What neither could see was ORDER. Pick B, then revert to
+/// A while B is still transforming: the revert matches what is currently rendered, so the event correctly
+/// concludes it has nothing to do — and then B lands. Settings say A, the book shows B, and because
+/// settings already hold A no further event will ever be raised.
+/// </para>
+///
+/// <para>
+/// The fix is not a third field. It is asking the question after the fact, when there is a settled answer:
+/// <see cref="BookDisplayViewModel.CompletedRenderIsStale"/> runs when a render finishes and compares what
+/// it set out to do against what the settings now say. Every interleaving reduces to that one comparison,
+/// which is why these tests can drive it as data.
+/// </para>
+/// </summary>
+public class BookFaceRenderDecisionTests
+{
+    private const string A = "\"Times Ext Roman\", Tahoma";
+    private const string B = "\"Doulos SIL\"";
+
+    // ---- The reported bug, as a sequence ---------------------------------------------------------
+
+    [Fact]
+    public void Reverting_to_the_current_face_mid_render_is_caught_when_that_render_lands()
+    {
+        // 1. Showing A. 2. User picks B — a render starts, attempting B.
+        var attempted = B;
+
+        // 3. User reverts to A while B is transforming. The event is dropped: a render is in flight, and it
+        //    cannot know whether that render already covers this. Dropping it is now SAFE rather than a
+        //    silent loss, because of step 4.
+        Assert.False(BookDisplayViewModel.FaceChangeNeedsRender(A, renderedFace: A, renderInFlight: true));
+
+        // 4. B lands. The settings say A; this render attempted B. Stale — regenerate.
+        Assert.True(BookDisplayViewModel.CompletedRenderIsStale(currentFace: A, attemptedFace: attempted));
+    }
+
+    [Fact]
+    public void The_correction_settles_rather_than_ping_ponging()
+    {
+        // The re-render attempts A, and by then the settings still say A — so the chain stops. Convergence
+        // is the property that makes a self-scheduling correction safe to have at all.
+        Assert.False(BookDisplayViewModel.CompletedRenderIsStale(currentFace: A, attemptedFace: A));
+    }
+
+    [Fact]
+    public void A_render_that_failed_is_not_perpetually_stale()
+    {
+        // Why the comparison is against what the render ATTEMPTED rather than what it applied. A book whose
+        // XML directory is misconfigured renders an error page and applies no face at all; if staleness were
+        // judged against the applied face, every completion would look stale and re-post itself forever.
+        Assert.False(BookDisplayViewModel.CompletedRenderIsStale(currentFace: B, attemptedFace: B));
+    }
+
+    // ---- The event decision ----------------------------------------------------------------------
+
+    [Fact]
+    public void A_change_to_a_new_face_with_nothing_in_flight_renders()
+    {
+        Assert.True(BookDisplayViewModel.FaceChangeNeedsRender(B, renderedFace: A, renderInFlight: false));
+    }
+
+    [Fact]
+    public void An_event_that_does_not_change_this_books_face_is_ignored()
+    {
+        // Font settings are per script and the event is global: touching another script's chrome font must
+        // not regenerate every open book.
+        Assert.False(BookDisplayViewModel.FaceChangeNeedsRender(A, renderedFace: A, renderInFlight: false));
+    }
+
+    [Fact]
+    public void The_first_event_on_a_book_that_has_never_rendered_renders()
+    {
+        Assert.True(BookDisplayViewModel.FaceChangeNeedsRender(A, renderedFace: null, renderInFlight: false));
+    }
+
+    [Fact]
+    public void Nothing_starts_a_second_render_while_one_is_running()
+    {
+        // Even for a genuinely different face. The completion check picks it up — and unlike a queued
+        // render, it cannot stack up one regeneration per keystroke in the picker.
+        Assert.False(BookDisplayViewModel.FaceChangeNeedsRender(B, renderedFace: A, renderInFlight: true));
+    }
+
+    // ---- Comparison semantics --------------------------------------------------------------------
+
+    [Fact]
+    public void Faces_are_compared_exactly()
+    {
+        // These are CSS font stacks the app itself produced, not user input: two that differ in case or
+        // spacing are two different declarations, and rendering one while believing the other is showing is
+        // the whole failure mode here. BookFontResolver has already normalised and quoted anything the user
+        // supplied by the time either of these sees it.
+        Assert.True(BookDisplayViewModel.FaceChangeNeedsRender(
+            "\"Doulos SIL\"", renderedFace: "\"doulos sil\"", renderInFlight: false));
+        Assert.True(BookDisplayViewModel.CompletedRenderIsStale(
+            "\"Doulos SIL\", Tahoma", attemptedFace: "\"Doulos SIL\",Tahoma"));
+    }
+
+    [Fact]
+    public void A_book_that_has_never_rendered_counts_as_stale_against_any_face()
+    {
+        // Guards the null side of the completion check: a first render whose attempt was never recorded
+        // must not silently be treated as up to date.
+        Assert.True(BookDisplayViewModel.CompletedRenderIsStale(A, attemptedFace: null));
+    }
+}

--- a/src/CST.Avalonia/Services/BookFontResolver.cs
+++ b/src/CST.Avalonia/Services/BookFontResolver.cs
@@ -84,8 +84,9 @@ public static class BookFontResolver
     {
         var sb = new System.Text.StringBuilder(family.Length + 8);
         sb.Append('"');
-        foreach (var c in family)
+        for (var i = 0; i < family.Length; i++)
         {
+            var c = family[i];
             switch (c)
             {
                 // CSS string escapes.
@@ -107,7 +108,23 @@ public static class BookFontResolver
                     // fails the whole transform and the book renders as the error page. Dropped rather
                     // than escaped: no font family legitimately contains them. (fable review)
                     if (c < 0x20 && c != '\t') break;
-                    if (char.IsSurrogate(c)) break;
+
+                    // UNPAIRED surrogates only. char.IsSurrogate is true for both halves of a well-formed
+                    // pair, which is legal XML and legal CSS and is not what the XmlWriter objects to — the
+                    // wider test silently renamed any astral-plane family (U+1D400 "FONT" became "Font").
+                    // A well-formed pair is copied through as a unit; a half without its partner is dropped,
+                    // which is the only case that would fail the transform. (#615)
+                    if (char.IsHighSurrogate(c))
+                    {
+                        if (i + 1 < family.Length && char.IsLowSurrogate(family[i + 1]))
+                        {
+                            sb.Append(c).Append(family[i + 1]);
+                            i++;
+                        }
+                        break;   // a high surrogate with nothing after it, or followed by a non-low unit
+                    }
+                    if (char.IsLowSurrogate(c)) break;   // a low surrogate never preceded by its high half
+
                     sb.Append(c);
                     break;
             }

--- a/src/CST.Avalonia/Services/DataMigrations.cs
+++ b/src/CST.Avalonia/Services/DataMigrations.cs
@@ -14,7 +14,9 @@ namespace CST.Avalonia.Services;
 /// stay free of DI and of app services so they remain directly unit-testable against a temp directory.
 ///
 /// Applied migrations are recorded by id in <see cref="ApplicationState.AppliedDataMigrations"/>, so each
-/// runs exactly once. Ids are permanent: renaming one re-runs it on every existing install.
+/// runs exactly once - unless it is marked <see cref="Migration.Recurring"/>, which re-runs it every launch
+/// for the case where an older build can recreate the condition it fixes (#616). Ids are permanent:
+/// renaming one re-runs it on every existing install.
 ///
 /// <b>Write every migration to be idempotent anyway.</b> The recorded id is the primary guard, but a
 /// migration can also meet a half-finished state from an interrupted run, or a data directory restored
@@ -64,7 +66,17 @@ public static class DataMigrations
     /// </summary>
     public const string FailureMarker = "FAILED";
 
-    public sealed record Migration(string Id, string Description, Func<Context, List<string>, Outcome> Apply);
+    /// <param name="Recurring">
+    /// Run on EVERY launch rather than once. For a migration whose condition an older build can recreate:
+    /// recording it as done would then be a promise the app cannot keep. Only for migrations whose no-op
+    /// path is cheap and whose effect is idempotent — they still get recorded the first time, so the log
+    /// shows when they first ran, and they stay silent on the launches where they find nothing. (#616)
+    /// </param>
+    public sealed record Migration(
+        string Id,
+        string Description,
+        Func<Context, List<string>, Outcome> Apply,
+        bool Recurring = false);
 
     /// <summary>Ordered. Append new migrations; never renumber or rename existing ids.</summary>
     public static readonly IReadOnlyList<Migration> All = new List<Migration>
@@ -72,9 +84,13 @@ public static class DataMigrations
         new("2026-08-retire-en-hi-dictionary-ids",
             "Remove the superseded en/hi dictionary directories left behind by the #522 rename",
             RetireEnHiDictionaryIds),
+        // Recurring: a still-installed Beta 5 recreates xsl/ on its next launch, and a once-only migration
+        // would then skip it forever - leaving behind exactly the authoritative-looking, inert directory
+        // this exists to remove. Its no-op path is one Directory.Exists. (#616)
         new("2026-08-retire-user-xsl-directory",
             "Retire the user-editable XSL directory, superseded by the single bundled stylesheet (#42)",
-            RetireUserXslDirectory),
+            RetireUserXslDirectory,
+            Recurring: true),
     };
 
     /// <summary>
@@ -98,7 +114,11 @@ public static class DataMigrations
 
         foreach (var migration in migrations)
         {
-            if (applied.Contains(migration.Id, StringComparer.Ordinal))
+            // A recurring migration runs again even once recorded - see Migration.Recurring. Everything
+            // below keys off `recorded` rather than re-testing the list, so a recurring re-run stays silent
+            // unless it actually does something. (#616)
+            var recorded = applied.Contains(migration.Id, StringComparer.Ordinal);
+            if (recorded && !migration.Recurring)
                 continue;
 
             try
@@ -108,19 +128,22 @@ public static class DataMigrations
 
                 if (outcome == Outcome.Retry)
                 {
-                    if (notes.Count == before)
+                    if (notes.Count == before && !recorded)
                         notes.Add($"migration {migration.Id}: deferred, will retry next launch");
                     continue;
                 }
 
-                applied.Add(migration.Id);
+                if (!recorded)
+                {
+                    applied.Add(migration.Id);
 
-                // Only announce migrations that actually did something; a no-op on a clean install is the
-                // common case and does not deserve a line in everyone's log. This note is also what makes
-                // notes.Count > 0 on a clean install, which is what gets the record persisted at all - do
-                // not make it conditional.
-                if (notes.Count == before)
-                    notes.Add($"migration {migration.Id}: nothing to do");
+                    // Only announce migrations that actually did something; a no-op on a clean install is
+                    // the common case and does not deserve a line in everyone's log. This note is also what
+                    // makes notes.Count > 0 on a clean install, which is what gets the record persisted at
+                    // all - do not make it conditional on anything but the first run.
+                    if (notes.Count == before)
+                        notes.Add($"migration {migration.Id}: nothing to do");
+                }
             }
             catch (Exception ex)
             {

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -911,7 +911,14 @@ namespace CST.Avalonia.ViewModels
         private async Task LoadBookContentAsync()
         {
             await Dispatcher.UIThread.InvokeAsync(() => IsLoading = true);
-            
+
+            // #613: the face this render is ATTEMPTING, recorded before it starts and left alone however it
+            // ends. The completion check below compares against this rather than against what the render
+            // managed to apply — a render that failed must not read as a stale one, or it would re-post
+            // itself forever against a book that cannot render at all.
+            _attemptedBookFontFamily = BookFontResolver.Resolve(_settingsService, _bookScript);
+            _bookFontRenderInFlight = true;
+
             try
             {
                 var htmlContent = await GenerateHtmlContentAsync();
@@ -925,9 +932,64 @@ namespace CST.Avalonia.ViewModels
             }
             finally
             {
+                // Cleared in the finally, so EVERY exit releases it — the previous design cleared an
+                // equivalent flag at each return site and missed two of them. (#613, #612 review)
+                _bookFontRenderInFlight = false;
                 await Dispatcher.UIThread.InvokeAsync(() => IsLoading = false);
+                RerenderIfTheFaceMovedUnderneathThisRender();
             }
         }
+
+        /// <summary>
+        /// The correction that makes a face change safe to miss. (#613)
+        ///
+        /// <para>
+        /// A font event that arrives while a render is in flight is deliberately ignored — it cannot tell
+        /// whether the render already covers it. This runs when that render finishes and asks the only
+        /// question that settles it: is what we just rendered still what the settings say? Because it is
+        /// asked after the fact it needs no knowledge of how many changes happened in between, which is
+        /// exactly what comparing two point-in-time strings could not do. The book that was reverted to its
+        /// original face mid-render — the reported bug — is simply a render whose answer is "no".
+        /// </para>
+        ///
+        /// <para>
+        /// It converges: the re-render records its own attempt, so a settled face makes the next answer
+        /// "yes" and the chain stops. A failing render also answers "yes", since attempted is what it tried.
+        /// </para>
+        /// </summary>
+        private void RerenderIfTheFaceMovedUnderneathThisRender()
+        {
+            var current = BookFontResolver.Resolve(_settingsService, _bookScript);
+            if (!CompletedRenderIsStale(current, _attemptedBookFontFamily)) return;
+
+            _logger.Information(
+                "Book face for {Script} moved during the render ({Attempted} -> {Current}) - regenerating",
+                _bookScript, _attemptedBookFontFamily ?? "(none)", current);
+
+            _pendingPositionToken ??= _lastPositionToken;
+            Dispatcher.UIThread.Post(async () => await LoadBookContentAsync());
+        }
+
+        /// <summary>
+        /// Whether a font-settings event should start a render. Pure so it can be tested without a view
+        /// model; the ordering problem it used to get wrong is handled by
+        /// <see cref="RerenderIfTheFaceMovedUnderneathThisRender"/>, not here. (#613)
+        /// </summary>
+        /// <param name="renderInFlight">
+        /// When true this returns false and the event is dropped ON PURPOSE — the in-flight render's
+        /// completion check is what will notice, and it can compare against a settled value where this
+        /// cannot.
+        /// </param>
+        internal static bool FaceChangeNeedsRender(string currentFace, string? renderedFace, bool renderInFlight) =>
+            !renderInFlight && !string.Equals(currentFace, renderedFace, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Whether a finished render is out of date: the face it ATTEMPTED is no longer the face the
+        /// settings resolve to. Compared against the attempt rather than the result so that a failed render
+        /// is not perpetually stale. (#613)
+        /// </summary>
+        internal static bool CompletedRenderIsStale(string currentFace, string? attemptedFace) =>
+            !string.Equals(currentFace, attemptedFace, StringComparison.Ordinal);
 
         private async Task<string> GenerateHtmlContentAsync()
         {
@@ -939,7 +1001,6 @@ namespace CST.Avalonia.ViewModels
                     var booksDir = GetBooksDirectory();
                     if (booksDir == null)
                     {
-                        _requestedBookFontFamily = null;   // same reasoning as the catch below
                         _logger.Error("Cannot load book - no valid XML directory configured");
                         return "<html><body><h3>Error: No XML directory configured</h3><p>Please configure a valid XML directory in Settings.</p></body></html>";
                     }
@@ -950,7 +1011,6 @@ namespace CST.Avalonia.ViewModels
                     
                     if (!File.Exists(xmlPath))
                     {
-                        _requestedBookFontFamily = null;   // same reasoning as the catch below
                         _logger.Warning("XML file not found: {XmlPath}", xmlPath);
                         return "<html><body><h1>Book file not found</h1><p>File: " + xmlPath + "</p></body></html>";
                     }
@@ -998,7 +1058,6 @@ namespace CST.Avalonia.ViewModels
 
                     if (xslPath == null || !File.Exists(xslPath))
                     {
-                        _requestedBookFontFamily = null;   // same reasoning as the catch below
                         _logger.Error("Book stylesheet not found: {XslPath}", xslPath ?? "(unresolved)");
                         return "<html><body><h1>Stylesheet not found</h1><p>The book stylesheet could not be " +
                                "located in the application bundle.</p></body></html>";
@@ -1009,7 +1068,14 @@ namespace CST.Avalonia.ViewModels
 
                     // #42: the face is injected rather than baked into a per-script stylesheet. One
                     // stylesheet now serves all fourteen scripts — they differed only in this one line.
-                    var bookFont = BookFontResolver.Resolve(_settingsService, _bookScript);
+                    //
+                    // Taken from the value the caller recorded rather than resolved again here, so what was
+                    // ATTEMPTED and what was APPLIED cannot disagree — resolving twice would let a settings
+                    // change land between them and render a face the completion check then believes is
+                    // current. The fallback is unreachable in practice: LoadBookContentAsync sets this
+                    // immediately before calling, and it is the only caller. (#613)
+                    var bookFont = _attemptedBookFontFamily
+                                   ?? BookFontResolver.Resolve(_settingsService, _bookScript);
                     var xslArgs = new XsltArgumentList();
                     xslArgs.AddParam("bookFontFamily", "", bookFont);
                     _logger.Debug("Book font for {Script}: {Font}", _bookScript, bookFont);
@@ -1022,7 +1088,6 @@ namespace CST.Avalonia.ViewModels
                     // retrying it. Also covers a book opened after a face change: it starts out in sync
                     // rather than regenerating on its first font event. (fable review)
                     _appliedBookFontFamily = bookFont;
-                    _requestedBookFontFamily = null;
                     
                     var htmlContent = stringWriter.ToString();
                     _logger.Debug("Generated HTML content - length: {Length}", htmlContent.Length);
@@ -1031,9 +1096,6 @@ namespace CST.Avalonia.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    // Nothing rendered, so release the in-flight claim: the next font-settings event must be
-                    // free to retry this face rather than seeing it as already handled.
-                    _requestedBookFontFamily = null;
                     _logger.Error(ex, "Error generating HTML content");
                                         return $"<html><body><h1>Error loading book</h1><p>{ex.Message}</p><pre>{ex.StackTrace}</pre></body></html>";
                 }
@@ -1963,15 +2025,9 @@ namespace CST.Avalonia.ViewModels
             // face actually changed, or every book would re-render whenever any script's chrome font was
             // touched.
             var face = BookFontResolver.Resolve(_settingsService, _bookScript);
-            // Compare against what is RENDERED, or what is already on its way — either means this event
-            // needs no action. Two separate fields, deliberately: recording the requested face as though it
-            // were rendered is what made the earlier fix half a fix. If the reload then failed, the view
-            // believed it already showed that face and no later event would retry, leaving the book stuck
-            // on the error page until the user picked a DIFFERENT face. (fable review)
-            if (face == _appliedBookFontFamily || face == _requestedBookFontFamily) return;
+            if (!FaceChangeNeedsRender(face, _appliedBookFontFamily, _bookFontRenderInFlight)) return;
 
             _logger.Information("Book font for {Script} changed to {Face} - regenerating", _bookScript, face);
-            _requestedBookFontFamily = face;
 
             // Carry the reading position across the reflow. A font change moves every anchor, and without
             // this the reader is thrown elsewhere in the book on each adjustment — the requirement #42
@@ -1981,12 +2037,17 @@ namespace CST.Avalonia.ViewModels
         }
 
         // The face the currently rendered HTML was produced with — set only once a transform has succeeded.
-        // Null until the first successful render.
-        private string? _appliedBookFontFamily;
-        // The face a reload was requested for but which has not yet rendered. Exists purely to suppress
-        // duplicate reloads while one is in flight; cleared when the render finishes, either way, so a
-        // failure leaves nothing claiming to be current.
-        private string? _requestedBookFontFamily;
+        // Null until the first successful render. Read by the settings event to skip a render that would
+        // change nothing; NOT used to decide staleness, which is what _attemptedBookFontFamily is for.
+        private volatile string? _appliedBookFontFamily;
+
+        // The face the in-flight (or most recent) render set out to produce, whatever became of it. (#613)
+        private volatile string? _attemptedBookFontFamily;
+
+        // Whether a render is running. Volatile because it is written from the render task and read by the
+        // settings event on the UI thread; the same is true of the two faces above, which were plain fields
+        // being handed between threads. (#613)
+        private volatile bool _bookFontRenderInFlight;
 
         /// <summary>
         /// Releases this VM's reactive subscriptions and the FontService event subscription.

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -468,6 +468,30 @@ namespace CST.Avalonia.ViewModels
             return match ?? ScriptFontSettingViewModel.BookFontDefaultLabel;
         }
 
+        /// <summary>
+        /// The saved face, when it is not among the installed ones — the entry the book list has to carry so
+        /// the picker can show what is actually configured. Null when there is no saved face, or when it is
+        /// installed and therefore already in the list. (#614)
+        ///
+        /// <para>
+        /// The face is listed under its own name, with no "(missing)" decoration. Two reasons: the entry has
+        /// to round-trip through <see cref="ScriptFontSettingViewModel.BookFontFamily"/>, where a decorated
+        /// label would be stored verbatim as the face name; and telling the user a chosen font is not
+        /// installed is #573's job, which can say it once, in one place, for chrome and book alike.
+        /// </para>
+        /// </summary>
+        internal static string? SavedFaceMissingFrom(IReadOnlyList<string> bookFonts, string? savedFont)
+        {
+            if (string.IsNullOrWhiteSpace(savedFont))
+                return null;
+
+            var saved = savedFont.Trim();
+            var installed = bookFonts.Any(f =>
+                string.Equals(f?.Trim(), saved, StringComparison.OrdinalIgnoreCase));
+
+            return installed ? null : saved;
+        }
+
         private async Task LoadSystemDefaultSafe(ScriptFontSettingViewModel scriptVm)
         {
             try { await scriptVm.LoadSystemDefaultFontAsync(); }
@@ -704,6 +728,19 @@ namespace CST.Avalonia.ViewModels
                 // app's shipped stack for this script, not the OS default.
                 var bookFonts = new List<string> { BookFontDefaultLabel };
                 bookFonts.AddRange(fonts.Where(f => f != "System Default"));
+
+                // A SAVED FACE THAT IS NOT INSTALLED JOINS THE LIST. Without this the picker fell back to
+                // showing "Default" while the renderer went on using the missing name, so the two disagreed
+                // about what was configured - and the obvious correction, choosing "Default", did nothing at
+                // all: the ComboBox raises no change for the entry already displayed, and the setter's
+                // equality guard would have swallowed it regardless. The only way out was the undiscoverable
+                // pick-another-font-then-Default. Listing the saved face makes the picker tell the truth and
+                // makes clearing it a real selection change. #67's rule is untouched - the stored value is
+                // still never erased by a load, so reinstalling the font restores it as an ordinary match.
+                // Saying that it is missing is #573's job, not the list's. (#614)
+                if (AppearanceSettingsViewModel.SavedFaceMissingFrom(bookFonts, _bookFontFamily) is { } missing)
+                    bookFonts.Insert(1, missing);
+
                 AvailableBookFonts = new ObservableCollection<string>(bookFonts);
 
                 // Resolve against the list rather than assigning the saved string: a SelectedItem that is


### PR DESCRIPTION
The four findings filed during the review of #612 rather than fixed there. Closes #613, #614, #615, #616.

Each is mutation-verified: reverting the fix fails its own tests and only those. **1476 passed, 0 failed** (from 1455 — 21 new tests).

---

## #613 — reverting mid-render left the superseded face displayed

The guard compared the new face against what was rendered *and* against what was on its way. Both comparisons were correct in isolation; neither could see **order**.

> Showing A → pick B, a render starts → revert to A while B is still transforming. The revert matches what is currently rendered, so the event correctly concludes it has nothing to do. Then B lands. Settings say A, the book shows B, and no further event is ever raised because settings already hold A.

**Fixed by asking the question when there is a settled answer, not by adding a third field.** A render records the face it *attempts*; when it finishes it compares that against what the settings now say, and re-posts if they differ. Every interleaving reduces to that one comparison.

Two properties make it safe to have a render schedule its own successor:

- **It converges.** The correction records its own attempt, so a settled face makes the next answer "up to date" and the chain stops.
- **It cannot spin on a broken book.** Staleness is judged against what the render *attempted*, not what it *applied*. A book whose XML directory is misconfigured applies no face at all; judging against the applied face would make every completion look stale forever.

Both decisions are now `static` and pure, so the interleaving above is a **test** rather than a race nobody can reproduce. That also retires the caveat in `c9df749` that its two fixes rested on inspection — the in-flight flag is released in a `finally`, so all four exits are covered by construction rather than by remembering. The three fields involved were plain fields handed between the render task and the UI thread; they are now `volatile`.

## #614 — a saved-but-uninstalled face could not be cleared

The picker fell back to displaying "Default" while the renderer went on using the missing name — the two disagreed about what was configured, and nothing on screen said so. The obvious correction was a double no-op: the ComboBox raises no change for the entry already displayed, and the setter's equality guard would have swallowed it anyway. The only way out was the undiscoverable pick-another-font-then-Default.

The saved face now **joins the list**. That makes the picker tell the truth about what is configured, and makes clearing it a real selection change.

Listed under its own name with no "(missing)" decoration, for two reasons: the entry has to round-trip through `BookFontFamily`, where a decorated label would be stored verbatim as the face name; and saying a chosen font is not installed is **#573's** job, which can say it once for chrome and book alike. #67's rule is untouched — the stored value is still never erased by a load, so reinstalling the font restores it as an ordinary match.

## #615 — valid surrogate pairs were being stripped

`char.IsSurrogate` is true for **both halves of a well-formed pair**, not only unpaired ones. Only an unpaired half troubles the `XmlWriter` behind `XslCompiledTransform` — which is the entire justification for dropping anything there. A well-formed pair is legal XML and legal CSS, so `U+1D400` + `"Font"` was silently becoming `"Font"`.

Now pairs are copied through as a unit and only genuinely unpaired halves are dropped. Tests cover both directions: a valid pair survives; a high surrogate followed by ordinary text, a trailing low surrogate, and a half-pair split by a character are all still removed.

## #616 — a Beta 5 relaunch defeated the XSL retirement

Beta 6 retires `xsl/` and records the migration id. A still-installed Beta 5 launched against the same data directory recreates it. The recorded id then made Beta 6 skip forever — restoring exactly the authoritative-looking, inert directory the migration exists to remove. A tester running both betas is the normal case, not an exotic one.

Migrations can now be marked **`Recurring`**: recorded on the first run so the log still shows when it happened, re-evaluated every launch, and **silent** on launches where they find nothing — a recurring migration must not add a line to every startup log, or the log stops being a record of things that happened. Its no-op path is one `Directory.Exists`.

The re-retire path is tested end to end, including that the second copy lands in `xsl-retired-2` rather than over the first, since the earlier one may hold the user's hand edits. A separate test pins that ordinary migrations still run exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)