### PR TITLE
Windows: give the local-API token file an explicit owner-only ACL (#505)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LocalApi/LocalApiInfoPermissionsTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApi/LocalApiInfoPermissionsTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using CST.Avalonia.Services.LocalApi;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.LocalApi;
+
+/// <summary>
+/// Who can read the handshake file. (#303, #505)
+///
+/// <para>It carries the per-session bearer token for the local API, so "only this user" is the whole
+/// requirement. macOS and Linux state that as mode <c>0600</c>; Windows had nothing explicit and relied on
+/// <c>%APPDATA%</c> being ACL'd per user - true by default, but inheritance is precisely what a redirected
+/// folder or an over-broad grant higher up the tree can undo, silently.</para>
+/// </summary>
+public class LocalApiInfoPermissionsTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "cst-handshake-perms", Guid.NewGuid().ToString("N"));
+
+    public LocalApiInfoPermissionsTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private void Write() => new LocalApiInfo(51234, "a-session-secret", Environment.ProcessId, 7).Write(_dir);
+
+    [WindowsFact]
+    [SupportedOSPlatform("windows")]
+    public void The_token_file_is_detached_from_inherited_permissions()
+    {
+        // The load-bearing half of the fix. Without protection the file keeps whatever the directory hands
+        // down, so a permissive grant higher up the tree silently applies to a session secret.
+        Write();
+
+        var security = new FileInfo(LocalApiInfo.PathIn(_dir)).GetAccessControl();
+
+        Assert.True(security.AreAccessRulesProtected,
+            "the handshake still inherits permissions from its directory");
+    }
+
+    [WindowsFact]
+    [SupportedOSPlatform("windows")]
+    public void Only_the_current_user_is_granted_access()
+    {
+        // Mirrors 0600. Anything else in the list means somebody besides the owner can read the token.
+        Write();
+
+        var rules = new FileInfo(LocalApiInfo.PathIn(_dir))
+            .GetAccessControl()
+            .GetAccessRules(includeExplicit: true, includeInherited: true, typeof(SecurityIdentifier))
+            .Cast<FileSystemAccessRule>()
+            .ToList();
+
+        var me = WindowsIdentity.GetCurrent().User!;
+
+        Assert.All(rules, rule => Assert.Equal(me, rule.IdentityReference));
+        Assert.Contains(rules, rule =>
+            rule.AccessControlType == AccessControlType.Allow &&
+            rule.FileSystemRights.HasFlag(FileSystemRights.Read));
+    }
+
+    [WindowsFact]
+    [SupportedOSPlatform("windows")]
+    public void The_owner_can_still_read_what_it_wrote()
+    {
+        // The obvious way to get this wrong is to protect the ACL and then grant nobody, locking the app out
+        // of its own handshake. Reading it back is the check that matters.
+        Write();
+
+        var read = LocalApiInfo.Read(_dir);
+
+        Assert.NotNull(read);
+        Assert.Equal("a-session-secret", read!.Token);
+    }
+
+    [WindowsFact]
+    [SupportedOSPlatform("windows")]
+    public void Rewriting_keeps_the_file_protected()
+    {
+        // The swap goes through File.Replace on Windows, which preserves the DESTINATION's ACL rather than the
+        // temp's. That happens to be what we want here - but it is a property of ReplaceFile rather than
+        // something this code states, so it is worth pinning: a second write must not quietly restore
+        // inheritance.
+        Write();
+        Write();
+
+        var security = new FileInfo(LocalApiInfo.PathIn(_dir)).GetAccessControl();
+
+        Assert.True(security.AreAccessRulesProtected, "a rewrite reinstated inherited permissions");
+        Assert.Equal("a-session-secret", LocalApiInfo.Read(_dir)!.Token);
+    }
+
+    [Fact]
+    public void Unix_permissions_are_unchanged_by_the_Windows_work()
+    {
+        // The Unix path is the one that was already correct; this guards it against collateral damage.
+        if (OperatingSystem.IsWindows()) return;
+
+        Write();
+
+        Assert.Equal(
+            UnixFileMode.UserRead | UnixFileMode.UserWrite,
+            File.GetUnixFileMode(LocalApiInfo.PathIn(_dir)));
+    }
+}

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiInfo.cs
@@ -3,6 +3,9 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Threading;
 using Serilog;
 
@@ -156,12 +159,29 @@ namespace CST.Avalonia.Services.LocalApi
             }
         }
 
