### PR TITLE
Name an unknown request key instead of ignoring or refusing it namelessly (#558)

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/UnknownRequestKeyTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/UnknownRequestKeyTests.cs
@@ -102,5 +102,78 @@ namespace CST.Avalonia.Tests.Integration
 
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         }
+
+        [Fact]
+        public async Task A_bad_key_INSIDE_the_filter_is_named_too()
+        {
+            // The issue's SECOND reported case, and the one a top-level-only check silently leaves broken:
+            // ToolBookFilter refuses unknown members itself, so binding already rejected this - with an
+            // empty 400, which is the exact diagnostic this change exists to replace.
+            var (status, body) = await Post("/v1/search",
+                "{\"query\":\"dhamma\",\"filter\":{\"nosuchkey\":true}}");
+
+            Assert.Equal(HttpStatusCode.BadRequest, status);
+
+            using var doc = JsonDocument.Parse(body);
+            var error = doc.RootElement.GetProperty("error").GetString()!;
+
+            Assert.Contains("filter.nosuchkey", error);
+            // The keys listed are the FILTER's, not the request's - naming top-level keys here would send
+            // the caller looking in the wrong place.
+            Assert.Contains("mula", error);
+            Assert.DoesNotContain("query", error);
+        }
+
+        [Fact]
+        public async Task A_valid_filter_still_works()
+        {
+            using var http = _api.Http();
+            var resp = await http.PostAsync("/v1/search",
+                Json("{\"query\":\"dhamma\",\"filter\":{\"mula\":true}}"));
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("/v1/convert", "{\"text\":\"dhamma\",\"outputScript\":\"Devanagari\",\"nosuchkey\":1}")]
+        [InlineData("/v1/dictionary/lookup", "{\"language\":\"en\",\"query\":\"dhamma\",\"nosuchkey\":1}")]
+        public async Task The_remaining_mapped_endpoints_name_the_key_too(string path, string body)
+        {
+            // The rejection is global (the Disallow backstop), but the NAMING depends on each entry in
+            // ContractFor. A typo'd entry regresses that endpoint to the bodiless 400 with every other test
+            // still green, so each mapped endpoint is asserted rather than assumed. (fable review)
+            var (status, text) = await Post(path, body);
+
+            Assert.Equal(HttpStatusCode.BadRequest, status);
+            Assert.Contains("nosuchkey", text);
+        }
+
+        [Fact]
+        public async Task An_unauthenticated_docs_path_does_not_reach_the_body_check()
+        {
+            // /docs is deliberately unauthenticated so a cold agent can orient itself. Matching the contract
+            // by path SUFFIX made POST /docs/search select the search contract, so an unauthenticated caller
+            // could make the server buffer an arbitrary body. Matching the full path closes it. (fable review)
+            using var http = new HttpClient { BaseAddress = new System.Uri(_api.BaseUrl) };   // NO token
+
+            var resp = await http.PostAsync("/docs/search", Json("{\"nosuchkey\":1}"));
+
+            Assert.NotEqual(HttpStatusCode.BadRequest, resp.StatusCode);   // not our unknown-key answer
+            Assert.Empty(await resp.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task A_trailing_slash_or_odd_casing_still_gets_the_named_error()
+        {
+            // Route matching tolerates both; an Ordinal suffix match did not, so these fell through to the
+            // bodiless 400 this exists to remove. (fable review)
+            foreach (var path in new[] { "/v1/search/", "/v1/Search" })
+            {
+                var (status, body) = await Post(path, "{\"query\":\"dhamma\",\"nosuchkey\":1}");
+
+                Assert.Equal(HttpStatusCode.BadRequest, status);
+                Assert.Contains("nosuchkey", body);
+            }
+        }
     }
 }

