### PR TITLE
Connections in settings, and the service the UI binds to (#689)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -1,0 +1,253 @@
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// #689: the service the connections UI (#691/#692/#693) binds to. Settings-backed; no credential handling
+/// yet, which is what lets the UI work start in parallel with the keychain re-keying.
+/// </summary>
+public class AiConnectionServiceTests
+{
+    private static (AiConnectionService Service, Settings Settings) Make()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        return (new AiConnectionService(svc.Object), settings);
+    }
+
+    private static AiConnectionDraft Draft(string name = "My box", string url = "http://localhost:8000/v1") =>
+        new(name, ChatProviderKind.OpenAiCompatible, url,
+            new List<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>());
+
+    // ---- ids ------------------------------------------------------------------------------------------
+
+    /// <summary>The id becomes the credential's account name, so a duplicate would mean one connection
+    /// quietly inheriting another's key. Refused explicitly rather than overwriting.</summary>
+    [Fact]
+    public void A_duplicate_id_is_refused()
+    {
+        var (service, _) = Make();
+        Assert.True(service.Add("my-box", Draft()).Ok);
+
+        var second = service.Add("my-box", Draft("Another"));
+
+        Assert.False(second.Ok);
+        Assert.Contains("already", second.Problem);
+    }
+
+    /// <summary>Preset ids are reserved: taking one by hand would collide with the built-in the reader might
+    /// add later, and the collision would be a credential mix-up rather than a visible error.</summary>
+    [Fact]
+    public void A_preset_id_cannot_be_taken_by_a_custom_connection()
+    {
+        var (service, _) = Make();
+
+        var result = service.Add("openrouter", Draft());
+
+        Assert.False(result.Ok);
+        Assert.Contains("built-in", result.Problem);
+    }
+
+    [Theory]
+    [InlineData("My-Box")]      // uppercase
+    [InlineData("my box")]      // space
+    [InlineData("my.box")]      // dot
+    [InlineData("-leading")]    // leading hyphen
+    [InlineData("")]
+    public void An_id_that_is_not_a_slug_is_refused(string id)
+    {
+        var (service, _) = Make();
+        Assert.False(service.Add(id, Draft()).Ok);
+    }
+
+    // ---- presets --------------------------------------------------------------------------------------
+
+    /// <summary>An added preset drops out of the available list, so the "add a provider" section always reads
+    /// as what you could add next rather than a list where some rows are already spoken for.</summary>
+    [Fact]
+    public void An_added_preset_leaves_the_available_list()
+    {
+        var (service, _) = Make();
+        Assert.Contains(service.AvailablePresets, p => p.Id == "openrouter");
+
+        service.AddFromPreset("openrouter", new Dictionary<string, string>());
+
+        Assert.DoesNotContain(service.AvailablePresets, p => p.Id == "openrouter");
+        Assert.Contains(service.Connections, c => c.Id == "openrouter");
+    }
+
+    [Fact]
+    public void A_preset_arrives_with_its_url_and_kind_filled_in()
+    {
+        var (service, _) = Make();
+
+        var result = service.AddFromPreset("openrouter", new Dictionary<string, string>());
+
+        Assert.True(result.Ok);
+        Assert.Equal("https://openrouter.ai/api/v1", result.Connection!.BaseUrl);
+        Assert.Equal(ChatProviderKind.OpenAiCompatible, result.Connection.Kind);
+    }
+
+    /// <summary>
+    /// A preset whose URL is a template must not be addable without its inputs — the connection would keep its
+    /// {placeholders} and could never send anything, failing later as a DNS error naming nothing.
+    /// </summary>
+    [Fact]
+    public void A_templated_preset_is_refused_without_its_inputs()
+    {
+        var (service, _) = Make();
+
+        var result = service.AddFromPreset("azure", new Dictionary<string, string>());
+
+        Assert.False(result.Ok);
+        Assert.Contains("resource name", result.Problem, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void A_templated_preset_resolves_its_url_once_the_inputs_are_given()
+    {
+        var (service, _) = Make();
+
+        var result = service.AddFromPreset("azure", new Dictionary<string, string> { ["resourceName"] = "acme" });
+
+        Assert.True(result.Ok);
+        Assert.False(result.Connection!.IsIncomplete);
+        Assert.Equal("https://acme.openai.azure.com/openai/v1", result.Connection.ResolvedBaseUrl);
+    }
+
+    // ---- active selection ------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_first_connection_added_becomes_active()
+    {
+        var (service, _) = Make();
+        service.Add("first", Draft());
+        service.Add("second", Draft());
+
+        Assert.Equal("first", service.Active!.Id);
+    }
+
+    /// <summary>Selecting a model that the connection does not offer must fail rather than store a value that
+    /// resolves to nothing at send time.</summary>
+    [Fact]
+    public void An_unknown_model_cannot_be_made_active()
+    {
+        var (service, _) = Make();
+        service.Add("box", Draft());
+
+        Assert.False(service.SetActive("box", "no-such-model").Ok);
+    }
+
+    [Fact]
+    public void A_model_the_connection_offers_can_be_made_active()
+    {
+        var (service, _) = Make();
+        service.Add("box", Draft() with { Models = new[] { new AiModelEntry("llama-3", "Llama 3") } });
+
+        Assert.True(service.SetActive("box", "llama-3").Ok);
+        Assert.Equal("llama-3", service.ActiveModelId);
+    }
+
+    /// <summary>
+    /// Removing the active connection must not leave the pointer dangling. A stale id reads as "configured"
+    /// to anything that only checks for null, which would present as a request going nowhere.
+    /// </summary>
+    [Fact]
+    public void Removing_the_active_connection_moves_the_pointer()
+    {
+        var (service, settings) = Make();
+        service.Add("first", Draft());
+        service.Add("second", Draft());
+
+        Assert.True(service.Remove("first").Ok);
+
+        Assert.Equal("second", settings.Ai.Chat.ActiveConnectionId);
+        Assert.Null(settings.Ai.Chat.ActiveModelId);
+    }
+
+    [Fact]
+    public void Removing_the_last_connection_leaves_nothing_active()
+    {
+        var (service, settings) = Make();
+        service.Add("only", Draft());
+
+        service.Remove("only");
+
+        Assert.Null(settings.Ai.Chat.ActiveConnectionId);
+        Assert.Null(service.Active);
+    }
+
+    // ---- models ---------------------------------------------------------------------------------------
+
+    /// <summary>Models arrive enabled. All-on is neutral; a pre-selected subset would be a quality verdict,
+    /// which is the registry removed in #670/#681 wearing a toggle.</summary>
+    [Fact]
+    public void Models_are_enabled_by_default()
+    {
+        var (service, _) = Make();
+        var result = service.Add("box", Draft() with
+        {
+            Models = new[] { new AiModelEntry("a", "A"), new AiModelEntry("b", "B") }
+        });
+
+        Assert.All(result.Connection!.Models, m => Assert.True(m.Enabled));
+    }
+
+    [Fact]
+    public void A_model_can_be_switched_off_without_removing_it()
+    {
+        var (service, _) = Make();
+        service.Add("box", Draft() with { Models = new[] { new AiModelEntry("a", "A") } });
+
+        Assert.True(service.SetModelEnabled("box", "a", false).Ok);
+
+        var model = Assert.Single(service.Connections.Single().Models);
+        Assert.False(model.Enabled);
+        Assert.Equal("a", model.Id);
+    }
+
+    // ---- change notification ---------------------------------------------------------------------------
+
+    /// <summary>The UI rebinds on this; a mutation that does not raise it presents as a screen that has
+    /// silently stopped matching what is stored.</summary>
+    [Fact]
+    public void Every_mutation_raises_the_change_event()
+    {
+        var (service, _) = Make();
+        int raised = 0;
+        service.ConnectionsChanged += (_, _) => raised++;
+
+        service.Add("box", Draft() with { Models = new[] { new AiModelEntry("a", "A") } });
+        service.Update("box", Draft("Renamed"));
+        service.Add("other", Draft() with { Models = new[] { new AiModelEntry("a", "A") } });
+        service.SetModelEnabled("other", "a", false);
+        service.SetActive("other", "a");
+        service.Remove("other");
+
+        Assert.Equal(6, raised);
+    }
+
+    /// <summary>The id is immutable because the credential is filed under it; an update must not silently
+    /// change it even if a draft carried one.</summary>
+    [Fact]
+    public void Updating_edits_everything_except_the_id()
+    {
+        var (service, _) = Make();
+        service.Add("box", Draft("Original", "http://a/v1"));
+
+        var result = service.Update("box", Draft("Renamed", "http://b/v1"));
+
+        Assert.True(result.Ok);
+        Assert.Equal("box", result.Connection!.Id);
+        Assert.Equal("Renamed", result.Connection.DisplayName);
+        Assert.Equal("http://b/v1", result.Connection.BaseUrl);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -5,6 +5,7 @@ using CST.Avalonia.Services;
 using CST.Avalonia.Services.Ai;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using System.Linq;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services.Ai;
@@ -53,10 +54,26 @@ public class ChatProviderResolverTests
             new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan });
     }
 
+    /// <summary>
+    /// The active connection, created on demand. #689 replaced the scalar Provider/BaseUrl/Model on
+    /// ChatSettings with a list of connections plus an active id, so these tests configure a connection
+    /// rather than three loose fields.
+    /// </summary>
+    private static CST.Avalonia.Models.AiConnectionRecord Conn(CST.Avalonia.Models.ChatSettings chat)
+    {
+        var existing = chat.Connections.FirstOrDefault();
+        if (existing is not null) return existing;
+
+        var created = new CST.Avalonia.Models.AiConnectionRecord { Id = "test", DisplayName = "test" };
+        chat.Connections.Add(created);
+        chat.ActiveConnectionId = created.Id;
+        return created;
+    }
+
     [Fact]
     public void Anthropic_resolves_with_a_stored_key()
     {
-        var resolver = Resolver(c => { c.Provider = "anthropic"; c.Model = " claude-opus-5 "; }, apiKey: "sk-ant-x");
+        var resolver = Resolver(c => { Conn(c).Kind = "anthropic"; c.ActiveModelId = " claude-opus-5 "; }, apiKey: "sk-ant-x");
 
         var resolution = resolver.Resolve(out var problem);
 
@@ -68,7 +85,7 @@ public class ChatProviderResolverTests
     [Fact]
     public void Anthropic_without_a_key_says_so_rather_than_failing_at_the_wire()
     {
-        var resolver = Resolver(c => { c.Provider = "anthropic"; c.Model = "claude-opus-5"; });
+        var resolver = Resolver(c => { Conn(c).Kind = "anthropic"; c.ActiveModelId = "claude-opus-5"; });
 
         Assert.Null(resolver.Resolve(out var problem));
         Assert.Contains("API key", problem);
@@ -84,7 +101,7 @@ public class ChatProviderResolverTests
         // Windows', which stopped being true when DPAPI landed (#579) - a fixture that quotes a real message
         // should not outlive it.
         var resolver = Resolver(
-            c => { c.Provider = "anthropic"; c.Model = "claude-opus-5"; },
+            c => { Conn(c).Kind = "anthropic"; c.ActiveModelId = "claude-opus-5"; },
             storageUnavailable: "Secure key storage is not available on this platform.");
 
         Assert.Null(resolver.Resolve(out var problem));
@@ -99,9 +116,9 @@ public class ChatProviderResolverTests
         // one here would lock out the configuration surface B was built to serve.
         var resolver = Resolver(c =>
         {
-            c.Provider = "openai-compatible";
-            c.BaseUrl = "http://localhost:11434/v1";
-            c.Model = "gemma4:cloud";
+            Conn(c).Kind = "openai-compatible";
+            Conn(c).BaseUrl = "http://localhost:11434/v1";
+            c.ActiveModelId = "gemma4:cloud";
         });
 
         var resolution = resolver.Resolve(out var problem);
@@ -114,7 +131,7 @@ public class ChatProviderResolverTests
     public void An_openai_compatible_endpoint_without_a_base_url_is_refused()
     {
         // No default is possible: the base URL IS the provider.
-        var resolver = Resolver(c => { c.Provider = "openai-compatible"; c.Model = "deepseek-chat"; });
+        var resolver = Resolver(c => { Conn(c).Kind = "openai-compatible"; c.ActiveModelId = "deepseek-chat"; });
 
         Assert.Null(resolver.Resolve(out var problem));
         Assert.Contains("base URL", problem);
@@ -123,7 +140,7 @@ public class ChatProviderResolverTests
     [Fact]
     public void No_model_is_refused_before_anything_else_is_examined()
     {
-        var resolver = Resolver(c => { c.Provider = "anthropic"; c.Model = null; }, apiKey: "sk-ant-x");
+        var resolver = Resolver(c => { Conn(c).Kind = "anthropic"; c.ActiveModelId = null; }, apiKey: "sk-ant-x");
 
         Assert.Null(resolver.Resolve(out var problem));
         Assert.Contains("model", problem);
@@ -133,7 +150,7 @@ public class ChatProviderResolverTests
     public void The_master_switch_being_off_is_reported_as_a_setting_not_a_fault()
     {
         var resolver = Resolver(
-            c => { c.Provider = "anthropic"; c.Model = "claude-opus-5"; }, apiKey: "sk-ant-x", aiEnabled: false);
+            c => { Conn(c).Kind = "anthropic"; c.ActiveModelId = "claude-opus-5"; }, apiKey: "sk-ant-x", aiEnabled: false);
 
         Assert.Null(resolver.Resolve(out var problem));
         Assert.Contains("turned off", problem);
@@ -142,7 +159,7 @@ public class ChatProviderResolverTests
     [Fact]
     public void An_unknown_provider_name_names_itself_in_the_message()
     {
-        var resolver = Resolver(c => { c.Provider = "bedrock"; c.Model = "x"; }, apiKey: "k");
+        var resolver = Resolver(c => { Conn(c).Kind = "bedrock"; c.ActiveModelId = "x"; }, apiKey: "k");
 
         Assert.Null(resolver.Resolve(out var problem));
         Assert.Contains("bedrock", problem);

--- a/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
@@ -147,6 +147,12 @@ namespace CST.Avalonia.Tests.ViewModels
             Assert.Contains("No secure storage", vm.KeyStatus);
         }
 
+        /// <summary>The connection the single-provider fields edit. #689 made the model plural; these fields
+        /// now write to the active connection rather than to scalar settings.</summary>
+        private static CST.Avalonia.Models.AiConnectionRecord Active(CST.Avalonia.Models.Settings settings) =>
+            settings.Ai.Chat.Connections.FirstOrDefault(
+                c => c.Id == settings.Ai.Chat.ActiveConnectionId) ?? settings.Ai.Chat.Connections.First();
+
         [Fact]
         public void Choosing_a_provider_records_the_string_the_resolver_parses()
         {
@@ -157,7 +163,7 @@ namespace CST.Avalonia.Tests.ViewModels
             // The stored value has to be one ChatProviderResolver.TryParseKind accepts, or the UI would
             // configure a provider the app then reports as unknown.
             Assert.True(CST.Avalonia.Services.Ai.ChatProviderResolver.TryParseKind(
-                settings.Ai.Chat.Provider, out var kind));
+                Active(settings).Kind, out var kind));
             Assert.Equal(CST.Avalonia.Services.Ai.ChatProviderKind.OpenAiCompatible, kind);
         }
 
@@ -188,7 +194,7 @@ namespace CST.Avalonia.Tests.ViewModels
             {
                 vm.SelectedProvider = choice;
                 Assert.True(CST.Avalonia.Services.Ai.ChatProviderResolver.TryParseKind(
-                    settings.Ai.Chat.Provider, out var kind), $"unparseable: {settings.Ai.Chat.Provider}");
+                    Active(settings).Kind, out var kind), $"unparseable: {Active(settings).Kind}");
                 Assert.Equal(choice.Kind, kind);
             }
         }
