### PR TITLE
Clear every build warning in both projects

### DIFF
--- a/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
+++ b/src/CST.Avalonia.Tests/CST.Avalonia.Tests.csproj
@@ -26,7 +26,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <!-- MCP client, to round-trip the in-app /mcp endpoint the way Claude Desktop's bridge does (#191). -->
     <PackageReference Include="ModelContextProtocol" Version="2.0.0" />
   </ItemGroup>

--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryCloseBookTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryCloseBookTests.cs
@@ -35,6 +35,12 @@ public class CstDockFactoryCloseBookTests
 
     private static Document Doc(string id, bool canClose = true) => new() { Id = id, CanClose = canClose };
 
+    // IDock.VisibleDockables is nullable, and the assertions below take non-nullable collections (CS8604).
+    // Every dock Window() builds has one, so a null here is a broken fixture — worth failing the test with a
+    // named reason rather than waving through with `!` and getting an unattributed NullReferenceException.
+    private static IList<IDockable> Contents(IDock dock) =>
+        dock.VisibleDockables ?? throw new InvalidOperationException($"{dock.Id} has no VisibleDockables");
+
     [Fact]
     public void CloseBook_removes_a_book_in_a_floating_window()
     {
@@ -47,8 +53,8 @@ public class CstDockFactoryCloseBookTests
 
         f.CloseBook("floatBook");
 
-        Assert.DoesNotContain(a, floatDock.VisibleDockables);          // removed from the FLOATING dock
-        Assert.Contains(b, floatDock.VisibleDockables);                // sibling untouched
+        Assert.DoesNotContain(a, Contents(floatDock));          // removed from the FLOATING dock
+        Assert.Contains(b, Contents(floatDock));                // sibling untouched
         Assert.Equal(b, floatDock.ActiveDockable);                     // sibling activated after the active doc closed
     }
 
@@ -62,8 +68,8 @@ public class CstDockFactoryCloseBookTests
 
         f.CloseBook("mainBook");
 
-        Assert.DoesNotContain(a, mainDock.VisibleDockables);
-        Assert.Contains(b, mainDock.VisibleDockables);
+        Assert.DoesNotContain(a, Contents(mainDock));
+        Assert.Contains(b, Contents(mainDock));
     }
 
     [Fact]
@@ -75,7 +81,7 @@ public class CstDockFactoryCloseBookTests
 
         f.CloseBook("does-not-exist");   // must not throw
 
-        Assert.Single(mainDock.VisibleDockables);
+        Assert.Single(Contents(mainDock));
     }
 
     [Fact]
@@ -89,6 +95,6 @@ public class CstDockFactoryCloseBookTests
 
         f.CloseBook("WelcomeDocument");
 
-        Assert.Contains(welcome, mainDock.VisibleDockables);   // still present
+        Assert.Contains(welcome, Contents(mainDock));   // still present
     }
 }

--- a/src/CST.Avalonia.Tests/Services/RetireUserXslDirectoryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/RetireUserXslDirectoryTests.cs
@@ -152,7 +152,8 @@ public class RetireUserXslDirectoryTests : IDisposable
         RunOnlyThisMigration(state, Context());
         RunOnlyThisMigration(state, Context());
 
-        Assert.Single(state.AppliedDataMigrations!.Where(id => id == "2026-08-retire-user-xsl-directory"));
+        Assert.NotNull(state.AppliedDataMigrations);
+        Assert.Single(state.AppliedDataMigrations, id => id == "2026-08-retire-user-xsl-directory");
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
+++ b/src/CST.Avalonia.Tests/Tools/SearchToolTests.cs
@@ -117,7 +117,9 @@ namespace CST.Avalonia.Tests.Tools
 
             // Opt in: the full per-book breakdown comes back.
             var full = await tool.SearchAsync(new SearchToolRequest("q", IncludeBooks: true));
-            Assert.Equal(2, Assert.Single(full.Terms).Books.Count);
+            var books = Assert.Single(full.Terms).Books;
+            Assert.NotNull(books);                     // opting in must populate it, not merely leave it null
+            Assert.Equal(2, books.Count);
         }
 
         [Fact]
@@ -138,6 +140,7 @@ namespace CST.Avalonia.Tests.Tools
             var term = Assert.Single(result.Terms);
             Assert.Equal(ScriptConverter.Convert("abc", Script.Ipe, Script.Latin), term.Term);
 
+            Assert.NotNull(term.Books);                // IncludeBooks: true was requested above
             var hit = Assert.Single(term.Books);
             Assert.Equal(book.FileName, hit.BookId);
             Assert.False(string.IsNullOrEmpty(hit.BookName));

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -129,9 +129,14 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
 
     /// <param name="callerToken">The consumer's own token. Cancelling it must throw, as any .NET async method
     /// would; cancelling only ours means superseded or stopped, which ends the turn quietly.</param>
