### PR TITLE
Book zoom: a percentage control in the book toolbar (#618)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/BookZoomReadoutTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/BookZoomReadoutTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.ViewModels;
+using CST.Conversion;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// The toolbar zoom control (#618), driven against a real <see cref="BookZoomService"/> and no browser.
+///
+/// <para>
+/// <c>BookZoomServiceTests</c> already covers the ladder and the clamping, so nothing here re-tests those.
+/// What is new in this feature is everything AROUND the number: which book an event concerns, what a typed
+/// string means, and whether the readout follows a book that changes script — the last of which is the
+/// difference between a correct readout and one that lies with authority.
+/// </para>
+/// </summary>
+public class BookZoomReadoutTests
+{
+    private static (BookZoomService svc, Settings settings) CreateService()
+    {
+        var settings = new Settings();
+        var mock = new Mock<ISettingsService>();
+        mock.SetupGet(s => s.Settings).Returns(settings);
+        return (new BookZoomService(mock.Object), settings);
+    }
+
+    /// <summary>A readout over a mutable script, with a count of how many times it asked for a refresh.</summary>
+    private sealed class Harness : IDisposable
+    {
+        public readonly BookZoomService Service;
+        public Script Script;
+        public int Notifications;
+        public readonly BookZoomReadout Readout;
+
+        public Harness(Script script = Script.Devanagari)
+        {
+            (Service, _) = CreateService();
+            Script = script;
+            Readout = new BookZoomReadout(Service, () => Script, () => Notifications++);
+        }
+
+        public void Dispose() => Readout.Dispose();
+    }
+
+    // ---- What the control shows ------------------------------------------------------------------
+
+    [Fact]
+    public void An_unzoomed_book_reads_one_hundred_percent()
+    {
+        using var h = new Harness();
+        Assert.Equal("100%", h.Readout.Display);
+    }
+
+    [Fact]
+    public void A_zoomed_book_reads_its_percentage()
+    {
+        using var h = new Harness();
+        h.Service.SetZoom(Script.Devanagari, 1.25);
+        Assert.Equal("125%", h.Readout.Display);
+    }
+
+    [Fact]
+    public void An_off_rung_value_is_displayed_as_typed_not_snapped()
+    {
+        using var h = new Harness();
+        h.Service.SetZoom(Script.Devanagari, 1.15);
+        Assert.Equal("115%", h.Readout.Display);
+    }
+
+    // ---- Which book an event concerns ------------------------------------------------------------
+
+    [Fact]
+    public void A_change_to_this_books_script_refreshes_the_readout()
+    {
+        using var h = new Harness();
+        h.Service.SetZoom(Script.Devanagari, 1.25);
+        Assert.Equal(1, h.Notifications);
+    }
+
+    [Fact]
+    public void A_change_to_another_script_does_not()
+    {
+        using var h = new Harness(Script.Devanagari);
+        h.Service.SetZoom(Script.Latin, 1.25);
+
+        // Every open book hears every change — a Latin book's zoom must not repaint a Devanagari toolbar.
+        Assert.Equal(0, h.Notifications);
+        Assert.Equal("100%", h.Readout.Display);
+    }
+
+    [Fact]
+    public void A_change_made_in_another_tab_of_the_same_script_reaches_this_one()
+    {
+        // Two readouts on one service is exactly two book tabs showing the same script. The second is what
+        // a change made in the first has to reach, or the two tabs disagree about what they are showing.
+        using var first = new Harness(Script.Myanmar);
+        var secondNotifications = 0;
+        using var second = new BookZoomReadout(first.Service, () => Script.Myanmar, () => secondNotifications++);
+
+        first.Service.SetZoom(Script.Myanmar, 1.5);
+
+        Assert.Equal(1, secondNotifications);
+        Assert.Equal("150%", second.Display);
+    }
+
+    [Fact]
+    public void Disposing_leaves_no_subscription_behind()
+    {
+        // The service is a singleton, so a subscription left behind roots a closed book's VM for the
+        // session — and keeps refreshing a toolbar nobody is looking at.
+        var h = new Harness();
+        h.Readout.Dispose();
+
+        h.Service.SetZoom(Script.Devanagari, 1.25);
+        Assert.Equal(0, h.Notifications);
+    }
+
+    // ---- Following a book that changes script ----------------------------------------------------
+
+    [Fact]
+    public void Changing_the_books_script_re_reads_the_new_scripts_zoom()
+    {
+        using var h = new Harness(Script.Devanagari);
+        h.Service.SetZoom(Script.Devanagari, 1.25);
+        h.Service.SetZoom(Script.Myanmar, 1.75);
+
+        h.Script = Script.Myanmar;
+        h.Notifications = 0;
+        h.Readout.ScriptChanged();
+
+        // Nothing stored changed here — but which stored value this control is showing did.
+        Assert.Equal("175%", h.Readout.Display);
+
+        // And it must SAY so. Display re-reads the script on every access, so the assertion above passes
+        // even if ScriptChanged does nothing at all — while the shipped box, which repaints only when the
+        // VM raises property-changed, would sit on the old script's percentage until the next zoom event.
+        // (fable review)
+        Assert.Equal(1, h.Notifications);
+    }
+
+    [Fact]
+    public void After_a_script_change_events_for_the_old_script_are_ignored()
+    {
+        using var h = new Harness(Script.Devanagari);
+        h.Script = Script.Latin;
+        h.Notifications = 0;
+
+        h.Service.SetZoom(Script.Devanagari, 1.25);
+
+        // The script is read on every event rather than captured at construction, which is what stops a
+        // re-scripted book from tracking the script it used to show.
+        Assert.Equal(0, h.Notifications);
+    }
+
+    // ---- The step buttons ------------------------------------------------------------------------
+
+    [Fact]
+    public void Step_buttons_are_live_in_the_middle_of_the_ladder()
+    {
+        using var h = new Harness();
+        Assert.True(h.Readout.CanZoomIn);
+        Assert.True(h.Readout.CanZoomOut);
+    }
+
+    [Fact]
+    public void Each_step_button_goes_dead_at_its_own_end()
+    {
+        using var h = new Harness();
+
+        h.Service.SetZoom(Script.Devanagari, BookZoomService.MaxZoom);
+        Assert.False(h.Readout.CanZoomIn);
+        Assert.True(h.Readout.CanZoomOut);
+
+        h.Service.SetZoom(Script.Devanagari, BookZoomService.MinZoom);
+        Assert.True(h.Readout.CanZoomIn);
+        Assert.False(h.Readout.CanZoomOut);
+    }
+
+    // ---- What a typed string means ---------------------------------------------------------------
+
+    [Theory]
+    [InlineData("115", 1.15)]
+    [InlineData("115%", 1.15)]
+    [InlineData("  115 % ", 1.15)]
+    [InlineData("100", 1.0)]      // the reset, typed — which is why there is no reset button
+    [InlineData("50", 0.5)]
+    [InlineData("300", 3.0)]
+    public void The_things_people_actually_type_are_accepted(string text, double expected)
+    {
+        Assert.True(BookZoomReadout.TryParseEntry(text, out var zoom));
+        Assert.Equal(expected, zoom, 6);
+    }
+
+    [Fact]
+    public void A_fractional_percentage_is_rounded_to_what_the_box_can_display()
+    {
+        // NOT the ladder snapping #618 rules out — 115 stays 115, nowhere near a rung. This is so the
+        // stored value and the displayed one cannot disagree, since the box shows whole percent.
+        Assert.True(BookZoomReadout.TryParseEntry("115.4", out var down));
+        Assert.Equal(1.15, down, 6);
+
+        Assert.True(BookZoomReadout.TryParseEntry("115.6", out var up));
+        Assert.Equal(1.16, up, 6);
+    }
+
+    [Fact]
+    public void A_decimal_typed_in_the_users_own_culture_is_understood()
+    {
+        var original = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+            Assert.True(BookZoomReadout.TryParseEntry("115,6", out var zoom));
+            Assert.Equal(1.16, zoom, 6);
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = original;
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("%")]
+    [InlineData("0")]
+    [InlineData("-50")]
+    public void Nonsense_is_rejected_rather_than_guessed_at(string? text)
+    {
+        // A rejected entry leaves the stored zoom alone; the caller puts the box back. Guessing here would
+        // render the book at a size nobody asked for.
+        Assert.False(BookZoomReadout.TryParseEntry(text, out _));
+    }
+
+    [Fact]
+    public void An_out_of_range_entry_is_left_for_the_service_to_clamp()
+    {
+        // Parsing accepts it; clamping 500 to 300% answers the intent better than refusing to do anything.
+        Assert.True(BookZoomReadout.TryParseEntry("500", out var zoom));
+        Assert.Equal(5.0, zoom, 6);
+
+        using var h = new Harness();
+        Assert.Equal(BookZoomService.MaxZoom, h.Service.SetZoom(Script.Devanagari, zoom));
+        Assert.Equal("300%", h.Readout.Display);
+    }
+
+    [Fact]
+    public void A_typed_value_and_the_keyboard_coexist()
+    {
+        // The whole reason free entry needs no ladder awareness: from 115%, a step lands on the next
+        // DEFINED rung in the direction of travel.
+        using var h = new Harness();
+        Assert.True(BookZoomReadout.TryParseEntry("115", out var typed));
+        h.Service.SetZoom(Script.Devanagari, typed);
+
+        Assert.Equal(1.25, h.Service.ZoomIn(Script.Devanagari), 6);
+        Assert.Equal(1.10, h.Service.ZoomOut(Script.Devanagari), 6);
+    }
+}

--- a/src/CST.Avalonia/Services/BookZoomService.cs
+++ b/src/CST.Avalonia/Services/BookZoomService.cs
@@ -96,9 +96,16 @@ public class BookZoomService : IBookZoomService
     public static double MaxZoom => Ladder[^1];
     public const double DefaultZoom = 1.0;
 
-    // Two ladder rungs can sit 0.05 apart, so the tolerance for "already on this rung" has to be well below
-    // that. Also absorbs the float error from a JSON round-trip of 0.67.
-    private const double Epsilon = 0.001;
+    /// <summary>
+    /// The tolerance for "already at this zoom". Two ladder rungs can sit 0.05 apart, so it has to be well
+    /// below that; it also absorbs the float error from a JSON round-trip of 0.67.
+    ///
+    /// Public because anything deciding whether a zoom command would DO something has to use the same
+    /// number this type uses to decide whether to act. A caller with a tighter tolerance concludes a step
+    /// is available, this type concludes it changes nothing and returns early, and the caller is left
+    /// offering a control that does nothing when pressed. (fable review)
+    /// </summary>
+    public const double Epsilon = 0.001;
 
     private readonly ISettingsService _settingsService;
     private readonly ILogger _logger;

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -43,6 +43,9 @@ namespace CST.Avalonia.ViewModels
         // service locator (this VM is constructed directly, not via DI); handler unsubscribed in Dispose.
         private readonly IScriptService? _scriptService;
         private Action<Script>? _globalScriptChangedHandler;
+        // #618: the toolbar zoom control's state. Resolved from the service locator like _scriptService
+        // above, and disposed in Dispose — it holds a subscription on the singleton zoom service.
+        private readonly BookZoomReadout? _zoomReadout;
         private readonly Book _book;
         private readonly List<string>? _searchTerms;
         private readonly List<TermPosition>? _searchPositions;  // NEW: Store positions with IsFirstTerm flags
@@ -320,6 +323,28 @@ namespace CST.Avalonia.ViewModels
                     Dispatcher.UIThread.Post(() => BookScript = newScript);
                 _scriptService.ScriptChanged += _globalScriptChangedHandler;
             }
