### PR TITLE
Punctuate verse as verse in passages and snippets (#680)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiTextGathaDandaTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiTextGathaDandaTests.cs
@@ -1,0 +1,166 @@
+using CST.Conversion;
+using CST.Search;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Search
+{
+    /// <summary>
+    /// #680: in verse a single danda ends a pada and reads ";" in Latin, while a double ends the verse and
+    /// reads "."; the double dandas around *namo tassa* are dropped. Those rules are written against markup,
+    /// so #669 could not apply them in Convert (which receives tag-stripped text) and flattened every stop to
+    /// a period — showing a model every line of a gatha ending identically. Clean still has the tags, so the
+    /// decision is made there instead.
+    ///
+    /// Devanagari is written with \uXXXX escapes throughout, never literal glyphs.
+    /// </summary>
+    public class TeiTextGathaDandaTests
+    {
+        private const char Danda = '\u0964';
+        private const char DoubleDanda = '\u0965';
+
+        // Trimmed the way TeiPassageReader trims: a closing tag leaves a space, which is not what is under
+        // test here.
+        private static string Render(string xml) =>
+            TeiText.Convert(TeiText.Clean(xml, 0, xml.Length, includeNotes: false, Script.Latin), Script.Latin)
+                .Trim();
+
+        [Fact]
+        public void In_a_gatha_a_single_danda_is_a_semicolon_and_a_double_is_a_period()
+        {
+            string xml = $"<p rend=\"gatha1\">pada one{Danda} pada two{DoubleDanda}</p>";
+
+            Assert.Equal("pada one; pada two.", Render(xml));
+        }
+
+        [Fact]
+        public void Every_gatha_rend_variant_counts_as_verse()
+        {
+            // The reader matches rend="gatha[a-z0-9]*", so gathalast and gatha2 are verse as much as gatha1.
+            foreach (var rend in new[] { "gatha1", "gatha2", "gatha3", "gathalast" })
+            {
+                string xml = $"<p rend=\"{rend}\">pada{Danda}</p>";
+                Assert.Equal("pada;", Render(xml));
+            }
+        }
+
+        [Fact]
+        public void In_prose_both_dandas_are_periods()
+        {
+            string xml = $"<p rend=\"bodytext\">first{Danda} second{DoubleDanda}</p>";
+
+            Assert.Equal("first. second.", Render(xml));
+        }
+
+        [Fact]
+        public void A_paragraph_with_no_rend_is_prose()
+        {
+            string xml = $"<p>plain{Danda}</p>";
+
+            Assert.Equal("plain.", Render(xml));
+        }
+
+        [Fact]
+        public void Namo_tassa_loses_its_double_dandas_but_keeps_a_single_one()
+        {
+            // rend="centre" is the namo tassa paragraph; the reader shows no stop there.
+            string xml = $"<p rend=\"centre\">namo tassa{DoubleDanda}</p>";
+            Assert.Equal("namo tassa", Render(xml));
+
+            string single = $"<p rend=\"centre\">namo tassa{Danda}</p>";
+            Assert.Equal("namo tassa.", Render(single));
+        }
+
+        [Fact]
+        public void A_dropped_double_danda_does_not_leave_a_double_space()
+        {
+            // The mark sits between words with a space on each side; removing it must close the gap to one.
+            string xml = $"<p rend=\"centre\">assa {DoubleDanda} bhagava</p>";
+
+            Assert.Equal("assa bhagava", Render(xml));
+        }
+
+        [Fact]
+        public void A_window_that_begins_mid_verse_is_still_punctuated_as_verse()
+        {
+            // The regression this guards: a snippet window usually starts mid-paragraph, so the opening <p>
+            // is behind `start` and the walk never sees it. Without looking backwards, every such snippet
+            // would be punctuated as prose.
+            string xml = $"<p rend=\"gatha1\">first pada{Danda} second pada{Danda}</p>";
+            int start = xml.IndexOf("second", System.StringComparison.Ordinal);
+
+            string text = TeiText.Convert(
+                TeiText.Clean(xml, start, xml.Length, includeNotes: false, Script.Latin), Script.Latin).Trim();
+
+            Assert.Equal("second pada;", text);
+        }
+
+        [Fact]
+        public void A_window_beginning_after_a_closed_verse_is_prose_again()
+        {
+            string xml = $"<p rend=\"gatha1\">verse{Danda}</p><p rend=\"bodytext\">prose{Danda}</p>";
+            int start = xml.IndexOf("prose", System.StringComparison.Ordinal);
+
+            string text = TeiText.Convert(
+                TeiText.Clean(xml, start, xml.Length, includeNotes: false, Script.Latin), Script.Latin).Trim();
+
+            Assert.Equal("prose.", text);
+        }
+
+        [Fact]
+        public void A_verse_and_the_prose_after_it_are_punctuated_differently_in_one_range()
+        {
+            // A passage spans paragraphs, which is why a single "is this verse?" flag on the range would not
+            // have worked — the decision has to be made per mark, as the walk passes each <p>.
+            string xml = $"<p rend=\"gatha1\">pada{Danda}</p><p rend=\"bodytext\">sentence{Danda}</p>";
+
+            Assert.Equal("pada; sentence.", Render(xml));
+        }
+
+        [Fact]
+        public void Non_Latin_output_keeps_the_dandas_for_its_own_converter()
+        {
+            // Clean must not impose Latin punctuation on a script that has its own marks.
+            string xml = $"<p rend=\"gatha1\">pada{Danda}</p>";
+
+            string cleaned = TeiText.Clean(xml, 0, xml.Length, includeNotes: false, Script.Devanagari);
+
+            Assert.Contains(Danda, cleaned);
+            Assert.DoesNotContain(';', cleaned);
+        }
+
+        [Fact]
+        public void The_default_overload_is_unchanged_for_callers_that_only_measure_length()
+        {
+            // VisibleLen and the older tests call Clean without a script; that path must still be identity.
+            string xml = $"<p rend=\"gatha1\">pada{Danda}</p>";
+
+            Assert.Contains(Danda, TeiText.Clean(xml, 0, xml.Length, includeNotes: false));
+        }
+
+        [Theory]
+        [InlineData("<p rend=\"gatha1\">x", "gatha1")]
+        [InlineData("<p>x", "")]
+        [InlineData("<p rend=\"centre\">x", "centre")]
+        public void ParagraphRendAt_reads_the_enclosing_paragraph(string prefix, string expected)
+        {
+            Assert.Equal(expected, TeiText.ParagraphRendAt(prefix + "yyy", prefix.Length + 1));
+        }
+
+        [Fact]
+        public void ParagraphRendAt_is_not_fooled_by_other_tags_beginning_with_p()
+        {
+            // <paranum> and <pb> both start "<p"; only "<p " or "<p>" is a paragraph.
+            const string xml = "<p rend=\"gatha1\"><hi rend=\"paranum\">12</hi><pb ed=\"V\" n=\"1\"/>text";
+
+            Assert.Equal("gatha1", TeiText.ParagraphRendAt(xml, xml.Length - 1));
+        }
+
+        [Fact]
+        public void ParagraphRendAt_returns_nothing_outside_a_paragraph()
+        {
+            const string xml = "<p rend=\"gatha1\">verse</p>between";
+
+            Assert.Equal("", TeiText.ParagraphRendAt(xml, xml.Length - 1));
+        }
+    }
+}

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -68,13 +68,13 @@ namespace CST.Search
                 // {reading (sigla)} spans out into structured notes and return brace-free text. The note text is
                 // therefore already in the output script and offsets index the returned brace-free text. (#267)
                 string braced = TeiText.Collapse(
-                    TeiText.Convert(TeiText.Clean(xml, readStart, end, includeNotes: true), outputScript)).Trim();
+                    TeiText.Convert(TeiText.Clean(xml, readStart, end, includeNotes: true, outputScript), outputScript)).Trim();
                 (text, notes) = SplitBracedNotes(braced);
             }
             else
             {
                 text = TeiText.Collapse(
-                    TeiText.Convert(TeiText.Clean(xml, readStart, end, includeVariants), outputScript)).Trim();
+                    TeiText.Convert(TeiText.Clean(xml, readStart, end, includeVariants, outputScript), outputScript)).Trim();
             }
 
             int? next = end < xml.Length ? end : (int?)null;

