### PR TITLE
Book information: an "i" panel naming the source file (#628)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/BookInformationTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/BookInformationTests.cs
@@ -27,13 +27,20 @@ public class BookInformationTests
     // ---- The file name ---------------------------------------------------------------------------
 
     [Fact]
-    public void The_file_name_is_shown_exactly_as_it_is_on_disk()
+    public void Putting_a_file_name_through_the_panels_conversion_would_corrupt_it()
     {
-        // It names a file. Converting it — as every other string in this panel is converted — would
-        // produce something that looks like an answer and matches nothing on the filesystem, in the
-        // repository, or in an issue report.
-        var book = new Book { FileName = "s0203m.mul.xml", LongNavPath = DevaNavPath };
-        Assert.Equal("s0203m.mul.xml", book.FileName);
+        // Why XmlFileName must never be converted, demonstrated rather than asserted. Every other string in
+        // this panel goes through FormatNavPath; a file name put through the same call comes back altered,
+        // and an altered file name is worse than none — it looks like an answer while matching nothing on
+        // disk, in the repository, or in an issue report.
+        //
+        // The invariant itself lives at the property (BookDisplayViewModel.XmlFileName returns
+        // Book.FileName untouched) and CANNOT be reached from here: constructing a BookDisplayViewModel
+        // needs ReactiveUI initialized, which the headless test host does not provide. So this pins the
+        // STAKES, not the rule. The rule rests on the property's own doc comment and on review.
+        var converted = BookDisplayViewModel.FormatNavPath("s0203m.mul.xml", Script.Latin);
+
+        Assert.NotEqual("s0203m.mul.xml", converted);
     }
 
     // ---- The nav path ----------------------------------------------------------------------------

--- a/src/CST.Avalonia.Tests/ViewModels/BookInformationTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/BookInformationTests.cs
@@ -1,0 +1,110 @@
+using CST;
+using CST.Avalonia.ViewModels;
+using CST.Conversion;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// The book-information panel's formatting (#628).
+///
+/// <para>
+/// The panel exists for text-correction work: an error found while reading is reported against the source
+/// file, and until now the reader never showed which file it was displaying. What is testable here is the
+/// formatting — the file name must survive untouched, and the nav path must follow the reading script,
+/// because a path shown in the wrong script is worse than no path at all to someone cross-referencing.
+/// </para>
+/// </summary>
+public class BookInformationTests
+{
+    // Devanagari written as escapes, per the project rule against literal non-Latin characters in source.
+    // DevaVinaya spells "vinaya" and DevaSutta spells "sutta". The corpus stores
+    // every nav path in Devanagari whatever script the reader is using.
+    private const string DevaVinaya = "\u0935\u093F\u0928\u092F";
+    private const string DevaSutta = "\u0938\u0941\u0924\u094D\u0924";
+    private const string DevaNavPath = DevaVinaya + "/" + DevaSutta;
+
+    // ---- The file name ---------------------------------------------------------------------------
+
+    [Fact]
+    public void The_file_name_is_shown_exactly_as_it_is_on_disk()
+    {
+        // It names a file. Converting it — as every other string in this panel is converted — would
+        // produce something that looks like an answer and matches nothing on the filesystem, in the
+        // repository, or in an issue report.
+        var book = new Book { FileName = "s0203m.mul.xml", LongNavPath = DevaNavPath };
+        Assert.Equal("s0203m.mul.xml", book.FileName);
+    }
+
+    // ---- The nav path ----------------------------------------------------------------------------
+
+    [Fact]
+    public void The_nav_path_follows_the_reading_script()
+    {
+        var deva = BookDisplayViewModel.FormatNavPath(DevaNavPath, Script.Devanagari);
+        var latin = BookDisplayViewModel.FormatNavPath(DevaNavPath, Script.Latin);
+
+        Assert.NotEqual(deva, latin);
+        // Asserted on the stems rather than the whole word, so this pins "it was converted to Latin"
+        // without restating the converter's capitalization rules — which are its business, not this
+        // method's, and are covered by the converter's own tests.
+        Assert.Contains("inaya", latin);
+        Assert.Contains("utta", latin);
+    }
+
+    [Fact]
+    public void Devanagari_is_passed_through_rather_than_round_tripped()
+    {
+        // Reading in Devanagari must not run the converter at all: a Deva->Deva round trip is a no-op at
+        // best, and this panel is the one place a corrupted path would look authoritative.
+        var formatted = BookDisplayViewModel.FormatNavPath(DevaNavPath, Script.Devanagari);
+        Assert.Equal(DevaVinaya + " / " + DevaSutta, formatted);
+    }
+
+    [Fact]
+    public void Separators_are_spaced_so_a_long_path_can_wrap()
+    {
+        Assert.Equal("a / b / c", BookDisplayViewModel.FormatNavPath("a/b/c", Script.Devanagari));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void A_book_with_no_nav_path_shows_nothing_rather_than_a_stray_separator(string? path)
+    {
+        Assert.Equal("", BookDisplayViewModel.FormatNavPath(path, Script.Latin));
+    }
+
+    // ---- The classification labels ---------------------------------------------------------------
+
+    [Theory]
+    [InlineData(Pitaka.Vinaya, "Vinaya")]
+    [InlineData(Pitaka.Sutta, "Sutta")]
+    [InlineData(Pitaka.Abhidhamma, "Abhidhamma")]
+    [InlineData(Pitaka.Other, "Other")]
+    public void Every_pitaka_has_a_label(Pitaka pitaka, string expected)
+    {
+        Assert.Equal(expected, BookDisplayViewModel.DescribePitaka(pitaka));
+    }
+
+    [Theory]
+    [InlineData(CommentaryLevel.Mula)]
+    [InlineData(CommentaryLevel.Atthakatha)]
+    [InlineData(CommentaryLevel.Tika)]
+    [InlineData(CommentaryLevel.Other)]
+    public void Every_commentary_level_has_a_label(CommentaryLevel level)
+    {
+        Assert.False(string.IsNullOrWhiteSpace(BookDisplayViewModel.DescribeCommentaryLevel(level)));
+    }
+
+    [Fact]
+    public void The_commentary_level_is_named_in_Pali_and_glossed_in_English()
+    {
+        // Both halves are deliberate: the Pāli term is what the texts and the people reporting errors in
+        // them use, and the reader offers no English gloss for it anywhere else.
+        Assert.Equal("Mūla (root text)", BookDisplayViewModel.DescribeCommentaryLevel(CommentaryLevel.Mula));
+        Assert.Equal("Aṭṭhakathā (commentary)", BookDisplayViewModel.DescribeCommentaryLevel(CommentaryLevel.Atthakatha));
+        Assert.Equal("Ṭīkā (sub-commentary)", BookDisplayViewModel.DescribeCommentaryLevel(CommentaryLevel.Tika));
+    }
+}

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -235,6 +235,14 @@ namespace CST.Avalonia.ViewModels
                         this.RaisePropertyChanged(nameof(CurrentScriptFontFamily));
                         this.RaisePropertyChanged(nameof(CurrentScriptFontSize));
 
+                        // The information panel's nav path is script-converted too (#628), and is raised
+                        // HERE rather than after the reload: it reads only _bookScript, which is already
+                        // updated by the time this subscription runs, so it has no reason to wait on the
+                        // WebView. Below the await it would be stranded whenever the JS round-trip is slow
+                        // — and permanently if it throws, since the whole body shares one catch — leaving an
+                        // open flyout showing the OLD script's text in the NEW script's font. (fable review)
+                        this.RaisePropertyChanged(nameof(BookNavPath));
+
                         // Capture the exact reading position (#434 token) BEFORE the reload, while the current
                         // script's DOM is still rendered. The token interpolates between the anchors bracketing
                         // the viewport top, so restore lands on the same reading position rather than a page
@@ -256,8 +264,6 @@ namespace CST.Avalonia.ViewModels
                             BookInfoText = GetBookInfoDisplayName(_book);
                             // Notify that DisplayTitle has changed (for tab updates)
                             this.RaisePropertyChanged(nameof(DisplayTitle));
-                            // The information panel's nav path is script-converted too (#628).
-                            this.RaisePropertyChanged(nameof(BookNavPath));
 
                             // Preserve the current selected chapter
                             var currentSelectedChapter = SelectedChapter;

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -256,6 +256,8 @@ namespace CST.Avalonia.ViewModels
                             BookInfoText = GetBookInfoDisplayName(_book);
                             // Notify that DisplayTitle has changed (for tab updates)
                             this.RaisePropertyChanged(nameof(DisplayTitle));
+                            // The information panel's nav path is script-converted too (#628).
+                            this.RaisePropertyChanged(nameof(BookNavPath));
 
                             // Preserve the current selected chapter
                             var currentSelectedChapter = SelectedChapter;
@@ -432,6 +434,73 @@ namespace CST.Avalonia.ViewModels
             get => _bookInfoText;
             set => this.RaiseAndSetIfChanged(ref _bookInfoText, value);
         }
+
+        #region Book information panel (#628)
+
+        // Requested for text-correction work: an error found while reading has to be reported against the
+        // SOURCE FILE, and the reader was the one tool in that workflow that never showed which file it was
+        // displaying — so the file name had to be looked up in another program every time.
+        //
+        // A panel rather than another status-bar field: the file name is the ask, but it is not the only
+        // thing that identifies a book to someone filing a report, and the status bar is already carrying
+        // five page-numbering systems (#541).
+
+        /// <summary>
+        /// The source XML file, e.g. <c>s0203m.mul.xml</c>. The one value in this panel that is not
+        /// script-dependent — it names a file on disk, so it is deliberately never converted or localized.
+        /// </summary>
+        public string XmlFileName => _book.FileName;
+
+        /// <summary>
+        /// The book's place in the collection, converted to the script the book is being read in, with the
+        /// separators spaced so a long path stays readable at panel width.
+        /// </summary>
+        public string BookNavPath => FormatNavPath(_book.LongNavPath, _bookScript);
+
+        /// <summary>Vinaya, Sutta or Abhidhamma — the division the book belongs to.</summary>
+        public string PitakaName => DescribePitaka(_book.Pitaka);
+
+        /// <summary>Whether this is a root text, a commentary, or a sub-commentary.</summary>
+        public string TextTypeName => DescribeCommentaryLevel(_book.Matn);
+
+        /// <summary>
+        /// The nav path in <paramref name="script"/>. Static and pure so the conversion and the spacing can
+        /// be tested without a Book, a dock factory or a WebView.
+        /// </summary>
+        public static string FormatNavPath(string? longNavPath, Script script)
+        {
+            if (string.IsNullOrWhiteSpace(longNavPath)) return "";
+
+            // The corpus stores nav paths in Devanagari whatever the reading script, exactly as the book
+            // titles are stored.
+            var path = script == Script.Devanagari
+                ? longNavPath
+                : ScriptConverter.Convert(longNavPath, Script.Devanagari, script, true);
+
+            return path.Replace("/", " / ");
+        }
+
+        /// <summary>
+        /// Pāli names rather than the English ones: these are the terms the texts and the people reporting
+        /// errors in them use, and the reader has no English gloss for them anywhere else either.
+        /// </summary>
+        public static string DescribePitaka(Pitaka pitaka) => pitaka switch
+        {
+            Pitaka.Vinaya => "Vinaya",
+            Pitaka.Sutta => "Sutta",
+            Pitaka.Abhidhamma => "Abhidhamma",
+            _ => "Other"
+        };
+
+        public static string DescribeCommentaryLevel(CommentaryLevel level) => level switch
+        {
+            CommentaryLevel.Mula => "Mūla (root text)",
+            CommentaryLevel.Atthakatha => "Aṭṭhakathā (commentary)",
+            CommentaryLevel.Tika => "Ṭīkā (sub-commentary)",
+            _ => "Other"
+        };
+
+        #endregion
 
         public string HitStatusText
         {

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml
@@ -175,6 +175,66 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
+                <!-- #628: book information. Requested for text-correction work — an error found while
+                     reading has to be reported against the SOURCE FILE, and the reader was the one tool in
+                     that workflow that never showed which file it was displaying.
+
+                     A flyout rather than another status-bar field: the file name is the ask, but it is not
+                     the only thing that identifies a book to someone filing a report, and the status bar
+                     already carries five page-numbering systems (#541).
+
+                     Every value is a SelectableTextBlock, because the point of showing them is to paste
+                     them somewhere else. The file name additionally gets a one-click copy, since it is the
+                     one field that gets pasted every time. -->
+                <StackPanel Orientation="Horizontal" Margin="5" VerticalAlignment="Center">
+                    <Button x:Name="bookInfoButton"
+                            Margin="2" Padding="9,2" MinWidth="0"
+                            ToolTip.Tip="Book information (source file, collection, type)">
+                        <TextBlock Text="i" FontWeight="Bold"/>
+                        <Button.Flyout>
+                            <Flyout Placement="BottomEdgeAlignedLeft">
+                                <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*"
+                                      MaxWidth="460">
+                                    <Grid.Styles>
+                                        <Style Selector="TextBlock.label">
+                                            <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                            <Setter Property="Margin" Value="0,3,12,3"/>
+                                            <Setter Property="VerticalAlignment" Value="Center"/>
+                                        </Style>
+                                        <Style Selector="SelectableTextBlock">
+                                            <Setter Property="Margin" Value="0,3"/>
+                                            <Setter Property="VerticalAlignment" Value="Center"/>
+                                            <Setter Property="TextWrapping" Value="Wrap"/>
+                                        </Style>
+                                    </Grid.Styles>
+
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Classes="label" Text="XML file"/>
+                                    <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
+                                        <SelectableTextBlock Text="{Binding XmlFileName}" FontFamily="{DynamicResource ContentControlThemeFontFamily}"/>
+                                        <Button x:Name="copyXmlFileNameButton"
+                                                Margin="10,0,0,0" Padding="6,1" MinWidth="0"
+                                                ToolTip.Tip="Copy the file name">
+                                            <TextBlock Text="Copy"/>
+                                        </Button>
+                                    </StackPanel>
+
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Classes="label" Text="Book"/>
+                                    <SelectableTextBlock Grid.Row="1" Grid.Column="1"
+                                                         Text="{Binding BookNavPath}"
+                                                         converters:FontHelper.DynamicFontFamily="{Binding CurrentScriptFontFamily}"
+                                                         converters:FontHelper.DynamicFontSize="{Binding CurrentScriptFontSize}"/>
+
+                                    <TextBlock Grid.Row="2" Grid.Column="0" Classes="label" Text="Piṭaka"/>
+                                    <SelectableTextBlock Grid.Row="2" Grid.Column="1" Text="{Binding PitakaName}"/>
+
+                                    <TextBlock Grid.Row="3" Grid.Column="0" Classes="label" Text="Level"/>
+                                    <SelectableTextBlock Grid.Row="3" Grid.Column="1" Text="{Binding TextTypeName}"/>
+                                </Grid>
+                            </Flyout>
+                        </Button.Flyout>
+                    </Button>
+                </StackPanel>
+
                 <!-- #618: book text zoom — Chrome's PDF-viewer control: step down, the value, step up.
                      No reset button; typing 100 is the reset, and Cmd/Ctrl+0 remains the keyboard route.
 

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -135,6 +135,9 @@ public partial class BookDisplayView : UserControl
         // #618: wire the toolbar's zoom control (step buttons and the percentage box).
         SetupZoomControl();
 
+        // #628: wire the book-information flyout's copy button.
+        SetupBookInfoPanel();
+
         // Try to create WebView browser
         TryCreateWebView();
     }
@@ -496,6 +499,7 @@ public partial class BookDisplayView : UserControl
         if (_viewModel != null)
         {
             _viewModel.BookDisplayControl = this;
+
             _viewModel.PropertyChanged += OnViewModelPropertyChanged;
             _viewModel.NavigateToHighlightRequested += NavigateToHighlight;
             _viewModel.NavigateToChapterRequested += NavigateToAnchor;
@@ -1040,6 +1044,46 @@ public partial class BookDisplayView : UserControl
         // other, so a second tab showing the same script updates by exactly the same route.
         var zoom = step(_bookZoomService);
         _logger.Debug("Zoom {What} requested for {Script} - now {Zoom:P0}", what, _viewModel.BookScript, zoom);
+    }
+
+    #endregion
+
+    #region Book information (#628)
+
+    private void SetupBookInfoPanel()
+    {
+        var copy = this.FindControl<Button>("copyXmlFileNameButton");
+        if (copy != null) copy.Click += (_, _) => CopyXmlFileName();
+    }
+
+    /// <summary>
+    /// Puts the source file name on the clipboard — the field that gets pasted into a correction report
+    /// every time, so it is worth a click rather than a select-and-copy.
+    /// </summary>
+    private async void CopyXmlFileName()
+    {
+        try
+        {
+            var fileName = _viewModel?.XmlFileName;
+            if (string.IsNullOrEmpty(fileName)) return;
+
+            // GetTopLevel rather than a cached window: this View is recycled across float/unfloat, so the
+            // window it belongs to is not the one it was created in.
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard == null)
+            {
+                _logger.Warning("Copy file name: no clipboard available");
+                return;
+            }
+
+            await clipboard.SetTextAsync(fileName);
+            _logger.Information("Copied XML file name to clipboard: {FileName}", fileName);
+        }
+        catch (Exception ex)
+        {
+            // async void: an escaping exception here would be an unhandled crash, not a failed copy.
+            _logger.Error(ex, "Failed to copy the XML file name to the clipboard");
+        }
     }
 
     #endregion


### PR DESCRIPTION
An error found while reading has to be reported against the **source file**, and the reader was the one tool in that workflow that never showed which file it was displaying — so the name had to be looked up in another program every time.

An **"i"** button in the book toolbar opens a flyout:

```
XML file   s0203m.mul.xml  [Copy]
Book       Vinayapiṭaka / Pārājikapāḷi
Piṭaka     Vinaya
Level      Mūla (root text)
```

## Why a panel rather than another status-bar field

The file name is the ask, but it is not the only thing that identifies a book to someone filing a report — and the status bar already carries five page-numbering systems for every book, whether or not the book has them (#541). A flyout costs one button of toolbar width and leaves room to add to it later.

## Copyable, deliberately

Every value is a `SelectableTextBlock`: the whole point of showing these is to paste them somewhere else. The file name additionally gets a one-click **Copy**, since it is the field that gets pasted every time.

## The one rule worth stating in code

**The file name is never script-converted.** Every other string in this panel is, and a converted file name would look like an answer while matching nothing on disk, in the repository, or in an issue report. The nav path *is* converted, and follows the script the book is being read in — a path shown in the wrong script is worse than no path at all to someone cross-referencing.

## Testing

The formatting is static and pure, so it is tested without a `Book`, a dock factory or a WebView — the same shape as the zoom readout and the book-face decisions. Covered: the conversion, the Devanagari pass-through (a Deva→Deva round trip is a no-op at best, and this panel is where a corrupted path would look authoritative), the empty-path case, and every enum label.

Full suite **1553 passed, 0 failed**, including 16 new tests. Verified in the running app, and a screenshot is on the issue.

Closes #628.
