### PR TITLE
Give the Assistant a way back, and open it narrower (#656)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
@@ -220,4 +220,93 @@ public class CstDockFactoryTests
         Assert.Same(existing, dock);                              // reused, not recreated
         Assert.Equal(before, mainDock.VisibleDockables!.Count);  // nothing inserted
     }
+
+    // ---- The assistant's own container (#656) ----
+
+    [Fact]
+    public void EnsureRightToolDock_RecreatesUnderMainDock_WhenMissing()
+    {
+        // The assistant can be floated into its own window and that window closed, which takes the panel out
+        // of the layout entirely. It is the only tool whose dock is on the right, so it needs its own
+        // recreate path — and since the panel holds the whole session's transcript, having no way back lost
+        // that too.
+        var f = new CstDockFactory();
+        var doc = new DocumentDock { Id = "MainDocumentDock", VisibleDockables = List() };
+        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(doc) };
+        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
+        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
+        f._rootDock = root;
+        f._mainDock = mainDock;
+
+        var dock = f.EnsureRightToolDock();
+
+        Assert.NotNull(dock);
+        Assert.Equal("RightToolDock", dock!.Id);
+        Assert.Contains(mainDock.VisibleDockables!, d => d.Id == "RightTools");
+    }
+
+    [Fact]
+    public void EnsureRightToolDock_AppendsAfterTheDocuments()
+    {
+        // Right of the books, not left of them: it is inserted by position, and getting the ends confused
+        // would put the assistant where the book tree lives.
+        var f = new CstDockFactory();
+        var doc = new DocumentDock { Id = "MainDocumentDock", VisibleDockables = List() };
+        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(doc) };
+        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
+        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
+        f._rootDock = root;
+        f._mainDock = mainDock;
+
+        f.EnsureRightToolDock();
+
+        var ids = mainDock.VisibleDockables!.Select(d => d.Id).ToList();
+        Assert.True(ids.IndexOf("RightTools") > ids.IndexOf("MainDocumentDock"));
+    }
+
+    [Fact]
+    public void EnsureRightToolDock_ReusesExisting_WhenPresent()
+    {
+        var f = new CstDockFactory();
+        var existing = new ToolDock { Id = "RightToolDock", VisibleDockables = List() };
+        var rightTools = new ProportionalDock { Id = "RightTools", VisibleDockables = List(existing) };
+        var doc = new DocumentDock { Id = "MainDocumentDock", VisibleDockables = List() };
+        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(doc, rightTools) };
+        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
+        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
+        f._rootDock = root;
+        f._mainDock = mainDock;
+        var before = mainDock.VisibleDockables!.Count;
+
+        var dock = f.EnsureRightToolDock();
+
+        Assert.Same(existing, dock);
+        Assert.Equal(before, mainDock.VisibleDockables!.Count);
+    }
+
+    [Fact]
+    public void The_assistant_opens_narrower_than_the_documents()
+    {
+        // Reported: "the default width of the Assistant is too wide — often wider than the book area". Split
+        // the documents into two books side by side and each gets half the middle column, so a quarter-width
+        // assistant is exactly as wide as either book. The middle column has to stay wide enough that a split
+        // book is still the widest thing on screen.
+        var f = new CstDockFactory();
+        f.EnsureRightToolDock();   // no MainDock: just proves the constant is not the old 0.25
+
+        var doc = new DocumentDock { Id = "MainDocumentDock", VisibleDockables = List() };
+        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(doc) };
+        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
+        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
+        f._rootDock = root;
+        f._mainDock = mainDock;
+
+        f.EnsureRightToolDock();
+        var assistant = mainDock.VisibleDockables!.First(d => d.Id == "RightTools");
+
+        Assert.True(assistant.Proportion < 0.25, $"assistant opens at {assistant.Proportion}");
+        // Half the middle column, which is what a side-by-side book gets, must still beat it.
+        var middle = 1.0 - 0.25 - assistant.Proportion;
+        Assert.True(middle / 2 > assistant.Proportion, "a split book would be narrower than the assistant");
+    }
 }

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -97,6 +97,7 @@ public partial class App : Application
     private List<NativeMenuItem> _selectBookMenuItems = new List<NativeMenuItem>();
     private List<NativeMenuItem> _searchMenuItems = new List<NativeMenuItem>();
     private List<NativeMenuItem> _dictionaryMenuItems = new List<NativeMenuItem>();
+    private List<NativeMenuItem> _assistantMenuItems = new List<NativeMenuItem>();
 
     // #284: the per-window "Window" submenu (main + each floating window). Each is repopulated with the
     // live window list (Minimize + a "jump to window" entry per open window) whenever windows open, close,
@@ -1405,6 +1406,19 @@ public partial class App : Application
                                             ToggleDictionaryPanel();
                                         };
                                     }
