### PR TITLE
Restore books that were floated or moved to another split (#623)

### DIFF
--- a/docs/architecture/DOCK_WEBVIEW_WORKAROUNDS.md
+++ b/docs/architecture/DOCK_WEBVIEW_WORKAROUNDS.md
@@ -71,9 +71,35 @@ candidate to *replace* (not re-add) in the overhaul.
 | `RemoveToolFromLayout` finds owning floating window + closes it when empty; `IsLayoutEmpty` recursion | LayoutViewModel ~301–367, 475–501 | Need to find which window owns a now-empty dock and close it. (This is what removes `LeftToolDock` → panel-restore no-op bug.) |
 | Unfloat cleans up **only the source** floating window, NOT all ("DO NOT check all — was causing other floating windows to disappear") | CstDockFactory ~1508–1528 | Global empty-check closed windows whose document refs were transiently null. |
 | Float wrapped in try-catch; on failure re-add to main dock | CstDockFactory ~1245–1285 | Partial float (removed from source, window-create failed) would orphan the document. |
-| Remove book-window **state before** removing the dockable; capture source window **before** removal | CstDockFactory ~1330–1332, 1455–1466 | Removal fires collection-changed handlers; ordering avoids double-cleanup / lost references. |
+| ~~Remove book-window **state before** removing the dockable~~ — **REVERSED, see below.** Capture source window **before** removal still applies | CstDockFactory (state: `CloseDockable`; window capture ~1455–1466) | Capturing the source window before removal still avoids lost references. The state half was wrong and caused #623. |
 | `CreateWindowFrom` try-catch → basic `CreateCstHostWindow` fallback | CstDockFactory ~1769–1801 | Host-window customization can fail; a basic window beats a crash. |
 | Deferred empty floating-window auto-close via collection-changed handler | CstDockFactory ~1848–1854 | Can't close a window synchronously during collection modification. |
+
+### E.1 Book-window state is deleted in exactly ONE place (#623)
+
+**`CloseDockable` is the only place that may delete a `BookWindowState`, and it must do so AFTER
+`base.CloseDockable` and only if the dockable actually left.** Do not add state cleanup to a
+collection-changed handler, to `RemoveDockable`, or to any other removal path, however reasonable it looks
+there.
+
+The reason is a property of Dock rather than of this app: **a move and a close are the same removal.**
+Floating a book, or dragging it to another split, calls `RemoveDockable` and raises collection-changed on the
+source dock — indistinguishable from closing it. Cleanup wired to those events therefore destroys the saved
+state of a book the user merely moved, and the book silently fails to reopen on the next launch. That was
+#623, and it had accumulated across **four** call sites, three of them wrong.
+
+`CloseDockable` is reached by every genuine close: the tab close button, ⌘W in the main window and in a
+floating window, `CloseBook(id)`, Close Others/All, and closing a floating window that still holds books
+(which closes its tabs individually first). The only Dock path that bypasses it, `HideDockable`, is
+unreachable here — `HideDocumentsOnClose` / `HideToolsOnClose` are never set.
+
+The ordering matters too: `base.CloseDockable` can **decline** (`CanClose` false, `CanCloseLastDockable`, a
+closing-event veto). Deleting first left an open book with no state, and since this is now the only deletion
+site, nothing would heal it.
+
+**Companion rule:** `SaveAllBookWindowStatesAsync` must walk **every** document dock — main-window splits and
+every floating window — not `FindDocumentDock()`, which returns only the first one it finds in the main tree.
+With a main-only walk, a moved book's entry survives but never updates, so it reopens at a stale position.
 
 ## F. Async / render timing
 

--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryBookStateScopeTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryBookStateScopeTests.cs
@@ -1,0 +1,184 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// #623: books floated into a separate window, or dragged to a second split, were not reopened at startup.
+///
+/// <para>
+/// Two defects, one on top of the other. The visible one was that the saved state was <b>deleted on a
+/// move</b>: Dock uses the same removal for "moved" and "closed", so cleanup wired to removal events
+/// destroyed the state of a book the user had merely dragged. Underneath it, the save walk only ever visited
+/// the <b>first</b> document dock in the main window — so even with the deletes gone, a moved book's entry
+/// would survive but never update again, reopening at a stale reading position with a tab index frozen at
+/// zero.
+/// </para>
+///
+/// <para>
+/// The second defect is what these tests pin, because it is the one with a pure, reachable seam. The deletion
+/// sites need a live <c>BookDisplayViewModel</c> (services and a CEF View), so they are covered by the
+/// documented invariant in DOCK_WEBVIEW_WORKAROUNDS.md §E.1 and by manual verification, not from here.
+/// </para>
+/// </summary>
+public class CstDockFactoryBookStateScopeTests
+{
+    private sealed class TestDockFactory : CstDockFactory
+    {
+        private readonly List<IDock> _floating = new();
+        public void SetFloatingLayouts(params IDock[] layouts) { _floating.Clear(); _floating.AddRange(layouts); }
+        internal override IEnumerable<IDock> GetFloatingLayouts() => _floating;
+    }
+
+    private static DocumentDock Dock(string id, params IDockable[] docs)
+    {
+        var dock = new DocumentDock { Id = id, VisibleDockables = new ObservableCollection<IDockable>(docs) };
+        foreach (var d in docs) d.Owner = dock;
+        return dock;
+    }
+
+    private static RootDock Root(string id, params IDockable[] children)
+    {
+        var root = new RootDock { Id = id, VisibleDockables = new ObservableCollection<IDockable>(children) };
+        foreach (var c in children) c.Owner = root;
+        return root;
+    }
+
+    private static Document Doc(string id) => new() { Id = id };
+
+    // ---- The walk ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_walk_reaches_a_second_split_in_the_main_window()
+    {
+        // FindDocumentDock returns the FIRST document dock and stops. A book dragged into a split beside it
+        // was therefore never re-saved, so its position and tab index froze where it left.
+        var f = new TestDockFactory();
+        var left = Dock("LeftDock", Doc("a"));
+        var right = Dock("RightDock", Doc("b"));
+        f._context = Root("MainRoot", left, right);
+
+        var docks = f.CollectAllBookDocks();
+
+        Assert.Contains(left, docks);
+        Assert.Contains(right, docks);
+    }
+
+    [Fact]
+    public void The_walk_reaches_floating_windows()
+    {
+        var f = new TestDockFactory();
+        var main = Dock("MainDock", Doc("a"));
+        var floated = Dock("FloatDock", Doc("b"));
+        f._context = Root("MainRoot", main);
+        f.SetFloatingLayouts(Root("FloatRoot", floated));
+
+        var docks = f.CollectAllBookDocks();
+
+        Assert.Contains(main, docks);
+        Assert.Contains(floated, docks);
+    }
+
+    [Fact]
+    public void The_walk_finds_docks_nested_below_splitters()
+    {
+        // A real split is not a flat sibling — Dock nests ProportionalDocks. A non-recursive walk would see
+        // the outer container and miss every document dock inside it.
+        var f = new TestDockFactory();
+        var inner = Dock("InnerDock", Doc("a"));
+        var middle = Root("Splitter", inner);
+        f._context = Root("MainRoot", middle);
+
+        Assert.Contains(inner, f.CollectAllBookDocks());
+    }
+
+    [Fact]
+    public void Main_window_docks_come_before_floating_ones()
+    {
+        // The tab order persisted for restore is a single counter over this walk, so the walk order IS the
+        // restored order. Main-window books ahead of floated ones is the rule; what matters for the test is
+        // that it is deterministic rather than incidental.
+        var f = new TestDockFactory();
+        var main = Dock("MainDock", Doc("a"));
+        var floated = Dock("FloatDock", Doc("b"));
+        f._context = Root("MainRoot", main);
+        f.SetFloatingLayouts(Root("FloatRoot", floated));
+
+        var docks = f.CollectAllBookDocks();
+
+        Assert.True(docks.IndexOf(main) < docks.IndexOf(floated));
+    }
+
+    [Fact]
+    public void Multiple_floating_windows_are_all_walked_in_order()
+    {
+        var f = new TestDockFactory();
+        var one = Dock("Float1Dock", Doc("a"));
+        var two = Dock("Float2Dock", Doc("b"));
+        f._context = Root("MainRoot");
+        f.SetFloatingLayouts(Root("Float1Root", one), Root("Float2Root", two));
+
+        var docks = f.CollectAllBookDocks();
+
+        Assert.Equal(new[] { one, two }, docks);
+    }
+
+    [Fact]
+    public void A_layout_with_no_document_docks_yields_nothing_rather_than_throwing()
+    {
+        var f = new TestDockFactory();
+        f._context = Root("MainRoot");
+
+        Assert.Empty(f.CollectAllBookDocks());
+    }
+
+    // ---- Restore order ----------------------------------------------------------------------------
+
+    private static BookWindowState Book(string id, int tabIndex) =>
+        new() { WindowId = id, TabIndex = tabIndex, BookIndex = 0 };
+
+    [Fact]
+    public void Books_are_restored_in_tab_order_not_in_list_order()
+    {
+        // BookWindows is maintained by remove-then-add, so its natural order is LAST-TOUCHED: scrolling the
+        // first tab moves it to the end of the list. Restoring in list order shuffled the tabs on every
+        // launch.
+        var saved = new[] { Book("third", 2), Book("first", 0), Book("second", 1) };
+
+        Assert.Equal(new[] { "first", "second", "third" },
+            BookRestoreOrder.Apply(saved).Select(b => b.WindowId));
+    }
+
+    [Fact]
+    public void A_tie_falls_back_to_the_persisted_order_rather_than_an_arbitrary_one()
+    {
+        // Entries need not all come from the same save, so two can share an index. A stable sort makes that
+        // deterministic; an unstable one would reintroduce the shuffle intermittently, which is far worse to
+        // diagnose than doing it every time.
+        var saved = new[] { Book("a", 1), Book("b", 1), Book("c", 1) };
+
+        Assert.Equal(new[] { "a", "b", "c" }, BookRestoreOrder.Apply(saved).Select(b => b.WindowId));
+    }
+
+    [Fact]
+    public void An_empty_or_null_set_restores_nothing()
+    {
+        Assert.Empty(BookRestoreOrder.Apply(null));
+        Assert.Empty(BookRestoreOrder.Apply(new List<BookWindowState>()));
+    }
+
+    [Fact]
+    public void Every_saved_book_survives_the_ordering()
+    {
+        // The ordering must not be a filter. Losing a book here would look exactly like the bug being fixed.
+        var saved = Enumerable.Range(0, 20).Select(i => Book($"b{i}", 19 - i)).ToList();
+
+        Assert.Equal(20, BookRestoreOrder.Apply(saved).Count);
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -839,7 +839,9 @@ public partial class App : Application
                 // First pass: open all books (on the UI thread) and note which one should be selected
                 await Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    var bookWindowsCopy = bookWindows.ToList();
+                    // Restored in TAB ORDER, not in list order — see BookRestoreOrder for why the distinction
+                    // exists and why the sort has to be a stable one. (#623)
+                    var bookWindowsCopy = BookRestoreOrder.Apply(bookWindows);
                     foreach (var bookWindowState in bookWindowsCopy)
                     {
                         try

--- a/src/CST.Avalonia/Models/BookRestoreOrder.cs
+++ b/src/CST.Avalonia/Models/BookRestoreOrder.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CST.Avalonia.Models;
+
+/// <summary>
+/// The order saved books are reopened in. (#623)
+///
+/// <para>
+/// Its own type, small as it is, because the ordering is not a property of the list it is applied to.
+/// <c>ApplicationState.BookWindows</c> is maintained by remove-then-add
+/// (<c>ApplicationStateService.UpdateBookWindowState</c>), so its natural order is <b>last-touched</b> — read
+/// the file and the books appear in the order they were last scrolled, not the order they sat in. Restoring
+/// in list order therefore shuffled the tabs, and no amount of correctness elsewhere would have fixed it.
+/// </para>
+///
+/// <para>
+/// Restoration flattens every book into the main window's document dock beside the Welcome page. Restoring
+/// the LAYOUT — which window, which split — is deliberately out of scope, so a single flat index is the whole
+/// of what has to survive.
+/// </para>
+/// </summary>
+internal static class BookRestoreOrder
+{
+    /// <summary>
+    /// Saved books in the order they should be reopened.
+    ///
+    /// <para>
+    /// <b>Stable, and that is load-bearing.</b> Not every entry is necessarily written by the same save: an
+    /// entry can carry an index from an earlier walk, so two books can share one. LINQ's <c>OrderBy</c> is
+    /// documented as a stable sort, which makes a tie fall back to the persisted list order rather than to
+    /// an arbitrary one — the same two books come back in the same two places on every launch. Swapping in
+    /// an unstable sort would reintroduce the shuffle this exists to remove, and only intermittently.
+    /// </para>
+    /// </summary>
+    internal static List<BookWindowState> Apply(IEnumerable<BookWindowState>? books) =>
+        books is null
+            ? new List<BookWindowState>()
+            : books.OrderBy(b => b.TabIndex).ToList();
+}

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -136,12 +136,15 @@ namespace CST.Avalonia.Services
                         {
                             Log.Information("*** REMOVED ITEM: {ItemType} {ItemId} ***", item?.GetType().Name, (item as IDockable)?.Id);
 
-                            // Clean up application state when documents are removed
-                            if (item is BookDisplayViewModel removedBookViewModel)
-                            {
-                                Log.Debug("*** Document removed from UI - cleaning up application state: {DocumentId} ***", removedBookViewModel.Id);
-                                RemoveBookWindowState(removedBookViewModel.Id);
-                            }
+                            // NO STATE CLEANUP HERE, deliberately. A removal from this collection does not mean
+                            // the book was closed: floating it, or dragging it to another split, removes it from
+                            // this dock and adds it to another. Dock reuses the same removal for both, so this
+                            // event cannot tell them apart — and deleting the saved state on a MOVE is why a
+                            // floated or re-split book never came back on the next launch.
+                            //
+                            // CloseDockable is the only place that knows a close is a close, and it is reached
+                            // by every genuine close path: the tab button, Cmd+W in either window kind,
+                            // CloseBook(id), and closing a floating window that still holds books. (#623)
                         }
                     }
                     if (e.NewItems != null)
@@ -593,26 +596,61 @@ namespace CST.Avalonia.Services
             _logger.Debug("PDF document created: {DocumentId} with title: {Title}", pdfViewModel.Id, pdfViewModel.Title);
         }
 
+        /// <summary>
+        /// Every document dock that can hold a book, in the order the persisted tab order depends on: the
+        /// main window's docks in tree-traversal order, then each floating window's, in HostWindows order.
+        ///
+        /// <para>
+        /// The walk used to be <see cref="FindDocumentDock"/>, which returns the FIRST document dock in the
+        /// main tree and nothing else — so a book that had been floated or dragged into a second split was
+        /// never re-saved. Its entry survived (once the move-path deletes were removed) but froze at whatever
+        /// was true when it left the original dock, which would have reopened it at a stale reading position
+        /// and left its tab index permanently at zero. (#623)
+        /// </para>
+        /// </summary>
+        internal List<DocumentDock> CollectAllBookDocks()
+        {
+            var docks = FindAllDocumentDocksInLayout(_context as IDock);
+            foreach (var layout in GetFloatingLayouts())
+                docks.AddRange(FindAllDocumentDocksInLayout(layout));
+            return docks;
+        }
+
         public async Task SaveAllBookWindowStatesAsync()
         {
             try
             {
-                var documentDock = FindDocumentDock();
-                if (documentDock?.VisibleDockables == null) return;
+                var docks = CollectAllBookDocks();
+                if (docks.Count == 0) return;
 
-                var activeDocument = documentDock.ActiveDockable;
-                Log.Debug("*** Saving all book states - Active document: {ActiveId} ***", activeDocument?.Id ?? "none");
+                // Exactly ONE book may carry IsSelected: restore flattens every book into the main dock and
+                // takes the LAST entry flagged true, so two of them would make the restored selection depend
+                // on list order. The main dock's active document is the rule — it is the tab the user was
+                // looking at in the window they were working in. (#623)
+                var mainActive = FindDocumentDock()?.ActiveDockable;
+                Log.Debug("*** Saving all book states across {DockCount} dock(s) - Active document: {ActiveId} ***",
+                    docks.Count, mainActive?.Id ?? "none");
 
-                // Snapshot before iterating: there is an await inside the loop, and a concurrent dock
-                // drag/cleanup can modify VisibleDockables during it, throwing "Collection was modified".
-                foreach (var dockable in documentDock.VisibleDockables.ToList())
+                // One flat counter across the whole walk. Per-dock indices plus a dock ordinal would buy
+                // nothing while restore flattens everything, and when layout restoration does arrive it will
+                // need dock IDENTITY rather than an ordinal — so half-building it now would be wasted.
+                var tabIndex = 0;
+
+                foreach (var dock in docks)
                 {
-                    if (dockable is BookDisplayViewModel bookDisplayViewModel &&
-                        bookDisplayViewModel.Book != null)
+                    if (dock.VisibleDockables == null) continue;
+
+                    // Snapshot before iterating: there is an await inside the loop, and a concurrent dock
+                    // drag/cleanup can modify VisibleDockables during it, throwing "Collection was modified".
+                    foreach (var dockable in dock.VisibleDockables.ToList())
                     {
+                        if (dockable is not BookDisplayViewModel bookDisplayViewModel ||
+                            bookDisplayViewModel.Book == null)
+                            continue;
+
                         // The snapshot can contain books closed since we started; don't touch their
                         // (possibly disposed) WebView state. (DOCK-3)
-                        if (!documentDock.VisibleDockables.Contains(dockable))
+                        if (!dock.VisibleDockables.Contains(dockable))
                         {
                             Log.Debug("*** Skipping state save for {BookFileName} - closed before capture ***",
                                 bookDisplayViewModel.Book.FileName);
@@ -626,18 +664,21 @@ namespace CST.Avalonia.Services
                         // already run for that book, and saving now would re-ADD the removed state
                         // (UpdateBookWindowState is add-if-missing) — a ghost tab on next launch.
                         // Re-check against the LIVE collection, not the snapshot. (DOCK-3)
-                        if (!documentDock.VisibleDockables.Contains(dockable))
+                        //
+                        // Still required after #622, and arguably more so: CloseDockable is now the only
+                        // thing that deletes book state, so a re-add here would never be corrected.
+                        if (!dock.VisibleDockables.Contains(dockable))
                         {
                             Log.Debug("*** Skipping state save for {BookFileName} - closed during save loop ***",
                                 bookDisplayViewModel.Book.FileName);
                             continue;
                         }
 
-                        // Only the active document gets IsSelected = true
-                        var isSelected = dockable == activeDocument;
-                        SaveBookWindowState(bookDisplayViewModel.Book, bookDisplayViewModel, isSelected);
-                        Log.Debug("*** Saved state for {BookFileName} - IsSelected: {IsSelected} ***",
-                            bookDisplayViewModel.Book.FileName, isSelected);
+                        var isSelected = ReferenceEquals(dockable, mainActive);
+                        SaveBookWindowState(bookDisplayViewModel.Book, bookDisplayViewModel, isSelected, tabIndex);
+                        Log.Debug("*** Saved state for {BookFileName} - Tab: {TabIndex}, IsSelected: {IsSelected} ***",
+                            bookDisplayViewModel.Book.FileName, tabIndex, isSelected);
+                        tabIndex++;
                     }
                 }
             }
@@ -647,7 +688,14 @@ namespace CST.Avalonia.Services
             }
         }
 
-        private void SaveBookWindowState(CST.Book book, BookDisplayViewModel bookDisplayViewModel, bool? isSelected = null)
+        /// <param name="tabIndex">
+        /// Position in the flat walk order, or null to derive it from the book's OWN owner dock. Null is for
+        /// callers outside <see cref="SaveAllBookWindowStatesAsync"/>, which have no walk to count against —
+        /// deriving it from <see cref="FindDocumentDock"/> instead would give every floated book the index it
+        /// would have had in the main dock, which is nonsense. (#623)
+        /// </param>
+        private void SaveBookWindowState(CST.Book book, BookDisplayViewModel bookDisplayViewModel,
+            bool? isSelected = null, int? tabIndex = null)
         {
             try
             {
@@ -672,6 +720,15 @@ namespace CST.Avalonia.Services
                 // Use provided isSelected value or determine it dynamically
                 var isSelectedValue = isSelected ?? (bookDisplayViewModel == FindDocumentDock()?.ActiveDockable);
 
+                // From the book's OWN dock, not the main one — a book opened straight into a floating window
+                // or a second split still gets a meaningful position among its siblings. Only relative order
+                // survives to restore, so a raw IndexOf is enough; Welcome and PDF tabs occupying slots is
+                // harmless for the same reason. (#623)
+                var tabIndexValue = tabIndex
+                    ?? (bookDisplayViewModel.Owner as IDock)?.VisibleDockables?.IndexOf(bookDisplayViewModel)
+                    ?? 0;
+                if (tabIndexValue < 0) tabIndexValue = 0;
+
                 // Get the cached scroll position anchor for restoration on next startup
                 // The anchor is updated every 200ms by the scroll timer and persists in the ViewModel
                 string? currentAnchor = bookDisplayViewModel.LastCapturedAnchor;
@@ -692,7 +749,7 @@ namespace CST.Avalonia.Services
                     ReadingPosition = bookDisplayViewModel.LastPositionToken, // #434 exact reading position (preferred)
                     CurrentHitIndex = bookDisplayViewModel.CurrentHitIndex, // Save which search hit was active
                     TotalHits = bookDisplayViewModel.TotalHits,
-                    TabIndex = 0, // TODO: Get actual tab index from dock
+                    TabIndex = tabIndexValue,
                     IsSelected = isSelectedValue,
                     ShowFootnotes = bookDisplayViewModel.ShowFootnotes,
                     ShowSearchTerms = bookDisplayViewModel.ShowSearchTerms
@@ -1579,14 +1636,22 @@ namespace CST.Avalonia.Services
 
             if (dockable != null)
             {
-                // Remove from application state if it's a BookDisplayViewModel
-                if (dockable is BookDisplayViewModel)
+                base.CloseDockable(dockable);
+
+                // AFTER the base call, and only if the dockable actually left. base.CloseDockable can DECLINE
+                // (CanClose false, CanCloseLastDockable, a closing-event veto), and deleting first meant a
+                // declined close left an open book with no saved state — invisible until it failed to reappear
+                // next launch. This is now the ONLY place book state is deleted, so nothing else would heal it.
+                // Same tripwire idiom as CloseBook(id). (#623)
+                if (dockable is BookDisplayViewModel && FindDockable(dockable.Id) == null)
                 {
                     RemoveBookWindowState(dockable.Id);
                     Log.Debug("*** Removed book window state for {DockableId} ***", dockable.Id);
                 }
-
-                base.CloseDockable(dockable);
+                else if (dockable is BookDisplayViewModel)
+                {
+                    Log.Debug("*** Close declined for {DockableId} - book window state kept ***", dockable.Id);
+                }
 
                 // Tab permanently closed: release the VM's subscriptions and drop its GoTo id so
                 // neither leaks for the rest of the session. (Safe here — CloseDockable is the real
@@ -1812,13 +1877,10 @@ namespace CST.Avalonia.Services
             Log.Debug("*** RemoveDockable called - Dockable: {DockableId}, Collapse: {Collapse} ***", dockable?.Id, collapse);
             if (dockable != null)
             {
-                // Remove from application state if it's a BookDisplayViewModel
-                if (dockable is BookDisplayViewModel)
-                {
-                    RemoveBookWindowState(dockable.Id);
-                    Log.Debug("*** Removed book window state for {DockableId} ***", dockable.Id);
-                }
-
+                // NO STATE CLEANUP HERE. This is Dock's generic removal and it is what runs during a REPARENT:
+                // SplitToWindow calls RemoveDockable before re-adding to the new window, and a cross-dock
+                // MoveDockable does the same. Deleting the saved state here meant every float and every drag
+                // between splits destroyed it. A real close arrives via CloseDockable instead. (#623)
                 base.RemoveDockable(dockable, collapse);
             }
             else
@@ -1937,12 +1999,10 @@ namespace CST.Avalonia.Services
                             {
                                 Log.Debug("*** FLOATING WINDOW REMOVED ITEM: {ItemType} {ItemId} ***", item?.GetType().Name, (item as IDockable)?.Id);
 
-                                // Clean up application state when documents are removed from floating windows
-                                if (item is BookDisplayViewModel removedBookViewModel)
-                                {
-                                    Log.Debug("*** Document removed from floating window - cleaning up application state: {DocumentId} ***", removedBookViewModel.Id);
-                                    RemoveBookWindowState(removedBookViewModel.Id);
-                                }
+                                // NO STATE CLEANUP HERE — same reasoning as the main-dock monitor in
+                                // CreateLayout, and the twin this fix would have missed. Removing it from the
+                                // main monitor alone would have fixed float-OUT while leaving float-BACK and
+                                // float-to-float still deleting the state on the way past. (#623)
                             }
                         }
                         if (e.NewItems != null)


### PR DESCRIPTION
Closes #623. Diagnosis reviewed by Fable **before** implementation — which caught two things my original plan missed, both noted below.

## Not a missing feature — the state was being deleted

Session restoration reopened books left in the original DocumentDock and silently dropped any book that had been floated or dragged to another split.

The cause is a property of Dock rather than of this app: **a move and a close are the same removal.** `SplitToWindow` calls `RemoveDockable` before re-adding to the new window; a cross-dock `MoveDockable` does the same; both raise collection-changed on the source dock. So no removal event can classify itself, and cleanup wired to one is guessing.

That guess was wired into **four** places, three of them wrong:

| Site | What it is | Fires on a move? |
|---|---|---|
| `CstDockFactory.cs:143` | `CollectionChanged` on the main DocumentDock | **Yes** |
| `CstDockFactory.cs:1585` | `CloseDockable` — the real close path | No |
| `CstDockFactory.cs:1818` | `RemoveDockable` | **Yes** |
| `CstDockFactory.cs:1944` | `CollectionChanged` per floating window | **Yes** |

Deletion is now `CloseDockable` only, which is reached by every genuine close: tab button, ⌘W in either window kind, `CloseBook(id)`, Close Others/All, and closing a floating window that still holds books. Each removed site carries a comment saying why *not* — the wrong version looks entirely reasonable in place, which is how it got to four.

> **Fable caught the fourth site.** I had found three; I missed `:1944` because I piped a grep through `head`. Fixing only the first three would have repaired float-*out* while leaving float-*back* and float-to-float still deleting state on the way past.

## The half-fix underneath

`SaveAllBookWindowStatesAsync` walked `FindDocumentDock()` — the **first** document dock in the main tree, never a split, never a floating window. So with the deletes gone, a moved book's entry would have *survived but never updated*: reading position, hit index, `IsSelected` and `TabIndex` frozen at the moment it left the original dock. It would reopen at a stale position, and the tab-order work below would have been **inert for exactly the books this fixes**.

The walk now covers main-window splits plus every floating window, reusing the existing `FindAllDocumentDocksInLayout` and `GetFloatingLayouts` seams. No new triggers were added — mid-drag `CaptureCurrentPositionAsync` round-trips are DOCK-3 territory.

## Ordering hardened

`CloseDockable` deleted state **before** calling `base`, which can decline (`CanClose` false, `CanCloseLastDockable`, a closing-event veto). A declined close left an open book with no state — and now that this is the only deletion site, nothing would heal it. It deletes afterwards, and only if the dockable actually left, using the same tripwire idiom as `CloseBook(id)`.

## Tab order was a stub

`TabIndex` was written as a hardcoded `0` behind a `// TODO` and never read. Since `BookWindows` is maintained by remove-then-add, its natural order is **last-touched** — books came back shuffled.

Now a single flat counter over one deterministic walk, sorted on restore by a small extracted `BookRestoreOrder`. Extracted so that two things are stated and tested in one place: that ordering is not a property of the list, and that **the sort must be stable** — entries need not come from the same save, so two can share an index, and an unstable sort would reintroduce the shuffle *intermittently*, which is far worse to diagnose than doing it every time.

`IsSelected` is assigned to exactly one book, since restore takes the last entry flagged true.

## Scope

Every book reopens in the main window's dock beside the Welcome page. **Restoring the layout — which window, which split — is deliberately out of scope.**

## The inventory said to do the wrong thing

`DOCK_WEBVIEW_WORKAROUNDS.md` §E carried a row instructing *"Remove book-window state before removing the dockable"* — the precise ordering that caused this. Struck, and replaced with **§E.1** stating the invariant, why a move and a close are indistinguishable, why `CloseDockable` is sufficient, and the companion rule about the walk. Left as-is, it would have led the next reader straight back in.

## Verification

**1528/1528**, rebased onto and re-run against #622 (merged as `94774fe`) — no file overlap, clean rebase.

**Mutation-verified:** reverting the walk to `FindDocumentDock()` fails exactly the four coverage tests and no others. The deletion sites need a live `BookDisplayViewModel` with services and a CEF View, so they rest on the documented invariant and manual verification rather than unit tests — stated plainly in the test file's header rather than implied by its absence.

## Deferred

**#624** — an end-of-walk prune making the persisted set *derived* from the dock tree, which would remove the move-vs-close classification problem entirely rather than narrowing it. Deferred because the walk spans `await`s, so a book mid-drag is transiently absent and a naive prune would delete it; the two constraints for doing it safely are written down there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)