### PR TITLE
Render Markdown tables in the assistant answer

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AnswerMarkupTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AnswerMarkupTests.cs
@@ -9,17 +9,23 @@ namespace CST.Avalonia.Tests.Services.Ai;
 ///
 /// <para>The reported defect: "It shows single and double asterisks around text rather than applying whatever
 /// formatting is intended." Every model emits light Markdown, and we teach it to — the prompts are Markdown,
-/// and the word-analysis section is a table.</para>
+/// and the word-analysis section handed to the model is itself a table.</para>
 ///
 /// <para>The governing rule for all of it: <b>a reader's copy must come out as clean prose</b>. This panel
-/// exists so translations can be copied out of it.</para>
+/// exists so translations can be copied out of it, so <see cref="AnswerMarkup.PlainText"/> is asserted
+/// alongside nearly every rendering case.</para>
 /// </summary>
 public class AnswerMarkupTests
 {
-    private static string Rendered(string source) => AnswerMarkup.PlainText(AnswerMarkup.Parse(source));
+    private static string Rendered(string? source) => AnswerMarkup.PlainText(AnswerMarkup.Parse(source));
+
+    private static AnswerSpan[] Spans(string source) =>
+        AnswerMarkup.Parse(source).OfType<AnswerParagraph>().SelectMany(p => p.Spans).ToArray();
 
     private static AnswerStyle StyleOf(string source, string fragment) =>
-        AnswerMarkup.Parse(source).First(s => s.Text.Contains(fragment)).Style;
+        Spans(source).First(s => s.Text.Contains(fragment)).Style;
+
+    // ---- Inline emphasis --------------------------------------------------------------------------
 
     [Fact]
     public void Bold_and_italic_markers_are_applied_rather_than_shown()
@@ -43,20 +49,15 @@ public class AnswerMarkupTests
     [Fact]
     public void Headings_become_emphasis_and_lose_their_hashes()
     {
-        var spans = AnswerMarkup.Parse("## Word by word\n\nappamādo: heedfulness");
-
-        Assert.Contains(spans, s => s.Text == "Word by word" && s.Style.HasFlag(AnswerStyle.Heading));
+        Assert.Contains(Spans("## Word by word\n\nappamādo: heedfulness"),
+            s => s.Text == "Word by word" && s.Style.HasFlag(AnswerStyle.Heading));
         Assert.DoesNotContain("##", Rendered("## Word by word\n\nappamādo: heedfulness"));
     }
 
     [Fact]
     public void Bullets_become_a_glyph_so_a_copied_answer_still_reads_as_a_list()
     {
-        // Not a list control: the whole answer has to stay one selectable run of text. A copied bullet list
-        // that has lost its bullets reads as run-together sentences.
-        var rendered = Rendered("- first\n- second");
-
-        Assert.Equal("• first\n• second", rendered);
+        Assert.Equal("• first\n• second", Rendered("- first\n- second"));
     }
 
     [Fact]
@@ -79,18 +80,6 @@ public class AnswerMarkupTests
         Assert.Equal("stars ** here", Rendered("stars ** here"));
     }
 
-    [Fact]
-    public void Table_rows_keep_their_pipes_in_fixed_pitch()
-    {
-        // Deliberately not parsed into a grid — that would need separate controls per cell and break
-        // selection across the answer. Fixed pitch at least lines the columns up.
-        var source = "| word | stem |\n| --- | --- |\n| appamādo | appamāda |";
-        var spans = AnswerMarkup.Parse(source);
-
-        Assert.All(spans.Where(s => s.Text.Contains('|')), s => Assert.Equal(AnswerStyle.Monospace, s.Style));
-        Assert.Equal(source, Rendered(source));   // nothing is lost
-    }
-
     [Theory]
     [InlineData("")]
     [InlineData(null)]
@@ -108,7 +97,7 @@ public class AnswerMarkupTests
             + "The verse turns on a single pair of opposites.";
 
         Assert.Equal(prose, Rendered(prose));
-        Assert.All(AnswerMarkup.Parse(prose), s => Assert.Equal(AnswerStyle.None, s.Style));
+        Assert.All(Spans(prose), s => Assert.Equal(AnswerStyle.None, s.Style));
     }
 
     [Fact]
