### PR TITLE
Derive the persisted book set from the dock tree (#624)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/BookStatePruneTests.cs
+++ b/src/CST.Avalonia.Tests/Services/BookStatePruneTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Models;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// #624: the persisted book set becomes DERIVED from the live docks rather than maintained by removal events.
+///
+/// <para>
+/// #623's fix narrowed state deletion to <c>CloseDockable</c>, the one removal that genuinely means "closed".
+/// That is correct but still a classification scheme, and Dock gives no way to classify: a move and a close
+/// are the same removal. A set derived from what is actually open cannot be wrong about the distinction,
+/// because it never asks.
+/// </para>
+///
+/// <para>
+/// These tests are about <b>which set is sampled, and when</b> — the part that decides whether this is a
+/// cleanup or a data-loss bug. The threading that makes the sample trustworthy (a synchronous re-walk on the
+/// UI thread, with no <c>await</c> between the check and the removals) lives in
+/// <c>CstDockFactory.PruneStateForVanishedBooks</c> and is argued in its remarks.
+/// </para>
+/// </summary>
+public class BookStatePruneTests
+{
+    private static BookWindowState Book(string windowId) =>
+        new() { WindowId = windowId, BookIndex = 0 };
+
+    private static List<BookWindowState> Persisted(params string[] ids) =>
+        ids.Select(Book).ToList();
+
+    // ---- The guard that stops this destroying a session ------------------------------------------
+
+    [Fact]
+    public void An_empty_live_set_prunes_nothing()
+    {
+        // THE case this must never get wrong. At startup the layout is built with only the Welcome page,
+        // which becomes the active dockable, which fires the tab-change save — and that save runs BEFORE the
+        // restore path has copied the entries it is about to reopen. It walks real docks and finds no books.
+        // Pruning here would delete the entire saved session on every single launch, before anything read it.
+        Assert.Empty(BookStatePrune.Vanished(Persisted("a", "b", "c"), new List<string>()));
+    }
+
+    [Fact]
+    public void A_null_live_set_prunes_nothing()
+    {
+        Assert.Empty(BookStatePrune.Vanished(Persisted("a"), null));
+    }
+
+    [Fact]
+    public void Nothing_persisted_yields_nothing_to_prune()
+    {
+        Assert.Empty(BookStatePrune.Vanished(null, new[] { "a" }));
+        Assert.Empty(BookStatePrune.Vanished(new List<BookWindowState>(), new[] { "a" }));
+    }
+
+    // ---- What it is for --------------------------------------------------------------------------
+
+    [Fact]
+    public void An_entry_with_no_live_book_is_pruned()
+    {
+        var vanished = BookStatePrune.Vanished(Persisted("open", "gone"), new[] { "open" });
+
+        Assert.Equal(new[] { "gone" }, vanished);
+    }
+
+    [Fact]
+    public void Every_live_book_survives_however_many_docks_it_took_to_find_them()
+    {
+        // The live set is gathered across the main dock, every split and every floating window. A book is
+        // live wherever it lives — that is the whole point, and getting it wrong here would silently delete
+        // floated books, which is the bug #623 fixed.
+        var live = new[] { "main", "split", "floated" };
+
+        Assert.Empty(BookStatePrune.Vanished(Persisted("main", "split", "floated"), live));
+    }
+
+    [Fact]
+    public void A_book_present_at_sampling_time_is_kept_even_if_it_moved_during_the_save()
+    {
+        // The drag case, expressed as what it actually is: a question of WHEN the live set is sampled. The
+        // save loop is interleaved with awaits and can see a dragged book transiently in no dock; the prune
+        // samples afterwards, synchronously, and sees it in its new home. Passing the later sample is what
+        // keeps it.
+        var liveAfterTheDragLanded = new[] { "dragged" };
+
+        Assert.Empty(BookStatePrune.Vanished(Persisted("dragged"), liveAfterTheDragLanded));
+    }
+
+    // ---- Shape ------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Entries_with_no_window_id_are_ignored_rather_than_pruned_by_id()
+    {
+        // Removal is keyed by WindowId, so an entry without one cannot be addressed. Returning it would
+        // produce a removal call that silently matches nothing — or, worse, matches another blank entry.
+        var persisted = new List<BookWindowState> { Book(""), Book("real-and-gone") };
+
+        Assert.Equal(new[] { "real-and-gone" }, BookStatePrune.Vanished(persisted, new[] { "live" }));
+    }
+
+    [Fact]
+    public void A_duplicated_entry_is_reported_once()
+    {
+        // Duplicates should not exist, but UpdateBookWindowState is add-if-missing and a stale writer could
+        // produce one. Removing by the same id twice is harmless; reporting it twice is noise in the log.
+        var persisted = Persisted("gone", "gone");
+
+        Assert.Equal(new[] { "gone" }, BookStatePrune.Vanished(persisted, new[] { "live" }));
+    }
+
+    [Fact]
+    public void Window_ids_are_matched_exactly()
+    {
+        // They are GUIDs generated by the app, not user text. Case-insensitive matching would only create a
+        // way for two distinct books to be treated as one.
+        var vanished = BookStatePrune.Vanished(Persisted("ABC"), new[] { "abc" });
+
+        Assert.Equal(new[] { "ABC" }, vanished);
+    }
+}

--- a/src/CST.Avalonia/Models/BookStatePrune.cs
+++ b/src/CST.Avalonia/Models/BookStatePrune.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CST.Avalonia.Models;
+
+/// <summary>
+/// Which persisted book entries no longer correspond to an open book. (#624)
+///
+/// <para>
+/// The point of pruning is to stop <c>BookWindows</c> being maintained by <b>event bookkeeping</b> and make it
+/// <b>derived</b> from what actually exists. Dock uses the same removal operation for "moved" and "closed"
+/// (<c>SplitToWindow</c> removes before re-adding; a cross-dock <c>MoveDockable</c> does the same), so no
+/// removal event can classify itself — which is exactly how #623 happened, with the guess wired into four
+/// call sites, three of them wrong. A set derived from the live docks cannot be wrong about it, because it
+/// never asks.
+/// </para>
+///
+/// <para>
+/// Pure, and separate from the walk that feeds it, because the interesting cases are about <b>which set is
+/// sampled when</b> rather than about threading — and that is testable here without a dock, a view model or
+/// a browser. Same reasoning as <see cref="BookRestoreOrder"/>.
+/// </para>
+/// </summary>
+internal static class BookStatePrune
+{
+    /// <summary>
+    /// The <c>WindowId</c>s to remove: persisted entries with no live book.
+    ///
+    /// <para>
+    /// <b>An empty live set prunes nothing.</b> Not an optimisation — it is the guard that stops this from
+    /// destroying a session on every launch. At startup the layout is built with only the Welcome page, which
+    /// makes it the active dockable, which fires the tab-change save. That save walks real docks and finds no
+    /// books, and it runs BEFORE the restore path has copied the entries it is about to reopen. Pruning on an
+    /// empty live set would therefore delete the whole saved session, every time, before anything could read
+    /// it.
+    /// </para>
+    ///
+    /// <para>
+    /// Nothing is lost by the guard: with no books open, every removal has already gone through
+    /// <c>CloseDockable</c>, which deletes immediately. A prune has nothing to contribute in that state.
+    /// </para>
+    /// </summary>
+    internal static List<string> Vanished(
+        IEnumerable<BookWindowState>? persisted,
+        IReadOnlyCollection<string>? liveWindowIds)
+    {
+        if (persisted is null || liveWindowIds is null || liveWindowIds.Count == 0)
+            return new List<string>();
+
+        var live = new HashSet<string>(liveWindowIds, System.StringComparer.Ordinal);
+
+        return persisted
+            .Where(b => !string.IsNullOrEmpty(b.WindowId) && !live.Contains(b.WindowId))
+            .Select(b => b.WindowId)
+            .Distinct(System.StringComparer.Ordinal)
+            .ToList();
+    }
+}

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -681,10 +681,62 @@ namespace CST.Avalonia.Services
                         tabIndex++;
                     }
                 }
