### PR TITLE
Show which book is selected, and let ⌘O reach it (#646)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/BookTreeNodeTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/BookTreeNodeTests.cs
@@ -94,4 +94,23 @@ public class BookTreeNodeTests
 
         Assert.Equal(1, raised);
     }
+
+    [Fact]
+    public void ExpandAncestors_OnAnAlreadyOpenBranchRaisesNothing()
+    {
+        // Cmd+O is pressed repeatedly, and every raise costs a full-tree key walk plus a state broadcast.
+        // Re-revealing a book that is already visible must be free.
+        var root = Node("Tika");
+        var nikaya = AddChild(root, Node("Anguttara"));
+        var book = AddChild(nikaya, Node("A book", BookTreeNodeType.Book));
+        book.ExpandAncestors();
+
+        var raised = 0;
+        root.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(BookTreeNode.IsExpanded)) raised++; };
+        nikaya.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(BookTreeNode.IsExpanded)) raised++; };
+
+        book.ExpandAncestors();
+
+        Assert.Equal(0, raised);
+    }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/BookTreeNodeTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/BookTreeNodeTests.cs
@@ -1,0 +1,97 @@
+using CST.Avalonia.ViewModels;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// #646: ⌘O has to be able to reach the remembered book. Fluent realises no TreeViewItem container inside a
+/// collapsed branch, so a selection under one is unfocusable, unscrollable and invisible — ⌘O appears to do
+/// nothing. ExpandAncestors opens the way to it.
+/// </summary>
+public class BookTreeNodeTests
+{
+    private static BookTreeNode Node(string text, BookTreeNodeType type = BookTreeNodeType.Category)
+        => new() { OriginalDevanagariText = text, DisplayName = text, NodeType = type };
+
+    // Mirrors BuildBookTreeAsync, which sets Parent as it descends and leaves roots with Parent == null.
+    private static BookTreeNode AddChild(BookTreeNode parent, BookTreeNode child)
+    {
+        child.Parent = parent;
+        parent.Children.Add(child);
+        return child;
+    }
+
+    [Fact]
+    public void ExpandAncestors_OpensEveryBranchOnTheWayDown()
+    {
+        var root = Node("Tika");
+        var pitaka = AddChild(root, Node("Sutta"));
+        var nikaya = AddChild(pitaka, Node("Anguttara"));
+        var book = AddChild(nikaya, Node("Duka-Tika", BookTreeNodeType.Book));
+
+        book.ExpandAncestors();
+
+        Assert.True(root.IsExpanded);
+        Assert.True(pitaka.IsExpanded);
+        Assert.True(nikaya.IsExpanded);
+    }
+
+    [Fact]
+    public void ExpandAncestors_LeavesTheNodeItselfClosed()
+    {
+        // A category the user deliberately collapsed must stay collapsed: revealing a node is not the same
+        // as opening it.
+        var root = Node("Anya");
+        var category = AddChild(root, Node("Visuddhimagga"));
+        AddChild(category, Node("A book", BookTreeNodeType.Book));
+
+        category.ExpandAncestors();
+
+        Assert.True(root.IsExpanded);
+        Assert.False(category.IsExpanded);
+    }
+
+    [Fact]
+    public void ExpandAncestors_LeavesSiblingBranchesAlone()
+    {
+        var root = Node("Mula");
+        var sutta = AddChild(root, Node("Sutta"));
+        var vinaya = AddChild(root, Node("Vinaya"));
+        var book = AddChild(sutta, Node("Digha", BookTreeNodeType.Book));
+
+        book.ExpandAncestors();
+
+        Assert.True(sutta.IsExpanded);
+        Assert.False(vinaya.IsExpanded);
+    }
+
+    [Fact]
+    public void ExpandAncestors_OnARootNodeChangesNothing()
+    {
+        var root = Node("Mula");
+
+        root.ExpandAncestors();
+
+        Assert.False(root.IsExpanded);
+        Assert.Null(root.Parent);
+    }
+
+    [Fact]
+    public void ExpandAncestors_RaisesPropertyChangedSoTheExpansionIsPersisted()
+    {
+        // OpenBookDialogViewModel persists expansion by subscribing to IsExpanded on every node, so an
+        // ancestor opened this way must announce itself or the state is lost at the next restart.
+        var root = Node("Tika");
+        var book = AddChild(root, Node("A book", BookTreeNodeType.Book));
+
+        var raised = 0;
+        root.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(BookTreeNode.IsExpanded)) raised++;
+        };
+
+        book.ExpandAncestors();
+
+        Assert.Equal(1, raised);
+    }
+}