@@ -116,18 +105,125 @@ public class AnswerMarkupTests
     {
         // A long answer would otherwise be one run per line, and the panel re-lays-out the whole answer on
         // every 100ms flush.
-        var spans = AnswerMarkup.Parse("one\ntwo\nthree\nfour");
+        var paragraph = Assert.IsType<AnswerParagraph>(Assert.Single(AnswerMarkup.Parse("one\ntwo\nthree\nfour")));
 
-        Assert.Single(spans);
+        Assert.Single(paragraph.Spans);
     }
 
     [Fact]
     public void A_pali_word_in_the_middle_of_a_sentence_keeps_its_diacritics()
     {
-        // The formatter runs over text that has already had its Pāli quote markers stripped, so what it sees
-        // is ordinary letters — but a parser that slices by index is exactly where a combining mark gets
-        // orphaned.
         Assert.Equal("the line appamādo amatapadaṃ is the opening",
             Rendered("the line **appamādo amatapadaṃ** is the opening"));
+    }
+
+    // ---- Tables -----------------------------------------------------------------------------------
+
+    private const string WordTable =
+        "| form | stem | form | meaning here |\n"
+        + "|---|---|---|---|\n"
+        + "| appamādo | appamāda | nom. sg. m. | heedfulness |\n"
+        + "| amatapadaṃ | amatapada | nom. sg. n. | the deathless state |";
+
+    [Fact]
+    public void A_pipe_table_becomes_a_table_with_its_header_and_rows()
+    {
+        // We hand the model a Markdown table of word analysis, so a word-by-word answer comes back as one.
+        // Setting the pipes in monospace and hoping they line up fails at exactly this panel's width.
+        var table = Assert.IsType<AnswerTable>(Assert.Single(AnswerMarkup.Parse(WordTable)));
+
+        Assert.Equal(4, table.Header.Count);
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal("appamādo", string.Concat(table.Rows[0][0].Spans.Select(s => s.Text)));
+        Assert.Equal("the deathless state", string.Concat(table.Rows[1][3].Spans.Select(s => s.Text)));
+    }
+
+    [Fact]
+    public void A_header_row_without_its_delimiter_is_still_ordinary_text()
+    {
+        // Streaming safety, and the reason the delimiter is what makes a table a table: mid-stream the
+        // header line arrives one flush before the delimiter, and a layout that flips from paragraph to
+        // table and back would flicker on every answer containing one.
+        var blocks = AnswerMarkup.Parse("| form | stem |");
+
+        Assert.IsType<AnswerParagraph>(Assert.Single(blocks));
+        Assert.Equal("| form | stem |", Rendered("| form | stem |"));
+    }
+
+    [Fact]
+    public void Prose_around_a_table_stays_prose()
+    {
+        var blocks = AnswerMarkup.Parse("Word by word:\n" + WordTable + "\nAnd the running translation.");
+
+        Assert.Equal(3, blocks.Count);
+        Assert.IsType<AnswerParagraph>(blocks[0]);
+        Assert.IsType<AnswerTable>(blocks[1]);
+        Assert.IsType<AnswerParagraph>(blocks[2]);
+    }
+
+    [Fact]
+    public void Cell_contents_are_styled_like_any_other_text()
+    {
+        var table = Assert.IsType<AnswerTable>(Assert.Single(AnswerMarkup.Parse(
+            "| word | note |\n|---|---|\n| **appamādo** | the *first* word |")));
+
+        Assert.Equal(AnswerStyle.Bold, Assert.Single(table.Rows[0][0].Spans).Style);
+        Assert.Contains(table.Rows[0][1].Spans, s => s.Text == "first" && s.Style == AnswerStyle.Italic);
+    }
+
+    [Theory]
+    [InlineData(":---", AnswerAlign.Left)]
+    [InlineData("---", AnswerAlign.Left)]
+    [InlineData(":---:", AnswerAlign.Center)]
+    [InlineData("---:", AnswerAlign.Right)]
+    public void Column_alignment_comes_from_the_delimiter_row(string delimiter, AnswerAlign expected)
+    {
+        var table = Assert.IsType<AnswerTable>(Assert.Single(AnswerMarkup.Parse(
+            $"| a |\n| {delimiter} |\n| x |")));
+
+        Assert.Equal(expected, table.Header[0].Align);
+        Assert.Equal(expected, table.Rows[0][0].Align);
+    }
+
+    [Fact]
+    public void A_ragged_row_does_not_lose_the_cells_it_does_have()
+    {
+        // Models produce these. Dropping the row, or throwing, would lose analysis the reader can still use.
+        var table = Assert.IsType<AnswerTable>(Assert.Single(AnswerMarkup.Parse(
+            "| a | b | c |\n|---|---|---|\n| one | two |\n| 1 | 2 | 3 |")));
+
+        Assert.Equal(2, table.Rows[0].Count);
+        Assert.Equal(3, table.Rows[1].Count);
+    }
+
+    [Fact]
+    public void A_copied_table_is_aligned_and_still_a_markdown_table()
+    {
+        // What lands in the reader's document. Columns padded so it reads in a plain-text editor, and the
+        // separator kept so it is still a table anywhere that understands Markdown.
+        var copied = Rendered(WordTable);
+
+        Assert.Contains("| appamādo   | appamāda  |", copied);
+        Assert.Contains("| amatapadaṃ | amatapada |", copied);
+        Assert.Contains("|---", copied.Replace(" ", ""));
+    }
+
+    [Fact]
+    public void A_table_with_no_body_rows_yet_still_renders_its_header()
+    {
+        // The state between the delimiter arriving and the first row: the header should appear rather than
+        // the block vanishing until the model gets round to the data.
+        var table = Assert.IsType<AnswerTable>(Assert.Single(AnswerMarkup.Parse("| a | b |\n|---|---|")));
+
+        Assert.Equal(2, table.Header.Count);
+        Assert.Empty(table.Rows);
+    }
+
+    [Fact]
+    public void A_line_of_dashes_that_is_not_a_table_is_left_alone()
+    {
+        // The delimiter test must not fire on ordinary prose punctuation, or a line of em-dashes eats the
+        // paragraph after it.
+        Assert.Equal("--- a thematic break ---", Rendered("--- a thematic break ---"));
     }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -646,6 +646,7 @@ public class AiAssistantViewModelTests
         await vm.AskAsync(AiTask.Explain);
 
         Assert.Equal("The term **appamāda** matters.", vm.LastTurn!.Answer);