@@ -199,12 +205,12 @@ namespace CST.Avalonia.Tests.ViewModels
             var (vm, settings, _) = MakeWithAssistant();
 
             vm.Model = "  claude-sonnet-4-5  ";
-            Assert.Equal("claude-sonnet-4-5", settings.Ai.Chat.Model);
+            Assert.Equal("claude-sonnet-4-5", settings.Ai.Chat.ActiveModelId);
 
             vm.Model = "   ";
             // Null rather than whitespace: the resolver tests IsNullOrWhiteSpace, but a stored "   " would
             // read as configured to anything that only checks for null.
-            Assert.Null(settings.Ai.Chat.Model);
+            Assert.Null(settings.Ai.Chat.ActiveModelId);
         }
 
         [Fact]

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1302,6 +1302,10 @@ public partial class App : Application
         // entered" and "this build cannot store one".
         services.AddSingleton<Services.Ai.IAiCredentialStore, Services.Ai.Credentials.AiCredentialStore>();
 
+        // Endpoints the reader has configured (#689). Singleton because the UI binds to its ConnectionsChanged
+        // event and every consumer must see the same list.
+        services.AddSingleton<Services.Ai.IAiConnectionService, Services.Ai.AiConnectionService>();
+
         // The fidelity advisory (#584). Data only — Settings (#585) and the panel (#586) surface it.
         services.AddSingleton<ILemmaReportService, LemmaReportService>();
 

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -79,33 +79,76 @@ namespace CST.Avalonia.Models
         public bool Enabled { get; set; } = false;
 
         /// <summary>