--- a/src/CST.Avalonia/Styles/DockStyles.axaml
+++ b/src/CST.Avalonia/Styles/DockStyles.axaml
@@ -51,7 +51,7 @@
         <Setter Property="Margin" Value="0"/>
     </Style>
 
-    <!-- #270: unify the tool-pane tabs (Search / Select a Book) with the book (document) tabs.
+    <!-- #270: unify the tool-pane tabs (Search / Open a Book) with the book (document) tabs.
          The stock ToolTabStripItem theme signals "selected" with a NEUTRAL fill and merely tints
          the tab TEXT accent-colored, whereas DocumentTabStripItem signals it with an accent-FILLED
          tab (accent background + accent-contrast text), dimming to grey only when the tab's dock

--- a/src/CST.Avalonia/ViewModels/OpenBookDialogViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/OpenBookDialogViewModel.cs
@@ -715,6 +715,18 @@ public class BookTreeNode : INotifyPropertyChanged
         }
     }
 
+    /// <summary>
+    /// Expands every ancestor of this node, so its TreeViewItem container can be realised. Fluent binds
+    /// <c>PART_ItemsPresenter</c> to <c>IsExpanded</c>, so a node inside a collapsed branch has no container
+    /// at all — nothing to focus, scroll to, or highlight. Ancestors only: expanding the node itself would
+    /// open a category the user had deliberately closed. (#646)
+    /// </summary>
+    public void ExpandAncestors()
+    {
+        for (var ancestor = Parent; ancestor != null; ancestor = ancestor.Parent)
+            ancestor.IsExpanded = true;
+    }
+
     // Computed properties
     public bool HasChildren => Children.Count > 0;
     public bool IsCategory => NodeType == BookTreeNodeType.Category;

--- a/src/CST.Avalonia/ViewModels/OpenBookDialogViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/OpenBookDialogViewModel.cs
@@ -700,6 +700,13 @@ public class BookTreeNode : INotifyPropertyChanged
         get => _isExpanded;
         set
         {
+            // Guarded: every raise costs a full-tree CollectExpandedKeys walk plus a StateChanged broadcast
+            // (OpenBookDialogViewModel.OnNodeExpansionChanged). The TreeViewItem's TwoWay binding and
+            // ExpandAncestors both write the value they already hold, so an unguarded setter turns one
+            // Cmd+O into a save per ancestor. (#646)
+            if (_isExpanded == value)
+                return;
+
             _isExpanded = value;
             OnPropertyChanged();
         }

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml
@@ -51,25 +51,38 @@
                                     <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}"/>
                                     <Setter Property="Background" Value="Transparent"/>
                                 </Style>
