### PR TITLE
Source PDF: real start pages for six Burmese Anya scans (#627)

### DIFF
--- a/src/CST.Core/Sources.cs
+++ b/src/CST.Core/Sources.cs
@@ -583,17 +583,17 @@ public class Sources
 		addSource("e0906n.nrf.xml", SourceType.BurmeseAnya, 1, $"{BurmeseAnyaSangayana}/6. Abhidhammapiṭaka (Pu-Vi).pdf");
 
 		// Leḍī Sayāḍo. e0301 (Paramatthadīpanī) has no PDF.
-		addSource("e0201n.nrf.xml", SourceType.BurmeseAnya, 1, $"{BurmeseAnyaLedi}/1. Niruttidīpanī.pdf");
-		addSource("e0401n.nrf.xml", SourceType.BurmeseAnya, 1, $"{BurmeseAnyaLedi}/3. Anudīpanīpāṭha.pdf");
+		addSource("e0201n.nrf.xml", SourceType.BurmeseAnya, 112, $"{BurmeseAnyaLedi}/1. Niruttidīpanī.pdf");
+		addSource("e0401n.nrf.xml", SourceType.BurmeseAnya, 8, $"{BurmeseAnyaLedi}/3. Anudīpanīpāṭha.pdf");
 		addSource("e0501n.nrf.xml", SourceType.BurmeseAnya, 1, $"{BurmeseAnyaLedi}/4. Paṭṭhānuddesa dīpanīpāṭha_printed.pdf");
 
 		// Buddha-vandanā. e0603–e0608 have no PDF.
-		addSource("e0601n.nrf.xml", SourceType.BurmeseAnya, 1, $"{BurmeseAnyaBuddhaVandana}/1. Namakkāraṭīkā.pdf");
-		addSource("e0602n.nrf.xml", SourceType.BurmeseAnya, 1, $"{BurmeseAnyaBuddhaVandana}/2. Mahāpaṇāmapāṭha.pdf");
+		addSource("e0601n.nrf.xml", SourceType.BurmeseAnya, 14, $"{BurmeseAnyaBuddhaVandana}/1. Namakkāraṭīkā.pdf");
+		addSource("e0602n.nrf.xml", SourceType.BurmeseAnya, 4, $"{BurmeseAnyaBuddhaVandana}/2. Mahāpaṇāmapāṭha.pdf");
 
 		// Vaṃsa. e0701 (Cūḷagandhavaṃsa) has no PDF. e0703 (Mahāvaṃsa) is multi-vol → Vol 1.
-		addSource("e0702n.nrf.xml", SourceType.BurmeseAnya, 1, $"{BurmeseAnyaVamsa}/3. Sāsanavaṃsappadīpikā.pdf");
-		addSource("e0703n.nrf.xml", SourceType.BurmeseAnya, 1, $"{BurmeseAnyaVamsa}/2. Mahāvaṃsa (Vol-1).pdf");
+		addSource("e0702n.nrf.xml", SourceType.BurmeseAnya, 16, $"{BurmeseAnyaVamsa}/3. Sāsanavaṃsappadīpikā.pdf");
+		addSource("e0703n.nrf.xml", SourceType.BurmeseAnya, 7, $"{BurmeseAnyaVamsa}/2. Mahāvaṃsa (Vol-1).pdf");
 
 		// Byākaraṇa (grammar). e0808/e0809/e0811 share one combined PDF (offsets to distinguish → deferred).
 		// e0812 (Subodhālaṅkāraṭīkā) has no PDF.


### PR DESCRIPTION
Six Burmese Anya sources were mapped with `pageStart=1`. That is not a measurement — it is a placeholder, and it asserts that printed page 1 is the first page of the scan, i.e. that the volume has no front matter at all. Every one of these does, so View Source landed short by the length of it. The report called it "at least ten pages" on the Namakkāraṭīkā; it is 13.

| Book | | old | new |
|---|---|---|---|
| `e0201n` | Niruttidīpanī | 1 | **112** |
| `e0401n` | Anudīpanīpāṭha | 1 | **8** |
| `e0601n` | Namakkāraṭīkā | 1 | **14** |
| `e0602n` | Mahāpaṇāmapāṭha | 1 | **4** |
| `e0702n` | Sāsanavaṃsappadīpikā | 1 | **16** |
| `e0703n` | Mahāvaṃsa (Vol-1) | 1 | **7** |

`pageStart` is the PDF page carrying **printed page 1**: `pdfPage = PageStart + (printPage - 1) - skipped`.

## Two checked against the scans

Not taken on trust — I read the pages. I picked the two most likely to be wrong: the one in the report, and the largest offset, where a transposed digit would be invisible.

**`e0601n` = 14.** PDF page 14 is the title `နမက္ကာရပါဠိ`, the `namo tassa` salutation and verses ၁–၅. PDF page 15 carries the printed page number **၂** under the running head. So `14 + (2−1) = 15`, exactly.

**`e0201n` = 112.** PDF page 112 is the title `နိရုတ္တိဒီပနီပါဠိ`, the `namo tassa` and the ganthārambha verses ၁–၄, with a printer's signature mark at the foot — printed page 1.

That second one is worth recording, because I first read it as off by one and it isn't. The chapter opening on PDF 113 (`၁-သန္ဓိကဏ္ဍ`) carries **no** page number, as chapter openings in these volumes don't, so the first *numbered* page you meet scanning forward is printed page 3 — which reads as page 2 if you assume every page is numbered. An offset checked that way lands one page short, and the error is invisible because the text still looks nearly right.

The remaining four are as measured by the maintainer.

## Not covered

This fixes the six placeholders in the Anya set. It does not address #546 (books whose Myanmar page numbers restart mid-volume) or #549 (pages missing from a scan beyond what the XML reveals), which are different failure modes in the same mapping.

Closes #627.
