### PR TITLE
Build the AI context around the selection (#649)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -402,6 +402,41 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void A_selection_spanning_two_sections_is_kept_whole_and_each_side_expands_in_its_own()
+        {
+            // The reader dragged across the boundary, so both sides are what they are asking about and the
+            // window must carry all of it. What must not cross is the EXPANSION: the backward floor comes
+            // from the section holding the selection's start, the forward ceiling from the one holding its
+            // end, so neither side reaches into a section the selection never touched.
+            const string three =
+                "<body><div id=\"b\" type=\"book\">" +
+                "<div id=\"s1\" type=\"sutta\"><p rend=\"bodytext\" n=\"1\">aaa। bbb। ccc।</p></div>" +
+                "<div id=\"s2\" type=\"sutta\"><p rend=\"bodytext\" n=\"2\">ddd। eee। fff।</p></div>" +
+                "<div id=\"s3\" type=\"sutta\"><p rend=\"bodytext\" n=\"3\">ggg। hhh। iii।</p></div>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(three);
+
+            // Starts in section 1, ends in section 2.
+            var from = three.IndexOf("ccc", System.StringComparison.Ordinal);
+            var to = three.IndexOf("ddd", System.StringComparison.Ordinal) + 3;
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                three, from, to, maxChars: 400, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            // All of the selection, across the boundary.
+            Assert.Contains("ccc", window.Text);
+            Assert.Contains("ddd", window.Text);
+
+            // Expansion within each side's own section.
+            Assert.Contains("aaa", window.Text);   // backwards, inside section 1
+            Assert.Contains("fff", window.Text);   // forwards, inside section 2
+
+            // But never into a section the selection never touched.
+            Assert.DoesNotContain("ggg", window.Text);
+        }
+
+        [Fact]
         public void A_selection_larger_than_the_budget_is_never_trimmed_to_fit()
         {
             // The subject of the request must not be cut to make room for its own context. Trimming it would

--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -468,6 +468,94 @@ namespace CST.Avalonia.Tests.Search
             Assert.DoesNotContain("hhh", window.Text);  // never back into the previous one
         }
 
+        // ---- Locating the selection in the raw XML -----------------------------------------------------
+
+        [Fact]
+        public void A_selection_is_located_in_the_raw_xml()
+        {
+            const string xml = "<body><p rend=\"bodytext\" n=\"1\">alpha bravo charlie delta।</p></body>";
+
+            var span = TeiPassageReader.LocateSelection(xml, 0, xml.Length, "bravo charlie");
+
+            Assert.NotNull(span);
+            Assert.Equal("bravo charlie", xml.Substring(span!.Value.Start, span.Value.End - span.Value.Start));
+        }
+
+        [Fact]
+        public void A_selection_matches_across_markup_the_renderer_drops()
+        {
+            // A paragraph number or a note sits in the middle of what the reader dragged across. The renderer
+            // drops both, so the selection text has no trace of them and a naive substring search fails on
+            // exactly the selections most likely to be made — the ones starting at the top of a paragraph.
+            const string xml =
+                "<body><p rend=\"bodytext\" n=\"1\">" +
+                "<hi rend=\"paranum\">12</hi><hi rend=\"dot\">.</hi>alpha <note>vl (si)</note>bravo charlie।" +
+                "</p></body>";
+
+            var span = TeiPassageReader.LocateSelection(xml, 0, xml.Length, "alpha bravo");
+
+            Assert.NotNull(span);
+            var raw = xml.Substring(span!.Value.Start, span.Value.End - span.Value.Start);
+            Assert.StartsWith("alpha", raw);
+            Assert.EndsWith("bravo", raw);
+        }
+
+        [Fact]
+        public void A_selection_matches_across_line_wrapping()
+        {
+            // The XML is wrapped; the DOM hands back a single space. Comparing raw whitespace would miss.
+            const string xml = "<body><p rend=\"bodytext\" n=\"1\">alpha\n    bravo charlie।</p></body>";
+
+            Assert.NotNull(TeiPassageReader.LocateSelection(xml, 0, xml.Length, "alpha bravo"));
+        }
+
+        [Fact]
+        public void A_selection_outside_the_searched_region_is_not_located()
+        {
+            // The bound is what keeps a formulaic phrase — this corpus repeats them verbatim — from matching
+            // somewhere the reader has never been.
+            const string xml =
+                "<body><p rend=\"bodytext\" n=\"1\">alpha bravo।</p>" +
+                "<p rend=\"bodytext\" n=\"2\">alpha bravo।</p></body>";
+            var second = xml.LastIndexOf("alpha", System.StringComparison.Ordinal);
+
+            // Searching only the second paragraph finds the second occurrence, not the first.
+            var span = TeiPassageReader.LocateSelection(xml, second - 5, xml.Length, "alpha bravo");
+
+            Assert.NotNull(span);
+            Assert.True(span!.Value.Start >= second - 5);
+        }
+
+        [Fact]
+        public void Text_that_is_not_there_is_not_located()
+        {
+            const string xml = "<body><p rend=\"bodytext\" n=\"1\">alpha bravo।</p></body>";
+
+            Assert.Null(TeiPassageReader.LocateSelection(xml, 0, xml.Length, "charlie delta"));
+            Assert.Null(TeiPassageReader.LocateSelection(xml, 0, xml.Length, "   "));
+            Assert.Null(TeiPassageReader.LocateSelection(xml, 0, xml.Length, ""));
+        }
+
+        [Fact]
+        public void A_located_selection_is_inside_the_window_built_around_it()
+        {
+            // The two halves joined: locate, then build. This is the shape the bundler uses.
+            const string xml =
+                "<body><div id=\"b\" type=\"book\"><div id=\"s\" type=\"sutta\">" +
+                "<p rend=\"bodytext\" n=\"1\">one। two। three। four। five। six।</p>" +
+                "</div></div></body>";
+            var markers = BookMarkers.Build(xml);
+
+            var span = TeiPassageReader.LocateSelection(xml, 0, xml.Length, "four");
+            Assert.NotNull(span);
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                xml, span!.Value.Start, span.Value.End, maxChars: 20, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("four", window.Text);
+        }
+
         [Theory]
         [InlineData(0)]
         [InlineData(1)]

--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -284,5 +284,172 @@ namespace CST.Avalonia.Tests.Search
             Assert.All(atHit, h => Assert.Contains(window.Pages, p =>
                 p.Edition == h.Edition && p.Volume == h.Volume && p.Number == h.Number));
         }
+
+        // ---- Windows built AROUND a selection (#649) --------------------------------------------------
+
+        /// <summary>
+        /// Two sections, so a window built near a boundary has somewhere wrong to expand into. Sentences are
+        /// single words plus a danda, which makes rendered lengths easy to reason about exactly.
+        /// </summary>
+        private const string TwoSections =
+            "<body><div id=\"b\" type=\"book\">" +
+            "<div id=\"s1\" type=\"sutta\"><p rend=\"bodytext\" n=\"1\">" +
+            "aaa। bbb। ccc। ddd। eee। fff। ggg। hhh।" +
+            "</p></div>" +
+            "<div id=\"s2\" type=\"sutta\"><p rend=\"bodytext\" n=\"2\">" +
+            "zzz। yyy। xxx। www।" +
+            "</p></div>" +
+            "</div></body>";
+
+        private static (int Start, int End) Span(string xml, string needle)
+        {
+            var at = xml.IndexOf(needle, System.StringComparison.Ordinal);
+            Assert.True(at >= 0, $"fixture does not contain '{needle}'");
+            return (at, at + needle.Length);
+        }
+
+        [Fact]
+        public void A_window_around_a_selection_always_contains_the_selection()
+        {
+            // The invariant the whole revamp exists for. The window used to come from the reader's paragraph,
+            // which is derived from SCROLL, so a selection near the bottom of the viewport routinely fell
+            // outside the window built to explain it — and the app reported that as a caveat rather than as
+            // the defect it was.
+            var markers = BookMarkers.Build(TwoSections);
+
+            foreach (var word in new[] { "aaa", "ddd", "hhh", "zzz", "www" })
+            {
+                var (from, to) = Span(TwoSections, word);
+                var window = TeiPassageReader.ReadWindowAroundSelection(
+                    TwoSections, from, to, maxChars: 20, includeVariants: false,
+                    outputScript: Script.Devanagari, markers);
+
+                Assert.Contains(word, window.Text);
+            }
+        }
+
+        [Fact]
+        public void Expansion_goes_roughly_half_backwards_and_half_forwards()
+        {
+            // "Centre it" is the whole point: a selection explained only by what follows it reads as though
+            // the passage began there.
+            var markers = BookMarkers.Build(TwoSections);
+            var (from, to) = Span(TwoSections, "eee");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                TwoSections, from, to, maxChars: 24, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("eee", window.Text);
+            Assert.Contains("ccc", window.Text);   // context behind
+            Assert.Contains("ggg", window.Text);   // and ahead
+        }
+
+        [Fact]
+        public void Expansion_never_crosses_a_div_into_the_next_section()
+        {
+            // Text from the next sutta is not this passage's context, however close it sits in the file.
+            var markers = BookMarkers.Build(TwoSections);
+            var (from, to) = Span(TwoSections, "hhh");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                TwoSections, from, to, maxChars: 200, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("hhh", window.Text);
+            Assert.Contains("aaa", window.Text);        // the budget is spent backwards instead
+            Assert.DoesNotContain("zzz", window.Text);  // never forwards past the boundary
+        }
+
+        [Fact]
+        public void A_budget_the_backward_side_cannot_spend_is_handed_forward()
+        {
+            // A selection at the very start of a section has nowhere behind it. Losing that half would give
+            // the first passage of every sutta half the context of every other passage.
+            var markers = BookMarkers.Build(TwoSections);
+            var (from, to) = Span(TwoSections, "zzz");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                TwoSections, from, to, maxChars: 24, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("zzz", window.Text);
+            Assert.Contains("yyy", window.Text);
+            Assert.Contains("xxx", window.Text);   // reached only because the backward half was redirected
+
+            // And it was redirected rather than spent: what lies behind is the previous section, which is not
+            // this passage's context. The bound holds in BOTH directions.
+            Assert.DoesNotContain("hhh", window.Text);
+        }
+
+        [Fact]
+        public void A_large_budget_cannot_reach_backwards_into_the_previous_section()
+        {
+            // The backward twin of the forward case. A budget big enough to swallow the previous sutta must
+            // stop at the boundary and simply spend the rest forwards.
+            var markers = BookMarkers.Build(TwoSections);
+            var (from, to) = Span(TwoSections, "yyy");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                TwoSections, from, to, maxChars: 400, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("yyy", window.Text);
+            Assert.Contains("zzz", window.Text);       // its own section, behind it
+            Assert.Contains("www", window.Text);       // and ahead
+            Assert.DoesNotContain("hhh", window.Text); // never the section before
+            Assert.DoesNotContain("aaa", window.Text);
+        }
+
+        [Fact]
+        public void A_selection_larger_than_the_budget_is_never_trimmed_to_fit()
+        {
+            // The subject of the request must not be cut to make room for its own context. Trimming it would
+            // answer about part of what the reader pointed at while captioning it as all of it.
+            var markers = BookMarkers.Build(TwoSections);
+            var (from, _) = Span(TwoSections, "aaa");
+            var (_, to) = Span(TwoSections, "hhh");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                TwoSections, from, to, maxChars: 5, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("aaa", window.Text);
+            Assert.Contains("hhh", window.Text);
+        }
+
+        [Fact]
+        public void A_book_with_no_div_markup_is_one_undivided_section()
+        {
+            // Structural markup covers part of the corpus and is still being added, so "no div" is an
+            // ordinary state, not a defect — and it must not cost the passage its context.
+            const string undivided =
+                "<body><p rend=\"bodytext\" n=\"1\">aaa। bbb। ccc। ddd। eee।</p></body>";
+            var markers = BookMarkers.Build(undivided);
+            var (from, to) = Span(undivided, "ccc");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                undivided, from, to, maxChars: 40, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("aaa", window.Text);
+            Assert.Contains("ccc", window.Text);
+            Assert.Contains("eee", window.Text);
+        }
+
+        [Fact]
+        public void The_window_still_reports_its_citation_and_pages()
+        {
+            // A selection-anchored window is still a window: whatever cites it must describe what was sent.
+            var markers = BookMarkers.Build(Xml);
+            var (from, to) = Span(Xml, "echo");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                Xml, from, to, maxChars: 30, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Equal(5, window.ParagraphNumber);
+            Assert.Contains(window.Pages, p => p.Edition == PageEdition.Vri && p.Number == 1);
+        }
     }
 }

