### PR TITLE
Index ranged paragraph numbers instead of dropping them (#446)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/BookMarkersTests.cs
+++ b/src/CST.Avalonia.Tests/Search/BookMarkersTests.cs
@@ -26,5 +26,131 @@ namespace CST.Avalonia.Tests.Search
             var xml = "<div type=\"chapter\" id=\"c1\"><p n=\"1\">a</p><p n=\"2\">b</p></div>";
             Assert.Empty(BookMarkers.Build(xml).DistinctBookCodes());
         }
+
+        // ---- Ranged paragraph @n (#446) ------------------------------------------------------------
+
+        // 3,618 paragraphs across 87 of the 217 corpus files carry a non-integer @n. They used to fail
+        // int.TryParse and be dropped from the index, which did not produce a MISSING citation but a WRONG
+        // one: the lookup answered with the last paragraph it had indexed, i.e. the one before the block.
+
+        [Theory]
+        [InlineData("21", 21, 21)]           // the ordinary case, 97% of the corpus
+        [InlineData("16-26", 16, 26)]        // a full range - vin02t.tik.xml
+        [InlineData("196-7", 196, 197)]      // ABBREVIATED tail: 196..197, not 196..7
+        [InlineData("266-7-8", 266, 268)]    // vin11t.nrf.xml; the next numbered paragraph there is 269
+        [InlineData("292-3-6", 292, 296)]    // s0105t.nrf.xml; followed by 297
+        [InlineData("18-19-20", 18, 20)]     // e0812n.nrf.xml, unabbreviated list form
+        public void A_paragraph_number_spans_every_form_the_corpus_uses(string n, int first, int last)
+        {
+            Assert.True(BookMarkers.TryParseParagraphSpan(n, out var f, out var l));
+            Assert.Equal(first, f);
+            Assert.Equal(last, l);
+        }
+
+        [Fact]
+        public void The_abbreviated_tail_is_expanded_not_taken_literally()
+        {
+            // The distinction the whole rule turns on. Read literally, "196-7" is a span from 196 down to 7
+            // and would swallow 189 paragraphs; read as an abbreviation it is 196..197. 1,518 paragraphs use
+            // this form, so getting it backwards would be worse than the bug being fixed.
+            BookMarkers.TryParseParagraphSpan("196-7", out var f, out var l);
+
+            Assert.Equal(196, f);
+            Assert.Equal(197, l);
+            Assert.Equal(2, l - f + 1);
+        }
+
+        [Theory]
+        [InlineData("179-", 179, 179)]   // e0812n.nrf.xml - a real corpus typo; 179 is still a real paragraph
+        public void A_trailing_hyphen_keeps_its_number_rather_than_being_dropped(string n, int first, int last)
+        {
+            // Discarding it would reintroduce exactly the defect this fixes: a paragraph missing from the
+            // index means the NEXT lookup answers with an earlier one and calls it correct.
+            Assert.True(BookMarkers.TryParseParagraphSpan(n, out var f, out var l));
+            Assert.Equal(first, f);
+            Assert.Equal(last, l);
+        }
+
+        [Theory]
+        [InlineData("-")]        // e1207n.nrf.xml - a bare hyphen, no number at all
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData(null)]
+        [InlineData("iv")]       // no digits: not a paragraph number we understand
+        public void A_value_with_no_number_is_not_indexed(string? n)
+        {
+            Assert.False(BookMarkers.TryParseParagraphSpan(n, out _, out _));
+        }
+
+        [Fact]
+        public void A_hit_inside_a_ranged_paragraph_is_no_longer_attributed_to_the_one_before_it()
+        {
+            // The reported bug, as a sequence. vin02t.tik.xml runs 13, 15, 16-26, 35 - so every hit inside
+            // the range used to be reported as paragraph 15, a different paragraph, with nothing to signal
+            // that anything had been approximated.
+            var xml = "<p n=\"13\">a</p><p n=\"15\">b</p><p n=\"16-26\">TARGET</p><p n=\"35\">d</p>";
+            var markers = BookMarkers.Build(xml);
+
+            var pos = xml.IndexOf("TARGET");
+
+            Assert.Equal(16, markers.RefsAt(pos).Number);   // was 15
+        }
+
+        [Fact]
+        public void Every_number_inside_a_range_addresses_the_paragraph_that_contains_it()
+        {
+            // PositionOfParagraph returned -1 for any N inside a range, so addressing into these 3,618
+            // paragraphs failed outright rather than landing slightly off.
+            var xml = "<p n=\"15\">b</p><p n=\"16-26\">TARGET</p><p n=\"35\">d</p>";
+            var markers = BookMarkers.Build(xml);
+            var expected = xml.IndexOf("<p n=\"16-26\"");
+
+            foreach (var n in new[] { 16, 20, 26 })
+                Assert.Equal(expected, markers.PositionOfParagraph(n));
+
+            Assert.Equal(-1, markers.PositionOfParagraph(27));   // past the range - still not there
+            Assert.Equal(-1, markers.PositionOfParagraph(14));   // between 13 and 15 - still not there
+        }
+
+        [Fact]
+        public void A_ranged_paragraph_keeps_its_sub_book_code()
+        {
+            // Multi books resolve a paragraph number within a sub-book; a ranged paragraph must not lose that
+            // qualification on the way into the index.
+            var xml = "<div type=\"book\" id=\"an5\"><p n=\"16-26\">TARGET</p></div>";
+            var markers = BookMarkers.Build(xml);
+
+            var refs = markers.RefsAt(xml.IndexOf("TARGET"));
+
+            Assert.Equal(16, refs.Number);
+            Assert.Equal("an5", refs.BookCode);
+            Assert.Equal(xml.IndexOf("<p"), markers.PositionOfParagraph(20, "an5"));
+            Assert.Equal(-1, markers.PositionOfParagraph(20, "an6"));
+        }
+
+        [Fact]
+        public void A_backwards_span_is_read_as_a_typo_and_keeps_only_its_opening_number()
+        {
+            // abh05t.nrf.xml carries n="706-608" between 703-705 and 709-710, so the intent is 706-708 and
+            // the 6 is a slip. Swapping the ends would invent a 99-paragraph block from a digit error, and
+            // that block would then shadow every real paragraph from 608 to 705.
+            Assert.True(BookMarkers.TryParseParagraphSpan("706-608", out var f, out var l));
+
+            Assert.Equal(706, f);
+            Assert.Equal(706, l);
+        }
+
+        [Fact]
+        public void A_standalone_paragraph_beats_a_range_that_merely_covers_its_number()
+        {
+            // In 36 corpus files a ranged paragraph spans numbers that also exist in their own right —
+            // abh03a.att.xml has 1,445 such overlaps. Handing those to the range would be worse than the -1
+            // this returned before the fix: confidently wrong rather than absent.
+            var xml = "<p n=\"7-10\">RANGE</p><p n=\"8\">EXACT</p>";
+            var markers = BookMarkers.Build(xml);
+
+            Assert.Equal(xml.IndexOf("<p n=\"8\""), markers.PositionOfParagraph(8));   // not the range
+            Assert.Equal(xml.IndexOf("<p n=\"7-10\""), markers.PositionOfParagraph(9)); // only inside it
+        }
     }
 }

