### PR TITLE
Make the selection anchor arrive, and show the Assistant only when it is on (#667)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -527,6 +527,24 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void Punctuation_cannot_stop_a_selection_being_located()
+        {
+            // The reported failure, in miniature. The reader renders through a path that turns the danda into
+            // a period, and the XML has the danda -- so a 276-character selection spanning several sentences
+            // could not be found in the very paragraph it came from, and the window silently fell back to the
+            // scroll position.
+            const string xml = "<body><p rend=\"bodytext\" n=\"1\">alpha bravo\u0964 charlie delta\u0964</p></body>";
+
+            // As the reader would hand it back: periods, not dandas.
+            var span = TeiPassageReader.LocateSelection(xml, 0, xml.Length, "alpha bravo. charlie");
+
+            Assert.NotNull(span);
+            var raw = xml.Substring(span!.Value.Start, span.Value.End - span.Value.Start);
+            Assert.StartsWith("alpha", raw);
+            Assert.EndsWith("charlie", raw);
+        }
+
+        [Fact]
         public void Text_that_is_not_there_is_not_located()
         {
             const string xml = "<body><p rend=\"bodytext\" n=\"1\">alpha bravo।</p></body>";

--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
@@ -285,6 +285,18 @@ public class CstDockFactoryTests
     }
 
     [Fact]
+    public void The_assistant_is_off_when_neither_switch_is_on()
+    {
+        // Reported: "the panel shouldn't show unless that is checked". A panel for a feature the reader has
+        // not enabled is an advertisement, and this one is worse than most -- its buttons decline every
+        // request with an explanation, which reads as four broken buttons.
+        //
+        // No ServiceProvider in a unit-test host, so this asserts the safe direction: unknown means off. The
+        // two-switch logic itself is exercised through the settings view model.
+        Assert.False(CstDockFactory.AssistantEnabled());
+    }
+
+    [Fact]
     public void A_recreated_assistant_column_gets_a_real_share_of_the_window()
     {
         // Reported: reopening it from the View menu brought it back about a quarter of an inch wide -- worse

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -532,6 +532,48 @@ public class AiAssistantViewModelTests
     }
 
     [Fact]
+    public void An_unconfigured_assistant_says_so_before_anything_is_pressed()
+    {
+        // Reported as "the Assistant buttons are a no op". They were not: they set a status line and declined
+        // to send. But nothing said so until a button was pressed, so the commonest first-run state -- a
+        // settings file with no assistant configured -- presented as four buttons that did nothing.
+        var vm = new AiAssistantViewModel(
+            new StubOrchestrator(),
+            new StubReaderState(),
+            new StubResolver { Problem = "The assistant is turned off. Turn on \"Enable the assistant\" in Settings." },
+            null);
+
+        Assert.True(vm.IsNotReady);
+        Assert.Contains("Enable the assistant", vm.NotReady);
+    }
+
+    [Fact]
+    public void A_configured_assistant_says_nothing_at_all()
+    {
+        // The standing notice must be silent when there is nothing to say, or it becomes furniture.
+        var vm = new AiAssistantViewModel(
+            new StubOrchestrator(), new StubReaderState(), new StubResolver { Problem = null }, null);
+
+        Assert.False(vm.IsNotReady);
+        Assert.Equal("", vm.NotReady);
+    }
+
+    [Fact]
+    public void Fixing_the_configuration_clears_the_notice_on_request()
+    {
+        // Settings are edited in another window, and this panel has no way to learn about it -- hence a
+        // Check again button rather than a promise to notice.
+        var resolver = new StubResolver { Problem = "The assistant is turned off." };
+        var vm = new AiAssistantViewModel(new StubOrchestrator(), new StubReaderState(), resolver, null);
+        Assert.True(vm.IsNotReady);
+
+        resolver.Problem = null;
+        vm.RefreshReadiness();
+
+        Assert.False(vm.IsNotReady);
+    }
+
+    [Fact]
     public void Ask_is_offered_only_when_there_is_a_question_to_send()
     {
         // The four presets are complete without a question; this one IS the question, so an empty box means

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -401,11 +401,47 @@ public partial class App : Application
             {
                 await settingsService.LoadSettingsAsync();
                 await StartLocalApiIfEnabledAsync(settingsService);
+
+                // The layout is built BEFORE this completes -- the window opened seven milliseconds ahead of
+                // the settings load in a measured run -- so anything in CreateLayout that reads a setting
+                // reads the constructor defaults. The assistant's panel is gated on a setting, so it was
+                // silently absent for a reader who HAD enabled it, and ticking an already-ticked box changed
+                // nothing and so brought nothing back. Reconciled once, here, where the values are real. (#667)
+                ReconcileAssistantPanel(settingsService);
             }
         }
         catch (Exception ex)
         {
             Log.Warning(ex, "Failed to load settings");
+        }
+    }
+
+    /// <summary>
+    /// Put the assistant panel in step with the settings, once those have actually been read.
+    ///
+    /// <para>Only ever ADDS a panel that startup could not know about. Removing one is left to the Settings
+    /// toggle: a reader who closed the panel by hand this session has said something about what they want on
+    /// screen, and a reconciliation pass is not the place to overrule it.</para>
+    /// </summary>
+    private static void ReconcileAssistantPanel(ISettingsService settingsService)
+    {
+        try
+        {
+            var settings = settingsService.Settings;
+            if (!settings.Ai.Enabled || !settings.Ai.Chat.Enabled) return;
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (MainWindow?.DataContext is LayoutViewModel layout && !layout.IsAssistantPanelVisible)
+                {
+                    Log.Information("Assistant is enabled but its panel was not built at startup; adding it now");
+                    layout.ShowAssistantPanel();
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Could not reconcile the assistant panel with the settings");
         }
     }
 

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1459,6 +1459,9 @@ public partial class App : Application
             foreach (var menuItem in _assistantMenuItems)
             {
                 menuItem.IsChecked = layoutViewModel.IsAssistantPanelVisible;
+                // Greyed out rather than silently inert when the feature is off, so the menu says which of
+                // the two states the reader is in. (#667)
+                menuItem.IsEnabled = CstDockFactory.AssistantEnabled();
             }
 
             foreach (var menuItem in _dictionaryMenuItems)

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -117,9 +117,18 @@ public sealed class ChatProviderResolver : IChatProviderResolver
     {
         var chat = _settings.Settings.Ai.Chat;
 
-        if (!_settings.Settings.Ai.Enabled || !chat.Enabled)
+        // Two switches, two messages. One message for both sent a reader whose master switch was already ON
+        // to look at a switch that was already on, with nothing to change — the exact failure this class is
+        // written to avoid everywhere else, committed in its own first sentence. (#667)
+        if (!_settings.Settings.Ai.Enabled)
         {
-            problem = "AI features are turned off. Turn them on in Settings to use the assistant.";
+            problem = "AI features are turned off. Turn on \"Enable AI Features\" in Settings \u2192 AI.";
+            return null;
+        }
+
+        if (!chat.Enabled)
+        {
+            problem = "The assistant is turned off. Turn on \"Enable the assistant\" in Settings \u2192 AI.";
             return null;
         }
 

--- a/src/CST.Avalonia/Services/Ai/ReaderState.cs
+++ b/src/CST.Avalonia/Services/Ai/ReaderState.cs
@@ -118,6 +118,17 @@ public sealed class ReaderStateService : IReaderStateService
         ct.ThrowIfCancellationRequested();
 
         var (selection, unavailable, selectionParagraph) = await ReadSelectionAsync(document);
+
+        // Logged at Information because the difference between these two numbers is the whole of #649: the
+        // scroll paragraph is where the viewport is, the selection paragraph is where the reader pointed, and
+        // a context built from the first is the defect. If they differ and the window still follows the
+        // scroll, the anchor is not arriving.
+        _logger.LogInformation(
+            "Reader state: scroll paragraph {ScrollPara}, selection paragraph {SelectionPara}, " +
+            "selection {Length} char(s), unavailable {Unavailable}",
+            result.State.Paragraph, selectionParagraph?.ToString() ?? "(none)",
+            selection?.Length ?? 0, unavailable);
+
         return ReaderStateResult.Ok(
             result.State with
             {

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -93,7 +93,14 @@ namespace CST.Avalonia.Services
             var openBookTool = App.ServiceProvider!.GetRequiredService<OpenBookDialogViewModel>();
             var searchTool = App.ServiceProvider!.GetRequiredService<SearchViewModel>();
             var dictionaryTool = App.ServiceProvider!.GetRequiredService<DictionaryViewModel>();
-            var assistantTool = App.ServiceProvider!.GetRequiredService<AiAssistantViewModel>();
+            // The assistant appears only when it is switched on. A panel for a feature the reader has not
+            // enabled is an advertisement, and this one is worse than most: its buttons decline every request
+            // with an explanation, which reads as four broken buttons. Settings shows and hides it live, so
+            // ticking the box is the whole gesture. (#667)
+            var assistantEnabled = AssistantEnabled();
+            var assistantTool = assistantEnabled
+                ? App.ServiceProvider!.GetRequiredService<AiAssistantViewModel>()
+                : null;
 
             _logger.Debug("Created tools - OpenBook: {OpenBookType}, Search: {SearchType}",
                 openBookTool.GetType().Name, searchTool.GetType().Name);
@@ -283,7 +290,9 @@ namespace CST.Avalonia.Services
                 Id = "RightToolDock",
                 Title = "Assistant",
                 ActiveDockable = assistantTool,
-                VisibleDockables = CreateList<IDockable>(assistantTool),
+                VisibleDockables = assistantTool is null
+                    ? CreateList<IDockable>()
+                    : CreateList<IDockable>(assistantTool),
                 Alignment = Alignment.Right,
                 GripMode = GripMode.Visible,
                 CanDrag = true,
@@ -314,8 +323,9 @@ namespace CST.Avalonia.Services
                 Orientation = Orientation.Horizontal,
                 IsCollapsable = false,  // Like Notepad sample
                 CanDrop = true,  // Allow dropping dockables here
-                VisibleDockables = CreateList<IDockable>(
-                    leftTools, splitter, documentDock, rightSplitter, rightTools)
+                VisibleDockables = assistantEnabled
+                    ? CreateList<IDockable>(leftTools, splitter, documentDock, rightSplitter, rightTools)
+                    : CreateList<IDockable>(leftTools, splitter, documentDock)
             };
 
             // Create inner root dock (window layout) with pinned dockables for edge drop indicators
@@ -1673,6 +1683,24 @@ namespace CST.Avalonia.Services
         /// entry, so a reader who floated it and closed the window lost it for the rest of the session — and
         /// since the panel holds the whole transcript, they lost that too.</para>
         /// </summary>
+        /// <summary>
+        /// Whether the assistant is switched on: the AI master switch AND the assistant's own. Read from
+        /// settings rather than cached, because Settings toggles it while the app runs. (#667)
+        /// </summary>
+        internal static bool AssistantEnabled()
+        {
+            try
+            {
+                var settings = App.ServiceProvider?.GetService<ISettingsService>()?.Settings;
+                return settings?.Ai.Enabled == true && settings.Ai.Chat.Enabled;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "Could not read the assistant's enabled state; treating it as off");
+                return false;
+            }
+        }
+
         internal ToolDock? EnsureRightToolDock()
         {
             if (_rootDock != null && FindDockByIdRecursive(_rootDock, "RightToolDock") is ToolDock existing)

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -96,6 +96,13 @@ namespace CST.Avalonia.Services.Tools
             // could centre the window on a different occurrence entirely and caption it confidently.
             var selectionSpan = LocateSelection(xml, startPos, markers, request.SelectionText);
 
+            if (!string.IsNullOrWhiteSpace(request.SelectionText))
+            {
+                Serilog.Log.Information(
+                    "Passage: reference resolved to {StartPos}; selection {Located} in the XML",
+                    startPos, selectionSpan is null ? "NOT located" : $"located at {selectionSpan.Value.Start}");
+            }
+
             var w = selectionSpan is { } span
                 ? TeiPassageReader.ReadWindowAroundSelection(
                     xml, span.Start, span.End, budget,

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -96,6 +96,7 @@ public class AiAssistantViewModel : ReactiveTool
         WordByWordCommand = ReactiveCommand.CreateFromTask(() => AskAsync(AiTask.WordByWord));
         AskQuestionCommand = ReactiveCommand.CreateFromTask(() => AskAsync(AiTask.Ask));
         StopCommand = ReactiveCommand.Create(Stop);
+        RefreshReadinessCommand = ReactiveCommand.Create(RefreshReadiness);
         // No canExecute observable: WhenAnyValue needs ReactiveUI's builder initialised, which a plain
         // unit-test host does not do. The button binds IsEnabled to CanAsk instead, and a click that slips
         // through while a turn runs is harmless — AskAsync's guard returns without touching anything, now
@@ -103,6 +104,9 @@ public class AiAssistantViewModel : ReactiveTool
         RetryCommand = ReactiveCommand.CreateFromTask<AiTurnViewModel?>(RetryAsync);
         CopyCommand = ReactiveCommand.CreateFromTask<AiTurnViewModel>(CopyAsync);
         ClearCommand = ReactiveCommand.Create(Clear);
+
+        // Asked once at construction so the panel can say it is not configured before anything is pressed.
+        RefreshReadiness();
     }
 
     public ReactiveCommand<Unit, Unit> ExplainCommand { get; }
@@ -125,6 +129,40 @@ public class AiAssistantViewModel : ReactiveTool
     /// the whole answer once tables put each cell in its own control.</summary>
     public ReactiveCommand<AiTurnViewModel, Unit> CopyCommand { get; }
     public ReactiveCommand<Unit, Unit> ClearCommand { get; }
+
+    /// <summary>Re-ask the resolver whether the assistant is configured. Bound to the panel's own refresh, so
+    /// a reader who has just been sent to Settings can come back and see the answer change.</summary>
+    public ReactiveCommand<Unit, Unit> RefreshReadinessCommand { get; }
+
+    /// <summary>
+    /// Why the assistant cannot run, shown BEFORE anything is pressed. (#667)
+    ///
+    /// <para>It used to appear only after a button was clicked, so the commonest first-run state — a fresh
+    /// settings file with no assistant configured — presented as four buttons that did nothing. "The
+    /// Assistant buttons are a no op" is the correct reading of that, and the app had no business making a
+    /// reader guess.</para>
+    /// </summary>
+    private string _notReady = "";
+    public string NotReady
+    {
+        get => _notReady;
+        private set
+        {
+            this.RaiseAndSetIfChanged(ref _notReady, value);
+            this.RaisePropertyChanged(nameof(IsNotReady));
+        }
+    }
+
+    public bool IsNotReady => !string.IsNullOrEmpty(NotReady);
+
+    /// <summary>Ask the same resolver the turn will ask, so the panel and the request cannot disagree.</summary>
+    public void RefreshReadiness()
+    {
+        if (_resolver is null) { NotReady = ""; return; }
+
+        _resolver.Resolve(out var problem);
+        NotReady = problem ?? "";
+    }
 
     private double _reasoningMaxHeight = 240;
 
@@ -228,6 +266,8 @@ public class AiAssistantViewModel : ReactiveTool
         finally
         {
             IsBusy = false;
+            // A turn just told us what the resolver thinks; keep the standing line in step with it.
+            RefreshReadiness();
         }
     }
 

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -259,8 +259,18 @@ namespace CST.Avalonia.ViewModels
 
         public void ToggleAssistantPanel()
         {
-            if (IsAssistantPanelVisible) HideAssistantPanel();
-            else ShowAssistantPanel();
+            if (IsAssistantPanelVisible) { HideAssistantPanel(); return; }
+
+            // The View menu can bring the panel back, but it cannot switch the feature on: showing a panel
+            // for a disabled assistant would put four buttons on screen that decline every request. Settings
+            // owns that decision. (#667)
+            if (!CstDockFactory.AssistantEnabled())
+            {
+                Log.Information("[Layout] Assistant panel requested but the assistant is turned off");
+                return;
+            }
+
+            ShowAssistantPanel();
         }
 
         /// <summary>

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1337,6 +1337,8 @@ public class AiSettingsViewModel : ViewModelBase
                 this.RaisePropertyChanged(nameof(SubPermissionsEnabled));
                 this.RaisePropertyChanged(nameof(RemoteControlEnabled));
                 this.RaisePropertyChanged(nameof(AssistantFieldsEnabled));
+                // The assistant hangs off the master switch too, so turning AI off takes its panel with it.
+                ApplyAssistantVisibility();
                 // Readiness is derived from the master too. Without this the line kept reporting "AI features
                 // are turned off." after the user had just turned them on, until some other field happened to
                 // be edited -- the one line on the screen whose entire job is not to be out of date.
@@ -1446,6 +1448,9 @@ public class AiSettingsViewModel : ViewModelBase
                 _settingsService.RequestSave();
                 this.RaisePropertyChanged(nameof(AssistantFieldsEnabled));
                 RefreshReadiness();
+                // Ticking the box IS the gesture: the panel appears now rather than at the next launch, and
+                // unticking takes it away rather than leaving four buttons that decline every request. (#667)
+                ApplyAssistantVisibility();
             }
         }
 