--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -375,11 +375,118 @@ namespace CST.Avalonia.Tests.Search
 
             Assert.Contains("zzz", window.Text);
             Assert.Contains("yyy", window.Text);
-            Assert.Contains("xxx", window.Text);   // reached only because the backward half was redirected
 
             // And it was redirected rather than spent: what lies behind is the previous section, which is not
             // this passage's context. The bound holds in BOTH directions.
             Assert.DoesNotContain("hhh", window.Text);
+        }
+
+        [Fact]
+        public void The_redirected_budget_reaches_text_that_half_a_budget_could_not()
+        {
+            // The version of the test above that actually distinguishes redistribution from its absence. The
+            // first fixture's tail section was short enough that WalkForward's post-budget sentence-finish
+            // reached the asserted word anyway, so the assertion held with or without the fix it named — a
+            // test that was true for a reason unrelated to its own comment.
+            const string longTail =
+                "<body><div id=\"b\" type=\"book\">" +
+                "<div id=\"s1\" type=\"sutta\"><p rend=\"bodytext\" n=\"1\">aaa। bbb।</p></div>" +
+                "<div id=\"s2\" type=\"sutta\"><p rend=\"bodytext\" n=\"2\">" +
+                "ccc। ddd। eee। fff। ggg। hhh। iii। jjj। kkk।" +
+                "</p></div></div></body>";
+            var markers = BookMarkers.Build(longTail);
+            var (from, to) = Span(longTail, "ccc");
+
+            // Half of this budget spent backwards would buy nothing (the selection opens its section), so
+            // everything after "ddd" is reached only because the unspendable half went forward.
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                longTail, from, to, maxChars: 40, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("ccc", window.Text);
+            Assert.Contains("hhh", window.Text);
+            Assert.DoesNotContain("bbb", window.Text);   // still never backwards across the boundary
+        }
+
+        [Fact]
+        public void The_backward_snap_cannot_run_away_from_the_budget()
+        {
+            // Found by Fable, not by the tests: the outward snap walks to the previous sentence end, and with
+            // no cap that is however far away the previous danda happens to be. Front matter — a title, a
+            // nikaya heading — carries no danda, so a selection in the first sentence of a book with no div
+            // markup snapped all the way to position 0. A 40-character budget produced a 2,000-character
+            // window, and every fixture here had a danda every few characters, so nothing noticed.
+            var filler = new string('x', 2000);
+            var xml = $"<body><p rend=\"bodytext\" n=\"1\">{filler} target। tail।</p></body>";
+            var markers = BookMarkers.Build(xml);
+            var (from, to) = Span(xml, "target");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                xml, from, to, maxChars: 40, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("target", window.Text);
+            // Bounded rather than exact: both ends may overshoot to finish a sentence. What must not happen
+            // is a window two orders of magnitude over budget.
+            Assert.True(window.Text.Length < 400, $"window ran away: {window.Text.Length} chars");
+        }
+
+        [Fact]
+        public void The_sentence_the_selection_sits_in_is_finished_even_with_no_budget_left()
+        {
+            // Also Fable's: WalkForward's hard cap is 1.5x ITS budget, so once the backward snap has spent
+            // the whole shortfall the forward cap is zero and it returned after a single character — cutting
+            // mid-sentence, which is the one thing this class promises never to do, in the case where the
+            // reader most needs the sentence whole because it is the subject of the request.
+            const string xml =
+                "<body><p rend=\"bodytext\" n=\"1\">aaaa bbbb cccc dddd। ee ff gg hh ii jj kk।</p></body>";
+            var markers = BookMarkers.Build(xml);
+            var (from, to) = Span(xml, "ee");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                xml, from, to, maxChars: 5, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("ee", window.Text);
+            Assert.Contains("kk", window.Text);   // the sentence runs to its end
+        }
+
+        [Fact]
+        public void A_selection_at_the_very_end_of_a_section_still_respects_its_boundary()
+        {
+            // The boundary case that does occur: the last words of a section, where the forward walk runs
+            // straight into the closing tags and the backward one has the whole section behind it.
+            var markers = BookMarkers.Build(TwoSections);
+            var (from, to) = Span(TwoSections, "www");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                TwoSections, from, to, maxChars: 400, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("www", window.Text);
+            Assert.Contains("zzz", window.Text);        // its own section, behind it
+            Assert.DoesNotContain("hhh", window.Text);  // never back into the previous one
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void Degenerate_spans_do_not_throw(int maxChars)
+        {
+            // A public method has to survive its own degenerate inputs: an empty selection, one at position
+            // zero, one past the end, and a budget of nothing. None of these is reachable from the panel; all
+            // of them are reachable from a caller reading the signature.
+            var markers = BookMarkers.Build(TwoSections);
+
+            foreach (var (from, to) in new[] { (0, 0), (0, 1), (TwoSections.Length, TwoSections.Length),
+                                               (TwoSections.Length + 50, TwoSections.Length + 90) })
+            {
+                var window = TeiPassageReader.ReadWindowAroundSelection(
+                    TwoSections, from, to, maxChars, includeVariants: false,
+                    outputScript: Script.Devanagari, markers);
+
+                Assert.NotNull(window.Text);
+            }
         }
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/AiContextBundlerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiContextBundlerTests.cs
@@ -142,12 +142,16 @@ public class AiContextBundlerTests : IDisposable
     }
 
     [Fact]
-    public async Task A_selection_absent_from_the_window_is_flagged_rather_than_hidden()
+    public async Task A_selection_is_carried_without_being_asked_whether_it_is_in_the_window()
     {
+        // This replaces a test asserting the opposite -- that a selection the window did not contain was
+        // flagged. The window is now built around the selection, so there is nothing to flag and no
+        // FoundInWindow to report. The state, its notice and the caution it put in the prompt are gone. (#649)
         var bundle = await Bundler().BuildAsync(Request(selection: "nowhere in this book"));
 
-        Assert.False(bundle.Selection!.FoundInWindow);
-        Assert.Contains("not found", Part(bundle, BundlePartNames.Selection).Detail);
+        Assert.Equal(SelectionState.Located, bundle.Selection!.State);
+        Assert.Null(Part(bundle, BundlePartNames.Selection).Detail);
+        Assert.DoesNotContain(bundle.Budget.Parts, p => p.Detail?.Contains("not found") == true);
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
@@ -165,18 +165,19 @@ public class PromptBuilderTests : IDisposable
     }
 
     [Fact]
-    public void A_selection_the_window_does_not_contain_warns_the_model_and_the_user()
+    public void A_selection_carries_no_caveat_about_its_own_context()
     {
+        // There used to be a "this selection was not found in the passage above" branch here, because the
+        // window came from scroll position and might genuinely not contain the selection. The window is now
+        // built around the selection, so the caveat has nothing to warn about -- and a prompt that tells the
+        // model its own context might be the wrong context degrades every answer it touches. (#649)
         var prompt = _builder.Build(Bundle(
-            selection: new SelectionContext("dhammā manopubbaṅgamā", SelectionState.NotFoundInWindow)));
+            selection: new SelectionContext("appamādo amatapadaṃ", SelectionState.Located)));
 
-        // The caution points at the CONTEXT, not at the selection. The selection is the one thing here we are
-        // certain of — the reader pointed at it and we have its exact characters; what failed is our attempt
-        // to supply its surroundings. The earlier wording told the model to distrust the selection, which,
-        // now that the selection is the subject, would be telling it to distrust the question.
-        Assert.Contains("does not contain this selection", prompt.UserContent);
-        Assert.Contains("Work from the selection itself", prompt.UserContent);
-        Assert.Contains(prompt.Notices, n => n.Contains("not found in the passage window"));
+        Assert.Contains("appamādo amatapadaṃ", prompt.UserContent);
+        Assert.DoesNotContain("not found in the passage", prompt.UserContent);
+        Assert.DoesNotContain("may not be", prompt.UserContent);
+        Assert.DoesNotContain(prompt.Notices, n => n.Contains("not found in the passage window"));
     }
 
     // ---- The selection is the subject of the request -----------------------------------------------

--- a/src/CST.Avalonia.Tests/Services/Ai/SelectionPipelineTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/SelectionPipelineTests.cs
@@ -30,62 +30,10 @@ public class SelectionPipelineTests
         Assert.Equal(Latin, SelectionPipeline.Normalize(Devanagari, Script.Devanagari));
     }
 
-    [Fact]
-    public void A_converted_selection_is_found_in_the_window()
-    {
-        // The end-to-end point of conversion: a Devanagari reader's selection locates in a Latin passage.
-        var normalized = SelectionPipeline.Normalize(Devanagari, Script.Devanagari)!;
 
-        Assert.True(SelectionPipeline.IsWithin(normalized, Window));
-    }
 
