### PR TITLE
Source PDF: open with the thumbnail sidebar collapsed (#630)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/PdfUrlTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/PdfUrlTests.cs
@@ -20,20 +20,47 @@ public class PdfUrlTests
         var url = PdfDisplayViewModel.BuildPdfUrl(path, 5);
 
         Assert.StartsWith("file:///", url);   // a real file URI, not "file://<raw path>"
-        Assert.EndsWith("#page=5", url);
+        Assert.Contains("#page=5", url);
         Assert.Contains("%20", url);           // space escaped
         Assert.DoesNotContain(" ", url);       // no raw spaces
     }
 
     [Fact]
-    public void BuildPdfUrl_EscapesHashInPath_SoTheOnlyFragmentIsThePage()
+    public void BuildPdfUrl_CollapsesTheThumbnailSidebar()
+    {
+        // #630. Chromium's viewer only leaves the sidebar to its remembered state when navpanes AND
+        // toolbar are both absent; any explicit navpanes decides it, and only '1' opens it. So this must
+        // be PRESENT rather than merely not '1' — dropping the parameter hands the decision back to
+        // whatever the embedded viewer last remembered, which is exactly the behaviour being fixed.
+        var url = PdfDisplayViewModel.BuildPdfUrl(Path.Combine(Path.GetTempPath(), "src.pdf"), 12);
+
+        Assert.Contains("navpanes=0", url);
+        Assert.EndsWith("#page=12&navpanes=0", url);
+        // One '#': the parameters live in a single fragment, separated by '&'. A second '#' would make
+        // everything after it part of the fragment's value rather than a parameter.
+        Assert.Equal(1, url.Count(c => c == '#'));
+    }
+
+    [Fact]
+    public void BuildPdfUrl_LeavesTheToolbarAlone()
+    {
+        // shouldShowToolbar is `navpanes === '1' || toolbar !== '0'`. Passing toolbar=0 to tidy the view
+        // would take the zoom and page controls with it — and the page number is what a source PDF is
+        // being read for. Pinned because "hide the sidebar" and "hide the toolbar" look like neighbours.
+        var url = PdfDisplayViewModel.BuildPdfUrl(Path.Combine(Path.GetTempPath(), "src.pdf"), 1);
+
+        Assert.DoesNotContain("toolbar", url);
+    }
+
+    [Fact]
+    public void BuildPdfUrl_EscapesHashInPath_SoThePathCannotOpenTheFragment()
     {
         var path = Path.Combine(Path.GetTempPath(), "a#b.pdf");
 
         var url = PdfDisplayViewModel.BuildPdfUrl(path, 2);
 
-        Assert.Contains("a%23b.pdf", url);            // '#' inside the path is escaped, not a fragment
-        Assert.EndsWith("#page=2", url);
-        Assert.Equal(1, url.Count(c => c == '#'));    // exactly one '#': the page fragment
+        Assert.Contains("a%23b.pdf", url);              // '#' inside the path is escaped, not a fragment
+        Assert.EndsWith("#page=2&navpanes=0", url);
+        Assert.Equal(1, url.Count(c => c == '#'));      // exactly one '#': the viewer parameters
     }
 }

--- a/src/CST.Avalonia/ViewModels/PdfDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/PdfDisplayViewModel.cs
@@ -216,8 +216,22 @@ namespace CST.Avalonia.ViewModels
         // Build the browser URL for a local PDF at a given page: a properly-escaped file:// URI plus the
         // PDFium #page=N fragment. Uri.AbsoluteUri escapes spaces / '#' and emits file:///C:/... on Windows;
         // the old $"file://{path}#page=N" produced malformed, unescaped URLs. (NET-5)
+        //
+        // navpanes=0 collapses the thumbnail sidebar (#630). It is not cosmetic sugar on top of page=: it is
+        // the only lever available, because Chromium renders a PDF in an internal plugin frame that
+        // ExecuteScript cannot reach (#518, measured), so there is no scripting route to the viewer's UI.
+        //
+        // It also changes the DEFAULT rather than just the initial state. Chromium's parser reads:
+        //
+        //     if (navpanes === null && toolbar === null) return !sidenavCollapsed;
+        //     return navpanes === '1';
+        //
+        // so with no parameter the sidebar follows viewer state this app never set, and an explicit
+        // navpanes short-circuits that and answers the same way every time. The toolbar survives, since
+        // shouldShowToolbar is `navpanes === '1' || toolbar !== '0'` and we pass no toolbar parameter — and
+        // the reader can still open the sidebar by hand; this only decides where it starts.
         internal static string BuildPdfUrl(string localPath, int page)
-            => new Uri(localPath).AbsoluteUri + $"#page={page}";
+            => new Uri(localPath).AbsoluteUri + $"#page={page}&navpanes=0";
 
         private static string GetSourceTypeName(Sources.SourceType sourceType)
         {


### PR DESCRIPTION
The source-PDF viewer opened with Chromium's thumbnail sidebar expanded, taking a wide strip out of a pane that is usually docked beside a book. For error-correction work the thumbnails are never the point — the page is.

```csharp
=> new Uri(localPath).AbsoluteUri + $"#page={page}&navpanes=0";
```

## Why a URL parameter, and not something nicer

There is nothing nicer available. Chromium renders a PDF in an internal plugin frame that `ExecuteScript` cannot reach — measured on Windows for #518, where the same wall killed the keyboard-shortcut relay. The URL is the only lever, and it turns out to be enough.

## What actually changes: who decides

From `chrome/browser/resources/pdf/open_pdf_params_parser.ts` in Chromium 120, the version behind CEF 120.1.8:

```ts
shouldShowSidenav(url: string, sidenavCollapsed: boolean): boolean {
  const navpanes = urlParams.get('navpanes');
  const toolbar = urlParams.get('toolbar');
  if (navpanes === null && toolbar === null) {
    return !sidenavCollapsed;
  }
  return navpanes === '1';
}
```

With no parameter the sidebar follows `sidenavCollapsed` — persisted viewer state this app never set. So the current behaviour is not a default anyone chose; it is whatever the embedded viewer last remembered. An explicit `navpanes` short-circuits that and answers the same way on every open.

The reader can still open the sidebar by hand. This only decides where it starts.

## The toolbar is deliberately untouched

`shouldShowToolbar` is `navpanes === '1' || toolbar !== '0'`, and no `toolbar` parameter is passed, so the second clause holds. Passing `toolbar=0` looks like a neighbouring tidy-up and would take the zoom and page-number controls with it — and the page number is what a source PDF is being read for. There is a test pinning that we never send it.

## Testing

Full suite **1555 passed, 0 failed**, including 2 new tests: that `navpanes=0` is present (its *absence* is the bug, since that hands the decision back to remembered state), that the fragment stays a single `#` with `&`-separated parameters, and that no `toolbar` parameter is sent.

One pre-existing test asserted the URL *ended* with `#page=N`; updated to the new ending rather than loosened to a `Contains`.

Worth one manual check on Windows, where the PDF viewer has behaved differently before (#518, #520).

Closes #630.
