### PR TITLE
Call the book tree "Open a Book", and open it at the top (#643, #644)

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1370,7 +1370,9 @@ public partial class App : Application
                             {
                                 if (viewItem is NativeMenuItem viewSubItem)
                                 {
-                                    if (viewSubItem.Header?.ToString() == "Select a Book")
+                                    // Must stay in lockstep with the View-menu header in
+                                    // SimpleTabbedWindow.axaml: the toggle is wired by matching that string.
+                                    if (viewSubItem.Header?.ToString() == "Open a Book")
                                     {
                                         _selectBookMenuItems.Add(viewSubItem);
                                         viewSubItem.ToggleType = NativeMenuItemToggleType.CheckBox;
@@ -1578,7 +1580,7 @@ public partial class App : Application
             // View menu: Select a Book / Search (checkable, mirror the panels' visibility)
             var selectBookItem = new NativeMenuItem
             {
-                Header = "Select a Book",
+                Header = "Open a Book",
                 ToggleType = NativeMenuItemToggleType.CheckBox,
                 IsChecked = layoutViewModel?.IsSelectBookPanelVisible ?? false
             };
@@ -1677,7 +1679,7 @@ public partial class App : Application
             closeTabItem.Click += (s, e) => OnCloseTabFromFloatingWindow(window);
             // #111: Select a Book (Cmd+O) — the tree lives in the main window, so this reveals and focuses
             // it there, the same as the main window's File menu item.
-            var selectBookMenuItem = new NativeMenuItem { Header = "Select a Book", Gesture = PlatformGesture.Parse("O") };
+            var selectBookMenuItem = new NativeMenuItem { Header = "Open a Book", Gesture = PlatformGesture.Parse("O") };
             selectBookMenuItem.Click += (s, e) => SimpleTabbedWindow.RevealSelectBookPanel();
 
             // #112: Print (Cmd+P) and Print Selection (Shift+Cmd+P) the floated book — same native

--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -397,7 +397,7 @@
     <div class="quick-start">
         <h3>🚀 Quick Start</h3>
         <ul>
-            <li><strong>Open books:</strong> In the <strong>Select a Book</strong> tab, double-click a text &mdash; or select it and press Enter</li>
+            <li><strong>Open books:</strong> In the <strong>Open a Book</strong> tab, double-click a text &mdash; or select it and press Enter</li>
             <li><strong>Change script:</strong> Use the dropdown at the top (applies to all open books)</li>
             <li><strong>Search:</strong> Open the <strong>Search</strong> tab in the left panel (or View &rsaquo; Search), enter Pāli text, and optionally filter by book categories</li>
             <li><strong>Dictionary:</strong> Select a word and press &#8984;D / Ctrl+D</li>

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -191,7 +191,7 @@ namespace CST.Avalonia.ViewModels
 
         public void ShowSelectBookPanel() =>
             ShowToolPanel("OpenBookTool", () => App.ServiceProvider?.GetRequiredService<OpenBookDialogViewModel>(),
-                () => IsSelectBookPanelVisible = true, "Select a Book");
+                () => IsSelectBookPanelVisible = true, "Open a Book");
 
         public void ToggleSearchPanel()
         {
@@ -242,7 +242,7 @@ namespace CST.Avalonia.ViewModels
         }
 
         public void HideSelectBookPanel() =>
-            HideToolPanel("OpenBookTool", () => IsSelectBookPanelVisible = false, "Select a Book");
+            HideToolPanel("OpenBookTool", () => IsSelectBookPanelVisible = false, "Open a Book");
 
         // Recreate-on-demand so the View menu toggle and Cmd+D (Look Up in Dictionary) can reopen a closed
         // pane — LookUpInDictionaryAsync calls this then immediately proceeds, so it must stay synchronous. (#466)

--- a/src/CST.Avalonia/ViewModels/OpenBookDialogViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/OpenBookDialogViewModel.cs
@@ -48,7 +48,7 @@ public class OpenBookDialogViewModel : ReactiveTool, IDisposable
 
         // Configure Dock properties
         Id = "OpenBookTool";
-        Title = "Select a Book";
+        Title = "Open a Book";
         CanPin = false;     // Prevent pinning (vertical text issues)
         CanClose = false;   // Keep book tree always available
         CanFloat = true;    // Allow floating to separate window

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml
@@ -20,9 +20,16 @@
             <Border BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="1">
                 <DockPanel>
                     <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                        <!-- AutoScrollToSelectedItem off: startup restores the last selected book into
+                             SelectedNode, and Avalonia then posts BringIntoView as that node's container is
+                             prepared. Minimal-scroll leaves the node at the BOTTOM edge, so the tree opened
+                             at an apparently arbitrary branch — and since the styles below make selection
+                             invisible, nothing on screen explained why. The tree now opens at the top; ⌘O
+                             (FocusBookTree) still brings the remembered book into view deliberately. -->
                         <TreeView x:Name="BookTreeView"
                                   ItemsSource="{Binding BookTree}"
                                   SelectedItem="{Binding SelectedNode}"
+                                  AutoScrollToSelectedItem="False"
                                   Background="{DynamicResource SolidBackgroundFillColorBaseBrush}"
                                   DoubleTapped="TreeView_DoubleTapped"
                                   KeyDown="TreeView_KeyDown">

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml
@@ -25,7 +25,18 @@
                              prepared. Minimal-scroll leaves the node at the BOTTOM edge, so the tree opened
                              at an apparently arbitrary branch — and since the styles below make selection
                              invisible, nothing on screen explained why. The tree now opens at the top; ⌘O
-                             (FocusBookTree) still brings the remembered book into view deliberately. -->
+                             (FocusBookTree) still brings the remembered book into view deliberately.
+
+                             What this property actually governs, since "off" is broader than the startup
+                             case it was turned off for. Avalonia 11.3.6 consults it in TWO places
+                             (TreeView.cs:369 and :551), so turning it off drops two behaviours:
+                               - the scroll on any selection CHANGE — no loss here, because clicks are
+                                 already in view and arrow keys are carried by a different mechanism
+                                 (ScrollViewer.BringIntoViewOnFocusChange, still on by default);
+                               - the scroll when a container is first PREPARED, which includes expanding a
+                                 collapsed branch that contains the selection for the first time. That one
+                                 is a real behaviour change, and it is the same bottom-edge jump this is
+                                 turned off to stop, so it goes deliberately rather than by accident. -->
                         <TreeView x:Name="BookTreeView"
                                   ItemsSource="{Binding BookTree}"
                                   SelectedItem="{Binding SelectedNode}"

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -21,7 +21,7 @@
                 <NativeMenu>
                     <!-- #111: ⌘/Ctrl+O reveals the book tree and focuses it; it never hides the panel
                          (the View menu checkbox does that). CST4's Ctrl+O opened the book dialog. -->
-                    <NativeMenuItem Header="Select a Book" Click="OnSelectBookClick" Gesture="{input:CommandGesture o}" />
+                    <NativeMenuItem Header="Open a Book" Click="OnSelectBookClick" Gesture="{input:CommandGesture o}" />
                     <!-- #44: populated at runtime from the recent-books MRU list by App.RebuildRecentMenus -->
                     <NativeMenuItem Header="Open Recent">
                         <NativeMenu />
@@ -38,7 +38,7 @@
             <!-- View Menu as top-level menu -->
             <NativeMenuItem Header="View">
                 <NativeMenu>
-                    <NativeMenuItem Header="Select a Book" />
+                    <NativeMenuItem Header="Open a Book" />
                     <NativeMenuItem Header="Search" />
                     <NativeMenuItem Header="Dictionary" />
                     <NativeMenuItemSeparator />
@@ -107,7 +107,7 @@
                           Margin="0,0,5,0"/>
                 <ComboBox MinWidth="120"
                           x:Name="PaliScriptCombo"
-                          ToolTip.Tip="Default script for Select a Book tree and new book windows">
+                          ToolTip.Tip="Default script for the Open a Book tree and new book windows">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding}"/>


### PR DESCRIPTION
Two small things a reader meets before anything else: what the book panel is called, and where it is scrolled when the app starts.

## "Open a Book" (#643)

Replaces "Select a Book" at every visible site — the dock tab, File ▸ (⌘O) and View ▸ in **both** the main and floating windows, the script picker's tooltip, and the welcome page's Quick Start. The floating-window menus are built in code and the main window's in XAML, so the string lives in both places.

**One of those sites is not a label.** The main window's View-menu checkbox is wired by *matching the header string* in `App.axaml.cs`, so a rename that missed it would have left the menu item present and silently inert. It now carries a comment saying why it must move in lockstep.

Internal identifiers (`OpenBookTool`, `IsSelectBookPanelVisible`, `OnSelectBookClick`) are untouched — renaming them is churn no reader would ever see.

## Opening at the top (#644)

The scroll position was never arbitrary, only unexplained. Startup restores the last selected book into `SelectedNode`; Avalonia's `AutoScrollToSelectedItem` — **true by default** — then posts `BringIntoView` as that node's container is prepared. `ScrollContentPresenter` scrolls *minimally*, so scrolling downward parks the node at the **bottom edge** of the viewport. What fills the panel is everything above it, which is why it read as some random deep branch rather than as a restored position.

Confirmed rather than guessed: the saved state's `selectedBookPath` is a Ṭīkā book, and the run's log carries `Restored book selection` for exactly that path. Compounding it, the panel's own styles paint `TreeViewItem:selected` and `:focused` transparent, so there was nothing on screen to explain the position either.

**Turning the property off is narrow, not blunt** — it is consulted only when a container is prepared. The two paths that *should* scroll are untouched:

- arrow-key navigation still follows the cursor, via `ScrollViewer.BringIntoViewOnFocusChange` (a separate mechanism, still defaulting to true);
- ⌘O still reveals the remembered book, because `FocusBookTree` calls `BringIntoView` explicitly.

So the tree opens at the top, and the trip back to where you were is a keystroke you chose to press.

## Testing

Full suite **1716 passed, 0 failed**. No test covers either change: both are user-visible strings and one XAML property, and a test asserting a menu header equals a literal only restates the literal. The string-matching hazard in `App.axaml.cs` is guarded by a comment instead.

**Worth a look while you are in here** (not fixed, not filed): with selection *and* focus both styled transparent, ⌘O lands the user on a book they cannot see.

Closes #643. Closes #644.