-        /// <c>anthropic</c> or <c>openai-compatible</c>.
+        /// Every endpoint the reader has configured. (#689)
         ///
-        /// <para>The OpenAI-compatible shape is the default because it is what most readers will actually
-        /// reach for: it serves OpenRouter, DeepSeek, Together, Google's endpoint, and every local runner,
-        /// whereas Anthropic requires API credits bought separately from any Claude subscription — a Max
-        /// subscription does not grant API access, so even a paying Anthropic customer cannot use that path
-        /// without a second purchase.</para>
+        /// <para>Replaces the single scalar <c>Provider</c>/<c>BaseUrl</c>/<c>Model</c> this shipped with.
+        /// Those were deleted outright rather than deprecated: <c>ChatSettings</c> postdates the beta 5 tag
+        /// (<c>git grep -l ChatSettings v5.0.0-beta.5</c> returns nothing), so there is no persisted state in
+        /// the wild to migrate and no reader to break.</para>
         ///
-        /// <para>This is only which entry the Settings dropdown opens on; nothing is configured until the
-        /// reader sets a model, and an endpoint is required for this shape.</para>
+        /// <para>Plural because switching endpoints is the point — comparing two models on the same passage
+        /// is the task the assistant exists for, and it was impossible while one base URL and one credential
+        /// slot had to be overwritten each time.</para>
         /// </summary>