+
+            // #618: the toolbar zoom readout. Subscribing here rather than reusing the View's subscription
+            // because the toolbar is data-bound XAML whose DataContext is this VM, and a change made in
+            // ANOTHER tab of the same script has to update this one's readout too.
+            var zoomService = App.ServiceProvider?.GetService<IBookZoomService>();
+            if (zoomService != null)
+            {
+                _zoomReadout = new BookZoomReadout(
+                    zoomService,
+                    () => BookScript,
+                    // The service raises on whichever thread made the change — a keystroke is already on the
+                    // UI thread, but the Settings dialog and a future agent call need not be.
+                    () => Dispatcher.UIThread.Post(RaiseZoomReadoutChanged));
+            }
+
+            // A book can change script at runtime, and the readout must follow it to the NEW script's zoom.
+            // Separate from the reload subscription above so a failure there cannot leave the readout
+            // describing the script the book is no longer showing.
+            this.WhenAnyValue(x => x.BookScript)
+                .Skip(1)
+                .Subscribe(_ => _zoomReadout?.ScriptChanged())
+                .DisposeWith(_disposables);
 
             this.WhenAnyValue(x => x.SelectedChapter)
                 .Where(chapter => chapter != null && !_isInitializing)
@@ -659,6 +684,30 @@ namespace CST.Avalonia.ViewModels
         // Font properties for tab title, chapter dropdown, and status bar
         public string CurrentScriptFontFamily => _fontService?.GetScriptFontFamily(BookScript) ?? "Helvetica";
         public int CurrentScriptFontSize => _fontService?.GetScriptFontSize(BookScript) ?? 12;
