### PR TITLE
Windows: a second launch brings the running window forward (#568)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/InstanceActivationTests.cs
+++ b/src/CST.Avalonia.Tests/Services/InstanceActivationTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// Bringing the running instance forward when a second launch happens. (#568)
+///
+/// <para>The pipe name is what decides WHICH instance is asked, so it carries the whole correctness argument:
+/// too loose and two copies running against different data directories would activate each other; too strict
+/// and the second launch fails to find the first over something as trivial as a trailing separator.</para>
+/// </summary>
+public class InstanceActivationTests
+{
+    private static string TempDir(string leaf) =>
+        Path.Combine(Path.GetTempPath(), "cst-activation-tests", leaf);
+
+    [Fact]
+    public void The_same_data_directory_always_resolves_to_the_same_pipe()
+    {
+        // Both processes compute the name independently; if they ever disagreed the second launch would sit
+        // waiting on a pipe nobody is serving, and the user would be back to the silent exit.
+        var dir = TempDir("alpha");
+
+        Assert.Equal(InstanceActivation.PipeNameFor(dir), InstanceActivation.PipeNameFor(dir));
+    }
+
+    [Fact]
+    public void Different_data_directories_get_different_pipes()
+    {
+        // The lock is per data directory, so activation must be too. Two copies pointed at separate data
+        // directories are both legitimately running, and neither should be able to raise the other.
+        Assert.NotEqual(
+            InstanceActivation.PipeNameFor(TempDir("alpha")),
+            InstanceActivation.PipeNameFor(TempDir("beta")));
+    }
+
+    [Fact]
+    public void A_trailing_separator_does_not_change_the_pipe()
+    {
+        // The same directory can reach this with or without a trailing slash depending on how it was composed.
+        var dir = TempDir("gamma");
+
+        Assert.Equal(
+            InstanceActivation.PipeNameFor(dir),
+            InstanceActivation.PipeNameFor(dir + Path.DirectorySeparatorChar));
+    }
+
+    [Fact]
+    public void Case_follows_the_filesystem_rather_than_the_string()
+    {
+        // Windows and macOS treat these as one directory, so the pipe must agree - otherwise a shortcut whose
+        // target is cased differently from the running instance's path silently fails to activate it.
+        var lower = TempDir("delta");
+        var upper = lower.ToUpperInvariant();
+
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+            Assert.Equal(InstanceActivation.PipeNameFor(lower), InstanceActivation.PipeNameFor(upper));
+        else
+            Assert.NotEqual(InstanceActivation.PipeNameFor(lower), InstanceActivation.PipeNameFor(upper));
+    }
+
+    [Fact]
+    public void The_pipe_name_is_legal_and_short_enough_to_use()
+    {
+        // A data directory can be long and can hold characters that are not valid in a pipe name, which is why
+        // the path is hashed rather than embedded. This pins that it stays true for a hostile path.
+        var awkward = Path.Combine(Path.GetTempPath(), new string('x', 300), "a b:c*d?e");
+
+        var name = InstanceActivation.PipeNameFor(awkward);
+
+        Assert.True(name.Length < 200, $"pipe name is {name.Length} chars");
+        Assert.DoesNotContain(Path.DirectorySeparatorChar, name);
+        Assert.DoesNotContain(Path.AltDirectorySeparatorChar, name);
+        Assert.All(name, c => Assert.True(char.IsLetterOrDigit(c) || c == '-', $"illegal character '{c}'"));
+    }
+
+    [Fact]
+    public void Asking_when_nobody_is_listening_reports_failure_rather_than_throwing()
+    {
+        // The realistic case is a running instance from an OLDER build, which holds the lock but serves no
+        // pipe. That has to degrade to "just exit" - the previous behaviour - not to an exception on a path
+        // whose whole purpose is to make a second launch feel normal.
+        var nobody = TempDir("nobody-" + Guid.NewGuid().ToString("N"));
+
+        Assert.False(InstanceActivation.RequestActivation(nobody));
+    }
+
+    [WindowsFact]
+    public void A_listening_instance_is_asked_to_come_forward()
+    {
+        // The mechanism end to end, in-process: a listener is started, a request is sent, and the callback the
+        // app uses to raise its window actually runs.
+        var dir = TempDir("roundtrip-" + Guid.NewGuid().ToString("N"));
+        using var raised = new ManualResetEventSlim(false);
+
+        InstanceActivation.StartListener(dir, () => raised.Set());
+
+        // The listener binds on a background thread; give it a moment to be accepting before asking.
+        Assert.True(SpinUntil(() => InstanceActivation.RequestActivation(dir), TimeSpan.FromSeconds(10)),
+            "the request was never delivered");
+        Assert.True(raised.Wait(TimeSpan.FromSeconds(10)), "the activation callback never ran");
+    }
+
+    private static bool SpinUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            Thread.Sleep(100);
+        }
+        return false;
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -227,6 +227,11 @@ public partial class App : Application
             // Close application when main window is closed
             desktop.ShutdownMode = ShutdownMode.OnMainWindowClose;
 
+            // #568: a second launch (taskbar, Start menu, desktop shortcut) should bring THIS window forward
+            // rather than appear to do nothing. macOS gets that from LaunchServices; everywhere else the
+            // running process has to be asked, so start listening now that there is a window to raise.
+            StartInstanceActivationListener();
+
             // Set up window-level menu events (View toggles + checkmarks). On macOS these back the system
             // menu bar; on Windows/Linux they back the in-window <NativeMenuBar/>. SetupWindowMenuEvents is
             // platform-agnostic; the macOS-only #284 Window-list helpers it calls simply no-op off macOS.
@@ -1355,6 +1360,59 @@ public partial class App : Application
             sp.GetService<Services.Ai.IChatProviderResolver>(),
             sp.GetService<ISettingsService>()));
         // services.AddTransient<MainWindowViewModel>();