--- a/src/CST.Core/Search/TeiSnippetExtractor.cs
+++ b/src/CST.Core/Search/TeiSnippetExtractor.cs
@@ -84,19 +84,19 @@ namespace CST.Search
 
             sb.Append(ellipsisStart ? "... " : "");
             sb.Append(TeiText.Collapse(TeiText.Convert(
-                TeiText.Clean(xml, winStart, ms[0].Start, renderBraces), opts.OutputScript)).TrimStart());
+                TeiText.Clean(xml, winStart, ms[0].Start, renderBraces, opts.OutputScript), opts.OutputScript)).TrimStart());
 
             for (int i = 0; i < ms.Count; i++)
             {
                 string markText = TeiText.Convert(
-                    TeiText.Clean(xml, ms[i].Start, ms[i].End, renderBraces), opts.OutputScript).Trim();
+                    TeiText.Clean(xml, ms[i].Start, ms[i].End, renderBraces, opts.OutputScript), opts.OutputScript).Trim();
                 highlights.Add(new SnippetHighlight(sb.Length, markText.Length, ms[i].IsAnchor));
                 sb.Append(markText);
 
                 if (i < ms.Count - 1)
                 {
                     string gap = TeiText.Collapse(TeiText.Convert(
-                        TeiText.Clean(xml, ms[i].End, ms[i + 1].Start, renderBraces), opts.OutputScript));
+                        TeiText.Clean(xml, ms[i].End, ms[i + 1].Start, renderBraces, opts.OutputScript), opts.OutputScript));
                     sb.Append(gap.Length == 0 ? " " : gap); // never fuse two distinct marked words
                 }
             }