--- a/src/CST.Core/Search/BookMarkers.cs
+++ b/src/CST.Core/Search/BookMarkers.cs
@@ -15,8 +15,9 @@ namespace CST.Search
         private static readonly Regex TagRx = new(@"<[^>]*>", RegexOptions.Compiled);
         private static readonly Regex AttrRx = new("(\\w+)\\s*=\\s*\"([^\"]*)\"", RegexOptions.Compiled);
 
-        // Ascending-by-position lists.
-        private readonly List<(int Pos, int Number, string? BookCode)> _paras = new();
+        // Ascending-by-position lists. A paragraph spans First..Last inclusive; the two are equal for the
+        // ordinary single-numbered case, which is 97% of the corpus. (#446)
+        private readonly List<(int Pos, int First, int Last, string? BookCode)> _paras = new();
         // Raw is the VERBATIM @n ("1.0023"). The HTML anchor is ed + that exact string and the reader looks it
         // up case/character-exactly, so the raw spelling — not the parsed ints — is what can be navigated to.
         private readonly Dictionary<PageEdition, List<(int Pos, int Volume, int Number, string Raw)>> _pages = new();
@@ -52,20 +53,39 @@ namespace CST.Search
                         break;
 
                     case "p":
-                        if (!closing && attrs.TryGetValue("n", out var nStr) && int.TryParse(nStr, out int pnum))
-                            m._paras.Add((tag.Index, pnum, CurrentBook(divStack)));
+                        if (!closing && attrs.TryGetValue("n", out var nStr)
+                            && TryParseParagraphSpan(nStr, out int first, out int last))
+                            m._paras.Add((tag.Index, first, last, CurrentBook(divStack)));
                         break;
                 }
             }
             return m;
         }
 