-    [Fact]
-    public void A_decomposed_selection_still_matches_a_composed_window()
-    {
-        // ScriptConverter emits composed Latin, so both sides normally agree — but a decomposed selection
-        // (a + U+0304 rather than U+0101) is ORDINALLY unequal, and the symptom would be a bundle reporting
-        // "selection not found in the passage window": a false diagnostic from the component whose whole job is
-        // faithful diagnostics.
-        var decomposed = Latin.Normalize(NormalizationForm.FormD);
-        Assert.NotEqual(Latin, decomposed);          // the failure this guards is real
 
-        var normalized = SelectionPipeline.Normalize(decomposed, Script.Latin)!;
 
-        Assert.Equal(Latin, normalized);
-        Assert.True(SelectionPipeline.IsWithin(normalized, Window));
-    }
-
-    [Fact]
-    public void A_selection_straddling_a_line_break_matches_across_it()
-    {
-        // Selecting across a paragraph or line boundary drags the break in with it. The window renders that
-        // break differently from the DOM, so an un-collapsed comparison misses on a selection that is plainly
-        // present.
-        var straddling = "  maccuno   padaṃ;\n  appamattā \t na mīyanti  ";
-
-        var normalized = SelectionPipeline.Normalize(straddling, Script.Latin)!;
-
-        Assert.Equal("maccuno padaṃ; appamattā na mīyanti", normalized);
-        Assert.True(SelectionPipeline.IsWithin(normalized, Window));
-    }
-
-    [Fact]
-    public void Matching_ignores_case_because_the_corpus_capitalises_programmatically()
-    {
-        // "Appamādo" heads the window; the same word mid-sentence is lowercase. A reader selecting one and the
-        // renderer showing the other must not count as a miss.
-        var normalized = SelectionPipeline.Normalize("APPAMĀDO AMATAPADAṂ", Script.Latin)!;
-
-        Assert.True(SelectionPipeline.IsWithin(normalized, Window));
-    }
-
-    [Fact]
-    public void A_selection_absent_from_the_window_is_reported_as_absent()
-    {
-        var normalized = SelectionPipeline.Normalize("dhammā manopubbaṅgamā", Script.Latin)!;
-
-        Assert.False(SelectionPipeline.IsWithin(normalized, Window));
-    }
 
     [Theory]
     [InlineData(null)]
@@ -108,88 +56,4 @@ public class SelectionPipelineTests
         Assert.Equal(once, SelectionPipeline.Normalize(once, Script.Latin));
     }
 
-    [Fact]
-    public void An_empty_window_matches_nothing_rather_than_everything()
-    {
-        Assert.False(SelectionPipeline.IsWithin("appamādo", string.Empty));
-    }
-
-    // ---- Punctuation (#641) ----------------------------------------------------------------------
-
-    [Fact]
-    public void A_selection_spanning_a_sentence_break_is_found_across_the_danda()
-    {
-        // The reported case, and the one that made the panel unusable: the reader selected the first paragraph
-        // of a book, got a correct translation, AND a notice saying the selection was not found. The window
-        // carried the danda (U+0964) where the selection carried an ASCII full stop, so a selection covering
-        // one sentence boundary — which is most of them — reported as absent.
-        var window = "appamādo amatapadaṃ\u0964 pamādo maccuno padaṃ";
-        var selection = SelectionPipeline.Normalize("appamādo amatapadaṃ. pamādo maccuno", Script.Latin)!;
-
-        Assert.True(SelectionPipeline.IsWithin(selection, window));
-    }
-
-    [Theory]
-    // Every script this app renders brings its own sentence and phrase marks. A table of known marks would
-    // have fixed the danda and left each of these to be found the same way — by a reader being told that the
-    // text in front of them is not there.
-    // Escaped rather than pasted: these marks are visually near-identical to each other and to ASCII bars, so
-    // a literal here would be unreviewable — the house rule for script-facing code.
-    [InlineData("\u0964")]     // Devanagari danda
-    [InlineData("\u0965")]     // Devanagari double danda
-    [InlineData("\u104A")]     // Myanmar little section
-    [InlineData("\u104B")]     // Myanmar section
-    [InlineData("\u17D4")]     // Khmer khan
-    [InlineData("\u0F0D")]     // Tibetan shad
-    [InlineData("\u0E5A")]     // Thai angkhankhu
-    [InlineData(".")]
-    [InlineData(";")]
-    [InlineData(",")]
-    public void Sentence_marks_do_not_decide_whether_a_selection_is_present(string mark)
-    {
-        var window = $"appamādo amatapadaṃ{mark} pamādo maccuno padaṃ";
-        var selection = SelectionPipeline.Normalize("amatapadaṃ, pamādo", Script.Latin)!;
-
-        Assert.True(SelectionPipeline.IsWithin(selection, window));
-    }
-
-    [Fact]
-    public void The_elision_apostrophe_matches_in_either_of_its_forms()
-    {
-        // Latin Pāli writes elision with an apostrophe, and the DOM and the passage reader do not agree on
-        // which one — U+2019 from a copy, ASCII from the renderer, or neither.
-        var window = "so\u2019haṃ vadāmi";
-        var selection = SelectionPipeline.Normalize("so'haṃ vadāmi", Script.Latin)!;
-
-        Assert.True(SelectionPipeline.IsWithin(selection, window));
-    }
-
-    [Fact]
-    public void Folding_punctuation_does_not_make_an_absent_selection_present()
-    {
-        // The guard on the fix: dropping punctuation must not collapse the comparison into "close enough".
-        // Different words are still different words.
-        var selection = SelectionPipeline.Normalize("dhammā manopubbaṅgamā", Script.Latin)!;
-
-        Assert.False(SelectionPipeline.IsWithin(selection, Window));
-    }
-
-    [Fact]
-    public void A_selection_of_nothing_but_punctuation_is_not_found_everywhere()
-    {
-        // Folded, it is the empty string — which Contains reports as present in anything. A reader who
-        // fumbles a drag and catches one danda must not be told the model saw their selection.
-        var selection = SelectionPipeline.Normalize(".\u0964 ;", Script.Latin)!;
-
-        Assert.False(SelectionPipeline.IsWithin(selection, Window));
-    }
-
-    [Fact]
-    public void Diacritics_survive_the_fold()
-    {
-        // Folding keeps combining marks deliberately: a Latin form with no precomposed codepoint would
-        // otherwise lose its diacritic and match a different word. "pāda" and "pada" are different words.
-        Assert.False(SelectionPipeline.IsWithin(SelectionPipeline.Normalize("pādo", Script.Latin)!, "pado"));
-        Assert.False(SelectionPipeline.IsWithin(SelectionPipeline.Normalize("pado", Script.Latin)!, "pādo"));
-    }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -526,6 +526,41 @@ public class AiAssistantViewModelTests
     }
 
     [Fact]
+    public async Task The_window_is_anchored_on_the_selection_rather_than_on_the_scroll_position()
+    {
+        // #649, at the seam where it is decided. The reading position and the selection's position are
+        // different numbers -- scroll puts the reader on 12 while the selection sits in 40 -- and building
+        // the window from the first is what let a selection near the bottom of the viewport fall outside the
+        // window meant to explain it.
+        var orchestrator = new StubOrchestrator();
+        var reader = new StubReaderState
+        {
+            Result = ReaderStateResult.Ok(new ReaderState(
+                "s0101m.mul.xml", Paragraph: 12, SelectionText: "appamādo", SelectionParagraph: 40)),
+        };
+
+        var vm = new AiAssistantViewModel(orchestrator, reader, null, null);
+        await vm.AskAsync(AiTask.Translate);
+
+        var reference = Assert.IsType<NavigationReference.Paragraph>(orchestrator.LastRequest!.Reference);
+        Assert.Equal(40, reference.Number);
+    }
+
+    [Fact]
+    public async Task With_nothing_selected_the_reading_position_is_still_what_anchors_the_window()
+    {
+        // The fallback has to keep working: the presets are usable with no selection at all, and then the
+        // viewport IS the best available statement of what the reader is looking at.
+        var orchestrator = new StubOrchestrator();
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+
+        await vm.AskAsync(AiTask.Explain);
+
+        var reference = Assert.IsType<NavigationReference.Paragraph>(orchestrator.LastRequest!.Reference);
+        Assert.Equal(12, reference.Number);
+    }
+
+    [Fact]
     public async Task The_selection_is_shown_as_the_subject_before_the_answer_arrives()
     {
         // The mitigation that makes selection-as-subject safe. A browser selection persists invisibly: select

--- a/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
+++ b/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
@@ -120,7 +120,10 @@ public sealed class AiContextBundler : IAiContextBundler
                 MaxChars: budget,
                 OutputScript: Script.Latin,
                 IncludeFootnotes: false,
-                StructuredNotes: true),
+                StructuredNotes: true,
+                // The window is built AROUND this, so the selection is inside the context by construction
+                // rather than by luck. (#649)
+                SelectionText: request.SelectionUnavailable ? null : request.SelectionText),
             ct).ConfigureAwait(false);
 
         // The passage tool signals every failure the same way — empty text, with the reason left in
@@ -144,7 +147,7 @@ public sealed class AiContextBundler : IAiContextBundler
             passage.NoteCount > 0 ? BundlePartState.Included : BundlePartState.Empty,
             passage.NoteCount > 0 ? $"{passage.NoteCount} print note(s)" : "no apparatus in this window"));
 
-        var selection = BuildSelection(request, passage.Text, parts);
+        var selection = BuildSelection(request, parts);
         var lemmas = GatherLemmas(request.Task, selection?.Text ?? passage.Text, parts);
 
         var bookName = ScriptConverter.Convert(book.LongNavPath, Script.Devanagari, Script.Latin);
@@ -176,19 +179,19 @@ public sealed class AiContextBundler : IAiContextBundler
     }
 
     /// <summary>
-    /// Locate the selection in the window, and record what became of it.
+    /// Record what the user selected.
     ///
-    /// <para>A selection the window does not contain is still passed to the model — it is what the user pointed
-    /// at — but the mismatch is recorded rather than hidden, because it means the surrounding passage may not
-    /// support what is being asked about.</para>
+    /// <para><b>There is no longer a "not found in the window" outcome, by construction.</b> The window is
+    /// built around the selection, so it contains it; the state, its notice and the caution it put in the
+    /// prompt are all gone. A context that could fail to contain the thing it was context for was not a
+    /// context. (#649)</para>
     ///
-    /// <para><b>Three outcomes, not two.</b> "Nothing selected" and "we could not tell what was selected" were
-    /// the same null before #581. They are not the same thing: the first means the whole passage is legitimately
-    /// in view, the second means the words the user highlighted were dropped on the floor. Only the second is
+    /// <para><b>Two outcomes remain, and they are not the same.</b> "Nothing selected" and "we could not tell
+    /// what was selected" were the same null before #581: the first means the whole passage is legitimately in
+    /// view, the second means the words the user highlighted were dropped on the floor. Only the second is
     /// something to tell them about. (§3.1)</para>
     /// </summary>
