### PR TITLE
Key credentials by connection, not by provider kind (#678)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -250,4 +250,77 @@ public class AiConnectionServiceTests
         Assert.Equal("Renamed", result.Connection.DisplayName);
         Assert.Equal("http://b/v1", result.Connection.BaseUrl);
     }
+
+    /// <summary>An in-memory credential store, keyed by connection id exactly as the real one now is.</summary>
+    private sealed class Keys : IAiCredentialStore
+    {
+        private readonly Dictionary<string, string> _byConnection = new();
+        public bool IsAvailable => true;
+        public string? Unavailable => null;
+        public string? GetApiKey(string connectionId) =>
+            _byConnection.TryGetValue(connectionId, out var k) ? k : null;
+        public bool SetApiKey(string connectionId, string apiKey) { _byConnection[connectionId] = apiKey; return true; }
+        public bool DeleteApiKey(string connectionId) { _byConnection.Remove(connectionId); return true; }
+    }
+
+    private static (AiConnectionService Service, Settings Settings, Keys Keys) MakeWithKeys()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var keys = new Keys();
+        return (new AiConnectionService(svc.Object, keys), settings, keys);
+    }
+
+    // ---- credentials, keyed per connection (#678) --------------------------------------------------------
+
+    /// <summary>
+    /// The defect #678 exists for, stated as a test. Two OpenAI-compatible endpoints previously shared one
+    /// credential slot, because the store was keyed by a two-member provider-kind enum — so storing the second
+    /// key silently replaced the first, and the reader got a 401 naming neither cause.
+    /// </summary>
+    [Fact]
+    public void Two_openai_compatible_endpoints_keep_separate_keys()
+    {
+        var (service, _, keys) = MakeWithKeys();
+        service.Add("openrouter-box", Draft("OpenRouter", "https://openrouter.ai/api/v1"));
+        service.Add("local-ollama", Draft("Ollama", "http://localhost:11434/v1"));
+
+        keys.SetApiKey("openrouter-box", "or-key");
+        keys.SetApiKey("local-ollama", "ollama-key");
+
+        Assert.Equal("or-key", keys.GetApiKey("openrouter-box"));
+        Assert.Equal("ollama-key", keys.GetApiKey("local-ollama"));
+    }
+
+    /// <summary>A connection reports where its credential came from, so the UI can name the source and — for
+    /// an environment-sourced one — offer no remove action rather than a button that would lie.</summary>
+    [Fact]
+    public void A_connection_reports_whether_a_key_is_stored_for_it()
+    {
+        var (service, _, keys) = MakeWithKeys();
+        service.Add("box", Draft());
+
+        Assert.Equal(CredentialSource.None, service.Connections.Single().KeySource);
+
+        keys.SetApiKey("box", "k");
+
+        Assert.Equal(CredentialSource.Keychain, service.Connections.Single().KeySource);
+    }
+
+    /// <summary>
+    /// Removing a connection takes its credential with it. An orphaned key is unreachable and uncleanable —
+    /// and worse, would be silently re-adopted by a later connection that happened to take the same id.
+    /// </summary>
+    [Fact]
+    public void Removing_a_connection_removes_its_key()
+    {
+        var (service, _, keys) = MakeWithKeys();
+        service.Add("box", Draft());
+        keys.SetApiKey("box", "k");
+
+        service.Remove("box");
+
+        Assert.Null(keys.GetApiKey("box"));
+    }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
@@ -49,9 +49,11 @@ public class AiCredentialStoreTests : IDisposable
 
     public void Dispose()
     {
+        // Connection ids now, not provider kinds (#678): keys are keyed per endpoint, so the cleanup list is
+        // whatever ids the tests in this class use rather than an enum's members.
         if (_store.IsAvailable)
-            foreach (var provider in Enum.GetValues<ChatProviderKind>())
-                _store.DeleteApiKey(provider);
+            foreach (var id in new[] { "anthropic", "openai-compatible", "openrouter-box", "local-ollama" })
+                _store.DeleteApiKey(id);
     }
 
     // ---- The acceptance test ------------------------------------------------------------------------------
@@ -64,9 +66,9 @@ public class AiCredentialStoreTests : IDisposable
         // is the easier one to introduce by accident.
         if (!_store.IsAvailable) return;
 