-        Assert.Equal("The term appamāda matters.", AnswerMarkup.PlainText(vm.LastTurn!.Spans));
+        Assert.Equal("The term appamāda matters.", AnswerMarkup.PlainText(vm.LastTurn!.Blocks));
+        Assert.Equal("The term appamāda matters.", vm.LastTurn!.CopyText);
     }
 }

--- a/src/CST.Avalonia/Resources/Ai/system.md
+++ b/src/CST.Avalonia/Resources/Ai/system.md
@@ -58,6 +58,6 @@ from Pāli.
   terms in whatever language you are writing in, in place of whatever that language's default phrase would be.
 - Be concrete. Show the reader what is in the passage rather than summarizing it from a distance.
 - No preamble about what you are about to do. Answer.
-- Structure the answer with short headings, bold, and bullet lists only where they genuinely help. **Do not
-  use tables.** The answer is read in a narrow side panel, and a table there is unreadable. Where you would
-  reach for one -- a word and its stem and its form -- use one labelled line per word instead.
+- Structure the answer with short headings, bold, bullet lists and tables where they genuinely help. The
+  answer is read in a narrow side panel, so keep tables to the few columns that carry the point -- a word,
+  its stem, its form, what it means here -- rather than one column per thing you could say about it.

--- a/src/CST.Avalonia/Services/Ai/AnswerMarkup.cs
+++ b/src/CST.Avalonia/Services/Ai/AnswerMarkup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace CST.Avalonia.Services.Ai;
@@ -15,97 +16,198 @@ public enum AnswerStyle
     /// <summary>A heading line. Drawn as emphasis, not as a new font size — this is a side panel.</summary>
     Heading = 4,
 
-    /// <summary>Fixed-pitch: inline code, and the fallback for table-shaped lines.</summary>
+    /// <summary>Fixed-pitch: inline code.</summary>
     Monospace = 8,
+}
+
+/// <summary>Column alignment, as the table's delimiter row declared it.</summary>
+public enum AnswerAlign
+{
+    Left,
+    Center,
+    Right,
 }
 
 /// <summary>One run of answer text and how to draw it.</summary>
 public sealed record AnswerSpan(string Text, AnswerStyle Style);
 
+/// <summary>A piece of a rendered answer: a run of prose, or a table.</summary>
+public abstract record AnswerBlock;
+
+/// <summary>Prose — possibly many lines, with headings and bullets already resolved into spans.</summary>
+public sealed record AnswerParagraph(IReadOnlyList<AnswerSpan> Spans) : AnswerBlock;
+
+/// <summary>One table cell: its styled content and the column's alignment.</summary>
+public sealed record AnswerCell(IReadOnlyList<AnswerSpan> Spans, AnswerAlign Align);
+
+/// <summary>A pipe table. <paramref name="Header"/> may be empty if the table had no header text.</summary>
+public sealed record AnswerTable(
+    IReadOnlyList<AnswerCell> Header,
+    IReadOnlyList<IReadOnlyList<AnswerCell>> Rows) : AnswerBlock;
+
 /// <summary>
-/// The light Markdown the models actually emit, turned into styled spans. (#586)
+/// The light Markdown the models actually emit, turned into blocks the panel can draw. (#586)
 ///
 /// <para><b>Why this exists.</b> The answer was rendered as plain text, so a model writing
-/// <c>**appamāda**</c> — which they all do — put literal asterisks on screen. We are not innocent bystanders
-/// here either: the prompts are themselves Markdown, headings and bold and bullet lists, and
-/// <see cref="PromptBuilder"/> hands the model a word-analysis TABLE. A model shown a table answers in
-/// tables.</para>
+/// <c>**appamāda**</c> — which they all do — put literal asterisks on screen. We are not bystanders: the
+/// prompts are themselves Markdown, and <see cref="PromptBuilder"/> hands the model a word-analysis table.
+/// A model shown a table answers in tables.</para>
 ///
-/// <para><b>Why hand-rolled rather than a Markdown library.</b> Two reasons, and the second is the deciding
-/// one. A library renders into a tree of separate controls, and a reader cannot drag-select across separate
-/// controls — copying the translation out is the thing this panel exists for. And v1.1 has to render
-/// <see cref="PaliQuoteMarkers"/> spans in the reader's own script, which means styled runs inside one
-/// selectable control anyway; no Markdown library can host that. This is the same streaming transform
-/// <see cref="PaliQuoteFilter"/> already performs, extended to carry style.</para>
+/// <para><b>Tables are parsed, not merely aligned.</b> The first version set table-shaped lines in fixed
+/// pitch and the system prompt asked the model not to emit tables at all — on the reasoning that a real table
+/// needs one control per cell and a drag-selection cannot cross separate controls. That traded a capability
+/// for a copy path, and it was the wrong trade twice over: instruction-following on "no formatting" is
+/// unreliable on exactly the weak models this app must support, so the tables arrived anyway; and copy is
+/// better served by an explicit control than by drag-select, which no longer has to carry the whole burden.
+/// See <see cref="PlainText"/> — copying is now a first-class operation over the parsed blocks.</para>
 ///
