### PR TITLE
Clear the question box, and make the reasoning panel actually resizable

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -523,6 +524,70 @@ public class AiAssistantViewModelTests
 
         Assert.Equal("what governs bhavissanti?", vm.LastTurn!.Question);
         Assert.True(vm.LastTurn!.HasQuestion);
+    }
+
+    [Fact]
+    public async Task Asking_moves_the_question_out_of_the_box_and_into_the_turn()
+    {
+        // The box kept the question after the answer arrived, so the next preset silently re-sent it. It
+        // belongs to the turn now, and the turn shows it above its own answer.
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.Add(AiTurnEvent.ForCompleted(new PaliMarkerReport(0, 0)));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null)
+        {
+            Question = "what governs bhavissanti?",
+        };
+        await vm.AskAsync(AiTask.Explain);
+
+        Assert.Equal("", vm.Question);
+        Assert.Equal("what governs bhavissanti?", vm.LastTurn!.Question);
+    }
+
+    [Fact]
+    public async Task A_refusal_leaves_the_question_where_the_reader_typed_it()
+    {
+        // The reason it is cleared when the turn STARTS rather than when the button is clicked. Not
+        // configured and no-book-open never create a turn, so clearing on the click would throw away what
+        // the reader typed in order to tell them to go and configure something -- and they would have to
+        // type it again to act on the advice.
+        var orchestrator = new StubOrchestrator();
+        var vm = new AiAssistantViewModel(
+            orchestrator,
+            new StubReaderState { Result = ReaderStateResult.Fail(ReaderStateProblem.NoBookOpen) },
+            null,
+            null)
+        {
+            Question = "what governs bhavissanti?",
+        };
+
+        await vm.AskAsync(AiTask.Explain);
+
+        Assert.Equal("what governs bhavissanti?", vm.Question);
+        Assert.Empty(vm.Turns);
+    }
+
+    [Fact]
+    public async Task Retry_puts_the_question_back_in_the_box()
+    {
+        // Retry re-runs the last turn, and its question has to come back with it -- the box was cleared when
+        // that turn started.
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.Add(AiTurnEvent.ForError(new AiError(AiErrorKind.Network, "dropped")));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null)
+        {
+            Question = "why anicca?",
+        };
+        await vm.AskAsync(AiTask.Explain);
+        Assert.Equal("", vm.Question);
+
+        await vm.RetryCommand.Execute().ToTask();
+
+        Assert.Equal(2, vm.Turns.Count);
+        Assert.Equal("why anicca?", vm.Turns[1].Question);
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -584,10 +584,76 @@ public class AiAssistantViewModelTests
         await vm.AskAsync(AiTask.Explain);
         Assert.Equal("", vm.Question);
 
-        await vm.RetryCommand.Execute().ToTask();
+        await vm.RetryCommand.Execute(vm.LastTurn).ToTask();
 
         Assert.Equal(2, vm.Turns.Count);
         Assert.Equal("why anicca?", vm.Turns[1].Question);
