### PR TITLE
Give a typed question its own verb: the Ask button

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
@@ -165,6 +165,40 @@ public class PromptBuilderTests : IDisposable
     }
 
     [Fact]
+    public void An_asked_question_leads_the_prompt_rather_than_riding_on_a_preset()
+    {
+        // Before this task existed, a reader with a question had to pick a preset to carry it -- Explain, in
+        // practice -- so the model was told to explain the passage AND answer a question, and the preset's
+        // instructions competed with the question for what the answer should be about.
+        var prompt = _builder.Build(Bundle(task: AiTask.Ask, userQuestion: "what governs bhavissanti?"));
+
+        Assert.Contains("what governs bhavissanti?", prompt.UserContent);
+        Assert.Contains("Answer the reader's question", prompt.UserContent);
+
+        // No preset instruction survives to compete with it.
+        Assert.DoesNotContain("Explain this passage", prompt.UserContent);
+        Assert.DoesNotContain("Translate this passage", prompt.UserContent);
+
+        // And the question comes before the passage it is asked about.
+        var question = prompt.UserContent.IndexOf("what governs bhavissanti?", StringComparison.Ordinal);
+        var passage = prompt.UserContent.IndexOf("appamādo", StringComparison.Ordinal);
+        Assert.True(question < passage, "the question must lead the prompt");
+    }
+
+    [Fact]
+    public void A_question_about_a_selection_makes_the_selection_the_subject()
+    {
+        var prompt = _builder.Build(Bundle(
+            task: AiTask.Ask,
+            userQuestion: "which word is the verb?",
+            selection: new SelectionContext("appamādo amatapadaṃ", SelectionState.Located)));
+
+        Assert.Contains("which word is the verb?", prompt.UserContent);
+        Assert.Contains("about the text they have selected", prompt.UserContent);
+        Assert.Contains("for context only", prompt.UserContent);
+    }
+
+    [Fact]
     public void A_clean_request_produces_no_notices_however_many_paragraphs_it_covers()
     {
         // A window spanning several paragraphs used to raise "The passage window covers N paragraphs, not
@@ -221,6 +255,7 @@ public class PromptBuilderTests : IDisposable
     [InlineData(AiTask.Translate)]
     [InlineData(AiTask.Grammar)]
     [InlineData(AiTask.WordByWord)]
+    [InlineData(AiTask.Ask)]
     public void Every_preset_demotes_the_passage_to_context_when_something_is_selected(AiTask task)
     {
         // Pins the whole set rather than the one preset that was reported. All four had the same shape, so
@@ -230,7 +265,9 @@ public class PromptBuilderTests : IDisposable
             selection: new SelectionContext("appamādo amatapadaṃ", SelectionState.Located)));
 
         Assert.Contains("for context only", prompt.UserContent);
-        Assert.Contains("It is not what you were asked to", prompt.UserContent);
+        // Each preset disclaims the passage in its own words -- "not what you were asked to translate", "not
+        // what the question is about" -- so the assertion is on the disclaimer, not on one phrasing of it.
+        Assert.Contains("It is not what", prompt.UserContent);
 
         // The selection has to be present in full, above the context, or the heading is a lie.
         var subject = prompt.UserContent.IndexOf("appamādo amatapadaṃ", StringComparison.Ordinal);

--- a/src/CST.Avalonia.Tests/Services/Ai/PromptTemplateStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptTemplateStoreTests.cs
@@ -43,6 +43,8 @@ public class PromptTemplateStoreTests : IDisposable
     [InlineData(PromptTemplateNames.TranslateSelection)]
     [InlineData(PromptTemplateNames.GrammarSelection)]
     [InlineData(PromptTemplateNames.WordByWordSelection)]
+    [InlineData(PromptTemplateNames.Ask)]
+    [InlineData(PromptTemplateNames.AskSelection)]
     public void Every_shipped_template_passes_the_validation_it_imposes_on_the_user(string name)
     {
         // If a built-in cannot meet the bar we hold user edits to, either the template or the bar is wrong.

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -527,6 +527,40 @@ public class AiAssistantViewModelTests
     }
 
     [Fact]