-/// <para><b>The ambition is capped on purpose:</b> bold, italic, inline code, headings, bullet lists, and a
-/// fixed-pitch fallback for table-shaped lines. Everything else is left as written. Blockquotes, links and
-/// nested emphasis are deliberately absent — the moment they are wanted, a library is the better answer.
-/// Anything unparsed renders as itself, which is exactly what a reader would have seen before.</para>
+/// <para><b>Streaming safety.</b> A table is only recognised once its delimiter row has arrived, so a header
+/// row alone renders as ordinary text and becomes a table on the next flush rather than flickering between
+/// two layouts. Anything unrecognised renders as itself, which is what a reader would have seen before.</para>
 /// </summary>
 public static class AnswerMarkup
 {
-    /// <summary>
-    /// Parse an answer into styled spans. Line breaks are carried as <c>\n</c> inside span text, so the whole
-    /// answer can be one selectable control and a copy comes out as clean prose.
-    /// </summary>
-    public static IReadOnlyList<AnswerSpan> Parse(string? text)
+    /// <summary>Parse an answer into blocks.</summary>
+    public static IReadOnlyList<AnswerBlock> Parse(string? text)
     {
-        var spans = new List<AnswerSpan>();
-        if (string.IsNullOrEmpty(text)) return spans;
+        var blocks = new List<AnswerBlock>();
+        if (string.IsNullOrEmpty(text)) return blocks;
 
         var lines = text.Replace("\r\n", "\n").Split('\n');
+        var prose = new List<AnswerSpan>();
+
         for (var i = 0; i < lines.Length; i++)
         {
-            var line = lines[i];
-            var newline = i < lines.Length - 1 ? "\n" : string.Empty;
-
-            var trimmed = line.TrimStart();
-            var indent = line[..(line.Length - trimmed.Length)];
-
-            // Table-shaped: leave the pipes alone and set them in fixed pitch so the columns at least line
-            // up. Parsing tables into a grid would break the single-control selection this panel needs.
-            if (IsTableRow(trimmed))
+            // A table needs its delimiter row before it is a table. Until then the header row is just a line
+            // of text — which is what it looks like mid-stream, one flush before the delimiter arrives.
+            if (i + 1 < lines.Length && IsPipeRow(lines[i]) && IsDelimiterRow(lines[i + 1]))
             {
-                Add(spans, line + newline, AnswerStyle.Monospace);
+                FlushProse(blocks, prose);
+
+                var aligns = Alignments(lines[i + 1]);
+                var header = Cells(lines[i], aligns);
+                var rows = new List<IReadOnlyList<AnswerCell>>();
+
+                var row = i + 2;
+                while (row < lines.Length && IsPipeRow(lines[row]))
+                {
+                    rows.Add(Cells(lines[row], aligns));
+                    row++;
+                }
+
+                blocks.Add(new AnswerTable(header, rows));
+                i = row - 1;
                 continue;
             }
 
-            if (HeadingBody(trimmed) is { } heading)
-            {
-                AddInline(spans, heading, AnswerStyle.Heading | AnswerStyle.Bold);
-                if (newline.Length > 0) Add(spans, newline, AnswerStyle.None);
-                continue;
-            }
-
-            if (BulletBody(trimmed) is { } bullet)
-            {
-                // A literal bullet glyph rather than a list control, so a copied answer reads as a list
-                // instead of as run-together sentences.
-                Add(spans, indent + "• ", AnswerStyle.None);
-                AddInline(spans, bullet, AnswerStyle.None);
-                if (newline.Length > 0) Add(spans, newline, AnswerStyle.None);
-                continue;
-            }
-
-            AddInline(spans, line, AnswerStyle.None);
-            if (newline.Length > 0) Add(spans, newline, AnswerStyle.None);
+            AppendLine(prose, lines[i], last: i == lines.Length - 1);
         }
 
-        return Merge(spans);
+        FlushProse(blocks, prose);
+        return blocks;
     }
 
-    /// <summary>The plain text of a parsed answer — what a copy should produce. Also the test seam that
-    /// proves parsing never loses or invents a character of the reader's text.</summary>
-    public static string PlainText(IReadOnlyList<AnswerSpan> spans)
+    /// <summary>
+    /// The plain text of a parsed answer — what Copy hands over, and the test seam that proves parsing never
+    /// loses or invents a character of the reader's text. Tables come back as aligned pipe rows, which is
+    /// what pastes usefully into a document or a message.
+    /// </summary>
+    public static string PlainText(IReadOnlyList<AnswerBlock> blocks)
     {
         var text = new StringBuilder();
-        foreach (var span in spans) text.Append(span.Text);
+
+        foreach (var block in blocks)
+        {
+            switch (block)
+            {
+                case AnswerParagraph paragraph:
+                    foreach (var span in paragraph.Spans) text.Append(span.Text);
+                    break;
+
+                case AnswerTable table:
+                    AppendTable(text, table);
+                    break;
+            }
+        }
+
         return text.ToString();
     }
 
-    private static bool IsTableRow(string trimmed) =>
-        trimmed.StartsWith('|') && trimmed.TrimEnd().EndsWith('|') && trimmed.Length > 1;
+    private static void AppendTable(StringBuilder text, AnswerTable table)
+    {
+        var rows = new List<IReadOnlyList<AnswerCell>>();
+        if (table.Header.Count > 0) rows.Add(table.Header);
+        rows.AddRange(table.Rows);
+        if (rows.Count == 0) return;
+
+        var columns = rows.Max(r => r.Count);
+        var widths = new int[columns];
+        for (var c = 0; c < columns; c++)
+            widths[c] = rows.Max(r => c < r.Count ? Text(r[c]).Length : 0);
+
+        for (var r = 0; r < rows.Count; r++)
+        {
+            text.Append('|');
+            for (var c = 0; c < columns; c++)
+            {
+                var cell = c < rows[r].Count ? Text(rows[r][c]) : string.Empty;
+                text.Append(' ').Append(cell.PadRight(widths[c])).Append(" |");
+            }
+            text.Append('\n');
+
+            // The separator goes back in under the header, so a pasted table is still a Markdown table.
+            if (r == 0 && table.Header.Count > 0)
+            {
+                text.Append('|');
+                for (var c = 0; c < columns; c++) text.Append(' ').Append(new string('-', widths[c])).Append(" |");
+                text.Append('\n');
+            }
+        }
+    }
+
+    private static string Text(AnswerCell cell) =>
+        string.Concat(cell.Spans.Select(s => s.Text));
+
+    // ---- Prose ---------------------------------------------------------------------------------------
+
+    private static void FlushProse(List<AnswerBlock> blocks, List<AnswerSpan> prose)
+    {
+        if (prose.Count == 0) return;
+
+        // A paragraph ending immediately before a table would otherwise carry a dangling newline into a block
+        // that is about to be followed by one anyway.
+        var merged = Merge(prose);
+        blocks.Add(new AnswerParagraph(merged));
+        prose.Clear();
+    }
+
+    private static void AppendLine(List<AnswerSpan> spans, string line, bool last)
+    {
+        var newline = last ? string.Empty : "\n";
+
+        var trimmed = line.TrimStart();
+        var indent = line[..(line.Length - trimmed.Length)];
+
+        if (HeadingBody(trimmed) is { } heading)
+        {
+            AddInline(spans, heading, AnswerStyle.Heading | AnswerStyle.Bold);
+            Add(spans, newline, AnswerStyle.None);
+            return;
+        }
+
+        if (BulletBody(trimmed) is { } bullet)
+        {
+            // A literal bullet glyph rather than a list control, so a copied answer reads as a list instead
+            // of as run-together sentences.
+            Add(spans, indent + "• ", AnswerStyle.None);
+            AddInline(spans, bullet, AnswerStyle.None);
+            Add(spans, newline, AnswerStyle.None);
+            return;
+        }
+
+        AddInline(spans, line, AnswerStyle.None);
+        Add(spans, newline, AnswerStyle.None);
+    }
 
     /// <summary>The text of an ATX heading line, or null.</summary>
     private static string? HeadingBody(string trimmed)
@@ -126,6 +228,61 @@ public static class AnswerMarkup
         if (trimmed[1] != ' ') return null;
         return trimmed[2..];
     }