-    /// <param name="token">The linked token actually passed downstream.</param>
+    /// <param name="token">The linked token actually passed downstream. Carries
+    /// [EnumeratorCancellation] because it is the one with teeth: a token handed to
+    /// GetAsyncEnumerator has to reach the provider call to stop anything, and callerToken never
+    /// leaves this method — it only classifies a cancellation once one happens.</param>
     private async IAsyncEnumerable<AiTurnEvent> RunCoreAsync(
-        AiTurnRequest request, CancellationToken callerToken, CancellationToken token)
+        AiTurnRequest request,
+        CancellationToken callerToken,
+        [EnumeratorCancellation] CancellationToken token)
     {
         var provider = _resolver.Resolve(out var problem);
         if (provider is null)
@@ -187,6 +192,17 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
         if (assemblyFailure is not null)
         {
             yield return AiTurnEvent.ForError(assemblyFailure);
+            yield break;
+        }
+
+        // Unreachable: the two are assigned together, and every failure above sets `superseded` or
+        // `assemblyFailure`. Stated anyway, because the compiler cannot relate the three locals (CS8602)
+        // and because the alternative — a null-forgiving `!` — would turn a future break in that invariant
+        // into a NullReferenceException mid-turn, which the panel would show as a raw crash.
+        if (bundle is null || prompt is null)
+        {
+            yield return AiTurnEvent.ForError(new AiError(
+                AiErrorKind.Provider, "The assistant could not assemble this request."));
             yield break;
         }
 

--- a/src/CST.Avalonia/Services/DocumentFocusReporter.cs
+++ b/src/CST.Avalonia/Services/DocumentFocusReporter.cs
@@ -140,7 +140,10 @@ internal static class DocumentFocusReporter
     /// </summary>
     internal static IDockable? ResolveDockable(object? source)
     {
-        if (source is not Visual element) return null;
+        // Nullable walker rather than a pattern-declared non-nullable: GetVisualParent() returns Visual?,
+        // and assigning that to a non-nullable local was the whole of CS8600. A non-Visual source simply
+        // never enters the loop, which is what the old early return did.
+        var element = source as Visual;
 
         while (element != null)
         {


### PR DESCRIPTION
Both projects printed warnings on every build — four in the app, eight in the tests — and had for the whole Surface B run. A build that always warns is a build nobody reads warnings from, so a real one would have arrived unnoticed. **Both are now 0 warnings, 0 errors.**

# The app (4)

## CS8600 — `DocumentFocusReporter.ResolveDockable`

`GetVisualParent()` returns `Visual?`, but the loop variable came from `source is not Visual element`, so it was non-nullable. Walking with a nullable local says what the walk actually does. A non-`Visual` source now simply never enters the loop — exactly what the old early return did, one line shorter.

## CS8602 ×2 — `AiChatOrchestrator.RunCoreAsync`

`bundle` and `prompt` are assigned together inside the `try`, and every failure path sets `superseded` or `assemblyFailure`, so by the time they are read they cannot be null. The compiler can't relate three separate locals, hence the warning.

Rather than silence it with `!`, the invariant is written down:

```csharp
if (bundle is null || prompt is null)
{
    yield return AiTurnEvent.ForError(new AiError(
        AiErrorKind.Provider, "The assistant could not assemble this request."));
    yield break;
}
```

Unreachable today. The point is what happens if a future edit breaks it: the turn ends with a sentence in the panel rather than a `NullReferenceException` mid-stream. That's the difference between a bug report and a crash report — and `!` would have chosen the crash.

## CS8425 — the same method

Of its two tokens, `token` is the one with teeth: it is what reaches the provider call. `callerToken` never leaves the method — it only classifies a cancellation once one happens, in the `when (!callerToken.IsCancellationRequested)` filter. So `[EnumeratorCancellation]` goes on `token`, because a token handed to `GetAsyncEnumerator` has to reach the provider to stop anything; putting it on `callerToken` would have produced a cancellation that changes a label and stops no work.

**No behaviour changes today**: the only call site passes both tokens explicitly and never uses `WithCancellation`, so the attribute is inert until someone does.

# The tests (8)

## CS8604 ×4 — `CstDockFactoryCloseBookTests`

`IDock.VisibleDockables` is nullable and the xUnit collection assertions are not. A `Contents(dock)` helper throws with the dock's id if it is ever null. Not ceremony: `!` here would have turned a broken fixture into an unattributed `NullReferenceException` *inside an assertion*, which is a bad half hour for whoever inherits it.

## CS8602 + CS8604 — `SearchToolTests`

Both sites dereference `Books` immediately after asking for `IncludeBooks: true`. Asserting `NotNull` first removes the warning **and adds the check that was implied all along** — that opting in actually populates the breakdown rather than leaving it null. A regression there would previously have surfaced as a `NullReferenceException` rather than a failed assertion.

## xUnit2031 — `RetireUserXslDirectoryTests`

`Assert.Single(x.Where(p))` becomes `Assert.Single(x, p)`. Beyond satisfying the analyzer, the filtering overload reports *how many* matched; the `Where` form can only say the sequence wasn't of length one.

## NU1510

`Microsoft.Extensions.Logging.Abstractions` was referenced directly but arrives through the app project anyway, so NuGet flagged it as dead weight. Removed; the logging types still resolve.

# Testing

Both builds **0 warnings, 0 errors**. Full suite **1783 passed, 0 failed**.