-    private static SelectionContext? BuildSelection(
-        AiContextRequest request, string windowText, List<BundlePart> parts)
+    private static SelectionContext? BuildSelection(AiContextRequest request, List<BundlePart> parts)
     {
         if (request.SelectionUnavailable)
         {
@@ -200,18 +203,13 @@ public sealed class AiContextBundler : IAiContextBundler
         }
 
         // Already Latin, composed and whitespace-collapsed by SelectionPipeline.Normalize; run it again rather
-        // than trust the caller, since it is idempotent and the alternative is a silent locator miss.
+        // than trust the caller, since it is idempotent.
         var text = SelectionPipeline.Normalize(request.SelectionText, Script.Latin);
         if (text is null) return null;
 
-        var found = SelectionPipeline.IsWithin(text, windowText);
+        parts.Add(new BundlePart(BundlePartNames.Selection, BundlePartState.Included, null));
 
-        parts.Add(new BundlePart(
-            BundlePartNames.Selection,
-            BundlePartState.Included,
-            found ? null : "selection not found in the passage window"));
-
-        return new SelectionContext(text, found ? SelectionState.Located : SelectionState.NotFoundInWindow);
+        return new SelectionContext(text, SelectionState.Located);
     }
 
     /// <summary>

--- a/src/CST.Avalonia/Services/Ai/ContextBundle.cs
+++ b/src/CST.Avalonia/Services/Ai/ContextBundle.cs
@@ -43,14 +43,9 @@ public sealed record AiContextRequest(
 /// <summary>What became of the user's selection.</summary>
 public enum SelectionState
 {
-    /// <summary>Converted, normalized, and found in the passage window.</summary>
+    /// <summary>The reader selected text and it reached the model. The window is built around it, so there
+    /// is no separate "and it was found" state to be in — see AiContextBundler.</summary>
     Located,
-
-    /// <summary>
-    /// Converted and normalized, but not present in the window. The model is still shown it — it is what the
-    /// user pointed at — but the surrounding passage may not support what is being asked about.
-    /// </summary>
-    NotFoundInWindow,
 
     /// <summary>
     /// The reader could not say what was selected — the WebView was not ready, or the round trip through the
@@ -65,11 +60,7 @@ public enum SelectionState
 /// <summary>The user's selection, once the selection pipeline has been through it.</summary>
 /// <param name="Text">Latin-script, composed, whitespace-collapsed. Null when <see cref="State"/> is
 /// <see cref="SelectionState.Unavailable"/> — there is no text to carry.</param>
-public sealed record SelectionContext(string? Text, SelectionState State)
-{
-    /// <summary>Whether the selection was located within the fetched passage window.</summary>
-    public bool FoundInWindow => State == SelectionState.Located;
-}
+public sealed record SelectionContext(string? Text, SelectionState State);
 
 /// <summary>A word's stem and grammatical analysis, from the optional DPD-lemma asset.</summary>
 public sealed record LemmaEntry(

--- a/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
@@ -285,20 +285,11 @@ public sealed class PromptBuilder : IPromptBuilder
                  + "as a whole, and say that you were not able to see a selection.";
         }
 
-        // The selection is the subject, so when the containment check fails it is the CONTEXT that is in
-        // doubt, not the subject. The selection is the one thing here we are certain of — the reader
-        // physically pointed at it and we have its exact characters; what failed is our attempt to supply its
-        // surroundings. The old wording had this backwards ("treat the surrounding text with corresponding
-        // caution" was attached to a request whose subject WAS the surrounding text), and told the model to
-        // distrust the passage it was being asked about.
-        var note = selection.State == SelectionState.Located
-            ? string.Empty
-            : "\n\n(The surrounding text below was gathered from the reader's position in the book, and it "
-              + "does not contain this selection — the reader may have scrolled since selecting. It may not be "
-              + "this selection's context. Work from the selection itself, draw on the surrounding text only "
-              + "where it clearly connects, and say if you are answering without context.)";
-
-        return $"{selection.Text}{note}";
+        // No caveat, because there is no longer a case to caveat: the window is built around the selection,
+        // so the surrounding text IS this selection's context rather than whatever the viewport happened to
+        // be showing. The sentence that used to live here told the model its own context might be the wrong
+        // context, and it earned that only because the window was anchored on scroll position. (#649)
+        return selection.Text ?? string.Empty;
     }
 
     private static string Lemmas(AiContextBundle bundle)
@@ -464,9 +455,6 @@ public sealed class PromptBuilder : IPromptBuilder
 
         switch (bundle.Selection?.State)
         {
-            case SelectionState.NotFoundInWindow:
-                notices.Add("The selected text was not found in the passage window the model was given.");
-                break;
             case SelectionState.Unavailable:
                 // The one the user most needs: otherwise this reads as "the AI ignored my selection".
                 notices.Add("Your selection could not be read, so the answer covers the whole passage.");

--- a/src/CST.Avalonia/Services/Ai/ReaderState.cs
+++ b/src/CST.Avalonia/Services/Ai/ReaderState.cs
@@ -40,11 +40,22 @@ public enum ReaderStateProblem
 /// the <c>document.title</c> round trip timed out. <b>Not the same as a null
 /// <paramref name="SelectionText"/></b>: conflating them is what makes a dropped selection look to the user
 /// like "the AI ignored my selection". (#581)</param>
+/// <param name="SelectionParagraph">
+/// The paragraph the SELECTION sits in, resolved from its own position in the document — not from
+/// <paramref name="Paragraph"/>, which is derived from scroll.
+///
+/// <para>The distinction is the whole of #649. The passage window used to be built around the scroll
+/// position, so a selection near the bottom of the viewport landed outside the window meant to explain it,
+/// and the app reported that as a caveat instead of as the defect it was. Null when there is no selection,
+/// or when the anchor cache could not place it — the caller then falls back to
+/// <paramref name="Paragraph"/>.</para>
+/// </param>
 public sealed record ReaderState(
     string BookId,
     int Paragraph,
     string? SelectionText,
-    bool SelectionUnavailable = false);
+    bool SelectionUnavailable = false,
+    int? SelectionParagraph = null);
 
 /// <summary>Success or a named refusal. Never a partial answer.</summary>
 public readonly record struct ReaderStateResult(ReaderState? State, ReaderStateProblem? Problem)
@@ -106,9 +117,14 @@ public sealed class ReaderStateService : IReaderStateService
 
         ct.ThrowIfCancellationRequested();
 
-        var (selection, unavailable) = await ReadSelectionAsync(document);
+        var (selection, unavailable, selectionParagraph) = await ReadSelectionAsync(document);
         return ReaderStateResult.Ok(
-            result.State with { SelectionText = selection, SelectionUnavailable = unavailable });
+            result.State with
+            {
+                SelectionText = selection,
+                SelectionUnavailable = unavailable,
+                SelectionParagraph = selectionParagraph,
+            });
     }
 
     private (ReaderStateResult Result, BookDisplayViewModel? Document) ReadActiveBook()
@@ -174,17 +190,20 @@ public sealed class ReaderStateService : IReaderStateService
     /// handler, it drives CEF, and it writes a single-slot completion source a concurrent Cmd+D would
     /// otherwise clobber.</para>
     /// </summary>
-    private static async Task<(string? Text, bool Unavailable)> ReadSelectionAsync(BookDisplayViewModel document)
+    private static async Task<(string? Text, bool Unavailable, int? Paragraph)> ReadSelectionAsync(
+        BookDisplayViewModel document)
     {
-        var raw = await Dispatcher.UIThread.InvokeAsync(async () =>
+        var (raw, paragraph) = await Dispatcher.UIThread.InvokeAsync(async () =>
         {
             var control = document.BookDisplayControl;
-            return control is null ? null : await control.GetWebViewSelectionAsync();
+            return control is null
+                ? ((string?)null, (int?)null)
+                : await control.GetWebViewSelectionWithParagraphAsync();
         });
 
         // null = could not read it; "" = read it, and there was nothing to read.
-        if (raw is null) return (null, true);
+        if (raw is null) return (null, true, null);
 
-        return (SelectionPipeline.Normalize(raw, document.BookScript), false);
+        return (SelectionPipeline.Normalize(raw, document.BookScript), false, paragraph);
     }
 }

--- a/src/CST.Avalonia/Services/Ai/SelectionPipeline.cs
+++ b/src/CST.Avalonia/Services/Ai/SelectionPipeline.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using CST.Conversion;
@@ -13,10 +12,11 @@ namespace CST.Avalonia.Services.Ai;
 /// from the tool layer, which owns its formats; this arrives in the user's display script, through a
 /// <c>document.title</c> round trip, with a timeout. So it gets the handling that deserves.</para>
 ///