--- a/src/CST.Avalonia.Tests/Integration/UnknownRequestKeyTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/UnknownRequestKeyTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CST.Avalonia.Tests.TestSupport;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Integration
+{
+    /// <summary>
+    /// #558: a misnamed body key must be REJECTED and NAMED, on every endpoint.
+    ///
+    /// <para>
+    /// Found in a cold-agent round by an agent making the mistake naturally, which is what those runs are for.
+    /// The surface had two different bad reactions to one user error, and the asymmetry pointed the wrong way:
+    /// sending <c>highlight</c> instead of <c>terms</c> to <c>navigate</c> returned 200 with
+    /// <c>highlights: 0</c> and no note, while the SAME response for the CORRECT key explained itself. The
+    /// agent's own mistake got the worse diagnostic of the two, and the friction reports show agents reasoning
+    /// onward from it rather than retrying.
+    /// </para>
+    ///
+    /// <para>
+    /// These run against the real server, because the defect lived in the JSON/binding seam that a mocked
+    /// endpoint test steps straight over.
+    /// </para>
+    /// </summary>
+    [Collection("LocalApiIntegration")]
+    public class UnknownRequestKeyTests : IAsyncLifetime
+    {
+        private LocalApiTestServer _api = null!;
+
+        public async Task InitializeAsync() => _api = await LocalApiTestServer.StartAsync();
+        public async Task DisposeAsync() => await _api.DisposeAsync();
+
+        private static StringContent Json(string body) => new(body, Encoding.UTF8, "application/json");
+
+        private async Task<(HttpStatusCode Status, string Body)> Post(string path, string body)
+        {
+            using var http = _api.Http();
+            var resp = await http.PostAsync(path, Json(body));
+            return (resp.StatusCode, await resp.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task A_plausible_wrong_key_is_rejected_rather_than_ignored()
+        {
+            // The issue's own example is `highlight` for `terms` on /v1/navigate, which this fixture does not
+            // map (navigate needs a presentation service, i.e. a reader window). The defect was never
+            // navigate-specific though - it was the JSON default applying to the whole surface - so it is
+            // driven here through an endpoint the harness does expose.
+            var (status, body) = await Post("/v1/search", "{\"query\":\"dhamma\",\"highlight\":\"metta\"}");
+
+            Assert.Equal(HttpStatusCode.BadRequest, status);
+            Assert.Contains("highlight", body);
+        }
+
+        [Fact]
+        public async Task The_offending_key_is_named_and_the_valid_ones_listed()
+        {
+            var (_, body) = await Post("/v1/search", "{\"query\":\"dhamma\",\"nosuchkey\":1}");
+
+            using var doc = JsonDocument.Parse(body);
+            var error = doc.RootElement.GetProperty("error").GetString()!;
+
+            Assert.Contains("'nosuchkey'", error);
+            Assert.Contains("query", error);          // a key that WOULD have worked, offered back
+        }
+
+        [Fact]
+        public async Task The_error_uses_the_same_shape_as_every_other_failure_on_this_surface()
+        {
+            // /v1/occurrences already answered an unknown BOOK with {"error":"..."}. An unknown KEY answering
+            // with an empty body was the inconsistency; both are now the same shape.
+            var (_, body) = await Post("/v1/occurrences",
+                "{\"bookId\":\"nope.xml\",\"nosuchkey\":true}");
+
+            using var doc = JsonDocument.Parse(body);
+            Assert.True(doc.RootElement.TryGetProperty("error", out var e));
+            Assert.False(string.IsNullOrWhiteSpace(e.GetString()));
+        }
+
+        [Theory]
+        [InlineData("/v1/occurrences", "{\"bookId\":\"a.xml\",\"term\":\"x\",\"nosuchkey\":1}")]
+        [InlineData("/v1/passage", "{\"bookId\":\"a.xml\",\"nosuchkey\":1}")]
+        public async Task Every_endpoint_rejects_an_unknown_key_rather_than_dropping_it(string path, string body)
+        {
+            // The default that caused this applied to the whole surface, not to navigate alone - so the fix
+            // has to be checked across it, or the next endpoint added inherits the old behaviour.
+            var (status, text) = await Post(path, body);
+
+            Assert.Equal(HttpStatusCode.BadRequest, status);
+            Assert.Contains("nosuchkey", text);
+        }
+
+        [Fact]
+        public async Task A_correct_body_is_unaffected()
+        {
+            // The point is to reject what was already broken, not to narrow what works.
+            using var http = _api.Http();
+            var resp = await http.PostAsync("/v1/search", Json("{\"query\":\"dhamma\"}"));
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+    }
+}

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -121,11 +121,13 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   canonical result you must set `other:false`. Strictly-canonical commentaries-only is therefore
   `{ "mula": false, "atthakatha": true, "tika": true, "other": false }`. Unknown filter keys are REJECTED
   with 400 (so a misnamed key can't silently return the unfiltered corpus).
-  MISNAMED KEYS ARE ALWAYS AN ERROR, ON EVERY POST ENDPOINT, NOT JUST HERE. An unrecognised key in any
-  request body gets a 400 naming it and listing the ones that would have worked -
-  `{"error":"Unknown key 'highlight' in the request body. Valid keys: bookId, terms, ..."}`. Nothing is
-  silently ignored, so if a call succeeded, every key you sent was understood. If you get this, fix the key
-  and retry rather than concluding the corpus lacks what you asked for.
+  MISNAMED KEYS ARE ALWAYS AN ERROR, ON EVERY POST ENDPOINT, NOT JUST HERE. An unrecognised key in a
+  request body gets a 400 naming it and listing the ones valid at that level -
+  `{"error":"Unknown key 'highlight' in the request body. Valid keys: bookId, terms, ..."}`. Nested objects
+  are checked too, and reported by path: a bad key inside `filter` comes back as `filter.nosuchkey` with the
+  FILTER's keys listed, not the request's. Nothing is silently ignored, so if a call succeeded, every key you
+  sent was understood. If you get this, fix the key and retry rather than concluding the corpus lacks what
+  you asked for.
   Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, skip?, includeBooks?,
   proximityDistance?, outputScript? }`.
   PAGING: `maxTerms` is the PAGE SIZE, `skip` (default 0) the offset. Page by re-requesting with

--- a/src/CST.Avalonia/Resources/LocalApi/llms.txt
+++ b/src/CST.Avalonia/Resources/LocalApi/llms.txt
@@ -121,6 +121,11 @@ This document is served WITHOUT authentication. Every other endpoint requires a 
   canonical result you must set `other:false`. Strictly-canonical commentaries-only is therefore
   `{ "mula": false, "atthakatha": true, "tika": true, "other": false }`. Unknown filter keys are REJECTED
   with 400 (so a misnamed key can't silently return the unfiltered corpus).
+  MISNAMED KEYS ARE ALWAYS AN ERROR, ON EVERY POST ENDPOINT, NOT JUST HERE. An unrecognised key in any
+  request body gets a 400 naming it and listing the ones that would have worked -
+  `{"error":"Unknown key 'highlight' in the request body. Valid keys: bookId, terms, ..."}`. Nothing is
+  silently ignored, so if a call succeeded, every key you sent was understood. If you get this, fix the key
+  and retry rather than concluding the corpus lacks what you asked for.
   Body: `{ query, mode?: "Exact"|"Wildcard"|"Regex", filter?, maxTerms?, skip?, includeBooks?,
   proximityDistance?, outputScript? }`.
   PAGING: `maxTerms` is the PAGE SIZE, `skip` (default 0) the offset. Page by re-requesting with

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.RateLimiting;
 using System.Threading.Tasks;
@@ -15,6 +16,7 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -179,6 +181,19 @@ namespace CST.Avalonia.Services.LocalApi
                 o.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
                 o.SerializerOptions.Converters.Add(new ScriptJsonConverter()); // reject Ipe/Unknown outputScript (before the enum factory)
                 o.SerializerOptions.Converters.Add(new JsonStringEnumConverter()); // "Latin" not 3, for other enums
+
+                // AN UNKNOWN BODY KEY IS AN ERROR, NOT SOMETHING TO SKIP PAST. System.Text.Json's default is to
+                // drop what it cannot map, which turned a caller's typo into a silent no-op: `navigate` with
+                // "highlight" instead of "terms" opened the book, highlighted nothing, and returned
+                // highlights:0 with no note — while the SAME response for the correct key explains itself. The
+                // agent's own mistake got the worse diagnostic of the two, and agents reason onward from it
+                // rather than retrying. (#558)
+                //
+                // Safe here in a way it would not be for a public API: this is loopback-only, and an agent
+                // reads its contract (llms.txt) from the SAME running instance it then calls, so a client
+                // cannot be newer than the server it is talking to. The MCP surface is unaffected — those
+                // tools bind to the tool interfaces through DI, never over HTTP.
+                o.SerializerOptions.UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow;
             });
 
             // MCP surface (#191): expose the read tool set over the Streamable HTTP transport at /mcp — MCP is
@@ -287,6 +302,40 @@ namespace CST.Avalonia.Services.LocalApi
                 await next();
             });
 
+            // A REJECTED BODY MUST SAY WHY, so the body is checked HERE rather than left to model binding.
+            // With UnmappedMemberHandling.Disallow set above, an unknown key already makes binding fail — but
+            // minimal APIs answer that internally with a 400 carrying NO BODY, which is the second half of
+            // #558: the caller learns only that something was unacceptable. .NET 10 has no ThrowOnBadRequest
+            // switch to route it out to middleware, so this inspects the body first and answers in the same
+            // { error } shape every other failure on this surface uses, naming the offending key and the ones
+            // that would have worked. Binding's own rejection stays as the backstop for anything missed.
+            app.Use(async (context, next) =>
+            {
+                if (HttpMethods.IsPost(context.Request.Method) &&
+                    ContractFor(context.Request.Path) is { } contract)
+                {
+                    context.Request.EnableBuffering();
+                    string body;
+                    using (var reader = new StreamReader(
+                               context.Request.Body, Encoding.UTF8, leaveOpen: true))
+                        body = await reader.ReadToEndAsync();
+                    context.Request.Body.Position = 0;   // rewind for the real binder
+
+                    if (UnknownKeyIn(body, contract) is { } bad)
+                    {
+                        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        await context.Response.WriteAsJsonAsync(new
+                        {
+                            error = $"Unknown key '{bad}' in the request body. "
+                                  + $"Valid keys: {ValidKeysFor(contract)}."
+                        });
+                        return;
+                    }
+                }
+
+                await next();
+            });
+
             // Apply the concurrency cap AFTER the security gate, so unauthorized requests never consume a permit.
             app.UseRateLimiter();
 
@@ -390,6 +439,68 @@ namespace CST.Avalonia.Services.LocalApi
         private static bool BookExists(string? bookId) =>
             !string.IsNullOrEmpty(bookId) &&
             Books.Inst.Any(b => string.Equals(b.FileName, bookId, StringComparison.OrdinalIgnoreCase));
+
+        // ---- Naming a rejected body key (#558) ----------------------------------------------------------
+
+        /// <summary>
+        /// The first body key the contract does not declare, or null when every key maps. Case-insensitive,
+        /// matching the binder's own camelCase-insensitive behaviour, so this cannot reject something binding
+        /// would have accepted.
+        /// </summary>
+        private static string? UnknownKeyIn(string body, Type contract)
+        {
+            if (string.IsNullOrWhiteSpace(body)) return null;
+
+            JsonElement root;
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                if (doc.RootElement.ValueKind != JsonValueKind.Object) return null;   // not ours to judge
+                root = doc.RootElement.Clone();
+            }
+            catch (JsonException)
+            {
+                return null;   // malformed JSON is binding's to report, not a naming problem
+            }
+
+            var known = KnownKeys(contract);
+            foreach (var prop in root.EnumerateObject())
+                if (!known.Contains(prop.Name)) return prop.Name;
+
+            return null;
+        }
+
+        /// <summary>
+        /// The body keys a route accepts, read from the request contract itself so this cannot drift out of
+        /// step with the endpoint the way a hand-maintained list would.
+        /// </summary>
+        private static string ValidKeysFor(Type contract) =>
+            string.Join(", ", KnownKeys(contract).OrderBy(n => n, StringComparer.Ordinal));
+
+        private static HashSet<string> KnownKeys(Type contract) =>
+            new(contract.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                    .Where(p => p.CanWrite || p.CanRead)
+                    .Select(p => JsonNamingPolicy.CamelCase.ConvertName(p.Name)),
+                StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// The request contract behind a POST route. Every /v1 POST endpoint is listed: the default that
+        /// caused #558 applied to the whole surface, so a partial map would leave the next endpoint silently
+        /// dropping keys exactly as before.
+        /// </summary>
+        private static Type? ContractFor(PathString path)
+        {
+            var p = path.HasValue ? path.Value! : "";
+            if (p.EndsWith("/search", StringComparison.Ordinal)) return typeof(SearchToolRequest);
+            if (p.EndsWith("/occurrences", StringComparison.Ordinal)) return typeof(OccurrenceRequest);
+            if (p.EndsWith("/dictionary/lookup", StringComparison.Ordinal)) return typeof(DictionaryRequest);
+            if (p.EndsWith("/passage", StringComparison.Ordinal)) return typeof(PassageHttpRequest);
+            if (p.EndsWith("/ai/context-preview", StringComparison.Ordinal)) return typeof(ContextPreviewRequest);
+            if (p.EndsWith("/convert", StringComparison.Ordinal)) return typeof(ConvertRequest);
+            if (p.EndsWith("/navigate", StringComparison.Ordinal)) return typeof(NavigateRequest);
+            if (p.EndsWith("/forms", StringComparison.Ordinal)) return typeof(LemmaFormsUnionRequest);
+            return null;
+        }
 
         private static bool IsDiscoveryPath(PathString path) =>
             !path.HasValue || path == "/"

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.RateLimiting;
 using System.Threading.Tasks;
@@ -16,7 +15,6 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -302,6 +300,14 @@ namespace CST.Avalonia.Services.LocalApi
                 await next();
             });
 
+            // Apply the concurrency cap AFTER the security gate, so unauthorized requests never consume a permit.
+            app.UseRateLimiter();
+
+            // AFTER the security gate and the concurrency cap, deliberately. This reads the whole body into
+            // memory, so it must not run for a request that is about to be rejected as unauthorized or
+            // queued behind the 1024-deep limiter - the cap exists because this Kestrel shares a process
+            // with the UI. (fable review)
+            //
             // A REJECTED BODY MUST SAY WHY, so the body is checked HERE rather than left to model binding.
             // With UnmappedMemberHandling.Disallow set above, an unknown key already makes binding fail — but
             // minimal APIs answer that internally with a 400 carrying NO BODY, which is the second half of
@@ -326,8 +332,8 @@ namespace CST.Avalonia.Services.LocalApi
                         context.Response.StatusCode = StatusCodes.Status400BadRequest;
                         await context.Response.WriteAsJsonAsync(new
                         {
-                            error = $"Unknown key '{bad}' in the request body. "
-                                  + $"Valid keys: {ValidKeysFor(contract)}."
+                            error = $"Unknown key '{bad.Path}' in the request body. "
+                                  + $"Valid keys: {ValidKeysFor(bad.Container)}."
                         });
                         return;
                     }
@@ -336,8 +342,6 @@ namespace CST.Avalonia.Services.LocalApi
                 await next();
             });
 
-            // Apply the concurrency cap AFTER the security gate, so unauthorized requests never consume a permit.
-            app.UseRateLimiter();
 
             // Unauthenticated root pointer, so an agent that connects via local-api.json isn't left staring at
             // an empty "/" — it names where the docs and status live. (Cold-agent test finding.)
@@ -443,31 +447,67 @@ namespace CST.Avalonia.Services.LocalApi
         // ---- Naming a rejected body key (#558) ----------------------------------------------------------
 
         /// <summary>
-        /// The first body key the contract does not declare, or null when every key maps. Case-insensitive,
-        /// matching the binder's own camelCase-insensitive behaviour, so this cannot reject something binding
-        /// would have accepted.
+        /// The first body key the contract does not declare, as a dotted path, or null when every key maps.
+        ///
+        /// <para><b>Nested objects are checked too</b>, because the issue's second reported case IS a nested
+        /// one: <c>{"query":"…","filter":{"nosuchkey":true}}</c>. <c>ToolBookFilter</c> already refuses
+        /// unknown members on its own, so binding rejected that body — with an EMPTY 400, which is precisely
+        /// the diagnostic this change exists to replace. Checking only the top level would have left half of
+        /// #558 unfixed while claiming otherwise in llms.txt. (fable review)</para>
+        ///
+        /// <para>Case-insensitive, matching the binder's own behaviour, so this can never reject something
+        /// binding would have accepted.</para>
         /// </summary>
-        private static string? UnknownKeyIn(string body, Type contract)
+        private static (string Path, Type Container)? UnknownKeyIn(string body, Type contract)
         {
             if (string.IsNullOrWhiteSpace(body)) return null;
 
-            JsonElement root;
             try
             {
                 using var doc = JsonDocument.Parse(body);
-                if (doc.RootElement.ValueKind != JsonValueKind.Object) return null;   // not ours to judge
-                root = doc.RootElement.Clone();
+                return doc.RootElement.ValueKind != JsonValueKind.Object
+                    ? null                                   // not an object: binding's to judge, not ours
+                    : FirstUnknown(doc.RootElement, contract, prefix: "");
             }
             catch (JsonException)
             {
                 return null;   // malformed JSON is binding's to report, not a naming problem
             }
+        }
 
-            var known = KnownKeys(contract);
-            foreach (var prop in root.EnumerateObject())
-                if (!known.Contains(prop.Name)) return prop.Name;
+        // Returns the offending key's dotted path AND the contract that should have declared it, so the
+        // message lists the keys valid AT THAT LEVEL - naming the top-level ones for a bad filter sub-key
+        // would send the caller looking in the wrong place.
+        private static (string Path, Type Container)? FirstUnknown(JsonElement obj, Type contract, string prefix)
+        {
+            var properties = contract.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var prop in obj.EnumerateObject())
+            {
+                var match = properties.FirstOrDefault(p => string.Equals(
+                    JsonNamingPolicy.CamelCase.ConvertName(p.Name), prop.Name, StringComparison.OrdinalIgnoreCase));
+
+                if (match == null) return (prefix + prop.Name, contract);
+
+                // Recurse into a nested contract object. Only into types of ours: a string, a number or a
+                // collection has no key set to check, and reflecting over a framework type would invent
+                // "valid keys" nobody can send.
+                if (prop.Value.ValueKind == JsonValueKind.Object && IsRequestContract(match.PropertyType))
+                {
+                    var nested = FirstUnknown(prop.Value, Nullable.GetUnderlyingType(match.PropertyType)
+                                                          ?? match.PropertyType,
+                                              prefix + prop.Name + ".");
+                    if (nested != null) return nested;
+                }
+            }
 
             return null;
+        }
+
+        private static bool IsRequestContract(Type type)
+        {
+            var t = Nullable.GetUnderlyingType(type) ?? type;
+            return t.IsClass && t != typeof(string) && t.Namespace?.StartsWith("CST", StringComparison.Ordinal) == true;
         }
 
         /// <summary>
@@ -475,31 +515,37 @@ namespace CST.Avalonia.Services.LocalApi
         /// step with the endpoint the way a hand-maintained list would.
         /// </summary>
         private static string ValidKeysFor(Type contract) =>
-            string.Join(", ", KnownKeys(contract).OrderBy(n => n, StringComparer.Ordinal));
-
-        private static HashSet<string> KnownKeys(Type contract) =>
-            new(contract.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                    .Where(p => p.CanWrite || p.CanRead)
-                    .Select(p => JsonNamingPolicy.CamelCase.ConvertName(p.Name)),
-                StringComparer.OrdinalIgnoreCase);
+            string.Join(", ", contract.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(p => JsonNamingPolicy.CamelCase.ConvertName(p.Name))
+                .OrderBy(n => n, StringComparer.Ordinal));
 
         /// <summary>
-        /// The request contract behind a POST route. Every /v1 POST endpoint is listed: the default that
-        /// caused #558 applied to the whole surface, so a partial map would leave the next endpoint silently
-        /// dropping keys exactly as before.
+        /// The request contract behind a POST route, matched on the FULL path.
+        ///
+        /// <para>Suffix matching was wrong twice over. <c>/docs</c> is deliberately unauthenticated so a cold
+        /// agent can orient itself, and <c>EndsWith("/search")</c> matched <c>POST /docs/search</c> — letting
+        /// an unauthenticated caller reach the body-buffering below. It also missed the real route whenever
+        /// the path varied harmlessly, <c>/v1/search/</c> or <c>/v1/Search</c>, silently dropping back to the
+        /// bodiless 400 this exists to remove. (fable review)</para>
+        ///
+        /// <para>Every /v1 POST endpoint is listed: the default that caused #558 applied to the whole
+        /// surface, so a partial map would leave the next endpoint dropping keys exactly as before.</para>
         /// </summary>
         private static Type? ContractFor(PathString path)
         {
-            var p = path.HasValue ? path.Value! : "";
-            if (p.EndsWith("/search", StringComparison.Ordinal)) return typeof(SearchToolRequest);
-            if (p.EndsWith("/occurrences", StringComparison.Ordinal)) return typeof(OccurrenceRequest);
-            if (p.EndsWith("/dictionary/lookup", StringComparison.Ordinal)) return typeof(DictionaryRequest);
-            if (p.EndsWith("/passage", StringComparison.Ordinal)) return typeof(PassageHttpRequest);
-            if (p.EndsWith("/ai/context-preview", StringComparison.Ordinal)) return typeof(ContextPreviewRequest);
-            if (p.EndsWith("/convert", StringComparison.Ordinal)) return typeof(ConvertRequest);
-            if (p.EndsWith("/navigate", StringComparison.Ordinal)) return typeof(NavigateRequest);
-            if (p.EndsWith("/forms", StringComparison.Ordinal)) return typeof(LemmaFormsUnionRequest);
-            return null;
+            if (!path.HasValue) return null;
+            var p = path.Value!.TrimEnd('/');
+            const string v = "/" + ApiVersion;
+
+            return p.Equals(v + "/search", StringComparison.OrdinalIgnoreCase) ? typeof(SearchToolRequest)
+                 : p.Equals(v + "/occurrences", StringComparison.OrdinalIgnoreCase) ? typeof(OccurrenceRequest)
+                 : p.Equals(v + "/dictionary/lookup", StringComparison.OrdinalIgnoreCase) ? typeof(DictionaryRequest)
+                 : p.Equals(v + "/passage", StringComparison.OrdinalIgnoreCase) ? typeof(PassageHttpRequest)
+                 : p.Equals(v + "/ai/context-preview", StringComparison.OrdinalIgnoreCase) ? typeof(ContextPreviewRequest)
+                 : p.Equals(v + "/convert", StringComparison.OrdinalIgnoreCase) ? typeof(ConvertRequest)
+                 : p.Equals(v + "/navigate", StringComparison.OrdinalIgnoreCase) ? typeof(NavigateRequest)
+                 : p.Equals(v + "/forms", StringComparison.OrdinalIgnoreCase) ? typeof(LemmaFormsUnionRequest)
+                 : null;
         }
 
         private static bool IsDiscoveryPath(PathString path) =>


### PR DESCRIPTION
Closes #558.

## The asymmetry pointed the wrong way

Found in a cold-agent round by an agent making the mistake naturally, which is what those runs are for.

```
navigate {"highlight":"mettā"}  → 200  highlights:0  note:null              ← the caller's error, silent
navigate {"terms":"mettā"}      → 200  highlights:0  note:"No occurrences…" ← harmless case, explained
```

**The agent's own mistake got the worse diagnostic of the two.** It concludes the phrase is absent and reasons onward — and `navigate` is the one endpoint with a visible side effect, so the person at the screen feels it. Separately, `search`'s deliberate 400 for a bad filter key carried a **zero-length body**.

## It was one default, not two bugs

There is no `UnmappedMemberHandling` anywhere in the repo, so `System.Text.Json` silently dropped unknown keys on **all eight** `/v1` POST endpoints: `search`, `occurrences`, `dictionary/lookup`, `passage`, `ai/context-preview`, `convert`, `navigate`, `forms`.

Patching the two reported paths would have left the other six — and the next endpoint added would inherit it. So the issue's own item 3 ("check the other endpoints for the same asymmetry") is answered by construction rather than by inspection.

Every POST body is now checked against its own contract before binding, and an unrecognised key gets a 400 in the established shape:

```json
{"error":"Unknown key 'highlight' in the request body. Valid keys: bookId, terms, …"}
```

Valid keys are read from the contract type by **reflection**, not hand-maintained, so they cannot drift from the endpoint.

## Two things measured rather than assumed

**`Disallow` alone gives the right status and an empty body.** My first attempt put the handler in exception-catching middleware — and the tests caught that it was dead code, because minimal APIs handle a binding failure internally instead of letting it reach the pipeline. .NET 10 has no `RouteHandlerOptions.ThrowOnBadRequest` to route it back out; **the type is not in the 10.0.9 reference assemblies at all.** So the check moved ahead of binding, where it is fully ours. `Disallow` stays as the backstop.

**Rejecting unknown keys is safe here in a way it would not be for a public API.** Loopback only, and an agent reads `llms.txt` from the *same instance* it then calls, so a client cannot be newer than its server. MCP is unaffected — those tools bind to the tool interfaces through DI, never over HTTP. And the entire existing suite passes unchanged, so nothing in-repo relied on extra keys being dropped.

## Testing

Against the **real server**, since the defect lived in the JSON/binding seam a mocked endpoint test steps straight over. Mutation-verified: bypassing the check fails five of the six.

One test is retargeted from `navigate` to `search` and says why — the fixture doesn't map `navigate`, which needs a presentation service. The defect was never navigate-specific, so driving it through a mapped endpoint tests the same thing.

`llms.txt` now states the rule where agents read it, including the actionable half: *if you get this, fix the key and retry rather than concluding the corpus lacks what you asked for.*

**1624/1624.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)