+
+    // ---- Tables --------------------------------------------------------------------------------------
+
+    private static bool IsPipeRow(string line)
+    {
+        var trimmed = line.Trim();
+        return trimmed.Length > 1 && trimmed.StartsWith('|') && trimmed.EndsWith('|');
+    }
+
+    /// <summary>A row of nothing but dashes, colons, pipes and spaces — the thing that makes a table a table.</summary>
+    private static bool IsDelimiterRow(string line)
+    {
+        if (!IsPipeRow(line)) return false;
+
+        var seenDash = false;
+        foreach (var c in line.Trim())
+        {
+            if (c == '-') seenDash = true;
+            else if (c is not ('|' or ':' or ' ')) return false;
+        }
+        return seenDash;
+    }
+
+    private static IReadOnlyList<AnswerAlign> Alignments(string delimiter) =>
+        SplitRow(delimiter)
+            .Select(cell => cell.Trim())
+            .Select(cell => (cell.StartsWith(':'), cell.EndsWith(':')) switch
+            {
+                (true, true) => AnswerAlign.Center,
+                (false, true) => AnswerAlign.Right,
+                _ => AnswerAlign.Left,
+            })
+            .ToList();
+
+    private static IReadOnlyList<AnswerCell> Cells(string line, IReadOnlyList<AnswerAlign> aligns) =>
+        SplitRow(line)
+            .Select((cell, index) =>
+            {
+                var spans = new List<AnswerSpan>();
+                AddInline(spans, cell.Trim(), AnswerStyle.None);
+                return new AnswerCell(
+                    Merge(spans),
+                    index < aligns.Count ? aligns[index] : AnswerAlign.Left);
+            })
+            .ToList();
+
+    /// <summary>Split a pipe row into cells, dropping the leading and trailing pipes.</summary>
+    private static IReadOnlyList<string> SplitRow(string line)
+    {
+        var trimmed = line.Trim();
+        var inner = trimmed[1..^1];
+        return inner.Split('|');
+    }
+
+    // ---- Inline emphasis -----------------------------------------------------------------------------
 
     /// <summary>
     /// Emphasis within one line: <c>**bold**</c>, <c>*italic*</c>, <c>`code`</c>. Scanned longest-marker

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -96,6 +96,7 @@ public class AiAssistantViewModel : ReactiveTool
         WordByWordCommand = ReactiveCommand.CreateFromTask(() => AskAsync(AiTask.WordByWord));
         StopCommand = ReactiveCommand.Create(Stop);
         RetryCommand = ReactiveCommand.CreateFromTask(RetryAsync);