-/// <para><b>Two phases, because they run in different places.</b> <see cref="Normalize"/> needs the display
-/// script, which only the reader knows; <see cref="IsWithin"/> needs the passage window, which only the bundler
-/// has. Keeping them one class keeps the normalization rules in one place — the two sides of a comparison
-/// drifting apart is exactly how a locator starts reporting false misses.</para>
+/// <para><b>Normalization only, since #649.</b> This class used to carry a second phase — asking whether the
+/// normalized selection appeared in the passage window — because the window was built from scroll position and
+/// might not contain it. The window is now built around the selection, so the question has no answer to give
+/// and both it and the punctuation folding it needed are gone. Locating a selection in the corpus is
+/// <see cref="CST.Search.TeiPassageReader.LocateSelection"/>'s job, against the raw XML.</para>
 /// </summary>
 public static class SelectionPipeline
 {
@@ -34,8 +34,8 @@ public static class SelectionPipeline
     /// composed Latin (ā is U+0101), and the passage text comes through the same converter, so in the ordinary
     /// path both sides already agree. But a decomposed selection — a different input path, an OS that
     /// normalizes on copy — is <i>ordinally unequal</i> to the composed form (a + U+0304 ≠ U+0101), and the
-    /// symptom would be a bundle reporting "selection not found in the passage window": a false diagnostic
-    /// from the one component whose job is faithful diagnostics.</para>
+    /// symptom would be a dictionary or lemma lookup silently missing on text the reader is looking straight
+    /// at — a false negative from the one component whose job is faithful handling of what they selected.</para>
     /// </summary>
     public static string? Normalize(string? raw, Script sourceScript)
     {
@@ -49,74 +49,5 @@ public static class SelectionPipeline
         latin = Whitespace.Replace(latin, " ").Trim();
 
         return latin.Length == 0 ? null : latin;
-    }
-
-    /// <summary>
-    /// Whether a normalized selection appears in a passage window.
-    ///
-    /// <para>The window is normalized the same way here rather than at its source, because the window is the
-    /// tool layer's output and must not be silently rewritten on its way to the model — only the copy used for
-    /// this comparison is.</para>
-    ///
-    /// <para><b>Ordinal, case-insensitively.</b> Case-insensitive because the corpus capitalises
-    /// programmatically at sentence starts, so a selection lifted from mid-sentence and the same words at a
-    /// sentence head differ only in case. Ordinal rather than culture-aware because a culture-aware comparison
-    /// would fold characters Pāli distinguishes.</para>
-    ///
-    /// <para><b>Punctuation is folded away on both sides.</b> See <see cref="Fold"/>. Without it a selection
-    /// spanning a single sentence break reports as absent. (#641)</para>
-    /// </summary>
-    public static bool IsWithin(string normalizedSelection, string windowText)
-    {
-        if (string.IsNullOrEmpty(normalizedSelection) || string.IsNullOrEmpty(windowText)) return false;
-
-        var selection = Fold(normalizedSelection);
-        if (selection.Length == 0) return false;   // punctuation only: nothing to locate
-
-        return Fold(windowText).Contains(selection, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// The comparison form: letters, digits and combining marks only, whitespace collapsed. Used on both sides
-    /// of <see cref="IsWithin"/> and nowhere else — what reaches the model is always the verbatim selection.
-    ///
-    /// <para><b>Why punctuation goes.</b> The two sides of this comparison reach it by different routes: the
-    /// window is rendered by the passage reader, the selection is scraped from the DOM and converted from the
-    /// user's display script. Those routes do not agree about sentence punctuation. A selection spanning one
-    /// sentence break carried an ASCII full stop while the window carried the danda (U+0964), so the
-    /// containment test failed and the user was told their selection was not in the passage — while looking
-    /// straight at it. (#641)</para>
-    ///
-    /// <para><b>Why the whole category rather than a table of marks.</b> The danda was one mark of many: the
-    /// scripts this app renders carry their own sentence and phrase marks (Myanmar U+104A and U+104B, Khmer
-    /// U+17D4, Tibetan U+0F0D, Thai U+0E5A), and Latin Pāli carries the elision apostrophe in both its ASCII
-    /// and typographic (U+2019) forms. A table would fix the mark that was
-    /// reported and leave the next one to be discovered the same way — by a reader being told their own
-    /// selection is not there. Dropping the category closes the class.</para>
-    ///
-    /// <para><b>The error this can introduce is the cheap one.</b> Folding admits a false match between two
-    /// spans differing only in punctuation (an elided form written with an apostrophe against the same letters
-    /// written without one). The cost of that is one
-    /// caution the user does not see; the cost of a false miss is the model being told to distrust the
-    /// surrounding text and the user being told they selected something absent. Not symmetric.</para>
-    /// </summary>
-    internal static string Fold(string text)
-    {
-        var composed = text.Normalize(NormalizationForm.FormC);
-
-        var kept = new StringBuilder(composed.Length);
-        foreach (var c in composed)
-        {
-            // Combining marks are kept explicitly: they are not letters, and a Latin form with no precomposed
-            // codepoint would otherwise lose its diacritic here and match a different word.
-            if (char.IsLetterOrDigit(c)
-                || char.IsWhiteSpace(c)
-                || CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.NonSpacingMark)
-            {
-                kept.Append(c);
-            }
-        }
-
-        return Whitespace.Replace(kept.ToString(), " ").Trim();
     }
 }

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CST;
+using CST.Conversion;
 using CST.Navigation;
 using CST.Search;
 using CST.Tools;
@@ -34,6 +35,38 @@ namespace CST.Avalonia.Services.Tools
             !string.IsNullOrEmpty(bookId) &&
             Books.Inst.Any(b => string.Equals(b.FileName, bookId, StringComparison.OrdinalIgnoreCase));
 
+        /// <summary>
+        /// Where the reader's selection sits in the raw XML, or null when there is none or it cannot be
+        /// placed. Bounded to the paragraph the reader's own anchor reports.
+        /// </summary>
+        /// <remarks>
+        /// Converted to the corpus script before matching. The selection arrives in Latin — every downstream
+        /// lookup wants it that way — but the XML is Devanagari, and script conversion is not
+        /// length-preserving, so there is no offset arithmetic that could relate the two. Converting the
+        /// short needle is exact and cheap; converting the haystack would be neither.
+        /// </remarks>
+        private static (int Start, int End)? LocateSelection(
+            string xml, int startPos, BookMarkers markers, string? selectionLatin)
+        {
+            if (string.IsNullOrWhiteSpace(selectionLatin)) return null;
+
+            string needle;
+            try
+            {
+                needle = ScriptConverter.Convert(selectionLatin, Script.Latin, Script.Devanagari);
+            }
+            catch (Exception)
+            {
+                // A selection that will not convert is not a reason to fail the whole request: fall back to
+                // the paragraph window, which is what every caller got before selections were considered.
+                return null;
+            }
+
+            // The paragraph the anchor named, bounded by its section so the search cannot wander.
+            var (_, sectionEnd) = markers.EnclosingDivRange(startPos);
+            return TeiPassageReader.LocateSelection(xml, startPos, sectionEnd, needle);
+        }
+
         public async Task<PassageResult> FetchPassageAsync(PassageRequest request, CancellationToken ct = default)
         {
             var dir = _settings.Settings?.XmlBooksDirectory;
@@ -52,13 +85,30 @@ namespace CST.Avalonia.Services.Tools
             if (startPos < 0) return Empty(request, "reference not found");
             startPos = Math.Clamp(startPos, 0, xml.Length);
 
-            // A cursor points AT a hit (mid-sentence); snap the window start back to the enclosing sentence so
-            // the hit is read with its governing clause. A paragraph reference already starts clean - no snap.
-            var w = TeiPassageReader.ReadWindow(
-                xml, startPos, Math.Clamp(request.MaxChars, 1, MaxPassageChars),
-                request.IncludeFootnotes, request.OutputScript, markers,
-                snapStartToSentence: request.Cursor.HasValue,
-                structuredNotes: request.StructuredNotes);
+            var budget = Math.Clamp(request.MaxChars, 1, MaxPassageChars);
+
+            // With a selection, the window is built AROUND it instead of from the paragraph's start, so the
+            // words the reader highlighted are always inside the context sent to explain them. (#649)
+            //
+            // The search is bounded to the referenced paragraph, which is where the reader's own anchor says
+            // the selection is. That bound is load-bearing rather than an optimisation: this canon is
+            // pericope-built and formulaic passages repeat verbatim across books, so an unbounded search
+            // could centre the window on a different occurrence entirely and caption it confidently.
+            var selectionSpan = LocateSelection(xml, startPos, markers, request.SelectionText);
+
+            var w = selectionSpan is { } span
+                ? TeiPassageReader.ReadWindowAroundSelection(
+                    xml, span.Start, span.End, budget,
+                    request.IncludeFootnotes, request.OutputScript, markers,
+                    structuredNotes: request.StructuredNotes)
+                // A cursor points AT a hit (mid-sentence); snap the window start back to the enclosing
+                // sentence so the hit is read with its governing clause. A paragraph reference already
+                // starts clean - no snap.
+                : TeiPassageReader.ReadWindow(
+                    xml, startPos, budget,
+                    request.IncludeFootnotes, request.OutputScript, markers,
+                    snapStartToSentence: request.Cursor.HasValue,
+                    structuredNotes: request.StructuredNotes);
 
             return new PassageResult(
                 BookId: request.BookId,

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -200,7 +200,11 @@ public class AiAssistantViewModel : ReactiveTool
             var request = new AiTurnRequest(
                 task,
                 state.BookId,
-                new NavigationReference.Paragraph(state.Paragraph),
+                // The SELECTION's paragraph when there is one, not the scroll's. Building the window around
+                // the viewport is what let a selection near the bottom of the screen fall outside the window
+                // meant to explain it. Falls back to the reading position when nothing is selected, or when
+                // the anchor cache could not place what was. (#649)
+                new NavigationReference.Paragraph(state.SelectionParagraph ?? state.Paragraph),
                 state.SelectionText,
                 question,
                 // Carried rather than collapsed into "no selection": a selection the reader could not read is

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -35,6 +35,12 @@ public partial class BookDisplayView : UserControl
     private bool _isShutDown;   // set once the tab is really closed; prevents WebView resurrection (BOOK-1)
     // Completes when OnTitleChanged receives the CST_LOOKUP_SEL selection pushed for a Cmd+D lookup. (#25)
     private TaskCompletionSource<string?>? _lookupSelectionTcs;
+
+    // The assistant's selection round-trip (#649). A SEPARATE slot from the lookup one above, deliberately:
+    // that field is already documented as a shared single slot a concurrent Cmd+D clobbers, and the assistant
+    // reads the selection while the user is free to press Cmd+D. Two single-slot channels cannot race; one
+    // shared slot would silently hand one caller the other's answer.
+    private TaskCompletionSource<(string? Text, int? Paragraph)>? _aiSelectionTcs;
     private ScrollViewer? _fallbackBrowser;
     private IDisposable? _lifecycleSubscription; // Subscription to WebViewLifecycleOperation changes
     private int _lastScrollPosition = 0;
@@ -254,6 +260,71 @@ public partial class BookDisplayView : UserControl
         {
             _logger.Error(ex, "Failed to initialize WebView");
             _webView = null;
+        }
+    }
+
+    /// <summary>
+    /// The selection AND the paragraph it actually sits in. (#649)
+    ///
+    /// <para><b>Why this is not <see cref="GetWebViewSelectionAsync"/> plus the status readout.</b> The
+    /// status readout's paragraph is derived from SCROLL position, so the assistant built its passage window
+    /// around wherever the viewport happened to be rather than around the words the reader highlighted — and
+    /// a selection near the bottom of the viewport routinely fell outside the window meant to explain it.
+    /// The paragraph here is resolved from the selection's own position in the document.</para>
+    ///
+    /// <para>The anchor lookup is deliberately NOT <c>cstAnchorCache.getCurrentParagraph</c>: that adds a
+    /// +100px "just above the fold" offset, which is right for a scroll position and wrong for a selection —
+    /// it would attribute a selection in the first hundred pixels of a paragraph to the previous one.</para>
+    /// </summary>
+    /// <returns>
+    /// Text null means the selection could not be read at all (browser not ready, or the round trip timed
+    /// out) — distinct from an empty string, which means the reader genuinely selected nothing. Paragraph
+    /// null means the anchor cache could not place it, in which case the caller falls back to the reading
+    /// position, exactly as before this existed.
+    /// </returns>
+    public async Task<(string? Text, int? Paragraph)> GetWebViewSelectionWithParagraphAsync()
+    {
+        if (_webView == null || !_isBrowserInitialized)
+            return (null, null);
+        try
+        {
+            var tcs = new TaskCompletionSource<(string? Text, int? Paragraph)>();
+            _aiSelectionTcs = tcs;
+
+            var script = @"
+                (function() {
+                try {
+                    var sel = window.getSelection ? window.getSelection() : null;
+                    var text = sel ? sel.toString() : '';
+                    var para = '';
+                    if (sel && sel.rangeCount > 0 && text.length > 0) {
+                        var rect = sel.getRangeAt(0).getBoundingClientRect();
+                        var y = rect.top + window.pageYOffset;
+                        var cache = window.cstAnchorCache;
+                        if (cache && cache.isBuilt && cache.sortedParagraphAnchors) {
+                            var list = cache.sortedParagraphAnchors;
+                            for (var i = 0; i < list.length; i++) {
+                                if (list[i].position <= y) para = list[i].name.replace('para', '');
+                                else break;
+                            }
+                        }
+                    }
+                    document.title = 'CST_AI_SEL:' + encodeURIComponent(text) + '|PARA=' + para + '|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                } catch (e) {
+                    document.title = 'CST_AI_SEL:|PARA=|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                }
+                })();";
+            script = script.Replace("__TAB_ID_PLACEHOLDER__", _tabId);
+            _webView.ExecuteScript(script);
+
+            var done = await Task.WhenAny(tcs.Task, Task.Delay(700));
+            _aiSelectionTcs = null;
+            return done == tcs.Task ? await tcs.Task : (null, null);
+        }
+        catch (Exception ex)
+        {
+            _logger.Information(ex, "GetWebViewSelectionWithParagraph failed");
+            return (null, null);
         }
     }
 
@@ -2583,6 +2654,37 @@ public partial class BookDisplayView : UserControl
     {
         var title = _webView?.Title ?? "";
         _logger.Debug("Page title changed | {Details}", title);
+
+        // The assistant's selection round-trip: text plus the paragraph the selection itself sits in. (#649)
+        if (title != null && title.StartsWith("CST_AI_SEL:"))
+        {
+            try
+            {
+                var data = title.Substring("CST_AI_SEL:".Length);
+                var parts = data.Split('|');
+                string messageTabId = "";
+                foreach (var p in parts)
+                    if (p.StartsWith("TAB:")) { messageTabId = p.Substring(4); break; }
+                if (messageTabId != _tabId)
+                    return;   // not for this tab
+
+                var encoded = parts.Length > 0 ? parts[0] : "";
+                string sel;
+                try { sel = Uri.UnescapeDataString(encoded); } catch { sel = encoded; }
+
+                int? para = null;
+                foreach (var p in parts)
+                    if (p.StartsWith("PARA=") && int.TryParse(p.Substring(5), out var n)) { para = n; break; }
+
+                _aiSelectionTcs?.TrySetResult((sel, para));
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, "Failed to parse CST_AI_SEL");
+                _aiSelectionTcs?.TrySetResult((null, null));
+            }
+            return;
+        }
 
         // Cmd+D lookup: the page pushed the current selection back to us through the title. (#25)
         if (title != null && title.StartsWith("CST_LOOKUP_SEL:"))

--- a/src/CST.Core/Search/BookMarkers.cs
+++ b/src/CST.Core/Search/BookMarkers.cs
@@ -115,6 +115,12 @@ namespace CST.Search
             var start = 0;
             var end = _length;
 
+            // A position AT the end of the document is inside the last div, not outside every div. Without
+            // this the containment test below (pos < divEnd) fails for every span, the whole document comes
+            // back as the section, and an expansion from there crosses every boundary in the book.
+            if (pos >= _length) pos = _length - 1;
+            if (pos < 0) return (0, end);
+
             // Innermost wins: later-starting divs are nested inside earlier ones, so the last container found
             // scanning forward is the tightest.
             foreach (var (divStart, divEnd) in _divs)

--- a/src/CST.Core/Search/BookMarkers.cs
+++ b/src/CST.Core/Search/BookMarkers.cs
@@ -23,13 +23,30 @@ namespace CST.Search
         // up case/character-exactly, so the raw spelling — not the parsed ints — is what can be navigated to.
         private readonly Dictionary<PageEdition, List<(int Pos, int Volume, int Number, string Raw)>> _pages = new();
 
+        /// <summary>
+        /// Every <c>&lt;div&gt;</c>'s span, in document order, all nesting levels. A div is a structural
+        /// boundary, and so the limit a reading window must not expand past: context drawn from the next
+        /// section is not this passage's context, however close it sits in the file.
+        ///
+        /// <para><b>Assume nothing about the markup beyond this.</b> Divs may be absent, present, or nested
+        /// to any depth; their <c>type</c> may be any of a growing set; and coverage across the corpus is
+        /// partial and actively being extended. So nothing here reads a type, counts a level, or treats
+        /// either "there is a div" or "there is none" as the normal case. The only property relied on is the
+        /// one that will still hold when the markup is finished: <b>a div boundary separates one section from
+        /// another, so a reading window must not cross it.</b></para>
+        /// </summary>
+        private readonly List<(int Start, int End)> _divs = new();
+
+        private int _length;
+
         private BookMarkers() { }
 
         /// <summary>Scan a decoded book XML string and index its page/paragraph markers.</summary>
         public static BookMarkers Build(string xml)
         {
             var m = new BookMarkers();
-            var divStack = new List<(bool IsBook, string? Id)>();
+            m._length = xml.Length;
+            var divStack = new List<(bool IsBook, string? Id, int Start)>();
 
             foreach (Match tag in TagRx.Matches(xml))
             {
@@ -37,10 +54,19 @@ namespace CST.Search
                 switch (name)
                 {
                     case "div":
-                        if (closing) { if (divStack.Count > 0) divStack.RemoveAt(divStack.Count - 1); }
+                        if (closing)
+                        {
+                            if (divStack.Count > 0)
+                            {
+                                // Record the span as the div closes, so nesting needs no second pass.
+                                m._divs.Add((divStack[^1].Start, tag.Index + tag.Value.Length));
+                                divStack.RemoveAt(divStack.Count - 1);
+                            }
+                        }
                         else if (!tag.Value.EndsWith("/>"))
                             divStack.Add((attrs.TryGetValue("type", out var t) && t == "book",
-                                          attrs.TryGetValue("id", out var id) ? id : null));
+                                          attrs.TryGetValue("id", out var id) ? id : null,
+                                          tag.Index));
                         break;
 
                     case "pb":
@@ -60,7 +86,48 @@ namespace CST.Search
                         break;
                 }
             }
+
+            // An unclosed div (truncated or malformed file) still bounds everything after it, which is the
+            // safe direction: it can only make a window smaller, never let it cross into another section.
+            foreach (var open in divStack)
+                m._divs.Add((open.Start, xml.Length));
+
+            m._divs.Sort((a, b) => a.Start.CompareTo(b.Start));
             return m;
+        }
+
+        /// <summary>
+        /// The span of the INNERMOST <c>&lt;div&gt;</c> containing <paramref name="pos"/>, or the whole
+        /// document when there is none.
+        ///
+        /// <para><b>Innermost, because that is the tightest unit the reader is inside.</b> What that unit is
+        /// called varies by book and the rule does not care: whichever it is, stopping there stops at the edge
+        /// of the text the passage belongs to. Innermost can only make a window smaller, which is the safe
+        /// direction to be wrong in.</para>
+        ///
+        /// <para><b>The whole document is the right answer when there is no enclosing div</b>, not a refusal.
+        /// A book whose structure is not marked up yet must behave as one undivided section rather than lose
+        /// its context, and it must start behaving as a divided one the moment its markup lands — with no
+        /// change here.</para>
+        /// </summary>
+        public (int Start, int End) EnclosingDivRange(int pos)
+        {
+            var start = 0;
+            var end = _length;
+
+            // Innermost wins: later-starting divs are nested inside earlier ones, so the last container found
+            // scanning forward is the tightest.
+            foreach (var (divStart, divEnd) in _divs)
+            {
+                if (divStart > pos) break;
+                if (pos < divEnd && divStart >= start)
+                {
+                    start = divStart;
+                    end = divEnd;
+                }
+            }
+
+            return (start, end);
         }
 
         /// <summary>
@@ -282,7 +349,7 @@ namespace CST.Search
             return lo;
         }
 
-        private static string? CurrentBook(List<(bool IsBook, string? Id)> stack)
+        private static string? CurrentBook(List<(bool IsBook, string? Id, int Start)> stack)
         {
             foreach (var d in stack) if (d.IsBook && d.Id != null) return d.Id;  // outermost book div
             return null;

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -174,23 +174,80 @@ namespace CST.Search
                 // Snapped OUTWARDS, to the start of the sentence the budget landed inside — not forwards to
                 // the next one. WalkBackward snaps forward, which is right for a paging cursor and wrong
                 // here: it discards the partial sentence, so a half-budget reliably bought one sentence less
-                // than it paid for and the window came out lopsided towards what follows the selection. This
-                // is also what makes the two directions symmetric, since the forward walk likewise extends
-                // past its budget to finish the sentence it is in.
+                // than it paid for and the window came out lopsided towards what follows the selection.
+                //
+                // The two directions are NOT symmetric and it is worth not pretending otherwise: forward
+                // extends past its budget only once the budget is spent, backward always snaps — so a
+                // selection one character under budget gets a preceding sentence and one exactly at budget
+                // gets none. A discontinuity at the edge, accepted because the alternative is cutting the
+                // sentence the selection sits in.
+                // The snap gets the SAME hard cap the forward walk has (1.5x its budget), and for the same
+                // reason. Unbounded, it walks to the previous danda however far away that is: a selection in
+                // the danda-free front matter of a book with no div markup snapped to position 0, and a
+                // 40-character budget produced a 2,000-character window. Bounding the floor rather than
+                // rejecting the snap keeps the behaviour it was added for — finishing the sentence the budget
+                // landed inside — while making the total window actually bounded.
+                int floor = RawBackward(xml, selectionStart, half + half / 2, sectionStart);
                 int rough = RawBackward(xml, selectionStart, half, sectionStart);
-                var boundaryNotes = TeiText.NoteRegions(xml, sectionStart, selectionStart);
-                start = SnapBackToSentenceStart(xml, rough, sectionStart, boundaryNotes);
+                var boundaryNotes = TeiText.NoteRegions(xml, floor, selectionStart);
+                start = SnapBackToSentenceStart(xml, rough, floor, boundaryNotes);
 
                 int spentBack = RenderedLength(xml, start, selectionStart, includeNotes);
 
-                // Clamped at zero: snapping outwards can spend more than half, and a negative budget would
-                // make WalkForward stop at the first boundary as though the budget were exhausted — which it
-                // then does anyway, finishing the selection's own sentence and no more.
+                // Clamped at zero: snapping outwards can spend more than half.
                 int forwardBudget = Math.Max(0, shortfall - spentBack);
                 end = WalkForward(xml, selectionEnd, forwardBudget, includeNotes, sectionEnd);
             }
 
+            // Finish the sentence the window ends inside, whatever the budget had left.
+            //
+            // WalkForward's hard cap is 1.5x ITS budget, so a budget of zero caps at zero and it returns after
+            // a single character — cutting mid-sentence, which is the one thing this class promises never to
+            // do. That is reachable whenever the backward snap spends the whole shortfall, and it is exactly
+            // the case where the reader most needs the sentence intact, because the selection is the subject.
+            end = ExtendToSentenceEnd(xml, end, sectionEnd, includeNotes);
+
+            {
+            }
+
             return Materialize(xml, start, end, maxChars, includeVariants, outputScript, markers, structuredNotes);
+        }
+
+        /// <summary>
+        /// Walk on to the end of the sentence in progress, ignoring any budget. Bounded by the section and by
+        /// a generous cap, so a text with no sentence punctuation ahead cannot run to the end of the book.
+        /// </summary>
+        private static int ExtendToSentenceEnd(string xml, int from, int limit, bool includeNotes)
+        {
+            const int Cap = 4000;
+
+            var notes = TeiText.NoteRegions(xml, from, Math.Min(limit, from + Cap));
+
+            int i = from, seen = 0;
+            while (i < limit && seen < Cap)
+            {
+                char c = xml[i];
+                if (c == '<')
+                {
+                    int gt = xml.IndexOf('>', i);
+                    if (gt < 0) break;
+                    string tag = xml.Substring(i, gt - i + 1);
+                    string name = TeiText.TagName(tag);
+                    if (name == "note" && !includeNotes && !tag.EndsWith("/>", StringComparison.Ordinal))
+                        i = tag.StartsWith("</", StringComparison.Ordinal)
+                            ? gt + 1
+                            : TeiText.SkipSubtree(xml, gt + 1, "note", limit);
+                    else i = gt + 1;
+                    continue;
+                }
+
+                // A danda inside a note is apparatus punctuation, not a base-text sentence end. (#310 A4-2)
+                if (TeiText.IsBoundary(c) && !TeiText.InNote(i, notes)) return i + 1;
+                i++;
+                seen++;
+            }
+
+            return Math.Min(i, limit);
         }
 
         /// <summary>

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -46,6 +46,19 @@ namespace CST.Search
             // (and thus nextCursor) can't land mid-note and leave an unmatched brace / apparatus in the clean
             // base text — even if includeFootnotes is also set. (#267 review, Defect 2)
             int end = WalkForward(xml, readStart, maxChars, includeNotes: includeVariants && !structuredNotes, xml.Length);
+
+            return Materialize(xml, readStart, end, maxChars, includeVariants, outputScript, markers, structuredNotes);
+        }
+
+        /// <summary>
+        /// Render a raw span into a <see cref="PassageWindow"/>: the text in the requested script, the paging
+        /// cursors, the citation refs and the apparatus. Shared by both entry points so a window built from a
+        /// paragraph and one built around a selection cannot describe themselves differently.
+        /// </summary>
+        private static PassageWindow Materialize(
+            string xml, int readStart, int end, int maxChars, bool includeVariants, Script outputScript,
+            BookMarkers markers, bool structuredNotes)
+        {
             IReadOnlyList<ApparatusNote> notes = System.Array.Empty<ApparatusNote>();
             string text;
             if (structuredNotes)
@@ -94,6 +107,117 @@ namespace CST.Search
             var (endNum, endCode, _) = markers.RefsAt(Math.Max(readStart, end - 1));
 
             return new PassageWindow(text, prev, next, num, code, pages, noteCount, notes, endNum, endCode);
+        }
+
+        /// <summary>
+        /// A reading window built AROUND a selection, so the selection is always inside it. (#649)
+        ///
+        /// <para><b>Why this exists at all.</b> The window used to be fetched from the reader's paragraph,
+        /// which is derived from SCROLL position — so a selection near the bottom of the viewport routinely
+        /// fell outside the window built to explain it, and the app went on to report that as a caveat. A
+        /// context that can fail to contain the thing it is context FOR is not a context; it is a coincidence
+        /// that usually holds. There is deliberately no longer any way to express "the selection was not
+        /// found in the window", because with the window built from the selection there is no such state.</para>
+        ///
+        /// <para><b>The rule.</b> If the selection is already at or over budget, it IS the window — never
+        /// trimmed, because the subject of the request must not be cut to make room for its own context.
+        /// Otherwise the shortfall is split: roughly half is spent expanding backwards, the rest forwards.
+        /// Whatever the backward side cannot spend — because it hit the start of the section — is handed to
+        /// the forward side rather than lost, so a selection at the top of a sutta still gets a full budget's
+        /// worth of context, all of it below.</para>
+        ///
+        /// <para><b>Neither direction crosses a <c>&lt;div&gt;</c>.</b> A div boundary separates one section
+        /// from the next, and text from the next section is not this passage's context however close it sits
+        /// in the file. Where a book carries no div markup the whole document is the bound — see
+        /// <see cref="BookMarkers.EnclosingDivRange"/>.</para>
+        /// </summary>
+        /// <param name="selectionStart">Start of the selection, as a character position in the raw XML.</param>
+        /// <param name="selectionEnd">End of the selection, exclusive.</param>
+        public static PassageWindow ReadWindowAroundSelection(
+            string xml, int selectionStart, int selectionEnd, int maxChars, bool includeVariants,
+            Script outputScript, BookMarkers markers, bool structuredNotes = false)
+        {
+            selectionStart = Math.Clamp(selectionStart, 0, xml.Length);
+            selectionEnd = Math.Clamp(selectionEnd, selectionStart, xml.Length);
+            if (maxChars < 1) maxChars = 1;
+
+            // The section the selection sits in. Both expansions are bounded by it, and it is measured from
+            // the selection's START: a selection that somehow straddled a boundary should be given the
+            // context of where it began rather than none at all.
+            var (sectionStart, sectionEnd) = markers.EnclosingDivRange(selectionStart);
+            sectionStart = Math.Min(sectionStart, selectionStart);
+            sectionEnd = Math.Max(sectionEnd, selectionEnd);
+
+            bool includeNotes = includeVariants && !structuredNotes;
+
+            int start = selectionStart;
+            int end = selectionEnd;
+
+            int selectionLength = RenderedLength(xml, selectionStart, selectionEnd, includeNotes);
+            if (selectionLength < maxChars)
+            {
+                int shortfall = maxChars - selectionLength;
+                int half = shortfall / 2;
+
+                // Backwards first, so what it cannot spend is known before the forward budget is set.
+                //
+                // Snapped OUTWARDS, to the start of the sentence the budget landed inside — not forwards to
+                // the next one. WalkBackward snaps forward, which is right for a paging cursor and wrong
+                // here: it discards the partial sentence, so a half-budget reliably bought one sentence less
+                // than it paid for and the window came out lopsided towards what follows the selection. This
+                // is also what makes the two directions symmetric, since the forward walk likewise extends
+                // past its budget to finish the sentence it is in.
+                int rough = RawBackward(xml, selectionStart, half, sectionStart);
+                var boundaryNotes = TeiText.NoteRegions(xml, sectionStart, selectionStart);
+                start = SnapBackToSentenceStart(xml, rough, sectionStart, boundaryNotes);
+
+                int spentBack = RenderedLength(xml, start, selectionStart, includeNotes);
+
+                // Clamped at zero: snapping outwards can spend more than half, and a negative budget would
+                // make WalkForward stop at the first boundary as though the budget were exhausted — which it
+                // then does anyway, finishing the selection's own sentence and no more.
+                int forwardBudget = Math.Max(0, shortfall - spentBack);
+                end = WalkForward(xml, selectionEnd, forwardBudget, includeNotes, sectionEnd);
+            }
+
+            return Materialize(xml, start, end, maxChars, includeVariants, outputScript, markers, structuredNotes);
+        }
+
+        /// <summary>
+        /// Rendered characters between two raw positions — tags free, stripped subtrees free. The same
+        /// accounting <see cref="WalkForward"/> spends its budget in, so "half the shortfall" means the same
+        /// thing to the measurement and to the walk.
+        /// </summary>
+        private static int RenderedLength(string xml, int from, int to, bool includeNotes)
+        {
+            if (to <= from) return 0;
+
+            int i = from, rendered = 0;
+            while (i < to)
+            {
+                char c = xml[i];
+                if (c == '<')
+                {
+                    int gt = xml.IndexOf('>', i);
+                    if (gt < 0 || gt >= to) break;
+                    string tag = xml.Substring(i, gt - i + 1);
+                    string name = TeiText.TagName(tag);
+                    if (name == "note" && !includeNotes && !tag.EndsWith("/>", StringComparison.Ordinal))
+                        i = tag.StartsWith("</", StringComparison.Ordinal)
+                            ? gt + 1
+                            : TeiText.SkipSubtree(xml, gt + 1, "note", to);
+                    else if (name == "hi" && TeiText.IsStructuralHi(tag) && !tag.EndsWith("/>", StringComparison.Ordinal))
+                        i = TeiText.SkipSubtree(xml, gt + 1, "hi", to);
+                    else i = gt + 1;
+                }
+                else
+                {
+                    rendered++;
+                    i++;
+                }
+            }
+
+            return rendered;
         }
 
         // Strip the {reading (sigla)} apparatus spans out of already-rendered text into structured notes