+    }
+
+    [Fact]
+    public async Task Retry_does_not_destroy_a_draft_the_reader_has_started_typing()
+    {
+        // Found by Fable. Retry used to write the turn's question INTO the box before re-asking, which was
+        // harmless while the box kept its text and became data loss the moment the box started holding only
+        // unsent drafts: a reader who typed a rephrase and then clicked Try again lost the rephrase and
+        // re-sent the old question.
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.Add(AiTurnEvent.ForError(new AiError(AiErrorKind.Network, "dropped")));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null)
+        {
+            Question = "why anicca?",
+        };
+        await vm.AskAsync(AiTask.Explain);
+
+        vm.Question = "a rephrasing I am still writing";
+        await vm.RetryCommand.Execute(vm.LastTurn).ToTask();
+
+        Assert.Equal("a rephrasing I am still writing", vm.Question);   // the draft survives
+        Assert.Equal("why anicca?", vm.Turns[1].Question);              // and the retry repeats the turn
+    }
+
+    [Fact]
+    public async Task Retry_repeats_the_turn_whose_button_was_pressed()
+    {
+        // Old failed turns keep their Try again button, so the command has to be told which turn it is
+        // retrying. Using the newest turn meant pressing turn one's button re-sent turn two.
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.Add(AiTurnEvent.ForError(new AiError(AiErrorKind.Network, "dropped")));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+
+        vm.Question = "first question";
+        await vm.AskAsync(AiTask.Explain);
+        vm.Question = "second question";
+        await vm.AskAsync(AiTask.Translate);
+
+        await vm.RetryCommand.Execute(vm.Turns[0]).ToTask();
+
+        Assert.Equal(3, vm.Turns.Count);
+        Assert.Equal("first question", vm.Turns[2].Question);
+        Assert.Equal(AiTask.Explain, vm.Turns[2].Task);
+    }
+
+    [Fact]
+    public void The_reasoning_panel_height_is_shared_and_cannot_be_dragged_to_nothing()
+    {
+        // The control this replaces could only SHRINK, with no floor and no way back: in Avalonia 11.3.6 a
+        // GridSplitter as the last row computes a maximum delta of exactly zero, so it could never grow the
+        // panel it existed to grow.
+        var vm = new AiAssistantViewModel(null, null, null, null);
+        var start = vm.ReasoningHeight;
+
+        vm.ResizeReasoning(120);
+        Assert.Equal(start + 120, vm.ReasoningHeight);
+
+        vm.ResizeReasoning(-100000);
+        Assert.True(vm.ReasoningHeight >= 60, $"dragged away to {vm.ReasoningHeight}");
+
+        vm.ResizeReasoning(100000);
+        Assert.True(vm.ReasoningHeight <= 1200);
     }
 
     [Fact]

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -342,6 +342,16 @@ public class AiAssistantViewModel : ReactiveTool
         this.RaisePropertyChanged(nameof(HasTurns));
         this.RaisePropertyChanged(nameof(LastTurn));
 
+        // The question has moved into the transcript, so the box empties — the same way every chat box the
+        // reader has ever used behaves. Nothing is lost: the turn keeps the question and shows it above its
+        // own answer, and Retry puts it back in the box.
+        //
+        // Cleared HERE rather than on the click, because the refusals above this point never create a turn.
+        // Clearing on the click would throw away what the reader typed to tell them the assistant is not
+        // configured, or that no book is open — and then they would have to type it again to act on the
+        // advice.
+        Question = "";
+
         _current = turn;
         _sawText = false;
         _sawReasoning = false;

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -95,7 +95,11 @@ public class AiAssistantViewModel : ReactiveTool
         GrammarCommand = ReactiveCommand.CreateFromTask(() => AskAsync(AiTask.Grammar));
         WordByWordCommand = ReactiveCommand.CreateFromTask(() => AskAsync(AiTask.WordByWord));
         StopCommand = ReactiveCommand.Create(Stop);
-        RetryCommand = ReactiveCommand.CreateFromTask(RetryAsync);
+        // No canExecute observable: WhenAnyValue needs ReactiveUI's builder initialised, which a plain
+        // unit-test host does not do. The button binds IsEnabled to CanAsk instead, and a click that slips
+        // through while a turn runs is harmless — AskAsync's guard returns without touching anything, now
+        // that Retry no longer writes to the question box.
+        RetryCommand = ReactiveCommand.CreateFromTask<AiTurnViewModel?>(RetryAsync);
         CopyCommand = ReactiveCommand.CreateFromTask<AiTurnViewModel>(CopyAsync);
         ClearCommand = ReactiveCommand.Create(Clear);
     }
@@ -105,12 +109,32 @@ public class AiAssistantViewModel : ReactiveTool
     public ReactiveCommand<Unit, Unit> GrammarCommand { get; }
     public ReactiveCommand<Unit, Unit> WordByWordCommand { get; }
     public ReactiveCommand<Unit, Unit> StopCommand { get; }
-    public ReactiveCommand<Unit, Unit> RetryCommand { get; }
+    public ReactiveCommand<AiTurnViewModel?, Unit> RetryCommand { get; }
 
     /// <summary>Copies one turn's answer. Explicit rather than left to drag-select, which stopped covering
     /// the whole answer once tables put each cell in its own control.</summary>
     public ReactiveCommand<AiTurnViewModel, Unit> CopyCommand { get; }
     public ReactiveCommand<Unit, Unit> ClearCommand { get; }