-        _store.SetApiKey(ChatProviderKind.Anthropic, Secret);
-        _store.GetApiKey(ChatProviderKind.Anthropic);
-        _store.DeleteApiKey(ChatProviderKind.Anthropic);
+        _store.SetApiKey("anthropic", Secret);
+        _store.GetApiKey("anthropic");
+        _store.DeleteApiKey("anthropic");
 
         Assert.NotEmpty(_log.Lines);   // the logger really was wired, so absence means absence
         foreach (var line in _log.Lines)
@@ -85,8 +87,8 @@ public class AiCredentialStoreTests : IDisposable
     {
         if (!_store.IsAvailable) return;
 
-        Assert.True(_store.SetApiKey(ChatProviderKind.Anthropic, Secret));
-        Assert.Equal(Secret, _store.GetApiKey(ChatProviderKind.Anthropic));
+        Assert.True(_store.SetApiKey("anthropic", Secret));
+        Assert.Equal(Secret, _store.GetApiKey("anthropic"));
     }
 
     [Fact]
@@ -96,10 +98,10 @@ public class AiCredentialStoreTests : IDisposable
         // a window with no key at all if the add failed.
         if (!_store.IsAvailable) return;
 
-        _store.SetApiKey(ChatProviderKind.Anthropic, Secret);
-        Assert.True(_store.SetApiKey(ChatProviderKind.Anthropic, "sk-ant-second-value"));
+        _store.SetApiKey("anthropic", Secret);
+        Assert.True(_store.SetApiKey("anthropic", "sk-ant-second-value"));
 
-        Assert.Equal("sk-ant-second-value", _store.GetApiKey(ChatProviderKind.Anthropic));
+        Assert.Equal("sk-ant-second-value", _store.GetApiKey("anthropic"));
     }
 
     [Fact]
@@ -108,11 +110,11 @@ public class AiCredentialStoreTests : IDisposable
         // The ordinary case for someone comparing a hosted model against a local one.
         if (!_store.IsAvailable) return;
 
-        _store.SetApiKey(ChatProviderKind.Anthropic, "sk-ant-aaa");
-        _store.SetApiKey(ChatProviderKind.OpenAiCompatible, "sk-oai-bbb");
+        _store.SetApiKey("anthropic", "sk-ant-aaa");
+        _store.SetApiKey("openai-compatible", "sk-oai-bbb");
 
-        Assert.Equal("sk-ant-aaa", _store.GetApiKey(ChatProviderKind.Anthropic));
-        Assert.Equal("sk-oai-bbb", _store.GetApiKey(ChatProviderKind.OpenAiCompatible));
+        Assert.Equal("sk-ant-aaa", _store.GetApiKey("anthropic"));
+        Assert.Equal("sk-oai-bbb", _store.GetApiKey("openai-compatible"));
     }
 
     [Fact]
@@ -120,7 +122,7 @@ public class AiCredentialStoreTests : IDisposable
     {
         if (!_store.IsAvailable) return;
 
-        Assert.Null(_store.GetApiKey(ChatProviderKind.Anthropic));
+        Assert.Null(_store.GetApiKey("anthropic"));
     }
 
     [Fact]
@@ -129,7 +131,7 @@ public class AiCredentialStoreTests : IDisposable
         // Idempotent: Settings should be able to offer "forget this key" without first checking.
         if (!_store.IsAvailable) return;
 
-        Assert.True(_store.DeleteApiKey(ChatProviderKind.Anthropic));
+        Assert.True(_store.DeleteApiKey("anthropic"));
     }
 
     [Fact]
@@ -137,10 +139,10 @@ public class AiCredentialStoreTests : IDisposable
     {
         if (!_store.IsAvailable) return;
 
-        _store.SetApiKey(ChatProviderKind.Anthropic, Secret);
-        Assert.True(_store.DeleteApiKey(ChatProviderKind.Anthropic));
+        _store.SetApiKey("anthropic", Secret);
+        Assert.True(_store.DeleteApiKey("anthropic"));
 
-        Assert.Null(_store.GetApiKey(ChatProviderKind.Anthropic));
+        Assert.Null(_store.GetApiKey("anthropic"));
     }
 
     [Fact]
