### PR TITLE
Give the Assistant panel a right margin

### DIFF
--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -81,8 +81,13 @@
         </Border>
 
         <!-- ============ The transcript, scrolling ============ -->
-        <ScrollViewer Padding="8" VerticalScrollBarVisibility="Auto">
-            <StackPanel Spacing="14">
+        <!-- The inset is a MARGIN on the content, not Padding on the ScrollViewer. ScrollViewer.Padding sits
+             inside the scrollable extent: the left half lands at the scroll origin and looks right, while the
+             right half scrolls off the end instead of reserving width, so the longest lines ran under the
+             edge and lost their last characters. The extra on the right clears the overlay scrollbar, which
+             Fluent draws on top of the content rather than beside it. -->
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Spacing="14" Margin="8,8,16,8">
 
                 <TextBlock Text="Ask about the passage you are reading. Select some text first and the answer will be about the selection."
                            IsVisible="{Binding !HasTurns}"
@@ -190,9 +195,13 @@
                                     <StackPanel>
                                         <ScrollViewer VerticalScrollBarVisibility="Auto"
                                                       Height="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).ReasoningHeight}">
+                                            <!-- Its own right inset: this scroller has an overlay scrollbar
+                                                 too, and reasoning is the longest unbroken text in the
+                                                 panel, so it is where clipping shows first. -->
                                             <SelectableTextBlock Text="{Binding Reasoning}"
                                                                  TextWrapping="Wrap"
                                                                  FontSize="11"
+                                                                 Margin="0,0,10,0"
                                                                  Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                         </ScrollViewer>
                                         <Thumb Name="ReasoningResizer"


### PR DESCRIPTION
The longest lines ran under the right edge and lost their last characters.

## Cause

The transcript used `ScrollViewer Padding="8"`. `ScrollViewer.Padding` sits **inside the scrollable extent**: the left half lands at the scroll origin and looks correct, while the right half scrolls off the end rather than reserving width. Content was measured as if the full viewport were available, so the last characters of a wrapped line ended up past the visible edge.

The inset is a `Margin` on the content now, which the layout pass subtracts from the available width before the text wraps.

The right inset is larger than the left (16 vs 8) because Fluent's scrollbar is an **overlay** — drawn on top of the content rather than beside it — so a symmetric margin would still leave the scrollbar sitting over the last glyph whenever the transcript is long enough to scroll.

The reasoning scroller has the same shape and gets its own right inset: it also has an overlay scrollbar, and reasoning is the longest unbroken run of text in the panel, so it is where clipping shows first.

## Testing

Full suite **1746 passed, 0 failed** — unchanged, as expected for a layout-only change. Clean app startup.

**Not verified by me**: that the text now clears the edge. This is a pixel question and I have no eyes on a running window. The reasoning above explains why the old markup could not reserve right-hand space; whether 16px is *enough* to clear the scrollbar on your display is exactly the kind of thing I have been wrong about today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)