-        public string Provider { get; set; } = "openai-compatible";
+        public List<AiConnectionRecord> Connections { get; set; } = new();
 
-        /// <summary>
-        /// Endpoint base URL. Optional for Anthropic (it has a real default); <b>required</b> for
-        /// OpenAI-compatible, where the base URL is what selects the provider.
-        /// </summary>
-        public string? BaseUrl { get; set; }
+        /// <summary>The connection a request goes to, by <see cref="AiConnectionRecord.Id"/>. Null until one
+        /// is configured.</summary>
+        public string? ActiveConnectionId { get; set; }
 
-        /// <summary>Model id, verbatim. Never validated against a list — see <c>ChatProviderResolution</c>.</summary>
-        public string? Model { get; set; }
+        /// <summary>The model within that connection. Null until one is chosen.</summary>
+        public string? ActiveModelId { get; set; }
 
         /// <summary>
         /// Language the ANSWER is written in — a separate axis from the script quoted Pāli is rendered in
         /// (AI_SURFACE_B.md §9). Not optional in the bundle: "translate" has to mean translate into something.
         /// </summary>
         public string AnswerLanguage { get; set; } = "English";
+    }
+
+    /// <summary>
+    /// One configured endpoint, as persisted. (#689)
+    ///
+    /// <para>Deliberately a mutable class with plain collections rather than the
+    /// <c>CST.Avalonia.Models.Ai.AiConnection</c> record: this is what
+    /// <c>System.Text.Json</c> round-trips into <c>settings.json</c>, and it carries only what is actually
+    /// stored. The runtime record adds what is <i>derived</i> — where the credential came from, and whether
+    /// the endpoint has been reached — neither of which belongs in a settings file.</para>
+    /// </summary>
+    public class AiConnectionRecord
+    {
+        /// <summary>Stable slug, immutable once created, and the account the credential is filed under.</summary>
+        public string Id { get; set; } = "";
+
+        public string DisplayName { get; set; } = "";
+
+        /// <summary><c>anthropic</c> or <c>openai-compatible</c>. A string rather than the enum so a rename
+        /// on our side cannot silently invalidate a reader's settings file.</summary>
+        public string Kind { get; set; } = "openai-compatible";
+
+        /// <summary>May contain <c>{key}</c> placeholders filled from <see cref="Inputs"/> — Azure and
+        /// Cloudflare have a URL shape rather than a URL.</summary>
+        public string BaseUrl { get; set; } = "";
+
+        public List<AiModelRecord> Models { get; set; } = new();
+
+        /// <summary>Extra request headers. Never the credential, which lives in the OS credential store.</summary>
+        public Dictionary<string, string> Headers { get; set; } = new();
+
+        /// <summary>Answers to the preset's prompts — resource name, account id, region — substituted into
+        /// <see cref="BaseUrl"/> and <see cref="Headers"/>.</summary>
+        public Dictionary<string, string> Inputs { get; set; } = new();
+    }
+
+    /// <summary>One model a connection offers, as persisted.</summary>
+    public class AiModelRecord
+    {
+        public string Id { get; set; } = "";
+        public string DisplayName { get; set; } = "";
+
+        /// <summary>Whether it appears in the per-turn picker. Defaults true: all-on is neutral, whereas a
+        /// pre-selected subset would be a quality verdict (#670/#681).</summary>
+        public bool Enabled { get; set; } = true;
     }
 
     /// <summary>Permissions for the loopback API server that exposes the corpus tools to agents (surface C).</summary>

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using CST.Avalonia.Models;
+using CST.Avalonia.Models.Ai;
+
+namespace CST.Avalonia.Services.Ai
+{
+    /// <summary>The outcome of an operation that can fail for a reason worth showing the reader.</summary>
+    public sealed record AiConnectionResult(bool Ok, string? Problem = null, AiConnection? Connection = null)
+    {
+        public static AiConnectionResult Success(AiConnection c) => new(true, null, c);
+        public static AiConnectionResult Fail(string problem) => new(false, problem);
+    }
+
+    /// <summary>
+    /// Everything the UI needs to manage endpoints, without touching <c>settings.json</c> or the credential
+    /// store itself. (#689; consumed by #691, #692, #693)
+    /// </summary>
+    public interface IAiConnectionService
+    {
+        /// <summary>What is configured now, in the order the reader added it.</summary>
+        IReadOnlyList<AiConnection> Connections { get; }
+
+        /// <summary>Named endpoints a reader can add. Facts only — no model lists, no rankings.</summary>
+        IReadOnlyList<AiProviderPreset> Presets { get; }
+
+        /// <summary>Presets with no connection yet, i.e. what an "add a provider" list should show. A preset
+        /// drops out once added, so the catalogue always reads as "what you could add next".</summary>
+        IReadOnlyList<AiProviderPreset> AvailablePresets { get; }
+
+        /// <summary>The connection a request goes to, or null when nothing is configured.</summary>
+        AiConnection? Active { get; }
+
+        /// <summary>The model within <see cref="Active"/>, or null.</summary>
+        string? ActiveModelId { get; }
+
+        /// <summary>Raised when the list, or any connection's state, changes. Rebind on this.</summary>
+        event EventHandler? ConnectionsChanged;
+
+        AiConnectionResult Add(string id, AiConnectionDraft draft);
+
+        /// <summary>Creates a connection from a preset, with its base URL, kind and headers pre-filled.</summary>
+        /// <param name="inputs">Answers to the preset's <see cref="AiProviderPreset.Prompts"/> — resource
+        /// name, account id and so on. Pass an empty dictionary when the preset asks for nothing.</param>
+        AiConnectionResult AddFromPreset(string presetId, IReadOnlyDictionary<string, string> inputs);
+
+        /// <summary>Edits everything except the id, which is immutable because the credential is filed under it.</summary>
+        AiConnectionResult Update(string id, AiConnectionDraft draft);
+
+        /// <summary>Removes the connection and its models. Does not touch the credential — that is a separate
+        /// action, because for a custom endpoint the hand-entered model list is real user work and destroying
+        /// it on an action meant only to stop billing would be data loss.</summary>
+        AiConnectionResult Remove(string id);
+
+        /// <summary>Chooses what the next request uses. A null model clears the choice.</summary>
+        AiConnectionResult SetActive(string connectionId, string? modelId);
+
+        /// <summary>Turns one model on or off in the per-turn picker.</summary>
+        AiConnectionResult SetModelEnabled(string connectionId, string modelId, bool enabled);
+    }
+
+    /// <summary>
+    /// Settings-backed implementation. (#689)
+    ///
+    /// <para><b>No credential handling yet, by design.</b> <see cref="AiConnection.KeySource"/> reports
+    /// <c>None</c> and <see cref="AiConnection.State"/> reports <c>Configured</c> until the credential
+    /// re-keying and the reachability write-back land. Both are already on the record, so neither addition
+    /// changes a signature the UI binds to — which is what lets the three UI issues start now rather than
+    /// waiting on keychain plumbing.</para>
+    /// </summary>
+    public sealed class AiConnectionService : IAiConnectionService
+    {
+        private static readonly Regex SlugPattern = new("^[a-z0-9][a-z0-9_-]*$", RegexOptions.Compiled);
+
+        private readonly ISettingsService _settings;
+
+        public AiConnectionService(ISettingsService settings) => _settings = settings;
+
+        public event EventHandler? ConnectionsChanged;
+
+        private ChatSettings Chat => _settings.Settings.Ai.Chat;
+
+        public IReadOnlyList<AiConnection> Connections =>
+            Chat.Connections.Select(ToRuntime).ToList();
+
+        public IReadOnlyList<AiProviderPreset> Presets => AiProviderPresets.All;
+
+        public IReadOnlyList<AiProviderPreset> AvailablePresets =>
+            AiProviderPresets.All
+                .Where(p => !Chat.Connections.Any(c => IdMatches(c.Id, p.Id)))
+                .ToList();
+
+        public AiConnection? Active =>
+            Find(Chat.ActiveConnectionId) is { } record ? ToRuntime(record) : null;
+
+        public string? ActiveModelId => Chat.ActiveModelId;
+
+        public AiConnectionResult Add(string id, AiConnectionDraft draft)
+        {
+            var problem = ValidateId(id, existingAllowed: false);
+            if (problem is not null) return AiConnectionResult.Fail(problem);
+
+            var record = new AiConnectionRecord { Id = id };
+            Apply(record, draft);
+            Chat.Connections.Add(record);
+            Chat.ActiveConnectionId ??= record.Id;
+
+            return Saved(record);
+        }
+
+        public AiConnectionResult AddFromPreset(string presetId, IReadOnlyDictionary<string, string> inputs)
+        {
+            var preset = AiProviderPresets.ById(presetId);
+            if (preset is null) return AiConnectionResult.Fail($"'{presetId}' is not a known provider.");
+
+            if (Find(preset.Id) is not null)
+                return AiConnectionResult.Fail($"{preset.DisplayName} is already configured.");
+
+            // A preset's prompts are required inputs: without them the base URL keeps its {placeholders} and
+            // the connection can never send anything. Refuse here rather than create something unusable.
+            foreach (var key in AiTemplate.PlaceholdersIn(preset.BaseUrl))
+                if (!inputs.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+                    return AiConnectionResult.Fail(
+                        $"{preset.DisplayName} needs {PromptLabel(preset, key)} before it can be added.");
+
+            var record = new AiConnectionRecord
+            {
+                Id = preset.Id,
+                DisplayName = preset.DisplayName,
+                Kind = preset.Kind == ChatProviderKind.Anthropic ? "anthropic" : "openai-compatible",
+                BaseUrl = preset.BaseUrl,
+                Headers = new Dictionary<string, string>(preset.Headers ?? new Dictionary<string, string>()),
+                Inputs = new Dictionary<string, string>(inputs),
+            };
+            Chat.Connections.Add(record);
+            Chat.ActiveConnectionId ??= record.Id;
+
+            return Saved(record);
+        }
+
+        public AiConnectionResult Update(string id, AiConnectionDraft draft)
+        {
+            if (Find(id) is not { } record) return AiConnectionResult.Fail($"No connection called '{id}'.");
+
+            Apply(record, draft);
+            return Saved(record);
+        }
+
+        public AiConnectionResult Remove(string id)
+        {
+            if (Find(id) is not { } record) return AiConnectionResult.Fail($"No connection called '{id}'.");
+
+            Chat.Connections.Remove(record);
+
+            // Do not leave the active pointer dangling at something that no longer exists - a stale id reads
+            // as "configured" to anything that only checks for null.
+            if (IdMatches(Chat.ActiveConnectionId, id))
+            {
+                Chat.ActiveConnectionId = Chat.Connections.FirstOrDefault()?.Id;
+                Chat.ActiveModelId = null;
+            }
+
+            _settings.RequestSave();
+            ConnectionsChanged?.Invoke(this, EventArgs.Empty);
+            return new AiConnectionResult(true);
+        }
+
+        public AiConnectionResult SetActive(string connectionId, string? modelId)
+        {
+            if (Find(connectionId) is not { } record)
+                return AiConnectionResult.Fail($"No connection called '{connectionId}'.");
+
+            if (modelId is not null &&
+                !record.Models.Any(m => string.Equals(m.Id, modelId, StringComparison.Ordinal)))
+                return AiConnectionResult.Fail($"'{modelId}' is not a model on {record.DisplayName}.");
+
+            Chat.ActiveConnectionId = record.Id;
+            Chat.ActiveModelId = modelId;
+            return Saved(record);
+        }
+
+        public AiConnectionResult SetModelEnabled(string connectionId, string modelId, bool enabled)
+        {
+            if (Find(connectionId) is not { } record)
+                return AiConnectionResult.Fail($"No connection called '{connectionId}'.");
+
+            var model = record.Models.FirstOrDefault(m => string.Equals(m.Id, modelId, StringComparison.Ordinal));
+            if (model is null) return AiConnectionResult.Fail($"'{modelId}' is not a model on {record.DisplayName}.");
+
+            model.Enabled = enabled;
+            return Saved(record);
+        }
+
+        // ---- internals -------------------------------------------------------------------------------
+
+        private AiConnectionRecord? Find(string? id) =>
+            id is null ? null : Chat.Connections.FirstOrDefault(c => IdMatches(c.Id, id));
+
+        private static bool IdMatches(string? a, string? b) =>
+            string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+
+        private AiConnectionResult Saved(AiConnectionRecord record)
+        {
+            _settings.RequestSave();
+            ConnectionsChanged?.Invoke(this, EventArgs.Empty);
+            return AiConnectionResult.Success(ToRuntime(record));
+        }
+
+        private static void Apply(AiConnectionRecord record, AiConnectionDraft draft)
+        {
+            record.DisplayName = draft.DisplayName;
+            record.Kind = draft.Kind == ChatProviderKind.Anthropic ? "anthropic" : "openai-compatible";
+            record.BaseUrl = draft.BaseUrl;
+            record.Models = draft.Models
+                .Select(m => new AiModelRecord { Id = m.Id, DisplayName = m.DisplayName, Enabled = m.Enabled })
+                .ToList();
+            record.Headers = new Dictionary<string, string>(draft.Headers);
+            record.Inputs = new Dictionary<string, string>(draft.Inputs);
+        }
+
+        private static AiConnection ToRuntime(AiConnectionRecord r) => new(
+            r.Id,
+            r.DisplayName,
+            ChatProviderResolver.TryParseKind(r.Kind, out var kind) ? kind : ChatProviderKind.OpenAiCompatible,
+            r.BaseUrl,
+            r.Models.Select(m => new AiModelEntry(m.Id, m.DisplayName, m.Enabled)).ToList(),
+            new Dictionary<string, string>(r.Headers),
+            new Dictionary<string, string>(r.Inputs));
+
+        /// <summary>
+        /// Ids are the reserved namespace a custom connection may not take, and they become the credential's
+        /// account name — so a collision would mean one connection quietly inheriting another's key.
+        /// </summary>
+        private string? ValidateId(string id, bool existingAllowed)
+        {
+            if (string.IsNullOrWhiteSpace(id)) return "A connection needs an id.";
+            if (!SlugPattern.IsMatch(id))
+                return "An id may use only lowercase letters, numbers, hyphens and underscores.";
+            if (AiProviderPresets.IsReservedId(id))
+                return $"'{id}' is the id of a built-in provider. Add it from the provider list instead.";
+            if (!existingAllowed && Find(id) is not null)
+                return $"There is already a connection called '{id}'.";
+            return null;
+        }
+
+        private static string PromptLabel(AiProviderPreset preset, string key) =>
+            preset.Prompts?.FirstOrDefault(p => p.Key == key)?.Message ?? key;
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using CST.Avalonia.Models;
@@ -117,6 +118,13 @@ public sealed class ChatProviderResolver : IChatProviderResolver
     {
         var chat = _settings.Settings.Ai.Chat;
 
+        // The active connection replaces the scalar provider/base-URL/model this used to read (#689). Null
+        // when nothing is configured yet, which is a different problem from a misconfigured one and gets its
+        // own message below.
+        var connection = chat.Connections.FirstOrDefault(
+            c => string.Equals(c.Id, chat.ActiveConnectionId, StringComparison.Ordinal))
+            ?? chat.Connections.FirstOrDefault();
+
         // Two switches, two messages. One message for both sent a reader whose master switch was already ON
         // to look at a switch that was already on, with nothing to change — the exact failure this class is
         // written to avoid everywhere else, committed in its own first sentence. (#667)
@@ -132,15 +140,32 @@ public sealed class ChatProviderResolver : IChatProviderResolver
             return null;
         }
 
-        if (string.IsNullOrWhiteSpace(chat.Model))
+        if (connection is null)
+        {
+            problem = "No provider is configured. Add one in Settings \u2192 AI.";
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(chat.ActiveModelId))
         {
             problem = "No model is configured. Choose one in Settings.";
             return null;
         }
 
-        if (!TryParseKind(chat.Provider, out var kind))
+        if (!TryParseKind(connection.Kind, out var kind))
         {
-            problem = $"'{chat.Provider}' is not a provider this build knows how to talk to.";
+            problem = $"'{connection.Kind}' is not a provider this build knows how to talk to.";
+            return null;
+        }
+
+        // A connection whose URL still contains an unfilled {placeholder} - Azure without its resource name -
+        // must be refused HERE. Sent anyway it fails as a DNS error naming nothing, which tells the reader
+        // neither what is wrong nor where to fix it. (#689)
+        var baseUrl = CST.Avalonia.Models.Ai.AiTemplate.Expand(connection.BaseUrl, connection.Inputs);
+        if (CST.Avalonia.Models.Ai.AiTemplate.HasUnresolvedPlaceholders(baseUrl))
+        {
+            var missing = string.Join(", ", CST.Avalonia.Models.Ai.AiTemplate.PlaceholdersIn(baseUrl));
+            problem = $"This provider still needs: {missing}. Fill it in under Settings \u2192 AI.";
             return null;
         }
 
@@ -161,11 +186,11 @@ public sealed class ChatProviderResolver : IChatProviderResolver
                 return new ChatProviderResolution(
                     new AnthropicMessagesProvider(
                         _http,
-                        new AnthropicOptions(apiKey, NullIfBlank(chat.BaseUrl)),
+                        new AnthropicOptions(apiKey, NullIfBlank(baseUrl)),
                         _loggerFactory.CreateLogger<AnthropicMessagesProvider>()),
-                    chat.Model!.Trim());
+                    chat.ActiveModelId!.Trim());
 
-            case ChatProviderKind.OpenAiCompatible when string.IsNullOrWhiteSpace(chat.BaseUrl):
+            case ChatProviderKind.OpenAiCompatible when string.IsNullOrWhiteSpace(baseUrl):
                 // No default is possible here — the base URL IS the provider. This is the field that makes one
                 // adapter serve DeepSeek, OpenRouter, Ollama and LM Studio.
                 problem = "No endpoint address is configured. Enter the provider's base URL in Settings.";
@@ -177,12 +202,12 @@ public sealed class ChatProviderResolver : IChatProviderResolver
                 return new ChatProviderResolution(
                     new OpenAiCompatibleProvider(
                         _http,
-                        new OpenAiCompatibleOptions(chat.BaseUrl!.Trim(), NullIfBlank(apiKey)),
+                        new OpenAiCompatibleOptions(baseUrl.Trim(), NullIfBlank(apiKey)),
                         _loggerFactory.CreateLogger<OpenAiCompatibleProvider>()),
-                    chat.Model!.Trim());
+                    chat.ActiveModelId!.Trim());
 
             default:
-                problem = $"'{chat.Provider}' is not a provider this build knows how to talk to.";
+                problem = $"'{connection.Kind}' is not a provider this build knows how to talk to.";
                 return null;
         }
     }

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1308,11 +1308,14 @@ public class AiSettingsViewModel : ViewModelBase
 
             var chat = ai.Chat;
             _chatEnabled = chat.Enabled;