+
+        #region Book text zoom readout (#618)
+
+        // The state itself lives in BookZoomReadout, where it can be tested without a Book or a browser.
+        // These are the bindable face of it.
+
+        /// <summary>"125%" — the entry box's text when it is not being typed into.</summary>
+        public string ZoomDisplay => _zoomReadout?.Display ?? "100%";
+
+        public bool CanZoomIn => _zoomReadout?.CanZoomIn ?? true;
+        public bool CanZoomOut => _zoomReadout?.CanZoomOut ?? true;
+
+        /// <summary>
+        /// Re-reads everything the zoom control shows. Raised for a zoom change in THIS book's script
+        /// (including one made in another tab) and when the book's own script changes.
+        /// </summary>
+        private void RaiseZoomReadoutChanged()
+        {
+            this.RaisePropertyChanged(nameof(ZoomDisplay));
+            this.RaisePropertyChanged(nameof(CanZoomIn));
+            this.RaisePropertyChanged(nameof(CanZoomOut));
+        }
+
+        #endregion
 
         private string GetBookDisplayName(Book book)
         {
@@ -2066,6 +2115,9 @@ namespace CST.Avalonia.ViewModels
 
             if (_scriptService != null && _globalScriptChangedHandler != null)
                 _scriptService.ScriptChanged -= _globalScriptChangedHandler;
+
+            // Releases the ZoomChanged subscription on the singleton zoom service (#618).
+            _zoomReadout?.Dispose();
 
             _disposables.Dispose();
         }

