### PR TITLE
Slow CefGlue's macOS message pump from ~1 kHz to 30 Hz (#523)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/CefMessagePumpSeamTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CefMessagePumpSeamTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using CST.Avalonia.Services;
+using Xilium.CefGlue;
+using Xilium.CefGlue.Avalonia;
+using Xilium.CefGlue.Common.Handlers;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// #523: the macOS pump fix replaces CefGlue's browser-process handler at runtime, reaching into four
+/// non-public members BY NAME.
+///
+/// <para><b>These tests exist because the failure mode is silent.</b> If a package upgrade renames any of
+/// them, <c>CefMessagePump</c> logs a warning and leaves CefGlue's repeating 1 ms timer in place — no crash,
+/// no error, just ~38% of a core burned at idle on every macOS install, which nobody would notice until
+/// someone re-measured. Pinning the members here turns that into a build failure.</para>
+///
+/// <para>Same reasoning and same idiom as <c>CefBrowserAccessTests</c>, which pins the reflection chain book
+/// zoom depends on. Nothing here initializes CEF — these are metadata lookups, so they run anywhere.</para>
+/// </summary>
+public class CefMessagePumpSeamTests
+{
+    /// <summary><c>CefApp._roots</c> is how we find the live app instance after CEF starts.</summary>
+    [Fact]
+    public void CefAppRootsField_StillExists()
+    {
+        var roots = CefMessagePump.RootsField();
+
+        Assert.NotNull(roots);
+        Assert.True(roots!.IsStatic);
+        Assert.True(typeof(IDictionary).IsAssignableFrom(roots.FieldType),
+            $"CefApp._roots must stay dictionary-like to enumerate; it is now {roots.FieldType}.");
+    }
+
+    /// <summary>
+    /// <c>BrowserCefApp._browserProcessHandler</c>. Located on the internal concrete app type, so this test
+    /// finds that type the same way the code does — by looking for the field on a candidate type.
+    /// </summary>
+    [Fact]
+    public void BrowserCefApp_StillHoldsItsProcessHandler()
+    {
+        var appType = typeof(BrowserProcessHandler).Assembly.GetType("Xilium.CefGlue.Common.BrowserCefApp");
+
+        Assert.True(appType is not null,
+            "BrowserCefApp not found. CefMessagePump.FindLiveCefApp scans _roots for a type carrying " +
+            "_browserProcessHandler, so a rename here means the pump fix silently stops applying (#523).");
+
+        Assert.NotNull(CefMessagePump.BrowserProcessHandlerField(appType!));
+    }
+
+    /// <summary>
+    /// <c>CommonBrowserProcessHandler._handler</c> is the slot we overwrite. Declared readonly — reflection can
+    /// still write it — but the field must exist and must hold a <see cref="BrowserProcessHandler"/>.
+    /// </summary>
+    [Fact]
+    public void CommonBrowserProcessHandler_StillHasTheSwappableHandlerSlot()
+    {
+        var type = typeof(BrowserProcessHandler).Assembly
+            .GetType("Xilium.CefGlue.Common.InternalHandlers.CommonBrowserProcessHandler");
+
+        Assert.True(type is not null, "CommonBrowserProcessHandler not found (#523).");
+
+        var field = CefMessagePump.InnerHandlerField(type!);
+        Assert.NotNull(field);
+        Assert.Equal(typeof(BrowserProcessHandler), field!.FieldType);
+    }
+
+    /// <summary>
+    /// <c>AvaloniaBrowserProcessHandler._current</c> holds the running 1 ms subscription we dispose. Losing
+    /// this one is the mildest failure — both timers would run — so the code only warns, and this test is what
+    /// makes it visible.
+    /// </summary>
+    [Fact]
+    public void OutgoingHandler_StillExposesItsRunningSubscription()
+    {
+        var type = typeof(AvaloniaCefBrowser).Assembly
+            .GetType("Xilium.CefGlue.Avalonia.AvaloniaBrowserProcessHandler");
+
+        Assert.True(type is not null,
+            "CefGlue no longer ships AvaloniaBrowserProcessHandler. Re-measure idle CPU (#523): the upstream " +
+            "1 ms pump may have been fixed, in which case CefMessagePump can be deleted rather than repaired.");
+
+        var field = CefMessagePump.CurrentSubscriptionField(type!);
+        Assert.NotNull(field);
+        Assert.True(typeof(IDisposable).IsAssignableFrom(field!.FieldType),
+            $"_current must stay IDisposable to be stopped; it is now {field.FieldType}.");
+    }
+
+    /// <summary>
+    /// Our replacement derives from the public <see cref="BrowserProcessHandler"/> and overrides
+    /// <c>OnScheduleMessagePumpWork(long)</c>. If that stops being overridable our override is never called and
+    /// the swap achieves nothing.
+    /// </summary>
+    [Fact]
+    public void OnScheduleMessagePumpWork_IsStillOverridable()
+    {
+        var method = typeof(CefBrowserProcessHandler).GetMethod(
+            "OnScheduleMessagePumpWork",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+
+        Assert.NotNull(method);
+        Assert.True(method!.IsVirtual, "OnScheduleMessagePumpWork must stay virtual (#523).");
+        Assert.False(method.IsFinal, "OnScheduleMessagePumpWork must not be sealed (#523).");
+
+        var parameters = method.GetParameters();
+        Assert.Single(parameters);
+        Assert.Equal(typeof(long), parameters[0].ParameterType);
+    }
+
+    /// <summary><see cref="BrowserProcessHandler"/> is the one supported, non-reflective part of this.</summary>
+    [Fact]
+    public void BrowserProcessHandler_IsStillPublicAndInheritable()
+    {
+        Assert.True(typeof(BrowserProcessHandler).IsPublic);
+        Assert.False(typeof(BrowserProcessHandler).IsSealed);
+    }
+
+    /// <summary>
+    /// Before CEF starts there is no app instance, so the lookup must return null rather than throw — that is
+    /// what lets the install poll harmlessly until CEF is up.
+    /// </summary>
+    [Fact]
+    public void FindLiveCefApp_ReturnsNull_BeforeCefStarts()
+    {
+        Assert.Null(CefMessagePump.FindLiveCefApp());
+    }
+
+    // ---- behaviour, not just metadata (fable review) --------------------------------------------------
+
+    /// <summary>
+    /// A request of "now" must stay "now". Upstream turned <c>&lt;= 0</c> into a 1 ms wait; turning it into a
+    /// 33 ms wait would add latency to every urgent wake, which is the regression this change must not cause.
+    /// </summary>
+    [Fact]
+    public void DueDelay_TreatsNowAsNow()
+    {
+        Assert.Equal(0, CefMessagePump.DueDelayMs(0));
+        Assert.Equal(0, CefMessagePump.DueDelayMs(-1));
+        Assert.Equal(0, CefMessagePump.DueDelayMs(long.MinValue));
+    }
+
+    /// <summary>A request shorter than the pump period is honoured exactly — we never make CEF wait longer
+    /// than it asked.</summary>
+    [Theory]
+    [InlineData(1L)]
+    [InlineData(5L)]
+    [InlineData(32L)]
+    public void DueDelay_HonoursShortRequests(long requested)
+    {
+        Assert.Equal(requested, CefMessagePump.DueDelayMs(requested));
+    }
+
+    /// <summary>
+    /// Long requests are capped at the pump period. The repeating timer doubles as the watchdog that recovers a
+    /// lost tick, so it must never sleep for the multi-second delay CEF asks for when it is idle.
+    /// </summary>
+    [Theory]
+    [InlineData(34L)]
+    [InlineData(1000L)]
+    [InlineData(long.MaxValue)]
+    public void DueDelay_CapsLongRequestsAtThePumpPeriod(long requested)
+    {
+        Assert.Equal(33, CefMessagePump.DueDelayMs(requested));
+    }
+
+    /// <summary>
+    /// The swap writes a <c>readonly</c> instance field by reflection. That is legal today, but .NET already
+    /// refuses reflection writes to <i>static</i> InitOnly fields and the instance case could follow — in which
+    /// case the swap throws, is caught, and the pump silently stays at 1 kHz. No metadata assertion can catch a
+    /// runtime-behaviour change, so actually perform the write. (fable review)
+    /// </summary>
+    [Fact]
+    public void ReadonlyHandlerField_IsStillWritableByReflection()
+    {
+        var type = typeof(BrowserProcessHandler).Assembly
+            .GetType("Xilium.CefGlue.Common.InternalHandlers.CommonBrowserProcessHandler");
+        Assert.True(type is not null, "CommonBrowserProcessHandler not found (#523).");
+
+        var field = CefMessagePump.InnerHandlerField(type!);
+        Assert.NotNull(field);
+
+        // An uninitialized instance is enough: we are testing the field write, not the type's behaviour.
+        var instance = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(type!);
+        var sentinel = new SentinelHandler();
+
+        field!.SetValue(instance, sentinel);
+
+        Assert.Same(sentinel, field.GetValue(instance));
+    }
+
+    private sealed class SentinelHandler : BrowserProcessHandler { }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -184,6 +184,13 @@ public partial class App : Application
         WebView.Settings.PersistCache = false;
         // Leave CachePath as default (temp directory) to avoid ArgumentNullException on cleanup
 
+        // Slow CefGlue's macOS message pump from ~1 kHz to 30 Hz (#523). CefGlue drives CEF with a REPEATING
+        // 1 ms timer, so the UI thread wakes ~1000x/second to be told there is no work - ~38% CPU with a book
+        // open, almost all system time. This only ARRANGES the swap; it happens once CefGlue has initialized CEF
+        // normally, because pre-empting that initialization breaks the browser (see CefMessagePump). No-op off
+        // macOS, where CEF runs its own loop.
+        CefMessagePump.ScheduleInstall();
+
         // Welcome page will show startup status instead of separate splash screen
         Log.Information("Starting application with Welcome page status display");
 

--- a/src/CST.Avalonia/Services/CefMessagePump.cs
+++ b/src/CST.Avalonia/Services/CefMessagePump.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reflection;
+using Avalonia.Threading;
+using Serilog;
+using Xilium.CefGlue;
+using Xilium.CefGlue.Common;
+using Xilium.CefGlue.Common.Handlers;
+
+namespace CST.Avalonia.Services
+{
+    /// <summary>
+    /// Slows CefGlue's macOS message pump from ~1 kHz to 30 Hz. (#523)
+    ///
+    /// <para><b>What CEF asks for.</b> On macOS CEF does not run its own loop — CefGlue sets
+    /// <c>ExternalMessagePump = true</c> (hard-coded; <c>MultiThreadedMessageLoop</c> on Windows and Linux,
+    /// which is why this is macOS-only) and the host must drive it. CEF calls
+    /// <c>OnScheduleMessagePumpWork(delayMs)</c> to ask for a <c>DoMessageLoopWork()</c> call.</para>
+    ///
+    /// <para><b>What CefGlue does.</b> <c>AvaloniaBrowserProcessHandler</c>, decompiled from the shipped
+    /// <c>Xilium.CefGlue.Avalonia.dll</c> 120.6099.207 and unchanged upstream since 2019:</para>
+    /// <code>
+    /// if (delayMs &lt;= 0) delayMs = 1L;
+    /// _current = Observable.Interval(TimeSpan.FromMilliseconds(delayMs))   // repeating
+    ///     .ObserveOn(AvaloniaScheduler.Instance)
+    ///     .Subscribe(_ =&gt; CefRuntime.DoMessageLoopWork());
+    /// </code>
+    /// <para>The 1 ms floor is the defect: the interval repeats until a later schedule call replaces it, so the
+    /// UI thread wakes ~1000 times a second to ask CEF for work and be told there is none. Measured on an M4:
+    /// ~3,000–3,900 context switches/second and 37–39% CPU with a book open, almost all of it system time.</para>
+    ///
+    /// <para><b>Why this keeps the repeating timer.</b> A single-shot pump is what CEF's own reference
+    /// implementation uses, and it was tried first — it breaks the browser. CEF calls
+    /// <c>OnScheduleMessagePumpWork</c> during <c>CefRuntime.Initialize</c>, before Avalonia's dispatcher loop
+    /// is running; if those early ticks are dropped a one-shot chain never rearms, and CEF — which launches its
+    /// child processes and drives navigation inside <c>DoMessageLoopWork</c> — silently stops. Observed: browser
+    /// created, one subprocess instead of six, no navigation, no exception. <b>The repeating interval is an
+    /// accidental watchdog</b>, and removing it removes the recovery. So keep the structure and fix only the
+    /// floor: 33 ms, matching CEF's reference <c>kMaxTimerDelay</c> of 1000/30. Same self-healing, 30× fewer
+    /// wakeups. Do not "improve" this into a bare one-shot without pairing it with a keepalive.</para>
+    /// </summary>
+    internal static class CefMessagePump
+    {
+        /// <summary>
+        /// The pump period. CEF's reference pump caps its timer delay at 1000/30 ms so a scheduled tick cannot
+        /// sleep too long; we use the same number as a floor as well, since the interval repeats.
+        /// </summary>
+        private const long PumpIntervalMs = 33;
+
+        /// <summary>
+        /// How many one-second attempts to make ONCE CEF IS UP before giving up.
+        ///
+        /// <para>Deliberately not a wall-clock cap. CEF initializes lazily on the first WebView, and a restored
+        /// layout with no welcome tab, no book and no dictionary panel creates no WebView at startup — so CEF
+        /// may not exist until the reader opens a book, which could be an hour in. A wall-clock cap would expire
+        /// long before that and leave the whole session on the 1 kHz pump, silently. (fable review)</para>
+        /// </summary>
+        private const int MaxAttemptsAfterCefIsUp = 30;
+
+        /// <summary>How long after the swap to re-check for a subscription re-armed by a racing schedule call.</summary>
+        private const int RaceRecheckMs = 250;
+
+        /// <summary>
+        /// Set when the install loop is DONE — whether it succeeded, gave up, or threw. Named for what it
+        /// actually guards; it does not mean the pump was replaced. (fable review: the old name lied.)
+        /// </summary>
+        private static bool _finished;
+
+        /// <summary>
+        /// Arranges for the pump to be replaced once CefGlue has initialized CEF <b>normally</b>.
+        ///
+        /// <para><b>Why not initialize CEF ourselves.</b> The staged-initialization seam
+        /// (<c>CefRuntimeLoader._delayedInitialization</c>) does let a host pre-initialize CEF with its own
+        /// handler, and it was tried — it works, and it breaks the browser for the reason in the class remarks:
+        /// CEF's first pump requests arrive before the dispatcher loop is running. Letting CefGlue do exactly
+        /// what it always does, and swapping the handler afterwards, removes every ordering question.</para>
+        ///
+        /// <para>Polls on the UI thread because there is no event for "CEF is up" that does not couple this to a
+        /// particular view. The timer stops on the first success, and gives up only after
+        /// <see cref="MaxAttemptsAfterCefIsUp"/> attempts made while CEF is actually running.</para>
+        ///
+        /// <para><b>The cost, stated plainly:</b> the swap reaches into four non-public members by name. A
+        /// package upgrade that renames any of them leaves us on the 1 kHz pump — a performance regression with
+        /// no error. Guarded two ways: every lookup is null-checked and the whole thing no-ops rather than
+        /// throwing, and <c>CefMessagePumpSeamTests</c> pins each member so a bump fails the build. Same
+        /// approach, and the same reasoning, as <see cref="CefBrowserAccess"/>.</para>
+        /// </summary>
+        public static void ScheduleInstall()
+        {
+            if (!OperatingSystem.IsMacOS()) return;   // no external pump on Windows/Linux
+
+            int attemptsAfterCefIsUp = 0;
+            DispatcherTimer? timer = null;
+            timer = new DispatcherTimer(TimeSpan.FromSeconds(1), DispatcherPriority.Background, (_, _) =>
+            {
+                if (_finished || TryReplaceHandler())
+                {
+                    timer!.Stop();
+                    return;
+                }
+
+                // Only count attempts once CEF actually exists. Before that we are waiting for the reader to
+                // open something that creates a WebView, and that wait is legitimately unbounded.
+                if (!CefRuntime.IsInitialized) return;
+
+                if (++attemptsAfterCefIsUp >= MaxAttemptsAfterCefIsUp)
+                {
+                    timer!.Stop();
+                    _finished = true;
+                    Log.Warning("CEF pump NOT replaced after {Attempts} attempts with CEF running; continuing on " +
+                                "CefGlue's 1 kHz pump. Expect elevated idle CPU on macOS (#523).",
+                        MaxAttemptsAfterCefIsUp);
+                }
+            });
+            timer.Start();
+        }
+
+        /// <summary>
+        /// Swaps our handler in, primes it, then stops the outgoing 1 ms interval — in that order, so the pump
+        /// is never unattended. Returns false (quietly) until CEF is up.
+        /// </summary>
+        private static bool TryReplaceHandler()
+        {
+            try
+            {
+                if (!CefRuntime.IsInitialized) return false;
+
+                var app = FindLiveCefApp();
+                if (app is null) return false;
+
+                var commonHandler = BrowserProcessHandlerField(app.GetType())?.GetValue(app);
+                if (commonHandler is null) return false;
+
+                var handlerField = InnerHandlerField(commonHandler.GetType());
+                if (handlerField is null) return false;
+
+                var outgoing = handlerField.GetValue(commonHandler);
+
+                var ours = new ThrottledPumpHandler();
+                handlerField.SetValue(commonHandler, ours);   // future schedule calls come to us
+                ours.Prime();                                 // start pumping BEFORE stopping the old timer
+
+                StopOutgoingInterval(outgoing);
+
+                // CEF may call OnScheduleMessagePumpWork from a non-UI thread. A call already inside the OLD
+                // handler when we swapped can assign a fresh 1 ms subscription AFTER we disposed the one we
+                // read - leaving an undisposed 1 kHz timer running beside ours while we log success. The write
+                // above is a plain reflection store with no barrier, so the window is real if brief. Re-check
+                // shortly after, by which time any in-flight call has landed. (fable review)
+                DispatcherTimer.RunOnce(() => StopOutgoingInterval(outgoing),
+                    TimeSpan.FromMilliseconds(RaceRecheckMs));
+
+                _finished = true;
+                Log.Information("CEF message pump replaced: {Interval} ms interval, was 1 ms (#523).", PumpIntervalMs);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "CEF pump replacement failed; continuing on CefGlue's default pump (#523).");
+                _finished = true;   // an operation that threw once will throw every second; do not spam
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// The live <c>BrowserCefApp</c>. <c>CefApp</c> keeps its instances in a private static dictionary,
+        /// populated when CEF first asks for the browser-process handler — so this returns null until CEF is up.
+        /// </summary>
+        internal static object? FindLiveCefApp()
+        {
+            var roots = RootsField()?.GetValue(null) as IDictionary;
+            if (roots is null) return null;
+
+            foreach (var value in roots.Values)
+                if (value is not null && BrowserProcessHandlerField(value.GetType()) is not null)
+                    return value;
+
+            return null;
+        }
+
+        /// <summary><c>CefApp._roots</c> — the live app instances.</summary>
+        internal static FieldInfo? RootsField() =>
+            typeof(CefApp).GetField("_roots", BindingFlags.NonPublic | BindingFlags.Static);
+
+        /// <summary><c>BrowserCefApp._browserProcessHandler</c>.</summary>
+        internal static FieldInfo? BrowserProcessHandlerField(Type appType) =>
+            appType.GetField("_browserProcessHandler", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        /// <summary>
+        /// <c>CommonBrowserProcessHandler._handler</c> — the swappable slot. Declared readonly; readonly
+        /// instance fields are still writable through reflection.
+        /// </summary>
+        internal static FieldInfo? InnerHandlerField(Type commonHandlerType) =>
+            commonHandlerType.GetField("_handler", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        /// <summary><c>AvaloniaBrowserProcessHandler._current</c> — the running 1 ms subscription.</summary>
+        internal static FieldInfo? CurrentSubscriptionField(Type handlerType) =>
+            handlerType.GetField("_current", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        /// <summary>
+        /// Disposes the outgoing handler's subscription. Best-effort: if the field has moved, the old 1 ms
+        /// interval keeps running alongside ours, which costs CPU but breaks nothing — so this must never throw
+        /// the swap away after it has already succeeded.
+        /// </summary>
+        private static void StopOutgoingInterval(object? outgoing)
+        {
+            if (outgoing is null) return;
+            try
+            {
+                if (CurrentSubscriptionField(outgoing.GetType())?.GetValue(outgoing) is IDisposable running)
+                    running.Dispose();
+                else
+                    Log.Warning("CEF pump: the outgoing handler's subscription was not found; its 1 ms timer " +
+                                "may still be running alongside the replacement (#523).");
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "CEF pump: could not stop the outgoing 1 ms timer (#523).");
+            }
+        }
+
+        /// <summary>Delay before the next pump tick, for a given CEF request. Extracted so the arithmetic is
+        /// testable without CEF. A request of &lt;= 0 means "now"; anything longer than the pump period is capped,
+        /// because the repeating interval is also the watchdog and must not sleep through a lost tick.</summary>
+        internal static long DueDelayMs(long requested) => requested <= 0 ? 0 : Math.Min(requested, PumpIntervalMs);
+
+        /// <summary>
+        /// CefGlue's pump with a sane period: repeating (so it is still self-healing), first tick honouring what
+        /// CEF asked for, and "now" meaning now.
+        ///
+        /// <para><b>Why it does not simply re-arm on every call.</b> Upstream disposes and recreates its
+        /// subscription on every <c>OnScheduleMessagePumpWork</c>, and CEF calls that in rapid succession while
+        /// it is busy. At a 1 ms period that reset is harmless. At 33 ms it is not: a burst of schedule calls
+        /// spaced under 33 ms apart would perpetually postpone the first tick, starving
+        /// <c>DoMessageLoopWork</c> exactly when CEF has the most to do. So a pending tick that already fires
+        /// soon enough is left alone, and a request for immediate work pumps immediately rather than waiting out
+        /// a fresh 33 ms. (fable review)</para>
+        /// </summary>
+        private sealed class ThrottledPumpHandler : BrowserProcessHandler
+        {
+            private readonly object _gate = new();
+            private IDisposable? _current;
+
+            /// <summary>When the pending tick is due, on <see cref="Environment.TickCount64"/>'s clock.</summary>
+            private long _dueAt;
+
+            /// <summary>Starts pumping immediately, so there is no gap between our handler being installed and
+            /// the outgoing timer being stopped.</summary>
+            internal void Prime() => Schedule(0);
+
+            protected override void OnScheduleMessagePumpWork(long delayMs) => Schedule(delayMs);
+
+            private void Schedule(long delayMs)
+            {
+                long due = DueDelayMs(delayMs);
+
+                lock (_gate)
+                {
+                    long now = Environment.TickCount64;
+
+                    // Leave a pending tick alone when it already fires at least as soon as this request wants.
+                    // This is what stops a burst of schedule calls from pushing the tick forever into the future.
+                    bool pendingIsSoonEnough = _current is not null && _dueAt <= now + due;
+
+                    if (!pendingIsSoonEnough)
+                    {
+                        _current?.Dispose();
+                        _dueAt = now + due;
+
+                        // dueTime + period: the first tick honours CEF's request, then it repeats as the
+                        // watchdog. Interval() could only do the latter.
+                        _current = Observable.Timer(
+                                TimeSpan.FromMilliseconds(due),
+                                TimeSpan.FromMilliseconds(PumpIntervalMs))
+                            .Subscribe(_ => OnTick());
+                    }
+                }
+
+                // "Now" means now. Upstream turned this into a 1 ms wait; turning it into a 33 ms wait would add
+                // latency to every urgent wake, which is the one regression this change must not cause.
+                if (delayMs <= 0) Pump();
+            }
+
+            private void OnTick()
+            {
+                lock (_gate) { _dueAt = Environment.TickCount64 + PumpIntervalMs; }
+                Pump();
+            }
+
+            /// <summary>
+            /// Upstream marshals with <c>.ObserveOn(AvaloniaScheduler.Instance)</c>; AvaloniaScheduler is not in
+            /// the Avalonia packages this project references, so post to the dispatcher directly — the same hop
+            /// at the same priority. <c>DoMessageLoopWork</c> must run on the thread that owns the CEF loop.
+            /// Normal priority deliberately: Background would risk starving the pump under sustained UI work,
+            /// which is worse than the reverse.
+            /// </summary>
+            private static void Pump() =>
+                Dispatcher.UIThread.Post(static () => CefRuntime.DoMessageLoopWork(), DispatcherPriority.Normal);
+        }
+    }
+}


### PR DESCRIPTION
Partial fix for #523 — **the issue should stay open**, see "What this does not fix".

## The defect

CefGlue drives CEF's external message pump on macOS with a **repeating** timer floored at **1 ms** (`AvaloniaBrowserProcessHandler`, decompiled from the shipped `Xilium.CefGlue.Avalonia.dll` 120.6099.207, unchanged upstream since 2019):

```csharp
if (delayMs <= 0) delayMs = 1L;
_current = Observable.Interval(TimeSpan.FromMilliseconds(delayMs))   // repeating
    .ObserveOn(AvaloniaScheduler.Instance)
    .Subscribe(_ => CefRuntime.DoMessageLoopWork());
```

It repeats until a later schedule call replaces it, so the UI thread wakes ~1000×/second to ask CEF for work and be told there is none. macOS-only because `CefRuntimeLoader.InternalInitialize` hard-codes `MultiThreadedMessageLoop` on Windows and Linux.

## Measurements

egret (M4, macOS 26.6.1, Debug `dotnet run`, identical restored layout, 175 s settle, `top -l 5 -s 10`):

| | CPU | csw/s | CEF subprocs | navigation |
|---|---|---|---|---|
| without | 36.9–38.8% | ~3,000–3,900 | 6 | ✅ |
| **with** | **32.2–33.6%** | **~1,560–1,700** | 6 | ✅ |

~5 points, roughly half the wakeups.

## What this does not fix

The prediction was ~40% → under 10%. **It isn't.** The pump is a contributor, not the dominant cost — and halving context switches bought only 14% of the CPU, which undercuts the "it's all scheduler overhead" explanation too. Roughly 32% is still unaccounted for and #523 stays open for it. The next step there is an Instruments System Trace on the main process (per-thread wakeup counts name the source), plus a re-measure on a Release `.app` rather than Debug.

## Two earlier approaches were wrong

Documented in the code so they aren't retried:

- **The issue blamed Avalonia's CFRunLoop `Signaler`** and pointed at the Avalonia 12 upgrade (#49). Refuted by measurement: a bare Avalonia 11.3.6 window on the same M4 idles at **0.3–0.4%**. Upstream AvaloniaUI#11070 was closed in July 2024 by the 11.1 CVDisplayLink work, which we already ship. **#49 will not fix this and should be decoupled from #523.**
- **A true single-shot pump plus pre-initializing CEF** through the staged-init seam installs cleanly and **silently breaks the browser**: CEF schedules pump work during `CefRuntime.Initialize`, before Avalonia's dispatcher loop runs, and a one-shot chain that loses those ticks never rearms. Observed: browser created, 1 CEF subprocess instead of 6, no navigation, no exception. The repeating interval turns out to be an accidental watchdog.

## Approach

Let CefGlue initialize CEF **completely normally**, then swap the handler by reflection. No bypass, no reordering, no early `CefRuntime.Initialize`.

## Fable review — three findings fixed

- **Schedule-reset starvation.** Upstream re-arms on every schedule call; harmless at 1 ms, not at 33 ms, where a burst spaced under 33 ms apart would postpone the tick indefinitely and starve `DoMessageLoopWork` exactly when CEF is busiest. A pending tick that already fires soon enough is now left alone, and `delayMs <= 0` pumps immediately rather than waiting out a fresh 33 ms.
- **The wall-clock give-up was a session-permanent silent failure.** CEF starts lazily on the first WebView, and a restored layout with no welcome tab, no book and no dictionary panel creates none — CEF might not exist until a book is opened an hour later. Attempts are now counted only while CEF is actually running.
- **A swap race.** A concurrent schedule call could re-arm the outgoing 1 ms subscription after we disposed it, leaving it running beside ours while we logged success. Closed by a 250 ms post-swap re-check.

## Risk

The swap reaches into four non-public members by name; a package bump that renames one leaves us on the 1 kHz pump with no error. Guarded by null-checked lookups that no-op rather than throw, and by 7 tests pinning each member so a bump fails the build — the same idiom and reasoning as the existing `CefBrowserAccess`. The remaining tests cover the delay arithmetic and perform a real reflection write to the `readonly` handler field, which no metadata assertion could cover.

**Manual check worth doing before merge:** scroll a book and type in search, watching for input lag. That is the one risk the tests can't cover.

Suite: **1783 passed, 0 failed.** Mutation-checked: making "now" wait 33 ms fails 1 test, removing the cap fails 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)