### PR TITLE
Read page-numbering availability from the book, not the scroll position (#457, #541)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/PageNumberingTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/PageNumberingTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using CST.Avalonia.ViewModels;
+using CST.Navigation;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// #457 / #541: which page-numbering systems a book carries is one fact, and both the Go To dialog's
+/// greying-out and the status bar's field list must read it from the same place. Before this, Go To derived
+/// availability from the page in effect at the current scroll position, and the status bar showed all five
+/// systems unconditionally — opposite symptoms of the same missing fact.
+/// </summary>
+public class PageNumberingTests
+{
+    private static IReadOnlyList<PageEdition> Eds(params PageEdition[] e) => e;
+
+    private static string Page(PageEdition e) => e switch
+    {
+        PageEdition.Vri => "1.0023",
+        PageEdition.Myanmar => "2.0117",
+        PageEdition.Pts => "1.0045",
+        PageEdition.Thai => "3.0210",
+        PageEdition.Other => "1.0002",
+        _ => "?",
+    };
+
+    // ---- Has ------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Has_IsTrue_OnlyForEditionsTheBookCarries()
+    {
+        var editions = Eds(PageEdition.Vri, PageEdition.Myanmar);
+
+        Assert.True(PageNumbering.Has(editions, PageEdition.Vri));
+        Assert.True(PageNumbering.Has(editions, PageEdition.Myanmar));
+        Assert.False(PageNumbering.Has(editions, PageEdition.Pts));
+        Assert.False(PageNumbering.Has(editions, PageEdition.Thai));
+        Assert.False(PageNumbering.Has(editions, PageEdition.Other));
+    }
+
+    /// <summary>
+    /// An empty list is a real answer — "this book carries no page numbering at all" — and must NOT be
+    /// confused with not knowing yet. Every system is unavailable.
+    /// </summary>
+    [Theory]
+    [InlineData(PageEdition.Vri)]
+    [InlineData(PageEdition.Myanmar)]
+    [InlineData(PageEdition.Pts)]
+    [InlineData(PageEdition.Thai)]
+    [InlineData(PageEdition.Other)]
+    public void Has_IsFalse_ForEveryEdition_WhenTheBookCarriesNone(PageEdition edition)
+    {
+        Assert.False(PageNumbering.Has(Array.Empty<PageEdition>(), edition));
+    }
+
+    /// <summary>
+    /// The #457 symptom that made the dialog useless: markers not yet built. Unknown must answer "available",
+    /// not "absent" — withholding a system the book has leaves the reader no route in, while offering one it
+    /// lacks costs a single failed lookup. This is the test that fails if someone "simplifies" null to empty.
+    /// </summary>
+    [Theory]
+    [InlineData(PageEdition.Vri)]
+    [InlineData(PageEdition.Myanmar)]
+    [InlineData(PageEdition.Pts)]
+    [InlineData(PageEdition.Thai)]
+    [InlineData(PageEdition.Other)]
+    public void Has_IsTrue_ForEveryEdition_WhenEditionsAreNotYetKnown(PageEdition edition)
+    {
+        Assert.True(PageNumbering.Has(null, edition));
+    }
+
+    // ---- DefaultType ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void DefaultType_PrefersVri_WhenThePresentEditionsIncludeIt()
+    {
+        Assert.Equal(
+            NavigationType.VriPage,
+            PageNumbering.DefaultType(Eds(PageEdition.Thai, PageEdition.Vri, PageEdition.Myanmar)));
+    }
+
+    /// <summary>
+    /// Order is by edition, not by the order the book happens to list them — a book that opens with a Thai
+    /// page break still defaults to VRI if it has VRI anywhere.
+    /// </summary>
+    [Fact]
+    public void DefaultType_IgnoresTheOrderTheEditionsArriveIn()
+    {
+        var a = PageNumbering.DefaultType(Eds(PageEdition.Vri, PageEdition.Myanmar));
+        var b = PageNumbering.DefaultType(Eds(PageEdition.Myanmar, PageEdition.Vri));
+        Assert.Equal(a, b);
+        Assert.Equal(NavigationType.VriPage, a);
+    }
+
+    [Fact]
+    public void DefaultType_FallsToTheNextEdition_WhenVriIsAbsent()
+    {
+        Assert.Equal(
+            NavigationType.MyanmarPage,
+            PageNumbering.DefaultType(Eds(PageEdition.Other, PageEdition.Myanmar)));
+    }
+
+    /// <summary>
+    /// Paragraph is the fallback, not the default: it is ambiguous in 102 of 217 books (#447), so it is what
+    /// we use only when the book offers nothing better.
+    /// </summary>
+    [Fact]
+    public void DefaultType_IsParagraph_OnlyWhenTheBookCarriesNoPageNumbering()
+    {
+        Assert.Equal(NavigationType.Paragraph, PageNumbering.DefaultType(Array.Empty<PageEdition>()));
+        Assert.Equal(NavigationType.Paragraph, PageNumbering.DefaultType(null));
+    }
+
+    [Theory]
+    [InlineData(PageEdition.Vri, NavigationType.VriPage)]
+    [InlineData(PageEdition.Myanmar, NavigationType.MyanmarPage)]
+    [InlineData(PageEdition.Pts, NavigationType.PtsPage)]
+    [InlineData(PageEdition.Thai, NavigationType.ThaiPage)]
+    [InlineData(PageEdition.Other, NavigationType.OtherPage)]
+    public void ToNavigationType_MapsEveryEdition(PageEdition edition, NavigationType expected)
+    {
+        Assert.Equal(expected, PageNumbering.ToNavigationType(edition));
+    }
+
+    // ---- ComposeStatus --------------------------------------------------------------------------------
+
+    /// <summary>The #541 defect: a book with no PTS pagination showed a permanently blank "PTS:" field,
+    /// which reads as missing data rather than as not applicable.</summary>
+    [Fact]
+    public void ComposeStatus_OmitsSystemsTheBookDoesNotCarry()
+    {
+        var text = PageNumbering.ComposeStatus(Eds(PageEdition.Vri, PageEdition.Myanmar), Page);
+
+        Assert.Equal("VRI: 1.0023   Myanmar: 2.0117", text);
+        Assert.DoesNotContain("PTS", text);
+        Assert.DoesNotContain("Thai", text);
+        Assert.DoesNotContain("Other", text);
+    }
+
+    /// <summary>The paragraph number was in the shipped status bar behind a comment calling it "for
+    /// debugging" (#541).</summary>
+    [Fact]
+    public void ComposeStatus_DoesNotCarryTheParagraphDebugField()
+    {
+        var text = PageNumbering.ComposeStatus(Eds(PageEdition.Vri), Page);
+        Assert.DoesNotContain("Para", text);
+    }
+
+    [Fact]
+    public void ComposeStatus_IsEmpty_WhenTheBookCarriesNoPageNumbering()
+    {
+        Assert.Equal("", PageNumbering.ComposeStatus(Array.Empty<PageEdition>(), Page));
+    }
+
+    /// <summary>Before markers are built we show everything, so the bar does not visibly fill in on load —
+    /// a bar that flickers from empty to populated reads as a fault.</summary>
+    [Fact]
+    public void ComposeStatus_ShowsEverySystem_WhenEditionsAreNotYetKnown()
+    {
+        var text = PageNumbering.ComposeStatus(null, Page);
+
+        Assert.Equal("VRI: 1.0023   Myanmar: 2.0117   PTS: 1.0045   Thai: 3.0210   Other: 1.0002", text);
+    }
+
+    /// <summary>
+    /// "*" means "no page of this edition is in effect at this scroll position" — a real state, and NOT a
+    /// reason to drop the field. Dropping it would make the bar's field list change as the reader scrolls,
+    /// which is the position-dependence #457 exists to remove.
+    /// </summary>
+    [Fact]
+    public void ComposeStatus_KeepsAFieldWhoseCurrentPageIsUnset()
+    {
+        var text = PageNumbering.ComposeStatus(
+            Eds(PageEdition.Vri, PageEdition.Myanmar),
+            e => e == PageEdition.Myanmar ? "*" : "1.0023");
+
+        Assert.Equal("VRI: 1.0023   Myanmar: *", text);
+    }
+
+    /// <summary>Fields appear in a fixed order regardless of how the book lists its editions, so the bar
+    /// does not reorder itself between books.</summary>
+    [Fact]
+    public void ComposeStatus_UsesAFixedFieldOrder()
+    {
+        var forward = PageNumbering.ComposeStatus(Eds(PageEdition.Vri, PageEdition.Thai), Page);
+        var reversed = PageNumbering.ComposeStatus(Eds(PageEdition.Thai, PageEdition.Vri), Page);
+
+        Assert.Equal(forward, reversed);
+        Assert.Equal("VRI: 1.0023   Thai: 3.0210", forward);
+    }
+
+    /// <summary>A single system produces no leading or trailing separator.</summary>
+    [Fact]
+    public void ComposeStatus_DoesNotPadASingleField()
+    {
+        Assert.Equal("Thai: 3.0210", PageNumbering.ComposeStatus(Eds(PageEdition.Thai), Page));
+    }
+}

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -15,6 +15,8 @@ using Avalonia.Threading;
 using ReactiveUI;
 using CST;
 using CST.Conversion;
+using CST.Navigation;
+using CST.Search;
 using CST.Avalonia.Services;
 using CST.Avalonia.Models;
 using CST.Avalonia.Constants;
@@ -93,6 +95,12 @@ namespace CST.Avalonia.ViewModels
         private string _thaiPage = "*";
         private string _otherPage = "*";
         private string _currentParagraph = "*";
+
+        // Which page-numbering systems this book actually carries (#457, #541). Null until the book's XML
+        // has been read - deliberately distinct from an empty list, which means "read, and it carries none".
+        // See PageNumbering.Has for why unknown is treated as available rather than as absent.
+        private IReadOnlyList<PageEdition>? _editions;
+
         private int _currentHitIndex;
         private int _totalHits;
         private bool _hasSearchHighlights;
@@ -456,6 +464,12 @@ namespace CST.Avalonia.ViewModels
         /// script-dependent — it names a file on disk, so it is deliberately never converted or localized.
         /// </summary>
         public string XmlFileName => _book.FileName;
+
+        /// <summary>
+        /// The page-numbering systems this book carries, from its <c>&lt;pb&gt;</c> markers (#457, #541).
+        /// Null until the XML has been read; see <see cref="PageNumbering.Has"/> for how that is treated.
+        /// </summary>
+        public IReadOnlyList<PageEdition>? Editions => _editions;
 
         /// <summary>
         /// The book's place in the collection, converted to the script the book is being read in, with the
@@ -1144,7 +1158,14 @@ namespace CST.Avalonia.ViewModels
                     // override this anyway, but a BOM-less file must not decode as mojibake).
                     _logger.Debug("Reading raw XML content as string");
                     string xmlContent = File.ReadAllText(xmlPath, System.Text.Encoding.Unicode);
-                    
+
+                    // Which page-numbering systems this book carries (#457, #541). Built from the RAW xml,
+                    // before search highlighting rewrites it - markers are a fact about the book, and must
+                    // not vary with whether the reader arrived here from a search.
+                    _editions = BookMarkers.Build(xmlContent).Editions();
+                    _logger.Debug("Page editions for {FileName}: {Editions}",
+                        _book.FileName, string.Join(",", _editions));
+
                     // Apply search highlighting to raw XML string if needed
                     if (_searchTerms?.Any() == true)
                     {
@@ -1958,14 +1979,17 @@ namespace CST.Avalonia.ViewModels
         {
             _logger.Debug("UpdatePageReferencesText called: {DisplayTitle}", DisplayTitle);
             
-            // Port of CST4's SetPageStatusText method
-            // TODO: Use LocalizationService once it's fully implemented
-            // For now, use the same format as CST4's PageNumbersStatusFormat from Resources.resx
-            // string format = _localizationService.GetString("PageNumbersStatusFormat");
-            // PageReferencesText = string.Format(format, VriPage, MyanmarPage, PtsPage, ThaiPage, OtherPage);
-            
-            // Temporary hardcoded format until localization is implemented - now includes paragraph number for debugging
-            var newText = $"VRI: {VriPage}   Myanmar: {MyanmarPage}   PTS: {PtsPage}   Thai: {ThaiPage}   Other: {OtherPage}   Para: {CurrentParagraph}";
+            // Only the systems this book actually carries (#541). The labels live in PageNumbering, which is
+            // the seam localization (#26) replaces - not an interpolated string to go hunting for.
+            var newText = PageNumbering.ComposeStatus(_editions, edition => edition switch
+            {
+                PageEdition.Vri => VriPage,
+                PageEdition.Myanmar => MyanmarPage,
+                PageEdition.Pts => PtsPage,
+                PageEdition.Thai => ThaiPage,
+                PageEdition.Other => OtherPage,
+                _ => "*",
+            });
             var oldText = PageReferencesText;
             PageReferencesText = newText;
             

--- a/src/CST.Avalonia/ViewModels/GoToDialogViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/GoToDialogViewModel.cs
@@ -4,6 +4,7 @@ using System.Reactive;
 using System.Text.RegularExpressions;
 using ReactiveUI;
 using CST;
+using CST.Navigation;
 using Serilog;
 
 namespace CST.Avalonia.ViewModels
@@ -39,15 +40,25 @@ namespace CST.Avalonia.ViewModels
             _thaiPage = bookViewModel.ThaiPage;
             _otherPage = bookViewModel.OtherPage;
 
-            // Set availability based on current book's page references
-            IsVriPageAvailable = bookViewModel.VriPage != "*";
-            IsMyanmarPageAvailable = bookViewModel.MyanmarPage != "*";
-            IsPtsPageAvailable = bookViewModel.PtsPage != "*";
-            IsThaiPageAvailable = bookViewModel.ThaiPage != "*";
-            IsOtherPageAvailable = bookViewModel.OtherPage != "*";
+            // Availability comes from what the BOOK CONTAINS, not from where the reader is sitting (#457).
+            // The previous test was `bookViewModel.VriPage != "*"`, reading the page in effect at the current
+            // scroll position: "*" means "no page of that edition is in effect HERE", never "this book has no
+            // such edition". So the dialog greyed out every system on every book when opened before the anchor
+            // cache resolved, and greyed out Myanmar on a Myanmar-paginated book whenever the reader was
+            // scrolled above its first page break.
+            var editions = bookViewModel.Editions;
+            IsVriPageAvailable = PageNumbering.Has(editions, PageEdition.Vri);
+            IsMyanmarPageAvailable = PageNumbering.Has(editions, PageEdition.Myanmar);
+            IsPtsPageAvailable = PageNumbering.Has(editions, PageEdition.Pts);
+            IsThaiPageAvailable = PageNumbering.Has(editions, PageEdition.Thai);
+            IsOtherPageAvailable = PageNumbering.Has(editions, PageEdition.Other);
 
-            _logger.Information("GoToDialog initialized for book: {Book}, Available pages: V={V}, M={M}, P={P}, T={T}, O={O}",
-                _book.FileName, IsVriPageAvailable, IsMyanmarPageAvailable, IsPtsPageAvailable, IsThaiPageAvailable, IsOtherPageAvailable);
+            // Open on a system the book actually has. Paragraph was hardcoded, and it is the weakest address
+            // available - ambiguous in 102 of 217 books because numbering restarts per sub-book (#447, #596).
+            SelectedType = PageNumbering.DefaultType(editions);
+
+            _logger.Information("GoToDialog initialized for book: {Book}, Available pages: V={V}, M={M}, P={P}, T={T}, O={O}, default={Default}",
+                _book.FileName, IsVriPageAvailable, IsMyanmarPageAvailable, IsPtsPageAvailable, IsThaiPageAvailable, IsOtherPageAvailable, SelectedType);
 
             // Commands
             var canNavigate = this.WhenAnyValue(

--- a/src/CST.Avalonia/ViewModels/PageNumbering.cs
+++ b/src/CST.Avalonia/ViewModels/PageNumbering.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CST.Navigation;
+
+namespace CST.Avalonia.ViewModels
+{
+    /// <summary>
+    /// What page-numbering systems a book actually carries, and how to present that.
+    ///
+    /// <para>#457 and #541 were the same missing fact seen from two sides: Go To <b>hid</b> systems a book
+    /// does have, because it read the page numbers in effect at the current scroll position; the status bar
+    /// <b>showed</b> systems the book does not have, because it composed all five unconditionally. Both are
+    /// answered by <c>BookMarkers.Editions()</c> — the distinct <c>&lt;pb&gt;</c> editions parsed out of the
+    /// book's XML, which depends on neither scroll position nor cache readiness.</para>
+    ///
+    /// <para><b>Absence is not a data gap.</b> Most of the corpus legitimately carries no PTS or Thai
+    /// numbering — the VRI print set is 140 volumes and the extra-canonical texts were never published
+    /// outside Myanmar. A blank <c>PTS:</c> field reads to a scholar as "the PTS page here is unknown", which
+    /// is a different and wrong claim. Omitting the field says "not applicable", which is the true one.</para>
+    /// </summary>
+    public static class PageNumbering
+    {
+        /// <summary>
+        /// Labels for the status bar, in display order.
+        ///
+        /// <para>Kept in one place deliberately. The format string this replaced was flagged in-code as
+        /// temporary pending localization (#26); this is the seam that work replaces, so a localized build
+        /// swaps this table rather than hunting an interpolated string.</para>
+        /// </summary>
+        private static readonly (PageEdition Edition, string Label)[] Order =
+        {
+            (PageEdition.Vri, "VRI"),
+            (PageEdition.Myanmar, "Myanmar"),
+            (PageEdition.Pts, "PTS"),
+            (PageEdition.Thai, "Thai"),
+            (PageEdition.Other, "Other"),
+        };
+
+        private const string Separator = "   ";
+
+        /// <summary>
+        /// Whether <paramref name="edition"/> is one the book carries.
+        ///
+        /// <para><b><paramref name="editions"/> is nullable on purpose</b>, and null does NOT mean "none".
+        /// It means the book's markers have not been built yet — the state #457's first symptom lived in,
+        /// where Go To opened before the anchor cache resolved and greyed out every system on every book.
+        /// Unknown answers <c>true</c>: offering a system that turns out to be empty costs the reader one
+        /// failed lookup, while withholding one the book has leaves them no route in at all. When the two
+        /// error directions are unequal, take the cheap one.</para>
+        /// </summary>
+        public static bool Has(IReadOnlyList<PageEdition>? editions, PageEdition edition)
+        {
+            if (editions is null) return true;
+            for (int i = 0; i < editions.Count; i++)
+                if (editions[i] == edition) return true;
+            return false;
+        }
+
+        /// <summary>
+        /// The navigation type Go To should open on.
+        ///
+        /// <para>Paragraph was the hardcoded default, and it is the <i>weakest</i> address in the corpus:
+        /// paragraph numbers restart per sub-book in the 7 Multi volumes, so a bare number is ambiguous in
+        /// 102 of 217 books (#447, #596). Where the book carries a page edition, prefer it — page numbers
+        /// are unambiguous within a volume. Editions are offered in <see cref="Order"/>, so VRI wins when
+        /// present, which is the numbering the reader is most likely holding.</para>
+        /// </summary>
+        public static NavigationType DefaultType(IReadOnlyList<PageEdition>? editions)
+        {
+            if (editions is null || editions.Count == 0) return NavigationType.Paragraph;
+
+            foreach (var (edition, _) in Order)
+                if (Has(editions, edition))
+                    return ToNavigationType(edition);
+
+            return NavigationType.Paragraph;
+        }
+
+        /// <summary>Maps an edition to the Go To navigation type that addresses it.</summary>
+        public static NavigationType ToNavigationType(PageEdition edition) => edition switch
+        {
+            PageEdition.Vri => NavigationType.VriPage,
+            PageEdition.Myanmar => NavigationType.MyanmarPage,
+            PageEdition.Pts => NavigationType.PtsPage,
+            PageEdition.Thai => NavigationType.ThaiPage,
+            PageEdition.Other => NavigationType.OtherPage,
+            _ => NavigationType.Paragraph,
+        };
+
+        /// <summary>
+        /// The status-bar text: only the systems this book carries, each with its page at the current
+        /// position.
+        ///
+        /// <para>The paragraph number is deliberately absent. It was in the shipped status bar behind a
+        /// comment describing it as "for debugging" (#541).</para>
+        ///
+        /// <para>A book whose markers are not built yet (<paramref name="editions"/> null) shows every
+        /// system, matching <see cref="Has"/> — the alternative is a status bar that flickers from empty to
+        /// populated on load, which reads as a fault.</para>
+        /// </summary>
+        /// <param name="pageFor">The page currently in effect for an edition, as the reader reports it.
+        /// <c>"*"</c> means no page of that edition is in effect at this scroll position — a real state
+        /// (above the first page break, say), distinct from the book not having the edition at all.</param>
+        public static string ComposeStatus(
+            IReadOnlyList<PageEdition>? editions,
+            Func<PageEdition, string> pageFor)
+        {
+            var sb = new StringBuilder();
+            foreach (var (edition, label) in Order)
+            {
+                if (!Has(editions, edition)) continue;
+                if (sb.Length > 0) sb.Append(Separator);
+                sb.Append(label).Append(": ").Append(pageFor(edition));
+            }
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #457. Fixes #541.

Two issues, one missing fact. Go To **hid** numbering systems a book has; the status bar **showed** systems it does not. Neither knew what numbering a book actually carries.

## What was wrong

**#457** — `GoToDialogViewModel` derived availability from the reader's current-position readouts:

```csharp
IsVriPageAvailable = bookViewModel.VriPage != "*";
```

Those are the pages in effect at the current scroll offset. `"*"` means *"no page of that edition is in effect here"*, never *"this book has no such edition"*. Two consequences: opening Go To before the anchor cache resolved greyed out **every** system on **every** book, and scrolling above a book's first Myanmar page break greyed out Myanmar on a Myanmar-paginated book. The fallback was paragraph — the weakest address in the corpus, ambiguous in 102 of 217 books (#447, #596).

**#541** — the status bar composed all five systems unconditionally, so a book with no PTS pagination showed a permanently blank `PTS:`. To a scholarly reader that reads as *"the PTS page here is unknown"*, when the truth is this text has no PTS pagination at all — expected for much of the corpus, since the VRI print set is 140 volumes and the extra-canonical texts were never published outside Myanmar. It also shipped `Para: {n}`, which its own comment called "for debugging".

## The fix

Both now read `BookMarkers.Editions()` — the distinct `<pb>` editions parsed from the book's XML, independent of scroll position and cache readiness. Built from the **raw** XML before search highlighting rewrites it, so the answer doesn't vary with whether the reader arrived from a search.

New `PageNumbering` holds the shared logic. The label table lives in one place: the format string it replaces was flagged in-code as temporary pending localization (#26), so this is the seam that work replaces rather than an interpolated string to hunt down.

## Two deliberate choices worth reviewing

**`Editions` is nullable, and null is not "none".** Null means "markers not built yet"; empty means "built, and this book carries none". Unknown answers *available* — withholding a system the book has leaves the reader no route in, while offering one it lacks costs a single failed lookup. Unequal error directions, so take the cheap one. There's a test that fails if someone collapses null into empty.

**Go To now opens on a system the book has**, preferring VRI, instead of defaulting to paragraph. #457 suggested this; flagging it because it changes behaviour beyond the greying-out.

## Testing

27 new tests, all pure — no VM construction needed. Mutation-checked:

| Mutation | Tests failed |
|---|---|
| unknown editions treated as absent | 6 |
| compose ignores the availability check | 5 |
| default type always paragraph | 3 |

Full suite: **1768 passed, 0 failed** (was 1741).

## Not covered

Neither issue's underlying data question is touched: #452's volume-0 collision and #453's page typos are unaffected, since `Editions()` answers only *which editions exist*. An edition whose page numbers are all non-integer would not be recorded by `BookMarkers` — no such case is known in the corpus, but it is a real edge of this approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)