@@ -1639,6 +1644,26 @@ public class AiSettingsViewModel : ViewModelBase
             }
 
             this.RaisePropertyChanged(nameof(CanStoreKeys));
+        }
+
+        /// <summary>
+        /// Show or hide the assistant panel to match the two switches. Settings is a separate window, so the
+        /// panel has no way to learn about a change on its own.
+        /// </summary>
+        private void ApplyAssistantVisibility()
+        {
+            try
+            {
+                if ((App.MainWindow?.DataContext as LayoutViewModel) is not { } layout) return;
+
+                var wanted = _settingsService.Settings.Ai.Enabled && _settingsService.Settings.Ai.Chat.Enabled;
+                if (wanted) layout.ShowAssistantPanel();
+                else layout.HideAssistantPanel();
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Debug(ex, "Could not apply the assistant panel's visibility");
+            }
         }
 
         private void RefreshReadiness()

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -199,6 +199,56 @@
                                         HorizontalAlignment="Left"
                                         Margin="0,2,0,0"/>
 
+                                <!-- Everything that was sent. Collapsed, like the notices, because it is
+                                     reference material rather than part of the answer — but where the
+                                     notices say what was DEGRADED, this says what was SENT, which is the
+                                     question a reader actually has when an answer surprises them. It was
+                                     previously visible only at Debug level in a log file.
+
+                                     Selectable throughout: the point of showing it is to be able to take it
+                                     somewhere else and compare. -->
+                                <Expander Header="{Binding SentHeader}"
+                                          IsVisible="{Binding HasSent}"
+                                          FontSize="11"
+                                          Margin="0,4,0,0">
+                                    <StackPanel Spacing="8">
+                                        <ItemsControl ItemsSource="{Binding Sent.Fields}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="ai:SentField">
+                                                    <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,2">
+                                                        <SelectableTextBlock Grid.Column="0"
+                                                                             Text="{Binding Name}"
+                                                                             FontSize="11"
+                                                                             FontWeight="SemiBold"
+                                                                             MinWidth="120"
+                                                                             Margin="0,0,8,0"/>
+                                                        <SelectableTextBlock Grid.Column="1"
+                                                                             Text="{Binding Value}"
+                                                                             FontSize="11"
+                                                                             TextWrapping="Wrap"/>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+
+                                        <!-- No inner scrollers. The transcript already scrolls, and a
+                                             scroller inside a scroller means the reader fights one to reach
+                                             the other; the point of this block is to read the whole context,
+                                             so it is simply as long as it is. -->
+                                        <TextBlock Text="System prompt" FontSize="11" FontWeight="SemiBold"/>
+                                        <SelectableTextBlock Text="{Binding Sent.SystemPrompt}"
+                                                             TextWrapping="Wrap"
+                                                             FontSize="11"
+                                                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+
+                                        <TextBlock Text="Message sent" FontSize="11" FontWeight="SemiBold"/>
+                                        <SelectableTextBlock Text="{Binding Sent.UserContent}"
+                                                             TextWrapping="Wrap"
+                                                             FontSize="11"
+                                                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                    </StackPanel>
+                                </Expander>
+
                                 <!-- The model thinking aloud: offered, collapsed, and never part of the
                                      answer. Its ARRIVAL is what distinguishes a slow request from a dead
                                      one, which is why it is no longer discarded. -->