@@ -112,7 +112,7 @@ namespace CST.Search
                 foreach (var (ns, ne) in winNotes)
                     if (suffixStart >= ns && suffixStart < ne) { suffixStart = Math.Min(ne, winEnd); break; }
             sb.Append(TeiText.Collapse(TeiText.Convert(
-                TeiText.Clean(xml, suffixStart, winEnd, renderBraces), opts.OutputScript)).TrimEnd());
+                TeiText.Clean(xml, suffixStart, winEnd, renderBraces, opts.OutputScript), opts.OutputScript)).TrimEnd());
             sb.Append(ellipsisEnd ? " ..." : "");
 
             var (num, code, pages) = markers.RefsAt(anchor.Start);

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -39,9 +39,9 @@ namespace CST.Search
             // shown. #641 folded punctuation out of ONE comparison to work around it; this removes the
             // divergence instead.
             //
-            // The gatha nuance (a single danda becomes ";" mid-verse) is not recoverable here and is not
-            // pretended at: without the markup there is no way to know a line is verse. A period is what the
-            // reader sees for prose, which is the overwhelming majority of what is sent.
+            // The markup-dependent rules (gatha, namo tassa) are applied by Clean, which still has the tags
+            // — see LatinStop. This is the fallback for the prose case and for any text that did not come
+            // through Clean, so the two never disagree the way the two Latin paths once did. (#680)
             if (output == Script.Latin)
                 converted = converted.Replace("\u0964", ".").Replace("\u0965", ".");
 
@@ -52,11 +52,24 @@ namespace CST.Search
 
         internal static int VisibleLen(string xml, int start, int end) => Clean(xml, start, end, false).Length;
 
