### PR TITLE
Filter the font picker by what each script actually needs (#29)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Platform/ScriptCoverageTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Platform/ScriptCoverageTests.cs
@@ -1,0 +1,136 @@
+using System.Linq;
+using CST.Avalonia.Services.Platform;
+using CST.Conversion;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Platform;
+
+/// <summary>
+/// What "this font supports this script" is allowed to mean. (#29)
+///
+/// <para>The font enumeration itself needs a live Avalonia <c>FontManager</c> and so is exercised by running
+/// the app; this half needs nothing, and it is the half where a mistake is invisible. Derive too few
+/// codepoints and the filter admits fonts that render tofu - which is the bug being fixed - while every test
+/// that merely counts fonts still passes.</para>
+///
+/// <para>Codepoints are written as integers rather than escaped string literals on purpose: a literal is at
+/// the mercy of the file's encoding, and this file is the reference for what the diacritics ARE.</para>
+/// </summary>
+public class ScriptCoverageTests
+{
+    // The Pāli diacritics in the probe phrase. A font that lacks these cannot set Pāli in Latin script, which
+    // is the single most likely wrong choice a user can make on a machine full of ASCII-only fonts.
+    private const int ALongA = 0x0101;      // a with macron
+    private const int TUnderdot = 0x1E6D;   // t with dot below
+    private const int MUnderdot = 0x1E43;   // m with dot below
+
+    [Theory]
+    [InlineData(Script.Latin)]
+    [InlineData(Script.Devanagari)]
+    [InlineData(Script.Bengali)]
+    [InlineData(Script.Cyrillic)]
+    [InlineData(Script.Gujarati)]
+    [InlineData(Script.Gurmukhi)]
+    [InlineData(Script.Kannada)]
+    [InlineData(Script.Khmer)]
+    [InlineData(Script.Malayalam)]
+    [InlineData(Script.Myanmar)]
+    [InlineData(Script.Sinhala)]
+    [InlineData(Script.Telugu)]
+    [InlineData(Script.Thai)]
+    [InlineData(Script.Tibetan)]
+    public void Every_readable_script_demands_something_of_a_font(Script script)
+    {
+        // An empty list means "offer every font", so a script that silently produced one would regress to
+        // exactly the unfiltered behaviour this exists to remove - without failing anything else.
+        Assert.NotEmpty(ScriptCoverage.CodepointsFor(script));
+    }
+
+    [Theory]
+    [InlineData(Script.Unknown)]
+    [InlineData(Script.Ipe)]
+    public void Scripts_that_are_not_scripts_impose_no_requirement(Script script)
+    {
+        // Unknown is not a script and Ipe is the internal search encoding, never shown to a reader. Filtering
+        // a font list for either would be inventing a requirement out of nothing.
+        Assert.Empty(ScriptCoverage.CodepointsFor(script));
+    }
+
+    [Fact]
+    public void Latin_requires_the_Pali_diacritics_not_merely_the_alphabet()
+    {
+        // The whole reason Latin is filtered at all. Most fonts on any machine draw "mahasatipatthanasuttam";
+        // far fewer draw it with the diacritics, and only the latter can set Pāli.
+        var codepoints = ScriptCoverage.CodepointsFor(Script.Latin);
+
+        Assert.Contains(ALongA, codepoints);
+        Assert.Contains(TUnderdot, codepoints);
+        Assert.Contains(MUnderdot, codepoints);
+    }
+
+    [Theory]
+    [InlineData(Script.Devanagari)]
+    [InlineData(Script.Myanmar)]
+    [InlineData(Script.Sinhala)]
+    [InlineData(Script.Tibetan)]
+    [InlineData(Script.Thai)]
+    [InlineData(Script.Khmer)]
+    public void A_converted_script_asks_for_its_own_characters_not_ASCII(Script script)
+    {
+        // Guards the conversion actually happening. Were it to return the Latin text unchanged, every font
+        // with a Latin alphabet would "support" Myanmar and the picker would be as useless as before.
+        var codepoints = ScriptCoverage.CodepointsFor(script);
+
+        Assert.All(codepoints, cp => Assert.True(cp >= 0x80,
+            $"{script} asked for U+{cp:X4}, which is ASCII - the sample was not converted."));
+    }
+
+    [Theory]
+    [InlineData(Script.Latin)]
+    [InlineData(Script.Devanagari)]
+    [InlineData(Script.Myanmar)]
+    [InlineData(Script.Tibetan)]
+    [InlineData(Script.Sinhala)]
+    public void Nothing_is_asked_for_twice(Script script)
+    {
+        // The phrase repeats letters. Testing a font for the same codepoint several times is wasted work on
+        // a path that runs across every installed font, for every script, at startup.
+        var codepoints = ScriptCoverage.CodepointsFor(script);
+
+        Assert.Equal(codepoints.Distinct().Count(), codepoints.Count);
+    }
+
+    [Theory]
+    [InlineData(Script.Devanagari)]
+    [InlineData(Script.Myanmar)]
+    [InlineData(Script.Tibetan)]
+    [InlineData(Script.Sinhala)]
+    [InlineData(Script.Khmer)]
+    public void The_character_used_to_ask_the_platform_is_one_that_identifies_the_script(Script script)
+    {
+        // This codepoint is handed to the platform's font fallback to ask what IT would use. An ASCII letter
+        // would match almost every font installed and answer nothing; a combining mark asks about a character
+        // that never stands alone.
+        var representative = ScriptCoverage.RepresentativeCodepoint(script);
+
+        Assert.NotNull(representative);
+        Assert.True(representative >= 0x80,
+            $"{script} would ask the platform about U+{representative:X4}, which is ASCII.");
+        Assert.Contains(representative!.Value, ScriptCoverage.CodepointsFor(script));
+    }
+
+    [Fact]
+    public void A_script_with_no_requirements_nominates_no_character_either()
+    {
+        // Consistency between the two halves: nothing to require means nothing to ask about.
+        Assert.Null(ScriptCoverage.RepresentativeCodepoint(Script.Unknown));
+        Assert.Null(ScriptCoverage.RepresentativeCodepoint(Script.Ipe));
+    }
+
+    [Fact]
+    public void Latin_asks_the_platform_about_a_diacritic()
+    {
+        // Not "m". The point of asking is to find a font that handles Pāli, and every font handles "m".
+        Assert.Equal(ALongA, ScriptCoverage.RepresentativeCodepoint(Script.Latin));
+    }
+}

--- a/src/CST.Avalonia/Services/FontService.cs
+++ b/src/CST.Avalonia/Services/FontService.cs
@@ -9,6 +9,7 @@ using CST.Avalonia.Models;
 #if MACOS
 using CST.Avalonia.Services.Platform.Mac;
 #endif
+using CST.Avalonia.Services.Platform;
 using CST.Conversion;
 using Microsoft.Extensions.Logging;
 
@@ -94,6 +95,11 @@ namespace CST.Avalonia.Services
         // ConcurrentDictionary: PreloadFontsForAllScriptsAsync writes this from many parallel task
         // continuations at once; a plain Dictionary can corrupt under concurrent writes. (SCRIPT-1)
         private readonly ConcurrentDictionary<Script, List<string>> _cachedFonts = new();
+
+        // Created lazily so that constructing a FontService - which several tests and the settings layer do -
+        // never has to touch Avalonia's FontManager. (#29)
+        private ScriptFontService? _scriptFonts;
+        private ScriptFontService ScriptFonts => _scriptFonts ??= new ScriptFontService(_logger);
         
         public async Task PreloadFontsForAllScriptsAsync()
         {
@@ -142,11 +148,12 @@ namespace CST.Avalonia.Services
             }
 #endif
         
-            // Fallback for non-Mac platforms
-            _logger.LogDebug("Using fallback method to get all system fonts.");
-            var fallbackFonts = FontManager.Current.SystemFonts.Select(f => f.Name).ToList();
-            _cachedFonts[script] = fallbackFonts; // Cache the result
-            return await Task.FromResult(fallbackFonts);
+            // Everywhere else, filter by actual glyph coverage rather than handing back every installed
+            // font. (#29) Before this, Windows offered the whole system list identically for all 14 scripts,
+            // so the fonts that work were indistinguishable from the ones that render tofu.
+            var detected = ScriptFonts.GetAvailableFontsForScript(script);
+            _cachedFonts[script] = detected; // Cache the result
+            return await Task.FromResult(detected);
         }
         
         public async Task<string?> GetSystemDefaultFontForScriptAsync(Script script)