--- a/src/CST.Avalonia/ViewModels/BookZoomReadout.cs
+++ b/src/CST.Avalonia/ViewModels/BookZoomReadout.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Globalization;
+using CST.Avalonia.Services;
+using CST.Conversion;
+
+namespace CST.Avalonia.ViewModels;
+
+/// <summary>
+/// The toolbar zoom control's state, as a plain object. (#618)
+///
+/// <para>
+/// This exists apart from <see cref="BookDisplayViewModel"/> for one reason: that VM cannot be constructed
+/// in a test — it needs a <c>Book</c>, a dock factory and a WebView, and it starts loading in its
+/// constructor. Everything the control does that could be wrong (which script an event belongs to, what a
+/// typed string means, whether a step button should be live) therefore lives here, where a test can drive it
+/// against a real <see cref="BookZoomService"/> and no browser at all. The VM keeps one of these and
+/// forwards its notifications as property changes; the same pattern as
+/// <c>BookFaceRenderDecisionTests</c> covers, one step up from static methods because this one has to hold a
+/// subscription.
+/// </para>
+///
+/// <para>
+/// It deliberately does no dispatching. The service raises <see cref="IBookZoomService.ZoomChanged"/> on
+/// whatever thread made the change, and marshalling is the VM's business — keeping <c>Dispatcher</c> out of
+/// here is what lets the tests run headless.
+/// </para>
+/// </summary>
+public sealed class BookZoomReadout : IDisposable
+{
+    private readonly IBookZoomService _service;
+    private readonly Func<Script> _currentScript;
+    private readonly Action _notify;
+    private EventHandler<BookZoomChangedEventArgs>? _handler;
+
+    /// <param name="currentScript">
+    /// Read on every access rather than captured, because a book can change script at runtime and the
+    /// readout has to follow it to the new script's zoom.
+    /// </param>
+    /// <param name="notify">Invoked when this book's readout has changed and the UI should re-read it.</param>
+    public BookZoomReadout(IBookZoomService service, Func<Script> currentScript, Action notify)
+    {
+        _service = service;
+        _currentScript = currentScript;
+        _notify = notify;
+
+        _handler = (_, args) =>
+        {
+            // Zoom is stored per script, so every open book hears every change. Only the ones showing that
+            // script are affected — and they all are, including the other tabs, which is what keeps two
+            // views of one script from disagreeing about what they are showing.
+            if (AppliesTo(args.Script, _currentScript())) _notify();
+        };
+        _service.ZoomChanged += _handler;
+    }
+
+    /// <summary>The stored zoom for the book's current script.</summary>
+    public double Zoom => _service.GetZoom(_currentScript());
+
+    /// <summary>
+    /// "125%" — what the entry box shows when it is not being typed into.
+    ///
+    /// The percentage alone, with no script name: zoom has been per script since #572, so a control that
+    /// changes every open book in the script is not introducing that behaviour, only giving it a second
+    /// surface. The scope is stated in the box's own tooltip instead of spent on toolbar width.
+    /// </summary>
+    public string Display => _service.FormatZoom(_currentScript());
+
+    // Greyed at the ends of the ladder rather than silently doing nothing, which is the difference between
+    // "you are at the limit" and "this button is broken". The service's own tolerance, not a tighter one of
+    // our own: a value inside its "unchanged" band makes it return early without raising ZoomChanged, so a
+    // button enabled on a finer comparison would be exactly the dead button this is here to avoid.
+    public bool CanZoomIn => Zoom < BookZoomService.MaxZoom - BookZoomService.Epsilon;
+    public bool CanZoomOut => Zoom > BookZoomService.MinZoom + BookZoomService.Epsilon;
+
+    /// <summary>
+    /// Call when the book's script changes. Nothing about the stored zoom changed, but which zoom this
+    /// readout is showing did — miss this and the control keeps displaying the old script's value, which is
+    /// worse than showing nothing because it looks authoritative.
+    /// </summary>
+    public void ScriptChanged() => _notify();
+
+    /// <summary>Whether a change for <paramref name="changed"/> concerns a book displaying <paramref name="book"/>.</summary>
+    public static bool AppliesTo(Script changed, Script book) => changed == book;
+
+    /// <summary>
+    /// Parses what the user typed into a zoom factor.
+    ///
+    /// <para>
+    /// Lenient about the things people actually type — surrounding space, a percent sign, a decimal point —
+    /// and silent about the rest: a failed parse leaves the stored zoom alone and the box is put back to the
+    /// real value, so a typo can never render the book at a size nobody asked for.
+    /// </para>
+    ///
+    /// <para>
+    /// The result is rounded to a whole percent. That is <b>not</b> the ladder snapping #618 rules out — 115
+    /// stays 115, well off any rung. It is so that what gets stored is what the box will display, since the
+    /// readout shows whole percent; storing 115.4 while displaying 115% would leave the control quietly
+    /// disagreeing with the setting behind it.
+    /// </para>
+    ///
+    /// <para>
+    /// Range is not checked here. <see cref="IBookZoomService.SetZoom"/> clamps, and clamping 500 to 300%
+    /// answers the user's intent better than refusing it.
+    /// </para>
+    /// </summary>
+    public static bool TryParseEntry(string? text, out double zoom)
+    {
+        zoom = 0;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+
+        var trimmed = text.Trim().TrimEnd('%', ' ', '\t');
+        // Both cultures: the box is seeded from an invariant-formatted string, but a user typing a decimal
+        // uses their own separator. Invariant first so "115.5" means the same thing everywhere.
+        if (!double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var percent) &&
+            !double.TryParse(trimmed, NumberStyles.Float, CultureInfo.CurrentCulture, out percent))
+            return false;
+
+        if (double.IsNaN(percent) || double.IsInfinity(percent) || percent <= 0) return false;
+
+        zoom = Math.Round(percent) / 100.0;
+        return zoom > 0;
+    }
+
+    public void Dispose()
+    {
+        // The service is a singleton, so this subscription roots the VM — the same leak shape the View's
+        // zoom and FontService subscriptions carry comments about.
+        if (_handler != null) _service.ZoomChanged -= _handler;
+        _handler = null;
+    }
+}

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml
@@ -175,6 +175,45 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
+                <!-- #618: book text zoom — Chrome's PDF-viewer control: step down, the value, step up.
+                     No reset button; typing 100 is the reset, and Cmd/Ctrl+0 remains the keyboard route.
+
+                     The value box is the only surface that can ARRIVE at a percentage instead of walking
+                     to it, and the only thing anywhere in the reader that says a book is zoomed at all —
+                     before this the sole disclosure was a line in the Settings dialog, so a book zoomed
+                     weeks ago just looked wrong.
+
+                     Zoom is stored per SCRIPT, so a change here moves every open book in that script. That
+                     is not new with this control — it is how Cmd/Ctrl +/- has always behaved — so it is
+                     stated in the value box's own tooltip rather than spent on toolbar width. It goes on
+                     the BOX, not on this panel: a tip on the group would be shadowed by every child's own
+                     tip, leaving it reachable only in the few pixels between the controls. (fable review) -->
+                <StackPanel Orientation="Horizontal" Margin="5" VerticalAlignment="Center">
+                    <Button x:Name="zoomOutButton"
+                            IsEnabled="{Binding CanZoomOut}"
+                            Margin="2" Padding="8,2" MinWidth="0"
+                            ToolTip.Tip="Zoom out">
+                        <TextBlock Text="&#x2212;"/>
+                    </Button>
+                    <!-- Fixed width: the box holds "50%" through "300%", and letting it size to content
+                         would reflow the WrapPanel on every step. -->
+                    <TextBox x:Name="zoomEntryBox"
+                             Text="{Binding ZoomDisplay, Mode=OneWay}"
+                             Width="58"
+                             MinHeight="26"
+                             Padding="4,2"
+                             Margin="2"
+                             VerticalContentAlignment="Center"
+                             TextAlignment="Center"
+                             ToolTip.Tip="Book text zoom, stored per script — it applies to every open book in this script. Type a percentage, e.g. 115. Enter to apply, Escape to cancel."/>
+                    <Button x:Name="zoomInButton"
+                            IsEnabled="{Binding CanZoomIn}"
+                            Margin="2" Padding="8,2" MinWidth="0"
+                            ToolTip.Tip="Zoom in">
+                        <TextBlock Text="+"/>
+                    </Button>
+                </StackPanel>
+
             </WrapPanel>
         </DockPanel>
 

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -132,6 +132,9 @@ public partial class BookDisplayView : UserControl
         // #570: wire the find bar's controls. The bar itself stays hidden until Cmd/Ctrl+F.
         SetupFindBar();
 