-        /// <summary>Render a raw XML range to text: drop tags (paranum/dot hi and, unless requested, notes are stripped whole).</summary>
-        internal static string Clean(string xml, int start, int end, bool includeNotes)
+        /// <summary>
+        /// Render a raw XML range to text: drop tags (paranum/dot hi and, unless requested, notes are stripped
+        /// whole). With <paramref name="output"/> = Latin the Devanagari stops are rendered as the reader
+        /// renders them, which needs the markup this method still has: in a gatha a single danda ends a pada
+        /// and becomes ";" while a double ends the verse and becomes ".", and the double dandas around
+        /// *namo tassa* are dropped. Any other output script keeps the dandas for the converter to handle.
+        /// (#680)
+        /// </summary>
+        internal static string Clean(string xml, int start, int end, bool includeNotes,
+            Script output = Script.Devanagari)
         {
             if (start >= end) return "";
             var sb = new StringBuilder(end - start);
+            // A window can begin mid-paragraph — a snippet usually does — so the opening <p> may be behind
+            // `start` and never seen by the walk below. Look it up rather than defaulting to prose, or every
+            // snippet that starts inside a verse would be punctuated as prose.
+            bool latin = output == Script.Latin;
+            string rend = latin ? ParagraphRendAt(xml, start) : "";
             int i = start;
             while (i < end)
             {
@@ -96,6 +109,8 @@ namespace CST.Search
                         i = gt + 1;
                     else
                     {
+                        if (latin && name == "p")
+                            rend = tag.StartsWith("</", System.StringComparison.Ordinal) ? "" : Attr(tag, "rend");
                         if (sb.Length > 0 && sb[sb.Length - 1] != ' ') sb.Append(' ');
                         i = gt + 1;
                     }
@@ -107,11 +122,63 @@ namespace CST.Search
                     // That punctuation should hug the preceding word, so drop the dangling space. (#292)
                     if (IsClosePunctuation(c) && sb.Length > 0 && sb[sb.Length - 1] == ' ')
                         sb.Length--;
-                    sb.Append(c);
+
+                    if (latin && IsBoundary(c))
+                    {
+                        // Dropping the mark rather than appending one is why the space is removed above and
+                        // not here: "assa U+0965 Bhagava" closes up to "assa Bhagava" on the following space,
+                        // instead of leaving two.
+                        if (LatinStop(c, rend) is { } stop) sb.Append(stop);
+                    }
+                    else sb.Append(c);
+
                     i++;
                 }
             }
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// How a Devanagari stop reads in Latin, given the <c>rend</c> of the paragraph it sits in. Mirrors
+        /// Deva2Latn.ConvertDandas, which the reader renders through; null means the mark is dropped. In verse
+        /// the distinction is metrical — a single danda ends a pada, a double ends the verse — so flattening
+        /// both to "." would show a model every line of a gatha ending identically. (#680)
+        /// </summary>
+        internal static char? LatinStop(char c, string rend)
+        {
+            if (rend.StartsWith("gatha", StringComparison.Ordinal))
+                return c == Danda ? ';' : '.';
+
+            // *Namo tassa* carries no stop in the reader. Single dandas are untouched there, so they are here.
+            if (rend == "centre" && c == DoubleDanda)
+                return null;
+
+            return '.';
+        }
+
+        /// <summary>
+        /// The <c>rend</c> of the <c>&lt;p&gt;</c> enclosing <paramref name="pos"/>, or "" outside one. Scans
+        /// back only as far as the previous <c>&lt;/p&gt;</c>, so it is bounded by one paragraph however large
+        /// the book is. (#680)
+        /// </summary>
+        internal static string ParagraphRendAt(string xml, int pos)
+        {
+            if (pos <= 0 || xml.Length == 0) return "";
+
+            int scan = Math.Min(pos, xml.Length) - 1;
+            int closed = xml.LastIndexOf("</p>", scan, StringComparison.Ordinal);
+
+            for (int i = scan; i > closed; i--)
+            {
+                // "<p" alone is not enough: <paranum> and <pb> start the same way.
+                if (xml[i] != '<' || i + 2 >= xml.Length || xml[i + 1] != 'p') continue;
+                if (xml[i + 2] != ' ' && xml[i + 2] != '>') continue;
+
+                int gt = xml.IndexOf('>', i);
+                return gt < 0 ? "" : Attr(xml.Substring(i, gt - i + 1), "rend");
+            }
+
+            return "";
         }
 
         // Punctuation that should sit directly after the preceding word (no space before it).

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -170,9 +170,12 @@ namespace CST.Search
 
             for (int i = scan; i > closed; i--)
             {
-                // "<p" alone is not enough: <paranum> and <pb> start the same way.
+                // "<p" alone is not enough: <paranum> and <pb> start the same way. Same whitespace set as
+                // TeiSnippetExtractor.FindLastPOpen, so the two scanners cannot disagree about what a
+                // paragraph tag is.
                 if (xml[i] != '<' || i + 2 >= xml.Length || xml[i + 1] != 'p') continue;
-                if (xml[i + 2] != ' ' && xml[i + 2] != '>') continue;
+                char after = xml[i + 2];
+                if (after != ' ' && after != '>' && after != '\t' && after != '\n' && after != '\r') continue;
 
                 int gt = xml.IndexOf('>', i);
                 return gt < 0 ? "" : Attr(xml.Substring(i, gt - i + 1), "rend");


### PR DESCRIPTION
#669 mapped both dandas to a period for Latin output so a reader's selection could be found in the passage sent to the model. That fixed the mismatch and knowingly lost a distinction: in a gāthā a single danda ends a *pāda* and reads `;`, a double ends the verse and reads `.`; the dandas around *namo tassa* are dropped entirely. A model reading a gāthā saw every line ending identically — and the distinction is metrical, so it is real information.

## Where the fix had to go

The rules could not be applied where the flattening happened. `Convert` receives text whose tags are already stripped, and "is this verse?" is a fact about markup. `Clean` still has the markup, so the decision moves there: it tracks the enclosing `<p rend>` as it walks and asks the new `LatinStop` what each mark reads as.

Two things this had to get right.

**A window usually begins mid-paragraph** — every search snippet does — so the opening `<p>` can sit behind `start` and never be seen by the walk. `Clean` now looks backwards for it, scanning only as far as the previous `</p>`, so the cost is one paragraph however large the book. Without that, snippets starting inside a verse would be punctuated as prose, which is most of them.

**A range spans paragraphs**, so a single "this range is verse" flag would have been wrong: a passage routinely runs verse into the prose after it. The decision is per mark, taken as the walk passes each `<p>`.

`Clean` takes the output script and defaults to `Devanagari`, meaning "leave the dandas for the converter". Only Latin is handled — it is the only script whose gāthā rule differs from its prose rule. Myanmar's `ConvertGathaDandas`, for instance, maps both marks to U+104B exactly as its prose path does. `Convert` keeps its blanket replace as the fallback for the prose case and for text that never went through `Clean`, so the two cannot drift the way the two Latin paths once did.

## Verification

Corpus, not fixtures: `gatha1/2/3`, `gathalast` and `centre` are the rends actually in use, with 41,150 gāthā paragraphs in the first 60 files alone, and real verse paragraphs carry `<pb/>` tags inside them — which the rend tracking ignores, as it must.

The Fable review then did better than either of us could argue. It ran a **differential over the entire corpus**: for every one of the **1,038,584 dandas in all 217 XML files**, it compared the reader's actual classification (Deva2Latn's real regexes, run over the raw XML) against `LatinStop(c, ParagraphRendAt(xml, pos))` by reflection into the built `CST.Core`. **Zero mismatches.** It found no defects.