@@ -177,6 +301,26 @@ namespace CST.Search
                 }
             }
             return i;
+        }
+
+        /// <summary>
+        /// Raw position ~<paramref name="maxChars"/> rendered characters before <paramref name="start"/>,
+        /// with no sentence snapping — the caller decides which way to snap. Tags are treated as zero-width
+        /// backwards, which is approximate and good enough for choosing where to begin looking.
+        /// </summary>
+        private static int RawBackward(string xml, int start, int maxChars, int limit)
+        {
+            int i = start - 1, rendered = 0;
+            while (i >= limit && rendered < maxChars)
+            {
+                if (xml[i] == '>')
+                {
+                    int lt = xml.LastIndexOf('<', i);
+                    i = lt >= limit ? lt - 1 : limit - 1;
+                }
+                else { rendered++; i--; }
+            }
+            return Math.Max(i + 1, limit);
         }
 
         // Start position ~maxChars rendered chars before <paramref name="start"/>, snapped forward to a

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -141,10 +141,20 @@ namespace CST.Search
             selectionEnd = Math.Clamp(selectionEnd, selectionStart, xml.Length);
             if (maxChars < 1) maxChars = 1;
 
-            // The section the selection sits in. Both expansions are bounded by it, and it is measured from
-            // the selection's START: a selection that somehow straddled a boundary should be given the
-            // context of where it began rather than none at all.
-            var (sectionStart, sectionEnd) = markers.EnclosingDivRange(selectionStart);
+            // Each direction is bounded by the section at ITS OWN end of the selection, not by one section
+            // chosen for the whole window.
+            //
+            // A selection may legitimately cross a div boundary — the reader dragged across it, so both sides
+            // are what they are asking about, and the window must carry all of it. What must not cross is the
+            // EXPANSION: text beyond the selection on the far side of a boundary is a different section and
+            // is not this passage's context. So the backward floor comes from the div holding the selection's
+            // start, and the forward ceiling from the div holding its end. For a selection inside one section
+            // these are the same div and this is the ordinary case; for one that spans two, each side expands
+            // within the section it actually reaches into.
+            int sectionStart = markers.EnclosingDivRange(selectionStart).Start;
+            int sectionEnd = markers.EnclosingDivRange(Math.Max(selectionStart, selectionEnd - 1)).End;
+
+            // The selection itself is never bounded away, whatever it spans.
             sectionStart = Math.Min(sectionStart, selectionStart);
             sectionEnd = Math.Max(sectionEnd, selectionEnd);
 

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using CST.Conversion;
 
 namespace CST.Search