+        CopyCommand = ReactiveCommand.CreateFromTask<AiTurnViewModel>(CopyAsync);
         ClearCommand = ReactiveCommand.Create(Clear);
     }
 
@@ -105,6 +106,10 @@ public class AiAssistantViewModel : ReactiveTool
     public ReactiveCommand<Unit, Unit> WordByWordCommand { get; }
     public ReactiveCommand<Unit, Unit> StopCommand { get; }
     public ReactiveCommand<Unit, Unit> RetryCommand { get; }
+
+    /// <summary>Copies one turn's answer. Explicit rather than left to drag-select, which stopped covering
+    /// the whole answer once tables put each cell in its own control.</summary>
+    public ReactiveCommand<AiTurnViewModel, Unit> CopyCommand { get; }
     public ReactiveCommand<Unit, Unit> ClearCommand { get; }
 
     /// <summary>Every turn this session, oldest first. The panel scrolls; this is what it scrolls.</summary>
@@ -233,6 +238,17 @@ public class AiAssistantViewModel : ReactiveTool
         if (LastTurn is not { } last) return;
         Question = last.Question ?? "";
         await AskAsync(last.Task);
+    }
+
+    private static async Task CopyAsync(AiTurnViewModel turn)
+    {
+        // global:: throughout: the app's own CST.Avalonia namespace shadows the framework's Avalonia one.
+        var clipboard = (global::Avalonia.Application.Current?.ApplicationLifetime
+                as global::Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)
+            ?.MainWindow?.Clipboard;
+
+        if (clipboard is null || turn is null) return;
+        await clipboard.SetTextAsync(turn.CopyText);
     }
 
     private void Clear()

--- a/src/CST.Avalonia/ViewModels/AiTurnViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiTurnViewModel.cs
@@ -49,17 +49,17 @@ public sealed class AiTurnViewModel : ReactiveObject
 
     // ---- The answer ------------------------------------------------------------------------------
 
-    private IReadOnlyList<AnswerSpan> _spans = Array.Empty<AnswerSpan>();
+    private IReadOnlyList<AnswerBlock> _blocks = Array.Empty<AnswerBlock>();
 
     /// <summary>
-    /// The answer as styled spans. Bound to a single selectable control: models emit light Markdown — and we
-    /// teach them to, since the prompts are Markdown — so rendering it as plain text put literal asterisks on
-    /// screen.
+    /// The answer as rendered blocks — prose and tables. Models emit light Markdown, and we teach them to,
+    /// since the prompts are Markdown and the word-analysis section is itself a table; rendering the answer
+    /// as plain text put literal asterisks and unaligned pipes on screen.
     /// </summary>
-    public IReadOnlyList<AnswerSpan> Spans
+    public IReadOnlyList<AnswerBlock> Blocks
     {
-        get => _spans;
-        private set => this.RaiseAndSetIfChanged(ref _spans, value);
+        get => _blocks;
+        private set => this.RaiseAndSetIfChanged(ref _blocks, value);
     }
 
     /// <summary>The raw answer, markup and all. What Copy hands over, and what a test asserts on.</summary>
@@ -83,9 +83,19 @@ public sealed class AiTurnViewModel : ReactiveObject
     /// <summary>Re-parse and publish. Called once per flush, not once per delta.</summary>
     internal void PublishAnswer()
     {
-        Spans = AnswerMarkup.Parse(_answer.ToString());
+        Blocks = AnswerMarkup.Parse(_answer.ToString());
         this.RaisePropertyChanged(nameof(Answer));
     }
+
+    /// <summary>
+    /// The answer as a reader would want it pasted: emphasis applied rather than spelled with asterisks,
+    /// bullets as glyphs, tables as aligned pipe rows.
+    ///
+    /// <para>An explicit operation rather than a consequence of drag-select. Tables put each cell in its own
+    /// control and a drag cannot cross controls, so once the panel renders tables, "select all of it and
+    /// copy" stops working — the copy path has to be owned rather than inherited.</para>
+    /// </summary>
+    public string CopyText => AnswerMarkup.PlainText(Blocks);
 
     // ---- Reasoning -------------------------------------------------------------------------------
 

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:CST.Avalonia.ViewModels"
              xmlns:views="using:CST.Avalonia.Views"