+    }
+
+    /// <summary>
+    /// Listen for "another launch happened - come forward" requests. (#568)
+    ///
+    /// <para>Windows only for now. macOS activates through LaunchServices and needs nothing here; Linux would
+    /// need a way to raise a window that does not exist yet, and shipping a listener whose request could not be
+    /// honoured would only move the silence somewhere else.</para>
+    /// </summary>
+    private void StartInstanceActivationListener()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        try
+        {
+            Services.InstanceActivation.StartListener(
+                Constants.AppConstants.DataDirectory,
+                () => Dispatcher.UIThread.Post(BringMainWindowForward));
+        }
+        catch (Exception ex)
+        {
+            // Never fatal: the app is entirely usable without it.
+            Log.Warning("Could not start the instance-activation listener | {Details}", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Raise and focus the main window in response to a second launch. (#568)
+    ///
+    /// <para>Restoring first matters: the likeliest reason someone re-launches is that they minimised the
+    /// window and forgot it was open, and <c>Activate()</c> on a minimised window does not restore it.</para>
+    /// </summary>
+    private void BringMainWindowForward()
+    {
+        try
+        {
+            if (ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop) return;
+            if (desktop.MainWindow is not { } window) return;
+
+            // Fully qualified: CST.Avalonia.Models has its own WindowState (saved layout state), and an
+            // unqualified name here binds to whichever the compiler prefers rather than the one meant.
+            if (window.WindowState == global::Avalonia.Controls.WindowState.Minimized)
+                window.WindowState = global::Avalonia.Controls.WindowState.Normal;
+
+            window.Show();
+            window.Activate();
+
+            Log.Information("Brought the main window forward for a second launch. (#568)");
+        }
+        catch (Exception ex)
+        {
+            Log.Warning("Could not bring the main window forward | {Details}", ex.Message);
+        }
     }
 
     private void SetupNativeMenuEvents()

--- a/src/CST.Avalonia/Program.cs
+++ b/src/CST.Avalonia/Program.cs
@@ -115,7 +115,7 @@ sealed class Program
             if (!SingleInstanceGuard.TryAcquire(appDataDir))
             {
                 Logger.Information("Another CST Reader instance already owns {Dir}; activating it and exiting.", appDataDir);
-                SingleInstanceGuard.ActivateRunningInstance();
+                SingleInstanceGuard.ActivateRunningInstance(appDataDir);
                 return;
             }
 

--- a/src/CST.Avalonia/Services/InstanceActivation.cs
+++ b/src/CST.Avalonia/Services/InstanceActivation.cs
@@ -1,0 +1,185 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace CST.Avalonia.Services
+{
+    /// <summary>
+    /// Lets a second launch bring the ALREADY-RUNNING instance to the front instead of exiting silently. (#568)
+    ///
+    /// <para>macOS needs none of this: <c>open</c>-ing the bundle asks LaunchServices to activate the registered
+    /// instance, and <see cref="SingleInstanceGuard.ActivateRunningInstance"/> keeps doing exactly that. Windows
+    /// has no equivalent, so the running process has to be asked directly - and it is the only one that can
+    /// raise its own window anyway.</para>
+    ///
+    /// <para><b>Why a pipe rather than finding the window.</b> The obvious alternative - enumerate top-level
+    /// windows for the known pid and <c>SetForegroundWindow</c> - runs straight into the foreground lock:
+    /// Windows refuses foreground changes from a process that does not already own the foreground, so it fails
+    /// silently or merely flashes the taskbar button. Asking the owner to raise itself sidesteps that, and it
+    /// is the conventional shape for this on Windows.</para>
+    ///
+    /// <para><b>The foreground handshake.</b> Even the owner cannot raise itself unaided, for the same reason.
+    /// But the SECOND process can: it was just launched by the user, so it holds the foreground privilege, and
+    /// <c>AllowSetForegroundWindow</c> lets it hand that privilege to a named pid. So the server sends its pid
+    /// first, the client grants it, and only then asks for activation. Without that step the request arrives and
+    /// the window stays stubbornly behind whatever the user was looking at.</para>
+    ///
+    /// <para>Deliberately not tied to Windows in its own right: the pipe half is cross-platform, and #507 needs
+    /// the same "activate the running instance" capability for <c>--mcp-bridge</c>. Only the foreground grant is
+    /// Windows-specific.</para>
+    /// </summary>
+    internal static class InstanceActivation
+    {
+        private const string ActivateCommand = "ACTIVATE";
+
+        /// <summary>Enough for a local connect on a machine under load, short enough not to hang a launch.</summary>
+        private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(3);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool AllowSetForegroundWindow(int dwProcessId);
+
+        /// <summary>
+        /// One pipe per DATA DIRECTORY, matching the granularity of the lock itself - two copies pointed at
+        /// different data directories are both legitimately running and must not activate each other.
+        ///
+        /// <para>Hashed rather than embedded: a path can exceed the pipe-name length limit and can contain
+        /// characters that are not legal in one. Case-folded because the comparison has to agree with the
+        /// filesystem's own view of whether two paths are the same directory.</para>
+        /// </summary>
+        internal static string PipeNameFor(string dataDirectory)
+        {
+            var normalized = dataDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+                normalized = normalized.ToLowerInvariant();
+
+            var digest = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+            return "CSTReader-activate-" + Convert.ToHexString(digest, 0, 8).ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Listen for activation requests for the lifetime of the process. Failure is non-fatal by design: the
+        /// app runs perfectly well without it, and the only casualty is that a second launch goes back to
+        /// exiting quietly - which is where this started.
+        /// </summary>
+        internal static void StartListener(string dataDirectory, Action onActivate)
+        {
+            var pipeName = PipeNameFor(dataDirectory);
+
+            // Long-running background loop rather than a Task on the pool: it spends its life blocked on a
+            // connection, which is precisely what the pool should not be used for.
+            var thread = new Thread(() => ListenLoop(pipeName, onActivate))
+            {
+                IsBackground = true,   // must never keep the process alive after the window closes
+                Name = "instance-activation",
+            };
+            thread.Start();
+
+            Log.Debug("InstanceActivation: listening on {PipeName} for {Dir}", pipeName, dataDirectory);
+        }
+
+        private static void ListenLoop(string pipeName, Action onActivate)
+        {
+            while (true)
+            {
+                try
+                {
+                    // Rebuilt per connection: a NamedPipeServerStream serves one client and cannot be reused.
+                    using var server = new NamedPipeServerStream(
+                        pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.None);
+
+                    server.WaitForConnection();
+
+                    using var reader = new StreamReader(server, Encoding.UTF8, false, 128, leaveOpen: true);
+                    using var writer = new StreamWriter(server, new UTF8Encoding(false), 128, leaveOpen: true)
+                    {
+                        AutoFlush = true,
+                    };
+
+                    // Our pid first, so the client can hand us the foreground privilege before asking.
+                    writer.WriteLine(Environment.ProcessId);
+
+                    if (reader.ReadLine() == ActivateCommand)
+                    {
+                        Log.Information("InstanceActivation: another launch asked us to come forward.");
+                        onActivate();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // A broken connection is ordinary - the client exits the moment it has sent the command.
+                    // Keep listening; a failure here must never take down the running app.
+                    Log.Debug("InstanceActivation: listener iteration ended | {Details}", ex.Message);
+
+                    // Guard against a tight spin if the pipe itself cannot be created at all (name taken by a
+                    // stale process, sandbox refusing it). Sleeping briefly keeps a broken state cheap.
+                    Thread.Sleep(250);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Ask the running instance to come forward. Returns false when there was nobody to ask or the request
+        /// could not be delivered - the caller then falls back to simply exiting, which is the previous
+        /// behaviour rather than a new failure.
+        /// </summary>
+        internal static bool RequestActivation(string dataDirectory)
+        {
+            var pipeName = PipeNameFor(dataDirectory);
+
+            try
+            {
+                using var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut);
+                client.Connect((int)ConnectTimeout.TotalMilliseconds);
+
+                using var reader = new StreamReader(client, Encoding.UTF8, false, 128, leaveOpen: true);
+                using var writer = new StreamWriter(client, new UTF8Encoding(false), 128, leaveOpen: true)
+                {
+                    AutoFlush = true,
+                };
+
+                var line = reader.ReadLine();
+                if (!int.TryParse(line, out var serverPid))
+                {
+                    Log.Warning("InstanceActivation: running instance did not identify itself; not activating.");
+                    return false;
+                }
+
+                // Hand over the foreground privilege we hold as the freshly-launched process. Without this the
+                // other instance is allowed to ask and Windows is entitled to ignore it. Best-effort: a false
+                // return still leaves the request worth sending, since the window may already be foreground-able.
+                if (OperatingSystem.IsWindows() && !AllowSetForegroundWindow(serverPid))
+                {
+                    Log.Debug("InstanceActivation: AllowSetForegroundWindow({Pid}) declined (error {Error}); "
+                              + "asking anyway.", serverPid, Marshal.GetLastWin32Error());
+                }
+
+                writer.WriteLine(ActivateCommand);
+
+                // Let the request land before this process exits and the pipe drops.
+                client.Flush();
+                Log.Information("InstanceActivation: asked instance {Pid} to come forward.", serverPid);
+                return true;
+            }
+            catch (TimeoutException)
+            {
+                // The lock is held but nothing is listening. Most likely an older build, or the running
+                // instance is mid-startup and has not begun listening yet.
+                Log.Information("InstanceActivation: the running instance is not accepting activation requests.");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning("InstanceActivation: could not ask the running instance to come forward | {Details}",
+                    ex.Message);
+                return false;
+            }
+        }
+    }
+}

--- a/src/CST.Avalonia/SingleInstanceGuard.cs
+++ b/src/CST.Avalonia/SingleInstanceGuard.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using CST.Avalonia.Services;
 using Serilog;
 
 namespace CST.Avalonia
@@ -118,13 +119,20 @@ namespace CST.Avalonia
         /// <summary>Best-effort: bring the already-running instance to the foreground (macOS <c>open</c> the
         /// enclosing <c>.app</c> bundle, which LaunchServices activates rather than relaunching). No-op in dev /
         /// outside a bundle, so it can never spawn a second GUI.</summary>
-        public static void ActivateRunningInstance()
+        /// <param name="dataDirectory">
+        /// The data directory whose instance should come forward. Off macOS the running process has to be asked
+        /// directly, and the request is addressed per data directory - see <see cref="InstanceActivation"/>.
+        /// </param>
+        public static void ActivateRunningInstance(string dataDirectory)
         {
             if (!OperatingSystem.IsMacOS())
             {
-                // No foreground-activation path on Windows/Linux yet — say so (to the now-real logger, #316 A6-3)
-                // instead of a silent no-op that looks broken. (#317 A6-6)
-                Log.Information("SingleInstanceGuard: another instance is running; activation is macOS-only, so just exiting.");
+                // Windows has no `open` equivalent, so ask the running instance to raise itself. (#568) It
+                // returning false is not an error - it means nothing was listening (an older build, or an
+                // instance still starting up), and exiting quietly is then the old behaviour rather than a
+                // new failure.
+                if (!InstanceActivation.RequestActivation(dataDirectory))
+                    Log.Information("SingleInstanceGuard: another instance is running but did not come forward; exiting.");
                 return;
             }
             try


### PR DESCRIPTION
Closes #568.

Launching CST Reader while it was already running did nothing visible on Windows. The single-instance guard detected the running instance and exited — correctly — but the other half, raising the window that already exists, was macOS-only.

## Why a pipe rather than `SetForegroundWindow`

The obvious approach — find the running process's top-level window and raise it from the second process — runs straight into the foreground lock. Windows refuses foreground changes from a process that does not own the foreground, so it fails silently or merely flashes the taskbar button. Asking the owner to raise itself avoids that, and is the conventional shape for this on Windows.

## The foreground handshake is what makes it work

The running instance cannot raise itself unaided either, for the same reason. But the **second** process can: it was just launched by the user, so it holds the foreground privilege, and `AllowSetForegroundWindow` hands that privilege to a named pid.

So the protocol is: server writes its pid → client grants it the foreground → client sends `ACTIVATE`.

Without that middle step the request is delivered, the log says it worked, and the window stays behind whatever the user was looking at. **That is why the verification below reads the actual foreground window rather than trusting the absence of an exception.**

## Built for #507 as well

`InstanceActivation` is its own service rather than buried in the guard, because #507 needs the same capability for `--mcp-bridge` and notes it is the same missing piece with a different caller. Only the foreground grant is Windows-specific; the pipe half is portable.

The listener starts on Windows alone — macOS has LaunchServices and needs none of it, and Linux has no way to raise a window yet, where shipping a listener whose request could not be honoured would only move the silence somewhere else.

## Details worth noting

- **Addressed per data directory**, matching the granularity of the lock: two copies pointed at different data directories are both legitimately running and must not activate each other.
- **The path is hashed** into the pipe name — a data directory can exceed the pipe-name length limit and can hold characters illegal in one — and **case-folded on Windows/macOS** so the comparison agrees with the filesystem about whether two paths are the same directory.
- **Degrades to the old behaviour, not to a new failure**: if nothing is listening (an older build, or an instance still starting up) the request reports failure and the second launch simply exits.

## Verification on Windows 11 ARM64

Not merely a log line:

```
second instance : "asked instance 11676 to come forward", exit 0
running instance: "another launch asked us to come forward"
                  "Brought the main window forward for a second launch"
GetForegroundWindow() -> pid 11676, CST.Avalonia, title "CST Reader"
```

And the case the issue actually describes — minimised and forgotten — by minimising via `ShowWindow(SW_MINIMIZE)` and launching again:

| | before | after |
|---|---|---|
| `IsIconic` | True | **False** |
| foreground pid | — | **11676** |

**1861 tests pass, 0 warnings.** 7 new tests cover the pipe-name contract (the part carrying the correctness argument: too loose and separate data directories activate each other; too strict and a trailing separator breaks it) plus an in-process round trip and the nobody-listening degradation.

Not yet tested on x64 — worth a look on Placid or Kingfisher, since the foreground handshake is the kind of thing that can behave differently under different shell/focus conditions.