@@ -211,6 +212,94 @@ namespace CST.Search
             }
 
             return Materialize(xml, start, end, maxChars, includeVariants, outputScript, markers, structuredNotes);
+        }
+
+        /// <summary>
+        /// Find a selection's raw span inside a bounded region of the XML, or null. (#649)
+        ///
+        /// <para><b>Matched against the RAW XML, not against rendered text.</b> The obvious approach — render
+        /// the region, find the selection's offset in it, map the offset back — cannot work: the renderer
+        /// converts script (one Devanagari character becomes several Latin ones), inserts a space for each
+        /// stripped tag, deletes a space before close punctuation, then collapses and trims. Rendered offsets
+        /// are not any function of raw offsets that counting can invert. Walking the raw text and skipping
+        /// what the renderer skips yields the raw span directly, with no arithmetic to get wrong.</para>
+        ///
+        /// <para><b>The needle must already be in the XML's own script.</b> Callers hold the selection in
+        /// Latin; converting it here would need a script this class does not know.</para>
+        ///
+        /// <para>Whitespace runs on either side compare equal to a single space, because the selection came
+        /// through the DOM and the XML is line-wrapped. Bounded to one region by the caller so a formulaic
+        /// phrase — this corpus repeats them verbatim across books — cannot match somewhere the reader has
+        /// never been.</para>
+        /// </summary>
+        public static (int Start, int End)? LocateSelection(string xml, int from, int to, string needle)
+        {
+            from = Math.Clamp(from, 0, xml.Length);
+            to = Math.Clamp(to, from, xml.Length);
+            if (string.IsNullOrWhiteSpace(needle)) return null;
+
+            // Collapse the needle the same way the comparison collapses the haystack.
+            var wanted = new StringBuilder(needle.Length);
+            foreach (var c in needle)
+            {
+                if (char.IsWhiteSpace(c))
+                {
+                    if (wanted.Length > 0 && wanted[^1] != ' ') wanted.Append(' ');
+                }
+                else wanted.Append(c);
+            }
+            var target = wanted.ToString().Trim();
+            if (target.Length == 0) return null;
+
+            for (int anchor = from; anchor < to; anchor++)
+            {
+                if (xml[anchor] == '<') continue;
+                if (char.IsWhiteSpace(xml[anchor])) continue;
+
+                int matched = 0, i = anchor, lastConsumed = anchor;
+                bool pendingSpace = false;
+
+                while (i < to && matched < target.Length)
+                {
+                    char c = xml[i];
+
+                    if (c == '<')
+                    {
+                        int gt = xml.IndexOf('>', i);
+                        if (gt < 0 || gt >= to) break;
+                        string tag = xml.Substring(i, gt - i + 1);
+                        string name = TeiText.TagName(tag);
+                        // Skip exactly what the renderer drops, so a note or a paragraph number sitting in the
+                        // middle of the reader's selection does not break the match.
+                        if ((name == "note" || (name == "hi" && TeiText.IsStructuralHi(tag)))
+                            && !tag.EndsWith("/>", StringComparison.Ordinal)
+                            && !tag.StartsWith("</", StringComparison.Ordinal))
+                            i = TeiText.SkipSubtree(xml, gt + 1, name, to);
+                        else
+                            i = gt + 1;
+                        continue;
+                    }
+
+                    if (char.IsWhiteSpace(c)) { pendingSpace = true; i++; continue; }
+
+                    if (pendingSpace)
+                    {
+                        pendingSpace = false;
+                        if (target[matched] == ' ') matched++;
+                        else break;
+                        if (matched == target.Length) { lastConsumed = i - 1; break; }
+                    }
+
+                    if (target[matched] != c) break;
+                    matched++;
+                    lastConsumed = i;
+                    i++;
+                }
+
+                if (matched == target.Length) return (anchor, lastConsumed + 1);
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/CST.Core/Tools/PassageToolContracts.cs
+++ b/src/CST.Core/Tools/PassageToolContracts.cs
@@ -26,6 +26,15 @@ namespace CST.Tools
     /// long paragraph becomes page 1 of N rather than a wall.
     /// </summary>
     /// <param name="Cursor">A page cursor from a prior <see cref="PassageResult"/>; overrides <see cref="Reference"/> when set.</param>
+    /// <param name="SelectionText">
+    /// Text the reader has selected, in Latin. When it can be found inside the referenced paragraph, the
+    /// window is built AROUND it rather than from the paragraph's start — half the budget behind, the rest
+    /// ahead, neither crossing a section boundary. (#649)
+    ///
+    /// <para>Set only by the in-app assistant, which is the only caller that has a selection. It exists on
+    /// the request rather than as a separate method so that "which window" stays one decision made in one
+    /// place; every other caller leaves it null and gets exactly the behaviour it always had.</para>
+    /// </param>
     /// <param name="MaxChars">Rendered-character budget for the window.</param>
     /// <param name="StructuredNotes">Return the apparatus as DATA instead of embedded braces: the <c>Text</c>
     /// comes back brace-free (clean, quotable Pāli) and each note appears in <see cref="PassageResult.Notes"/>
@@ -38,7 +47,8 @@ namespace CST.Tools
         int MaxChars = 1200,
         Script OutputScript = Script.Latin,
         bool IncludeFootnotes = false,
-        bool StructuredNotes = false);
+        bool StructuredNotes = false,
+        string? SelectionText = null);
 
     /// <summary>
     /// A reading window: the text, the citation refs at its start, and cursors to page through. Pass a cursor