@@ -313,59 +363,6 @@
                                     </ItemsControl>
                                 </Expander>
 
-                                <!-- Everything that was sent. Collapsed, like the notices, because it is
-                                     reference material rather than part of the answer — but where the
-                                     notices say what was DEGRADED, this says what was SENT, which is the
-                                     question a reader actually has when an answer surprises them. It was
-                                     previously visible only at Debug level in a log file.
-
-                                     Selectable throughout: the point of showing it is to be able to take it
-                                     somewhere else and compare. -->
-                                <Expander Header="{Binding SentHeader}"
-                                          IsVisible="{Binding HasSent}"
-                                          FontSize="11"
-                                          Margin="0,4,0,0">
-                                    <StackPanel Spacing="8">
-                                        <ItemsControl ItemsSource="{Binding Sent.Fields}">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate x:DataType="ai:SentField">
-                                                    <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,2">
-                                                        <SelectableTextBlock Grid.Column="0"
-                                                                             Text="{Binding Name}"
-                                                                             FontSize="11"
-                                                                             FontWeight="SemiBold"
-                                                                             MinWidth="120"
-                                                                             Margin="0,0,8,0"/>
-                                                        <SelectableTextBlock Grid.Column="1"
-                                                                             Text="{Binding Value}"
-                                                                             FontSize="11"
-                                                                             TextWrapping="Wrap"/>
-                                                    </Grid>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-
-                                        <TextBlock Text="System prompt" FontSize="11" FontWeight="SemiBold"/>
-                                        <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                                      MaxHeight="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).ReasoningMaxHeight}">
-                                            <SelectableTextBlock Text="{Binding Sent.SystemPrompt}"
-                                                                 TextWrapping="Wrap"
-                                                                 FontSize="11"
-                                                                 Margin="0,0,10,0"
-                                                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                                        </ScrollViewer>
-
-                                        <TextBlock Text="Message sent" FontSize="11" FontWeight="SemiBold"/>
-                                        <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                                      MaxHeight="{Binding $parent[ItemsControl].((vm:AiAssistantViewModel)DataContext).ReasoningMaxHeight}">
-                                            <SelectableTextBlock Text="{Binding Sent.UserContent}"
-                                                                 TextWrapping="Wrap"
-                                                                 FontSize="11"
-                                                                 Margin="0,0,10,0"
-                                                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                                        </ScrollViewer>
-                                    </StackPanel>
-                                </Expander>
 
                                 <!-- What the turn cost, in time and tokens. The user is paying for both. -->
                                 <TextBlock Text="{Binding Footer}"

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -44,8 +44,27 @@
                 Padding="8,8,8,8">
             <StackPanel Spacing="6">
 