@@ -150,9 +152,9 @@ public class AiCredentialStoreTests : IDisposable
         // a trailing newline, and storing that verbatim produces a 401 nobody can explain.
         if (!_store.IsAvailable) return;
 
-        _store.SetApiKey(ChatProviderKind.Anthropic, "  sk-ānt-ṃixed-42\n");
+        _store.SetApiKey("anthropic", "  sk-ānt-ṃixed-42\n");
 
-        Assert.Equal("sk-ānt-ṃixed-42", _store.GetApiKey(ChatProviderKind.Anthropic));
+        Assert.Equal("sk-ānt-ṃixed-42", _store.GetApiKey("anthropic"));
     }
 
     [Fact]
@@ -160,8 +162,8 @@ public class AiCredentialStoreTests : IDisposable
     {
         if (!_store.IsAvailable) return;
 
-        Assert.False(_store.SetApiKey(ChatProviderKind.Anthropic, "   "));
-        Assert.Null(_store.GetApiKey(ChatProviderKind.Anthropic));
+        Assert.False(_store.SetApiKey("anthropic", "   "));
+        Assert.Null(_store.GetApiKey("anthropic"));
     }
 
     // ---- Platform behaviour -------------------------------------------------------------------------------
@@ -198,8 +200,8 @@ public class AiCredentialStoreTests : IDisposable
     public void Each_provider_gets_its_own_account_name()
     {
         Assert.NotEqual(
-            AiCredentialStore.AccountFor(ChatProviderKind.Anthropic),
-            AiCredentialStore.AccountFor(ChatProviderKind.OpenAiCompatible));
+            AiCredentialStore.AccountFor("anthropic"),
+            AiCredentialStore.AccountFor("openai-compatible"));
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -30,9 +30,9 @@ public class ChatProviderResolverTests
 
         public bool IsAvailable => Unavailable is null;
         public string? Unavailable { get; }
-        public string? GetApiKey(ChatProviderKind provider) => _key;
-        public bool SetApiKey(ChatProviderKind provider, string apiKey) => throw new NotSupportedException();
-        public bool DeleteApiKey(ChatProviderKind provider) => throw new NotSupportedException();
+        public string? GetApiKey(string connectionId) => _key;
+        public bool SetApiKey(string connectionId, string apiKey) => throw new NotSupportedException();
+        public bool DeleteApiKey(string connectionId) => throw new NotSupportedException();
     }
 
     private static ChatProviderResolver Resolver(

--- a/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
@@ -43,25 +43,25 @@ namespace CST.Avalonia.Tests.ViewModels
         /// </summary>
         private sealed class FakeCredentialStore : CST.Avalonia.Services.Ai.IAiCredentialStore
         {
-            private readonly System.Collections.Generic.Dictionary<CST.Avalonia.Services.Ai.ChatProviderKind, string> _keys = new();
+            private readonly System.Collections.Generic.Dictionary<string, string> _keys = new();
 
             public bool Available { get; set; } = true;
             public bool IsAvailable => Available;
             public string? Unavailable => Available ? null : "No secure storage in this build.";
 
-            public string? GetApiKey(CST.Avalonia.Services.Ai.ChatProviderKind provider) =>
-                Available && _keys.TryGetValue(provider, out var k) ? k : null;
+            public string? GetApiKey(string connectionId) =>
+                Available && _keys.TryGetValue(connectionId, out var k) ? k : null;
 
-            public bool SetApiKey(CST.Avalonia.Services.Ai.ChatProviderKind provider, string apiKey)
+            public bool SetApiKey(string connectionId, string apiKey)
             {
                 if (!Available) return false;
-                _keys[provider] = apiKey;
+                _keys[connectionId] = apiKey;
                 return true;
             }
 
-            public bool DeleteApiKey(CST.Avalonia.Services.Ai.ChatProviderKind provider)
+            public bool DeleteApiKey(string connectionId)
             {
-                _keys.Remove(provider);
+                _keys.Remove(connectionId);
                 return true;
             }
         }
@@ -96,9 +96,9 @@ namespace CST.Avalonia.Tests.ViewModels
             var json = System.Text.Json.JsonSerializer.Serialize(settings);
             Assert.DoesNotContain("sk-ant-secret-value", json);
 
-            // Stored under whichever provider is selected -- which provider that is belongs to the default
-            // test, not to this one.
-            Assert.Equal("sk-ant-secret-value", keys.GetApiKey(vm.SelectedProvider.Kind));
+            // Stored under the ACTIVE CONNECTION's id (#678), not under a provider kind - which is the whole
+            // point: two OpenAI-compatible endpoints used to share one slot.
+            Assert.Equal("sk-ant-secret-value", keys.GetApiKey(Active(settings).Id));
         }
 
         [Fact]
