### PR TITLE
Docs: correct the branch list, and point L10N at where CST4 now lives

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ This repository contains multiple branches representing different stages of CST 
 - **`cst_4_2`**: CST 4.2 development branch featuring Lucene.NET 4.8 upgrade work (never released, but provided the foundation for the current search system)
 - **`cst_4_1`**: CST 4.1 — the released Windows version (tagged `v4.1.0.3-2022-04-05`), .NET Framework with WinForms
 - **`cst_4_0`**: CST 4.0 — previous stable Windows release (tagged `v4.0.0.15-2020-05-07`), also .NET Framework and WinForms
-- **`cst_avalonia`**: previous name for the current main branch (now obsolete)
 
-The legacy CST4 branches were Windows-only applications requiring Visual Studio 2022, WiX Toolset v3 for installer creation, and the separate tipitaka-xml repository for text data.
+The legacy CST4 branches were Windows-only applications requiring Visual Studio 2022, WiX Toolset v3 for installer creation, and the separate tipitaka-xml repository for text data. Their sources are no longer on `main`; see [Legacy CST4 Development](#legacy-cst4-development) for how to read them.
+
+One further branch, `experimental/cef-controlrecycling-workarounds`, is a 2025 spike rather than a stage of development. It is contained in `main`'s history and needs no attention.
 
 ## Features
 
@@ -63,7 +64,7 @@ An optional loopback HTTP API and **MCP server** let an AI assistant search the 
 ### Technical Architecture
 - **Stack**: .NET 10, Avalonia UI 11.3, ReactiveUI, Dock.Avalonia, dependency injection
 - **WebView Rendering**: WebViewControl-Avalonia (CEF) for book content and search highlighting
-- **Testing**: 1,000+ tests covering unit, integration, and performance scenarios
+- **Testing**: 1,400+ tests covering unit, integration, and performance scenarios
 - **Logging**: structured Serilog logging across all components
 
 ## Known Gaps
@@ -129,8 +130,16 @@ src/CST.Core/              # Book catalog, source-PDF mappings, shared contracts
 src/CST.Lucene/            # Search engine library
 src/CST.Lexicon/           # Dictionary asset format
 src/CST.Lemma/             # Lemma / morphology support
+src/CST.ScriptValidation/  # Round-trip validation harness for the 14 script converters
+src/CST.CharacterAnalysis/ # Finds characters in the corpus outside the standard Pāli set
 docs/                      # Architecture, features, research, release process
 ```
+
+The last two are standalone command-line tools, run by hand rather than referenced by the app.
+`CST.ScriptValidation` converts Devanagari → IPE → target script → IPE and requires the two IPE forms to
+match, which is the evidence behind the round-trip claim above; it has its own
+[README](src/CST.ScriptValidation/README.md). `CST.CharacterAnalysis` scans the XML for characters outside
+the expected Pāli inventory.
 
 The legacy CST4 sources are no longer in the working tree — see [Legacy CST4 Development](#legacy-cst4-development).
 
@@ -168,8 +177,8 @@ CST4 documentation stays in the tree — [docs/reference/cst4/](docs/reference/c
 [parity checklist](docs/testing/CST4_PARITY_CHECKLIST.md), and the feature specs that cite CST4 behaviour. The
 `src/Cst4/...` paths they reference resolve through the tags above.
 
-Branch history: **CST 4.1** (released) `cst_4_1`, **CST 4.2** (unreleased) `cst_4_2`, **CST 4.0** `cst_4_0`.
-Building CST4 requires Visual Studio 2022 and WiX Toolset v3; see individual branch READMEs.
+The branches those tags sit on are listed under [Branch Overview](#branch-overview); `cst4-final` is the tip of
+`cst_4_1`. Building CST4 needs Visual Studio 2022 and WiX Toolset v3 — see the README on the branch itself.
 
 ## Documentation & Roadmap
 

--- a/docs/features/planned/LOCALIZATION_STRATEGY.md
+++ b/docs/features/planned/LOCALIZATION_STRATEGY.md
@@ -2,6 +2,43 @@
 
 This document details the localization mechanism used in the CST4 WinForms application, which allows for dynamic, runtime language switching.
 
+> **Where these files are now.** The CST4 sources were removed from `main` in August 2026 (#611). Everything
+> described below is preserved and reachable, but not in the working tree — see
+> [Legacy CST4 Development](../../../README.md#legacy-cst4-development). **Section 4's Visual Studio
+> walkthrough requires a checkout first**; the rest of this document is read-only reference and needs nothing.
+
+## 0. What is preserved, and how much of it is reusable
+
+Verified against the `cst4-final` tag: **254 `.resx` files across 24 locales** — `bn cs de es fa fi fr gu hi
+id it mi-NZ ml no pa pl pt ru sv ta te th zh-CHS zh-CHT`. That is the source the CST 5 localization work is
+expected to mine, and the count independently confirms the "24 interface languages" figure quoted in the
+top-level README.
+
+They are **two different kinds of resource, and only one of them ports cleanly:**
+
+| | Path | Portability |
+|---|---|---|
+| **General string table** | `src/Cst4/Properties/Resources.<locale>.resx` | Plain key → string. Ports close to as-is. |
+| **Form resources** (14 forms) | `src/Cst4/Form*.<locale>.resx`, `AboutBox`, `SplashScreen` | Designer output. **Extract and remap, do not import.** |
+
+The form files interleave translated strings with control geometry, and their keys are WinForms *control
+names*. A sample: `FormSearch.fr.resx` holds 14 `.Text` entries against 12 `.Size`/`.Location` ones, plus
+`Color1`/`Bitmap1`/`Icon1` boilerplate. So roughly half of each form file is layout that means nothing in
+Avalonia, and the half that matters is keyed to control names (`btnSearch.Text`, `lblSearchFor.Text`) that
+will not match the Avalonia view's. The translations are the valuable part; the keys and the geometry are not.
+
+Two implementation files worth reading before designing the Avalonia equivalent, both preserved alongside:
+`src/Cst4/LanguageCollector.cs` (how CST4 discovers which languages are available) and
+`src/Cst4/FormLanguageSwitch.cs` (the switcher described in section 2).
+
+Extracting needs no checkout:
+
+```bash
+git show cst4-final:src/Cst4/Properties/Resources.fr.resx > Resources.fr.resx
+git archive cst4-final -- src/Cst4/Properties | tar -x     # the whole general string table
+git checkout cst4-final -- src/Cst4                        # only if you need to BUILD it (section 4)
+```
+
 ## 1. Core Technology
 
 The localization system is built entirely on the standard .NET Framework infrastructure for WinForms applications.


### PR DESCRIPTION
Follow-up to #611. Documentation only — no code, no tests affected.

## README — branches

- **Dropped `cst_avalonia`.** It is not on the remote, so the list documented a branch a reader cannot find.
- **Removed the third restatement of the branch list.** I introduced that duplication myself when adding the tag table in #611 — the branches were being described in three places. What replaced it is the one fact that section actually needed: **`cst4-final` is the tip of `cst_4_1`**, the link between the branch list and the tag table that had been left implicit.
- **Added `experimental/cef-controlrecycling-workarounds`**, which is on the remote and was previously unexplained. It is a Nov 2025 spike contained in `main`'s history; the note says so and says it needs no attention.

## README — project structure

Documented **`CST.ScriptValidation`** and **`CST.CharacterAnalysis`**, both deliberately kept in #611 and neither previously listed. Descriptions checked against what they do rather than inferred from their names — `ScriptValidation` converts Devanagari → IPE → target → IPE and requires the two IPE forms to match, which makes it the *evidence* behind the round-trip claim earlier in the same file, so those two statements are now linked.

Test count **1,000+ → 1,400+**. Kept as a threshold rather than the exact 1,490, so it does not go stale on the next merge.

## LOCALIZATION_STRATEGY.md

The resources this document describes are no longer in the working tree, and its **section 4 walks the reader through editing them in the Visual Studio designer** — so that section needs a checkout where the rest of the document needs nothing. The new callout distinguishes those two rather than leaving the whole file looking dead.

A new section 0 records what was **verified against `cst4-final`**, not assumed: **254 `.resx` files across 24 locales**, enumerated by name. That independently confirms the "CST4 offers 24 interface languages" figure the README has been quoting.

The load-bearing finding, and the reason this is worth writing down before the work starts rather than during it:

> These are **two kinds of resource and only one ports.** `Properties/Resources.<locale>.resx` is a plain key → string table. The 14 form files are designer output whose keys are WinForms **control names** (`btnSearch.Text`) and roughly half of whose rows are control geometry — `FormSearch.fr.resx` holds 14 `.Text` entries against 12 `.Size`/`.Location`. **Extract and remap, not import.**

Also verified while checking: the RESX files are **byte-identical** between the `4.1.0.3-2022-04-05` release tag and `cst4-final`, so any 4.1 reference point yields the same resources — and the `Latn2Deva.cs` drift found during #611 never touched localization.

## Deliberately left alone

Per the rule that this page describes the **released** build: the book-font Known Gap and the per-script `xsl/` description are both beta 6 work, and the beta 5 status line and the macOS idle-CPU figure stand as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)