+            // The existing single-provider fields now edit the ACTIVE connection (#689). Kept working, and
+            // deliberately not deleted, so the app stays configurable until the connections UI (#691) lands.
+            var active = ActiveConnection();
             _providerChoice = Providers.FirstOrDefault(
-                c => Services.Ai.ChatProviderResolver.TryParseKind(chat.Provider, out var k)
+                c => Services.Ai.ChatProviderResolver.TryParseKind(active.Kind, out var k)
                      && k == c.Kind) ?? Providers[0];
-            _baseUrl = chat.BaseUrl ?? "";
-            _model = chat.Model ?? "";
+            _baseUrl = active.BaseUrl;
+            _model = _settingsService.Settings.Ai.Chat.ActiveModelId ?? "";
             _answerLanguage = string.IsNullOrWhiteSpace(chat.AnswerLanguage) ? "English" : chat.AnswerLanguage;
 
             SaveApiKeyCommand = ReactiveCommand.Create(SaveApiKey);
@@ -1497,7 +1500,7 @@ public class AiSettingsViewModel : ViewModelBase
             set
             {
                 this.RaiseAndSetIfChanged(ref _providerChoice, value);
-                _settingsService.Settings.Ai.Chat.Provider = value?.Stored ?? "anthropic";
+                ActiveConnection().Kind = value?.Stored ?? "anthropic";
                 _settingsService.RequestSave();
                 this.RaisePropertyChanged(nameof(IsOpenAiCompatible));
                 this.RaisePropertyChanged(nameof(BaseUrlDescription));
@@ -1505,6 +1508,56 @@ public class AiSettingsViewModel : ViewModelBase
                 RefreshKeyStatus();
                 RefreshReadiness();
             }