-                                <!-- Remove selection highlighting -->
-                                <Style Selector="TreeViewItem:selected">
-                                    <Setter Property="Background" Value="Transparent"/>
+                                <!-- #646: the selected book is visible again. It used to be painted away —
+                                     selection AND focus, at the item, its template ContentPresenter and its
+                                     template Border — which left the tree with no "you are here" at all.
+                                     Survivable only while the tree opened scrolled to the remembered book;
+                                     #644 stopped that, so ⌘O became the one route back and it landed on a
+                                     node the reader could not identify before pressing Enter on it.
+
+                                     Colours follow the convention #270 established: Dock's FIXED VS-Code
+                                     blue, not the OS accent, so "selected" reads the same here as on the
+                                     book/tool tabs and in the Settings category list whatever accent the OS
+                                     is set to. (The Settings list also records that
+                                     SubtleFillColorSecondaryBrush was too faint to see in light mode.)
+
+                                     Fluent paints TreeViewItem selection on Border#PART_LayoutRoot and
+                                     colours the text through ContentPresenter#PART_HeaderPresenter, a DIRECT
+                                     CHILD of that border. Targeting the header presenter is what keeps the
+                                     accent off nested children: a child TreeViewItem is a visual descendant
+                                     of its parent, so a plain "TreeViewItem:selected TextBlock" would
+                                     recolour every book under a selected category. -->
+                                <Style Selector="TreeViewItem:selected /template/ Border#PART_LayoutRoot">
+                                    <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
+                                    <Setter Property="BorderBrush" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
                                 </Style>
-                                <Style Selector="TreeViewItem:selected /template/ ContentPresenter">
-                                    <Setter Property="Background" Value="Transparent"/>
+                                <Style Selector="TreeViewItem:selected:pointerover /template/ Border#PART_LayoutRoot">
+                                    <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushMed}"/>
+                                    <Setter Property="BorderBrush" Value="{DynamicResource DockApplicationAccentBrushMed}"/>
                                 </Style>
-                                <Style Selector="TreeViewItem:selected /template/ Border">
-                                    <Setter Property="Background" Value="Transparent"/>
-                                </Style>
-                                <!-- Also handle focused states -->
-                                <Style Selector="TreeViewItem:focused">
-                                    <Setter Property="Background" Value="Transparent"/>
-                                </Style>
-                                <Style Selector="TreeViewItem:focused /template/ ContentPresenter">
-                                    <Setter Property="Background" Value="Transparent"/>
-                                </Style>
-                                <Style Selector="TreeViewItem:focused /template/ Border">
-                                    <Setter Property="Background" Value="Transparent"/>
+                                <!-- Foreground is inherited, so this reaches the node's own label (and the
+                                     book count, which is dimmed with Opacity rather than a fixed brush so it
+                                     stays legible on the accent fill). -->
+                                <Style Selector="TreeViewItem:selected /template/ Border#PART_LayoutRoot > ContentPresenter#PART_HeaderPresenter">
+                                    <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}"/>
                                 </Style>
                             </TreeView.Styles>
                             <TreeView.DataTemplates>
@@ -110,11 +123,15 @@
                                                    converters:FontHelper.DynamicFontFamily="{Binding $parent[UserControl].DataContext.CurrentScriptFontFamily}"
                                                    converters:FontHelper.DynamicFontSize="{Binding $parent[UserControl].DataContext.CurrentScriptFontSize}"/>
                                         <!-- Book count for categories -->
+                                        <!-- Dimmed with Opacity rather than a fixed secondary brush: on a
+                                             selected node the row is accent-filled, and a fixed grey would
+                                             sit unreadably on it. Opacity rides whatever Foreground the
+                                             row inherits. (#646) -->
                                         <TextBlock Text="{Binding BookCount, StringFormat=(\{0\})}"
                                                    Margin="3,0,0,0"
                                                    VerticalAlignment="Center"
                                                    FontSize="9"
-                                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                   Opacity="0.7"
                                                    IsVisible="{Binding IsCategory}"/>
                                     </StackPanel>
                                 </TreeDataTemplate>

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml
@@ -65,23 +65,35 @@
                                      SubtleFillColorSecondaryBrush was too faint to see in light mode.)
 
                                      Fluent paints TreeViewItem selection on Border#PART_LayoutRoot and
