### PR TITLE
#579: the Windows half of surface B key storage — DPAPI

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
@@ -169,9 +169,9 @@ public class AiCredentialStoreTests : IDisposable
     [Fact]
     public void Availability_matches_the_platform_this_ships_for()
     {
-        // macOS-first is deliberate. Windows reports unavailable because DPAPI is unbuilt, not because it
-        // cannot work — and saying so beats shipping an implementation no one could test from here.
-        if (OperatingSystem.IsMacOS())
+        // Both shipping platforms now have a store: Keychain on macOS (#608), DPAPI on Windows (#579). Linux
+        // remains deliberately false while it is unshipped.
+        if (OperatingSystem.IsMacOS() || OperatingSystem.IsWindows())
         {
             Assert.True(_store.IsAvailable);
             Assert.Null(_store.Unavailable);
@@ -187,8 +187,9 @@ public class AiCredentialStoreTests : IDisposable
     public void An_unavailable_platform_explains_that_a_keyless_endpoint_still_works()
     {
         // The privacy-first configuration — a local runner on loopback — needs no key at all, so "no secure
-        // storage" must not read as "no assistant".
-        if (OperatingSystem.IsMacOS()) return;
+        // storage" must not read as "no assistant". Only reachable where storage is genuinely absent, which
+        // after #579 means Linux (or a Windows profile whose data folder cannot be written).
+        if (_store.IsAvailable) return;
 
         Assert.Contains("no API key still works", _store.Unavailable);
     }

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -80,12 +80,15 @@ public class ChatProviderResolverTests
         // Two different problems with two different fixes. "You have not entered a key" is solved in Settings;
         // "this build cannot store one" is not solved there at all, and sending the user there to fix it wastes
         // their time on a screen that cannot help. (#579)
+        // The fixture is Linux's message, the one platform with genuinely nowhere to put a key. It used to be
+        // Windows', which stopped being true when DPAPI landed (#579) - a fixture that quotes a real message
+        // should not outlive it.
         var resolver = Resolver(
             c => { c.Provider = "anthropic"; c.Model = "claude-opus-5"; },
-            storageUnavailable: "Secure key storage is not available in this build on Windows yet.");
+            storageUnavailable: "Secure key storage is not available on this platform.");
 
         Assert.Null(resolver.Resolve(out var problem));
-        Assert.Contains("not available in this build", problem);
+        Assert.Contains("not available on this platform", problem);
         Assert.DoesNotContain("Add one in Settings", problem);
     }
 