@@ -115,22 +115,30 @@ namespace CST.Avalonia.Tests.ViewModels
         }
 
         [Fact]
-        public void Keys_are_kept_per_provider()
+        public void Keys_are_kept_per_connection_not_per_provider_kind()
         {
-            var (vm, _, keys) = MakeWithAssistant();
+            var (vm, settings, keys) = MakeWithAssistant();
 
-            vm.SelectedProvider = Choice(vm, CST.Avalonia.Services.Ai.ChatProviderKind.Anthropic);
-            vm.ApiKeyEntry = "claude-key";
+            // TWO OpenAI-compatible endpoints - the case that was broken. Both are `openai-compatible`, so
+            // under the old provider-kind keying the second silently overwrote the first and the reader got a
+            // 401 naming neither cause (#678).
+            var chat = settings.Ai.Chat;
+            chat.Connections.Clear();
+            chat.Connections.Add(new CST.Avalonia.Models.AiConnectionRecord
+            { Id = "openrouter-box", DisplayName = "OpenRouter", BaseUrl = "https://openrouter.ai/api/v1" });
+            chat.Connections.Add(new CST.Avalonia.Models.AiConnectionRecord
+            { Id = "local-ollama", DisplayName = "Ollama", BaseUrl = "http://localhost:11434/v1" });
+
+            chat.ActiveConnectionId = "openrouter-box";
+            vm.ApiKeyEntry = "openrouter-key";
             vm.SaveApiKeyCommand.Execute().Subscribe();
 
-            vm.SelectedProvider = Choice(vm, CST.Avalonia.Services.Ai.ChatProviderKind.OpenAiCompatible);
-            vm.ApiKeyEntry = "other-key";
+            chat.ActiveConnectionId = "local-ollama";
+            vm.ApiKeyEntry = "ollama-key";
             vm.SaveApiKeyCommand.Execute().Subscribe();
 
-            // The ordinary case for someone comparing a hosted model against a local one — storing the
-            // second must not silently replace the first.
-            Assert.Equal("claude-key", keys.GetApiKey(CST.Avalonia.Services.Ai.ChatProviderKind.Anthropic));
-            Assert.Equal("other-key", keys.GetApiKey(CST.Avalonia.Services.Ai.ChatProviderKind.OpenAiCompatible));
+            Assert.Equal("openrouter-key", keys.GetApiKey("openrouter-box"));
+            Assert.Equal("ollama-key", keys.GetApiKey("local-ollama"));
         }
 
         [Fact]

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -75,8 +75,15 @@ namespace CST.Avalonia.Services.Ai
         private static readonly Regex SlugPattern = new("^[a-z0-9][a-z0-9_-]*$", RegexOptions.Compiled);
 
         private readonly ISettingsService _settings;
+        private readonly IAiCredentialStore? _credentials;
 
-        public AiConnectionService(ISettingsService settings) => _settings = settings;
+        /// <param name="credentials">Optional: a platform with nowhere safe to put a key still runs, and an
+        /// endpoint needing no key still works. Resolved with <c>GetService</c> for that reason.</param>
+        public AiConnectionService(ISettingsService settings, IAiCredentialStore? credentials = null)
+        {
+            _settings = settings;
+            _credentials = credentials;
+        }
 
         public event EventHandler? ConnectionsChanged;
 
@@ -84,6 +91,19 @@ namespace CST.Avalonia.Services.Ai
 
         public IReadOnlyList<AiConnection> Connections =>
             Chat.Connections.Select(ToRuntime).ToList();