-                                     colours the text through ContentPresenter#PART_HeaderPresenter, a DIRECT
-                                     CHILD of that border. Targeting the header presenter is what keeps the
-                                     accent off nested children: a child TreeViewItem is a visual descendant
-                                     of its parent, so a plain "TreeViewItem:selected TextBlock" would
-                                     recolour every book under a selected category. -->
+                                     colours the text through ContentPresenter#PART_HeaderPresenter. What
+                                     keeps the accent off nested children is /template/ itself: it matches
+                                     only controls whose TemplatedParent is THIS item, so a child book's own
+                                     header is out of reach. (A plain "TreeViewItem:selected TextBlock" would
+                                     not be — a child TreeViewItem is a visual descendant of its parent, so
+                                     that would recolour every book under a selected category.)
+
+                                     Do NOT write "Border#PART_LayoutRoot > ContentPresenter#PART_Header-
+                                     Presenter", however tidy it reads: Avalonia's > matches on LOGICAL
+                                     parent, and the header presenter's logical parent is Grid#PART_Header,
+                                     not the border. That selector matches nothing and fails silently.
+                                     Fluent's own foreground rules are written that way and are dead
+                                     upstream for the same reason, which is exactly how it gets copied. -->
                                 <Style Selector="TreeViewItem:selected /template/ Border#PART_LayoutRoot">
                                     <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
                                     <Setter Property="BorderBrush" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
                                 </Style>
-                                <Style Selector="TreeViewItem:selected:pointerover /template/ Border#PART_LayoutRoot">
+                                <!-- :pointerover goes on the BORDER, as Fluent scopes it, not on the item.
+                                     IsPointerOver is containment-based, so an item is "hovered" whenever the
+                                     pointer is anywhere in its subtree — on the item, hovering a book would
+                                     light up its selected parent category two rows away. -->
+                                <Style Selector="TreeViewItem:selected /template/ Border#PART_LayoutRoot:pointerover">
                                     <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushMed}"/>
                                     <Setter Property="BorderBrush" Value="{DynamicResource DockApplicationAccentBrushMed}"/>
                                 </Style>
                                 <!-- Foreground is inherited, so this reaches the node's own label (and the
                                      book count, which is dimmed with Opacity rather than a fixed brush so it
                                      stays legible on the accent fill). -->
-                                <Style Selector="TreeViewItem:selected /template/ Border#PART_LayoutRoot > ContentPresenter#PART_HeaderPresenter">
+                                <Style Selector="TreeViewItem:selected /template/ ContentPresenter#PART_HeaderPresenter">
                                     <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}"/>
                                 </Style>
                             </TreeView.Styles>

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml.cs
@@ -41,6 +41,13 @@ public partial class OpenBookPanel : UserControl
         if (tree.SelectedItem == null && DataContext is OpenBookDialogViewModel { BookTree.Count: > 0 } viewModel)
             tree.SelectedItem = viewModel.BookTree[0];
 
+        // Open the way to the selection before looking for its container. The remembered book can sit under
+        // a branch that was collapsed when state was saved, and Fluent realises no container inside a
+        // collapsed branch — so every retry below would miss and Cmd+O would fall back to focusing the
+        // TreeView: no scroll, no highlight, nothing visibly happening at all. (#646)
+        if (tree.SelectedItem is BookTreeNode selected)
+            selected.ExpandAncestors();
+
         FocusSelectedTreeItem(tree, attemptsLeft: 5);
     }
 


### PR DESCRIPTION
The book tree had no "you are here". Six styles painted `TreeViewItem:selected` **and** `:focused` Transparent — at the item, its template ContentPresenter and its template Border — so nothing on screen said which node was current.

That was survivable while the tree opened scrolled to the remembered book: it was at least in the viewport. #644 correctly stopped that, because landing at an unexplained deep branch was worse. Composed, the two removed both cues at once, and ⌘O became the one route back to a node the reader could not identify before pressing Enter on it.

## Selection is visible again

Accent-filled, following the convention #270 established: Dock's **fixed** VS-Code blue rather than the OS accent, so "selected" reads the same here as on the book and tool tabs and in the Settings category list whatever accent the OS is set to. That convention also rules out the issue's "subtle background" read literally — the Settings list carries a note that `SubtleFillColorSecondaryBrush` was too faint to see in light mode.

