### PR TITLE
Shrink the panel's expanders and drop the paragraph-span notice

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
@@ -165,6 +165,20 @@ public class PromptBuilderTests : IDisposable
     }
 
     [Fact]
+    public void A_clean_request_produces_no_notices_however_many_paragraphs_it_covers()
+    {
+        // A window spanning several paragraphs used to raise "The passage window covers N paragraphs, not
+        // just the one cited". It fired on almost every request, so the notice list read as a list of
+        // problems on requests that had none -- and since #649 the window is built around the reader's own
+        // selection, making its extent a consequence of what they asked about rather than something that
+        // happened to them. Asserted as "no notices at all" rather than as the absence of one string, so a
+        // differently-worded reintroduction fails too.
+        var prompt = _builder.Build(Bundle(paragraphsCovered: 29));
+
+        Assert.Empty(prompt.Notices);
+    }
+
+    [Fact]
     public void A_selection_carries_no_caveat_about_its_own_context()
     {
         // There used to be a "this selection was not found in the passage above" branch here, because the

--- a/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
@@ -461,14 +461,11 @@ public sealed class PromptBuilder : IPromptBuilder
                 break;
         }
 
-        // Says the number. "May extend past the reference" was true of almost every request and read like a
-        // rounding caveat; "covers 29 paragraphs" is a fact the reader can act on. (#602)
-        if (bundle.Budget.ParagraphsCovered is > 1 and int covered)
-        {
-            notices.Add(
-                $"The passage window covers {covered} paragraphs, not just the one cited — the answer may range "
-                + "wider than you asked.");
-        }
+        // No notice for a window spanning several paragraphs. It fired on almost every request, which made
+        // the notice list look like a list of problems on requests that had none — and since #649 the window
+        // is built around the reader's own selection rather than from a scroll position, so its extent is a
+        // consequence of what they asked about rather than something that happened to them. The model is
+        // still told the span, through {{scope}}, because it changes how the answer should be qualified.
 
         return notices;
     }

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -9,6 +9,22 @@
              x:Class="CST.Avalonia.Views.AiAssistantPanel"
              x:DataType="vm:AiAssistantViewModel">
 
+    <UserControl.Resources>
+        <!-- Compact expanders, for the collapsed chrome. Fluent sizes these for a settings page: a 48px
+             minimum height, a 32px chevron and 16px paddings, which is about 100px of furniture per turn once
+             Reasoning and Notes are both present — in a column a quarter of the window wide, holding a
+             transcript that grows all session. Retuned through the theme's own DynamicResource keys rather
+             than by overriding template parts, so nothing here breaks when the template changes.
+
+             Scoped to this panel: the same keys are used by expanders elsewhere in the app, which are not in
+             a narrow column and do not want this. -->
+        <x:Double x:Key="ExpanderMinHeight">26</x:Double>
+        <Thickness x:Key="ExpanderHeaderPadding">8,0,0,0</Thickness>
+        <Thickness x:Key="ExpanderChevronMargin">6,0,6,0</Thickness>
+        <x:Double x:Key="ExpanderChevronButtonSize">18</x:Double>
+        <Thickness x:Key="ExpanderContentPadding">8,4,8,6</Thickness>
+    </UserControl.Resources>
+
     <!-- #586: generated text renders HERE, in Avalonia controls, and never inside the book's CEF WebView.
          That makes "generated text is visually distinguishable from canonical text" a structural fact
          rather than a styling convention, and keeps live token streaming off the component that SIGSEGVs
@@ -146,11 +162,18 @@
                                      one, which is why it is no longer discarded. -->
                                 <Expander Header="{Binding ReasoningHeader}"
                                           IsVisible="{Binding HasReasoning}"
+                                          FontSize="11"
                                           Margin="0,2,0,0">
-                                    <SelectableTextBlock Text="{Binding Reasoning}"
-                                                         TextWrapping="Wrap"
-                                                         FontSize="11"
-                                                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                    <!-- Capped and scrolled. Reasoning runs to thousands of characters, and
+                                         un-capped it pushes the answer — the thing the reader came for —
+                                         below the fold on the very turns where they opened it to check
+                                         whether anything was happening at all. -->
+                                    <ScrollViewer MaxHeight="180" VerticalScrollBarVisibility="Auto">
+                                        <SelectableTextBlock Text="{Binding Reasoning}"
+                                                             TextWrapping="Wrap"
+                                                             FontSize="11"
+                                                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                    </ScrollViewer>
                                 </Expander>
 
                                 <!-- The answer, as blocks: prose in one selectable control per run, tables
@@ -197,6 +220,7 @@
                                      because at full weight beside the answer they read as a list of errors. -->
                                 <Expander Header="{Binding NoticesHeader}"
                                           IsVisible="{Binding HasNotices}"
+                                          FontSize="11"
                                           Margin="0,4,0,0">
                                     <ItemsControl ItemsSource="{Binding Notices}">
                                         <ItemsControl.ItemTemplate>


### PR DESCRIPTION
Two small things in the assistant panel.

## The expanders were too tall

Fluent sizes an `Expander` for a settings page: `ExpanderMinHeight` **48px**, a 32px chevron, 16px paddings. Two per turn — Reasoning and Notes — is roughly **100px of chrome before any content**, in a column a quarter of the window wide, holding a transcript that grows all session.

Retuned through the theme's own `DynamicResource` keys (`ExpanderMinHeight`, `ExpanderHeaderPadding`, `ExpanderChevronMargin`, `ExpanderChevronButtonSize`, `ExpanderContentPadding`) rather than by overriding template parts — nothing here breaks when the template changes. I read the actual values out of the Fluent theme at the version this project pins rather than guessing at part names.

Scoped to this panel, deliberately: the same keys serve expanders elsewhere in the app, which are not in a narrow column and do not want this.

Reasoning also gets a **capped, scrolling body** (180px). It runs to thousands of characters, and un-capped it pushes the answer — the thing the reader came for — below the fold on exactly the turns where they opened it to check whether anything was happening at all.

## The paragraph-span notice is gone

> "The passage window covers N paragraphs, not just the one cited — the answer may range wider than you asked."

It fired on almost every request, so the notice list read as a list of problems on requests that had none. It also stopped being true in spirit: since #649 the window is built around the reader's own selection, so its extent is a consequence of what they asked about rather than something that happened to them.

The model is still told the span through `{{scope}}`, where it genuinely changes how an answer should be qualified.

**No test covered that notice**, so it could have been reintroduced unnoticed. The replacement asserts a clean request produces **no notices at all** rather than the absence of one string, so a differently-worded reintroduction fails too.

## Testing

Full suite **1730 passed, 0 failed**. Clean app startup with the resource overrides in place — no XAML or resource-resolution failures.

**Not visually verified** — how much shorter the expanders actually read needs eyes on a running panel, and the 180px reasoning cap is a guess at a comfortable height that may want tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)