+
+                PruneStateForVanishedBooks();
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to save all book window states");
+            }
+        }
+
+        /// <summary>
+        /// Drops persisted entries whose book is in no dock, making the saved set DERIVED from what exists
+        /// rather than maintained by removal events. (#624)
+        ///
+        /// <para>
+        /// <b>Deliberately re-walks the docks instead of reusing the set the save loop just built.</b> That
+        /// loop is interleaved with <c>await</c>s — a JS round-trip into CEF per book — so a book being
+        /// dragged between docks can be transiently absent from every dock while it runs. Pruning against
+        /// what that loop happened to see would delete precisely the book the user is moving, which is #623
+        /// again in a new place and far harder to reproduce.
+        /// </para>
+        ///
+        /// <para>
+        /// <b>The re-walk and the removals are synchronous, with no <c>await</c> between them.</b> That is
+        /// what makes this atomic with respect to dock mutations rather than merely likely to be right:
+        /// Dock's moves run on the UI thread, so a walk that never yields cannot observe one half-finished.
+        /// The thread check below is therefore a correctness guard, not defensive habit — off the UI thread
+        /// the whole argument collapses, and skipping is the safe answer.
+        /// </para>
+        /// </summary>
+        private void PruneStateForVanishedBooks()
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                // Cannot establish the atomicity this depends on. CloseDockable still deletes on close, so
+                // skipping costs nothing but a delayed cleanup.
+                Log.Debug("*** Skipping book-state prune - not on the UI thread ***");
+                return;
+            }
+
+            var stateService = App.ServiceProvider?.GetService<IApplicationStateService>();
+            if (stateService == null) return;
+
+            var live = CollectAllBookDocks()
+                .SelectMany(d => d.VisibleDockables ?? Enumerable.Empty<IDockable>())
+                .OfType<BookDisplayViewModel>()
+                .Select(vm => vm.Id)
+                .Where(id => !string.IsNullOrEmpty(id))
+                .ToList();
+
+            var vanished = BookStatePrune.Vanished(stateService.Current.BookWindows, live);
+            if (vanished.Count == 0) return;
+
+            foreach (var windowId in vanished)
+            {
+                Log.Information("*** Pruning book state for {WindowId} - no longer in any dock ***", windowId);
+                stateService.RemoveBookWindowStateByWindowId(windowId);
             }
         }
 