+    public void Ask_is_offered_only_when_there_is_a_question_to_send()
+    {
+        // The four presets are complete without a question; this one IS the question, so an empty box means
+        // there is nothing to ask. Enter is bound to the same command, so the guard covers both.
+        var vm = new AiAssistantViewModel(new StubOrchestrator(), new StubReaderState(), null, null);
+
+        Assert.False(vm.CanAskQuestion);
+
+        vm.Question = "   ";
+        Assert.False(vm.CanAskQuestion);
+
+        vm.Question = "what governs bhavissanti?";
+        Assert.True(vm.CanAskQuestion);
+    }
+
+    [Fact]
+    public async Task An_asked_question_is_its_own_task_rather_than_a_rider_on_Explain()
+    {
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.Add(AiTurnEvent.ForCompleted(new PaliMarkerReport(0, 0)));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null)
+        {
+            Question = "what governs bhavissanti?",
+        };
+        await vm.AskAsync(AiTask.Ask);
+
+        Assert.Equal(AiTask.Ask, orchestrator.LastRequest!.Task);
+        Assert.Equal("what governs bhavissanti?", orchestrator.LastRequest!.UserQuestion);
+        Assert.Equal("Question", vm.LastTurn!.PresetLabel);
+    }
+
+    [Fact]
     public async Task Asking_moves_the_question_out_of_the_box_and_into_the_turn()
     {
         // The box kept the question after the answer arrived, so the next preset silently re-sent it. It

--- a/src/CST.Avalonia/Resources/Ai/ask-selection.md
+++ b/src/CST.Avalonia/Resources/Ai/ask-selection.md
@@ -1,0 +1,35 @@
+{{book}}
+{{citation}}
+
+{{userQuestion}}
+
+## What the reader has selected
+
+{{selection}}
+
+## The surrounding text, for context only
+
+Everything below is here so you can read the selection in its place. It is not what the question is about.
+
+{{passage}}
+
+## Print apparatus for this window
+
+{{apparatus}}
+
+## What you were and were not given
+
+{{provisions}}
+
+---
+
+Answer the reader's question, above, about the text they have selected.
+
+- The selection is what the question is about. The surrounding text is there to make sense of it — use it
+  where it bears on the answer, and do not answer about it for its own sake.
+- Where the selection answers the question, answer from it and show them the words that do it.
+- Where the question reaches past what you were given, say what you actually saw before you answer, and
+  answer from general knowledge of Pāli and of the commentarial tradition only after saying that is what you
+  are doing.
+- Where neither the selection nor its surroundings answer the question and general knowledge would only be a
+  guess, say so. That is a complete answer, and a better one than a plausible invention.

--- a/src/CST.Avalonia/Resources/Ai/ask.md
+++ b/src/CST.Avalonia/Resources/Ai/ask.md
@@ -1,0 +1,33 @@
+{{book}}
+{{citation}}
+
+{{userQuestion}}
+
+## The passage the reader has open
+
+{{passage}}
+
+## Selection
+
+{{selection}}
+
+## Print apparatus for this window
+
+{{apparatus}}
+
+## What you were and were not given
+
+{{provisions}}
+
+---
+
+Answer the reader's question, above.
+
+- The passage is the context they are asking from, not the subject. Answer what they asked; bring in the
+  passage where it bears on the answer, and do not summarize it for its own sake.
+- Where the passage answers the question, answer from the passage and show them the words that do it.
+- Where the question reaches past the passage — a whole sutta, a term's use across the canon, who someone is
+  — say what you were actually given before you answer, and answer from general knowledge of Pāli and of the
+  commentarial tradition only after saying that is what you are doing.
+- Where the passage does not answer the question and general knowledge would only be a guess, say so. That is
+  a complete answer, and a better one than a plausible invention.

--- a/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
+++ b/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
@@ -60,6 +60,9 @@ public sealed class AiContextBundler : IAiContextBundler
         [AiTask.Translate] = 2400,
         [AiTask.Grammar] = 900,
         [AiTask.WordByWord] = 600,
+        // Generous, like Translate: a reader's own question is the one task whose scope the app cannot
+        // predict, so the passage it is answered from should be the fullest one on offer.
+        [AiTask.Ask] = 2400,
     };
 
     /// <summary>How many distinct words get a lemma resolution — the grammatical presets only.</summary>

--- a/src/CST.Avalonia/Services/Ai/ContextBundle.cs
+++ b/src/CST.Avalonia/Services/Ai/ContextBundle.cs
@@ -13,6 +13,12 @@ public enum AiTask
     Translate,
     Grammar,
     WordByWord,
+
+    /// <summary>
+    /// The reader's own question, with the passage as its context. The only task that requires a question —
+    /// the other four are complete without one, and this one IS one.
+    /// </summary>
+    Ask,
 }
 
 /// <summary>

--- a/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
@@ -76,6 +76,7 @@ public sealed class PromptBuilder : IPromptBuilder
         [AiTask.Translate] = null,
         [AiTask.Grammar] = null,
         [AiTask.WordByWord] = null,
+        [AiTask.Ask] = null,
     };
 
     private readonly IPromptTemplateStore _templates;

--- a/src/CST.Avalonia/Services/Ai/PromptTemplates.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptTemplates.cs
@@ -26,6 +26,12 @@ public static class PromptTemplateNames
     public const string WordByWord = "word-by-word";
 
     /// <summary>