-        /// <summary>The character position of a numbered paragraph (optionally within a Multi sub-book), or -1.</summary>
+        /// <summary>
+        /// The character position of a numbered paragraph (optionally within a Multi sub-book), or -1.
+        ///
+        /// <para>Matches a number ANYWHERE in a paragraph's span, not just its label. Paragraph 20 of
+        /// <c>vin02t.tik.xml</c> is inside the block labelled <c>16-26</c>; before #446 this returned -1 for
+        /// every such N, so addressing into the 3,618 ranged paragraphs failed outright rather than landing
+        /// slightly off.</para>
+        /// </summary>
         public int PositionOfParagraph(int number, string? bookCode = null)
         {
+            // AN EXACTLY-NUMBERED PARAGRAPH WINS OVER A RANGE THAT MERELY COVERS THE NUMBER, and the two do
+            // collide: in 36 corpus files a ranged paragraph spans numbers that also exist in their own
+            // right — abh03a.att.xml has 1,445 such overlaps, where "7-10" precedes standalone 7, 8, 9 and
+            // 10. Taking the first positional match would hand every one of them to the range, which is a
+            // worse answer than the -1 this used to return, because it is confidently wrong rather than
+            // absent. The range is the fallback, for numbers that exist ONLY inside one. (#446)
             foreach (var p in _paras)
-                if (p.Number == number && (bookCode == null || p.BookCode == bookCode))
+                if (p.First == number && p.Last == number && (bookCode == null || p.BookCode == bookCode))
                     return p.Pos;
+
+            foreach (var p in _paras)
+                if (number >= p.First && number <= p.Last && (bookCode == null || p.BookCode == bookCode))
+                    return p.Pos;
+
             return -1;
         }
 
@@ -74,7 +94,11 @@ namespace CST.Search
         {
             int? number = null; string? code = null;
             var pi = UpperBound(_paras.Count, i => _paras[i].Pos <= pos) - 1;
-            if (pi >= 0) { number = _paras[pi].Number; code = _paras[pi].BookCode; }
+            // The span's FIRST number is what a ranged paragraph is cited by. Reporting the range itself is
+            // a change to this method's contract and belongs with the model work in #444; what #446 fixes is
+            // that a ranged paragraph used to be skipped entirely, so this answered with the last paragraph
+            // BEFORE it — a different paragraph, reported with no hint of approximation.
+            if (pi >= 0) { number = _paras[pi].First; code = _paras[pi].BookCode; }
 
             var pages = new List<SnippetPageRef>();
             foreach (var (edition, list) in _pages)
@@ -122,6 +146,78 @@ namespace CST.Search
                 if (p.BookCode is { } code && !codes.Contains(code)) codes.Add(code);
             return codes;
         }
+
+        /// <summary>
+        /// The inclusive paragraph span a <c>&lt;p&gt;</c>'s <c>@n</c> denotes. (#446)
+        ///
+        /// <para><b>Why this is not <c>int.TryParse</c>.</b> 3,618 paragraphs across 87 of the 217 corpus
+        /// files carry a non-integer <c>@n</c>. They used to fail the parse and be dropped from the index
+        /// silently, which did not produce a missing citation — it produced a WRONG one, because the lookup
+        /// then answered with the last paragraph it had indexed, the one before the block.</para>
+        ///
+        /// <para><b>One rule covers every form found in the corpus.</b> Split on the hyphen, expand each part
+        /// against the one before it, then take first-to-last as the span:</para>
+        ///
+        /// <list type="table">
+        /// <item><term><c>21</c></term><description>21..21 — the ordinary case, 97% of paragraphs</description></item>
+        /// <item><term><c>16-26</c></term><description>16..26 — a full range (2,094 of them)</description></item>
+        /// <item><term><c>196-7</c></term><description>196..197 — the tail is ABBREVIATED, sharing the leading
+        /// digits of its predecessor, so this is not 196..7 (1,518 of them)</description></item>
+        /// <item><term><c>266-7-8</c></term><description>266..268 — the same abbreviation applied twice; the
+        /// next numbered paragraph in vin11t is 269, which is what confirms the reading</description></item>
+        /// <item><term><c>292-3-6</c></term><description>292..296 — likewise, followed by 297 in s0105t</description></item>
+        /// </list>
+        ///
+        /// <para><b>The corpus also holds two genuine typos</b> — <c>179-</c> in e0812n and a bare <c>-</c> in
+        /// e1207n. The trailing-hyphen form keeps its leading number, since 179 is a real paragraph and
+        /// discarding it would reintroduce exactly the bug this fixes. A value with no digits at all has
+        /// nothing to report and is skipped, as before.</para>
+        /// </summary>
+        internal static bool TryParseParagraphSpan(string? n, out int first, out int last)
+        {
+            first = last = 0;
+            if (string.IsNullOrWhiteSpace(n)) return false;
+
+            string? previous = null;
+            bool any = false;
+
+            foreach (var raw in n.Split('-'))
+            {
+                var part = raw.Trim();
+                if (part.Length == 0) continue;              // "179-" and the bare "-"
+
+                // Non-numeric anywhere means this is not a paragraph number we understand. Stop rather than
+                // guess: a half-read value is indistinguishable from a correct one downstream.
+                bool digits = true;
+                foreach (var c in part) if (c < '0' || c > '9') { digits = false; break; }
+                if (!digits) break;
+
+                var expanded = Expand(previous, part);
+                if (!int.TryParse(expanded, out var value)) break;
+
+                if (!any) { first = value; any = true; }
+                last = value;                                // the span runs from the FIRST written number
+                previous = expanded;                         // to the LAST, not min to max
+            }
+
+            // A span that runs BACKWARDS is a typo, not a range. abh05t.nrf.xml has n="706-608" sitting
+            // between 703-705 and 709-710, so the intent is plainly 706-708 and the 6 is a slip. Swapping
+            // the ends would manufacture a 99-paragraph block out of a digit error, and that block would
+            // then shadow every real paragraph from 608 to 705. Keeping only the opening number cites the
+            // paragraph correctly and claims nothing about an extent we cannot know. (#446)
+            if (any && last < first) last = first;
+            return any;
+        }
+
+        /// <summary>
+        /// Expand an abbreviated continuation against the part before it: <c>292</c> then <c>3</c> is 293,
+        /// not 3. A part at least as long as its predecessor is already complete and stands as written, which
+        /// is what keeps <c>16-26</c> a range from 16 to 26 rather than 16 to 16.
+        /// </summary>
+        private static string Expand(string? previous, string part) =>
+            previous is null || part.Length >= previous.Length
+                ? part
+                : previous.Substring(0, previous.Length - part.Length) + part;
 
         // Largest index+1 whose predicate holds over an ascending-sorted list (i.e. count of leading trues).
         private static int UpperBound(int count, System.Func<int, bool> leadingTrue)