The category's book count moves from a fixed secondary brush to `Opacity`, so it dims against whatever foreground the row inherits instead of sitting grey-on-blue.

## ⌘O can reach the book

`FocusBookTree` walks realised `TreeViewItem`s to find the selection, but Fluent binds `PART_ItemsPresenter` to `IsExpanded`, so a book under a branch that was collapsed when state was saved has **no container** — all five retries miss and it falls back to focusing the TreeView. No expand, no scroll, nothing visible.

Pre-existing (the old auto-scroll could not reach a collapsed node either — `TreeContainerFromItem` returns null), but left alone it would have read as the styling fix having failed. `BookTreeNode.ExpandAncestors` opens the way down first. Ancestors only: revealing a node is not the same as opening it, and a category the user deliberately closed stays closed.

## What the Fable review caught

Three defects, all in the first commit, all fixed in the second. Worth reading because the first one is instructive:

**The centerpiece selector was dead.** `Border#PART_LayoutRoot > ContentPresenter#PART_HeaderPresenter` matched nothing. Avalonia's `>` resolves on **logical** parent, and the header presenter's logical parent is `Grid#PART_Header`, not the border — the template is `Border#PART_LayoutRoot → Grid#PART_Header → {chevron, header presenter}`. I had asserted the opposite in a comment; the decompiled theme shows the border's `Child` is a Grid.

So the accent foreground never applied. **In dark mode the default foreground is white and the bug is invisible**; in light mode a selected row was black text on `#007ACC`. Precisely the split the first commit said needed eyes on both variants — and eyes on one variant would have passed it. Fluent's own foreground rules carry the same `>` and are dead upstream for the same reason, which is how the mistake gets copied, so the comment now warns against the tidier-reading version in the imperative.

Dropping the `>` step fixes it. `/template/` was always what kept the accent off nested children — it matches only controls whose `TemplatedParent` is this item, so a child book's header is out of reach regardless.

**Hover lit the wrong row.** `IsPointerOver` is containment-based, so `TreeViewItem:selected:pointerover` fired whenever the pointer was anywhere in the item's subtree: mousing down the books under a selected category made the category header brighten and dim two rows away, alongside the book's own hover tint. The pseudo-class moves onto the border, which is how Fluent scopes it.

**Every ⌘O cost a save per ancestor.** `IsExpanded` had no equality guard, so `ExpandAncestors` re-raised `PropertyChanged` for branches already open, and each raise is a full-tree `CollectExpandedKeys` walk plus a `StateChanged` broadcast. Debounced before it reaches disk, so nothing was lost — but it ran on a hot path for no reason. The guard also covers the `TreeViewItem`'s TwoWay binding, which writes back the value it already holds.

Dropping the `:focused` rules was checked and is sound: the decompiled TreeViewItem theme has no `:focused` styles to resurface, directional focus updates selection in a TreeView so the two coincide, and the focus adorner was never suppressed by Background-only rules. Keeping them would also have let `:focused`, as the later style, blank the accent at exactly the moment the reader needs it.

## Testing

Full suite **1736 passed, 0 failed**. Six new tests on `ExpandAncestors`: the chain opens, the node itself stays closed, siblings are untouched, roots are a no-op, the expansion announces itself so it persists, and re-revealing an already-visible book raises nothing.

**The styling half has no automated coverage, and that is the gap that let defect 1 through.** The test project has no `Avalonia.Headless` reference; adding one is the only way to assert "this selector actually matched", and it is worth doing as its own change rather than smuggled in here. The corrected selectors were verified by running them in a headless Avalonia 11.3.6 app during review, and the template facts above come from the decompiled theme.

**Please look at it in both light and dark** — a selected book, a selected *category* with children expanded (its books must not be tinted), the pointer moving through those children, and ⌘O with the remembered book buried under a collapsed branch.

Closes #646.