+    /// The reader's own question. Unlike the four presets it is meaningless without one, which is why the
+    /// button that sends it is disabled until something is typed.
+    /// </summary>
+    public const string Ask = "ask";
+
+    /// <summary>
     /// The same four presets, for when the reader has selected something. <b>Separate documents rather than a
     /// conditional inside one.</b>
     ///
@@ -43,13 +49,14 @@ public static class PromptTemplateNames
     public const string TranslateSelection = "translate-selection";
     public const string GrammarSelection = "grammar-selection";
     public const string WordByWordSelection = "word-by-word-selection";
+    public const string AskSelection = "ask-selection";
 
     public static IReadOnlyList<string> All { get; } =
         new[]
         {
             System,
-            Explain, Translate, Grammar, WordByWord,
-            ExplainSelection, TranslateSelection, GrammarSelection, WordByWordSelection,
+            Explain, Translate, Grammar, WordByWord, Ask,
+            ExplainSelection, TranslateSelection, GrammarSelection, WordByWordSelection, AskSelection,
         };
 
     /// <summary>
@@ -68,10 +75,12 @@ public static class PromptTemplateNames
         (AiTask.Translate, false) => Translate,
         (AiTask.Grammar, false) => Grammar,
         (AiTask.WordByWord, false) => WordByWord,
+        (AiTask.Ask, false) => Ask,
         (AiTask.Explain, true) => ExplainSelection,
         (AiTask.Translate, true) => TranslateSelection,
         (AiTask.Grammar, true) => GrammarSelection,
         (AiTask.WordByWord, true) => WordByWordSelection,
+        (AiTask.Ask, true) => AskSelection,
         _ => throw new ArgumentOutOfRangeException(nameof(task), task, "No prompt template for this task."),
     };
 }
@@ -135,6 +144,7 @@ public static class PromptPlaceholders
             [PromptTemplateNames.Translate] = new[] { Passage, Citation, Selection, UserQuestion },
             [PromptTemplateNames.Grammar] = new[] { Passage, Citation, Lemmas, Selection, UserQuestion },
             [PromptTemplateNames.WordByWord] = new[] { Passage, Citation, Lemmas, Selection, UserQuestion },
+            [PromptTemplateNames.Ask] = new[] { Passage, Citation, Selection, UserQuestion },
 
             // The selection variants need BOTH: {{selection}} is the subject, and {{passage}} is the context
             // that makes the subject readable. An override that deletes the context validates cleanly and then
@@ -144,6 +154,7 @@ public static class PromptPlaceholders
             [PromptTemplateNames.GrammarSelection] = new[] { Passage, Citation, Lemmas, Selection, UserQuestion },
             [PromptTemplateNames.WordByWordSelection] =
                 new[] { Passage, Citation, Lemmas, Selection, UserQuestion },
+            [PromptTemplateNames.AskSelection] = new[] { Passage, Citation, Selection, UserQuestion },
         };
 }
 

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -94,6 +94,7 @@ public class AiAssistantViewModel : ReactiveTool
         TranslateCommand = ReactiveCommand.CreateFromTask(() => AskAsync(AiTask.Translate));
         GrammarCommand = ReactiveCommand.CreateFromTask(() => AskAsync(AiTask.Grammar));
         WordByWordCommand = ReactiveCommand.CreateFromTask(() => AskAsync(AiTask.WordByWord));
+        AskQuestionCommand = ReactiveCommand.CreateFromTask(() => AskAsync(AiTask.Ask));
         StopCommand = ReactiveCommand.Create(Stop);
         // No canExecute observable: WhenAnyValue needs ReactiveUI's builder initialised, which a plain
         // unit-test host does not do. The button binds IsEnabled to CanAsk instead, and a click that slips
@@ -108,6 +109,15 @@ public class AiAssistantViewModel : ReactiveTool
     public ReactiveCommand<Unit, Unit> TranslateCommand { get; }
     public ReactiveCommand<Unit, Unit> GrammarCommand { get; }
     public ReactiveCommand<Unit, Unit> WordByWordCommand { get; }
+
+    /// <summary>
+    /// Sends the typed question as the request itself, rather than as a rider on a preset.
+    ///
+    /// <para>Until this existed a reader with a question had to pick a preset to carry it — in practice
+    /// Explain — so the model was told to explain the passage AND answer a question, and the preset's
+    /// instructions competed with the question for what the answer should be about.</para>
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> AskQuestionCommand { get; }
     public ReactiveCommand<Unit, Unit> StopCommand { get; }
     public ReactiveCommand<AiTurnViewModel?, Unit> RetryCommand { get; }
 
@@ -148,8 +158,18 @@ public class AiAssistantViewModel : ReactiveTool
     public string Question
     {
         get => _question;
-        set => this.RaiseAndSetIfChanged(ref _question, value);
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _question, value);
+            this.RaisePropertyChanged(nameof(CanAskQuestion));
+        }
     }