+             xmlns:ai="using:CST.Avalonia.Services.Ai"
              mc:Ignorable="d" d:DesignWidth="380" d:DesignHeight="700"
              x:Class="CST.Avalonia.Views.AiAssistantPanel"
              x:DataType="vm:AiAssistantViewModel">
@@ -152,12 +153,45 @@
                                                          Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                 </Expander>
 
-                                <!-- The answer. One selectable control with styled runs, so a reader can drag
-                                     across the whole thing and copy it as clean prose. -->
-                                <SelectableTextBlock views:AnswerInlines.Spans="{Binding Spans}"
-                                                     IsVisible="{Binding HasAnswer}"
-                                                     TextWrapping="Wrap"
-                                                     Margin="0,4,0,0"/>
+                                <!-- The answer, as blocks: prose in one selectable control per run, tables
+                                     as real grids. Tables are here because we hand the model a Markdown
+                                     word-analysis table and it answers in kind; monospace pipes stopped
+                                     lining up at exactly this panel's width. The cost is that a drag cannot
+                                     cross a table, which is why Copy below is an explicit control. -->
+                                <ItemsControl ItemsSource="{Binding Blocks}"
+                                              IsVisible="{Binding HasAnswer}"
+                                              Margin="0,4,0,0">
+                                    <ItemsControl.DataTemplates>
+                                        <DataTemplate DataType="ai:AnswerParagraph">
+                                            <SelectableTextBlock views:AnswerInlines.Spans="{Binding Spans}"
+                                                                 TextWrapping="Wrap"/>
+                                        </DataTemplate>
+                                        <DataTemplate DataType="ai:AnswerTable">
+                                            <!-- Horizontal scroll rather than squeeze: a four-column word
+                                                 analysis in a narrow panel is worth scrolling to read, and
+                                                 the page body must never scroll sideways on its account. -->
+                                            <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                                          VerticalScrollBarVisibility="Disabled"
+                                                          Margin="0,6,0,6">
+                                                <Border BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                                        BorderThickness="1" CornerRadius="4"
+                                                        Padding="2">
+                                                    <Grid views:AnswerTableView.Table="{Binding}"/>
+                                                </Border>
+                                            </ScrollViewer>
+                                        </DataTemplate>
+                                    </ItemsControl.DataTemplates>
+                                </ItemsControl>
+
+                                <!-- Copy is owned, not inherited. Drag-select covered the whole answer while
+                                     it was one control; a table's cells are separate controls, so the
+                                     reader who came here to lift a translation out needs a button. -->
+                                <Button Content="Copy"
+                                        Command="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).CopyCommand}"
+                                        CommandParameter="{Binding}"
+                                        IsVisible="{Binding HasAnswer}"
+                                        HorizontalAlignment="Left"
+                                        Margin="0,6,0,0"/>
 
                                 <!-- Facts about how the request was assembled, not failures. Collapsed,
                                      because at full weight beside the answer they read as a list of errors. -->

