### PR TITLE
Windows: replace the handshake file with File.Replace, not File.Move (#506)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LocalApi/LocalApiInfoRewriteTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApi/LocalApiInfoRewriteTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.IO;
+using System.Linq;
+using CST.Avalonia.Services.LocalApi;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.LocalApi;
+
+/// <summary>
+/// Rewriting the handshake file while somebody is reading it. (#506)
+///
+/// <para>On Unix a rename over an open file always succeeds - the reader keeps the old inode - so this whole
+/// class of problem is invisible there, which is why it survived until Windows. Windows refuses to replace a
+/// file held without <c>FILE_SHARE_DELETE</c>, and the <c>--mcp-bridge</c> relay polls this file while the
+/// server may be rewriting it.</para>
+/// </summary>
+public class LocalApiInfoRewriteTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "cst-handshake-tests", Guid.NewGuid().ToString("N"));
+
+    public LocalApiInfoRewriteTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static LocalApiInfo Info(int port = 51234, string token = "tok") =>
+        new(port, token, Environment.ProcessId, 42);
+
+    [Fact]
+    public void The_handshake_round_trips()
+    {
+        // Baseline: the change to how the file is opened must not alter what it contains.
+        Info(5000, "secret").Write(_dir);
+
+        var read = LocalApiInfo.Read(_dir);
+
+        Assert.NotNull(read);
+        Assert.Equal(5000, read!.Port);
+        Assert.Equal("secret", read.Token);
+        Assert.Equal(42, read.StartToken);
+    }
+
+    [Fact]
+    public void A_rewrite_succeeds_while_a_reader_holds_the_file()
+    {
+        // The actual defect. The relay polls this file; on Windows a reader opened the ordinary way blocks the
+        // server's rewrite outright rather than queueing behind it, so the server's own startup could fail
+        // because a client was doing exactly what it is supposed to do.
+        //
+        // The handle here is opened the way LocalApiInfo.Read now opens it - share-delete - which is what makes
+        // the replace legal on Windows. Before the fix, Read used File.ReadAllText and this threw.
+        Info(1111, "first").Write(_dir);
+        var path = LocalApiInfo.PathIn(_dir);
+
+        using (var held = new FileStream(
+                   path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete))
+        {
+            Info(2222, "second").Write(_dir);   // must not throw
+        }
+
+        Assert.Equal(2222, LocalApiInfo.Read(_dir)!.Port);
+    }
+
+    [Fact]
+    public void Reading_does_not_block_a_rewrite()
+    {
+        // Stated from the reader's side, because that is the half that has to stay true as Read changes: a
+        // reader must never be the reason a write fails. Reads the file, keeps the handle open, and writes.
+        Info(3333, "before").Write(_dir);
+
+        var first = LocalApiInfo.Read(_dir);
+        using (var held = new FileStream(
+                   LocalApiInfo.PathIn(_dir), FileMode.Open, FileAccess.Read,
+                   FileShare.ReadWrite | FileShare.Delete))
+        {
+            Info(4444, "after").Write(_dir);
+        }
+
+        Assert.Equal(3333, first!.Port);
+        Assert.Equal(4444, LocalApiInfo.Read(_dir)!.Port);
+    }
+
+    [Fact]
+    public void A_write_leaves_no_temporary_file_behind()
+    {
+        // The temp is an implementation detail of making the swap atomic; it must never become litter beside a
+        // file whose whole job is to be found and parsed by other programs.
+        Info().Write(_dir);
+        Info(9999, "again").Write(_dir);
+
+        var stray = Directory.EnumerateFiles(_dir)
+            .Where(f => f.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        Assert.Empty(stray);
+        Assert.Single(Directory.EnumerateFiles(_dir));
+    }
+
+    [WindowsFact]
+    public void A_hostile_reader_is_retried_and_then_reported_without_leaving_a_temp()
+    {
+        // A reader we do NOT control - an antivirus scanner, a backup agent, a third-party client using
+        // File.ReadAllText - can still hold the file without share-delete. That is retried briefly, and if it
+        // never clears the failure is reported rather than swallowed: a handshake that was never written leaves
+        // the server running but undiscoverable, which is not something to hide.
+        //
+        // What must NOT happen is a temp file accumulating per failed attempt.
+        Info().Write(_dir);
+        var path = LocalApiInfo.PathIn(_dir);
+
+        using (var hostile = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            Assert.ThrowsAny<IOException>(() => Info(7777, "blocked").Write(_dir));
+        }
+
+        Assert.DoesNotContain(
+            Directory.EnumerateFiles(_dir),
+            f => f.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase));
+
+        // And once the hostile handle is gone, writing works again - the failure was transient, not terminal.
+        Info(8888, "recovered").Write(_dir);
+        Assert.Equal(8888, LocalApiInfo.Read(_dir)!.Port);
+    }
+
+    [Fact]
+    public void An_absent_handshake_reads_as_null_rather_than_throwing()
+    {
+        Assert.Null(LocalApiInfo.Read(Path.Combine(_dir, "nope")));
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using Serilog;
 
 namespace CST.Avalonia.Services.LocalApi
@@ -55,17 +56,31 @@ namespace CST.Avalonia.Services.LocalApi
             using (var w = new StreamWriter(fs, new UTF8Encoding(false)))
                 w.Write(json);
 
-            File.Move(tmp, path, overwrite: true);   // rename preserves the temp's 0600 mode
-            TrySetOwnerOnly(path);                    // belt-and-suspenders; also fixes a pre-existing file's mode
+            MoveIntoPlace(tmp, path);   // rename preserves the temp's 0600 mode
+            TrySetOwnerOnly(path);      // belt-and-suspenders; also fixes a pre-existing file's mode
         }
 