It also confirmed the things I could not have asserted safely:

- `LastIndexOf(string, int)` semantics — the match must *end* at or before `startIndex` — verified empirically, which is what makes the backwards scan's boundary correct.
- Snippet highlight offsets are computed from `sb.Length` at append time, i.e. from already-mapped text, so the dropped *namo tassa* mark shortens string and offsets together. Nothing shifts.
- `LocateSelection` (the #649 replacement) drops all punctuation from both sides, so the `;` cannot break it. No other selection-vs-passage comparison exists.
- Match tokens are letters-only, so a highlight range never contains a danda.

## Three latent divergences, all vacuous today

Worth recording, because they are the maintenance risk rather than a present bug. The reader and this path agree **because of corpus invariants**, and the review measured each one:

1. The reader's regex has no `Singleline`, so a gāthā paragraph containing a newline would be prose to the reader and verse here. **Zero of 183,225 gāthā and 21,288 centre paragraphs are multi-line.**
2. The reader's regex requires `rend` to be the literal first attribute; `Attr` does not. **All 521,172 `<p>` tags are `rend`-first.**
3. `StartsWith("gatha")` vs `gatha[a-z0-9]*` — the only gāthā rends in the corpus are `gatha1/2/3/gathalast`, so no over-match.

If VRI ever reissues XML violating one of these, both paths would diverge again — but they would diverge together from the same assumptions.

## One thing the review changed

`ParagraphRendAt` accepted only a space or `>` after `<p`, while `TeiSnippetExtractor.FindLastPOpen` — scanning for the same thing a few files away — also accepts tab, CR and LF. No corpus tag uses those, so it changes nothing today; two scanners disagreeing about what a paragraph tag is would only ever be found the hard way. Second commit.

## Testing

Full suite **1799 passed, 0 failed**; 16 new tests covering the per-mark rule across a verse→prose range, a window that starts mid-verse, the dropped-mark space closure, the non-Latin identity path, and the `<pb`/`<paranum` false-positive guard.

Closes #680.