### PR DESCRIPTION
Closes #446.

## The bug

`BookMarkers` indexed a paragraph only when its `@n` parsed as an integer, so the **3,618 paragraphs across 87 of the 217 corpus files** carrying a ranged `@n` were skipped silently.

That did not produce a *missing* citation — it produced a **wrong** one. `RefsAt` then answered with the last paragraph it had indexed, the one *before* the block. `vin02t.tik.xml` runs `13, 15, 16-26, 35`, so every hit inside the range was reported as **paragraph 15**, with nothing to signal an approximation. `PositionOfParagraph` returned `-1` for any N inside a range, so addressing into those blocks failed outright.

## One rule covers every form the corpus uses

Split on the hyphen, expand each part against the one before it, take the span from the first written number to the last:

| `@n` | span | count | note |
|---|---|---|---|
| `21` | 21…21 | ~118k | the ordinary case |
| `16-26` | 16…26 | 2,094 | full range |
| `196-7` | 196…197 | 1,518 | tail **abbreviated** — not 196…7 |
| `266-7-8` | 266…268 | — | vin11t's next paragraph is 269, confirming it |
| `292-3-6` | 292…296 | — | followed by 297 in s0105t |

## Two things the corpus taught that the issue did not record

Both found by running the real parser over all 217 files rather than trusting synthetic tests — and both would have been silent regressions.

**A backwards span is a typo, not a range.** `abh05t.nrf.xml` has `n="706-608"` sitting between `703-705` and `709-710`, so the intent is plainly 706-708. Taking min and max would manufacture a **99-paragraph block from a digit slip**, and that block would then shadow every real paragraph from 608 to 705. It keeps only its opening number — cites correctly, claims nothing about an extent that cannot be known. Reported upstream as VipassanaTech/tipitaka-xml#2708.

**An exactly-numbered paragraph must beat a range that merely covers its number.** In **36 files** the two collide — `abh03a.att.xml` alone has **1,445 overlaps**, where `7-10` precedes standalone 7, 8, 9 and 10. A first-positional match would hand all of them to the range, which is *worse* than the `-1` this used to return: confidently wrong rather than absent. The range is now the fallback, for numbers that exist only inside one.

## Scope

Deliberately the shipped bug. How a range is **represented** to callers — so a citation can read `16-26` rather than `16` — is the model question in #444, under epic #422, and it has UI consequences.

## Verification

Against the installed corpus: **3,617 of the 3,618 now index.** The one holdout is a bare `-` in `e1207n.nrf.xml` that carries no number at all — a word-continuation hyphen mis-marked as a paragraph number, reported upstream as #2710 (with #2709 for a third defect found in the same sweep).

**Mutation-verified:** reverting the parser to `int.TryParse` fails ten tests, including the reported-bug case.

**1595/1595.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)