@@ -161,9 +168,9 @@ namespace CST.Avalonia.Services
             }
 #endif
             
-            // Fallback for non-Mac platforms - return null to indicate system default
-            _logger.LogDebug("Using fallback method - returning null for system default");
-            return await Task.FromResult<string?>(null);
+            // Ask the platform which font IT would use for this script, rather than reporting "no opinion"
+            // and leaving the picker with nothing pre-selected. (#29)
+            return await Task.FromResult(ScriptFonts.GetSystemDefaultFontForScript(script));
         }
     }
 }

--- a/src/CST.Avalonia/Services/Platform/ScriptCoverage.cs
+++ b/src/CST.Avalonia/Services/Platform/ScriptCoverage.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using CST.Conversion;
+
+namespace CST.Avalonia.Services.Platform
+{
+    /// <summary>
+    /// Which codepoints a font has to be able to draw before it is worth offering for a given script. (#29)
+    ///
+    /// <para>Deliberately free of any Avalonia or OS dependency, so the part that decides what "supports this
+    /// script" means is testable on its own. The font enumeration around it needs a running
+    /// <c>FontManager</c>; this does not, and this is where a wrong answer would silently produce a picker
+    /// full of fonts that render tofu.</para>
+    /// </summary>
+    internal static class ScriptCoverage
+    {
+        /// <summary>
+        /// The probe text: <c>mahāsatipaṭṭhānasuttaṃ</c>, the same phrase <c>MacFontService</c> uses, so the two
+        /// platforms filter on identical evidence.
+        ///
+        /// <para>Written with escapes because CLAUDE.md requires it of script-conversion code - and the reason
+        /// applies with force here. The Pāli diacritics are exactly what a font is likely to lack, so a
+        /// mangled literal would not throw; it would quietly relax the test and admit fonts that cannot render
+        /// the text.</para>
+        /// </summary>
+        internal const string PaliSample = "mah\u0101satipa\u1E6D\u1E6Dh\u0101nasutta\u1E43";
+
+        /// <summary>
+        /// Scripts for which filtering is meaningless. <see cref="Script.Unknown"/> is not a script, and
+        /// <see cref="Script.Ipe"/> is the internal search encoding, never rendered to a reader - offering a
+        /// filtered font list for either would be inventing a requirement.
+        /// </summary>
+        private static bool IsRenderable(Script script) =>
+            script != Script.Unknown && script != Script.Ipe;
+
+        /// <summary>
+        /// Every distinct codepoint a font must cover for this script, or an EMPTY list meaning "do not
+        /// filter". Empty is returned when the script is not renderable, or when conversion yields nothing
+        /// usable - in which case showing every font is honest, where showing none would look like a bug.
+        /// </summary>
+        internal static IReadOnlyList<int> CodepointsFor(Script script)
+        {
+            if (!IsRenderable(script)) return Array.Empty<int>();
+
+            var sample = Convert(script);
+            if (string.IsNullOrEmpty(sample)) return Array.Empty<int>();
+
+            // By RUNE, not by char: Tibetan and others reach beyond the BMP, and testing a lone surrogate
+            // would ask the font for a glyph that cannot exist.
+            var codepoints = new List<int>();
+            foreach (var rune in sample.EnumerateRunes())
+            {
+                if (Rune.IsWhiteSpace(rune)) continue;
+                if (!codepoints.Contains(rune.Value)) codepoints.Add(rune.Value);
+            }
+
+            return codepoints;
+        }
+
+        /// <summary>
+        /// One codepoint that stands for the script, for asking the platform which font it would itself pick.
+        ///
+        /// <para>Chooses the first non-ASCII, non-combining character. ASCII would match nearly every font
+        /// installed and tell us nothing; a combining mark in isolation asks the question about a character
+        /// that never appears on its own.</para>
+        /// </summary>
+        internal static int? RepresentativeCodepoint(Script script)
+        {
+            foreach (var codepoint in CodepointsFor(script))
+            {
+                if (codepoint < 0x80) continue;
+
+                var category = Rune.GetUnicodeCategory(new Rune(codepoint));
+                if (category is UnicodeCategory.NonSpacingMark
+                             or UnicodeCategory.SpacingCombiningMark
+                             or UnicodeCategory.EnclosingMark
+                             or UnicodeCategory.Format)
+                {
+                    continue;
+                }
+
+                return codepoint;
+            }
+
+            // Latin is the case that legitimately lands here only if the sample lost its diacritics; every
+            // other script is non-ASCII throughout. Falling back to the first codepoint keeps a caller from
+            // having to special-case null when the list is non-empty.
+            return CodepointsFor(script).Cast<int?>().FirstOrDefault();
+        }
+
+        private static string? Convert(Script script)
+        {
+            try
+            {
+                return ScriptConverter.Convert(PaliSample, Script.Latin, script);
+            }
+            catch (Exception)
+            {
+                // A conversion that cannot be performed must not take the font picker down with it. The caller
+                // reads an empty list as "offer everything".
+                return null;
+            }
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/Platform/ScriptFontService.cs
+++ b/src/CST.Avalonia/Services/Platform/ScriptFontService.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using Avalonia.Media;
+using CST.Conversion;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Platform
+{
+    /// <summary>
+    /// Per-script font detection for every platform that is not macOS. (#29)
+    ///
+    /// <para>Windows previously had no script-aware path at all: the picker offered every installed font for
+    /// all 14 scripts, with no per-script default. Since most installed fonts cannot draw Sinhala or Myanmar,
+    /// the list actively misled - the entries that work were indistinguishable from the ones that produce
+    /// tofu, in an application whose whole promise is those 14 scripts.</para>
+    ///
+    /// <para><b>Managed, not DirectWrite.</b> The 2025 design for this called for DirectWrite COM interop -
+    /// several hundred lines of P/Invoke - because Avalonia offered nothing equivalent at the time. It does
+    /// now: <see cref="FontManager.TryGetGlyphTypeface"/> plus <see cref="IGlyphTypeface.TryGetGlyph"/> answers
+    /// "can this font draw this character", which is precisely what <c>IDWriteFont::HasCharacter</c> was
+    /// wanted for, and <see cref="FontManager.TryMatchCharacter"/> exposes the platform's own fallback chain,
+    /// which is what the hardcoded per-script default table was standing in for. No P/Invoke, no new
+    /// dependency, and it works on Linux too - which the DirectWrite route never would have.</para>
+    ///
+    /// <para><c>MacFontService</c> is deliberately left alone. It ships, it works, and rewriting a working
+    /// Core Text implementation to prove a point is not a fix.</para>
+    /// </summary>
+    public sealed class ScriptFontService
+    {
+        private readonly ILogger _logger;
+
+        public ScriptFontService(ILogger logger) => _logger = logger;
+
+        /// <summary>
+        /// The installed fonts that can actually render this script, sorted by name.
+        ///
+        /// <para><b>Returns an empty list when nothing on the machine can draw the script</b>, rather than
+        /// falling back to the unfiltered list. Offering every installed font in that situation would be
+        /// offering nothing but wrong answers, dressed as a working picker - the user would choose one, see
+        /// tofu, and have no way to tell whether they had picked badly or the system was missing a font.
+        /// Empty plus a warning names the actual problem: install a font for this script.</para>
+        /// </summary>
+        public List<string> GetAvailableFontsForScript(Script script)
+        {
+            var all = AllSystemFonts();
+            var required = ScriptCoverage.CodepointsFor(script);
+
+            // No opinion about this script (Unknown, Ipe, or a conversion that produced nothing usable).
+            if (required.Count == 0) return all;
+
+            var stopwatch = Stopwatch.StartNew();
+            var supported = new List<string>();
+
+            foreach (var family in SystemFontFamilies())
+            {
+                if (Supports(family, required)) supported.Add(family.Name);
+            }
+
+            // The font the platform would choose belongs in the list too. It has already been verified to
+            // cover the script (see GetSystemDefaultFontForScript), so this cannot reintroduce a font that
+            // fails the filter, and it cannot make the no-font case come back non-empty.
+            var systemDefault = GetSystemDefaultFontForScript(script);
+            if (systemDefault is not null && !supported.Contains(systemDefault))
+                supported.Add(systemDefault);
+
+            supported.Sort(StringComparer.CurrentCultureIgnoreCase);
+            stopwatch.Stop();
+
+            if (supported.Count == 0)
+            {
+                _logger.LogWarning(
+                    "NO INSTALLED FONT can render {Script}: none of the {Count} fonts on this system covers "
+                    + "all {Required} required characters. The font list for this script will be empty, and "
+                    + "text in it cannot display correctly until a suitable font is installed.",
+                    script, all.Count, required.Count);
+                return supported;
+            }
+
+            _logger.LogDebug("{Supported} of {Total} installed fonts cover {Script} ({Elapsed} ms)",
+                supported.Count, all.Count, script, stopwatch.ElapsedMilliseconds);
+
+            return supported;
+        }
+
+        /// <summary>
+        /// The font the platform would pick for this script itself, or null when it will not say.
+        ///
+        /// <para>Asked of the OS through Avalonia's fallback rather than hardcoded per script. A table of
+        /// "Nirmala UI for Devanagari, Myanmar Text for Myanmar" is a guess about someone else's machine: it
+        /// goes stale with a Windows release, and it is simply wrong on a system where those optional features
+        /// are not installed. Asking gets the right answer on the machine in front of us.</para>
+        ///
+        /// <para><b>The answer is verified, not trusted.</b> A fallback chain's job is to return SOMETHING, so
+        /// asked about a script with no font installed it can name one that cannot draw a single character of
+        /// it. Reporting that would be the worst of both worlds: a default that fails the very filter used to
+        /// build the list beside it, so the picker would name a default it does not offer. Checking coverage
+        /// makes the no-font case answer null - no opinion - which the caller renders as "System Default", and
+        /// <c>NoFontSupportsScript</c> is what tells the user why.</para>
+        /// </summary>
+        public string? GetSystemDefaultFontForScript(Script script)
+        {
+            var codepoint = ScriptCoverage.RepresentativeCodepoint(script);
+            if (codepoint is null) return null;
+
+            try
+            {
+                var matched = FontManager.Current.TryMatchCharacter(
+                    codepoint.Value,
+                    FontStyle.Normal,
+                    FontWeight.Normal,
+                    FontStretch.Normal,
+                    fontFamily: null,
+                    CultureInfo.CurrentCulture,
+                    out var typeface);
+
+                if (!matched) return null;
+
+                var name = typeface.FontFamily?.Name;
+                if (string.IsNullOrWhiteSpace(name)) return null;
+
+                // Only report it if it can really draw the script - see the note above.
+                var required = ScriptCoverage.CodepointsFor(script);
+                if (required.Count > 0 && !Supports(typeface.FontFamily!, required))
+                {
+                    _logger.LogDebug(
+                        "Platform fallback offered {Font} for {Script}, but it does not cover the script; "
+                        + "reporting no default instead.", name, script);
+                    return null;
+                }
+
+                return name;
+            }
+            catch (Exception ex)
+            {
+                // Never fatal: "no opinion" is a perfectly usable answer here, and the caller treats null as
+                // "use the system default".
+                _logger.LogDebug("No system default font for {Script} | {Details}", script, ex.Message);
+                return null;
+            }
+        }
+
+        private bool Supports(FontFamily family, IReadOnlyList<int> required)
+        {
+            try
+            {
+                if (!FontManager.Current.TryGetGlyphTypeface(new Typeface(family), out var glyphTypeface))
+                    return false;
+
+                // Every probe character, not most: a font missing one Pāli diacritic renders that character as
+                // tofu, and one tofu in a word is enough to make the text wrong.
+                foreach (var codepoint in required)
+                {
+                    if (!glyphTypeface.TryGetGlyph((uint)codepoint, out _)) return false;
+                }
+
+                return true;
+            }
+            catch (Exception)
+            {
+                // A font whose data cannot be loaded is not one to offer.
+                return false;
+            }
+        }
+
+        private IEnumerable<FontFamily> SystemFontFamilies()
+        {
+            try
+            {
+                return FontManager.Current.SystemFonts.ToList();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Could not enumerate system fonts");
+                return Array.Empty<FontFamily>();
+            }
+        }
+
+        private List<string> AllSystemFonts() =>
+            SystemFontFamilies().Select(f => f.Name).OrderBy(n => n, StringComparer.CurrentCultureIgnoreCase).ToList();
+    }
+}

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -731,6 +731,10 @@ namespace CST.Avalonia.ViewModels
             {
                 AvailableFonts = new ObservableCollection<string>(fonts);
 
+                // "System Default" is always present and is not a font, so the real question is whether
+                // anything else made it through the coverage filter. (#29)
+                NoFontSupportsScript = fonts.All(f => f == "System Default");
+
                 // The book list is the same faces under a different first entry: "Default" here means the
                 // app's shipped stack for this script, not the OS default.
                 var bookFonts = new List<string> { BookFontDefaultLabel };
@@ -783,6 +787,23 @@ namespace CST.Avalonia.ViewModels
         {
             get => _isLoadingFonts;
             set => this.RaiseAndSetIfChanged(ref _isLoadingFonts, value);
+        }
+
+        private bool _noFontSupportsScript;
+
+        /// <summary>
+        /// True when NOT ONE installed font can render this script. (#29)
+        ///
+        /// <para>Worth saying out loud in the window rather than only in the log. The picker still offers
+        /// "System Default" - that entry is the app's "do not override" token, not a font - so without this the
+        /// user sees a dropdown with a single unremarkable entry and no reason to suspect their system is
+        /// missing something. The old behaviour was worse still: every installed font was listed, so they would
+        /// pick one, get tofu, and reasonably conclude the application was broken.</para>
+        /// </summary>
+        public bool NoFontSupportsScript
+        {
+            get => _noFontSupportsScript;
+            private set => this.RaiseAndSetIfChanged(ref _noFontSupportsScript, value);
         }
 
         public ObservableCollection<string> AvailableFonts

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -229,6 +229,16 @@
                                                                   HorizontalAlignment="Stretch"/>
                                                     </DockPanel>
 
+                                                    <!-- #29: no installed font can draw this script. Said
+                                                         here because the picker still lists "System Default",
+                                                         so an otherwise-bare dropdown would look ordinary. -->
+                                                    <TextBlock Grid.Row="0" Grid.Column="1"
+                                                              IsVisible="{Binding SelectedScript.NoFontSupportsScript}"
+                                                              Text="No installed font can display this script. Install one to read texts in it."
+                                                              TextWrapping="Wrap"
+                                                              Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                                                              VerticalAlignment="Bottom" Margin="0,36,0,4"/>
+
                                                     <TextBlock Grid.Row="1" Grid.Column="0" Text="Size:"
                                                               VerticalAlignment="Center" Margin="0,0,10,0"/>
                                                     <NumericUpDown Grid.Row="1" Grid.Column="1" 


### PR DESCRIPTION
Closes #29.

Off macOS the font picker offered **every installed font, identically for all 14 scripts**, with no per-script default. On this base Windows 11 machine that is 81 fonts offered for Tibetan, of which **exactly one** can draw a single character of it. Nothing in the list distinguished them, so the likeliest outcome of using the picker was tofu — in the part of the app whose whole promise is those 14 scripts. It presented as working, which is why the issue title read as an enhancement rather than the defect it is.

## Managed, not DirectWrite

The design recorded on the issue calls for DirectWrite COM interop — several hundred lines of P/Invoke — because Avalonia had no equivalent when it was written in October 2025. It does now, and the job reduces to two calls:

| Need | Avalonia 11.3.6 | What the old design used |
|---|---|---|
| Can this font draw this character? | `FontManager.TryGetGlyphTypeface` + `IGlyphTypeface.TryGetGlyph` | `IDWriteFont::HasCharacter` |
| What font would the platform pick? | `FontManager.TryMatchCharacter` | `IDWriteTextLayout`, or a hardcoded table |

No P/Invoke, no new dependency, and it works on Linux too — which the DirectWrite route never would have. `MacFontService` is deliberately untouched: it ships and it works.

## Ask the platform, then verify the answer

The issue proposes a hardcoded default table (Nirmala UI, Myanmar Text, Leelawadee UI, Microsoft Himalaya…). Measured here, **that table would already have been wrong**: it gives `Segoe UI Variable` for Latin and Cyrillic, where Windows actually nominates `Segoe UI`. A table is a guess about someone else's machine and goes stale with a Windows release.

But the platform's answer is verified rather than trusted. A fallback chain's job is to return *something*, so asked about a script with no font installed it will name one that cannot draw a character of it. Reporting that would produce a default which fails the very filter used to build the list beside it — a default the picker does not offer. Coverage-checking it makes that case return null, which renders as "System Default".

## No font for a script means an empty list

Falling back to the unfiltered list there would offer nothing but wrong answers dressed as a working picker: the user picks one, sees tofu, and cannot tell whether they chose badly or their system is missing a font. Empty plus a warning names the real problem.

Since the Settings list always carries a `"System Default"` entry — the app's "do not override" token, not a font — an otherwise-bare dropdown would still look unremarkable, so `NoFontSupportsScript` says it in the window.

## Measured on this machine

Base Windows 11 ARM64, **81 font families installed**:

| Script | Fonts covering | Platform nominates | Verified |
|---|---|---|---|
| Latin | 16 | Segoe UI | yes |
| Cyrillic | 28 | Segoe UI | yes |
| Devanagari, Bengali, Gujarati, Gurmukhi, Kannada, Malayalam, Sinhala, Telugu | 2 each | Nirmala UI | yes |
| Thai | 3 | Leelawadee UI | yes |
| Khmer | 1 | Leelawadee UI | yes |
| Myanmar | 1 | Myanmar Text | yes |
| Tibetan | 1 | Microsoft Himalaya | yes |

**Every script is covered on a base install**, so no fonts need installing — which also answers the Pāli-script font item on the bare-metal checklist (#404). Every nominated default verified as genuinely covering its script, so the verification never fires here; it exists for the machine where it would.

## Tests

35 tests over the half with no Avalonia dependency — which is also the half where a mistake is invisible. Derive too few codepoints and the filter admits fonts that render tofu, while every test that merely counts fonts still passes. They assert codepoints as integers rather than escaped literals, since a literal is at the mercy of the file's encoding and this file is the reference for what the diacritics are.

## Verification

0 warnings, **1851 passed**. A running instance of the app holds the normal output directory, so this was built and tested to a scratch output path; the 4 failures are `DocumentFocusReporterTests` and `AiEvalHarness`, which locate the repo by walking up from `AppContext.BaseDirectory` and cannot find it from outside the tree. Unrelated to these changes — worth a confirming run once the app is closed.

**Not yet verified by eye**: nobody has opened Settings on a build containing this and looked at the lists. That is the next thing to do.
