### PR TITLE
Show the context a turn sent (#665)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -504,4 +504,30 @@ public class AiChatOrchestratorTests
     {
         Orchestrator(new FakeProvider()).Stop();
     }
+
+    [Fact]
+    public async Task The_started_event_carries_what_was_actually_sent()
+    {
+        // Assembled in the orchestrator because it is the only place holding the bundle, the rendered prompt
+        // and the resolved provider at once -- so it is also the only place that can be wrong about them
+        // without anything noticing.
+        var events = await CollectAsync(Orchestrator(new FakeProvider()));
+
+        var started = events.First(e => e.Kind == AiTurnEventKind.Started);
+        var sent = started.Context!.Sent;
+
+        Assert.NotNull(sent);
+        Assert.False(string.IsNullOrWhiteSpace(sent!.SystemPrompt));
+        Assert.False(string.IsNullOrWhiteSpace(sent.UserContent));
+
+        // The named fields a reader needs to tell one turn from another.
+        Assert.Contains(sent.Fields, f => f.Name == "Model");
+        Assert.Contains(sent.Fields, f => f.Name == "Provider");
+        Assert.Contains(sent.Fields, f => f.Name == "Book");
+        Assert.Contains(sent.Fields, f => f.Name == "Estimated context");
+
+        // Including every gathered part, present or absent: an absence is as much a part of what was sent as
+        // a presence, and much harder to notice.
+        Assert.Contains(sent.Fields, f => f.Name.StartsWith("Part: "));
+    }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -76,6 +76,11 @@ public class AiAssistantViewModelTests
             new BookContext("s0101m.mul.xml", "Sīlakkhandhavaggapāḷi", CST.Pitaka.Sutta, CST.CommentaryLevel.Mula),
             notices, passageTrimmed);
 
+    private static AiTurnContext ContextWithSent(SentContext sent) =>
+        new(AiTask.Explain, "English", Citation(),
+            new BookContext("s0101m.mul.xml", "Sīlakkhandhavaggapāḷi", CST.Pitaka.Sutta, CST.CommentaryLevel.Mula),
+            Array.Empty<string>(), false, sent);
+
     // ---- Not configured, and other ordinary refusals ---------------------------------------------
 
     [Fact]
@@ -558,6 +563,45 @@ public class AiAssistantViewModelTests
         Assert.Equal(AiTask.Ask, orchestrator.LastRequest!.Task);
         Assert.Equal("what governs bhavissanti?", orchestrator.LastRequest!.UserQuestion);
         Assert.Equal("Question", vm.LastTurn!.PresetLabel);
+    }
+
+    [Fact]
+    public async Task A_turn_keeps_what_it_sent_so_a_reader_can_read_it()
+    {
+        // Until this existed, the prompt was visible only at Debug level in a log file -- so the question a
+        // reader most wants answered about a surprising answer, "what did it actually see?", could not be
+        // answered from inside the app.
+        var sent = new SentContext(
+            new[] { new SentField("Model", "claude-sonnet-4-5"), new SentField("Part: passage", "Included") },
+            "You are a Pāli reading assistant.",
+            "## Passage\n\nappamādo amatapadaṃ");
+
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(ContextWithSent(sent)));
+        orchestrator.Events.Add(AiTurnEvent.ForCompleted(new PaliMarkerReport(0, 0)));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+        await vm.AskAsync(AiTask.Explain);
+
+        Assert.True(vm.LastTurn!.HasSent);
+        Assert.Equal("You are a Pāli reading assistant.", vm.LastTurn!.Sent!.SystemPrompt);
+        Assert.Contains("appamādo", vm.LastTurn!.Sent!.UserContent);
+        Assert.Contains(vm.LastTurn!.Sent!.Fields, f => f.Name == "Model" && f.Value == "claude-sonnet-4-5");
+    }
+
+    [Fact]
+    public async Task A_turn_that_sent_nothing_offers_nothing_to_read()
+    {
+        // The block is hidden rather than empty when a turn failed before it assembled a request: an empty
+        // "Context sent" would read as "nothing was sent", which is true but arrives as a defect.
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.Add(AiTurnEvent.ForCompleted(new PaliMarkerReport(0, 0)));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+        await vm.AskAsync(AiTask.Explain);
+
+        Assert.False(vm.LastTurn!.HasSent);
     }
 
     [Fact]

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -5,6 +5,8 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models;
+using CST.Navigation;
+using CST.Search;
 using Microsoft.Extensions.Logging;
 
 namespace CST.Avalonia.Services.Ai;
