### PR TITLE
Apply the AI settings live instead of requiring a restart (#529)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LocalApi/LocalApiLifecycleTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApi/LocalApiLifecycleTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services.LocalApi;
+using Serilog;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.LocalApi;
+
+/// <summary>
+/// #529: the AI settings used to be read once at startup, so toggling any of the three switches did nothing
+/// until relaunch. These cover the transitions — including the ones the issue calls out as the hard part,
+/// where one surface stays on while the other flips.
+///
+/// <para>These start a real Kestrel host on an ephemeral loopback port. That is deliberate: the defect being
+/// fixed is about actually starting and stopping a server, and a mocked host would assert the diff logic while
+/// leaving the thing that broke untested.</para>
+/// </summary>
+public class LocalApiLifecycleTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly AiSettings _settings = new();
+
+    public LocalApiLifecycleTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cst-529-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private LocalApiLifecycle NewLifecycle() =>
+        new(services: null, appVersion: "test", handshakeDirectory: _dir,
+            logger: Serilog.Core.Logger.None, readSettings: () => _settings);
+
+    private void Configure(bool master, bool rest, bool mcp)
+    {
+        _settings.Enabled = master;
+        _settings.LocalApi.Enabled = rest;
+        _settings.LocalApi.EnableMcpServer = mcp;
+    }
+
+    private bool HandshakeExists => File.Exists(LocalApiInfo.PathIn(_dir));
+
+    // ---- the defect ------------------------------------------------------------------------------------
+
+    /// <summary>The whole point: a toggle takes effect without a restart.</summary>
+    [Fact]
+    public async Task Turning_the_master_switch_on_starts_the_server()
+    {
+        Configure(master: false, rest: true, mcp: true);
+        await using var life = NewLifecycle();
+        await life.ApplyAsync();
+        Assert.Null(life.Server);
+
+        Configure(master: true, rest: true, mcp: true);
+        Assert.True(await life.ApplyAsync());
+
+        Assert.NotNull(life.Server);
+        Assert.True(life.Server!.IsRunning);
+        Assert.True(HandshakeExists);
+    }
+
+    [Fact]
+    public async Task Turning_the_master_switch_off_stops_the_server_and_removes_the_handshake_file()
+    {
+        Configure(master: true, rest: true, mcp: false);
+        await using var life = NewLifecycle();
+        await life.ApplyAsync();
+        Assert.True(HandshakeExists);
+
+        Configure(master: false, rest: true, mcp: false);
+        Assert.True(await life.ApplyAsync());
+
+        Assert.Null(life.Server);
+        Assert.False(HandshakeExists);
+    }
+
+    // ---- the four-valued surface space ------------------------------------------------------------------
+
+    /// <summary>
+    /// The transition the issue names as the hard one: MCP is added while REST stays on. The surfaces are fixed
+    /// at construction, so this necessarily rebuilds the host — what must hold is that both surfaces are
+    /// serving afterwards, not that the port survived.
+    /// </summary>
+    [Fact]
+    public async Task Adding_the_second_surface_leaves_both_serving()
+    {
+        Configure(master: true, rest: true, mcp: false);
+        await using var life = NewLifecycle();
+        await life.ApplyAsync();
+        Assert.Equal(new LocalApiLifecycle.Surfaces(Rest: true, Mcp: false), life.Running);
+
+        Configure(master: true, rest: true, mcp: true);
+        Assert.True(await life.ApplyAsync());
+
+        Assert.Equal(new LocalApiLifecycle.Surfaces(Rest: true, Mcp: true), life.Running);
+        Assert.True(life.Server!.IsRunning);
+    }
+
+    /// <summary>REST-only → MCP-only. Both flags change in one apply; the server must end up serving exactly
+    /// the new pair rather than the union or the old one.</summary>
+    [Fact]
+    public async Task Swapping_which_surface_is_on_serves_only_the_new_one()
+    {
+        Configure(master: true, rest: true, mcp: false);
+        await using var life = NewLifecycle();
+        await life.ApplyAsync();
+
+        Configure(master: true, rest: false, mcp: true);
+        Assert.True(await life.ApplyAsync());
+
+        Assert.Equal(new LocalApiLifecycle.Surfaces(Rest: false, Mcp: true), life.Running);
+        Assert.True(life.Server!.IsRunning);
+    }
+
+    /// <summary>Turning off the last remaining surface stops the host — the master switch is not the only way
+    /// to reach "off".</summary>
+    [Fact]
+    public async Task Turning_off_the_last_surface_stops_the_host()
+    {
+        Configure(master: true, rest: false, mcp: true);
+        await using var life = NewLifecycle();
+        await life.ApplyAsync();
+        Assert.NotNull(life.Server);
+
+        Configure(master: true, rest: false, mcp: false);
+        Assert.True(await life.ApplyAsync());
+
+        Assert.Null(life.Server);
+        Assert.False(HandshakeExists);
+    }
+
+    // ---- not disturbing a healthy server ----------------------------------------------------------------
+
+    /// <summary>
+    /// An apply that changes nothing must NOT bounce the server. Applies fire on every AI settings change, and
+    /// most of them — the API key, the model, remote-control consent — have nothing to do with which surfaces
+    /// are mounted. Restarting on those would hand every connected client a new port and token for no reason.
+    /// </summary>
+    [Fact]
+    public async Task An_apply_that_changes_nothing_leaves_the_server_untouched()
+    {
+        Configure(master: true, rest: true, mcp: true);
+        await using var life = NewLifecycle();
+        await life.ApplyAsync();
+
+        var before = life.Server;
+        var urlBefore = life.Server!.BaseUrl;
+        var tokenBefore = life.Server!.Token;
+
+        Assert.False(await life.ApplyAsync());   // reports "no transition"
+
+        Assert.Same(before, life.Server);
+        Assert.Equal(urlBefore, life.Server!.BaseUrl);
+        Assert.Equal(tokenBefore, life.Server!.Token);
+    }
+
+    /// <summary>Changing an unrelated AI setting must not restart the server either — the same guarantee, from
+    /// the direction a user would actually hit it.</summary>
+    [Fact]
+    public async Task Changing_an_unrelated_ai_setting_does_not_restart_the_server()
+    {
+        Configure(master: true, rest: true, mcp: false);
+        await using var life = NewLifecycle();
+        await life.ApplyAsync();
+        var tokenBefore = life.Server!.Token;
+
+        _settings.LocalApi.AllowRemoteControl = !_settings.LocalApi.AllowRemoteControl;
+        Assert.False(await life.ApplyAsync());
+
+        Assert.Equal(tokenBefore, life.Server!.Token);
+    }
+
+    // ---- rapid toggling --------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The trigger is a checkbox, and a user can flip one faster than Kestrel can bind and release a port.
+    /// Overlapping applies must serialise and settle on whatever the settings say LAST — and in particular must
+    /// not leave a server running after the reader switched AI off, which is the wrong direction to fail in.
+    /// </summary>
+    [Fact]
+    public async Task Rapid_toggling_settles_on_the_final_setting()
+    {
+        await using var life = NewLifecycle();
+
+        for (int i = 0; i < 6; i++)
+        {
+            Configure(master: i % 2 == 0, rest: true, mcp: i % 3 == 0);
+            _ = life.ApplyAsync();   // deliberately not awaited: overlap the transitions
+        }
+
+        Configure(master: false, rest: true, mcp: true);
+        await life.ApplyAsync();
+
+        Assert.Null(life.Server);
+        Assert.False(HandshakeExists);
+    }
+
+    // ---- start failure ---------------------------------------------------------------------------------
+
+    /// <summary>A stopped server must clear the failure flag: a stale one would keep Settings warning about a
+    /// server the reader has since switched off.</summary>
+    [Fact]
+    public async Task Stopping_clears_the_start_failure_flag()
+    {
+        Configure(master: true, rest: true, mcp: false);
+        await using var life = NewLifecycle();
+        await life.ApplyAsync();
+        Assert.False(life.StartFailed);
+
+        Configure(master: false, rest: false, mcp: false);
+        await life.ApplyAsync();
+
+        Assert.False(life.StartFailed);
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -48,7 +48,7 @@ public partial class App : Application
     public static Window? MainWindow { get; private set; }
 
     // Opt-in loopback API server for AI tools; gated on settings at launch (restart to apply). (#186)
-    private CST.Avalonia.Services.LocalApi.LocalApiServer? _localApiServer;
+    private CST.Avalonia.Services.LocalApi.LocalApiLifecycle? _localApi;
 
     /// <summary>
     /// True once application shutdown has begun. Floating windows close as part of shutdown too;
@@ -453,48 +453,32 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// Start the opt-in loopback API server if AI features + the local API are enabled. Gated at launch:
-    /// changes to the setting take effect on restart (live toggle is a later iteration). (#186)
+    /// Bring the loopback API server in line with the AI settings. This is BOTH the launch path and the path
+    /// every later settings toggle takes (#529) — one code path, so the two cannot drift. Before this the
+    /// settings were read once at startup and a toggle did nothing until relaunch.
     /// </summary>
-    private async Task StartLocalApiIfEnabledAsync(ISettingsService settingsService)
+    public static Task ApplyAiSettingsAsync()
     {
-        try
-        {
-            var ai = settingsService.Settings.Ai;
-            if (!ai.ServerShouldRun) return;
-
-            var dir = CST.Avalonia.Constants.AppConstants.DataDirectory;   // single source of truth (#317 A6-9)
-            System.IO.Directory.CreateDirectory(dir);
-
-            // #278 Phase 4: the loopback API is EPHEMERAL (OS-assigned port) with a PER-SESSION token — no stable
-            // secret is stored and there's no fixed port to collide. MCP clients don't need one either: the app's
-            // --mcp-bridge relay reads the current local-api.json each spawn. So we pass no port/token (server
-            // mints them) and mount each surface per its own permission.
-            var version = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown";
-            // Resolve the tools through the shared factory (covered by AppCompositionTests), so a tool that is
-            // registered but forgotten here can't silently 404 an endpoint again.
-            _localApiServer = ServiceProvider is { } sp
-                ? CST.Avalonia.Services.LocalApi.LocalApiServer.FromServiceProvider(
-                    sp, version, dir, Log.Logger, restApiEnabled: ai.LocalApiEnabled, mcpEnabled: ai.McpEnabled)
-                : new CST.Avalonia.Services.LocalApi.LocalApiServer(
-                    version, dir, Log.Logger, restApiEnabled: ai.LocalApiEnabled, mcpEnabled: ai.McpEnabled);
-            await _localApiServer.StartAsync();
-            LocalApiStartFailed = false;
-        }
-        catch (Exception ex)
-        {
-            // #316 A6-4: the API is EPHEMERAL now, so there is no "port in use" case — but ANY StartAsync failure
-            // (loopback bind blocked by security software, a DI fault) leaves AI shown as enabled while the server
-            // never started and every bridge spawn fails. Log it loudly and record the state so a Settings
-            // indicator can surface it (the old #277 port-in-use dialog was dead code and is removed).
-            LocalApiStartFailed = true;
-            Log.Error(ex, "Local API server failed to start — AI agent access will not work this session despite being enabled in Settings");
-        }
+        if (Current is App { _localApi: { } lifecycle }) return lifecycle.ApplyAsync();
+        return Task.CompletedTask;
     }
 
-    /// <summary>True when the loopback API was enabled but <c>StartAsync</c> threw, so AI access is silently
-    /// non-functional this session. Surfaced for a Settings status indicator. (#316 A6-4)</summary>
-    public bool LocalApiStartFailed { get; private set; }
+    private async Task StartLocalApiIfEnabledAsync(ISettingsService settingsService)
+    {
+        var dir = CST.Avalonia.Constants.AppConstants.DataDirectory;   // single source of truth (#317 A6-9)
+        var version = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown";
+
+        _localApi = new CST.Avalonia.Services.LocalApi.LocalApiLifecycle(
+            ServiceProvider, version, dir, Log.Logger, () => settingsService.Settings.Ai);
+
+        // The first apply IS the launch start - it reads the same settings and takes the same route a toggle
+        // would. LocalApiLifecycle swallows and records start failures, so this does not need its own try.
+        await _localApi.ApplyAsync();
+    }
+
+    /// <summary>True when the loopback API was enabled but starting it threw, so AI access is silently
+    /// non-functional. Surfaced for a Settings status indicator. (#316 A6-4)</summary>
+    public bool LocalApiStartFailed => _localApi?.StartFailed ?? false;
 
     /// <summary>
     /// Pre-load fonts for all scripts to avoid UI delays in settings
@@ -1140,9 +1124,9 @@ public partial class App : Application
                 Log.Information("SHUTDOWN: Pending settings save flushed");
             }
 
-            if (_localApiServer != null)
+            if (_localApi != null)
             {
-                await _localApiServer.StopAsync();
+                await _localApi.DisposeAsync();
                 Log.Information("SHUTDOWN: Local API server stopped");
             }
         }

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiLifecycle.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiLifecycle.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using Serilog;
+
+namespace CST.Avalonia.Services.LocalApi
+{
+    /// <summary>
+    /// Owns the loopback API server's lifetime and brings it in line with the AI settings on demand. (#529)
+    ///
+    /// <para>Before this, the settings were read <b>once at startup</b> and nothing subscribed to changes, so
+    /// toggling "Enable AI Features", "Run the local API server" or "Enable MCP access" did nothing until the
+    /// app was relaunched — which Settings had to apologise for in a note (#527/#528).</para>
+    ///
+    /// <para><b>One code path.</b> Startup and every later toggle both call <see cref="ApplyAsync"/>, which
+    /// diffs the running state against what the settings now ask for and performs the minimum transition. There
+    /// is deliberately no separate "start at launch" route: two paths would drift, and the launch one is simply
+    /// the first apply.</para>
+    ///
+    /// <para><b>Transitions are serialised</b> on a semaphore, because the trigger is a checkbox and a user can
+    /// flip one faster than Kestrel can bind and release a port. Without it, two overlapping applies could leave
+    /// a server running that the settings say should be stopped — the failure being that AI access stays live
+    /// after the reader switched it off, which is the wrong direction to fail in.</para>
+    /// </summary>
+    public sealed class LocalApiLifecycle : IAsyncDisposable
+    {
+        /// <summary>
+        /// Which surfaces should be mounted. <b>Not simply on/off</b>: /v1 and /mcp are enabled independently
+        /// and ride the same Kestrel host, so the state space is four-valued and the transitions between them
+        /// are what this type exists to get right.
+        /// </summary>
+        internal readonly record struct Surfaces(bool Rest, bool Mcp)
+        {
+            /// <summary>The host runs when either surface is wanted.</summary>
+            public bool ShouldRun => Rest || Mcp;
+
+            /// <summary>Reads the desired surfaces from settings. Both flags already fold in the master switch
+            /// (<c>AiSettings.LocalApiEnabled</c>/<c>McpEnabled</c> are <c>Enabled &amp;&amp; …</c>), so turning
+            /// AI off yields (false, false) without this type knowing about the master at all.</summary>
+            public static Surfaces From(AiSettings ai) => new(ai.LocalApiEnabled, ai.McpEnabled);
+
+            public override string ToString() =>
+                !ShouldRun ? "off" : $"{(Rest ? "/v1" : "")}{(Rest && Mcp ? "+" : "")}{(Mcp ? "/mcp" : "")}";
+        }
+
+        private readonly IServiceProvider? _services;
+        private readonly string _appVersion;
+        private readonly string _handshakeDirectory;
+        private readonly ILogger _logger;
+        private readonly Func<AiSettings> _readSettings;
+
+        private readonly SemaphoreSlim _gate = new(1, 1);
+        private LocalApiServer? _server;
+        private Surfaces _running;   // the surfaces the LIVE server was constructed with
+
+        public LocalApiLifecycle(
+            IServiceProvider? services,
+            string appVersion,
+            string handshakeDirectory,
+            ILogger logger,
+            Func<AiSettings> readSettings)
+        {
+            _services = services;
+            _appVersion = appVersion;
+            _handshakeDirectory = handshakeDirectory;
+            _logger = logger;
+            _readSettings = readSettings;
+        }
+
+        /// <summary>
+        /// True when the settings asked for a server and starting it threw, so AI access is enabled in the UI
+        /// but non-functional. Surfaced for the Settings indicator (#316 A6-4). Cleared by any apply that
+        /// succeeds or that stops the server — a stale failure flag would keep warning about a server the reader
+        /// has since switched off.
+        /// </summary>
+        public bool StartFailed { get; private set; }
+
+        /// <summary>The live server, or null. For tests and for anything needing the current base URL.</summary>
+        public LocalApiServer? Server => _server;
+
+        /// <summary>What the live server is currently serving, for logging and tests.</summary>
+        internal Surfaces Running => _running;
+
+        /// <summary>
+        /// Brings the server in line with the current settings. Safe to call repeatedly and concurrently; calls
+        /// are serialised and a call that finds nothing to change does nothing.
+        /// </summary>
+        /// <returns>True if a transition was performed.</returns>
+        public async Task<bool> ApplyAsync(CancellationToken ct = default)
+        {
+            var desired = Surfaces.From(_readSettings());
+
+            await _gate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (!desired.ShouldRun)
+                {
+                    if (_server is null) return false;
+                    await StopCoreAsync().ConfigureAwait(false);
+                    _logger.Information("Local API stopped: AI settings now ask for {Desired} (#529)", desired);
+                    return true;
+                }
+
+                // Already serving exactly this. Applies fire on any AI settings change, most of which - the API
+                // key, the model, remote-control consent - have nothing to do with which surfaces are mounted,
+                // so bailing out here is what keeps an unrelated edit from bouncing a live server and handing
+                // every connected client a new port and token for no reason.
+                if (_server is not null && _running == desired) return false;
+
+                // The surfaces are fixed at construction (LocalApiServer takes restApiEnabled/mcpEnabled as
+                // readonly fields and maps its routes once, at build). So a change in COMPOSITION cannot be
+                // applied in place - the host is rebuilt, and the port and token change with it. That is
+                // tolerable precisely because discovery is the handshake file rather than a fixed port: the
+                // --mcp-bridge relay re-reads local-api.json on every spawn (#278).
+                if (_server is not null)
+                    await StopCoreAsync().ConfigureAwait(false);
+
+                await StartCoreAsync(desired, ct).ConfigureAwait(false);
+                return true;
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        /// <summary>Stops and disposes the running server. Caller holds the gate.</summary>
+        private async Task StopCoreAsync()
+        {
+            if (_server is null) return;
+            try
+            {
+                await _server.StopAsync().ConfigureAwait(false);
+                await _server.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // A server that failed to stop cleanly must still be let go of, or the next start would leave
+                // the old one holding its port with nothing tracking it.
+                _logger.Warning(ex, "Local API did not stop cleanly; dropping the reference anyway (#529)");
+            }
+            finally
+            {
+                _server = null;
+                _running = default;
+                StartFailed = false;
+            }
+        }
+
+        /// <summary>Builds and starts a server for <paramref name="desired"/>. Caller holds the gate.</summary>
+        private async Task StartCoreAsync(Surfaces desired, CancellationToken ct)
+        {
+            try
+            {
+                System.IO.Directory.CreateDirectory(_handshakeDirectory);
+
+                // Resolve tools through the shared factory (covered by AppCompositionTests) so a tool that is
+                // registered but forgotten here cannot silently 404 an endpoint.
+                var server = _services is { } sp
+                    ? LocalApiServer.FromServiceProvider(
+                        sp, _appVersion, _handshakeDirectory, _logger,
+                        restApiEnabled: desired.Rest, mcpEnabled: desired.Mcp)
+                    : new LocalApiServer(
+                        _appVersion, _handshakeDirectory, _logger,
+                        restApiEnabled: desired.Rest, mcpEnabled: desired.Mcp);
+
+                await server.StartAsync(ct).ConfigureAwait(false);
+
+                _server = server;
+                _running = desired;
+                StartFailed = false;
+                _logger.Information("Local API started: serving {Desired} (#529)", desired);
+            }
+            catch (Exception ex)
+            {
+                // The API is ephemeral, so there is no "port in use" case - but any failure (loopback bind
+                // blocked by security software, a DI fault) leaves AI shown as enabled while nothing is
+                // listening and every bridge spawn fails. Record it so Settings can say so. (#316 A6-4)
+                _server = null;
+                _running = default;
+                StartFailed = true;
+                _logger.Error(ex, "Local API server failed to start - AI agent access will not work despite " +
+                                  "being enabled in Settings");
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _gate.WaitAsync().ConfigureAwait(false);
+            try { await StopCoreAsync().ConfigureAwait(false); }
+            finally { _gate.Release(); _gate.Dispose(); }
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -414,12 +414,23 @@ namespace CST.Avalonia.Services.LocalApi
             try
             {
                 if (_app == null) return;
+
+                // Delete the handshake file FIRST, before the port actually closes (#529). Discovery is the
+                // file, not a fixed port: --mcp-bridge reads local-api.json on every spawn (#278). Removing it
+                // up front means a client that polls stops finding a live endpoint slightly early, which costs
+                // nothing; the other order leaves a window where the file still advertises a port that is
+                // already refusing connections, and a bridge that reads it there fails with a confusing
+                // connection error instead of the plain "not running" it should see.
+                //
+                // NOTE: this ORDER is not covered by a test - the suite asserts the file is gone once StopAsync
+                // returns, which holds either way. Verified by reading, and left documented rather than pinned.
+                LocalApiInfo.Delete(_handshakeDirectory);
+
                 try { await _app.StopAsync(); } catch (Exception ex) { _logger.Warning(ex, "Local API stop error"); }
                 await _app.DisposeAsync();
                 _app = null;
                 BaseUrl = null;
                 Token = null;
-                LocalApiInfo.Delete(_handshakeDirectory);
                 _logger.Information("Local API stopped");
             }
             finally { _lifecycleLock.Release(); }

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1340,6 +1340,12 @@ public class AiSettingsViewModel : ViewModelBase
                 // are turned off." after the user had just turned them on, until some other field happened to
                 // be edited -- the one line on the screen whose entire job is not to be out of date.
                 RefreshReadiness();
+                // Apply live - no restart (#529). The server's surfaces are fixed at construction, so a change
+                // here rebuilds the host; discovery is the handshake file, not a fixed port, so clients pick up
+                // the new one on their next spawn (#278). Fire-and-forget with a logged failure: a checkbox must
+                // not block the UI thread on Kestrel binding a port.
+                _ = ApplyAiServerStateAsync();
+
             }
         }
 
@@ -1355,6 +1361,12 @@ public class AiSettingsViewModel : ViewModelBase
                 _settingsService.RequestSave();
                 // Remote control follows "a server surface is running", not the REST flag specifically. (#440)
                 this.RaisePropertyChanged(nameof(RemoteControlEnabled));
+                // Apply live - no restart (#529). The server's surfaces are fixed at construction, so a change
+                // here rebuilds the host; discovery is the handshake file, not a fixed port, so clients pick up
+                // the new one on their next spawn (#278). Fire-and-forget with a logged failure: a checkbox must
+                // not block the UI thread on Kestrel binding a port.
+                _ = ApplyAiServerStateAsync();
+
             }
         }
 
@@ -1371,6 +1383,32 @@ public class AiSettingsViewModel : ViewModelBase
                 _settingsService.RequestSave();
                 // navigate is offered over BOTH surfaces, so remote control is reachable whenever EITHER runs. (#440)
                 this.RaisePropertyChanged(nameof(RemoteControlEnabled));
+                // Apply live - no restart (#529). The server's surfaces are fixed at construction, so a change
+                // here rebuilds the host; discovery is the handshake file, not a fixed port, so clients pick up
+                // the new one on their next spawn (#278). Fire-and-forget with a logged failure: a checkbox must
+                // not block the UI thread on Kestrel binding a port.
+                _ = ApplyAiServerStateAsync();
+
+            }
+        }
+
+        /// <summary>
+        /// Applies the AI server settings live, logging rather than throwing. (#529)
+        ///
+        /// <para>Deliberately fire-and-forget from the setters: starting Kestrel and binding a loopback port
+        /// takes long enough to be visible, and a checkbox that freezes while it happens is a worse experience
+        /// than one that takes a moment to take effect. Failures are recorded on the lifecycle
+        /// (<c>App.LocalApiStartFailed</c>) for the Settings indicator, so a silent swallow here still surfaces.</para>
+        /// </summary>
+        private static async Task ApplyAiServerStateAsync()
+        {
+            try
+            {
+                await App.ApplyAiSettingsAsync();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to apply AI server settings live (#529)");
             }
         }
 

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -497,13 +497,6 @@
                                                  Margin="0,10,0,0"/>
                                         <TextBlock Text="When off, all AI features are disabled."
                                                   Classes="SettingDescription"/>
-                                        <!-- #527: the API server reads these settings once, at startup
-                                             (App.StartLocalApiIfEnabledAsync), so a toggle here does nothing until
-                                             relaunch. Without this note the feature simply looks broken. -->
-                                        <TextBlock Text="⚠ Takes effect after you restart CST Reader."
-                                                  Classes="SettingDescription"
-                                                  FontWeight="SemiBold"
-                                                  Margin="0,6,0,0"/>
                                     </StackPanel>
                                 </Border>
 


### PR DESCRIPTION
Fixes #529.

The AI settings were read **once, at startup**. `StartAsync` was called only from that path, `StopAsync` only at shutdown, and nothing subscribed to changes — so toggling **Enable AI Features**, **Run the local API server** or **Enable MCP access** did nothing until relaunch. Settings had to apologise for it with a *"⚠ Takes effect after you restart CST Reader"* note (#527/#528). That note is removed here, along with the reason for it.

## Approach

New `LocalApiLifecycle` owns the server's lifetime and diffs the running state against what the settings now ask for. **Startup and every later toggle both call `ApplyAsync`** — one code path rather than two that can drift; the launch start is simply the first apply.

**Transitions are serialised** on a semaphore. The trigger is a checkbox and a user can flip one faster than Kestrel can bind and release a port; without serialisation two overlapping applies could leave a server running that the settings say should be stopped — AI access staying live *after* the reader switched it off, which is the wrong direction to fail in.

**Surfaces are four-valued, not on/off.** `/v1` and `/mcp` are enabled independently and ride the same host, and `LocalApiServer` fixes them at construction (readonly fields, routes mapped once at build). So a change in *composition* rebuilds the host, and the port and token change with it. That is tolerable precisely because discovery is the handshake file rather than a fixed port — `--mcp-bridge` re-reads `local-api.json` on every spawn (#278).

**An apply that changes nothing does nothing.** Applies fire on every AI settings change, and most — the API key, the model, remote-control consent — have nothing to do with which surfaces are mounted. Restarting on those would hand every connected client a new port and token for no reason.

**`StopAsync` now deletes the handshake file before stopping the host** rather than after. The old order left a window where the file advertised a port that was already refusing connections, so a bridge reading it there failed with a confusing connection error instead of the plain "not running" it should see.

## Tests

9 covering the transitions the issue names — both single-surface flips, REST-only → MCP-only, turning off the last surface, rapid overlapping toggles settling on the final setting, and an unrelated setting change not bouncing the server.

They start a **real Kestrel host** on an ephemeral loopback port. Deliberate: the defect is about actually starting and stopping a server, and a mocked host would assert the diff logic while leaving the part that broke untested.

Mutation-checked: removing the no-change guard fails 2.

## Known gap — stated rather than papered over

**The handshake-delete *order* is not covered by any test.** The suite asserts the file is gone once `StopAsync` returns, which holds whichever order it happens in — I reverted the order as a mutation and nothing failed. Verified by reading, and documented in place so the next person doesn't assume a test is guarding it.

Also not covered: **a client connected mid-flight**, which the issue raises. Disabling AI during an in-flight MCP request should fail it cleanly; the host's own `StopAsync` handles graceful drain, but nothing here asserts it.

## Notes

Rebased on #687; both projects still build with **0 warnings**. Full suite: **1792 passed, 0 failed**.

Manual check worth doing: toggle each of the three switches with an MCP client connected, and confirm `local-api.json` appears and disappears as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)