### PR DESCRIPTION
> "It seems to be based on scroll position, not the location of the selection… This is not behavior to be patched. It should be revamped because it is simply wrong."

## What was wrong

The passage window was fetched using the paragraph from `ReaderStateService`, which derives it from **scroll position**. The selection was captured separately as text only, then merely *tested for containment* in whatever window the scroll produced. Nothing in the pipeline knew where the selection was, so a selection near the bottom of the viewport routinely fell outside the window built to explain it.

And the failure was **representable**: `SelectionState.NotFoundInWindow` existed, the bundler emitted a notice for it, and the prompt told the model to distrust its own context. A design admitting it could not do the thing it was for.

## The algorithm

1. Selection at or over budget → **it is the window**, never trimmed. The subject of a request must not be cut to make room for its own context.
2. Otherwise ~half the shortfall backwards, the rest forwards.
3. **Neither expansion crosses a `<div>`.** What one side cannot spend, because it hit the boundary, goes to the other — so a selection at the top of a section still gets a full budget of context.

A selection may itself cross a boundary; the window carries all of it. Only the *expansion* is bounded — backward floor from the div holding the selection's start, forward ceiling from the div holding its end.

**Nothing keys off div `type`, counts a level, or assumes divs exist.** Structural markup covers part of the corpus and is actively being extended, so the logic behaves identically before and after a book gains markup.

## Locating the selection

The reader now reports the selection's **own** paragraph, from its `getBoundingClientRect`, over a new `document.title` channel with its own completion source — not the Cmd+D lookup's, which is documented as a single slot a concurrent lookup clobbers. The anchor lookup deliberately avoids `getCurrentParagraph`, whose +100px "just above the fold" offset is right for a scroll position and wrong for a selection.

The locator matches against the **raw XML**, not rendered text. Rendering converts script (one Devanagari character becomes several Latin), inserts a space per stripped tag, deletes a space before close punctuation, then collapses and trims — rendered offsets are not any function of raw offsets that counting can invert. Walking raw text and skipping what the renderer skips yields the span directly.

Skipping what the renderer skips is load-bearing: a paragraph number or inline note sits in the middle of what the reader dragged across, and a naive substring search fails on exactly the selections most likely to be made. The search is bounded to the reader's reported paragraph — this canon is pericope-built and formulaic passages repeat verbatim, so an unbounded search could centre the window on a different occurrence and caption it confidently.

## Deleted

`SelectionState.NotFoundInWindow`, its bundler notice, the prompt caution, `SelectionContext.FoundInWindow`, and `SelectionPipeline.IsWithin` with the punctuation folding that existed to serve it.

## Four defects Fable found in code I had already mutation-tested

A useful reminder that mutation testing proves the tests catch what they *describe*, not that they describe the right things.

- **The backward snap was unbounded.** It walks to the previous sentence end with nothing capping the distance; a selection in danda-free front matter snapped to position 0, turning a 40-character budget into a 2,000-character window. Every fixture had a danda every few characters, so no test could see it. Now capped at 1.5×, like the forward walk.
- **A small forward budget cut mid-sentence.** `WalkForward`'s hard cap is 1.5× *its* budget, so once the backward snap spent the shortfall the forward cap was zero and it returned after one character — violating the class's own promise, in the case where the sentence being cut is the one the selection is in.
- **A position at the end of the document matched no div**, so the whole book came back as the section.
- **The symmetry claim was a story.** Forward extends past budget only once spent; backward always snaps. The discontinuity at the budget edge is accepted; the comment now says so instead of asserting a symmetry that is not there.

Also replaced a test that passed for the wrong reason — the redistribution case held with or without redistribution, because the fixture's tail was short enough for the post-budget sentence-finish to reach the asserted word anyway.

## Testing

Full suite **1729 passed, 0 failed**. Both new fixes mutation-tested; removing the div bound kills three tests in both directions. Clean app startup.

**Not verified in the app** — the reproduction needs a running reader and a real selection near the bottom of the viewport.

## Known and not addressed

Fable's finding 1: raw containment is guaranteed, **rendered** containment is not. A selection consisting of text the renderer strips — inside a `<note>`, or a paragraph number — is in the raw span but absent from the rendered window. Note text still reaches the model as structured `Notes[]`. Worth a follow-up issue rather than a silent assumption.

Closes #649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)