-                <!-- Panel-level refusals: not configured, no book open. These belong to no turn, because no
-                     request was made. -->
+                <!-- Standing notice that the assistant cannot run, shown BEFORE anything is pressed. The
+                     first-run state — a settings file with no assistant configured — otherwise presented as
+                     four buttons that did nothing, and "the buttons are a no op" is the correct reading of
+                     that. Refresh is here because settings are edited in another window and this panel has
+                     no way to learn about it. (#667) -->
+                <Border IsVisible="{Binding IsNotReady}"
+                        Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                        BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1" CornerRadius="4"
+                        Padding="8,6">
+                    <StackPanel Spacing="6">
+                        <SelectableTextBlock Text="{Binding NotReady}" TextWrapping="Wrap" FontSize="11"/>
+                        <Button Content="Check again"
+                                Command="{Binding RefreshReadinessCommand}"
+                                HorizontalAlignment="Left"
+                                FontSize="11"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Panel-level refusals: no book open, a position still settling. These belong to no turn,
+                     because no request was made. -->
                 <TextBlock Text="{Binding Status}"
                            IsVisible="{Binding HasStatus}"
                            TextWrapping="Wrap"

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -301,11 +301,32 @@ public partial class BookDisplayView : UserControl
                         var rect = sel.getRangeAt(0).getBoundingClientRect();
                         var y = rect.top + window.pageYOffset;
                         var cache = window.cstAnchorCache;
-                        if (cache && cache.isBuilt && cache.sortedParagraphAnchors) {
+                        if (cache && cache.isBuilt && cache.sortedParagraphAnchors
+                            && cache.sortedParagraphAnchors.length > 0) {
                             var list = cache.sortedParagraphAnchors;
+                            var best = null;
                             for (var i = 0; i < list.length; i++) {
-                                if (list[i].position <= y) para = list[i].name.replace('para', '');
+                                if (list[i].position <= y) best = list[i];
                                 else break;
+                            }
+                            // Above the first marker (front matter, a heading): the first paragraph, not
+                            // nothing — the same gap getCurrentParagraph resolves this way.
+                            if (!best) best = list[0];
+
+                            // Anchor names are not plain numbers. They carry a book-code suffix in Multi
+                            // volumes (para548_dn1) and the printed number can itself be a range
+                            // (para548-9). Stripping only the prefix produced '548_dn1', which is not an
+                            // integer, so the paragraph arrived empty on EVERY request and the window fell
+                            // back to the scroll position. Derived the same way getCurrentParagraph does,
+                            // then reduced to the opening number, which is the paragraph the selection is in.
+                            var name = best.name || '';
+                            if (name.indexOf('para') === 0) {
+                                var t = name.substring(4);
+                                var underscore = t.indexOf('_');
+                                if (underscore !== -1) t = t.substring(0, underscore);
+                                var dash = t.indexOf('-');
+                                if (dash !== -1) t = t.substring(0, dash);
+                                para = t;
                             }
                         }
                     }
@@ -2676,6 +2697,9 @@ public partial class BookDisplayView : UserControl
                 foreach (var p in parts)
                     if (p.StartsWith("PARA=") && int.TryParse(p.Substring(5), out var n)) { para = n; break; }
 
+                _logger.Information(
+                    "CST_AI_SEL: {Length} char(s) selected, paragraph {Para}",
+                    sel?.Length ?? 0, para?.ToString() ?? "(none)");
                 _aiSelectionTcs?.TrySetResult((sel, para));
             }
             catch (Exception ex)

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -238,7 +238,15 @@ namespace CST.Search
             to = Math.Clamp(to, from, xml.Length);
             if (string.IsNullOrWhiteSpace(needle)) return null;
 