+
+    /// <summary>
+    /// Whether there is a question to send. The four presets work with an empty box; this one is the
+    /// question, so an empty box means there is nothing to ask.
+    /// </summary>
+    public bool CanAskQuestion => CanAsk && !string.IsNullOrWhiteSpace(Question);
 
     /// <summary>
     /// Refusals that belong to the panel rather than to any turn — not configured, no book open. Kept off the
@@ -176,6 +196,7 @@ public class AiAssistantViewModel : ReactiveTool
         {
             this.RaiseAndSetIfChanged(ref _isBusy, value);
             this.RaisePropertyChanged(nameof(CanAsk));
+            this.RaisePropertyChanged(nameof(CanAskQuestion));
         }
     }
 

--- a/src/CST.Avalonia/ViewModels/AiTurnViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiTurnViewModel.cs
@@ -44,6 +44,7 @@ public sealed class AiTurnViewModel : ReactiveObject
         AiTask.Translate => "Translate",
         AiTask.Grammar => "Grammar",
         AiTask.WordByWord => "Word by word",
+        AiTask.Ask => "Question",
         _ => task.ToString(),
     };
 

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -51,14 +51,24 @@
                            TextWrapping="Wrap"
                            Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
 
+                <!-- Enter sends the question, which is what makes the box a question box rather than a
+                     modifier on whichever preset gets pressed next. -->
                 <TextBox Text="{Binding Question}"
-                         Watermark="Ask something about the passage (optional)"
+                         Watermark="Ask about the passage, or pick a preset below"
                          AcceptsReturn="False"
                          MaxHeight="90"
                          TextWrapping="Wrap"
-                         IsEnabled="{Binding CanAsk}"/>
+                         IsEnabled="{Binding CanAsk}">
+                    <TextBox.KeyBindings>
+                        <KeyBinding Gesture="Enter" Command="{Binding AskQuestionCommand}"/>
+                    </TextBox.KeyBindings>
+                </TextBox>
 
                 <WrapPanel Orientation="Horizontal">
+                    <!-- First, and disabled until something is typed: the other four are complete without a
+                         question, and this one IS the question. -->
+                    <Button Content="Ask" Command="{Binding AskQuestionCommand}"
+                            IsEnabled="{Binding CanAskQuestion}" Margin="0,0,10,4"/>
                     <Button Content="Explain" Command="{Binding ExplainCommand}"
                             IsEnabled="{Binding CanAsk}" Margin="0,0,4,4"/>
                     <Button Content="Translate" Command="{Binding TranslateCommand}"


### PR DESCRIPTION
> "If I ask a question — we don't have an 'Ask' button so I have been clicking 'Explain' —"

## Why the workaround was worse than it looked

The typed question was appended to whichever preset carried it. So the model was told to **explain the passage** *and* answer a question, and the preset's instructions competed with the question for what the answer should be about. A reader asking "which word is the verb?" got an explanation of the passage with their question addressed somewhere inside it, if at all.

## Ask as its own task

`AiTask.Ask`, with its own pair of templates (`ask.md` / `ask-selection.md`) following the same selection split as the other four.

**The question leads the prompt.** It is the request, not a rider on one; the passage follows as the context it is asked *from*. The instructions say so explicitly: answer what was asked, bring in the passage where it bears on the answer, don't summarize it for its own sake.

Two rules carried over from the grounding contract, because a free-form question is where they matter most:

- Where the question reaches past what was given — a whole sutta, a term across the canon, who someone is — say what was actually seen *before* answering, and reach for general knowledge only after saying that is what you're doing.
- Where nothing given answers it and general knowledge would only be a guess, say so. A plausible invention is the one answer worse than none.

With a selection, the question is about **the selection**, and the passage is demoted to context exactly as the other presets do it.

## The control

The button sits first and is **disabled until something is typed** — the four presets are complete without a question; this one *is* the question, so an empty box means there is nothing to ask. **Enter in the box sends it**, bound to the same command, which is what makes the box a question box rather than a modifier on whichever preset gets pressed next.

The passage budget matches Translate's, the most generous of the five: a reader's own question is the one task whose scope the app cannot predict.

## Testing

Full suite **1753 passed, 0 failed** (+7). Both new templates pass the same validation the app imposes on user edits, and the selection-demotion property is now asserted across all five tasks rather than four.

One existing assertion was relaxed: it pinned the exact sentence disclaiming the passage ("It is not what you were asked to translate"), and the new template phrases it "It is not what the question is about". The test now asserts the disclaimer exists rather than one phrasing of it.

**Not verified by me**: that Enter sends and the button greys correctly — both need a running window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)