+
+    private double _reasoningHeight = 240;
+
+    /// <summary>
+    /// How tall the reasoning panel is, shared by every turn and dragged by the handle under it.
+    ///
+    /// <para>Shared rather than per-turn: a reader who has decided how much reasoning they want to see has
+    /// decided it for the session, not for one answer. An earlier attempt used a GridSplitter per turn, on
+    /// the reasoning that a RowDefinition cannot bind to an ancestor's property — true, and beside the point,
+    /// because the ScrollViewer whose height actually matters is an ordinary control that binds like any
+    /// other.</para>
+    /// </summary>
+    public double ReasoningHeight
+    {
+        get => _reasoningHeight;
+        set => this.RaiseAndSetIfChanged(ref _reasoningHeight, Math.Clamp(value, 60, 1200));
+    }
+
+    /// <summary>Drag the reasoning panel taller or shorter. Clamped, so it cannot be dragged to nothing.</summary>
+    public void ResizeReasoning(double delta) => ReasoningHeight += delta;
 
     /// <summary>Every turn this session, oldest first. The panel scrolls; this is what it scrolls.</summary>
     public ObservableCollection<AiTurnViewModel> Turns { get; } = new();
@@ -161,10 +185,29 @@ public class AiAssistantViewModel : ReactiveTool
     /// Runs one turn. Every expected failure — not configured, no book, an unreadable position, a dead
     /// network — arrives as a sentence rather than an exception.
     /// </summary>