+
+        /// <summary>
+        /// Where this connection's credential came from. (#678, #689)
+        ///
+        /// <para>Only <c>Keychain</c> and <c>None</c> today. <c>Environment</c> arrives with the
+        /// <c>CST_AI_*</c> discovery work, and when it does the rule is that a found credential makes a
+        /// provider <i>available</i>, never <i>connected</i> — so it will be reported here without a
+        /// connection existing until the reader acts.</para>
+        /// </summary>
+        private CredentialSource SourceFor(string connectionId) =>
+            _credentials?.GetApiKey(connectionId) is not null
+                ? CredentialSource.Keychain
+                : CredentialSource.None;
 
         public IReadOnlyList<AiProviderPreset> Presets => AiProviderPresets.All;
 
@@ -154,6 +174,11 @@ namespace CST.Avalonia.Services.Ai
 
             Chat.Connections.Remove(record);
 
+            // The credential goes with the record. Removing a connection while leaving its key behind would
+            // leave an orphan in the keychain that nothing can ever reach or clean up - and that would be
+            // silently re-adopted if someone later created a connection with the same id.
+            _credentials?.DeleteApiKey(record.Id);
+
             // Do not leave the active pointer dangling at something that no longer exists - a stale id reads
             // as "configured" to anything that only checks for null.
             if (IdMatches(Chat.ActiveConnectionId, id))
@@ -220,14 +245,15 @@ namespace CST.Avalonia.Services.Ai
             record.Inputs = new Dictionary<string, string>(draft.Inputs);
         }
 
-        private static AiConnection ToRuntime(AiConnectionRecord r) => new(
+        private AiConnection ToRuntime(AiConnectionRecord r) => new(
             r.Id,
             r.DisplayName,
             ChatProviderResolver.TryParseKind(r.Kind, out var kind) ? kind : ChatProviderKind.OpenAiCompatible,
             r.BaseUrl,
             r.Models.Select(m => new AiModelEntry(m.Id, m.DisplayName, m.Enabled)).ToList(),
             new Dictionary<string, string>(r.Headers),
-            new Dictionary<string, string>(r.Inputs));
+            new Dictionary<string, string>(r.Inputs),
+            SourceFor(r.Id));
 
         /// <summary>
         /// Ids are the reserved namespace a custom connection may not take, and they become the credential's

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -32,14 +32,20 @@ public interface IAiCredentialStore
     /// <summary>Why not, phrased for the user to read. Null when storage is available.</summary>
     string? Unavailable { get; }
 
-    /// <summary>The stored key for a provider, or null when none is stored.</summary>
-    string? GetApiKey(ChatProviderKind provider);
+    /// <summary>
+    /// The stored key for a CONNECTION, or null when none is stored. (#678)
+    ///
+    /// <para>Keyed by connection id rather than by provider kind, which was a two-member enum — so every
+    /// OpenAI-compatible endpoint shared a single slot, and configuring a second one silently overwrote the
+    /// first.</para>
+    /// </summary>
+    string? GetApiKey(string connectionId);
 
-    /// <summary>Store or replace a provider's key. False when the platform cannot.</summary>
-    bool SetApiKey(ChatProviderKind provider, string apiKey);
+    /// <summary>Store or replace a connection's key. False when the platform cannot.</summary>
+    bool SetApiKey(string connectionId, string apiKey);
 
-    /// <summary>Forget a provider's key. Forgetting one never stored counts as success.</summary>
-    bool DeleteApiKey(ChatProviderKind provider);
+    /// <summary>Forget a connection's key. Forgetting one never stored counts as success.</summary>
+    bool DeleteApiKey(string connectionId);
 }
 
 /// <summary>
@@ -169,7 +175,7 @@ public sealed class ChatProviderResolver : IChatProviderResolver
             return null;
         }
 