--- a/src/CST.Avalonia/Views/AnswerTableView.cs
+++ b/src/CST.Avalonia/Views/AnswerTableView.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Layout;
+using Avalonia.Media;
+using CST.Avalonia.Services.Ai;
+
+namespace CST.Avalonia.Views;
+
+/// <summary>
+/// Draws a parsed <see cref="AnswerTable"/> into a <see cref="Grid"/>. (#586)
+///
+/// <para><b>Why a real grid and not aligned monospace.</b> The word-analysis table we hand the model is a
+/// Markdown table, so a word-by-word answer comes back as one — and in a 25%-wide panel, monospace pipes
+/// wrap and stop lining up at exactly the width where the table was supposed to help. Auto-sized columns
+/// wrap per cell instead, which is what a reader needs.</para>
+///
+/// <para><b>Cells are separate controls, so a drag cannot select across the whole answer.</b> That is the
+/// cost of rendering tables at all, and it is why each turn carries an explicit Copy control: copying is a
+/// first-class operation over the parsed blocks rather than a side effect of being able to drag across
+/// them. Each cell is still individually selectable for lifting one reading out.</para>
+/// </summary>
+public static class AnswerTableView
+{
+    public static readonly AttachedProperty<AnswerTable?> TableProperty =
+        AvaloniaProperty.RegisterAttached<Grid, AnswerTable?>("Table", typeof(AnswerTableView));
+
+    public static void SetTable(Grid element, AnswerTable? value) => element.SetValue(TableProperty, value);
+
+    public static AnswerTable? GetTable(Grid element) => element.GetValue(TableProperty);
+
+    static AnswerTableView()
+    {
+        TableProperty.Changed.AddClassHandler<Grid>((grid, args) => Apply(grid, args.NewValue as AnswerTable));
+    }
+
+    private static void Apply(Grid grid, AnswerTable? table)
+    {
+        grid.Children.Clear();
+        grid.RowDefinitions.Clear();
+        grid.ColumnDefinitions.Clear();
+        if (table is null) return;
+
+        var rows = new List<IReadOnlyList<AnswerCell>>();
+        if (table.Header.Count > 0) rows.Add(table.Header);
+        rows.AddRange(table.Rows);
+        if (rows.Count == 0) return;
+
+        var columns = 0;
+        foreach (var row in rows) columns = row.Count > columns ? row.Count : columns;
+
+        for (var c = 0; c < columns; c++)
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        for (var r = 0; r < rows.Count; r++)
+            grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+
+        var headerRows = table.Header.Count > 0 ? 1 : 0;
+
+        for (var r = 0; r < rows.Count; r++)
+        {
+            for (var c = 0; c < columns; c++)
+            {
+                var cell = c < rows[r].Count ? rows[r][c] : new AnswerCell(new List<AnswerSpan>(), AnswerAlign.Left);
+
+                var text = new SelectableTextBlock
+                {
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(6, 3),
+                    FontWeight = r < headerRows ? FontWeight.SemiBold : FontWeight.Normal,
+                    HorizontalAlignment = cell.Align switch
+                    {
+                        AnswerAlign.Center => HorizontalAlignment.Center,
+                        AnswerAlign.Right => HorizontalAlignment.Right,
+                        _ => HorizontalAlignment.Left,
+                    },
+                };
+
+                foreach (var span in cell.Spans)
+                {
+                    var run = new Run(span.Text);
+                    if (span.Style.HasFlag(AnswerStyle.Bold)) run.FontWeight = FontWeight.SemiBold;
+                    if (span.Style.HasFlag(AnswerStyle.Italic)) run.FontStyle = FontStyle.Italic;
+                    if (span.Style.HasFlag(AnswerStyle.Monospace)) run.FontFamily = FontFamily.Parse("monospace");
+                    text.Inlines?.Add(run);
+                }
+
+                // A rule under the header only. Full gridlines in a narrow panel are more ink than the data.
+                var border = new Border
+                {
+                    Child = text,
+                    BorderThickness = r == headerRows - 1 ? new Thickness(0, 0, 0, 1) : default,
+                    BorderBrush = Brushes.Gray,
+                };
+
+                Grid.SetRow(border, r);
+                Grid.SetColumn(border, c);
+                grid.Children.Add(border);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The panel needed table rendering. Doing it properly meant reversing a decision I made a few hours ago, so this explains the reversal rather than quietly patching over it.

## Why there were no tables

`PromptBuilder` hands the model a Markdown table of word analysis (`| form in the text | stem | part of speech | gloss |`), so a word-by-word answer naturally comes back as a table. The first formatter did not parse them: it set table-shaped lines in fixed pitch, and the system prompt was changed to say **"Do not use tables."**

The reasoning was that a real table needs one control per cell, an Avalonia drag-selection cannot cross controls, and copying a translation out is what this panel exists for.

That trade was wrong on both sides:

- **On the capability** — instruction-following on "no formatting" is least reliable on exactly the weak and free models this app has to support. The tables arrived anyway, as unaligned pipes.
- **On the copy path** — monospace pipes stop lining up at precisely this panel's width. The panel is now 25% of the window on the right, and a four-column analysis wraps there. The alignment that justified the whole compromise wasn't there when it mattered.

## What this does

`AnswerMarkup` now returns **blocks** rather than one flat span list. A pipe row followed by a delimiter row becomes an `AnswerTable` carrying per-column alignment from `:---` / `---:` / `:---:`; everything else stays prose with the existing heading, bullet and emphasis handling. `AnswerTableView` draws it as an auto-sized `Grid` inside a horizontal scroller — a four-column analysis in a narrow panel is worth scrolling to read, and the panel itself must never scroll sideways.

**The delimiter row is what makes a table a table**, and that is streaming safety, not pedantry: the header line arrives one flush before the delimiter, so recognising a table on pipes alone would make the layout flip between paragraph and table on every answer containing one.

## Copy becomes an operation

The objection that blocked tables is real and does not go away — a drag cannot cross a table. So copy stops being a side effect of the answer happening to be a single control:

- a **Copy** button per turn, over `AnswerMarkup.PlainText`;
- emphasis applied rather than spelled with asterisks, bullets as glyphs;
- tables padded into aligned pipe rows **with their separator kept**, so what lands in the reader's document reads correctly in a plain-text editor and is still a table anywhere that understands Markdown.

Individual cells remain selectable for lifting one reading out.

## The prompt

`system.md` stops forbidding tables — forbidding what we now render would make the renderer dead code. It keeps asking for few columns, which was the part that was actually true about a narrow panel.

## Testing

Full suite **1727 passed, 0 failed** (+11). Mutation-tested: disabling delimiter-row detection kills 10 of the new tests. Ragged rows, header-without-body, alignment, styled cell contents, and the "a line of dashes is not a table" case are each covered. Clean app startup, no XAML or binding failures.

**Not visually verified** — how a real table looks at this panel's width needs eyes on a running window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)