### PR TITLE
Restate the column widths when the Assistant comes back

### DIFF
--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
@@ -285,6 +285,55 @@ public class CstDockFactoryTests
     }
 
     [Fact]
+    public void A_recreated_assistant_column_gets_a_real_share_of_the_window()
+    {
+        // Reported: reopening it from the View menu brought it back about a quarter of an inch wide -- worse
+        // than not coming back, since a reader who did not know to drag it would think the menu had failed.
+        //
+        // Closing empties the ToolDock, the cleanup pass collapses the wrapper and its splitter, and what is
+        // left no longer sums to one -- so the framework rebalances around it. Re-inserting a dock that says
+        // 0.18 into a row that has already been rebalanced gives it 18% of nothing in particular. The whole
+        // row has to be restated, which is what this asserts.
+        var f = new CstDockFactory();
+        // The drifted state a hide leaves behind: two columns sharing the whole window between them.
+        var doc = new DocumentDock { Id = "MainDocumentDock", Proportion = 0.75, VisibleDockables = List() };
+        var leftTools = new ProportionalDock { Id = "LeftTools", Proportion = 0.25, VisibleDockables = List() };
+        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(leftTools, doc) };
+        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
+        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
+        f._rootDock = root;
+        f._mainDock = mainDock;
+
+        f.EnsureRightToolDock();
+
+        var assistant = mainDock.VisibleDockables!.First(d => d.Id == "RightTools");
+        Assert.True(assistant.Proportion > 0.1, $"came back at {assistant.Proportion}");
+
+        // And the row adds up, so nothing is left for the framework to guess about.
+        var total = leftTools.Proportion + doc.Proportion + assistant.Proportion;
+        Assert.Equal(1.0, total, 3);
+    }
+
+    [Fact]
+    public void Hiding_the_assistant_hands_its_width_to_the_documents()
+    {
+        var f = new CstDockFactory();
+        var doc = new DocumentDock { Id = "MainDocumentDock", Proportion = 0.57, VisibleDockables = List() };
+        var leftTools = new ProportionalDock { Id = "LeftTools", Proportion = 0.25, VisibleDockables = List() };
+        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(leftTools, doc) };
+        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
+        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
+        f._rootDock = root;
+        f._mainDock = mainDock;
+
+        // The assistant is already gone, as it is by the time the hide path rebalances.
+        f.RebalanceMainDock();
+
+        Assert.Equal(0.75, doc.Proportion, 3);
+        Assert.Equal(1.0, leftTools.Proportion + doc.Proportion, 3);
+    }
+
+    [Fact]
     public void The_assistant_opens_narrower_than_the_documents()
     {
         // Reported: "the default width of the Assistant is too wide — often wider than the book area". Split

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1721,6 +1721,20 @@ namespace CST.Avalonia.Services
             InitDockable(rightTools, _mainDock);
             InitDockable(rightToolDock, rightTools);
 
+            // A recreated column comes back a quarter of an inch wide without this, which is worse than not
+            // coming back at all: a reader who did not know to drag it would think the menu item had failed.
+            //
+            // Closing the panel empties its ToolDock, and the cleanup pass then collapses the wrapper and its
+            // splitter — so what is left in MainDock no longer sums to one, and the framework rebalances
+            // around it. Re-inserting a dock with a Proportion of 0.18 into a MainDock that has already been
+            // rebalanced does not give it 18% of anything. So the whole row is restated, not just the new
+            // member, and restated again after layout has run, because the framework recomputes proportions
+            // on its own schedule and the last writer wins.
+            _mainDockAssistantProportion = AssistantProportion;
+            ApplyMainDockProportions();
+            Dispatcher.UIThread.Post(ApplyMainDockProportions, DispatcherPriority.Render);
+            Dispatcher.UIThread.Post(ApplyMainDockProportions, DispatcherPriority.Loaded);
+
             return rightToolDock;
         }
         
@@ -3108,6 +3122,56 @@ namespace CST.Avalonia.Services
         /// Capture the current main dock proportions before adding documents
         /// This preserves any user adjustments to the splitter position
         /// </summary>