-        var apiKey = _credentials?.GetApiKey(kind);
+        var apiKey = _credentials?.GetApiKey(connection.Id);
 
         switch (kind)
         {

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
@@ -78,44 +78,44 @@ public sealed class AiCredentialStore : IAiCredentialStore
         : "Secure key storage is not available on this platform. "
           + "An endpoint that needs no API key still works.";
 
-    public string? GetApiKey(ChatProviderKind provider)
+    public string? GetApiKey(string connectionId)
     {
         if (!IsAvailable) return null;
 
         var key = OperatingSystem.IsWindows()
-            ? WindowsDpapiStore.Find(_service, AccountFor(provider))
-            : MacOsKeychain.Find(_service, AccountFor(provider));
+            ? WindowsDpapiStore.Find(_service, AccountFor(connectionId))
+            : MacOsKeychain.Find(_service, AccountFor(connectionId));
 
         // The OUTCOME, never the value — and not its length either, which narrows a guess.
-        _logger.LogDebug("Credential lookup for {Provider}: {Result}",
-            provider, key is null ? "none stored" : "found");
+        _logger.LogDebug("Credential lookup for {Connection}: {Result}",
+            connectionId, key is null ? "none stored" : "found");
 
         return key;
     }
 
     /// <summary>Store or replace the key for a provider. Returns false when the platform cannot.</summary>
-    public bool SetApiKey(ChatProviderKind provider, string apiKey)
+    public bool SetApiKey(string connectionId, string apiKey)
     {
         if (!IsAvailable || string.IsNullOrWhiteSpace(apiKey)) return false;
 
         var saved = OperatingSystem.IsWindows()
-            ? WindowsDpapiStore.Save(_service, AccountFor(provider), apiKey.Trim())
-            : MacOsKeychain.Save(_service, AccountFor(provider), apiKey.Trim());
-        _logger.LogInformation("Stored an API key for {Provider}: {Result}",
-            provider, saved ? "ok" : "failed");
+            ? WindowsDpapiStore.Save(_service, AccountFor(connectionId), apiKey.Trim())
+            : MacOsKeychain.Save(_service, AccountFor(connectionId), apiKey.Trim());
+        _logger.LogInformation("Stored an API key for {Connection}: {Result}",
+            connectionId, saved ? "ok" : "failed");
         return saved;
     }
 
     /// <summary>Forget the key for a provider. Forgetting one that was never stored counts as success.</summary>
-    public bool DeleteApiKey(ChatProviderKind provider)
+    public bool DeleteApiKey(string connectionId)
     {
         if (!IsAvailable) return false;
 
         var deleted = OperatingSystem.IsWindows()
-            ? WindowsDpapiStore.Delete(_service, AccountFor(provider))
-            : MacOsKeychain.Delete(_service, AccountFor(provider));
-        _logger.LogInformation("Removed the API key for {Provider}: {Result}",
-            provider, deleted ? "ok" : "failed");
+            ? WindowsDpapiStore.Delete(_service, AccountFor(connectionId))
+            : MacOsKeychain.Delete(_service, AccountFor(connectionId));
+        _logger.LogInformation("Removed the API key for {Connection}: {Result}",
+            connectionId, deleted ? "ok" : "failed");
         return deleted;
     }
 
@@ -123,10 +123,34 @@ public sealed class AiCredentialStore : IAiCredentialStore
     /// One item per provider, so a user can keep a Claude key and an OpenAI-compatible key at once — which is
     /// the ordinary case for someone comparing a hosted model against a local one.
     /// </summary>
-    internal static string AccountFor(ChatProviderKind provider) => provider switch
+    /// <summary>
+    /// The credential-store account a connection's key is filed under. (#678)
+    ///
+    /// <para><b>Was keyed by <c>ChatProviderKind</c>, a two-member enum</b> — so every OpenAI-compatible
+    /// endpoint shared one slot. A reader who stored an OpenRouter key and then pointed the app at DeepSeek
+    /// silently sent the wrong key and got a 401 naming neither cause. That is the defect this issue exists
+    /// for, and it made comparing a hosted model against a local one impossible.</para>
+    ///
+    /// <para><b>Why the connection id and not the base URL.</b> A URL-derived account orphans the credential
+    /// the moment someone changes a port or swaps <c>localhost</c> for <c>127.0.0.1</c> — and the resulting
+    /// failure presents as a bad key rather than a lost one, which sends the reader to re-paste a key that
+    /// was fine. The id is immutable for exactly this reason.</para>
+    /// </summary>
+    internal static string AccountFor(string connectionId) => Sanitize(connectionId);
+
+    /// <summary>
+    /// Ids are validated as slugs before they reach here, so this is a belt-and-braces guard rather than the
+    /// primary defence: a stray separator in an account name is the kind of thing that silently writes a
+    /// credential to a path nobody looks at again.
+    /// </summary>
+    private static string Sanitize(string id)
     {
-        ChatProviderKind.Anthropic => "anthropic",
-        ChatProviderKind.OpenAiCompatible => "openai-compatible",
-        _ => provider.ToString().ToLowerInvariant(),
-    };
+        if (string.IsNullOrWhiteSpace(id)) return "default";
+
+        var chars = id.Trim().ToLowerInvariant().ToCharArray();
+        for (int i = 0; i < chars.Length; i++)
+            if (!(char.IsAsciiLetterOrDigit(chars[i]) || chars[i] is '-' or '_'))
+                chars[i] = '-';
+        return new string(chars);
+    }
 }

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1724,7 +1724,7 @@ public class AiSettingsViewModel : ViewModelBase
         {
             if (_credentials == null || string.IsNullOrWhiteSpace(ApiKeyEntry)) return;
 
-            _credentials.SetApiKey(SelectedProvider.Kind, ApiKeyEntry);
+            _credentials.SetApiKey(ActiveConnection().Id, ApiKeyEntry);
             // Cleared immediately: the box exists to hand the key over, not to hold it.
             ApiKeyEntry = "";
             RefreshKeyStatus();
@@ -1733,7 +1733,7 @@ public class AiSettingsViewModel : ViewModelBase
 
         private void RemoveApiKey()
         {
-            _credentials?.DeleteApiKey(SelectedProvider.Kind);
+            _credentials?.DeleteApiKey(ActiveConnection().Id);
             ApiKeyEntry = "";
             RefreshKeyStatus();
             RefreshReadiness();
@@ -1754,9 +1754,13 @@ public class AiSettingsViewModel : ViewModelBase
             }
             else
             {
-                KeyStatus = _credentials.GetApiKey(SelectedProvider.Kind) is null
-                    ? "No key stored for this provider."
-                    : "A key is stored for this provider.";
+                // Named, because the whole failure mode #678 fixes is a key that exists but belongs to a
+                // DIFFERENT endpoint. "No key stored" without saying which connection is the message that
+                // let the old collision hide.
+                var connection = ActiveConnection();
+                KeyStatus = _credentials.GetApiKey(connection.Id) is null
+                    ? $"No key stored for {connection.DisplayName}."
+                    : $"A key is stored for {connection.DisplayName}.";
             }
 
             this.RaisePropertyChanged(nameof(CanStoreKeys));


### PR DESCRIPTION
Fixes #678. Part of #689.

`AiCredentialStore` filed every key under an account derived from `ChatProviderKind` — a **two-member enum**. So OpenRouter, DeepSeek, Together, Fireworks, a hosted vLLM and a local Ollama all shared one slot: storing a key for the second silently replaced the first, and the reader got a 401 naming neither cause.

That is why comparing a hosted model against a local one was impossible — the workflow this whole rework exists to enable.

## The fix

Keys are filed under the connection's `Id`.

**Deliberately not the base URL.** A URL-derived account orphans the credential the moment someone changes a port or swaps `localhost` for `127.0.0.1`, and the resulting failure presents as a *bad* key rather than a *lost* one — sending the reader off to re-paste a key that was fine. The id is immutable for exactly this reason.

## Three consequences

- **The Settings key status now names the connection** — "No key stored for Ollama" rather than "for this provider". A message that does not say *which* endpoint is the message that let the collision hide.
- **`AiConnection.KeySource`** reports `Keychain` or `None`, so #691 can show where a credential came from. `Environment` arrives with the `CST_AI_*` work; the rule there is that a found credential makes a provider *available*, never *connected*.
- **Removing a connection removes its key.** An orphaned credential is unreachable and uncleanable — and would be silently re-adopted by any later connection taking the same id.

## No migration

`ChatSettings` postdates the beta 5 tag, so nothing is stored in the wild under the old accounts.

## Testing

The test that asserted "keys are kept per provider" now asserts the case that was actually broken: **two OpenAI-compatible endpoints keeping separate keys**.

Mutation-checked: collapsing every connection to one shared account reproduces the original defect and fails 2 tests.

**1908 passing**, 0 warnings in both projects.

## Remaining on #689

`CST_AI_*` environment overrides, the reachability write-back (#673), and the three auth shapes (bearer / Anthropic's `x-api-key` / Azure's `api-key`, which requires *removing* `authorization`). None changes a signature the UI binds to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)