### PR TITLE
DPAPI credentials: make the escape hardening real, and pin it (#579)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/WindowsDpapiStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/WindowsDpapiStoreTests.cs
@@ -45,6 +45,21 @@ public class WindowsDpapiStoreTests : IDisposable
 
     private string TheFile => Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
 
+    [Fact]   // Not [WindowsFact]: a constant is worth pinning on every machine that runs the suite.
+    public void The_entropy_is_stable()
+    {
+        // Nothing else can catch a change to this. Save and Find share the value in-process, so every
+        // round-trip test stays green while every key already stored is silently orphaned - the user is simply
+        // told they have not configured one. The failure is invisible at exactly the moment it happens and
+        // undiagnosable afterwards, which is what earns a constant its own test.
+        //
+        // It doubles as the guard for the escaping: a commit once claimed these were escaped while the
+        // file still held literal em dashes, so if an editor ever resaves this file in another codepage, this
+        // is the test that goes red.
+        Assert.Equal("CST Reader \u2014 AI provider key \u2014 v1",
+                     Encoding.UTF8.GetString(WindowsDpapiStore.Entropy));
+    }
+
     [WindowsFact]
     public void The_key_is_not_written_to_disk_in_the_clear()
     {
@@ -129,7 +144,7 @@ public class WindowsDpapiStoreTests : IDisposable
     {
         // The real service name carries an em dash and spaces, and is free to change. Sanitizing is what keeps
         // a rename from silently producing an unwritable path.
-        var awkward = _service + " — with / \\ : * ? \" < > |";
+        var awkward = _service + " \u2014 with / \\ : * ? \" < > |";
 
         Assert.True(WindowsDpapiStore.Save(awkward, "anthropic", Secret));
         Assert.Equal(Secret, WindowsDpapiStore.Find(awkward, "anthropic"));

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
@@ -30,7 +30,7 @@ public sealed class AiCredentialStore : IAiCredentialStore
     /// </summary>
     // Escaped rather than a literal em dash: this string names the Keychain item on macOS and the on-disk
     // directory on Windows, so a codepage-changing resave would orphan every stored key with no error.
-    internal const string ServiceName = "CST Reader — AI provider";
+    internal const string ServiceName = "CST Reader \u2014 AI provider";
 
     private readonly ILogger<AiCredentialStore> _logger;
     private readonly string _service;

--- a/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
@@ -36,12 +36,17 @@ internal static class WindowsDpapiStore
     /// The real guarantee here is DPAPI's own: another local account, or someone reading the disk offline,
     /// cannot decrypt it.
     ///
-    /// <para>Written with escapes rather than literal em dashes on purpose. Changing this value orphans every
-    /// stored key silently - the user is simply told they have not configured one - so the bytes must not be
-    /// at the mercy of an editor resaving the file in a different codepage.</para>
+    /// <para>Written with escapes rather than literal em dashes on purpose, and the source bytes really are
+    /// <c>5c 75 32 30 31 34</c> - an earlier commit claimed this while the file still held literal em dashes,
+    /// which is worse than not claiming it, because the false comment discourages anyone from re-checking.
+    /// Changing this value orphans every stored key silently - the user is simply told they have not
+    /// configured one - so the bytes must not be at the mercy of an editor resaving in another codepage.
+    /// <c>WindowsDpapiStoreTests.The_entropy_is_stable</c> is what actually holds the line; the round-trip
+    /// tests cannot, since save and find share the value in-process and stay green while every stored key
+    /// silently orphans.</para>
     /// </summary>
-    private static readonly byte[] Entropy =
-        Encoding.UTF8.GetBytes("CST Reader — AI provider key — v1");
+    internal static readonly byte[] Entropy =
+        Encoding.UTF8.GetBytes("CST Reader \u2014 AI provider key \u2014 v1");
 
     /// <summary>Serializes the three operations, so a save racing a read cannot see a half-installed file.</summary>
     private static readonly object Gate = new();
@@ -60,9 +65,13 @@ internal static class WindowsDpapiStore
     /// DPAPI itself is always present on Windows; what can fail is writing to the data directory. Probing that
     /// here - rather than assuming - keeps <c>IsAvailable</c> honest on a locked-down or full disk.
     ///
-    /// <para>Probed ONCE and cached, mirroring <see cref="MacOsKeychain.IsAvailable"/>, because this is read on
-    /// every credential operation and on every Settings binding refresh. An uncached probe would mean reading a
-    /// credential writes to disk, per request, forever.</para>
+    /// <para>Latched rather than simply cached. It is read on every credential operation and every Settings
+    /// refresh, so probing each time would mean reading a credential writes to disk, per request, forever -
+    /// but caching the FIRST answer would strand a user who frees up disk space showing "not writable" until
+    /// they restart, with nothing to suggest a restart would help. So: retry while it is false, and stop
+    /// probing for good once it succeeds. Steady state is identical to caching; the difference is only in the
+    /// direction that can actually heal. (The parallel to <see cref="MacOsKeychain.IsAvailable"/> is inexact -
+    /// that one caches a dlsym result, which cannot change mid-process. Disk writability can.)</para>
     ///
     /// <para>It creates the real <c>credentials</c> root - the directory <see cref="Save"/> creates anyway -
     /// rather than a fake service segment. An earlier version probed <c>DirectoryFor("probe")</c> and left a
@@ -73,21 +82,27 @@ internal static class WindowsDpapiStore
     /// where writing a file would not. <see cref="Save"/> still reports its own failure, which is what the
     /// user actually sees.</para>
     /// </summary>
-    private static readonly Lazy<bool> Probe = new(() =>
-    {
-        if (!OperatingSystem.IsWindows()) return false;
-        try
-        {
-            Directory.CreateDirectory(Path.Combine(AppConstants.DataDirectory, "credentials"));
-            return true;
-        }
-        catch (Exception)
-        {
-            return false;
-        }
-    });
+    private static volatile bool _canStore;
 
-    internal static bool IsAvailable => Probe.Value;
+    internal static bool IsAvailable
+    {
+        get
+        {
+            if (_canStore) return true;
+            if (!OperatingSystem.IsWindows()) return false;
+
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(AppConstants.DataDirectory, "credentials"));
+                _canStore = true;
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
 
     /// <summary>The stored secret, or null when there is none - or when the blob cannot be decrypted.</summary>
     internal static string? Find(string service, string account)
@@ -136,6 +151,11 @@ internal static class WindowsDpapiStore
             {
                 // Unreadable file, transient IO, a concurrent writer. Report "none stored" and leave the file
                 // alone - destroying it on a hiccup would be data loss.
+                //
+                // Behaviourally identical to the catch above, and kept separate only to carry the two
+                // different explanations: the cases arrive for unrelated reasons and a future change is
+                // likelier to want to treat one of them differently. No test distinguishes them, and none
+                // can - both tests below would pass with these collapsed into one.
                 return null;
             }
         }


### PR DESCRIPTION
Follow-up to #690, from a second adversarial review pass. Four findings; the first is a **correction to #690**, not a new improvement.

### The escape hardening in #690 did not exist

#690 stated that both storage-naming constants were written with `\u2014` escapes, so that an editor resaving the file in a different codepage could not silently orphan every stored key. The source bytes said otherwise - `WindowsDpapiStore.Entropy` and `AiCredentialStore.ServiceName` both still contained literal em dashes (`e2 80 94`).

Something between the intent and the file renders the escape sequence into the character it denotes. This is reproducible: it happened **again** while writing this fix, and again while writing an unrelated constant in the #29 branch. So it is a property of the pipeline rather than a slip, and the only reliable check is reading the bytes back rather than reading the source.

The state #690 left behind was worse than not having tried: the risk was unchanged, and a confident comment stood in front of it discouraging anyone from re-checking. Both constants are now genuinely ASCII, verified by byte inspection.

### `Entropy` is now pinned by a test

Nothing could catch a change to it. `Save` and `Find` share the value in-process, so every round-trip test stays green while every key already stored orphans silently - and the user is told only that they have not configured one. Invisible at the moment it happens, undiagnosable afterwards. `ServiceName` already had such a test; `Entropy` did not.

It is now `internal` so the test can assert its exact bytes. The assertion is itself written with escapes - had both sides used literals, one codepage mangling would hit both identically and the test would pass while the value changed.

### `IsAvailable` latches on success rather than caching the first answer

The `Lazy<bool>` from #690 covered the direction that matters (cached `true`, then the disk fills - `Save` still reports its own failure). It did not cover the other: a user who frees up space keeps seeing "data folder is not writable" until an app restart, with nothing to suggest a restart would help. It now retries while false and stops probing for good once it succeeds - identical steady state, self-healing in the one direction `Lazy` cannot be.

The comment's stated parallel to `MacOsKeychain.IsAvailable` was also inexact and now says so: that one caches a `dlsym` result, which cannot change mid-process. Disk writability can.

### The two catch blocks in `Find` are documentary, and now say so

Since #690 stopped deleting undecryptable blobs, the `CryptographicException` catch and the general catch do exactly the same thing. #690's commit message claimed a test pins the distinction; no test can, and both tests would pass with the two collapsed into one. They stay separate to carry two unrelated explanations - the comment now says that, rather than implying a guard that does not exist.

## Verification

0 warnings. A running instance of the app holds the normal output directory, so this was built and tested to a scratch output path: **1816 passed**. The only 4 failures are `DocumentFocusReporterTests` and `AiEvalHarness`, which locate the repo by walking up from `AppContext.BaseDirectory` and cannot find it from outside the tree - an artifact of the redirect, unrelated to these changes. **All 25 credential tests pass**, including the new entropy pin. Worth a confirming run against the normal output path once the app is closed.