### PR DESCRIPTION
Closes #624. Follow-up to #623 — this removes the bug *class* that fix narrowed.

## Why, when #623 already works

#623 narrowed book-state deletion to `CloseDockable`, the one removal that genuinely means "closed". That is correct and sufficient today. But it is still a **classification scheme**, and Dock offers no way to classify: `SplitToWindow` removes before re-adding, a cross-dock `MoveDockable` does the same, and both raise collection-changed on the source dock. **A move and a close are the same removal.**

That is how the guess ended up wired into four call sites, three of them wrong, and how floated books stopped coming back. The next plausible-looking cleanup in a removal handler does it again, silently.

A set **derived from the live docks** cannot be wrong about the distinction, because it never asks.

## What changed

`SaveAllBookWindowStatesAsync` now ends by dropping any persisted entry whose book is in no dock. `CloseDockable` keeps its immediate delete as a fast path — a crash between saves must not resurrect a book the user just closed.

**The prune re-walks the docks rather than reusing what the save loop saw.** That loop is interleaved with `await`s — a JS round-trip into CEF per book — so a book being dragged can be transiently absent from every dock while it runs. Pruning against that sample would delete precisely the book the user is moving: #623 again, in a new place, and far harder to reproduce.

**The re-walk and the removals are synchronous, with no `await` between them.** That is what makes this atomic rather than merely likely to be right: Dock's moves run on the UI thread, so a walk that never yields cannot observe one half-finished. The `Dispatcher.UIThread.CheckAccess()` guard is therefore a correctness condition, not defensive habit — off the UI thread the whole argument collapses, and skipping is the safe answer.

## A hazard the issue had not named

Tracing the startup path turned this up, and it would have been severe:

> The layout is built with only the Welcome page → Welcome becomes `ActiveDockable` → that fires the tab-change save → the save walks **real docks** and finds **zero books** — and it runs **before** `App.axaml.cs:765` copies the entries it is about to reopen.

Pruning on an empty live set would have deleted **the entire saved session, on every launch**, before anything could read it. An empty live set now prunes nothing, and that costs nothing: with no books open, every removal has already gone through `CloseDockable`, so a prune has nothing to contribute in that state.

This is the guard the mutation test targets — removing it fails `An_empty_live_set_prunes_nothing` and nothing else.

## Testability

The decision is a pure function (`BookStatePrune.Vanished`), so the interesting cases — **which set is sampled, and when** — are testable without a dock, a view model or a browser. The drag case becomes a test about sampling time rather than about threading. Same reasoning as `BookRestoreOrder` in #623.

The threading argument itself is not unit-tested; it is stated where it has to hold, in `PruneStateForVanishedBooks`'s remarks, and rests on the UI-thread guard. Said plainly here rather than implied by an absent test.

## Verification

**1537/1537** (from 1528 — 9 new). Mutation-verified as above.

Worth a manual pass on macOS when convenient, since no headless test can cover it: drag a book between two windows while a save is in flight, and confirm it survives the next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)