+        /// <summary>
+        /// Read the handshake, or null when it is absent or unreadable.
+        ///
+        /// <para><b>Opened share-delete</b> rather than via <c>File.ReadAllText</c>. On Unix a rename over an
+        /// open file always succeeds - the reader simply keeps the old inode - but Windows refuses to replace a
+        /// file that someone holds without <c>FILE_SHARE_DELETE</c>, and <c>ReadAllText</c> does not ask for it.
+        /// Since the <c>--mcp-bridge</c> relay polls this file while the server may be rewriting it, the default
+        /// share mode turns a reader into a blocker and makes <see cref="Write"/> fail intermittently. (#506)</para>
+        /// </summary>
         public static LocalApiInfo? Read(string directory)
         {
             try
             {
                 var path = PathIn(directory);
                 if (!File.Exists(path)) return null;
-                return JsonSerializer.Deserialize<LocalApiInfo>(File.ReadAllText(path), Options);
+
+                using var fs = new FileStream(
+                    path, FileMode.Open, FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                using var reader = new StreamReader(fs, Encoding.UTF8);
+                return JsonSerializer.Deserialize<LocalApiInfo>(reader.ReadToEnd(), Options);
             }
             catch { return null; }
         }
@@ -73,6 +88,72 @@ namespace CST.Avalonia.Services.LocalApi
         public static void Delete(string directory)
         {
             try { File.Delete(PathIn(directory)); } catch { /* best effort */ }
+        }
+
+        /// <summary>
+        /// Put the temp file in place of the real one, tolerating a concurrent reader. (#506)
+        ///
+        /// <para><b>Measured on Windows 11, because the intuitive answer is wrong.</b> Replacing a file that
+        /// another handle has open behaves like this:</para>
+        ///
+        /// <code>
+        /// reader's FileShare      File.Move(overwrite: true)      File.Replace
+        /// Read                    UnauthorizedAccessException     IOException
+        /// ReadWrite               UnauthorizedAccessException     IOException
+        /// ReadWrite | Delete      UnauthorizedAccessException     OK
+        /// Delete                  UnauthorizedAccessException     OK
+        /// </code>
+        ///
+        /// <para>So <c>File.Move</c> NEVER replaces an open destination on Windows - not even when the reader
+        /// allowed delete, which is the case one would expect to work. Only <c>File.Replace</c> (Win32
+        /// <c>ReplaceFile</c>) can, and only when the reader permits deletion. BOTH halves are therefore
+        /// required: <see cref="Read"/> opens share-delete, and the swap goes through <c>File.Replace</c>.
+        /// Doing either alone leaves the failure exactly where it was.</para>
+        ///
+        /// <para><b>Windows only.</b> Unix renames over open files happily, and the existing <c>File.Move</c>
+        /// there carries a property worth keeping: the rename preserves the TEMP file's 0600 mode, which is how
+        /// the token avoids a world-readable window (#303). <c>ReplaceFile</c> semantics preserve the
+        /// DESTINATION's attributes instead, so switching Unix to it could silently inherit the permissions of
+        /// a pre-existing file. There is no problem to fix on that side, and a real property to lose.</para>
+        ///
+        /// <para><c>File.Replace</c> requires the destination to exist, so a first write still moves.</para>
+        /// </summary>
+        private static void MoveIntoPlace(string tmp, string path)
+        {
+            const int attempts = 5;
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    if (OperatingSystem.IsWindows() && File.Exists(path))
+                        File.Replace(tmp, path, destinationBackupFileName: null);
+                    else
+                        File.Move(tmp, path, overwrite: true);
+                    return;
+                }
+                catch (IOException ex) when (attempt < attempts)
+                {
+                    // A reader we do NOT control - an antivirus scanner, a backup agent, a third-party client
+                    // reading the file the obvious way - can still hold it without share-delete. The window is
+                    // milliseconds, so a short backoff turns a startup failure into a brief pause.
+                    //
+                    // FileNotFoundException is an IOException too, and lands here deliberately: it means the
+                    // destination vanished between the check and the call, and the retry simply takes the move
+                    // branch instead.
+                    var delay = 20 * (int)Math.Pow(2, attempt - 1);   // 20, 40, 80, 160 ms
+                    Log.Debug("Handshake swap blocked (attempt {Attempt}/{Total}, {Error}); retrying in {Delay} ms.",
+                        attempt, attempts, ex.GetType().Name, delay);
+                    Thread.Sleep(delay);
+                }
+                catch
+                {
+                    // Give up: remove the temp so repeated failures cannot leave a litter of them beside a file
+                    // whose whole job is to be found and parsed by other programs, then report. A handshake that
+                    // was never written leaves the server running but undiscoverable - not something to swallow.
+                    try { File.Delete(tmp); } catch { /* best effort */ }
+                    throw;
+                }
+            }
         }
 
         private static void TrySetOwnerOnly(string path)