@@ -203,7 +205,8 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
             p => p.Name == BundlePartNames.Passage && p.State == BundlePartState.TrimmedForBudget);
 
         yield return AiTurnEvent.ForStarted(new AiTurnContext(
-            bundle.Task, bundle.OutputLanguage, bundle.Citation, bundle.Book, prompt.Notices, passageTrimmed));
+            bundle.Task, bundle.OutputLanguage, bundle.Citation, bundle.Book, prompt.Notices, passageTrimmed,
+            Describe(bundle, prompt, provider)));
 
         // ---- Stream.
         var chat = new ChatRequest(
@@ -336,6 +339,55 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
     /// <item>Neither — the cap is small enough that nothing could be produced at all.</item>
     /// </list>
     /// </summary>
+    /// <summary>
+    /// What this turn sent, as named fields plus the two prompt halves. Assembled here because this is the
+    /// only place that holds the bundle, the rendered prompt and the resolved provider at once. (#665)
+    /// </summary>
+    private static SentContext Describe(
+        AiContextBundle bundle, RenderedPrompt prompt, ChatProviderResolution provider)
+    {
+        var fields = new List<SentField>
+        {
+            new("Provider", provider.Provider.Id),
+            new("Model", provider.Model),
+            new("Request", bundle.Task.ToString()),
+            new("Answer language", bundle.OutputLanguage),
+            new("Book", bundle.Book.Name),
+            new("Book id", bundle.Book.BookId),
+            new("Reference", bundle.Citation.NormalizedReference),
+            new("Estimated context", $"~{bundle.Budget.ApproximateTokens:N0} tokens"),
+        };
+
+        if (bundle.Budget.ParagraphsCovered is int covered)
+            fields.Add(new SentField("Paragraphs covered", covered.ToString()));
+
+        if (bundle.Citation.Pages.Count > 0)
+            fields.Add(new SentField("Pages", string.Join(", ", bundle.Citation.Pages.Select(PageRef))));
+
+        // What each gathered part contributed, including the ones that contributed nothing — an absence is
+        // as much a part of what was sent as a presence, and harder to notice.
+        foreach (var part in bundle.Budget.Parts)
+        {
+            var detail = string.IsNullOrWhiteSpace(part.Detail) ? part.State.ToString() : $"{part.State} — {part.Detail}";
+            fields.Add(new SentField($"Part: {part.Name}", detail));
+        }
+
+        return new SentContext(fields, prompt.System, prompt.UserContent);
+    }
+
+    private static string PageRef(SnippetPageRef page)
+    {
+        var edition = page.Edition switch
+        {
+            PageEdition.Vri => "VRI",
+            PageEdition.Myanmar => "Myanmar",
+            PageEdition.Pts => "PTS",
+            PageEdition.Thai => "Thai",
+            _ => "other",
+        };
+        return page.Volume > 0 ? $"{edition} {page.Volume}.{page.Number}" : $"{edition} {page.Number}";
+    }
+
     private static string TruncationMessage(bool sawText, bool sawReasoning) =>
         sawText
             ? "This answer is incomplete: the model reached its output limit and stopped part-way through."

--- a/src/CST.Avalonia/Services/Ai/AiTurn.cs
+++ b/src/CST.Avalonia/Services/Ai/AiTurn.cs
@@ -71,7 +71,31 @@ public sealed record AiTurnContext(
     CitationRef Citation,
     BookContext Book,
     IReadOnlyList<string> Notices,
-    bool PassageTrimmed);
+    bool PassageTrimmed,
+    SentContext? Sent = null);
+
+/// <summary>
+/// Everything the turn actually sent, for the reader to look at. (#665)
+///
+/// <para><b>Why this is on the contract rather than in a log.</b> The prompt was visible only at Debug level
+/// in a file, so the one question a reader is most likely to have about a surprising answer — what did it
+/// actually see? — could not be answered from inside the app. The notices say what was DEGRADED; this says
+/// what was sent, which is a different and larger thing, and the two disagreeing is itself worth being able
+/// to notice.</para>
+///
+/// <para>It carries no secret: the API key is a header the provider adds, never part of a prompt. What is
+/// here is corpus text, the reader's own question, and the app's instructions — all three of which the reader
+/// is entitled to read, and the last of which they can edit.</para>
+/// </summary>
+/// <param name="Fields">Named values, in display order — provider, model, task, language, book, reference,
+/// pages, the estimated token count, and what each gathered part contributed.</param>
+public sealed record SentContext(
+    IReadOnlyList<SentField> Fields,
+    string SystemPrompt,
+    string UserContent);
+
+/// <summary>One named value in <see cref="SentContext.Fields"/>.</summary>
+public sealed record SentField(string Name, string Value);
 
 /// <summary>
 /// How the model quoted Pāli, counted rather than merely repaired. (#587)

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -353,6 +353,7 @@ public class AiAssistantViewModel : ReactiveTool
                 foreach (var notice in context.Notices) turn.Notices.Add(notice);
                 turn.RaiseNoticesChanged();
                 turn.IsPartialPassage = context.PassageTrimmed;
+                turn.Sent = context.Sent;
                 turn.Status = WaitingMessage(_elapsed.Elapsed, sawReasoning: false);
                 break;
 

--- a/src/CST.Avalonia/ViewModels/AiTurnViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiTurnViewModel.cs
@@ -196,6 +196,33 @@ public sealed class AiTurnViewModel : ReactiveObject
         internal set => this.RaiseAndSetIfChanged(ref _isPartialPassage, value);
     }
 