+        // #618: wire the toolbar's zoom control (step buttons and the percentage box).
+        SetupZoomControl();
+
         // Try to create WebView browser
         TryCreateWebView();
     }
@@ -944,6 +947,85 @@ public partial class BookDisplayView : UserControl
 
     /// <summary>Back to 100% — the shipped stylesheet sizes exactly.</summary>
     public void ResetZoom() => StepZoom(s => s.ResetZoom(_viewModel!.BookScript), "reset");
+
+    /// <summary>
+    /// Set an arbitrary zoom. Public so the toolbar percentage box can drive it. (#618)
+    ///
+    /// Goes through <see cref="StepZoom"/> like the other three rather than calling CEF: the service raises
+    /// ZoomChanged, every view showing this script applies it, and that is what keeps a second tab from
+    /// disagreeing with this one about what it is displaying.
+    /// </summary>
+    public void SetZoom(double zoom) => StepZoom(s => s.SetZoom(_viewModel!.BookScript, zoom), "set");
+
+    // The toolbar percentage box. The step buttons need no state — they call the same ZoomIn/ZoomOut the
+    // keyboard does — but the box has to be put back to the stored value after every commit, so it is held.
+    private TextBox? _zoomEntryBox;
+
+    private void SetupZoomControl()
+    {
+        _zoomEntryBox = this.FindControl<TextBox>("zoomEntryBox");
+        if (_zoomEntryBox != null)
+        {
+            _zoomEntryBox.KeyDown += OnZoomEntryKeyDown;
+            // Committing on focus loss costs nothing: SetZoom no-ops when the value is unchanged, which is
+            // what leaving the box untouched produces.
+            _zoomEntryBox.LostFocus += (_, _) => CommitZoomEntry();
+            // Select on focus so typing replaces the percentage instead of appending to it. Posted, not
+            // immediate: on a pointer-initiated focus the TextBox positions the caret from the click AFTER
+            // raising GotFocus, which would undo a selection made here and leave typing inserting into
+            // "100%" — the very thing this exists to prevent. (fable review)
+            _zoomEntryBox.GotFocus += (_, _) => Dispatcher.UIThread.Post(() => _zoomEntryBox?.SelectAll());
+        }
+
+        var zoomOut = this.FindControl<Button>("zoomOutButton");
+        var zoomIn = this.FindControl<Button>("zoomInButton");
+        if (zoomOut != null) zoomOut.Click += (_, _) => ZoomOut();
+        if (zoomIn != null) zoomIn.Click += (_, _) => ZoomIn();
+    }
+
+    private void OnZoomEntryKeyDown(object? sender, KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Enter:
+                CommitZoomEntry();
+                e.Handled = true;
+                break;
+            case Key.Escape:
+                // Abandon the edit. Handled so it stays in the box rather than reaching the find bar's
+                // close-on-Escape.
+                RevertZoomEntryText();
+                e.Handled = true;
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Applies what is in the box, then puts the box back to what is actually stored.
+    ///
+    /// The second half is not redundant. A rejected entry must not sit there looking applied, and an
+    /// accepted one has been clamped and rounded on the way through the service — so the box showing "500"
+    /// while the book renders at 300% would be the control lying about the state it exists to report.
+    /// </summary>
+    private void CommitZoomEntry()
+    {
+        if (_isShutDown || _zoomEntryBox == null) return;
+
+        if (BookZoomReadout.TryParseEntry(_zoomEntryBox.Text, out var zoom))
+            SetZoom(zoom);
+
+        RevertZoomEntryText();
+    }
+
+    private void RevertZoomEntryText()
+    {
+        // StepZoom is synchronous on the UI thread, so by now the service holds the new value and the VM
+        // reads it straight through; the binding's own update arrives later and sets the same text.
+        // SetCurrentValue rather than the CLR setter: the box's Text carries a binding to ZoomDisplay, and
+        // this must not displace it — the binding is how a change made in another tab reaches this box.
+        if (_zoomEntryBox != null && _viewModel != null)
+            _zoomEntryBox.SetCurrentValue(TextBox.TextProperty, _viewModel.ZoomDisplay);
+    }
 
     private void StepZoom(Func<IBookZoomService, double> step, string what)
     {


### PR DESCRIPTION
Chrome's PDF-viewer control, in the book toolbar: `[−] [100%] [+]`.

The value box is the only surface that can **arrive** at a percentage instead of walking to it. It is also the only thing anywhere in the reader that says a book is zoomed at all — before this the sole disclosure was a line in the Settings dialog, so a book zoomed weeks ago just looked wrong with nothing in view to explain it.

The service layer landed in #619. This adds no mechanism, only a surface onto it: every path goes through `IBookZoomService`, so a change here re-zooms every open book in the script by exactly the route ⌘/Ctrl +/− already used, and nothing new touches CEF.

## Decisions taken during implementation

**No reset button, no preset menu.** Typing `100` is the reset, ⌘/Ctrl+0 remains the keyboard route, and the step buttons already walk the ladder. This settles the decision #618 §7 asked to be made rather than arrived at: #612's call to omit a reset affordance stands.

**No script name beside the value.** #618 §3 asked for `Devanagari 125%`. Zoom has been per script since #572, so this control is not introducing that behaviour, only giving it a second surface — labelling it here would be the control apologising for something it did not do. The scope is stated in the box's own tooltip instead of spent on toolbar width.

**Always visible**, rather than #618 §8's "occupies no visible width at 100%" — the reference model shows `100%` displayed.

**Typed values round to whole percent.** Not the ladder snapping §6 rules out — 115 stays 115, nowhere near a rung. It is so the stored value and the displayed one cannot disagree, since the box shows whole percent.

## Where the logic lives

`BookZoomReadout`, not `BookDisplayViewModel` — that VM cannot be constructed in a test: it needs a `Book`, a dock factory and a WebView, and it starts loading in its constructor. #618 §9 wants the event filtering, the script re-read and the parsing tested without a browser, so everything that could be wrong lives where a test can drive it against a real `BookZoomService`. Two readouts on one service is how the two-tabs-one-script case is covered.

## Review

Fable-reviewed; every finding fixed. Three worth recording:

- **The per-script scope was stated on a tooltip that could essentially never be shown.** It sat on the group panel, where each child's own tip shadows it, leaving it reachable only in the pixels between the controls — on a panel with no background, so probably not even there. Since dropping the script name made that tooltip the *only* disclosure, this was the substitute failing silently. It moves to the value box.
- **Select-all-on-focus was defeated by the mouse.** A `TextBox` positions the caret from the click *after* raising `GotFocus`, so typing would insert into `100%` rather than replace it — the very thing the handler exists to prevent. Now posted.
- **An epsilon divergence introduced here**, `0.0005` against the service's `0.001`. A value in the gap enables a step button that the service then treats as no change, so it does nothing when pressed: exactly the dead button the greying exists to avoid. Rather than re-tune the copy, the service's constant becomes public and the duplicate is deleted.

Also caught: **a test that passed with `ScriptChanged()` gutted to a no-op**, because `Display` re-reads the script on every access. The shipped box repaints only when the VM raises property-changed, so it would have sat on the old script's percentage after a script switch. Mutation-verified — the added assertion fails against that revert, and 27 of 28 still pass, which is what makes it the right assertion.

## Testing

Full suite **1518 passed, 0 failed**, including 28 new tests.

Verified in the running app by the maintainer. Three checks still want a human, none of them statically verifiable: hover the box to confirm the tooltip appears, click-then-type in it (the `GotFocus` fix above is Avalonia-version-dependent), and two tabs on one script moving together.

## Known, and not this PR

⌘/Ctrl +/− can act on the wrong document when focus is not inside a book's WebView — see #621, which this control sidesteps because each book's toolbar always acts on its own book.

Closes #618.