+        }
+
+        /// <summary>
+        /// The connection the single-provider fields edit, creating it on first use. (#689)
+        ///
+        /// <para>Surface B shipped with one provider, one base URL and one model; the model is now plural.
+        /// Rather than delete the working UI before its replacement (#691) exists, these fields edit the
+        /// <i>active</i> connection — so the app remains configurable, and whatever a reader sets here is a
+        /// real connection record that the new UI will show rather than state that has to be migrated.</para>
+        /// </summary>
+        private CST.Avalonia.Models.AiConnectionRecord ActiveConnection()
+        {
+            var chat = _settingsService.Settings.Ai.Chat;
+
+            var existing = chat.Connections.FirstOrDefault(
+                c => string.Equals(c.Id, chat.ActiveConnectionId, System.StringComparison.Ordinal));
+            if (existing is not null) return existing;
+
+            existing = chat.Connections.FirstOrDefault();
+            if (existing is not null)
+            {
+                chat.ActiveConnectionId = existing.Id;
+                return existing;
+            }
+
+            var created = new CST.Avalonia.Models.AiConnectionRecord
+            {
+                Id = "default",
+                DisplayName = "My provider",
+                Kind = "openai-compatible",
+                BaseUrl = "",
+            };
+            chat.Connections.Add(created);
+            chat.ActiveConnectionId = created.Id;
+            return created;
+        }
+
+        /// <summary>Sets the active model, keeping the connection's own list in step so the model a reader
+        /// typed here appears in the per-turn picker (#693) rather than only in this box.</summary>
+        private void SetActiveModel(string? value)
+        {
+            var chat = _settingsService.Settings.Ai.Chat;
+            var id = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+            chat.ActiveModelId = id;
+
+            if (id is null) return;
+
+            var connection = ActiveConnection();
+            if (!connection.Models.Any(m => string.Equals(m.Id, id, System.StringComparison.Ordinal)))
+                connection.Models.Add(new CST.Avalonia.Models.AiModelRecord { Id = id, DisplayName = id });
         }
 
         /// <summary>Whether the endpoint field is the load-bearing one — it is what selects the provider.</summary>
