### PR TITLE
Let Enter open a book instead of closing the category it is in (#658)

### DIFF
--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml
@@ -42,8 +42,7 @@
                                   SelectedItem="{Binding SelectedNode}"
                                   AutoScrollToSelectedItem="False"
                                   Background="{DynamicResource SolidBackgroundFillColorBaseBrush}"
-                                  DoubleTapped="TreeView_DoubleTapped"
-                                  KeyDown="TreeView_KeyDown">
+                                  DoubleTapped="TreeView_DoubleTapped">
                             <TreeView.Styles>
                                 <!-- Style for TreeViewItem -->
                                 <Style Selector="TreeViewItem" x:DataType="vm:BookTreeNode">

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml.cs
@@ -16,7 +16,13 @@ public partial class OpenBookPanel : UserControl
     public OpenBookPanel()
     {
         InitializeComponent();
-        
+
+        // Enter is claimed on the TUNNEL phase, and it has to be. See TreeView_KeyDown for why the bubble
+        // handler this replaces could never fire on a book. Wired through the x:Name field rather than
+        // FindControl so a rename is a compile error: a null-tolerant lookup here would silently detach
+        // Enter, which is the failure mode #658 was in the first place. (#658)
+        BookTreeView.AddHandler(InputElement.KeyDownEvent, TreeView_KeyDown, RoutingStrategies.Tunnel);
+
         // Debug: Check if DataContext is set
         this.DataContextChanged += (s, e) =>
         {
@@ -98,27 +104,28 @@ public partial class OpenBookPanel : UserControl
     }
 
     // Enter opens the selected book, as it did in CST4 — without it the tree can be reached and navigated
-    // by keyboard but not acted on, which is exactly the gap Cmd+O would otherwise leave. On a container
-    // node Enter expands/collapses instead, since there is nothing to open. (#111)
+    // by keyboard but not acted on, which is exactly the gap Cmd+O would otherwise leave. (#111)
+    //
+    // TUNNEL phase, deliberately (#658). This was a bubble handler on the TreeView, and it never once ran
+    // for a book: TreeViewItem's own class handler treats Return as expand/collapse, and on a leaf its
+    // ExpandItem finds nothing to expand and returns FALSE — leaving the event unhandled, so it bubbled on
+    // to the parent category, whose handler collapsed it and marked it handled. Pressing Enter on a book
+    // closed the category it was in. Tunnelling routes root -> source, so this sees the key before any item
+    // can claim it.
+    //
+    // Books only. Categories are left to the stock Return handling, which expands/collapses them and gives
+    // Ctrl+Return subtree expansion for free. (The branch that used to toggle IsExpanded here was dead for
+    // the same routing reason: on a category the item claims Return first, so it never ran either.)
     private void TreeView_KeyDown(object? sender, KeyEventArgs e)
     {
         if (e.Key != Key.Enter)
             return;
 
-        if (DataContext is not OpenBookDialogViewModel viewModel || viewModel.SelectedNode is not { } node)
+        if (DataContext is not OpenBookDialogViewModel viewModel
+            || viewModel.SelectedNode is not { NodeType: BookTreeNodeType.Book })
             return;
 
-        if (node.NodeType == BookTreeNodeType.Book)
-        {
-            OpenSelectedBook("Enter");
-        }
-        else
-        {
-            node.IsExpanded = !node.IsExpanded;
-            Log.Debug("[OpenBookPanel] Enter toggled node {NodeName} to expanded={Expanded}",
-                node.DisplayName, node.IsExpanded);
-        }
-
+        OpenSelectedBook("Enter");
         e.Handled = true;
     }
 


### PR DESCRIPTION
Enter on a selected book collapsed its parent category. It has never done anything else since the handler was added in #111.

## Why

`TreeViewItem`'s own class handler maps `Key.Return` to expand/collapse and assigns the result to `e.Handled`:

```csharp
Key.Return => ApplyToItemOrRecursivelyIfCtrl(IsExpanded ? CollapseItem : ExpandItem, e.KeyModifiers),
...
e.Handled = func(this);
```

A book is a leaf, so `ExpandItem` fails its `ItemCount > 0` guard and returns **false** — the event stays unhandled and bubbles to the **parent category**, whose handler finds children, collapses them, and returns true. Our handler sat on the TreeView on the **bubble** phase, downstream of every item in the route, so it never ran.

The XAML `KeyDown=` attribute can only ever give you a bubble handler. That is structurally the wrong side of the thing eating the key, which is why this looked like a logic bug and was a routing one.

## The fix

Enter is claimed on the **tunnel** phase. Avalonia raises the entire tunnel pass before the bubble pass and iterates it root → source, and `OnKeyDown` overrides are registered `Direct | Bubble` with `handledEventsToo: false` — so no `TreeViewItem` can see the key once we mark it handled.

**Books only.** Categories keep the stock Return toggle *and* Ctrl+Return subtree expansion. The branch that used to toggle `IsExpanded` for categories is deleted rather than ported: it was dead for the same routing reason — on a category the item claims Return first, so it never ran either. Categories have always expanded by the theme's doing, not ours.

Wired through the `x:Name` field rather than `FindControl`, so renaming the control is a compile error. A null-tolerant lookup would silently detach Enter — which is the failure mode this whole issue is.

## Verification

I asked for a Fable review specifically because the fix rests on a claim that fails silently if wrong: *a tunnel handler only runs if the event is registered with a Tunnel strategy at all.* If `KeyDownEvent` were bubble-only, this would have been a no-op that looks like a fix.

It checked out, against the decompiled 11.3.6 assemblies and in a headless Avalonia app driving real key events through the real Fluent theme:

- `InputElement.KeyDownEvent` is registered `RoutingStrategies.Tunnel | RoutingStrategies.Bubble`.
- The **old** arrangement reproduces #658 exactly — Enter on a focused, selected book never reaches the TreeView handler and collapses the parent.
- The **new** one runs the handler, opens the book, and leaves the category expanded.
- Ctrl+Return subtree expansion and plain Return on a category both still work.

Full suite **1746 passed, 0 failed**. No unit test covers this: it is routing, not logic, and a test asserting "this node is a book" would be theatre. #655 (Avalonia.Headless support) is what would close this class — the review's throwaway harness is evidence it is only ~60 lines away.

## Worth knowing

Enter follows the **selection highlight, not the focus ring**. They only diverge on a non-directional focus move, which no in-app path currently produces (pointer clicks select; `FocusSelectedTreeItem` focuses directionally; Fluent's chevron is `Focusable="False"`), and acting on `SelectedNode` matches both the visible accent and the double-tap path.

Modifier+Enter on a book now opens it. Previously Ctrl+Enter on a book recursively collapsed the parent subtree — the same bug family — so this is strictly better, but it does shadow any future modifier semantics on leaves.

## Manual check

⌘O, arrow to a book, Enter — it opens and the category stays put. Enter on a category — toggles. Ctrl+Return on a collapsed category — subtree expands.

Closes #658.
