### PR TITLE
Name the test project in every documented test command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,12 +21,15 @@ CST Reader (**CST = Chaṭṭha Saṅgāyana Tipiṭaka**) is a cross-platform P
 
 ## Build / run / test
 ```bash
-cd src/CST.Avalonia
-dotnet build
-dotnet run
-dotnet test                                                   # full suite
-dotnet test --filter "FullyQualifiedName~CstDockFactoryTests" # one class
+# from the repo root
+dotnet build src/CST.Avalonia
+dotnet run --project src/CST.Avalonia
+
+dotnet test src/CST.Avalonia.Tests                                     # full suite (~3 min)
+dotnet test src/CST.Avalonia.Tests --filter "FullyQualifiedName~CstDockFactoryTests"   # one class
 ```
+**Always name the test project.** There is no solution file, so a bare `dotnet test` acts on the project in the current directory — and in `src/CST.Avalonia` that is the app, which is not a test project: it restores, runs nothing, and **exits 0**. A silent green indistinguishable from a passing suite. `CST.Avalonia.Tests` is the only test project in the tree.
+
 macOS packaging/signing/notarization: `src/CST.Avalonia/package-macos.sh {arm64|x64}` then `notarize-macos.sh`. Full steps + the pre-release version-string checklist: [docs/development/RELEASE_PROCESS.md](docs/development/RELEASE_PROCESS.md).
 
 ## macOS code signing & entitlements

--- a/docs/development/CLOUD_SESSION_SETUP.md
+++ b/docs/development/CLOUD_SESSION_SETUP.md
@@ -109,7 +109,7 @@ Until one of those is in place, do build/test verification on a local machine (K
 
 ```bash
 export CST_XML_DIR="$HOME/cst-corpus/deva"
-cd src/CST.Avalonia
+cd src/CST.Avalonia.Tests   # not src/CST.Avalonia: dotnet test there runs nothing and exits 0
 dotnet test --filter "FullyQualifiedName~ConverterEquivalenceTests"        # byte-identical oracle
 dotnet test --filter "FullyQualifiedName~ScriptConverterPerformanceTests"  # before/after timings
 ```

--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -117,8 +117,9 @@ Before starting the release process, verify on Kestrel:
 - [ ] All version strings updated and consistent — see **Version strings: two timing buckets** below.
       By release time, bucket A should already be done (it is bumped at the *start* of the cycle);
       verify it rather than discovering it here. These all drifted before Beta 4.
-- [ ] Build succeeds: `dotnet build`
-- [ ] Tests pass: `dotnet test` (or acceptable skip rate documented)
+- [ ] Build succeeds: `dotnet build src/CST.Avalonia`
+- [ ] Tests pass: `dotnet test src/CST.Avalonia.Tests` (or acceptable skip rate documented) — pass the
+      project path or run from that directory; `dotnet test` in `src/CST.Avalonia` runs nothing and exits 0
 - [ ] All changes committed and pushed to `main` branch
 - [ ] No critical bugs or blockers
 


### PR DESCRIPTION
`dotnet test` run from `src/CST.Avalonia` restores, runs no tests, and **exits 0**.

There is no solution file in the tree, so `dotnet test` acts on the project in the current directory — and that project is the app, which is not a test project. The result is a silent green, indistinguishable from a passing suite. That is worse than a failure: a red run gets investigated.

I hit this while verifying #645 and only noticed because the captured log was two lines long.

## The three places that told a reader to do it

- **`CLAUDE.md`** — the build/run/test block, which is the first thing an agent reads.
- **`docs/development/CLOUD_SESSION_SETUP.md`** — the converter-verification block. The worst of the three: it exists to prove converter output is byte-identical, and would have reported success without comparing a single character.
- **`docs/development/RELEASE_PROCESS.md`** — the pre-release checklist item "Tests pass: `dotnet test`".

`README.md` was already correct — it passes the project path.

## The fix

Every documented command now names the project (or `cd`s to the test project), which removes the trap instead of warning about it. `CLAUDE.md` carries one line of *why*, so the next person does not reintroduce the bare form:

```bash
# from the repo root
dotnet build src/CST.Avalonia
dotnet run --project src/CST.Avalonia

dotnet test src/CST.Avalonia.Tests                                     # full suite (~3 min)
dotnet test src/CST.Avalonia.Tests --filter "FullyQualifiedName~CstDockFactoryTests"   # one class
```

`CST.Avalonia.Tests` is the only test project in the tree, so there is no ambiguity about which project to name.

## Verified

Each documented command actually run from the repo root: `dotnet build src/CST.Avalonia` → 0 errors; `dotnet test src/CST.Avalonia.Tests` → **1716 passed, 0 failed**; the filtered form → 16 passed.

Docs only — no code, and `docs/README.md` needs no update since no doc was added or removed.