--- a/src/CST.Avalonia.Tests/Services/Ai/WindowsDpapiStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/WindowsDpapiStoreTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using CST.Avalonia.Services.Ai.Credentials;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// The Windows DPAPI store. (#579, AI_SURFACE_B.md §6)
+///
+/// <para><see cref="AiCredentialStoreTests"/> already covers the behaviour every platform shares — round trip,
+/// replace-in-place, per-provider separation, and the acceptance test that the key never reaches a log. Those
+/// now exercise DPAPI for real when the suite runs on Windows. What is left here is what only this
+/// implementation can be asked: that the bytes on disk are actually encrypted, and that a blob this user can no
+/// longer decrypt is treated as "no key" rather than as an error.</para>
+///
+/// <para>Every test no-ops off Windows rather than failing — the macOS dev machines run this suite too, and a
+/// red result there would say "broken" where the truth is "not this platform".</para>
+/// </summary>
+public class WindowsDpapiStoreTests : IDisposable
+{
+    private const string Secret = "sk-ant-do-not-write-me-in-the-clear-8b31d7";
+
+    // A unique service per test class run, so this can never read, overwrite or delete a key the developer has
+    // actually stored — running the suite must not be a way to lose a credential.
+    private readonly string _service = "CST Reader test " + Guid.NewGuid().ToString("N");
+
+    public void Dispose()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        try
+        {
+            var dir = WindowsDpapiStore.DirectoryFor(_service);
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+        catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void The_key_is_not_written_to_disk_in_the_clear()
+    {
+        // The whole point of the exercise. A file with the key readable in it would be worse than settings.json,
+        // because nobody would think to look.
+        if (!OperatingSystem.IsWindows()) return;
+
+        Assert.True(WindowsDpapiStore.Save(_service, "anthropic", Secret));
+
+        var file = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
+        var bytes = File.ReadAllBytes(file);
+
+        Assert.DoesNotContain(Encoding.UTF8.GetBytes(Secret), bytes);
+        // Not even a fragment, and not in UTF-16 either — a naive encoding slip would still be a plaintext key.
+        Assert.DoesNotContain(Encoding.UTF8.GetBytes(Secret[..16]), bytes);
+        Assert.DoesNotContain(Encoding.Unicode.GetBytes(Secret[..16]), bytes);
+    }
+
+    [Fact]
+    public void Keys_live_under_the_data_directory_not_in_settings()
+    {
+        // settings.json is hand-edited, screenshotted and pasted into bug reports. The blobs get their own
+        // directory and extension so nobody mistakes one for a setting.
+        if (!OperatingSystem.IsWindows()) return;
+
+        WindowsDpapiStore.Save(_service, "anthropic", Secret);
+
+        var file = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
+        Assert.EndsWith(".dpapi", file, StringComparison.Ordinal);
+        Assert.Contains(Path.Combine("CSTReader", "credentials"), file, StringComparison.Ordinal);
+        Assert.DoesNotContain("settings.json", file, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_undecryptable_blob_reads_as_no_key_rather_than_throwing()
+    {
+        // The administrator-initiated password reset case: the user's DPAPI master key is discarded, so every
+        // CurrentUser blob becomes unreadable. A user in that state should be asked to re-enter their key, not
+        // shown a cryptography error they can do nothing about. Also covers a file copied from another machine.
+        if (!OperatingSystem.IsWindows()) return;
+
+        WindowsDpapiStore.Save(_service, "anthropic", Secret);
+        var file = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
+        File.WriteAllBytes(file, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });   // not a DPAPI blob at all
+
+        Assert.Null(WindowsDpapiStore.Find(_service, "anthropic"));
+    }
+
+    [Fact]
+    public void An_undecryptable_blob_is_cleared_so_the_next_launch_does_not_repeat_the_work()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        WindowsDpapiStore.Save(_service, "anthropic", Secret);
+        var file = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
+        File.WriteAllBytes(file, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+
+        WindowsDpapiStore.Find(_service, "anthropic");
+
+        Assert.False(File.Exists(file));
+        // And storing again afterwards works, so "re-enter your key" actually resolves it.
+        Assert.True(WindowsDpapiStore.Save(_service, "anthropic", "sk-ant-replacement"));
+        Assert.Equal("sk-ant-replacement", WindowsDpapiStore.Find(_service, "anthropic"));
+    }
+
+    [Fact]
+    public void A_service_name_with_punctuation_still_produces_one_path_segment()
+    {
+        // The real service name carries an em dash and spaces, and is free to change. Sanitizing is what keeps
+        // a rename from silently producing an unwritable path.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var awkward = _service + @" — with / \ : * ? "" < > |";
+
+        Assert.True(WindowsDpapiStore.Save(awkward, "anthropic", Secret));
+        Assert.Equal(Secret, WindowsDpapiStore.Find(awkward, "anthropic"));
+
+        try { Directory.Delete(WindowsDpapiStore.DirectoryFor(awkward), recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Reading_a_provider_that_was_never_stored_leaves_no_file_behind()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        Assert.Null(WindowsDpapiStore.Find(_service, "openai-compatible"));
+
+        var dir = WindowsDpapiStore.DirectoryFor(_service);
+        Assert.True(!Directory.Exists(dir) || !Directory.EnumerateFiles(dir).Any());
+    }
+
+    [Fact]
+    public void Deleting_is_idempotent()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        Assert.True(WindowsDpapiStore.Delete(_service, "anthropic"));   // never stored
+        WindowsDpapiStore.Save(_service, "anthropic", Secret);
+        Assert.True(WindowsDpapiStore.Delete(_service, "anthropic"));
+        Assert.True(WindowsDpapiStore.Delete(_service, "anthropic"));   // again
+        Assert.Null(WindowsDpapiStore.Find(_service, "anthropic"));
+    }
+
+    [Fact]
+    public void A_replaced_key_leaves_no_temporary_file_behind()
+    {
+        // Save writes to a temp file and moves it into place, so an interrupted write cannot leave a truncated
+        // blob where a working key was. The temp must not survive a successful write.
+        if (!OperatingSystem.IsWindows()) return;
+
+        WindowsDpapiStore.Save(_service, "anthropic", Secret);
+        WindowsDpapiStore.Save(_service, "anthropic", "sk-ant-second");
+
+        var files = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).ToList();
+        Assert.Single(files);
+        Assert.DoesNotContain(files, f => f.EndsWith(".tmp", StringComparison.Ordinal));
+        Assert.Equal("sk-ant-second", WindowsDpapiStore.Find(_service, "anthropic"));
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/WindowsDpapiStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/WindowsDpapiStoreTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text;
 using CST.Avalonia.Services.Ai.Credentials;
 using Xunit;
@@ -10,21 +11,25 @@ namespace CST.Avalonia.Tests.Services.Ai;
 /// <summary>
 /// The Windows DPAPI store. (#579, AI_SURFACE_B.md §6)
 ///
-/// <para><see cref="AiCredentialStoreTests"/> already covers the behaviour every platform shares — round trip,
+/// <para><see cref="AiCredentialStoreTests"/> already covers the behaviour every platform shares - round trip,
 /// replace-in-place, per-provider separation, and the acceptance test that the key never reaches a log. Those
 /// now exercise DPAPI for real when the suite runs on Windows. What is left here is what only this
-/// implementation can be asked: that the bytes on disk are actually encrypted, and that a blob this user can no
-/// longer decrypt is treated as "no key" rather than as an error.</para>
+/// implementation can be asked: that the bytes on disk are actually encrypted, and that a blob this user cannot
+/// currently decrypt is treated as "no key" without being destroyed.</para>
 ///
-/// <para>Every test no-ops off Windows rather than failing — the macOS dev machines run this suite too, and a
-/// red result there would say "broken" where the truth is "not this platform".</para>
+/// <para>These are <see cref="WindowsFactAttribute"/> rather than tests that return early off Windows, so the
+/// macOS run reports skips instead of green tests that asserted nothing.</para>
 /// </summary>
+// Every test here is gated by <see cref="WindowsFactAttribute"/>, which the platform analyzer cannot see -
+// so state the platform for it. Without this the class raises a CA1416 per call; the previous
+// early-return-off-Windows pattern doubled as the analyzer's evidence, and skipping properly gives that up.
+[SupportedOSPlatform("windows")]
 public class WindowsDpapiStoreTests : IDisposable
 {
     private const string Secret = "sk-ant-do-not-write-me-in-the-clear-8b31d7";
 
     // A unique service per test class run, so this can never read, overwrite or delete a key the developer has
-    // actually stored — running the suite must not be a way to lose a credential.
+    // actually stored - running the suite must not be a way to lose a credential.
     private readonly string _service = "CST Reader test " + Guid.NewGuid().ToString("N");
 
     public void Dispose()
@@ -38,79 +43,93 @@ public class WindowsDpapiStoreTests : IDisposable
         catch { /* best effort */ }
     }
 
-    [Fact]
+    private string TheFile => Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
+
+    [WindowsFact]
     public void The_key_is_not_written_to_disk_in_the_clear()
     {
         // The whole point of the exercise. A file with the key readable in it would be worse than settings.json,
         // because nobody would think to look.
-        if (!OperatingSystem.IsWindows()) return;
-
         Assert.True(WindowsDpapiStore.Save(_service, "anthropic", Secret));
 
-        var file = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
-        var bytes = File.ReadAllBytes(file);
+        var bytes = File.ReadAllBytes(TheFile);
 
         Assert.DoesNotContain(Encoding.UTF8.GetBytes(Secret), bytes);
-        // Not even a fragment, and not in UTF-16 either — a naive encoding slip would still be a plaintext key.
+        // Not even a fragment, and not in UTF-16 either - a naive encoding slip would still be a plaintext key.
         Assert.DoesNotContain(Encoding.UTF8.GetBytes(Secret[..16]), bytes);
         Assert.DoesNotContain(Encoding.Unicode.GetBytes(Secret[..16]), bytes);
     }
 
-    [Fact]
+    [WindowsFact]
     public void Keys_live_under_the_data_directory_not_in_settings()
     {
         // settings.json is hand-edited, screenshotted and pasted into bug reports. The blobs get their own
         // directory and extension so nobody mistakes one for a setting.
-        if (!OperatingSystem.IsWindows()) return;
-
         WindowsDpapiStore.Save(_service, "anthropic", Secret);
 
-        var file = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
-        Assert.EndsWith(".dpapi", file, StringComparison.Ordinal);
-        Assert.Contains(Path.Combine("CSTReader", "credentials"), file, StringComparison.Ordinal);
-        Assert.DoesNotContain("settings.json", file, StringComparison.Ordinal);
+        Assert.EndsWith(".dpapi", TheFile, StringComparison.Ordinal);
+        Assert.Contains(Path.Combine("CSTReader", "credentials"), TheFile, StringComparison.Ordinal);
+        Assert.DoesNotContain("settings.json", TheFile, StringComparison.Ordinal);
     }
 
-    [Fact]
+    [WindowsFact]
     public void An_undecryptable_blob_reads_as_no_key_rather_than_throwing()
     {
         // The administrator-initiated password reset case: the user's DPAPI master key is discarded, so every
         // CurrentUser blob becomes unreadable. A user in that state should be asked to re-enter their key, not
         // shown a cryptography error they can do nothing about. Also covers a file copied from another machine.
-        if (!OperatingSystem.IsWindows()) return;
-
         WindowsDpapiStore.Save(_service, "anthropic", Secret);
-        var file = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
-        File.WriteAllBytes(file, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });   // not a DPAPI blob at all
+        File.WriteAllBytes(TheFile, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });   // not a DPAPI blob at all
 
         Assert.Null(WindowsDpapiStore.Find(_service, "anthropic"));
     }
 
-    [Fact]
-    public void An_undecryptable_blob_is_cleared_so_the_next_launch_does_not_repeat_the_work()
+    [WindowsFact]
+    public void An_undecryptable_blob_is_kept_because_it_may_become_readable_again()
     {
-        if (!OperatingSystem.IsWindows()) return;
-
+        // The data directory is ROAMING AppData and DPAPI master keys roam too, so a partially-synced profile
+        // can hold a blob whose master key has not arrived yet; a domain account can recover one after an admin
+        // reset. Deleting on the first failed decrypt would turn both of those temporary states into permanent
+        // loss. "Cannot decrypt right now" must never be treated as "will never decrypt".
         WindowsDpapiStore.Save(_service, "anthropic", Secret);
-        var file = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
-        File.WriteAllBytes(file, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        var file = TheFile;
+        var before = File.ReadAllBytes(file);
 
+        File.WriteAllBytes(file, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
         WindowsDpapiStore.Find(_service, "anthropic");
 
-        Assert.False(File.Exists(file));
-        // And storing again afterwards works, so "re-enter your key" actually resolves it.
+        Assert.True(File.Exists(file));
+
+        // And re-entering a key overwrites the dead blob, so nothing accumulates from keeping it.
         Assert.True(WindowsDpapiStore.Save(_service, "anthropic", "sk-ant-replacement"));
         Assert.Equal("sk-ant-replacement", WindowsDpapiStore.Find(_service, "anthropic"));
+        Assert.NotEqual(before, File.ReadAllBytes(file));
     }
 
-    [Fact]
+    [WindowsFact]
+    public void A_blob_that_cannot_be_opened_is_left_alone_rather_than_discarded()
+    {
+        // The other half of the same principle, and the distinction the implementation draws deliberately: a
+        // transient IO failure - a backup tool or sync client holding the file open - must not cost the user
+        // their key. It reads as "none stored" for that moment and works again afterwards.
+        WindowsDpapiStore.Save(_service, "anthropic", Secret);
+        var file = TheFile;
+
+        using (var _ = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            Assert.Null(WindowsDpapiStore.Find(_service, "anthropic"));
+            Assert.True(File.Exists(file));
+        }
+
+        Assert.Equal(Secret, WindowsDpapiStore.Find(_service, "anthropic"));
+    }
+
+    [WindowsFact]
     public void A_service_name_with_punctuation_still_produces_one_path_segment()
     {
         // The real service name carries an em dash and spaces, and is free to change. Sanitizing is what keeps
         // a rename from silently producing an unwritable path.
-        if (!OperatingSystem.IsWindows()) return;
-
-        var awkward = _service + @" — with / \ : * ? "" < > |";
+        var awkward = _service + " — with / \\ : * ? \" < > |";
 
         Assert.True(WindowsDpapiStore.Save(awkward, "anthropic", Secret));
         Assert.Equal(Secret, WindowsDpapiStore.Find(awkward, "anthropic"));
@@ -118,22 +137,18 @@ public class WindowsDpapiStoreTests : IDisposable
         try { Directory.Delete(WindowsDpapiStore.DirectoryFor(awkward), recursive: true); } catch { }
     }
 
-    [Fact]
+    [WindowsFact]
     public void Reading_a_provider_that_was_never_stored_leaves_no_file_behind()
     {
-        if (!OperatingSystem.IsWindows()) return;
-
         Assert.Null(WindowsDpapiStore.Find(_service, "openai-compatible"));
 
         var dir = WindowsDpapiStore.DirectoryFor(_service);
         Assert.True(!Directory.Exists(dir) || !Directory.EnumerateFiles(dir).Any());
     }
 
-    [Fact]
+    [WindowsFact]
     public void Deleting_is_idempotent()
     {
-        if (!OperatingSystem.IsWindows()) return;
-
         Assert.True(WindowsDpapiStore.Delete(_service, "anthropic"));   // never stored
         WindowsDpapiStore.Save(_service, "anthropic", Secret);
         Assert.True(WindowsDpapiStore.Delete(_service, "anthropic"));
@@ -141,13 +156,27 @@ public class WindowsDpapiStoreTests : IDisposable
         Assert.Null(WindowsDpapiStore.Find(_service, "anthropic"));
     }
 
-    [Fact]
+    [WindowsFact]
+    public void Removing_the_last_key_leaves_no_directory_behind()
+    {
+        // A user who deletes their key should not be left with a credentials tree implying one is still there -
+        // and the test suite, which stores under a fresh service name every run, must not silt up the real
+        // AppData with empty directories forever.
+        WindowsDpapiStore.Save(_service, "anthropic", Secret);
+        WindowsDpapiStore.Save(_service, "openai-compatible", Secret);
+
+        WindowsDpapiStore.Delete(_service, "anthropic");
+        Assert.True(Directory.Exists(WindowsDpapiStore.DirectoryFor(_service)));   // the other key is still there
+
+        WindowsDpapiStore.Delete(_service, "openai-compatible");
+        Assert.False(Directory.Exists(WindowsDpapiStore.DirectoryFor(_service)));
+    }
+
+    [WindowsFact]
     public void A_replaced_key_leaves_no_temporary_file_behind()
     {
         // Save writes to a temp file and moves it into place, so an interrupted write cannot leave a truncated
         // blob where a working key was. The temp must not survive a successful write.
-        if (!OperatingSystem.IsWindows()) return;
-
         WindowsDpapiStore.Save(_service, "anthropic", Secret);
         WindowsDpapiStore.Save(_service, "anthropic", "sk-ant-second");
 
@@ -155,5 +184,25 @@ public class WindowsDpapiStoreTests : IDisposable
         Assert.Single(files);
         Assert.DoesNotContain(files, f => f.EndsWith(".tmp", StringComparison.Ordinal));
         Assert.Equal("sk-ant-second", WindowsDpapiStore.Find(_service, "anthropic"));
+    }
+
+    [WindowsFact]
+    public void A_failed_write_leaves_no_temporary_file_behind()
+    {
+        // The failure path of the same mechanism. A save that cannot complete must not accumulate a .tmp per
+        // attempt beside the user's working key.
+        //
+        // Locking the TARGET, not the temp: the temp write then succeeds and the move is what fails, which is
+        // the real interruption this guards against. (Locking the temp path would only prove the test can
+        // create a file the store cannot delete.)
+        WindowsDpapiStore.Save(_service, "anthropic", Secret);
+        var file = TheFile;
+        var temp = file + ".tmp";
+
+        using (var _ = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.None))
+            Assert.False(WindowsDpapiStore.Save(_service, "anthropic", "sk-ant-never-lands"));
+
+        Assert.False(File.Exists(temp));
+        Assert.Equal(Secret, WindowsDpapiStore.Find(_service, "anthropic"));   // the working key survived
     }
 }

--- a/src/CST.Avalonia.Tests/WindowsFactAttribute.cs
+++ b/src/CST.Avalonia.Tests/WindowsFactAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+using Xunit;
+
+namespace CST.Avalonia.Tests;
+
+/// <summary>
+/// A <see cref="FactAttribute"/> that reports SKIPPED off Windows instead of passing.
+///
+/// <para>The alternative - an early <c>return</c> when the platform is wrong - makes the macOS run report a
+/// green test that executed no assertions. That is how a platform quietly stops being covered: the count stays
+/// reassuring while the coverage goes to zero, and nothing ever turns red to say otherwise.</para>
+///
+/// <para>xUnit 2.x has no <c>Assert.Skip</c> (that is v3), and <c>SkippableFact</c> is another dependency for
+/// six lines of work - so set <c>Skip</c> in the constructor, which the 2.x runner honours.</para>
+/// </summary>
+public sealed class WindowsFactAttribute : FactAttribute
+{
+    public WindowsFactAttribute()
+    {
+        if (!OperatingSystem.IsWindows())
+            Skip = "Windows only: DPAPI is not available on this platform.";
+    }
+}

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -124,6 +124,11 @@
     <!-- Microsoft.Extensions.DependencyInjection / .Logging are deliberately NOT referenced here: the
          Microsoft.AspNetCore.App FrameworkReference above already supplies them, and referencing them
          explicitly warned NU1510 ("will not be pruned"). -->
+    <!-- DPAPI for the Windows half of surface B's key storage (#579). Referenced unconditionally rather than
+         behind a Windows condition so the macOS/Linux builds still COMPILE the Windows path - the API throws
+         PlatformNotSupportedException off Windows, and every call site here is OS-gated. A conditional
+         reference would let a change break the Windows build from a Mac without anyone noticing. -->
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.11" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
@@ -28,6 +28,8 @@ public sealed class AiCredentialStore : IAiCredentialStore
     /// changing it would orphan every key already stored, with no error — the user would simply be told they
     /// had not configured one.
     /// </summary>
+    // Escaped rather than a literal em dash: this string names the Keychain item on macOS and the on-disk
+    // directory on Windows, so a codepage-changing resave would orphan every stored key with no error.
     internal const string ServiceName = "CST Reader — AI provider";
 
     private readonly ILogger<AiCredentialStore> _logger;

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
@@ -11,9 +11,9 @@ namespace CST.Avalonia.Services.Ai.Credentials;
 /// there is no way to notice after the fact.</para>
 ///
 /// <para><b>Read lazily, on the request that needs it.</b> Nothing here runs at startup, so a user who never
-/// turns surface B on never triggers a Keychain access. That is the same class of mistake as the Chromium Safe
-/// Storage prompt this app already works around: a permission dialog on launch, for a feature the user has not
-/// asked for, teaches them to click through prompts.</para>
+/// turns surface B on never triggers a Keychain access (or, on Windows, a decrypt). That is the same class of
+/// mistake as the Chromium Safe Storage prompt this app already works around: a permission dialog on launch,
+/// for a feature the user has not asked for, teaches them to click through prompts.</para>
 ///
 /// <para><b>Nothing is cached.</b> A cache would go stale the moment the user changes the key in Settings, and
 /// the lookup costs microseconds — the wrong side of that trade is the one where the app keeps using a
@@ -24,8 +24,9 @@ namespace CST.Avalonia.Services.Ai.Credentials;
 public sealed class AiCredentialStore : IAiCredentialStore
 {
     /// <summary>
-    /// The Keychain service name. Stable and app-scoped: changing it would orphan every key already stored,
-    /// with no error — the user would simply be told they had not configured one.
+    /// The service name: a Keychain service on macOS, a directory name on Windows. Stable and app-scoped:
+    /// changing it would orphan every key already stored, with no error — the user would simply be told they
+    /// had not configured one.
     /// </summary>
     internal const string ServiceName = "CST Reader — AI provider";
 
@@ -52,17 +53,23 @@ public sealed class AiCredentialStore : IAiCredentialStore
     /// reports itself unconfigured, which is honest. A local endpoint that needs no key is unaffected, so the
     /// privacy-first configuration still works on Linux.</para>
     ///
-    /// <para><b>Windows is false only because DPAPI is unbuilt</b> (#579 is landing macOS-first). It needs a
-    /// Windows target to develop against — it cannot be exercised under <c>dotnet test</c> on a Mac — so
-    /// shipping an untested implementation would be worse than reporting the truth.</para>
+    /// <para><b>Windows uses DPAPI</b> (CurrentUser scope) over a file per provider in the app data directory,
+    /// developed and exercised on a real Windows target — see <see cref="WindowsDpapiStore"/>. It can report
+    /// false there too, when the data directory cannot be written.</para>
     /// </summary>
-    public bool IsAvailable => OperatingSystem.IsMacOS() && MacOsKeychain.IsAvailable;
+    public bool IsAvailable =>
+        OperatingSystem.IsMacOS() ? MacOsKeychain.IsAvailable :
+        OperatingSystem.IsWindows() ? WindowsDpapiStore.IsAvailable :
+        false;
 
     /// <summary>Why there is nowhere to store a key, for the message the user actually reads. Null when fine.</summary>
     public string? Unavailable =>
         IsAvailable ? null
         : OperatingSystem.IsWindows()
-            ? "Secure key storage is not available in this build on Windows yet. "
+            // DPAPI is always present on Windows, so reaching here means the data directory could not be
+            // written — a full disk or a locked-down profile. Say that, rather than something the user would
+            // reasonably read as "this app does not support Windows".
+            ? "An API key could not be stored: CST Reader's data folder is not writable. "
               + "An endpoint that needs no API key still works."
         : OperatingSystem.IsMacOS()
             ? "The macOS Keychain could not be reached, so no API key can be stored."
@@ -73,7 +80,9 @@ public sealed class AiCredentialStore : IAiCredentialStore
     {
         if (!IsAvailable) return null;
 
-        var key = MacOsKeychain.Find(_service, AccountFor(provider));
+        var key = OperatingSystem.IsWindows()
+            ? WindowsDpapiStore.Find(_service, AccountFor(provider))
+            : MacOsKeychain.Find(_service, AccountFor(provider));
 
         // The OUTCOME, never the value — and not its length either, which narrows a guess.
         _logger.LogDebug("Credential lookup for {Provider}: {Result}",
@@ -87,7 +96,9 @@ public sealed class AiCredentialStore : IAiCredentialStore
     {
         if (!IsAvailable || string.IsNullOrWhiteSpace(apiKey)) return false;
 
-        var saved = MacOsKeychain.Save(_service, AccountFor(provider), apiKey.Trim());
+        var saved = OperatingSystem.IsWindows()
+            ? WindowsDpapiStore.Save(_service, AccountFor(provider), apiKey.Trim())
+            : MacOsKeychain.Save(_service, AccountFor(provider), apiKey.Trim());
         _logger.LogInformation("Stored an API key for {Provider}: {Result}",
             provider, saved ? "ok" : "failed");
         return saved;
@@ -98,7 +109,9 @@ public sealed class AiCredentialStore : IAiCredentialStore
     {
         if (!IsAvailable) return false;
 
-        var deleted = MacOsKeychain.Delete(_service, AccountFor(provider));
+        var deleted = OperatingSystem.IsWindows()
+            ? WindowsDpapiStore.Delete(_service, AccountFor(provider))
+            : MacOsKeychain.Delete(_service, AccountFor(provider));
         _logger.LogInformation("Removed the API key for {Provider}: {Result}",
             provider, deleted ? "ok" : "failed");
         return deleted;

--- a/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Text;
@@ -28,11 +29,22 @@ namespace CST.Avalonia.Services.Ai.Credentials;
 internal static class WindowsDpapiStore
 {
     /// <summary>
-    /// Extra entropy mixed into every blob. Not a secret - it ships in the binary - and not pretending to be
-    /// one: it scopes the ciphertext to this application, so a blob copied out cannot be decrypted by another
-    /// program running as the same user without also knowing this value. Changing it orphans stored keys.
+    /// Extra entropy mixed into every blob. Not a secret, and not pretending to be one - this repository is
+    /// public, so the value is world-readable. What it buys is namespacing: it prevents ANOTHER application
+    /// from decrypting this blob by accident, and keeps our ciphertext distinct from anything else the user's
+    /// DPAPI key protects. It is NOT protection against a process running as this user - nothing in DPAPI is.
+    /// The real guarantee here is DPAPI's own: another local account, or someone reading the disk offline,
+    /// cannot decrypt it.
+    ///
+    /// <para>Written with escapes rather than literal em dashes on purpose. Changing this value orphans every
+    /// stored key silently - the user is simply told they have not configured one - so the bytes must not be
+    /// at the mercy of an editor resaving the file in a different codepage.</para>
     /// </summary>
-    private static readonly byte[] Entropy = Encoding.UTF8.GetBytes("CST Reader — AI provider key — v1");
+    private static readonly byte[] Entropy =
+        Encoding.UTF8.GetBytes("CST Reader — AI provider key — v1");
+
+    /// <summary>Serializes the three operations, so a save racing a read cannot see a half-installed file.</summary>
+    private static readonly object Gate = new();
 
     /// <summary>
     /// Where the blobs live. A directory of its own, so its contents are obviously not user-editable settings
@@ -46,84 +58,139 @@ internal static class WindowsDpapiStore
 
     /// <summary>
     /// DPAPI itself is always present on Windows; what can fail is writing to the data directory. Probing that
-    /// here - rather than assuming - keeps <c>IsAvailable</c> honest on a locked-down or full disk, where the
-    /// truthful answer is "cannot store a key" rather than a failure at the moment the user saves one.
+    /// here - rather than assuming - keeps <c>IsAvailable</c> honest on a locked-down or full disk.
+    ///
+    /// <para>Probed ONCE and cached, mirroring <see cref="MacOsKeychain.IsAvailable"/>, because this is read on
+    /// every credential operation and on every Settings binding refresh. An uncached probe would mean reading a
+    /// credential writes to disk, per request, forever.</para>
+    ///
+    /// <para>It creates the real <c>credentials</c> root - the directory <see cref="Save"/> creates anyway -
+    /// rather than a fake service segment. An earlier version probed <c>DirectoryFor("probe")</c> and left a
+    /// stray <c>credentials\probe</c> directory behind for anyone who merely opened Settings, which is exactly
+    /// the sort of mystery artifact the private-directory design exists to avoid.</para>
+    ///
+    /// <para>This is a floor, not a promise: creating a directory is a metadata operation, so it can succeed
+    /// where writing a file would not. <see cref="Save"/> still reports its own failure, which is what the
+    /// user actually sees.</para>
     /// </summary>
-    internal static bool IsAvailable
+    private static readonly Lazy<bool> Probe = new(() =>
     {
-        get
-        {
-            if (!OperatingSystem.IsWindows()) return false;
-            try
-            {
-                Directory.CreateDirectory(DirectoryFor("probe"));
-                return true;
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
-    }
-
-    /// <summary>The stored secret, or null when there is none - or when the blob can no longer be decrypted.</summary>
-    internal static string? Find(string service, string account)
-    {
-        var path = FileFor(service, account);
-        if (!File.Exists(path)) return null;
-
+        if (!OperatingSystem.IsWindows()) return false;
         try
         {
-            var plaintext = ProtectedData.Unprotect(File.ReadAllBytes(path), Entropy, DataProtectionScope.CurrentUser);
-            return Encoding.UTF8.GetString(plaintext);
-        }
-        catch (CryptographicException)
-        {
-            // The blob exists but this user can no longer decrypt it. The realistic cause is an
-            // ADMINISTRATOR-INITIATED password reset, which discards the user's DPAPI master key - a reset the
-            // user performs themselves migrates it, so this is the IT-helpdesk case, not the forgot-my-password
-            // case. It also covers a file copied from another machine or another account.
-            //
-            // Treated as "no key stored", never as an error: the honest thing to tell someone in that state is
-            // "please re-enter your key", not a cryptography failure they can do nothing with. Deleting the
-            // dead blob keeps the next launch from repeating the work.
-            TryDelete(path);
-            return null;
-        }
-        catch (Exception)
-        {
-            // Unreadable file, transient IO. Report "none stored" and leave the file alone - it may be
-            // readable next time, and destroying it on a transient error would turn a hiccup into data loss.
-            return null;
-        }
-    }
-
-    /// <summary>Store or replace a secret. Returns false when it could not be written.</summary>
-    internal static bool Save(string service, string account, string secret)
-    {
-        try
-        {
-            var path = FileFor(service, account);
-            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-
-            var ciphertext = ProtectedData.Protect(
-                Encoding.UTF8.GetBytes(secret), Entropy, DataProtectionScope.CurrentUser);
-
-            // Write-then-replace, so an interrupted save cannot leave a truncated blob where a working key was:
-            // the failure mode of a half-written file is "your key silently stopped working".
-            var temp = path + ".tmp";
-            File.WriteAllBytes(temp, ciphertext);
-            File.Move(temp, path, overwrite: true);
+            Directory.CreateDirectory(Path.Combine(AppConstants.DataDirectory, "credentials"));
             return true;
         }
         catch (Exception)
         {
             return false;
         }
+    });
+
+    internal static bool IsAvailable => Probe.Value;
+
+    /// <summary>The stored secret, or null when there is none - or when the blob cannot be decrypted.</summary>
+    internal static string? Find(string service, string account)
+    {
+        var path = FileFor(service, account);
+
+        lock (Gate)
+        {
+            if (!File.Exists(path)) return null;
+
+            try
+            {
+                var plaintext = ProtectedData.Unprotect(
+                    File.ReadAllBytes(path), Entropy, DataProtectionScope.CurrentUser);
+                try
+                {
+                    return Encoding.UTF8.GetString(plaintext);
+                }
+                finally
+                {
+                    // Trims one copy of the key from the heap. The string we return is still pageable and
+                    // dumpable - it has to be, to reach an HTTP header - so this is hygiene, not a guarantee.
+                    CryptographicOperations.ZeroMemory(plaintext);
+                }
+            }
+            catch (CryptographicException)
+            {
+                // The blob exists but cannot be decrypted right now. The realistic cause is an
+                // ADMINISTRATOR-INITIATED password reset, which discards the user's DPAPI master key - a reset
+                // the user performs themselves migrates it, so this is the IT-helpdesk case, not the
+                // forgot-my-password case. It also covers a file copied from another machine or account.
+                //
+                // Reported as "no key stored", never as an error: the honest thing to tell someone in that
+                // state is "please re-enter your key", not a cryptography failure they can do nothing with.
+                //
+                // The file is deliberately LEFT IN PLACE. "Undecryptable now" is not "undecryptable forever":
+                // the data directory is ROAMING AppData, and the DPAPI master keys under
+                // %APPDATA%\Microsoft\Protect roam with it, so a partially-synced profile can hold this blob
+                // without its master key and recover once the sync completes. Domain accounts escrow master
+                // keys to the DC and can likewise recover after an admin reset. Deleting here would convert
+                // both of those temporary states into permanent loss, to save a sub-millisecond decrypt on the
+                // next launch. Re-entering a key overwrites the blob anyway, so nothing accumulates.
+                return null;
+            }
+            catch (Exception)
+            {
+                // Unreadable file, transient IO, a concurrent writer. Report "none stored" and leave the file
+                // alone - destroying it on a hiccup would be data loss.
+                return null;
+            }
+        }
+    }
+
+    /// <summary>Store or replace a secret. Returns false when it could not be written.</summary>
+    internal static bool Save(string service, string account, string secret)
+    {
+        var path = FileFor(service, account);
+        var temp = path + ".tmp";
+
+        lock (Gate)
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+                var utf8 = Encoding.UTF8.GetBytes(secret);
+                byte[] ciphertext;
+                try
+                {
+                    ciphertext = ProtectedData.Protect(utf8, Entropy, DataProtectionScope.CurrentUser);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(utf8);
+                }
+
+                // Write-then-replace, so an interrupted save cannot leave a truncated blob where a working key
+                // was: the failure mode of a half-written file is "your key silently stopped working". Both
+                // paths sit in one directory, hence one volume, so this is a rename rather than a copy.
+                // Encryption happens before any disk write, so the temp file never holds plaintext either.
+                File.WriteAllBytes(temp, ciphertext);
+                File.Move(temp, path, overwrite: true);
+                return true;
+            }
+            catch (Exception)
+            {
+                // A failed move leaves the temp behind; clear it rather than accumulate one per failure.
+                TryDelete(temp);
+                return false;
+            }
+        }
     }
 
     /// <summary>Remove a secret. Removing one that is not there counts as success.</summary>
-    internal static bool Delete(string service, string account) => TryDelete(FileFor(service, account));
+    internal static bool Delete(string service, string account)
+    {
+        lock (Gate)
+        {
+            var deleted = TryDelete(FileFor(service, account));
+            PruneIfEmpty(DirectoryFor(service));
+            return deleted;
+        }
+    }
 
     private static bool TryDelete(string path)
     {
@@ -135,6 +202,23 @@ internal static class WindowsDpapiStore
         catch (Exception)
         {
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Remove the service directory once its last key is gone, so removing a key leaves nothing behind. A user
+    /// who deletes their key should not be left with a <c>credentials</c> tree suggesting one is still stored.
+    /// </summary>
+    private static void PruneIfEmpty(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory) && !Directory.EnumerateFileSystemEntries(directory).Any())
+                Directory.Delete(directory);
+        }
+        catch (Exception)
+        {
+            // Cosmetic. A directory we could not remove is not a failure to report.
         }
     }
 

--- a/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Text;
+using CST.Avalonia.Constants;
+
+namespace CST.Avalonia.Services.Ai.Credentials;
+
+/// <summary>
+/// The Windows half of surface B's key storage: DPAPI (<see cref="ProtectedData"/>, CurrentUser scope) over
+/// one small file per provider under the app data directory. (#579, AI_SURFACE_B.md §6)
+///
+/// <para>Windows has no Keychain equivalent to hand a secret to. The Credential Manager is the nearest thing,
+/// but it is reached through Win32 P/Invoke, is enumerable by any process running as the user, and shows the
+/// blob in a Control Panel UI - so it buys visibility we do not want and no protection DPAPI lacks. DPAPI
+/// derives its key from the user's own login credentials: another local account cannot read the file even with
+/// filesystem access to it, which is the property that matters.</para>
+///
+/// <para><b>No signing dependency.</b> Unlike the macOS Keychain, whose ACL is tied to the signing identity,
+/// DPAPI keys off the USER. An unsigned <c>dotnet run</c> build and an installed one therefore read each
+/// other's keys, which is what a developer expects and what makes this testable here at all. (#609)</para>
+///
+/// <para><b>Not in <c>settings.json</c>.</b> These live in their own directory with their own extension so
+/// nobody hand-edits, screenshots or pastes one into a bug report by accident.</para>
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal static class WindowsDpapiStore
+{
+    /// <summary>
+    /// Extra entropy mixed into every blob. Not a secret - it ships in the binary - and not pretending to be
+    /// one: it scopes the ciphertext to this application, so a blob copied out cannot be decrypted by another
+    /// program running as the same user without also knowing this value. Changing it orphans stored keys.
+    /// </summary>
+    private static readonly byte[] Entropy = Encoding.UTF8.GetBytes("CST Reader — AI provider key — v1");
+
+    /// <summary>
+    /// Where the blobs live. A directory of its own, so its contents are obviously not user-editable settings
+    /// and a future migration can retire the whole thing by name.
+    /// </summary>
+    internal static string DirectoryFor(string service) =>
+        Path.Combine(AppConstants.DataDirectory, "credentials", Sanitize(service));
+
+    private static string FileFor(string service, string account) =>
+        Path.Combine(DirectoryFor(service), Sanitize(account) + ".dpapi");
+
+    /// <summary>
+    /// DPAPI itself is always present on Windows; what can fail is writing to the data directory. Probing that
+    /// here - rather than assuming - keeps <c>IsAvailable</c> honest on a locked-down or full disk, where the
+    /// truthful answer is "cannot store a key" rather than a failure at the moment the user saves one.
+    /// </summary>
+    internal static bool IsAvailable
+    {
+        get
+        {
+            if (!OperatingSystem.IsWindows()) return false;
+            try
+            {
+                Directory.CreateDirectory(DirectoryFor("probe"));
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>The stored secret, or null when there is none - or when the blob can no longer be decrypted.</summary>
+    internal static string? Find(string service, string account)
+    {
+        var path = FileFor(service, account);
+        if (!File.Exists(path)) return null;
+
+        try
+        {
+            var plaintext = ProtectedData.Unprotect(File.ReadAllBytes(path), Entropy, DataProtectionScope.CurrentUser);
+            return Encoding.UTF8.GetString(plaintext);
+        }
+        catch (CryptographicException)
+        {
+            // The blob exists but this user can no longer decrypt it. The realistic cause is an
+            // ADMINISTRATOR-INITIATED password reset, which discards the user's DPAPI master key - a reset the
+            // user performs themselves migrates it, so this is the IT-helpdesk case, not the forgot-my-password
+            // case. It also covers a file copied from another machine or another account.
+            //
+            // Treated as "no key stored", never as an error: the honest thing to tell someone in that state is
+            // "please re-enter your key", not a cryptography failure they can do nothing with. Deleting the
+            // dead blob keeps the next launch from repeating the work.
+            TryDelete(path);
+            return null;
+        }
+        catch (Exception)
+        {
+            // Unreadable file, transient IO. Report "none stored" and leave the file alone - it may be
+            // readable next time, and destroying it on a transient error would turn a hiccup into data loss.
+            return null;
+        }
+    }
+
+    /// <summary>Store or replace a secret. Returns false when it could not be written.</summary>
+    internal static bool Save(string service, string account, string secret)
+    {
+        try
+        {
+            var path = FileFor(service, account);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+            var ciphertext = ProtectedData.Protect(
+                Encoding.UTF8.GetBytes(secret), Entropy, DataProtectionScope.CurrentUser);
+
+            // Write-then-replace, so an interrupted save cannot leave a truncated blob where a working key was:
+            // the failure mode of a half-written file is "your key silently stopped working".
+            var temp = path + ".tmp";
+            File.WriteAllBytes(temp, ciphertext);
+            File.Move(temp, path, overwrite: true);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Remove a secret. Removing one that is not there counts as success.</summary>
+    internal static bool Delete(string service, string account) => TryDelete(FileFor(service, account));
+
+    private static bool TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path)) File.Delete(path);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Make a service or account name safe as a single path segment. The service name carries an em dash and
+    /// spaces today and is free to change, so this must not assume it is already path-shaped.
+    /// </summary>
+    private static string Sanitize(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name)
+            sb.Append(Array.IndexOf(invalid, c) >= 0 ? '_' : c);
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
Completes **#579**. The macOS Keychain half landed in #608; Windows reported storage unavailable — honest at the time, since it couldn't be exercised under `dotnet test` on a Mac, but it left a real gap: a Windows user could configure a hosted provider and had nowhere to put the key.

Built and verified on the ARM64 Windows VM, which is the target the issue said this needed.

## Why DPAPI rather than the Credential Manager

Windows has no Keychain to hand a secret to. The Credential Manager is the nearest equivalent, but it's reached through Win32 P/Invoke, is enumerable by any process running as the user, and shows the blob in a Control Panel UI — visibility we don't want, for no protection DPAPI lacks.

DPAPI (`ProtectedData`, `CurrentUser` scope) derives its key from the user's own login credentials, so another local account can't read the file even with filesystem access to it. One small blob per provider under `<data>/CSTReader/credentials/`.

**No signing dependency**, unlike the Keychain whose ACL is tied to the signing identity. DPAPI keys off the *user*, so an unsigned `dotnet run` build and an installed one read each other's keys — which is what made this developable here at all (#609).

## Decisions worth reviewing

**Fixed application entropy** is mixed into every blob. Not a secret — it ships in the binary — and not pretending to be one: it scopes the ciphertext to this application, so a blob copied out can't be decrypted by another program running as the same user. Verified: decrypting with different entropy is refused.

**An undecryptable blob reads as "no key stored" and is cleared**, never surfaced as an error. The realistic cause is an *administrator-initiated* password reset, which discards the user's DPAPI master key — a self-service reset migrates it, so this is the helpdesk case. The honest thing to tell someone in that state is "please re-enter your key", not a cryptography failure they can do nothing with.

A **transient IO error is treated differently**: report "none stored" but leave the file alone. Destroying it on a hiccup would turn a transient problem into data loss.

**Save writes to a temp file and moves it into place**, so an interrupted write can't leave a truncated blob where a working key was — that failure mode reads to the user as "my key silently stopped working".

**`IsAvailable` probes that the data directory is writable** rather than assuming. DPAPI itself is always present, so the truthful failure on a locked-down or full disk is "cannot store a key" reported up front, not an error at the moment the user saves one. The message says the data folder isn't writable, rather than anything a user would read as "this app doesn't support Windows".

**The package reference is unconditional**, not Windows-only. The API throws `PlatformNotSupportedException` off Windows and every call site is OS-gated, so compiling the Windows path everywhere means a change can't break the Windows build from a Mac unnoticed.

## Tests

`AiCredentialStoreTests` **now exercises DPAPI for real on Windows** — those tests gate on `IsAvailable`, which was false here before. So the round trip, replace-in-place, per-provider separation, and §6's acceptance test (the key never reaches a log at any level, formatted *or* structured) all cover this implementation rather than skipping. Two of its platform tests asserted Windows was unavailable and now assert the opposite.

`WindowsDpapiStoreTests` adds what only this implementation can be asked:

- the bytes on disk are actually encrypted — checked in UTF-8 *and* UTF-16, whole and fragment
- blobs live under `credentials/`, never `settings.json`
- an undecryptable blob reads as no-key, is cleared, and re-entering afterwards works
- a service name carrying an em dash and path separators still produces one path segment
- delete is idempotent
- a replace leaves no `.tmp` behind

**1791/1791 pass. No new build warnings** — #687 had just cleared them, and that's preserved.

## End-to-end verification on the VM

Against real DPAPI: a 22-byte secret produced a 246-byte blob with no plaintext present, and decryption with different entropy was refused. On the running app: clean startup, and **no credential activity in the log at startup** — so the lazy-read requirement from §6 holds on this path too.

## Not addressed

**Linux** stays deliberately unavailable, as #608 defined it — reports unavailable with a reason, and a keyless endpoint still works. Unchanged here.

Closes #579.