+                                    // Must stay in lockstep with the View-menu header in
+                                    // SimpleTabbedWindow.axaml: the toggle is wired by matching that string.
+                                    else if (viewSubItem.Header?.ToString() == "Assistant")
+                                    {
+                                        _assistantMenuItems.Add(viewSubItem);
+                                        viewSubItem.ToggleType = NativeMenuItemToggleType.CheckBox;
+                                        viewSubItem.IsChecked = true;
+                                        viewSubItem.Click += (s, e) =>
+                                        {
+                                            Log.Information("Toggle Assistant panel clicked via View menu (main window)");
+                                            ToggleAssistantPanel();
+                                        };
+                                    }
                                 }
                             }
                         }
@@ -1440,6 +1454,11 @@ public partial class App : Application
             foreach (var menuItem in _searchMenuItems)
             {
                 menuItem.IsChecked = layoutViewModel.IsSearchPanelVisible;
+            }
+
+            foreach (var menuItem in _assistantMenuItems)
+            {
+                menuItem.IsChecked = layoutViewModel.IsAssistantPanelVisible;
             }
 
             foreach (var menuItem in _dictionaryMenuItems)
@@ -1616,6 +1635,21 @@ public partial class App : Application
                 ToggleDictionaryPanel();
             };
             _dictionaryMenuItems.Add(dictionaryItem);
+
+            // #656: the assistant can be floated and its window closed, which takes it out of the layout.
+            // Without an entry here a reader who did that from a floating window had no way back to it.
+            var assistantItem = new NativeMenuItem
+            {
+                Header = "Assistant",
+                ToggleType = NativeMenuItemToggleType.CheckBox,
+                IsChecked = layoutViewModel?.IsAssistantPanelVisible ?? false
+            };
+            assistantItem.Click += (s, e) =>
+            {
+                Log.Information("Toggle Assistant panel clicked via View menu (floating window)");
+                ToggleAssistantPanel();
+            };
+            _assistantMenuItems.Add(assistantItem);
 
             // #572: book zoom, mirroring the main window's View menu. macOS shows the menu bar of the
             // ACTIVE window, so without these three a floated book would have dead zoom keys — the same