### PR DESCRIPTION
Closes #506.

`local-api.json` is rewritten when the local API server starts, while the `--mcp-bridge` relay may be polling it. On Unix a rename over an open file always succeeds — the reader keeps the old inode — so this was invisible there. On Windows the rewrite could simply fail, because a client was doing exactly what it is supposed to do.

## The issue's suggested fix is necessary but not sufficient

The issue offered three options: open share-delete on the reader side, retry, or use `File.Replace`. Measuring on Windows 11 shows the reader-side change alone does **not** work, and that the intuitive expectation is wrong:

| reader's `FileShare` | `File.Move(overwrite: true)` | `File.Replace` |
|---|---|---|
| `Read` | UnauthorizedAccessException | IOException |
| `ReadWrite` | UnauthorizedAccessException | IOException |
| `ReadWrite \| Delete` | UnauthorizedAccessException | **OK** |
| `Delete` | UnauthorizedAccessException | **OK** |

**`File.Move` never replaces an open destination on Windows** — not even when the reader allowed delete, which is precisely the case one would expect to work. Only `File.Replace` (Win32 `ReplaceFile`) can, and only when the reader permits deletion.

So both halves are required, and either alone leaves the failure exactly where it was. This also explains why the exception seen in practice is `UnauthorizedAccessException`, not the sharing violation the issue anticipated.

## What changed

- **`Read`** opens `FileShare.ReadWrite | FileShare.Delete` instead of `File.ReadAllText`, which does not ask for it. Every reader in the tree goes through `Read`, so this covers the relay and the tests at once.
- **The swap uses `File.Replace` on Windows only.** Unix renames over open files happily, and the `File.Move` there carries a property worth keeping: the rename preserves the **temp file's** `0600` mode, which is how the token avoids a world-readable window (#303). `ReplaceFile` semantics preserve the **destination's** attributes instead, so moving Unix onto it could silently inherit the permissions of a pre-existing file — no problem to fix on that side, and a real property to lose. (`File.Replace` also requires the destination to exist, so a first write still moves.)
- **Bounded retry** (20/40/80/160 ms) for readers we don't control — an antivirus scanner, a backup agent, a third-party client reading the file the obvious way. `FileNotFoundException` lands in the retry deliberately: it means the destination vanished between the check and the call, and the retry takes the move branch instead.
- **The temp is deleted before rethrowing** on give-up, so repeated failures cannot leave a litter of temp files beside a file whose whole job is to be found and parsed by other programs. The failure itself still propagates — a handshake that was never written leaves the server running but undiscoverable.

## Tests

6 tests. The one that matters most is `A_rewrite_succeeds_while_a_reader_holds_the_file`: **it failed against my first version of this fix**, which is what prompted measuring the behaviour instead of assuming it. Also covers the hostile-reader path (retried, then reported, no temp left behind) and that a write leaves no `.tmp`.

**1832 pass, 0 warnings.**