+        /// <summary>
+        /// State the whole MainDock row at once — tools, documents, assistant — so the three always sum to
+        /// one. Unconditional, unlike <see cref="RestoreMainDockProportionsImpl"/>, which only acts when it
+        /// sees drift: after a column has been removed and rebuilt there is nothing to compare against, and
+        /// the values that need writing are frequently the ones already stored.
+        /// </summary>
+        private void ApplyMainDockProportions()
+        {
+            try
+            {
+                if (_mainDock?.VisibleDockables == null) return;
+
+                var left = _mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "LeftTools")
+                           ?? _mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "LeftToolDock");
+                var documents = _mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "MainDocumentDock");
+                var assistant = _mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "RightTools")
+                                ?? _mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "RightToolDock");
+
+                // Only the columns actually present get a share, so hiding one hands its width to the
+                // documents rather than leaving a gap the framework has to guess about.
+                var leftShare = left != null ? _mainDockLeftProportion : 0;
+                var assistantShare = assistant != null ? _mainDockAssistantProportion : 0;
+
+                if (left != null) left.Proportion = leftShare;
+                if (assistant != null) assistant.Proportion = assistantShare;
+                if (documents != null) documents.Proportion = 1.0 - leftShare - assistantShare;
+
+                _mainDockRightProportion = 1.0 - leftShare - assistantShare;
+
+                Log.Debug("*** ApplyMainDockProportions: left={Left:F3}, documents={Docs:F3}, assistant={Assistant:F3} ***",
+                    leftShare, 1.0 - leftShare - assistantShare, assistantShare);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "*** Error in ApplyMainDockProportions ***");
+            }
+        }
+
+        /// <summary>
+        /// Restate the column widths after a panel has been shown or hidden. The hide side matters as much as
+        /// the show side: without it the closed column's width is left unclaimed and the framework decides
+        /// what to do with it.
+        /// </summary>
+        internal void RebalanceMainDock()
+        {
+            ApplyMainDockProportions();
+            Dispatcher.UIThread.Post(ApplyMainDockProportions, DispatcherPriority.Render);
+            Dispatcher.UIThread.Post(ApplyMainDockProportions, DispatcherPriority.Loaded);
+        }
+
         private void CaptureMainDockProportions()
         {
             try

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -275,8 +275,13 @@ namespace CST.Avalonia.ViewModels
             ShowToolPanel("AiAssistantTool", () => App.ServiceProvider?.GetRequiredService<AiAssistantViewModel>(),
                 () => IsAssistantPanelVisible = true, "Assistant", right: true);
 
-        public void HideAssistantPanel() =>
+        public void HideAssistantPanel()
+        {
             HideToolPanel("AiAssistantTool", () => IsAssistantPanelVisible = false, "Assistant");
+
+            // Hand the freed width to the documents rather than leaving it unclaimed. (#656)
+            if (_factory is CstDockFactory factory) factory.RebalanceMainDock();
+        }
 
         // Recreate-on-demand so the View menu toggle and Cmd+D (Look Up in Dictionary) can reopen a closed
         // pane — LookUpInDictionaryAsync calls this then immediately proceeds, so it must stay synchronous. (#466)


### PR DESCRIPTION
Reopening the Assistant from the View menu brought it back about a quarter of an inch wide. That is worse than not coming back at all: a reader who did not know to drag it would conclude the menu item had failed.

## Cause

Closing the panel empties its `ToolDock`, and `CleanupEmptySplits` then collapses the `RightTools` wrapper and its splitter. What is left in `MainDock` no longer sums to one, so the framework rebalances around the gap.

Re-inserting a dock that *says* `Proportion = 0.18` into a row that has already been rebalanced does not give it 18% of anything — a proportion is one number in a set, and the set no longer agreed with itself.

## Fix

The whole row is restated rather than just the new member: tools, documents and assistant together, always summing to one, with only the columns actually present taking a share. Restated again after layout has run, because the framework recomputes on its own schedule and the last writer wins.

The **hide** side gets the same treatment, so a closed column hands its width to the documents instead of leaving it unclaimed for the framework to guess about.

`ApplyMainDockProportions` is deliberately unconditional, unlike the existing `RestoreMainDockProportions`, which only acts when it detects drift: after a column has been removed and rebuilt there is nothing to compare against, and the values that need writing are frequently the ones already stored.

## Testing

Full suite **1755 passed, 0 failed** (+2). Mutation-tested: without the restatement the recreated column comes back at the stale proportion and the row does not add up. Clean app startup.

**Not verified by me** — this is the same reopen gesture I could not perform last time, and the diagnosis above is reasoned from the cleanup path rather than observed. What the test pins is that the row sums to one and the assistant's share is real; whether that translates to the width you expect on screen still needs your eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)