### PR TITLE
Resolve the selection's paragraph by document order, not by pixels

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -527,6 +527,48 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
+        public void A_selection_opening_a_section_never_draws_context_from_the_one_before()
+        {
+            // The reported case. The selection was the first sentence of the first paragraph of a sutta, and
+            // the context reached back into the previous sutta -- rule 4, "do not cross a div boundary,
+            // because that gets into a different section/sutta/book".
+            const string twoSuttas =
+                "<body><div id=\"b\" type=\"book\">" +
+                "<div id=\"s1\" type=\"sutta\"><p rend=\"bodytext\" n=\"330\">" +
+                "old one\u0964 old two\u0964 old three\u0964 old four\u0964</p></div>" +
+                "<div id=\"s2\" type=\"sutta\"><p rend=\"bodytext\" n=\"331\">" +
+                "opening line\u0964 second line\u0964 third line\u0964</p></div>" +
+                "</div></body>";
+            var markers = BookMarkers.Build(twoSuttas);
+            var (from, to) = Span(twoSuttas, "opening line");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                twoSuttas, from, to, maxChars: 400, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Contains("opening line", window.Text);
+            Assert.Contains("third line", window.Text);      // the unspendable backward half goes forward
+            Assert.DoesNotContain("old four", window.Text);  // and never back across the boundary
+            Assert.DoesNotContain("old one", window.Text);
+        }
+
+        [Fact]
+        public void Attribute_text_is_never_matchable()
+        {
+            // A selection opening "331." matched the n="331" of the paragraph's own <p> element and returned
+            // a span beginning inside markup. The needle here appears ONLY inside an attribute, so a match of
+            // any kind proves the scanner is reading markup as text.
+            const string xml =
+                "<body><p rend=\"bodytext\" n=\"331\">alpha bravo\u0964</p></body>";
+
+            Assert.Null(TeiPassageReader.LocateSelection(xml, 0, xml.Length, "bodytext"));
+            Assert.Null(TeiPassageReader.LocateSelection(xml, 0, xml.Length, "331"));
+
+            // And real text is still found.
+            Assert.NotNull(TeiPassageReader.LocateSelection(xml, 0, xml.Length, "alpha bravo"));
+        }
+
+        [Fact]
         public void Punctuation_cannot_stop_a_selection_being_located()
         {
             // The reported failure, in miniature. The reader renders through a path that turns the danda into

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -67,6 +67,18 @@ namespace CST.Avalonia.Services.Tools
             return TeiPassageReader.LocateSelection(xml, startPos, sectionEnd, needle);
         }
 
+        /// <summary>
+        /// The end of the paragraph starting at <paramref name="from"/> — its own closing tag, or the end of
+        /// its section. Used as the stand-in span when a selection could not be located, so the window is
+        /// still section-bounded rather than free-running.
+        /// </summary>
+        private static int ParagraphEnd(string xml, int from, BookMarkers markers)
+        {
+            var sectionEnd = markers.EnclosingDivRange(from).End;
+            var close = xml.IndexOf("</p>", from, StringComparison.Ordinal);
+            return close < 0 || close > sectionEnd ? sectionEnd : close;
+        }
+
         public async Task<PassageResult> FetchPassageAsync(PassageRequest request, CancellationToken ct = default)
         {
             var dir = _settings.Settings?.XmlBooksDirectory;
@@ -103,7 +115,17 @@ namespace CST.Avalonia.Services.Tools
                     startPos, selectionSpan is null ? "NOT located" : $"located at {selectionSpan.Value.Start}");
             }
 
