### PR TITLE
Let the reasoning box take the height its text needs

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -672,22 +672,22 @@ public class AiAssistantViewModelTests
     }
 
     [Fact]
-    public void The_reasoning_panel_height_is_shared_and_cannot_be_dragged_to_nothing()
+    public void The_reasoning_ceiling_is_shared_and_cannot_be_dragged_to_nothing()
     {
         // The control this replaces could only SHRINK, with no floor and no way back: in Avalonia 11.3.6 a
         // GridSplitter as the last row computes a maximum delta of exactly zero, so it could never grow the
         // panel it existed to grow.
         var vm = new AiAssistantViewModel(null, null, null, null);
-        var start = vm.ReasoningHeight;
+        var start = vm.ReasoningMaxHeight;
 
         vm.ResizeReasoning(120);
-        Assert.Equal(start + 120, vm.ReasoningHeight);
+        Assert.Equal(start + 120, vm.ReasoningMaxHeight);
 
         vm.ResizeReasoning(-100000);
-        Assert.True(vm.ReasoningHeight >= 60, $"dragged away to {vm.ReasoningHeight}");
+        Assert.True(vm.ReasoningMaxHeight >= 60, $"dragged away to {vm.ReasoningMaxHeight}");
 
         vm.ResizeReasoning(100000);
-        Assert.True(vm.ReasoningHeight <= 1200);
+        Assert.True(vm.ReasoningMaxHeight <= 1200);
     }
 
     [Fact]

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -126,10 +126,14 @@ public class AiAssistantViewModel : ReactiveTool
     public ReactiveCommand<AiTurnViewModel, Unit> CopyCommand { get; }
     public ReactiveCommand<Unit, Unit> ClearCommand { get; }
 
-    private double _reasoningHeight = 240;
+    private double _reasoningMaxHeight = 240;
 
     /// <summary>
-    /// How tall the reasoning panel is, shared by every turn and dragged by the handle under it.
+    /// The MOST reasoning shown at once, shared by every turn and dragged by the handle under it.
+    ///
+    /// <para><b>A ceiling, not a height.</b> Bound as one, a short reasoning got a box twice its size and the
+    /// empty remainder pushed the answer down for nothing. As a maximum the box takes the height its text
+    /// needs and starts scrolling only once there is more than the reader asked to see.</para>
     ///
     /// <para>Shared rather than per-turn: a reader who has decided how much reasoning they want to see has
     /// decided it for the session, not for one answer. An earlier attempt used a GridSplitter per turn, on
@@ -137,14 +141,14 @@ public class AiAssistantViewModel : ReactiveTool
     /// because the ScrollViewer whose height actually matters is an ordinary control that binds like any
     /// other.</para>
     /// </summary>
-    public double ReasoningHeight
+    public double ReasoningMaxHeight
     {
-        get => _reasoningHeight;
-        set => this.RaiseAndSetIfChanged(ref _reasoningHeight, Math.Clamp(value, 60, 1200));
+        get => _reasoningMaxHeight;
+        set => this.RaiseAndSetIfChanged(ref _reasoningMaxHeight, Math.Clamp(value, 60, 1200));
     }
 
-    /// <summary>Drag the reasoning panel taller or shorter. Clamped, so it cannot be dragged to nothing.</summary>
-    public void ResizeReasoning(double delta) => ReasoningHeight += delta;
+    /// <summary>Drag the ceiling up or down. Clamped, so it cannot be dragged away to nothing.</summary>
+    public void ResizeReasoning(double delta) => ReasoningMaxHeight += delta;
 
     /// <summary>Every turn this session, oldest first. The panel scrolls; this is what it scrolls.</summary>
     public ObservableCollection<AiTurnViewModel> Turns { get; } = new();

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -203,8 +203,12 @@
                                          all, only shrink it, with no floor and no way back. Verified in the
                                          framework source, not assumed. -->
                                     <StackPanel>
+                                        <!-- MaxHeight, not Height: a short reasoning otherwise got a box
+                                             twice its size, and the empty remainder pushed the answer down
+                                             for nothing. As a ceiling the box takes the height its text
+                                             needs and scrolls only past what the reader asked to see. -->
                                         <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                                      Height="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).ReasoningHeight}">
+                                                      MaxHeight="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).ReasoningMaxHeight}">
                                             <!-- Its own right inset: this scroller has an overlay scrollbar
                                                  too, and reasoning is the longest unbroken text in the
                                                  panel, so it is where clipping shows first. -->


### PR DESCRIPTION
> "About the reasoning handle — if the text is smaller than the pre-configured size, can you make it smaller? I had one case where the box was about twice as big as the reasoning."

It was bound as `Height`, so every reasoning got the same box whatever it contained, and the empty remainder pushed the answer — the thing the reader came for — down the panel for nothing.

Bound as `MaxHeight` it becomes what it was always meant to be: **a ceiling on how much is shown at once, not a fixed size.** A short reasoning takes the height its text needs; a long one fills the ceiling and scrolls past it.

Dragging the handle still sets the ceiling, which is the question the reader is actually answering — *how much am I willing to give this at once*. One consequence worth knowing: while the content is shorter than the ceiling, dragging **down** has no visible effect, because there is nothing further to reveal. Dragging up still shrinks it immediately.

Renamed `ReasoningHeight` → `ReasoningMaxHeight` to match. A property called `ReasoningHeight` that is really a maximum invites the next person to bind it back to `Height`.

## Testing

Full suite **1755 passed, 0 failed** — unchanged, as expected for a layout change. Clean app startup.

**Not verified by me**: that a short reasoning now sits snug. `MaxHeight` on a `ScrollViewer` whose content is a wrapped `SelectableTextBlock` should measure to content, but that is the framework's arithmetic and I have no window to check it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)