@@ -2127,6 +2161,25 @@ public partial class App : Application
         catch (Exception ex)
         {
             Log.Error(ex, "Failed to toggle Search panel");
+        }
+    }
+
+    private void ToggleAssistantPanel()
+    {
+        try
+        {
+            if (MainWindow?.DataContext is LayoutViewModel layoutViewModel)
+            {
+                layoutViewModel.ToggleAssistantPanel();
+            }
+            else
+            {
+                Log.Warning("Cannot toggle Assistant panel - LayoutViewModel not available");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to toggle Assistant panel");
         }
     }
 

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -37,7 +37,15 @@ namespace CST.Avalonia.Services
         // Misnomer kept for the smaller diff: this is the DOCUMENT dock's proportion, which used to be the
         // rightmost thing in MainDock. Since #586 the assistant sits to its right and has its own field below.
         private double _mainDockRightProportion = 0.50;
-        private double _mainDockAssistantProportion = 0.25;
+        private double _mainDockAssistantProportion = AssistantProportion;
+
+        /// <summary>
+        /// How wide the assistant column opens. Narrower than the tool rail on the left: that one holds a
+        /// book tree whose entries are long canon paths, whereas this holds prose, which is easier to read in
+        /// a narrow measure than a wide one — and every pixel it takes comes off the book. A starting point,
+        /// not a verdict; the splitter beside it is the answer to disagreeing.
+        /// </summary>
+        private const double AssistantProportion = 0.18;
 
         // Typed references to two spine docks, set in CreateLayout, used to recreate the tool container
         // on demand (see EnsureLeftToolDock). Reference-stable: MainDock is protected and never removed.
@@ -140,7 +148,7 @@ namespace CST.Avalonia.Services
             {
                 Id = "MainDocumentDock",
                 Title = "Documents",
-                Proportion = 0.50, // the middle column: tools left, assistant right (#586)
+                Proportion = 1.0 - 0.25 - AssistantProportion,  // the middle column: tools left, assistant right (#586)
                 ActiveDockable = welcomeDocument,
                 VisibleDockables = CreateList<IDockable>(welcomeDocument),
                 CanCreateDocument = false, // Disable "+" button - books opened via "Select a Book" panel
@@ -285,7 +293,7 @@ namespace CST.Avalonia.Services
             var rightTools = new ProportionalDock
             {
                 Id = "RightTools",
-                Proportion = 0.25,
+                Proportion = AssistantProportion,
                 Orientation = Orientation.Vertical,
                 IsCollapsable = false,
                 CanDrop = true,
@@ -1654,6 +1662,66 @@ namespace CST.Avalonia.Services
             InitDockable(leftToolDock, leftTools);
 
             return leftToolDock;
+        }
+
+        /// <summary>
+        /// The RightToolDock that hosts the assistant, recreating it (and its RightTools wrapper) under the
+        /// protected MainDock if it has been removed. (#656)
+        ///
+        /// <para>The assistant can be floated into its own window, and closing that window takes the panel out
+        /// of the layout entirely. Without this there was no way back: it is the only tool with no View-menu
+        /// entry, so a reader who floated it and closed the window lost it for the rest of the session — and
+        /// since the panel holds the whole transcript, they lost that too.</para>
+        /// </summary>
+        internal ToolDock? EnsureRightToolDock()
+        {
+            if (_rootDock != null && FindDockByIdRecursive(_rootDock, "RightToolDock") is ToolDock existing)
+            {
+                return existing;
+            }
+
+            if (_mainDock?.VisibleDockables == null)
+            {
+                Log.Error("*** EnsureRightToolDock: MainDock unavailable - cannot recreate tool container ***");
+                return null;
+            }
+
+            Log.Information("*** EnsureRightToolDock: RightToolDock missing - recreating tool container under MainDock ***");
+
+            var rightToolDock = new ToolDock
+            {
+                Id = "RightToolDock",
+                Title = "Assistant",
+                Alignment = Alignment.Right,
+                GripMode = GripMode.Visible,
+                CanDrag = true,
+                CanDrop = true,
+                VisibleDockables = CreateList<IDockable>(),
+                Factory = this
+            };
+
+            var rightTools = new ProportionalDock
+            {
+                Id = "RightTools",
+                Proportion = AssistantProportion,
+                Orientation = Orientation.Vertical,
+                IsCollapsable = false,
+                CanDrop = true,
+                VisibleDockables = CreateList<IDockable>(rightToolDock),
+                Factory = this
+            };
+
+            // Appended at the right of MainDock (mirrors CreateLayout: [... documents, splitter, rightTools]).
+            var splitter = new ProportionalDockSplitter { Id = "RightSplitter", Title = "RightSplitter" };
+            _mainDock.VisibleDockables.Add(splitter);
+            _mainDock.VisibleDockables.Add(rightTools);
+
+            // Owner/Factory wiring, as EnsureLeftToolDock does: without a proper Owner, base.FloatDockable
+            // cannot detach these, so floating a recreated panel would silently no-op.
+            InitDockable(rightTools, _mainDock);
+            InitDockable(rightToolDock, rightTools);
+
+            return rightToolDock;
         }
         
         // Override to prevent accidental closes during drag operations

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -81,6 +81,14 @@ namespace CST.Avalonia.ViewModels
             private set => this.RaiseAndSetIfChanged(ref _isDictionaryPanelVisible, value);
         }
 
+        private bool _isAssistantPanelVisible = true;
+
+        public bool IsAssistantPanelVisible
+        {
+            get => _isAssistantPanelVisible;
+            private set => this.RaiseAndSetIfChanged(ref _isAssistantPanelVisible, value);
+        }
+
         // Event for notifying when panel visibility changes (for menu updates)
         public event EventHandler? PanelVisibilityChanged;
 
@@ -152,6 +160,10 @@ namespace CST.Avalonia.ViewModels
         // CreateLayout does at startup; wrapping it in a generic Tool { Context } renders an empty panel
         // because the view locator resolves by dockable type. (#84)
         private void ShowToolPanel(string toolId, Func<IDockable?> resolveVm, Action markVisible, string panelName)
+            => ShowToolPanel(toolId, resolveVm, markVisible, panelName, right: false);
+
+        private void ShowToolPanel(
+            string toolId, Func<IDockable?> resolveVm, Action markVisible, string panelName, bool right)
         {
             Log.Information("[Layout] Show {Panel} panel requested", panelName);
 
@@ -171,19 +183,20 @@ namespace CST.Avalonia.ViewModels
                 return;
             }
 
-            var leftToolDock = _factory.EnsureLeftToolDock();
-            if (leftToolDock == null)
+            // The assistant lives in its own dock on the right; the other three share the left rail.
+            var toolDock = right ? _factory.EnsureRightToolDock() : _factory.EnsureLeftToolDock();
+            if (toolDock == null)
             {
                 Log.Error("[Layout] Cannot add {Panel} panel - MainDock unavailable.", panelName);
                 return;
             }
 
             tool.Factory = _factory;
-            _factory.AddDockable(leftToolDock, tool);
+            _factory.AddDockable(toolDock, tool);
             _factory.SetActiveDockable(tool);
-            _factory.SetFocusedDockable(leftToolDock, tool);
+            _factory.SetFocusedDockable(toolDock, tool);
 
-            Log.Information("[Layout] {Panel} panel added to LeftToolDock", panelName);
+            Log.Information("[Layout] {Panel} panel added to {Dock}", panelName, toolDock.Id);
 
             markVisible();
             PanelVisibilityChanged?.Invoke(this, EventArgs.Empty);
@@ -243,6 +256,27 @@ namespace CST.Avalonia.ViewModels
 
         public void HideSelectBookPanel() =>
             HideToolPanel("OpenBookTool", () => IsSelectBookPanelVisible = false, "Open a Book");
+
+        public void ToggleAssistantPanel()
+        {
+            if (IsAssistantPanelVisible) HideAssistantPanel();
+            else ShowAssistantPanel();
+        }
+
+        /// <summary>
+        /// Bring the assistant back. (#656)
+        ///
+        /// <para>It could be floated into its own window and that window closed, which took it out of the
+        /// layout with no way to get it back — it was the one tool with no View-menu entry. Since the panel
+        /// holds the whole session's transcript, losing it lost that too. The view model is a singleton, so
+        /// what comes back is the same panel with its turns intact.</para>
+        /// </summary>
+        public void ShowAssistantPanel() =>
+            ShowToolPanel("AiAssistantTool", () => App.ServiceProvider?.GetRequiredService<AiAssistantViewModel>(),
+                () => IsAssistantPanelVisible = true, "Assistant", right: true);
+
+        public void HideAssistantPanel() =>
+            HideToolPanel("AiAssistantTool", () => IsAssistantPanelVisible = false, "Assistant");
 
         // Recreate-on-demand so the View menu toggle and Cmd+D (Look Up in Dictionary) can reopen a closed
         // pane — LookUpInDictionaryAsync calls this then immediately proceeds, so it must stay synchronous. (#466)
@@ -368,6 +402,7 @@ namespace CST.Avalonia.ViewModels
             IsSelectBookPanelVisible = present.Contains("OpenBookTool");
             IsSearchPanelVisible = present.Contains("SearchTool");
             IsDictionaryPanelVisible = present.Contains("DictionaryTool");
+            IsAssistantPanelVisible = present.Contains("AiAssistantTool");
 
             Log.Debug("[Layout] Panel visibility updated - SelectBook: {SelectBook}, Search: {Search}, Dictionary: {Dictionary}",
                 IsSelectBookPanelVisible, IsSearchPanelVisible, IsDictionaryPanelVisible);

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -41,6 +41,7 @@
                     <NativeMenuItem Header="Open a Book" />
                     <NativeMenuItem Header="Search" />
                     <NativeMenuItem Header="Dictionary" />
+                    <NativeMenuItem Header="Assistant" />
                     <NativeMenuItemSeparator />
                     <!-- #572 book zoom. The menu carries the discoverability: a beta tester asked for a way
                          to enlarge the text and, finding none, invented a copy-a-line-then-search ritual


### PR DESCRIPTION
## Float it, close the window, it's gone

The Assistant was the only tool with no View-menu entry. Open a Book, Search and Dictionary each have one, backed by `LayoutViewModel.Show*Panel` and `EnsureLeftToolDock` — the recreate-on-demand path from #84/#466. The Assistant was added straight into a new `RightToolDock` in `CreateLayout` and given neither, when I moved it there.

`CanClose = false` is why this wasn't obvious: it stops the **tab** closing. The way out is floating the panel and closing the **window**, which removes the whole layout it was living in. And since the panel holds the session's transcript, losing it lost that too.

Added: `EnsureRightToolDock` alongside its left twin, `Show`/`Hide`/`ToggleAssistantPanel` alongside the other three, and an **Assistant** entry in the View menu of both window kinds — the main window's discovered by header string (in lockstep with the XAML, with the comment that convention requires), the floating windows' built in code, the same split the other tools use. The view model is a singleton, so what comes back is the same panel with its turns intact.

## "Often wider than the book area"

It opened at 0.25 of the window against the documents' 0.50. Split the documents into two books side by side — ordinary use here — and each book gets 0.25: *exactly* the assistant's width, and narrower on any drift. That's the "often".

Now 0.18, with the middle column taking what it gives up. The test asserts the property rather than the number: half the middle column, which is what a split book gets, must still be wider than the assistant. So a future width change that reintroduces the problem fails.

The width is a starting point, not a verdict — the splitter beside it is the answer to disagreeing.

## Testing

Full suite **1746 passed, 0 failed** (+10). Clean app startup.

**Not verified by me**: that the View menu item actually reopens a closed panel, since that needs a running window to float and close. The recreate path is unit-tested — it builds the dock, appends it after the documents rather than before, and reuses an existing one — but the menu wiring itself is only as good as its symmetry with the three tools that already work this way.

Closes #656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)