+    private SentContext? _sent;
+
+    /// <summary>
+    /// Everything this turn sent — named fields and both prompt halves. (#665)
+    ///
+    /// <para>Collapsed, like the notices, because it is reference material rather than part of the answer.
+    /// But unlike the notices, which say what was DEGRADED, this says what was SENT: the question a reader
+    /// most wants answered about a surprising answer is what the model actually saw, and until now that was
+    /// only visible at Debug level in a log file.</para>
+    /// </summary>
+    public SentContext? Sent
+    {
+        get => _sent;
+        internal set
+        {
+            this.RaiseAndSetIfChanged(ref _sent, value);
+            this.RaisePropertyChanged(nameof(HasSent));
+            this.RaisePropertyChanged(nameof(SentHeader));
+        }
+    }
+
+    public bool HasSent => _sent is not null;
+
+    public string SentHeader => _sent is null
+        ? "Context sent"
+        : $"Context sent ({_sent.Fields.Count} fields)";
+
     private string _usage = "";
     public string Usage
     {

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -294,6 +294,60 @@
                                     </ItemsControl>
                                 </Expander>
 
+                                <!-- Everything that was sent. Collapsed, like the notices, because it is
+                                     reference material rather than part of the answer — but where the
+                                     notices say what was DEGRADED, this says what was SENT, which is the
+                                     question a reader actually has when an answer surprises them. It was
+                                     previously visible only at Debug level in a log file.
+
+                                     Selectable throughout: the point of showing it is to be able to take it
+                                     somewhere else and compare. -->
+                                <Expander Header="{Binding SentHeader}"
+                                          IsVisible="{Binding HasSent}"
+                                          FontSize="11"
+                                          Margin="0,4,0,0">
+                                    <StackPanel Spacing="8">
+                                        <ItemsControl ItemsSource="{Binding Sent.Fields}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="ai:SentField">
+                                                    <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,2">
+                                                        <SelectableTextBlock Grid.Column="0"
+                                                                             Text="{Binding Name}"
+                                                                             FontSize="11"
+                                                                             FontWeight="SemiBold"
+                                                                             MinWidth="120"
+                                                                             Margin="0,0,8,0"/>
+                                                        <SelectableTextBlock Grid.Column="1"
+                                                                             Text="{Binding Value}"
+                                                                             FontSize="11"
+                                                                             TextWrapping="Wrap"/>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+
+                                        <TextBlock Text="System prompt" FontSize="11" FontWeight="SemiBold"/>
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                                      MaxHeight="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).ReasoningMaxHeight}">
+                                            <SelectableTextBlock Text="{Binding Sent.SystemPrompt}"
+                                                                 TextWrapping="Wrap"
+                                                                 FontSize="11"
+                                                                 Margin="0,0,10,0"
+                                                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                        </ScrollViewer>
+
+                                        <TextBlock Text="Message sent" FontSize="11" FontWeight="SemiBold"/>
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                                      MaxHeight="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).ReasoningMaxHeight}">
+                                            <SelectableTextBlock Text="{Binding Sent.UserContent}"
+                                                                 TextWrapping="Wrap"
+                                                                 FontSize="11"
+                                                                 Margin="0,0,10,0"
+                                                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                        </ScrollViewer>
+                                    </StackPanel>
+                                </Expander>
+
                                 <!-- What the turn cost, in time and tokens. The user is paying for both. -->
                                 <TextBlock Text="{Binding Footer}"
                                            IsVisible="{Binding HasFooter}"


### PR DESCRIPTION
> "It would be helpful for debugging and understanding the Assistant if we show the context in one of these expanding blocks. It should have everything that is sent in the turn. If there are named fields, show them too."

The prompt was visible only at **Debug level in a log file**, so the question a reader most wants answered about a surprising answer — *what did it actually see?* — could not be answered from inside the app.

The notices already say what was **degraded**. That is a different and much smaller thing than what was **sent**, and the two disagreeing is itself worth being able to notice.

## What the block contains

**Named fields**: provider, model, request, answer language, book and book id, reference, pages, estimated context tokens, paragraphs covered — and **what each gathered part contributed**, including the parts that contributed nothing. An absence is as much a part of what was sent as a presence, and much harder to see.

**The system prompt** and **the message**, verbatim.

Selectable throughout, because the point of showing it is to be able to take it somewhere else and compare. The prompt halves get the same draggable ceiling the reasoning block uses, so a 2,400-character passage does not push the answer off the screen.

## Two decisions worth naming

**Assembled in the orchestrator**, because that is the only place holding the bundle, the rendered prompt and the resolved provider at once — which also makes it the only place that could be wrong about them without anything noticing. So it gets its own test rather than being trusted.

**Hidden rather than empty** when a turn failed before assembling a request. An empty "Context sent" would be literally true and would read as a defect.

## Not a disclosure concern

The API key is a header the provider adds, never part of a prompt. What is here is corpus text, the reader's own question, and the app's instructions — all three of which the reader may read, and the last of which they can already edit.

## Testing

Full suite **1758 passed, 0 failed** (+3). Clean app startup.

**Not verified by me**: how the block reads at panel width. The field rows use a 120px label column against a wrapping value, which is a guess at a comfortable split — a one-line change if it is wrong.

Closes #665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)