@@ -1522,7 +1575,7 @@ public class AiSettingsViewModel : ViewModelBase
             set
             {
                 this.RaiseAndSetIfChanged(ref _baseUrl, value);
-                _settingsService.Settings.Ai.Chat.BaseUrl = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+                ActiveConnection().BaseUrl = value?.Trim() ?? "";
                 _settingsService.RequestSave();
                 RefreshReadiness();
             }
@@ -1539,7 +1592,7 @@ public class AiSettingsViewModel : ViewModelBase
             set
             {
                 this.RaiseAndSetIfChanged(ref _model, value);
-                _settingsService.Settings.Ai.Chat.Model = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+                SetActiveModel(value);
                 _settingsService.RequestSave();
                 RefreshReadiness();
             }


### PR DESCRIPTION
Stacked on #698 — review that first; this PR's diff is against it.

The half of #689 that unblocks the UI work on kestrel (#691, #692, #693) without waiting on credential plumbing.

## Settings

`ChatSettings` loses `Provider`/`BaseUrl`/`Model` and gains `Connections[]` + `ActiveConnectionId` + `ActiveModelId`. **Deleted outright rather than deprecated** — `ChatSettings` postdates the beta 5 tag, so there is no persisted state in the wild and no reader to break.

`AiConnectionRecord` is a separate *persisted* class from the `AiConnection` record in #698. The persisted one carries only what is stored; the runtime one adds what is *derived* (credential source, reachability), and neither belongs in a settings file.