-    internal async Task AskAsync(AiTask task)
+    internal async Task AskAsync(AiTask task, string? questionOverride = null)
     {
         if (IsBusy) return;
 
+        // Claimed HERE, not in StartTurn. StartTurn runs after an await on the reader, which in the app does
+        // real WebView work — and Explain and Translate are different commands, so ReactiveCommand's own
+        // serialization does not hold between them. Two presets clicked inside that window both passed the
+        // guard and started turns: the first turn's flush timer was overwritten without being stopped and
+        // ticked for the rest of the session, and its cancellation source was disposed while its stream was
+        // still using it.
+        IsBusy = true;
+        try
+        {
+            await RunAsync(task, questionOverride);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private async Task RunAsync(AiTask task, string? questionOverride)
+    {
         Status = "";
 
         if (_orchestrator == null || _readerState == null)
@@ -192,8 +235,11 @@ public class AiAssistantViewModel : ReactiveTool
             return;
         }
 
-        var question = string.IsNullOrWhiteSpace(Question) ? null : Question.Trim();
-        var turn = StartTurn(task, question, state.SelectionText);
+        // An override comes from Retry, which must repeat the turn's OWN question rather than whatever is in
+        // the box — the box now holds unsent drafts, and those are precious.
+        var typed = questionOverride ?? Question;
+        var question = string.IsNullOrWhiteSpace(typed) ? null : typed.Trim();
+        var turn = StartTurn(task, question, state.SelectionText, clearBox: questionOverride is null);
 
         try
         {
@@ -237,11 +283,17 @@ public class AiAssistantViewModel : ReactiveTool
 
     /// <summary>Repeats the last turn. The evidence for offering this at all: an observed request returned a
     /// gateway 504 after 120s while the identical request to the same model answered in 33s.</summary>
-    private async Task RetryAsync()
+    private async Task RetryAsync(AiTurnViewModel? turn)
     {
-        if (LastTurn is not { } last) return;
-        Question = last.Question ?? "";
-        await AskAsync(last.Task);
+        // The turn to repeat is the one whose button was pressed, not the newest. Old failed turns keep their
+        // Try again button, so retrying turn 1 after turn 2 has run used to re-send turn 2.
+        turn ??= LastTurn;
+        if (turn is null) return;
+
+        // Its own question, passed directly. Writing it into the box first destroyed any draft the reader had
+        // started typing there — and when a turn was already running, AskAsync's IsBusy guard then returned
+        // without sending anything, so the draft was gone and nothing had happened.
+        await AskAsync(turn.Task, turn.Question ?? string.Empty);
     }
 
     private static async Task CopyAsync(AiTurnViewModel turn)
@@ -328,7 +380,7 @@ public class AiAssistantViewModel : ReactiveTool
         _turnCancellation?.Cancel();
     }
 
-    private AiTurnViewModel StartTurn(AiTask task, string? question, string? selection)
+    private AiTurnViewModel StartTurn(AiTask task, string? question, string? selection, bool clearBox)
     {
         var turn = new AiTurnViewModel(task, question)
         {
@@ -350,7 +402,10 @@ public class AiAssistantViewModel : ReactiveTool
         // Clearing on the click would throw away what the reader typed to tell them the assistant is not
         // configured, or that no book is open — and then they would have to type it again to act on the
         // advice.
-        Question = "";
+        //
+        // Not cleared for a Retry, which never took the question from the box in the first place: doing so
+        // would wipe a draft the reader is part-way through writing.
+        if (clearBox) Question = "";
 
         _current = turn;
         _sawText = false;
@@ -363,7 +418,6 @@ public class AiAssistantViewModel : ReactiveTool
 
         _turnCancellation?.Dispose();
         _turnCancellation = new CancellationTokenSource();
-        IsBusy = true;
 
         _elapsed.Restart();
         _flushTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(FlushIntervalMs) };
@@ -430,7 +484,6 @@ public class AiAssistantViewModel : ReactiveTool
         turn.Elapsed = FormatElapsed(_elapsed.Elapsed);
         turn.IsRunning = false;
         _current = null;
-        IsBusy = false;
     }
 
     /// <summary>Moves whatever has accumulated onto the screen, in one property change per kind.</summary>

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -97,10 +97,14 @@
                                 <!-- What was asked -->
                                 <TextBlock Text="{Binding PresetLabel}" FontWeight="SemiBold"/>
 
-                                <TextBlock Text="{Binding Question}"
-                                           IsVisible="{Binding HasQuestion}"
-                                           TextWrapping="Wrap"
-                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                <!-- Selectable, because the box is emptied when the turn starts and this
+                                     becomes the only copy of what the reader typed. A stopped turn offers no
+                                     Try again, so without this the question is unrecoverable except by
+                                     retyping it. -->
+                                <SelectableTextBlock Text="{Binding Question}"
+                                                     IsVisible="{Binding HasQuestion}"
+                                                     TextWrapping="Wrap"
+                                                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
 
                                 <!-- What it is about, on screen from the first second. A browser selection
                                      persists invisibly, so a stale one has to be visible BEFORE the answer
@@ -151,8 +155,12 @@
                                     </TextBlock.Styles>
                                 </TextBlock>
 
+                                <!-- Passes ITS OWN turn: old failed turns keep this button, and without a
+                                     parameter the command retried whichever turn happened to be newest. -->
                                 <Button Content="Try again"
                                         Command="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).RetryCommand}"
+                                        CommandParameter="{Binding}"
+                                        IsEnabled="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).CanAsk}"
                                         IsVisible="{Binding Failed}"
                                         HorizontalAlignment="Left"
                                         Margin="0,2,0,0"/>
@@ -169,30 +177,39 @@
                                          reader came for — below the fold on the very turns where they
                                          opened it to check whether anything was happening at all.
 
-                                         The cap is a starting height rather than a verdict: how much
-                                         reasoning is worth seeing at once depends on the model and on what
-                                         the reader is doing, which is not something to guess on their
-                                         behalf. The splitter resizes THIS turn's panel; each turn carries
-                                         its own, because a template cannot write back to a shared value —
-                                         a RowDefinition is not in the visual tree, so it cannot bind to an
-                                         ancestor's property. -->
-                                    <Grid RowDefinitions="240,Auto">
-                                        <ScrollViewer Grid.Row="0"
-                                                      VerticalScrollBarVisibility="Auto">
+                                         The height is SHARED across turns and bound: a reader who has
+                                         decided how much reasoning they want to see has decided it for the
+                                         session, not for one answer.
+
+                                         A Thumb rather than a GridSplitter, and not by preference. In
+                                         Avalonia 11.3.6 a GridSplitter placed as the last row raises its
+                                         neighbour's minimum to its own 6px length while that row IS 6px, so
+                                         GetDeltaConstraints computes maxDelta = 0: it cannot grow the row at
+                                         all, only shrink it, with no floor and no way back. Verified in the
+                                         framework source, not assumed. -->
+                                    <StackPanel>
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                                      Height="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).ReasoningHeight}">
                                             <SelectableTextBlock Text="{Binding Reasoning}"
                                                                  TextWrapping="Wrap"
                                                                  FontSize="11"
                                                                  Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                         </ScrollViewer>
-                                        <GridSplitter Grid.Row="1"
-                                                      Height="6"
-                                                      MinHeight="6"
-                                                      HorizontalAlignment="Stretch"
-                                                      ResizeDirection="Rows"
-                                                      ResizeBehavior="PreviousAndCurrent"
-                                                      Background="{DynamicResource CardStrokeColorDefaultBrush}"
-                                                      ToolTip.Tip="Drag to resize"/>
-                                    </Grid>
+                                        <Thumb Name="ReasoningResizer"
+                                               Height="7"
+                                               HorizontalAlignment="Stretch"
+                                               Cursor="SizeNorthSouth"
+                                               DragDelta="OnReasoningResize"
+                                               ToolTip.Tip="Drag to resize">
+                                            <Thumb.Template>
+                                                <ControlTemplate>
+                                                    <Border Background="{DynamicResource CardStrokeColorDefaultBrush}"
+                                                            CornerRadius="2"
+                                                            Margin="0,2,0,0"/>
+                                                </ControlTemplate>
+                                            </Thumb.Template>
+                                        </Thumb>
+                                    </StackPanel>
                                 </Expander>
 
                                 <!-- The answer, as blocks: prose in one selectable control per run, tables

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -164,16 +164,35 @@
                                           IsVisible="{Binding HasReasoning}"
                                           FontSize="11"
                                           Margin="0,2,0,0">
-                                    <!-- Capped and scrolled. Reasoning runs to thousands of characters, and
-                                         un-capped it pushes the answer — the thing the reader came for —
-                                         below the fold on the very turns where they opened it to check
-                                         whether anything was happening at all. -->
-                                    <ScrollViewer MaxHeight="180" VerticalScrollBarVisibility="Auto">
-                                        <SelectableTextBlock Text="{Binding Reasoning}"
-                                                             TextWrapping="Wrap"
-                                                             FontSize="11"
-                                                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                                    </ScrollViewer>
+                                    <!-- Capped, scrolled, and draggable. Reasoning runs to thousands of
+                                         characters, and un-capped it pushes the answer — the thing the
+                                         reader came for — below the fold on the very turns where they
+                                         opened it to check whether anything was happening at all.
+
+                                         The cap is a starting height rather than a verdict: how much
+                                         reasoning is worth seeing at once depends on the model and on what
+                                         the reader is doing, which is not something to guess on their
+                                         behalf. The splitter resizes THIS turn's panel; each turn carries
+                                         its own, because a template cannot write back to a shared value —
+                                         a RowDefinition is not in the visual tree, so it cannot bind to an
+                                         ancestor's property. -->
+                                    <Grid RowDefinitions="240,Auto">
+                                        <ScrollViewer Grid.Row="0"
+                                                      VerticalScrollBarVisibility="Auto">
+                                            <SelectableTextBlock Text="{Binding Reasoning}"
+                                                                 TextWrapping="Wrap"
+                                                                 FontSize="11"
+                                                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                        </ScrollViewer>
+                                        <GridSplitter Grid.Row="1"
+                                                      Height="6"
+                                                      MinHeight="6"
+                                                      HorizontalAlignment="Stretch"
+                                                      ResizeDirection="Rows"
+                                                      ResizeBehavior="PreviousAndCurrent"
+                                                      Background="{DynamicResource CardStrokeColorDefaultBrush}"
+                                                      ToolTip.Tip="Drag to resize"/>
+                                    </Grid>
                                 </Expander>
 
                                 <!-- The answer, as blocks: prose in one selectable control per run, tables

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml.cs
@@ -1,5 +1,7 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Markup.Xaml;
+using CST.Avalonia.ViewModels;
 
 namespace CST.Avalonia.Views;
 
@@ -7,9 +9,9 @@ namespace CST.Avalonia.Views;
 /// The in-app assistant's view. (#586)
 ///
 /// <para>
-/// Deliberately code-free: everything it shows is bound, and everything it does is a command on
-/// <c>AiAssistantViewModel</c>. There is no WebView here and there must never be one — see the panel's XAML
-/// header and AI_SURFACE_B.md §8.
+/// Everything it shows is bound and everything it does is a command on <c>AiAssistantViewModel</c>, with one
+/// exception below: a drag has no command form. There is no WebView here and there must never be one — see
+/// the panel's XAML header and AI_SURFACE_B.md §8.
 /// </para>
 /// </summary>
 public partial class AiAssistantPanel : UserControl
@@ -17,4 +19,16 @@ public partial class AiAssistantPanel : UserControl
     public AiAssistantPanel() => InitializeComponent();
 
     private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    /// <summary>
+    /// Drag the reasoning panel taller or shorter. The one piece of code-behind here, because
+    /// <c>DragDelta</c> carries the movement itself and there is no binding that expresses "add this delta to
+    /// that property" — the alternative is a behaviour class doing the same three lines further away from
+    /// the control it serves.
+    /// </summary>
+    private void OnReasoningResize(object? sender, global::Avalonia.Input.VectorEventArgs e)
+    {
+        if (DataContext is AiAssistantViewModel vm)
+            vm.ResizeReasoning(e.Vector.Y);
+    }
 }


### PR DESCRIPTION
## The question stayed in the box

After an answer arrived the box still held the question, so the next preset silently re-sent it. It belongs to the turn now — which already records it and shows it above its own answer — and the box empties.

Cleared when the turn **starts**, not when the button is clicked: the refusals above that point (not configured, no book open) never create a turn, so clearing on the click would discard what the reader typed in order to tell them to go and configure something.

## The reasoning panel is draggable — the second attempt

The first attempt used a `GridSplitter` and **did not work at all**. Fable checked Avalonia 11.3.6's `GridSplitter.cs` rather than reasoning from WPF habits: with the splitter as the last row, `GetDeltaConstraints` raises the neighbouring definition's minimum to the splitter's own 6px length while that definition *is* 6px, so

```
maxDelta = Math.Min(def1Max − 240, 6 − 6) = 0
minDelta = −Math.Min(240 − 0, ∞)         = −240
```

Dragging down did nothing, ever. Dragging up shrank the view with no floor, and no gesture brought it back. I had flagged it as unverified in the previous PR — which is not the same as verifying it, and this is the second time this session that "I can't check this from here" turned out to mean "this is broken."

A `Thumb` driving a bound height replaces it, clamped 60–1200px. The height is **shared across turns**, which is also the better design: a reader who has decided how much reasoning to see has decided it for the session. My stated reason for per-turn splitters — a `RowDefinition` cannot bind to an ancestor's property — was true and beside the point, since the `ScrollViewer` whose height actually matters binds like any other control.

## Three more, found while in there

- **Retry destroyed a typed draft.** It wrote the turn's question into the box before re-asking. Harmless while the box kept its text; data loss the moment the box began holding only unsent drafts. Worse mid-turn: the draft was clobbered, then `AskAsync`'s guard returned without sending anything — draft gone, nothing happened, no feedback. The question is passed directly now.
- **Retry repeated the wrong turn.** Old failed turns keep their button; the command used the newest turn rather than the one pressed.
- **Two presets in quick succession ran two concurrent turns.** `IsBusy` was claimed inside `StartTurn`, after an await on the reader — and the presets are *different* `ReactiveCommand`s, so command serialization doesn't hold between them. The first turn's flush timer was overwritten without being stopped and ticked for the rest of the session. Claimed at entry now.

Also: the transcript's question is now selectable. Once the box is cleared it is the only copy of what the reader typed, and a stopped turn offers no Try again.

## Testing

Full suite **1736 passed, 0 failed**. The clearing and the Retry draft-protection are mutation-tested. Clean app startup.

**Still not verified by me**: that the Thumb drags as intended. The arithmetic that broke the GridSplitter doesn't apply to a Thumb — it reports a delta and the view model clamps it — but I have no way to drag a running window, and I'd rather say that than imply otherwise twice in a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)