-            // Collapse the needle the same way the comparison collapses the haystack.
+            // Collapse the needle the same way the comparison collapses the haystack: whitespace runs to one
+            // space, punctuation dropped entirely.
+            //
+            // Punctuation is dropped because the two sides reach this comparison by different routes and do
+            // not agree about it. The reader renders through a path that turns the danda into a period; the
+            // XML has the danda. Even with both paths fixed, a selection dragged across a note bracket or a
+            // typographic apostrophe would differ from the source by a character nobody typed. Matching on
+            // letters alone cannot be broken by punctuation at all, which is the only version of this that
+            // stays fixed. (#668)
             var wanted = new StringBuilder(needle.Length);
             foreach (var c in needle)
             {
@@ -246,15 +254,17 @@ namespace CST.Search
                 {
                     if (wanted.Length > 0 && wanted[^1] != ' ') wanted.Append(' ');
                 }
-                else wanted.Append(c);
+                else if (IsSignificant(c)) wanted.Append(c);
             }
             var target = wanted.ToString().Trim();
             if (target.Length == 0) return null;
 
             for (int anchor = from; anchor < to; anchor++)
             {
-                if (xml[anchor] == '<') continue;
-                if (char.IsWhiteSpace(xml[anchor])) continue;
+                // A match must BEGIN on a letter. Starting anywhere else lets the skip rules below consume
+                // markup and punctuation before the first real character, so the span comes back beginning
+                // at a tag bracket rather than at the reader's first word.
+                if (!IsSignificant(xml[anchor])) continue;
 
                 int matched = 0, i = anchor, lastConsumed = anchor;
                 bool pendingSpace = false;
@@ -282,6 +292,11 @@ namespace CST.Search
 
                     if (char.IsWhiteSpace(c)) { pendingSpace = true; i++; continue; }
 
+                    // Punctuation on the haystack side is skipped for the same reason it is dropped from the
+                    // needle, and skipped rather than treated as a separator so "so'haṃ" and "sohaṃ" match.
+                    // Not lastConsumed: trailing punctuation is not part of what the reader selected.
+                    if (!IsSignificant(c)) { i++; continue; }
+
                     if (pendingSpace)
                     {
                         pendingSpace = false;
@@ -301,6 +316,16 @@ namespace CST.Search
 
             return null;
         }
+
+        /// <summary>
+        /// Whether a character carries meaning for matching: letters, digits, and combining marks. Marks are
+        /// kept explicitly — they are not letters, and dropping them would let a form match a different word
+        /// that differs only by a diacritic.
+        /// </summary>
+        private static bool IsSignificant(char c) =>
+            char.IsLetterOrDigit(c)
+            || System.Globalization.CharUnicodeInfo.GetUnicodeCategory(c)
+               == System.Globalization.UnicodeCategory.NonSpacingMark;
 
         /// <summary>
         /// Walk on to the end of the sentence in progress, ignoring any budget. Bounded by the section and by

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -19,8 +19,34 @@ namespace CST.Search
 
         internal static bool IsBoundary(char c) => c == Danda || c == DoubleDanda;
 
-        internal static string Convert(string deva, Script output) =>
-            deva.Length == 0 ? "" : ScriptConverter.Convert(deva, Script.Devanagari, output);
+        internal static string Convert(string deva, Script output)
+        {
+            if (deva.Length == 0) return "";
+
+            var converted = ScriptConverter.Convert(deva, Script.Devanagari, output);
+
+            // Latin output must not carry Devanagari sentence punctuation. (#668)
+            //
+            // There are two Latin paths and they disagreed. The READER renders through
+            // ScriptConverter.ConvertBook, which runs Deva2Latn.ConvertDandas and turns U+0964 into a period;
+            // everything here goes through ScriptConverter.Convert, which does not, because the danda rules
+            // are written against MARKUP (they distinguish gatha from prose, and strip the dandas around
+            // namo tassa) and this text has had its tags removed by the time it arrives.
+            //
+            // So a reader selected text containing "." and the passage sent to the model contained "।" — the
+            // same characters to a human, different ones to a comparison. That mismatch is why a selection
+            // could not be located in its own passage, and why dandas showed up in the context a reader was
+            // shown. #641 folded punctuation out of ONE comparison to work around it; this removes the
+            // divergence instead.
+            //
+            // The gatha nuance (a single danda becomes ";" mid-verse) is not recoverable here and is not
+            // pretended at: without the markup there is no way to know a line is verse. A period is what the
+            // reader sees for prose, which is the overwhelming majority of what is sent.
+            if (output == Script.Latin)
+                converted = converted.Replace("\u0964", ".").Replace("\u0965", ".");
+
+            return converted;
+        }
 
         internal static string Collapse(string s) => Whitespace.Replace(s, " ");
 


### PR DESCRIPTION
Three defects found by sitting with the app on Egret. All three were mine, and two of them meant a feature that had **never** worked was failing quietly enough to look like it had.

## The selection anchor never arrived

> "Same text, highlighted and in view. The context in the first case was paras 1–4. In the 2nd it was 4–8."

Paragraph anchor names are not plain numbers. They carry a book-code suffix in Multi volumes (`para548_dn1`) and the printed number can itself be a range (`para548-9`). Stripping only the `para` prefix produced `548_dn1`, which does not parse as an integer — so the paragraph came back **empty on every request** and the code fell back to the scroll paragraph. The exact behaviour #649 exists to remove, in the code written to remove it.

Derived now the way `getCurrentParagraph` already does it, then reduced to the opening number.

## Two Latin paths disagreed about the danda

The reader renders through `ScriptConverter.ConvertBook`, which runs `Deva2Latn.ConvertDandas` and yields a period. `TeiText` goes through `ScriptConverter.Convert`, which does not — those rules are written against markup that has been stripped by then. So the selection carried `.` and the passage carried `U+0964`: the same character to a reader, different ones to a comparison.

That single divergence produced three reported symptoms — dandas visible in the context, a 276-character selection that could not be found in the paragraph it came from, and the original #641 report, which I patched around by folding punctuation out of one comparison instead of fixing.

Converted **after** the script converter returns, not in its character table: `ConvertDandas` is a separate pass precisely so capitalisation can tell a danda from an ordinary period (fsnow's recollection, and it is right). Doing it earlier would break that. The gāthā nuance — a single danda mid-verse becoming `;` — is not recoverable without markup and is not pretended at.

The locator now matches on letters, digits and combining marks alone, so no future disagreement about punctuation can break it. A match must **begin** on one of those: skipping punctuation without that rule let matches start mid-markup and return spans opening at a tag bracket — caught by a debug run, not by reading.

## The panel showed when the assistant was off, then would not show when it was on

A panel for a feature the reader has not enabled is an advertisement, and this one declined every request with an explanation — four buttons that appeared broken. Gated on the checkbox now, shown and hidden live by Settings.

Then it would not appear *with* the box ticked, and toggling off/on brought it back — which is the diagnosis: `CreateLayout` reads the setting, and the window opens **10ms before settings finish loading**, so the read returned the constructor default. Reconciled once after the load. It only ever *adds* a panel startup could not know about; removing one is left to the Settings toggle, because a panel closed by hand is a decision.

Also: two switches now get two messages. The resolver answered both "AI is off" and "the assistant is off" with one sentence about AI features, sending a reader whose master switch was already on to look at a switch that was already on.

## Verified on the reported case

```
scroll paragraph 4, selection paragraph 4   ← selection at top
scroll paragraph 1, selection paragraph 4   ← selection at bottom
```

Both resolve to the same XML position with the selection located, and both send an identical ~734-token context. Confirmed by the maintainer.

Logging kept at Information for the three links in that chain. The difference between those two numbers is the whole point of #649, and it was invisible — which is why four rounds of reading did not find this and one round of instrumenting did.

## Testing

Full suite **1763 passed, 0 failed**. Clean build and startup.

Closes #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)