+        /// <summary>
+        /// Restrict the handshake to its owner. macOS/Linux get mode <c>0600</c>; Windows gets an explicit
+        /// owner-only ACL with inheritance switched off. (#303, #505)
+        ///
+        /// <para>Windows was previously a no-op here, which was not a hole so much as an unstated assumption:
+        /// <c>%APPDATA%</c> is the Roaming profile and is ACL'd per user by default, so another standard user
+        /// cannot read it. But that is inheritance doing the work, and inheritance is exactly the thing a
+        /// misconfigured profile, a redirected folder, or an over-broad grant higher up the tree can undo -
+        /// silently, with nothing here to notice. The Unix side does not lean on the directory, and neither
+        /// should this one.</para>
+        ///
+        /// <para><c>SetAccessRuleProtection(true, false)</c> is the important call: it detaches the file from
+        /// inherited permissions and drops the inherited entries rather than copying them down, so what remains
+        /// is the single rule added here. Without <c>preserveInheritance: false</c> the inherited grants would
+        /// be flattened onto the file and preserved, which looks like hardening while changing nothing.</para>
+        /// </summary>
         private static void TrySetOwnerOnly(string path)
         {
-            // Owner read/write only, where the OS models Unix permissions (macOS/Linux). No-op on Windows.
             try
             {
-                if (!OperatingSystem.IsWindows())
+                if (OperatingSystem.IsWindows())
+                    SetWindowsOwnerOnly(path);
+                else
                     File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
             }
             catch (Exception ex)
@@ -169,6 +189,24 @@ namespace CST.Avalonia.Services.LocalApi
                 // Don't swallow: a token file left group/world-readable is a real exposure worth a log line. (#303)
                 Log.Warning(ex, "Could not restrict permissions on {Path}; the local-API token may be readable by other local users.", path);
             }
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static void SetWindowsOwnerOnly(string path)
+        {
+            var user = WindowsIdentity.GetCurrent().User;
+            if (user is null)
+            {
+                // No SID to grant to. Better to leave the inherited ACL - which is per-user in the ordinary
+                // case - than to write a protected ACL granting nobody and lock the app out of its own file.
+                Log.Warning("Could not determine the current user's SID; leaving inherited permissions on {Path}.", path);
+                return;
+            }
+
+            var security = new FileSecurity();
+            security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+            security.AddAccessRule(new FileSystemAccessRule(user, FileSystemRights.FullControl, AccessControlType.Allow));
+            new FileInfo(path).SetAccessControl(security);
         }
     }
 }


### PR DESCRIPTION
Closes #505.

`local-api.json` carries the per-session bearer token for the loopback API. On macOS and Linux it is created `0600` and re-hardened after the swap. On Windows both calls were no-ops, so the file was written with whatever NTFS handed down.

## Why bother, given `%APPDATA%` is already per-user

This was never a gaping hole — and the issue says so. But the protection came entirely from **inheritance**: `%APPDATA%` is the Roaming profile and is ACL'd per user by default. Inheritance is exactly what a redirected folder, a misconfigured profile, or an over-broad grant higher up the tree can undo — silently, with nothing here to notice. The Unix side does not lean on its directory, and neither should this one.

## The call that actually does the work

```csharp
security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
```

It detaches the file from inherited permissions **and drops the inherited entries** rather than copying them down, so what remains is the single rule granting the current user. Passing `preserveInheritance: true` would flatten the inherited grants onto the file and keep them — which looks like hardening while changing nothing.

If the current user's SID cannot be determined, the inherited ACL is left alone rather than replaced: a protected ACL granting nobody would lock the app out of its own handshake, which is worse than the per-user default it replaced.

## No new dependency

The ACL APIs are reachable from plain `net10.0` — no package reference, no TFM change. They are Windows-only, so the helper carries `[SupportedOSPlatform("windows")]`, the same treatment the DPAPI work used, and the build stays at **0 warnings**.

## Verified with `icacls`, independently of the tests

| | ACL |
|---|---|
| A normal file in the same directory | `NT AUTHORITY\SYSTEM:(I)(F)`<br>`BUILTIN\Administrators:(I)(F)`<br>`MERLIN\frank:(I)(F)` |
| The handshake written by this code | **`MERLIN\frank:(F)`** |

No `(I)` markers, so nothing is inherited, and SYSTEM and Administrators are gone — the `0600` equivalent.

## Tests

5, covering: the file is detached from inheritance; only the current user appears in the ACL; **the owner can still read what it wrote** (the obvious way to get this wrong is to protect the ACL and then grant nobody); a rewrite keeps it protected — `File.Replace` preserves the *destination's* ACL, which is what we want here but is a property of `ReplaceFile` rather than something this code states, so it is worth pinning; and the Unix path is unchanged.

**1922 pass, 0 warnings.**
