### PR TITLE
Target window commands by interaction, not by tree order (#621)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/ActiveDocumentFeedTests.cs
+++ b/src/CST.Avalonia.Tests/Services/ActiveDocumentFeedTests.cs
@@ -1,0 +1,107 @@
+using CST.Avalonia.Services;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// Feed A of the interaction history (#621): the dock model's own activation signal.
+///
+/// <para>
+/// One subscription in <c>CstDockFactory</c>'s constructor is supposed to cover every dock in every window,
+/// including docks a split creates later and docks in floating windows. That claim rests entirely on a
+/// framework behaviour — Dock's <c>ActiveDockable</c> SETTER calling <c>InitActiveDockable</c>, which raises
+/// <c>ActiveDockableChanged</c> on the owning factory. If a Dock upgrade ever moves that call, the feed goes
+/// quiet with nothing to indicate it, and targeting silently reverts to the first-dock guess this fixes.
+/// These tests are the tripwire.
+/// </para>
+/// </summary>
+public class ActiveDocumentFeedTests
+{
+    private sealed class TestDocument : Document
+    {
+    }
+
+    private static (CstDockFactory Factory, ActiveDocumentTracker Tracker, DocumentDock Dock, TestDocument A, TestDocument B)
+        Build()
+    {
+        var factory = new CstDockFactory();
+        var tracker = new ActiveDocumentTracker();
+        factory.DocumentTracker = tracker;
+
+        var a = new TestDocument { Id = "a", Title = "A" };
+        var b = new TestDocument { Id = "b", Title = "B" };
+        var dock = new DocumentDock
+        {
+            Id = "MainDocumentDock",
+            Factory = factory,
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { a, b }
+        };
+
+        return (factory, tracker, dock, a, b);
+    }
+
+    [Fact]
+    public void Activating_a_tab_records_it()
+    {
+        var (_, tracker, dock, a, _) = Build();
+
+        dock.ActiveDockable = a;
+
+        Assert.Same(a, Assert.Single(tracker.Recent));
+    }
+
+    [Fact]
+    public void Successive_activations_build_the_history_in_order()
+    {
+        var (_, tracker, dock, a, b) = Build();
+
+        dock.ActiveDockable = a;
+        dock.ActiveDockable = b;
+
+        Assert.Equal(new IDockable[] { b, a }, tracker.Recent);
+    }
+
+    [Fact]
+    public void A_dock_created_after_the_factory_is_covered_too()
+    {
+        // The whole reason the subscription is on the FACTORY rather than per-dock: splits and floating
+        // windows create docks long after the constructor ran, and each would otherwise need wiring that
+        // someone has to remember.
+        var (factory, tracker, _, _, _) = Build();
+
+        var later = new TestDocument { Id = "later", Title = "Later" };
+        var newDock = new DocumentDock
+        {
+            Id = "MainDocumentDock",
+            Factory = factory,
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { later }
+        };
+
+        newDock.ActiveDockable = later;
+
+        Assert.Same(later, Assert.Single(tracker.Recent));
+    }
+
+    [Fact]
+    public void The_activation_event_carries_the_dockable_that_became_active()
+    {
+        // Pins the shape of the event args the feed reads, not just that something fired — reading the
+        // wrong member would record null and fail silently, which is the same as the feed not existing.
+        var factory = new CstDockFactory();
+        IDockable? seen = null;
+        factory.ActiveDockableChanged += (_, e) => seen = e.Dockable;
+
+        var doc = new TestDocument { Id = "x", Title = "X" };
+        var dock = new DocumentDock
+        {
+            Id = "MainDocumentDock",
+            Factory = factory,
+            VisibleDockables = new System.Collections.ObjectModel.ObservableCollection<IDockable> { doc }
+        };
+        dock.ActiveDockable = doc;
+
+        Assert.Same(doc, seen);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/ActiveDocumentTrackerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/ActiveDocumentTrackerTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Linq;
+using CST.Avalonia.Services;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// The interaction history behind #621.
+///
+/// <para>
+/// It records order and nothing else — no filtering, no notion of what a document is. That is the design:
+/// the resolver filters on read by asking a layout what it contains, which is what lets one flat history
+/// serve every window and what keeps tool activations from displacing documents. These tests pin the
+/// recording rules; <c>DocumentTargetResolverTests</c> pins what reading them means.
+/// </para>
+/// </summary>
+public class ActiveDocumentTrackerTests
+{
+    private sealed class TestDocument : Document
+    {
+    }
+
+    private static TestDocument Doc(string id) => new() { Id = id, Title = id };
+
+    [Fact]
+    public void The_most_recent_interaction_comes_first()
+    {
+        var tracker = new ActiveDocumentTracker();
+        var a = Doc("a");
+        var b = Doc("b");
+
+        tracker.Note(a);
+        tracker.Note(b);
+
+        Assert.Equal(new IDockable[] { b, a }, tracker.Recent);
+    }
+
+    [Fact]
+    public void Re_noting_moves_to_the_front_rather_than_duplicating()
+    {
+        var tracker = new ActiveDocumentTracker();
+        var a = Doc("a");
+        var b = Doc("b");
+
+        tracker.Note(a);
+        tracker.Note(b);
+        tracker.Note(a);
+
+        // The feeds overlap by design — a tab click raises an activation AND an Avalonia focus change —
+        // so redundant notes are the normal case, not an edge case.
+        Assert.Equal(new IDockable[] { a, b }, tracker.Recent);
+    }
+
+    [Fact]
+    public void Identity_is_by_reference_not_by_id()
+    {
+        var tracker = new ActiveDocumentTracker();
+        // Splits produce several docks all carrying the id "MainDocumentDock", and two tabs of the same
+        // book would compare equal on anything weaker than reference identity.
+        var first = new DocumentDock { Id = "MainDocumentDock" };
+        var second = new DocumentDock { Id = "MainDocumentDock" };
+
+        tracker.Note(first);
+        tracker.Note(second);
+
+        Assert.Equal(2, tracker.Recent.Count);
+        Assert.Same(second, tracker.Recent[0]);
+        Assert.Same(first, tracker.Recent[1]);
+    }
+
+    [Fact]
+    public void History_is_bounded()
+    {
+        var tracker = new ActiveDocumentTracker();
+        var docs = Enumerable.Range(0, 30).Select(i => Doc($"d{i}")).ToList();
+
+        foreach (var d in docs) tracker.Note(d);
+
+        Assert.True(tracker.Recent.Count <= 8);
+        Assert.Same(docs[^1], tracker.Recent[0]);
+    }
+
+    [Fact]
+    public void A_closed_document_is_forgotten()
+    {
+        var tracker = new ActiveDocumentTracker();
+        var a = Doc("a");
+        var b = Doc("b");
+        tracker.Note(a);
+        tracker.Note(b);
+
+        tracker.Forget(b);
+
+        Assert.Equal(new IDockable[] { a }, tracker.Recent);
+    }
+
+    [Fact]
+    public void Forgetting_something_never_recorded_is_harmless()
+    {
+        var tracker = new ActiveDocumentTracker();
+        tracker.Note(Doc("a"));
+
+        tracker.Forget(Doc("never-seen"));
+
+        Assert.Single(tracker.Recent);
+    }
+
+    [Fact]
+    public void Null_is_ignored_rather_than_recorded()
+    {
+        var tracker = new ActiveDocumentTracker();
+        // Every feed can produce one: a DataContext that is not a dockable, a view whose ViewModel has not
+        // been bound yet, an activation event for a dockable already gone.
+        tracker.Note(null);
+        tracker.Forget(null);
+
+        Assert.Empty(tracker.Recent);
+    }
+
+    [Fact]
+    public void Entries_do_not_keep_a_closed_documents_ViewModel_alive()
+    {
+        // The reason entries are weak. A book's ViewModel owns a CEF WebView; the history holding the last
+        // eight for the session would be a leak with a browser attached to it. Forget() covers the normal
+        // close path — this covers every other way a dockable can go away.
+        var tracker = new ActiveDocumentTracker();
+        var reference = NoteAndDrop(tracker);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        Assert.False(reference.IsAlive);
+        Assert.Empty(tracker.Recent);
+    }
+
+    // Kept out of the test body so the strong local cannot survive on the stack in a Debug build.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference NoteAndDrop(ActiveDocumentTracker tracker)
+    {
+        var doomed = Doc("doomed");
+        tracker.Note(doomed);
+        return new WeakReference(doomed);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/DocumentFocusReporterTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DocumentFocusReporterTests.cs
@@ -1,0 +1,55 @@
+using CST.Avalonia.Services;
+using CST.Avalonia.Views;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// Which Avalonia focus landings count as interactions (#621).
+///
+/// <para>
+/// This rule was written from a measurement, not from reasoning, and the measurement is worth keeping
+/// beside it. In a three-way split in a floating window, a single click into a book targeted the right book
+/// only about half the time, while a second click always worked. The log showed why: activating the window
+/// makes Avalonia focus the document VIEW, which emits a focus event naming whichever document held focus
+/// last — the same stale book every time, regardless of which one was clicked — landing within ~15ms of the
+/// correct CEF report. Whichever arrived second won.
+/// </para>
+/// </summary>
+public class DocumentFocusReporterTests
+{
+    private sealed class FakeBrowserView : IBrowserDocumentView
+    {
+    }
+
+    private sealed class SomethingElse
+    {
+    }
+
+    [Fact]
+    public void Focus_landing_on_a_browser_view_is_not_an_interaction()
+    {
+        // The echo. Ignoring it loses nothing: CEF reports this document's real focus directly.
+        Assert.False(DocumentFocusReporter.ShouldReport(new FakeBrowserView()));
+    }
+
+    [Fact]
+    public void Focus_landing_anywhere_else_is()
+    {
+        // The reason this feed exists at all — a tab-strip click raises no activation event when the tab is
+        // already the active one in its own split, and no CEF focus when it lands on the header.
+        Assert.True(DocumentFocusReporter.ShouldReport(new SomethingElse()));
+        Assert.True(DocumentFocusReporter.ShouldReport(null));
+    }
+
+    [Fact]
+    public void Every_browser_hosting_document_view_carries_the_marker()
+    {
+        // The rule is only as complete as the marker's application. A browser-hosting view that forgets it
+        // reintroduces the stale echo for its own document, and the symptom — a command acting on the wrong
+        // tab about half the time — reads as a race rather than as a missing interface.
+        Assert.True(typeof(IBrowserDocumentView).IsAssignableFrom(typeof(BookDisplayView)));
+        Assert.True(typeof(IBrowserDocumentView).IsAssignableFrom(typeof(PdfDisplayView)));
+        Assert.True(typeof(IBrowserDocumentView).IsAssignableFrom(typeof(WelcomeView)));
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/DocumentTargetResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DocumentTargetResolverTests.cs
@@ -204,6 +204,98 @@ public class DocumentTargetResolverTests
         Assert.True(new Tool() is Dock.Model.Controls.IDocument);
     }
 
+    // ---- #621: the interaction-history tier ------------------------------------------------------
+    //
+    // Every test above passes no history at all, which is also the "tracker unavailable" production path —
+    // so they double as the guarantee that this tier changed nothing about resolution when focus IS visible.
+
+    [Fact]
+    public void ResolveActiveDocument_FocusInvisible_UsesTheMostRecentDocument()
+    {
+        var (root, _, _, docA1, _, docB1) = BuildSplitLayout();
+
+        // The reported bug, as the app produces it: the user clicked into the second split's browser, so
+        // Avalonia has no focus to offer (preferred is null) and Dock's own record was never written.
+        Assert.Same(docA1, DocumentTargetResolver.ResolveActiveDocument(root));
+        Assert.Same(docB1, DocumentTargetResolver.ResolveActiveDocument(root, null, new[] { (IDockable)docB1 }));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_LiveFocusBeatsHistory()
+    {
+        var (root, _, _, docA1, _, docB1) = BuildSplitLayout();
+
+        // History describes the recent past; focus describes this instant. Where they disagree, focus has
+        // moved somewhere the history has not caught up with, and the present wins. This is also what
+        // guarantees #443's fix cannot regress.
+        Assert.Same(docA1, DocumentTargetResolver.ResolveActiveDocument(root, docA1, new[] { (IDockable)docB1 }));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_HistoryBeatsDockFocusAndFirstDock()
+    {
+        var (root, _, _, _, docA2, docB1) = BuildSplitLayout();
+
+        root.FocusedDockable = docA2;
+
+        // Dock's own record is written by the ActiveDockable setter on the NEAREST root, which in this
+        // app is not the root any caller holds — so it is stale-at-best and the history is the better
+        // answer. (The layout here is flat, so this test constructs the disagreement directly.)
+        Assert.Same(docB1, DocumentTargetResolver.ResolveActiveDocument(root, null, new[] { (IDockable)docB1 }));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_HistoryWalksPastEntriesThisLayoutDoesNotContain()
+    {
+        var (root, _, _, _, _, docB1) = BuildSplitLayout();
+        var (otherRoot, _, _, foreignDoc, _, _) = BuildSplitLayout();
+        Assert.NotNull(otherRoot);
+
+        var tool = new Tool { Id = "SearchTool", Title = "Search" };
+
+        // Three things at once, and all three are why the history is unfiltered at the point of writing:
+        // a tool activation, a document from ANOTHER window's layout, and finally this window's own.
+        // Containment is the only filter, and it rejects the first two without the tracker knowing what a
+        // tool or a window is.
+        var recents = new IDockable[] { tool, foreignDoc, docB1 };
+
+        Assert.Same(docB1, DocumentTargetResolver.ResolveActiveDocument(root, null, recents));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_HistoryEntryAlreadyClosed_FallsThroughToTheNextOne()
+    {
+        var (root, _, dockB, _, docA2, docB1) = BuildSplitLayout();
+
+        dockB.VisibleDockables!.Remove(docB1);
+        dockB.ActiveDockable = null;
+
+        // A closed tab is evicted at the close, but the history must degrade correctly regardless — a
+        // stale entry names a document that no longer exists, and acting on it would be worse than the
+        // first-dock guess this replaced.
+        Assert.Same(docA2, DocumentTargetResolver.ResolveActiveDocument(root, null, new IDockable[] { docB1, docA2 }));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_HistoryEntryIsADock_ReturnsItsActiveTab()
+    {
+        var (root, _, dockB, _, _, docB1) = BuildSplitLayout();
+
+        // Feed C walks up from the focused element, so it can land on the pane rather than on a tab.
+        Assert.Same(docB1, DocumentTargetResolver.ResolveActiveDocument(root, null, new IDockable[] { dockB }));
+    }
+
+    [Fact]
+    public void ResolveActiveDocument_NoUsableHistory_StillFallsBackToFirstDock()
+    {
+        var (root, _, _, docA1, _, _) = BuildSplitLayout();
+        var tool = new Tool { Id = "SearchTool", Title = "Search" };
+
+        // A session that has only ever touched tools resolves exactly as it did before #621.
+        Assert.Same(docA1, DocumentTargetResolver.ResolveActiveDocument(root, null, new IDockable[] { tool }));
+        Assert.Same(docA1, DocumentTargetResolver.ResolveActiveDocument(root, null, System.Array.Empty<IDockable>()));
+    }
+
     [Fact]
     public void ResolveActiveDocument_NullLayout_ReturnsNull()
     {

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1192,6 +1192,10 @@ public partial class App : Application
         // owns book content size, and #574 made zoom the only per-script size control there is.
         services.AddSingleton<IBookZoomService>(sp =>
             new BookZoomService(sp.GetRequiredService<ISettingsService>()));
+        // Which documents the user has recently worked in (#621). A singleton because it is one history
+        // across every window: each window selects its own entries by asking whether its layout contains
+        // them, which is also what keeps tool activations out of the answer.
+        services.AddSingleton<ActiveDocumentTracker>();
         services.AddSingleton<IApplicationStateService, ApplicationStateService>();
         services.AddSingleton<ChapterListsService>();
         // Recently-opened-books (MRU) list backing the File → Open Recent menu (#44).
@@ -2006,7 +2010,8 @@ public partial class App : Application
             return null;
 
         return DocumentTargetResolver.ResolveActiveDocument(
-            hostWindow.Layout, SimpleTabbedWindow.ResolveFocusedDockable(hostWindow)) as BookDisplayViewModel;
+            hostWindow.Layout, SimpleTabbedWindow.ResolveFocusedDockable(hostWindow),
+            ServiceProvider?.GetService<ActiveDocumentTracker>()?.Recent) as BookDisplayViewModel;
     }
 
     private void OnCloseTabFromFloatingWindow(Window floatingWindow)
@@ -2016,7 +2021,8 @@ public partial class App : Application
             if (floatingWindow is CstHostWindow hostWindow && hostWindow.Layout != null)
             {
                 SimpleTabbedWindow.CloseDockableIfClosable(DocumentTargetResolver.ResolveActiveDocument(
-                    hostWindow.Layout, SimpleTabbedWindow.ResolveFocusedDockable(hostWindow)));
+                    hostWindow.Layout, SimpleTabbedWindow.ResolveFocusedDockable(hostWindow),
+                    ServiceProvider?.GetService<ActiveDocumentTracker>()?.Recent));
             }
         }
         catch (Exception ex)
@@ -2032,7 +2038,8 @@ public partial class App : Application
             if (floatingWindow is CstHostWindow hostWindow && hostWindow.Layout != null)
             {
                 if (DocumentTargetResolver.ResolveActiveDocument(
-                        hostWindow.Layout, SimpleTabbedWindow.ResolveFocusedDockable(hostWindow)) is BookDisplayViewModel bookViewModel)
+                        hostWindow.Layout, SimpleTabbedWindow.ResolveFocusedDockable(hostWindow),
+                        ServiceProvider?.GetService<ActiveDocumentTracker>()?.Recent) is BookDisplayViewModel bookViewModel)
                 {
                     Log.Information("View Source ({Edition}) via floating-window menu for book: {BookFile}",
                         source2010 ? "2010" : "1957", bookViewModel.Book.FileName);

--- a/src/CST.Avalonia/Controls/CstWebView.cs
+++ b/src/CST.Avalonia/Controls/CstWebView.cs
@@ -1,0 +1,47 @@
+using System;
+using Avalonia.Threading;
+using WebViewControl;
+
+namespace CST.Avalonia.Controls;
+
+/// <summary>
+/// A <see cref="WebView"/> that reports when its BROWSER takes focus. (#621)
+///
+/// <para>
+/// Window-level commands resolve their target from Avalonia's keyboard focus, and a CEF WebView hosts a
+/// native surface: a click inside a book, a PDF or the Welcome page never reaches Avalonia, so focus
+/// resolution comes back empty and the command falls through to "the first document dock in tree order" —
+/// the wrong pane in any split. This is the only signal that can see such a click.
+/// </para>
+///
+/// <para>
+/// <b>Verified on macOS before the design was built on it</b>, because the assumption was not safe: the
+/// PDF's content lives in an internal plugin frame that has already defeated one mechanism here — the
+/// injected JS keydown relay is inert there (#518, measured on Windows). A logging build showed
+/// <c>OnGotFocus</c> firing for the book body, the PDF body, and alternating correctly between them, one
+/// event per click. It is reported at the browser level, above the plugin frame, which is why it survives
+/// where the in-page listener does not.
+/// </para>
+///
+/// <para>
+/// Two things that probe also settled, and that this class is shaped by: <c>OnLostFocus</c> never fired at
+/// all, so nothing may depend on being told focus LEFT; and <c>OnSetFocus</c> returned "suppress" every
+/// time while focus was granted regardless, so it is not a usable predictor. Only <c>OnGotFocus</c> is
+/// overridden here.
+/// </para>
+/// </summary>
+public class CstWebView : WebView
+{
+    /// <summary>
+    /// Raised when the browser takes focus. Marshalled to the UI thread: on macOS these arrived on it
+    /// already, but that is CEF's business, not a guarantee, and the handler touches app state.
+    /// </summary>
+    public event Action? BrowserGotFocus;
+
+    protected override void OnGotFocus()
+    {
+        var handler = BrowserGotFocus;
+        if (handler != null) Dispatcher.UIThread.Post(() => handler());
+        base.OnGotFocus();
+    }
+}

--- a/src/CST.Avalonia/Services/ActiveDocumentTracker.cs
+++ b/src/CST.Avalonia/Services/ActiveDocumentTracker.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dock.Model.Core;
+using Serilog;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Which documents the user has most recently worked in, most recent first. (#621)
+///
+/// <para>
+/// Window-level commands — zoom, ⌘W, ⌘G, ⌘E, ⌘D, ⌘F — have to know which document to act on, and
+/// <see cref="DocumentTargetResolver"/> answers that from Avalonia's keyboard focus. That works until focus
+/// is inside a CEF WebView, which hosts a native surface Avalonia never sees; resolution then falls through
+/// to "the first document dock in tree order", which in a split is simply the wrong pane. Since books, the
+/// PDF viewer and the Welcome page are ALL browsers, that is most of the reader's surface.
+/// </para>
+///
+/// <para>
+/// This holds the signal Avalonia cannot supply, fed from three places that CAN see an interaction: the
+/// dock model's own activation event, CEF's focus callback, and Avalonia focus transitions. What it stores
+/// is deliberately thin — it never decides anything, it only records order.
+/// </para>
+///
+/// <para>
+/// <b>Everything is recorded, tools included.</b> Filtering happens when the list is READ, by asking the
+/// caller's layout which of these dockables it contains. That single rule buys three things at once: a
+/// document whose <c>Owner</c> is not yet set on its first activation is still recorded; a tool activation
+/// can never clobber the document history, because tools simply fail the containment test; and one flat
+/// list serves every window, since each window's own layout selects its own entries. Keying by window was
+/// the obvious alternative and is a trap — Dock's <c>FindRoot</c> returns the NEAREST root, the inner
+/// <c>WindowLayout</c>, while every caller holds the outer <c>Root</c>, so the keys would never match.
+/// </para>
+///
+/// <para>
+/// Entries are weak. A closed tab is evicted explicitly, but the weak reference is what guarantees this can
+/// never be the thing keeping a disposed ViewModel — and its WebView — alive for the session.
+/// </para>
+/// </summary>
+public class ActiveDocumentTracker
+{
+    /// <summary>
+    /// How much history to keep. Deep enough to survive a detour through other tabs and back, shallow
+    /// enough that "most recent" still means something. The read side walks it in order and stops at the
+    /// first entry the asking layout contains, so extra depth costs a few reference comparisons.
+    /// </summary>
+    private const int Capacity = 8;
+
+    private readonly List<WeakReference<IDockable>> _recent = new();
+    private readonly object _gate = new();
+
+    /// <summary>
+    /// Records an interaction. Safe to call redundantly — the same dockable twice in a row is one entry,
+    /// which matters because the three feeds overlap by design: clicking a tab raises both an activation
+    /// and an Avalonia focus change, and clicking a book's text raises a CEF focus callback that may follow
+    /// either.
+    /// </summary>
+    /// <param name="source">
+    /// Which feed reported this, for the log. The feeds overlap, and when two of them disagree about what
+    /// the user just clicked — which is the failure #621 hit in a three-way split — the document alone does
+    /// not say who was wrong. (#621)
+    /// </param>
+    public void Note(IDockable? dockable, string source = "?")
+    {
+        if (dockable == null) return;
+
+        bool changed;
+        lock (_gate)
+        {
+            changed = _recent.Count == 0 || !(_recent[0].TryGetTarget(out var head) && ReferenceEquals(head, dockable));
+
+            // Reference identity, not Id: splits produce several docks sharing the id "MainDocumentDock",
+            // and two books of the same text would compare equal on anything less exact.
+            _recent.RemoveAll(w => !w.TryGetTarget(out var t) || ReferenceEquals(t, dockable));
+            _recent.Insert(0, new WeakReference<IDockable>(dockable));
+            if (_recent.Count > Capacity) _recent.RemoveRange(Capacity, _recent.Count - Capacity);
+        }
+
+        // Only when the front of the history actually moves. The three feeds overlap, so logging every
+        // note would emit several lines per click and say nothing the first one didn't.
+        if (changed)
+            Log.ForContext<ActiveDocumentTracker>()
+                .Debug("Active document is now {Dockable} (via {Source})", dockable.Id, source);
+    }
+
+    /// <summary>
+    /// Drops a dockable from the history — called when a tab closes, so the list cannot offer a document
+    /// that no longer exists. Not strictly required (the resolver's containment check rejects a closed
+    /// dockable anyway, and the weak reference eventually clears), but doing it at the close makes the
+    /// list's contents match reality at the moment reality changes, rather than eventually.
+    /// </summary>
+    public void Forget(IDockable? dockable)
+    {
+        if (dockable == null) return;
+
+        lock (_gate)
+        {
+            _recent.RemoveAll(w => !w.TryGetTarget(out var t) || ReferenceEquals(t, dockable));
+        }
+    }
+
+    /// <summary>
+    /// The live history, most recent first. Snapshotted, so a caller can walk it while a feed writes.
+    /// </summary>
+    public IReadOnlyList<IDockable> Recent
+    {
+        get
+        {
+            lock (_gate)
+            {
+                // Prune here as well as on write: a session that opens and closes documents without ever
+                // being asked for the history would otherwise accumulate dead references up to Capacity.
+                _recent.RemoveAll(w => !w.TryGetTarget(out _));
+                return _recent
+                    .Select(w => w.TryGetTarget(out var t) ? t : null)
+                    .Where(d => d != null)
+                    .Cast<IDockable>()
+                    .ToList();
+            }
+        }
+    }
+
+    /// <summary>Forgets everything. For tests; the app has no reason to call it.</summary>
+    internal void Clear()
+    {
+        lock (_gate) _recent.Clear();
+    }
+}

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -47,6 +47,30 @@ namespace CST.Avalonia.Services
         public CstDockFactory()
         {
             _logger = Log.ForContext<CstDockFactory>();
+
+            // #621 Feed A: the dock model's own activation signal. Dock raises this from the ActiveDockable
+            // SETTER (via InitActiveDockable), so one subscription here covers every dock in every window —
+            // including docks created later by a split and by floating windows — without per-dock wiring.
+            // It fires for user tab clicks, programmatic opens, layout restore, and the neighbour promotion
+            // inside CloseDockable, which is what makes the next command after a close land in the same pane.
+            //
+            // Everything is recorded, tools included; the tracker's contract is that filtering happens on
+            // read. A new document's Owner may not be set yet at its first activation, so a containment or
+            // type test HERE would silently drop exactly the tab the user just opened.
+            ActiveDockableChanged += (_, e) => DocumentTracker?.Note(e.Dockable, "dock-activation");
+        }
+
+        private ActiveDocumentTracker? _documentTracker;
+
+        /// <summary>
+        /// Interaction history for window-level command targeting (#621). Resolved from the service locator
+        /// rather than injected because this factory is constructed directly, in several places; settable so
+        /// a test can observe the activation feed without an App.
+        /// </summary>
+        internal ActiveDocumentTracker? DocumentTracker
+        {
+            get => _documentTracker ??= App.ServiceProvider?.GetService<ActiveDocumentTracker>();
+            set => _documentTracker = value;
         }
 
         public override RootDock CreateLayout()
@@ -1689,6 +1713,11 @@ namespace CST.Avalonia.Services
             if (dockable != null)
             {
                 base.CloseDockable(dockable);
+
+                // #621: drop it from the interaction history. The resolver's containment check would reject
+                // a closed dockable anyway and the weak reference would eventually clear, but evicting here
+                // keeps the history matching reality at the moment reality changes.
+                DocumentTracker?.Forget(dockable);
 
                 // AFTER the base call, and only if the dockable actually left. base.CloseDockable can DECLINE
                 // (CanClose false, CanCloseLastDockable, a closing-event veto), and deleting first meant a

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1714,17 +1714,23 @@ namespace CST.Avalonia.Services
             {
                 base.CloseDockable(dockable);
 
-                // #621: drop it from the interaction history. The resolver's containment check would reject
-                // a closed dockable anyway and the weak reference would eventually clear, but evicting here
-                // keeps the history matching reality at the moment reality changes.
-                DocumentTracker?.Forget(dockable);
-
                 // AFTER the base call, and only if the dockable actually left. base.CloseDockable can DECLINE
                 // (CanClose false, CanCloseLastDockable, a closing-event veto), and deleting first meant a
                 // declined close left an open book with no saved state — invisible until it failed to reappear
                 // next launch. This is now the ONLY place book state is deleted, so nothing else would heal it.
                 // Same tripwire idiom as CloseBook(id). (#623)
-                if (dockable is BookDisplayViewModel && FindDockable(dockable.Id) == null)
+                // Under the SAME guard, for the same reason. #621's eviction was placed above it, which put
+                // it back on the wrong side of the very rule the comment above states: a DECLINED close
+                // would drop the still-open document from the interaction history, and the next command
+                // resolved with focus in a browser would then pick an older entry or fall through to the
+                // first dock. Narrow in practice today — the reachable close paths pre-check CanClose — but
+                // this is the guard-placement mistake §E.1 exists to prevent, and the next decline path
+                // added would not heal it. (fable review)
+                var actuallyLeft = FindDockable(dockable.Id) == null;
+                if (actuallyLeft)
+                    DocumentTracker?.Forget(dockable);
+
+                if (dockable is BookDisplayViewModel && actuallyLeft)
                 {
                     RemoveBookWindowState(dockable.Id);
                     Log.Debug("*** Removed book window state for {DockableId} ***", dockable.Id);

--- a/src/CST.Avalonia/Services/CstHostWindow.cs
+++ b/src/CST.Avalonia/Services/CstHostWindow.cs
@@ -69,6 +69,12 @@ namespace CST.Avalonia.Services
             // Set up event handlers
             Closing += OnClosing;
             PositionChanged += OnPositionChanged;
+
+            // #621 Feed C, same as the main window: a floating window's commands resolve against its own
+            // layout, so its interactions have to reach the shared history too — otherwise a command here
+            // would fall through to this window's first dock.
+            AddHandler(GotFocusEvent, (_, e) => DocumentFocusReporter.NoteFocus(e.Source),
+                global::Avalonia.Interactivity.RoutingStrategies.Bubble);
         }
 
         private void OnPositionChanged(object? sender, PixelPointEventArgs e)

--- a/src/CST.Avalonia/Services/DocumentFocusReporter.cs
+++ b/src/CST.Avalonia/Services/DocumentFocusReporter.cs
@@ -1,0 +1,78 @@
+using Avalonia;
+using Avalonia.VisualTree;
+using Dock.Model.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Feed C of the interaction history (#621): Avalonia focus transitions, from a window-level GotFocus
+/// handler.
+///
+/// <para>
+/// The other two feeds each have a blind spot this covers. The dock model's activation event does not fire
+/// when the user clicks the tab of the pane that is ALREADY active — nothing about the model changed — and
+/// CEF's focus callback only speaks for clicks that land inside a browser. Between them sits a real case:
+/// click the already-active tab of the second split, then move focus to a tool, and without this the next
+/// ⌘W would close a tab in the other pane.
+/// </para>
+///
+/// <para>
+/// Kept out of <see cref="ActiveDocumentTracker"/> so that type stays free of Avalonia, which is what lets
+/// the history be tested headlessly.
+/// </para>
+/// </summary>
+internal static class DocumentFocusReporter
+{
+    /// <summary>
+    /// Records the dockable owning whatever just took focus. The same DataContext walk
+    /// <c>SimpleTabbedWindow.ResolveFocusedDockable</c> performs, run from the focus event's source rather
+    /// than by asking the FocusManager afterwards.
+    /// </summary>
+    public static void NoteFocus(object? source)
+    {
+        if (source is not Visual element) return;
+
+        while (element != null)
+        {
+            if (element is StyledElement { DataContext: IDockable dockable })
+            {
+                // A browser-hosting view speaks for itself through CEF, not through Avalonia — see
+                // ShouldReport.
+                if (!ShouldReport(element))
+                {
+                    Serilog.Log.ForContext(typeof(DocumentFocusReporter))
+                        .Debug("Avalonia focus ignored (browser view owns its focus): {Element} -> {Dockable}",
+                            element.GetType().Name, dockable.Id);
+                    return;
+                }
+
+                // Everything else is recorded, tools included — the tracker filters on read, by asking
+                // each window's layout what it contains.
+                App.ServiceProvider?.GetService<ActiveDocumentTracker>()?.Note(dockable, "avalonia-focus");
+                return;
+            }
+
+            element = element.GetVisualParent();
+        }
+    }
+
+    /// <summary>
+    /// Whether an Avalonia focus landing counts as an interaction.
+    ///
+    /// <para>
+    /// It does not when it lands on a browser-hosting document view. Those views are focusable and are what
+    /// Avalonia focuses when a window is activated or a layout rebuilt, so they emit a focus event naming
+    /// whichever document held focus LAST — a stale answer that arrives looking exactly like a fresh one,
+    /// within milliseconds of the correct CEF report, and wins whenever it happens to land second.
+    /// </para>
+    ///
+    /// <para>
+    /// Nothing is lost by ignoring them, because those are precisely the documents whose real focus CEF
+    /// reports directly (<c>CstWebView.BrowserGotFocus</c>). What Avalonia still speaks for — and what this
+    /// feed exists for — is everything else: a tab-strip click, which raises no activation when the tab is
+    /// already active in its own split, and the toolbar controls and tool panes.
+    /// </para>
+    /// </summary>
+    internal static bool ShouldReport(object? focusedElement) => focusedElement is not IBrowserDocumentView;
+}

--- a/src/CST.Avalonia/Services/DocumentTargetResolver.cs
+++ b/src/CST.Avalonia/Services/DocumentTargetResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Dock.Model.Controls;
 using Dock.Model.Core;
@@ -14,26 +15,59 @@ namespace CST.Avalonia.Services;
 ///
 /// Resolution now follows focus, which is what the user means by "this book", and falls back to the old
 /// first-dock behaviour when nothing usable is focused (a fresh layout, or focus sitting on a tool).
+///
+/// #621 added a tier between the two. Following focus is only as good as focus is visible, and inside a CEF
+/// WebView it is not visible at all - the browser owns a native surface, so a click into a book, a PDF or
+/// the Welcome page leaves Avalonia with nothing to report and resolution fell straight through to the
+/// first-dock guess. Since those three ARE most of the reader's surface, the #443 bug was reachable again
+/// the moment anyone clicked into a document rather than onto its tab. <see cref="ActiveDocumentTracker"/>
+/// supplies the missing signal.
 /// </summary>
 public static class DocumentTargetResolver
 {
     /// <summary>
-    /// The document the user is working in: the focused document, else the active document of the dock
-    /// that holds focus, else the active document of the first document dock in the layout.
+    /// The document the user is working in, in descending order of confidence: the focused document (or
+    /// the active document of the dock that holds focus), else the most recently interacted-with document
+    /// this layout contains, else Dock's own focus record, else the active document of the first document
+    /// dock in the layout.
     /// </summary>
     /// <param name="preferred">
     /// A dockable the caller believes the user is working in - normally derived from real Avalonia keyboard
     /// focus (see SimpleTabbedWindow.ResolveFocusedDockable). Used when it sits inside a document dock.
-    /// Dock's own <c>RootDock.FocusedDockable</c> is never populated in this app - it is null even right
-    /// after clicking a tab - so it cannot be the source of truth on its own.
     /// </param>
-    public static IDockable? ResolveActiveDocument(IDock? layout, IDockable? preferred = null)
+    /// <param name="recentDocuments">
+    /// Interaction history, most recent first, from <see cref="ActiveDocumentTracker"/> (#621). The tier
+    /// that exists because Avalonia focus goes BLIND inside a CEF WebView: a click into a book, a PDF or
+    /// the Welcome page reaches a native surface, <paramref name="preferred"/> comes back null, and without
+    /// this the answer would be the first-dock guess - the wrong pane in any split.
+    ///
+    /// <para>
+    /// Deliberately unfiltered by the caller: the first entry this layout CONTAINS wins, which is what
+    /// scopes a single app-wide history per window and what skips tool activations without the tracker
+    /// having to know what a tool is.
+    /// </para>
+    /// </param>
+    public static IDockable? ResolveActiveDocument(IDock? layout, IDockable? preferred = null,
+        IEnumerable<IDockable>? recentDocuments = null)
     {
         if (layout == null)
             return null;
 
         if (preferred != null && FindDocumentDockContaining(layout, preferred) is { } preferredDock)
             return preferred is IDock ? preferredDock.ActiveDockable : preferred;
+
+        // Live focus first, history second: when Avalonia CAN see focus it is describing this instant,
+        // while history describes the recent past. They agree except when focus has moved somewhere the
+        // history has not caught up with, and there the present is right.
+        if (recentDocuments != null)
+        {
+            foreach (var recent in recentDocuments)
+            {
+                if (recent == null) continue;
+                if (FindDocumentDockContaining(layout, recent) is not { } recentDock) continue;
+                return recent is IDock ? recentDock.ActiveDockable : recent;
+            }
+        }
 
         var focused = layout.FocusedDockable;
 

--- a/src/CST.Avalonia/Services/IBrowserDocumentView.cs
+++ b/src/CST.Avalonia/Services/IBrowserDocumentView.cs
@@ -1,0 +1,29 @@
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// A document view whose content is a CEF browser: the book reader, the source-PDF viewer, the Welcome
+/// page. (#621)
+///
+/// <para>
+/// Marks the views for which <b>CEF's own focus callback is authoritative and Avalonia's is not</b>. Focus
+/// inside these lands on a native surface, so Avalonia never sees the click that matters; what it does see
+/// is the view control itself being focused when the window is activated or the layout rebuilt — which
+/// names whichever document held focus last, not the one the user just clicked.
+/// </para>
+///
+/// <para>
+/// Measured, in a three-way split in a floating window: every window-activation echo arrived as
+/// <c>source=BookDisplayView</c> and named the same stale book regardless of which book was clicked,
+/// landing within ~15ms of the correct CEF report. Whichever arrived last won, so a single click targeted
+/// the right book only about half the time, while a second click — which produces no echo — always worked.
+/// </para>
+///
+/// <para>
+/// The marker exists rather than a type list in <see cref="DocumentFocusReporter"/> so that a fourth
+/// browser-hosting document, whenever one appears, states this property about itself instead of relying on
+/// someone finding a list in another namespace.
+/// </para>
+/// </summary>
+internal interface IBrowserDocumentView
+{
+}

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:CST.Avalonia.ViewModels"
              xmlns:wv="using:WebViewControl"
+             xmlns:ctl="using:CST.Avalonia.Controls"
              xmlns:converters="using:CST.Avalonia.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="CST.Avalonia.Views.BookDisplayView"
@@ -371,7 +372,7 @@
         <Border DockPanel.Dock="Top" BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="1">
             <Panel>
                 <!-- WebView Browser -->
-                <wv:WebView x:Name="webView" 
+                <ctl:CstWebView x:Name="webView" 
                            IsVisible="{Binding IsWebViewAvailable}"
                            Focusable="True"
                            IsTabStop="True"

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -227,8 +227,13 @@ public partial class BookDisplayView : UserControl, Services.IBrowserDocumentVie
                 // subscription follows the browser's lifecycle for free. Reads _viewModel at event time:
                 // ControlRecycling can rebind this View to a different book.
                 if (_webView is Controls.CstWebView focusReporter)
-                    focusReporter.BrowserGotFocus += () =>
-                        App.ServiceProvider?.GetService<ActiveDocumentTracker>()?.Note(_viewModel, "browser-focus:book");
+                {
+                    // A NAMED handler, not a lambda, so DisposeWebView can take it off again. FindControl
+                    // returns the same CstWebView on every recreate and Dispose does not clear an event's
+                    // handler list, so a lambda stacked one more copy per window change. (fable review)
+                    focusReporter.BrowserGotFocus -= OnBrowserGotFocus;
+                    focusReporter.BrowserGotFocus += OnBrowserGotFocus;
+                }
 
                 // Add diagnostic logging for focus on the WebView itself
                 _webView.GotFocus += (s, e) => _logger.Debug("FOCUS: WebView GotFocus. Source: {Source}", e.Source?.GetType().Name);
@@ -290,6 +295,13 @@ public partial class BookDisplayView : UserControl, Services.IBrowserDocumentVie
         }
     }
 
+    // Reads _viewModel at event time: ControlRecycling can rebind this View to a different book.
+
+    private void OnBrowserGotFocus() =>
+
+        App.ServiceProvider?.GetService<ActiveDocumentTracker>()?.Note(_viewModel, "browser-focus:book");
+
+
     private void DisposeWebView()
     {
         if (_webView != null)
@@ -301,6 +313,8 @@ public partial class BookDisplayView : UserControl, Services.IBrowserDocumentVie
                 // Unsubscribe from events
                 _webView.Navigated -= OnNavigationCompleted;
                 _webView.TitleChanged -= OnTitleChanged;
+                if (_webView is Controls.CstWebView focusReporter)
+                    focusReporter.BrowserGotFocus -= OnBrowserGotFocus;   // (fable review)
 
                 // Dispose the WebView to release native resources
                 _webView.Dispose();

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -17,11 +17,12 @@ using WebViewControl;
 using CST.Avalonia.ViewModels;
 using CST.Avalonia.Services;
 using CST.Avalonia.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 
 namespace CST.Avalonia.Views;
 
-public partial class BookDisplayView : UserControl
+public partial class BookDisplayView : UserControl, Services.IBrowserDocumentView
 {
     // Shared lock to serialize JavaScript execution across all instances
     private static readonly SemaphoreSlim _jsExecutionLock = new SemaphoreSlim(1, 1);
@@ -218,6 +219,16 @@ public partial class BookDisplayView : UserControl
                 // Set up event handlers
                 _webView.Navigated += OnNavigationCompleted;
                 _webView.TitleChanged += OnTitleChanged;
+
+                // #621: a click into the book's TEXT is invisible to Avalonia — CEF owns that surface — so
+                // without this the next window-level command would target whichever pane happens to be
+                // first in tree order. Subscribed here rather than once in the constructor because
+                // TryCreateWebView runs again after every float/unfloat dispose-and-recreate, so the
+                // subscription follows the browser's lifecycle for free. Reads _viewModel at event time:
+                // ControlRecycling can rebind this View to a different book.
+                if (_webView is Controls.CstWebView focusReporter)
+                    focusReporter.BrowserGotFocus += () =>
+                        App.ServiceProvider?.GetService<ActiveDocumentTracker>()?.Note(_viewModel, "browser-focus:book");
 
                 // Add diagnostic logging for focus on the WebView itself
                 _webView.GotFocus += (s, e) => _logger.Debug("FOCUS: WebView GotFocus. Source: {Source}", e.Source?.GetType().Name);

--- a/src/CST.Avalonia/Views/PdfDisplayView.axaml
+++ b/src/CST.Avalonia/Views/PdfDisplayView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:CST.Avalonia.ViewModels"
              xmlns:wv="using:WebViewControl"
+             xmlns:ctl="using:CST.Avalonia.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="CST.Avalonia.Views.PdfDisplayView"
              x:DataType="vm:PdfDisplayViewModel"
@@ -35,7 +36,7 @@
         <Border DockPanel.Dock="Top" BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="1">
             <Panel>
                 <!-- WebView for PDF Display (CEF's PDFium handles PDF rendering) -->
-                <wv:WebView x:Name="webView"
+                <ctl:CstWebView x:Name="webView"
                            IsVisible="{Binding IsWebViewAvailable}"
                            Focusable="True"
                            IsTabStop="True"

--- a/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
@@ -43,9 +43,11 @@ public partial class PdfDisplayView : UserControl, Services.IBrowserDocumentView
                 // acting on whatever book was in the first dock. Verified to fire even though Chromium
                 // renders the page in an internal plugin frame, which is where the #518 relay dies.
                 if (_webView is Controls.CstWebView focusReporter)
-                    focusReporter.BrowserGotFocus += () =>
-                        App.ServiceProvider?.GetService<Services.ActiveDocumentTracker>()
-                            ?.Note(DataContext as ViewModels.PdfDisplayViewModel, "browser-focus:pdf");
+                {
+                    // Named, so the dispose path can detach it — see BookDisplayView. (fable review)
+                    focusReporter.BrowserGotFocus -= OnBrowserGotFocus;
+                    focusReporter.BrowserGotFocus += OnBrowserGotFocus;
+                }
                 _logger.Debug("PDF WebView control found and events attached");
             }
             else
@@ -99,6 +101,15 @@ public partial class PdfDisplayView : UserControl, Services.IBrowserDocumentView
         WebViewShortcutRelay.TryHandle(_webView?.Title, _shortcutViewId, _logger);
     }
 
+    // Reads DataContext at event time, as the original lambda did.
+
+    private void OnBrowserGotFocus() =>
+
+        App.ServiceProvider?.GetService<Services.ActiveDocumentTracker>()
+
+            ?.Note(DataContext as ViewModels.PdfDisplayViewModel, "browser-focus:pdf");
+
+
     private void DisposeWebView()
     {
         if (_webView != null)
@@ -108,6 +119,8 @@ public partial class PdfDisplayView : UserControl, Services.IBrowserDocumentView
                 _logger.Information("Disposing PDF WebView");
                 _webView.Navigated -= OnNavigationCompleted;
                 _webView.TitleChanged -= OnShortcutTitleChanged;   // #518
+                if (_webView is Controls.CstWebView focusReporter)
+                    focusReporter.BrowserGotFocus -= OnBrowserGotFocus;   // (fable review)
                 _webView.Dispose();
                 _webView = null;
                 _hasPdfLoaded = false;  // Reset so PDF reloads after recreate

--- a/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
@@ -6,11 +6,12 @@ using ReactiveUI;
 using WebViewControl;
 using CST.Avalonia.Input;
 using CST.Avalonia.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 
 namespace CST.Avalonia.Views;
 
-public partial class PdfDisplayView : UserControl
+public partial class PdfDisplayView : UserControl, Services.IBrowserDocumentView
 {
     private readonly ILogger _logger;
     private PdfDisplayViewModel? _viewModel;
@@ -37,6 +38,14 @@ public partial class PdfDisplayView : UserControl
             {
                 _webView.Navigated += OnNavigationCompleted;
                 _webView.TitleChanged += OnShortcutTitleChanged;   // #518
+
+                // #621: the PDF body is the case that motivated this — clicking into it left the keyboard
+                // acting on whatever book was in the first dock. Verified to fire even though Chromium
+                // renders the page in an internal plugin frame, which is where the #518 relay dies.
+                if (_webView is Controls.CstWebView focusReporter)
+                    focusReporter.BrowserGotFocus += () =>
+                        App.ServiceProvider?.GetService<Services.ActiveDocumentTracker>()
+                            ?.Note(DataContext as ViewModels.PdfDisplayViewModel, "browser-focus:pdf");
                 _logger.Debug("PDF WebView control found and events attached");
             }
             else

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -66,6 +66,12 @@ public partial class SimpleTabbedWindow : Window
         // #28: and Settings has no entry point off macOS until we add one.
         AddSettingsMenuItemOffMacOS();
 
+        // #621 Feed C: record which document owns whatever just took focus, so a command pressed after a
+        // detour through a tool still targets the pane the user was working in. Bubbling and passive — it
+        // only reads the event.
+        AddHandler(GotFocusEvent, (_, e) => Services.DocumentFocusReporter.NoteFocus(e.Source),
+            RoutingStrategies.Bubble);
+
         // Add diagnostic logging for focus and keyboard events
         GotFocus += (s, e) => _logger.Debug("FOCUS: SimpleTabbedWindow GotFocus. Source: {Source}", e.Source?.GetType().Name);
         LostFocus += (s, e) => _logger.Debug("FOCUS: SimpleTabbedWindow LostFocus. Source: {Source}", e.Source?.GetType().Name);
@@ -885,7 +891,7 @@ public partial class SimpleTabbedWindow : Window
             // the pane they are actually in rather than always the first one. (#443)
             if (layoutViewModel.Layout is RootDock rootDock)
             {
-                var active = DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this));
+                var active = DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this), RecentDocuments());
                 if (active is BookDisplayViewModel bookViewModel)
                 {
                     _logger.Information("Triggering Go To dialog for active book: {BookFile}", bookViewModel.Book.FileName);
@@ -950,7 +956,11 @@ public partial class SimpleTabbedWindow : Window
             _logger.Debug("{What}: no active book in window {WindowTitle}", what, this.Title);
             return;
         }
-        _logger.Information("{What} from window: {WindowTitle}", what, this.Title);
+        // Naming the resolved book is what makes a wrong-target report diagnosable from a log rather than
+        // from a description: "it zoomed the other one" and "it zoomed this one" produce identical lines
+        // without it. (#621)
+        _logger.Information("{What} from window {WindowTitle} - target: {Book}", what, this.Title,
+            book.Book?.FileName ?? "(unknown)");
         action(book.BookDisplayControl);
     }
 
@@ -1123,7 +1133,7 @@ public partial class SimpleTabbedWindow : Window
             layoutViewModel.Layout is not RootDock rootDock)
             return null;
 
-        return DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this)) as BookDisplayViewModel;
+        return DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this), RecentDocuments()) as BookDisplayViewModel;
     }
 
     // Reduce a selection to a single lookup word: first whitespace-delimited token, minus surrounding
@@ -1161,7 +1171,7 @@ public partial class SimpleTabbedWindow : Window
                 layoutViewModel.Layout is not RootDock rootDock)
                 return;
 
-            CloseDockableIfClosable(DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this)));
+            CloseDockableIfClosable(DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this), RecentDocuments()));
         }
         catch (Exception ex)
         {
@@ -1180,6 +1190,13 @@ public partial class SimpleTabbedWindow : Window
     // safe is the containment check in DocumentTargetResolver: a dockable outside this window's layout is
     // contained by none of its document docks, so resolution falls back instead of reaching across windows.
     // A test covers this; do not drop the containment check.
+    /// <summary>
+    /// Interaction history for <see cref="DocumentTargetResolver.ResolveActiveDocument"/> (#621), most
+    /// recent first. Null when the tracker is unavailable, which resolves exactly as before this existed.
+    /// </summary>
+    private static IEnumerable<IDockable>? RecentDocuments() =>
+        App.ServiceProvider?.GetService<ActiveDocumentTracker>()?.Recent;
+
     internal static IDockable? ResolveFocusedDockable(Window? window)
     {
         var element = window?.FocusManager?.GetFocusedElement() as Visual;
@@ -1235,7 +1252,7 @@ public partial class SimpleTabbedWindow : Window
                 layoutViewModel.Layout is not RootDock rootDock)
                 return;
 
-            if (DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this)) is not BookDisplayViewModel bookViewModel)
+            if (DocumentTargetResolver.ResolveActiveDocument(rootDock, ResolveFocusedDockable(this), RecentDocuments()) is not BookDisplayViewModel bookViewModel)
                 return;
 
             _logger.Information("View Source ({Edition}) via menu/shortcut for book: {BookFile}",

--- a/src/CST.Avalonia/Views/WelcomeView.axaml
+++ b/src/CST.Avalonia/Views/WelcomeView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:wv="using:WebViewControl"
+             xmlns:ctl="using:CST.Avalonia.Controls"
              xmlns:vm="using:CST.Avalonia.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="CST.Avalonia.Views.WelcomeView"
@@ -30,7 +31,7 @@
             </Border>
 
             <!-- Welcome content -->
-            <wv:WebView Grid.Row="1"
+            <ctl:CstWebView Grid.Row="1"
                         x:Name="WelcomeWebView"
                         Focusable="True"
                         IsTabStop="True" />

--- a/src/CST.Avalonia/Views/WelcomeView.axaml.cs
+++ b/src/CST.Avalonia/Views/WelcomeView.axaml.cs
@@ -7,11 +7,12 @@ using Avalonia.Threading;
 using WebViewControl;
 using CST.Avalonia.Input;
 using CST.Avalonia.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 
 namespace CST.Avalonia.Views
 {
-    public partial class WelcomeView : UserControl
+    public partial class WelcomeView : UserControl, Services.IBrowserDocumentView
     {
         private WebView? _webView;
         private WelcomeViewModel? _viewModel;
@@ -34,6 +35,14 @@ namespace CST.Avalonia.Views
                 _webView.WebViewInitialized += OnWebViewInitialized;
                 _webView.Navigated += OnNavigated;
                 _webView.TitleChanged += OnShortcutTitleChanged;   // #518
+
+                // #621: Welcome is a document too, and clicking into it is as invisible to Avalonia as
+                // clicking into a book. Recording it matters mainly in the negative — it stops a command
+                // pressed here from acting on a book the user has not touched in a while.
+                if (_webView is Controls.CstWebView focusReporter)
+                    focusReporter.BrowserGotFocus += () =>
+                        App.ServiceProvider?.GetService<Services.ActiveDocumentTracker>()
+                            ?.Note(DataContext as ViewModels.WelcomeViewModel, "browser-focus:welcome");
 
                 // Log WebView state
                 Log.Information("WelcomeView: WebView control found and event handlers attached");


### PR DESCRIPTION
Window-level commands — zoom, ⌘W, ⌘G, ⌘E, ⌘D, ⌘F — resolve their target from Avalonia's keyboard focus, falling back to *the first document dock in tree order*. A CEF WebView hosts a native surface, so a click into a book, a PDF or the Welcome page leaves Avalonia with nothing to report and the fallback runs. Those three are most of the reader's surface, so **#443's bug was reachable again the moment anyone clicked into a document rather than onto its tab**.

`ActiveDocumentTracker` supplies the signal Avalonia cannot: a bounded, weakly-held history of interactions, read as one new tier between live focus and the first-dock guess.

| Feed | Sees |
|---|---|
| `dock-activation` | Dock's `ActiveDockable` setter — one subscription covering every dock in every window, including ones splits and floating windows create later |
| `browser-focus` | CEF's own focus callback — the only signal that can see a click into a browser body |
| `avalonia-focus` | window-level `GotFocus` — tab-strip clicks (no activation fires when the tab is already active in its own split), toolbar controls, tool panes |

**Everything is recorded, tools included, and filtering happens on read** by asking the caller's layout what it contains. That single rule buys three things: a new document whose `Owner` isn't set yet still registers; a tool activation can't displace the document history; and one flat list serves every window. Keying per window is a trap — Dock's `FindRoot` returns the *nearest* root, the inner `WindowLayout`, while every caller holds the outer `Root`, so the keys would never match.

Live focus still beats history, which is what makes #443 unable to regress. Every pre-existing resolver test passes unchanged, and they double as the guarantee: they pass no history, which is also the "tracker unavailable" production path.

## Two things measured rather than assumed

Both changed the design, and both are the kind of assumption that would have failed silently.

**CEF's `OnGotFocus` does fire for the PDF's internal plugin frame** — the place where the in-page keydown relay is already known to be inert (#518). Had it not, the browser feed couldn't have covered PDFs at all. The same probe settled two more: `OnLostFocus` never fires, so nothing may depend on being told focus *left*; and `OnSetFocus` reports "suppressed" while granting focus anyway, so it is not a usable predictor.

**Avalonia focus landing on a document view is a window-activation echo.** It names whichever document held focus last, not the one just clicked. Measured in a three-way split in a floating window: it named the same stale book every time, landing within ~15 ms of the correct CEF report, so a single click targeted the right book about half the time while a second click always worked. `IBrowserDocumentView` marks the views whose focus CEF speaks for, and the Avalonia feed ignores those landings — losing nothing, since that is exactly the set CEF reports directly.

## A correction to the record

`RootDock.FocusedDockable` is **not** "never populated in this app", as the resolver's comment claimed. It is populated on the **inner** root — Dock's `SetFocusedDockable` resolves via `FindRoot`, the nearest one — while every call site passes the **outer** `Root`. That is also why the repeated-⌘W nudge in `CloseDockableIfClosable` never worked: it writes where nobody reads. The activation feed repairs that as a side effect, since a close promotes a neighbour through the `ActiveDockable` setter.

## Scope: what this does not cover

With focus inside a book, CEF consumes the keystroke and the page relays it to its own view, so none of this is consulted — the target is then decided purely by which browser holds keyboard focus. That path has its own defect, **filed as #633**, and it is upstream of everything here.

## Testing

Full suite **1577 passed, 0 failed**, including 22 new tests: the tracker's recording rules, the resolver's new tier (including the reported sequence, and history walking past tools and other windows' documents), the echo rule, and a guard asserting that assigning `ActiveDockable` really does raise `ActiveDockableChanged` — if a Dock upgrade moves that call, the feed goes silent with nothing to show for it.

Verified in the running app on macOS: the PDF body no longer hijacks the keyboard, ⌘W closes what you are looking at, and Go To targets correctly across a three-way split in a floating window. **Windows unverified.**

Closes #621.
