### PR TITLE
Book zoom: a public entry point for an arbitrary value (#618)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/BookZoomServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/BookZoomServiceTests.cs
@@ -117,6 +117,97 @@ public class BookZoomServiceTests
         Assert.True(svc.ZoomOut(Script.Latin) < 1.13);
     }
 
+    // ---- Arbitrary zoom, for a percentage control -------------------------------------------------
+
+    [Fact]
+    public void SetZoom_StoresAValueBetweenRungsRatherThanSnappingIt()
+    {
+        // The whole point of a percentage field: arriving at a value the ladder does not contain. Snapping
+        // on entry would make the control silently disagree with what the user typed.
+        var (svc, _) = Create();
+
+        Assert.Equal(1.15, svc.SetZoom(Script.Latin, 1.15), precision: 3);
+        Assert.Equal(1.15, svc.GetZoom(Script.Latin), precision: 3);
+    }
+
+    [Theory]
+    [InlineData(0.97, 1.00)]    // Chrome's PDF viewer, exactly: 97% + lands on 100%...
+    [InlineData(1.00, 1.10)]    // ...and thereafter follows the sequence
+    [InlineData(1.13, 1.25)]
+    [InlineData(1.26, 1.50)]
+    public void FromAnyValue_ZoomIn_LandsOnTheNextDefinedPercentage(double from, double expected)
+    {
+        // The behaviour that lets a typed value and the keyboard coexist: after landing anywhere, + goes to
+        // the next DEFINED percentage rather than adding a fixed increment. Previously only asserted as a
+        // direction, so the destination itself was unpinned - and a percentage control is what finally makes
+        // off-rung starting values reachable by ordinary use rather than by hand-editing settings.
+        var (svc, _) = Create();
+        svc.SetZoom(Script.Latin, from);
+
+        Assert.Equal(expected, svc.ZoomIn(Script.Latin), precision: 3);
+    }
+
+    [Theory]
+    [InlineData(1.03, 1.00)]
+    [InlineData(1.00, 0.90)]
+    [InlineData(1.13, 1.10)]
+    public void FromAnyValue_ZoomOut_LandsOnThePreviousDefinedPercentage(double from, double expected)
+    {
+        var (svc, _) = Create();
+        svc.SetZoom(Script.Latin, from);
+
+        Assert.Equal(expected, svc.ZoomOut(Script.Latin), precision: 3);
+    }
+
+    [Theory]
+    [InlineData(9.0)]
+    [InlineData(0.01)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void SetZoom_ClampsWhatAControlCouldSend(double requested)
+    {
+        // A percentage field is free text: someone will type 900, or 0, or paste something that parses to
+        // NaN. The stored value has to stay inside the range the renderer can honour whatever arrives.
+        var (svc, _) = Create();
+
+        var stored = svc.SetZoom(Script.Latin, requested);
+
+        Assert.InRange(stored, BookZoomService.MinZoom, BookZoomService.MaxZoom);
+        Assert.InRange(svc.GetZoom(Script.Latin), BookZoomService.MinZoom, BookZoomService.MaxZoom);
+    }
+
+    [Fact]
+    public void SetZoom_NotifiesThatScriptOnly_SoEveryOpenBookInItRefreshes()
+    {
+        // A change made in one book applies to every open book of the same script - Frank's call, and the
+        // mechanism the keyboard path already relies on. A typed value must take the same route.
+        var (svc, _) = Create();
+        var seen = new List<(Script Script, double Zoom)>();
+        svc.ZoomChanged += (_, e) => seen.Add((e.Script, e.Zoom));
+
+        svc.SetZoom(Script.Devanagari, 1.15);
+
+        var raised = Assert.Single(seen);
+        Assert.Equal(Script.Devanagari, raised.Script);
+        Assert.Equal(1.15, raised.Zoom, precision: 3);
+        Assert.Equal(1.0, svc.GetZoom(Script.Latin), precision: 3);
+    }
+
+    [Fact]
+    public void SetZoom_ToTheValueAlreadyStored_DoesNothing()
+    {
+        // A control that re-sends its current value on focus loss must not wake every open book or schedule
+        // a save. ResetZoom is the deliberate exception, and stays one.
+        var (svc, _) = Create();
+        svc.SetZoom(Script.Latin, 1.15);
+
+        var raised = 0;
+        svc.ZoomChanged += (_, _) => raised++;
+        svc.SetZoom(Script.Latin, 1.15);
+
+        Assert.Equal(0, raised);
+    }
+
     [Fact]
     public void ResetZoom_ReturnsToOne_FromEitherDirection()
     {

--- a/src/CST.Avalonia/Services/BookZoomService.cs
+++ b/src/CST.Avalonia/Services/BookZoomService.cs
@@ -30,6 +30,26 @@ public interface IBookZoomService
     /// <summary>Returns to 1.0 — the shipped stylesheet sizes exactly.</summary>
     double ResetZoom(Script script);
 
+    /// <summary>
+    /// Sets an arbitrary zoom, clamped to the supported range. Returns the value actually stored.
+    ///
+    /// <para>
+    /// The one thing the keyboard structurally cannot do: <b>arrive at a value instead of traversing to
+    /// it</b>. <see cref="ZoomIn"/> and <see cref="ZoomOut"/> walk the ladder a rung per press, which is
+    /// right for a key you hold down and wrong for "make it 115%". A toolbar percentage is the surface that
+    /// needs this; the ladder stays what it should be — the preset list and the step targets, not the set of
+    /// legal values.
+    /// </para>
+    ///
+    /// <para>
+    /// A value between rungs is stored as given, not snapped. Chrome's PDF viewer is the model: land on 97%
+    /// and the next <c>+</c> takes you to 100%, then on up the sequence. <see cref="ZoomIn"/> already
+    /// behaves that way for any starting value, so nothing downstream has to care whether a zoom came from
+    /// a key or a field.
+    /// </para>
+    /// </summary>
+    double SetZoom(Script script, double zoom);
+
     /// <summary>True when this script is not at 100%, i.e. the readout should show something.</summary>
     bool IsZoomed(Script script);
 
@@ -117,6 +137,17 @@ public class BookZoomService : IBookZoomService
     /// page scale, so this is also the only thing that undoes a pinch. (fable review)
     /// </summary>
     public double ResetZoom(Script script) => SetZoom(script, DefaultZoom, alwaysNotify: true);
+
+    /// <summary>
+    /// Arbitrary zoom, for a percentage control. See the interface for why this is not a ladder operation.
+    ///
+    /// <para>
+    /// Everything a typed value needs already existed behind the private overload — clamping, the
+    /// already-there early return, the debounced save, and the per-script notification that re-zooms every
+    /// open book in that script. This adds no mechanism; it opens the door to it.
+    /// </para>
+    /// </summary>
+    public double SetZoom(Script script, double zoom) => SetZoom(script, zoom, alwaysNotify: false);
 
     public bool IsZoomed(Script script) => Math.Abs(GetZoom(script) - DefaultZoom) > Epsilon;
 


### PR DESCRIPTION
Service-layer groundwork for the toolbar percentage control specced in #618. **No UI** — that half is #618 itself, and the spec there now says "already built; do not rebuild" about exactly this.

## Why

⌘+/⌘- walk the ladder a rung per press. Right for a key you hold down, wrong for *"make it 115%"* — and structurally unable to land between rungs.

Everything a typed value needs already existed behind a **private** overload: clamping, the unchanged-value early return, the debounced save, and the per-script `ZoomChanged` that re-zooms every open book in that script. `SetZoom` joins `IBookZoomService`; no mechanism was added.

## Two decisions worth recording

**The value is stored unsnapped.** The ladder is the preset list and the targets a keypress steps to — not the set of legal values. Snapping on entry would make a percentage control silently disagree with what the user typed.

**Adding rungs was considered instead, and rejected.** Denser rungs only put more presses on the path the keyboard already walks; they add no capability. fsnow's point, and it's right.

## What the tests found

`Step` already implemented Chrome's PDF-viewer behaviour — `+` goes to the next *defined* percentage rather than adding a fixed increment — and documented why. But the existing off-ladder test asserted only the **direction** of travel (`> 1.13`), so the destinations were unpinned.

They're now pinned to exact values: **97% → 100% → 110%**, plus 1.13 → 1.25 and 1.26 → 1.50, and the same downward. That matters more than it did: until now nothing could *produce* an off-rung value except hand-editing settings, so the branch was effectively unreachable. A percentage field makes it an ordinary path.

Also covered, because a free-text field will send all of it: out-of-range, `NaN`, infinity, and the same value re-sent on focus loss (which must not wake every open book or schedule a save).

## Verification

**1490 passed, 0 failed** (from 1476 — 14 new).

Nothing in the shipping app calls `SetZoom` yet; the keyboard path is untouched and the private overload it uses is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)