## IAiConnectionService

What #691/#692/#693 bind to: connections, presets, available presets, active selection, add/update/remove, per-model enablement, and a `ConnectionsChanged` event.

**Deliberately no credential handling yet.** `KeySource` reports `None` and `State` reports `Configured` until the re-keying and reachability write-back land — both fields are already on the record, so neither addition changes a signature the UI touches. That is what makes the two halves parallel rather than sequential.

## Behaviour worth reviewing

- **A templated preset cannot be added without its inputs.** Azure without a resource name would keep its `{placeholder}` and fail later as a DNS error naming nothing; refused up front, naming the missing field.
- **Preset ids are reserved** against custom connections. The id becomes the credential's account name, so a collision would be one connection quietly inheriting another's key rather than a visible error.
- **Removing the active connection moves the pointer** rather than leaving it dangling — a stale id reads as "configured" to anything that only checks for null.
- **Models arrive enabled.** All-on is neutral; a pre-selected subset would be a quality verdict, i.e. #670/#681 wearing a toggle.

## The resolver

Now reads the active connection, and refuses one whose URL still has unfilled placeholders. A message naming the missing field beats a DNS failure naming nothing.

## The existing Settings UI still works

The single-provider fields were **not** deleted — they now edit the *active* connection. So the app stays configurable until #691 replaces them, and whatever a reader sets is a real connection record the new UI will show rather than state needing migration.

## Testing

20 new tests. **1858 passing**, 0 warnings in both projects.

## After this merges

All three UI issues are live, and the seam in #689 is real code rather than a proposal. Remaining backend: keychain re-keying by `Id`, `CST_AI_*` overrides, reachability write-back, and the three auth shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)