-            var w = selectionSpan is { } span
+            // When a selection was supplied but could not be located, the window is still built the
+            // selection way -- around the referenced PARAGRAPH's own span. Falling back to ReadWindow was
+            // wrong in a way that only showed up on this path: it walks with no section bound at all, so a
+            // request whose selection opened a sutta grew backwards into the previous one. Not crossing a
+            // <div> is a property of the context, not a reward for having found the selection.
+            var fallbackSpan = selectionSpan
+                ?? (string.IsNullOrWhiteSpace(request.SelectionText)
+                    ? null
+                    : (startPos, ParagraphEnd(xml, startPos, markers)));
+
+            var w = fallbackSpan is { } span
                 ? TeiPassageReader.ReadWindowAroundSelection(
                     xml, span.Start, span.End, budget,
                     request.IncludeFootnotes, request.OutputScript, markers,

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -298,36 +298,41 @@ public partial class BookDisplayView : UserControl
                     var text = sel ? sel.toString() : '';
                     var para = '';
                     if (sel && sel.rangeCount > 0 && text.length > 0) {
-                        var rect = sel.getRangeAt(0).getBoundingClientRect();
-                        var y = rect.top + window.pageYOffset;
-                        var cache = window.cstAnchorCache;
-                        if (cache && cache.isBuilt && cache.sortedParagraphAnchors
-                            && cache.sortedParagraphAnchors.length > 0) {
-                            var list = cache.sortedParagraphAnchors;
-                            var best = null;
-                            for (var i = 0; i < list.length; i++) {
-                                if (list[i].position <= y) best = list[i];
-                                else break;
+                        // DOCUMENT ORDER, not geometry. Comparing the selection's pixel top against an
+                        // anchor's was a race between an empty inline <a> box and a text line, with the
+                        // anchor positions rounded when the cache was built -- so a selection at the very
+                        // start of a paragraph resolved to the PREVIOUS one. That is not a cosmetic
+                        // off-by-one: the previous paragraph can be in the previous sutta, and then the
+                        // search for the selection is walled off from it by that sutta's own boundary and
+                        // the window is built in the wrong section entirely.
+                        var startNode = sel.getRangeAt(0).startContainer;
+                        var anchors = document.querySelectorAll('a[name]');
+                        var best = null;
+                        for (var i = 0; i < anchors.length; i++) {
+                            var a = anchors[i];
+                            if (!a.name || a.name.indexOf('para') !== 0) continue;
+                            var rel = a.compareDocumentPosition(startNode);
+                            // The selection's node comes after this anchor, so the anchor precedes it.
+                            if (rel === 0 || (rel & Node.DOCUMENT_POSITION_FOLLOWING)) best = a;
+                            // querySelectorAll returns document order: once one stops preceding, so do the rest.
+                            else break;
+                        }
+                        if (!best && anchors.length > 0) {
+                            for (var j = 0; j < anchors.length; j++) {
+                                if (anchors[j].name && anchors[j].name.indexOf('para') === 0) { best = anchors[j]; break; }
                             }
-                            // Above the first marker (front matter, a heading): the first paragraph, not
-                            // nothing — the same gap getCurrentParagraph resolves this way.
-                            if (!best) best = list[0];
+                        }
 
-                            // Anchor names are not plain numbers. They carry a book-code suffix in Multi
-                            // volumes (para548_dn1) and the printed number can itself be a range
-                            // (para548-9). Stripping only the prefix produced '548_dn1', which is not an
-                            // integer, so the paragraph arrived empty on EVERY request and the window fell
-                            // back to the scroll position. Derived the same way getCurrentParagraph does,
-                            // then reduced to the opening number, which is the paragraph the selection is in.
-                            var name = best.name || '';
-                            if (name.indexOf('para') === 0) {
-                                var t = name.substring(4);
-                                var underscore = t.indexOf('_');
-                                if (underscore !== -1) t = t.substring(0, underscore);
-                                var dash = t.indexOf('-');
-                                if (dash !== -1) t = t.substring(0, dash);
-                                para = t;
-                            }
+                        // Anchor names are not plain numbers: a book-code suffix in Multi volumes
+                        // (para548_dn1) and the printed number can be a range (para548-9).
+                        var name = best ? (best.name || '') : '';
+                        if (name.indexOf('para') === 0) {
+                            var t = name.substring(4);
+                            var underscore = t.indexOf('_');
+                            if (underscore !== -1) t = t.substring(0, underscore);
+                            var dash = t.indexOf('-');
+                            if (dash !== -1) t = t.substring(0, dash);
+                            para = t;
                         }
                     }
                     document.title = 'CST_AI_SEL:' + encodeURIComponent(text) + '|PARA=' + para + '|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -261,9 +261,22 @@ namespace CST.Search
 
             for (int anchor = from; anchor < to; anchor++)
             {
-                // A match must BEGIN on a letter. Starting anywhere else lets the skip rules below consume
-                // markup and punctuation before the first real character, so the span comes back beginning
-                // at a tag bracket rather than at the reader's first word.
+                // Tags are jumped WHOLE when looking for somewhere to start. Testing only the character
+                // meant an anchor could land inside a tag and match its attribute text: a selection opening
+                // "331." matched the n="331" of the paragraph's own <p> element, reporting a span that began
+                // inside markup. Attribute values are not text the reader can select and must never be
+                // matchable.
+                if (xml[anchor] == '<')
+                {
+                    int close = xml.IndexOf('>', anchor);
+                    if (close < 0 || close >= to) break;
+                    anchor = close;
+                    continue;
+                }
+
+                // A match must BEGIN on a letter, digit or mark. Starting anywhere else lets the skip rules
+                // below consume punctuation before the first real character, so the span comes back opening
+                // on something the reader did not select.
                 if (!IsSignificant(xml[anchor])) continue;
 
                 int matched = 0, i = anchor, lastConsumed = anchor;


### PR DESCRIPTION
A selection at the start of paragraph **331** resolved to paragraph **330**, and the context came back as paragraphs **330–332** — reaching into the sutta *before* the one being read.

That is **rule 4**: *do not cross a `<div>` boundary, because that gets into a different section/sutta/book.* I first identified rule 6, which was wrong — the selection was inside the window, incidentally, so containment held. The maintainer caught the misdiagnosis.

## The off-by-one

The paragraph was chosen by comparing the selection's pixel top against each anchor's. That is a race between an empty inline `<a>` box and a text line, with anchor positions rounded when the cache was built — so a selection *opening* a paragraph loses it and resolves to the previous one.

The app's own status bar read `Para: 331` while this read `330`. The scroll-derived value it was written to replace was right, and it was wrong.

**It is not cosmetic.** The previous paragraph was the last of the previous sutta, so the search for the selection ran from there, bounded by *that* sutta's end — which falls before the selection begins. The section bound worked correctly and walled the search off from the thing it was looking for. The selection was therefore "not located", and the window was built in the wrong section.

Now resolved by walking anchors in document order with `compareDocumentPosition`. No geometry, no rounding, no race.

## Rule 4 on every path

When a selection could not be located, the code fell back to `ReadWindow` — which walks with **no section bound at all**. So the rule was enforced only where the selection had already been found, and never on the path that actually needed it. The fallback now uses the paragraph's own span as the selection, so the window is section-bounded either way.

## Attribute text was matchable

The scanner could begin a match *inside a tag*: a selection opening `331.` matched the `n="331"` of the paragraph's own `<p>` element, returning a span that began in markup. Tags are now jumped whole when looking for somewhere to start.

The test for this **passed against the bug it named** until mutation testing exposed it — the needle couldn't appear in an attribute, so it proved nothing. It now uses a needle that exists *only* in an attribute.

## Testing

Full suite **1765 passed, 0 failed** (+2). The attribute test and the section-boundary test are both mutation-verified.

**Not verified in the app** — this is the fix for a defect the maintainer reproduced on Egret, and it has not been run there since. The specific check: select the first sentence of a paragraph that opens a sutta, and confirm the context does not reach into the previous one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)