### PR TITLE
Cut the explanatory prose from the AI settings

### DIFF
--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -136,7 +136,7 @@
                                                 <TextBox Text="{Binding IndexDirectory}" 
                                                         Watermark="Default location will be used if empty"/>
                                             </DockPanel>
-                                            <TextBlock Text="Location where search index files are stored (leave empty for default location)" 
+                                            <TextBlock Text="Location where search index files are stored" 
                                                       Classes="SettingDescription"/>
                                         </StackPanel>
                                         
@@ -492,13 +492,10 @@
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
                                         <TextBlock Text="AI Features" Classes="SettingLabel"/>
-                                        <TextBlock Text="Let AI agents access the Tipitaka corpus through a local, loopback-only API. All AI features are off by default and opt-in."
-                                                  Classes="SettingDescription"/>
-
                                         <CheckBox IsChecked="{Binding AiEnabled}"
                                                  Content="Enable AI Features"
                                                  Margin="0,10,0,0"/>
-                                        <TextBlock Text="Master switch. When off, nothing AI-related runs. Two access modes are available below: a local API for code agents, and MCP for chat clients like Claude Desktop."
+                                        <TextBlock Text="When off, all AI features are disabled."
                                                   Classes="SettingDescription"/>
                                         <!-- #527: the API server reads these settings once, at startup
                                              (App.StartLocalApiIfEnabledAsync), so a toggle here does nothing until
@@ -513,13 +510,10 @@
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
                                         <TextBlock Text="Access for AI Clients" Classes="SettingLabel"/>
-                                        <TextBlock Text="A loopback-only server that exposes read access to the corpus (search, dictionary, passages). Two surfaces run on it independently — enable either or both. Changes here also take effect after a restart."
-                                                  Classes="SettingDescription"/>
-
                                         <!-- REST surface (/v1): for code agents. -->
                                         <CheckBox IsChecked="{Binding LocalApiEnabled}"
                                                  IsEnabled="{Binding SubPermissionsEnabled}"
-                                                 Content="Run the local API server (for code agents)"
+                                                 Content="Run the local API server (Claude Code &amp; tool-calling agents)"
                                                  Margin="0,10,0,0"/>
 
                                         <!-- MCP surface (/mcp): for chat clients, reached via the app's mcp-bridge relay. #280 -->
@@ -534,8 +528,6 @@
                                                  IsEnabled="{Binding RemoteControlEnabled}"
                                                  Content="Allow agents to drive the reader (navigate and highlight)"
                                                  Margin="0,5,0,0"/>
-                                        <TextBlock Text="When off, agents can read the corpus but cannot control the reader window."
-                                                  Classes="SettingDescription"/>
 
                                         <!-- Copy the ready-made Claude Desktop MCP config: it launches CST Reader's
                                              mcp-bridge relay and carries no port/token. Clipboard is done in


### PR DESCRIPTION
Maintainer's edit to the AI settings page. I am carrying it, not authoring it.

The section explained itself three times before the reader reached a control: a paragraph under the heading, another under the master switch, and a third under "Access for AI Clients". The headings and checkbox labels already carried that information.

**Removed**

- The standalone blurbs under "AI Features" and "Access for AI Clients".
- The master switch's description is now "When off, all AI features are disabled." The two access modes were named in prose immediately above the two checkboxes that name them — a table of contents for a list three lines long.
- The trailing description under the remote-control checkbox, whose label already reads "Allow agents to drive the reader (navigate and highlight)".

**Reworded**

Two labels name the clients readers actually have in hand rather than categories: the local API is now "Claude Code & tool-calling agents", matching the MCP checkbox's existing "Claude Desktop & other chat clients".

**Kept**

The restart warning (#527), the MCP paste instructions and the configuration expander — those tell the reader something no label can.

**Also**, in Search settings: the index-directory description drops "(leave empty for default location)", which the field's own watermark already says.

## Safety of the deletions

Every deleted `TextBlock` was unnamed, so nothing could reference it. The only name-based lookup in this view is `CopyMcpConfirm` (found as a sibling of the copy button in `OnCopyMcpConfig`, since the AI DataTemplate is a separate namescope), and it is untouched — and null-tolerant regardless.

Full suite **1768 passed, 0 failed**; no test asserts any of these strings.

## Not verified

The AI page's `DataTemplate` only instantiates when that category is selected, so a clean build does not prove it renders. Worth one click on Settings ▸ AI before merging.
