### PR TITLE
Report what a request learns, and stop waiting ten minutes on a hosted endpoint (#673)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -323,4 +323,93 @@ public class AiConnectionServiceTests
 
         Assert.Null(keys.GetApiKey("box"));
     }
+
+    // ---- reachability write-back (#673) ------------------------------------------------------------------
+
+    /// <summary>
+    /// The honest default. "Configured" means the endpoint has never been contacted, NOT that it works —
+    /// conflating those is what lets a settings page claim "Connected" while the assistant reports it cannot
+    /// connect, which is the contradiction #673 exists to remove.
+    /// </summary>
+    [Fact]
+    public void A_new_connection_starts_as_configured_not_reachable()
+    {
+        var (service, _) = Make();
+        service.Add("box", Draft());
+
+        Assert.Equal(Reachability.Configured, service.Connections.Single().State);
+    }
+
+    [Fact]
+    public void A_failed_request_marks_the_endpoint_unreachable()
+    {
+        var (service, _) = Make();
+        service.Add("box", Draft());
+
+        service.ReportReachability("box", reachable: false);
+
+        Assert.Equal(Reachability.Unreachable, service.Connections.Single().State);
+    }
+
+    [Fact]
+    public void A_successful_request_marks_it_reachable_again()
+    {
+        var (service, _) = Make();
+        service.Add("box", Draft());
+        service.ReportReachability("box", reachable: false);
+
+        service.ReportReachability("box", reachable: true);
+
+        Assert.Equal(Reachability.Reachable, service.Connections.Single().State);
+    }
+
+    /// <summary>The UI rebinds on the change event, so a state change nobody is told about is a screen that
+    /// silently stops matching what the app knows — the whole defect, reintroduced.</summary>
+    [Fact]
+    public void A_reachability_change_raises_the_change_event()
+    {
+        var (service, _) = Make();
+        service.Add("box", Draft());
+
+        int raised = 0;
+        service.ConnectionsChanged += (_, _) => raised++;
+
+        service.ReportReachability("box", reachable: false);
+
+        Assert.Equal(1, raised);
+    }
+
+    /// <summary>Reporting the same state twice must not churn the UI — a turn a second reports success would
+    /// otherwise rebind every screen bound to the list.</summary>
+    [Fact]
+    public void Reporting_the_same_state_again_is_silent()
+    {
+        var (service, _) = Make();
+        service.Add("box", Draft());
+        service.ReportReachability("box", reachable: true);
+
+        int raised = 0;
+        service.ConnectionsChanged += (_, _) => raised++;
+        service.ReportReachability("box", reachable: true);
+
+        Assert.Equal(0, raised);
+    }
+
+    /// <summary>
+    /// Reachability is per-session and deliberately not persisted: "unreachable" is a fact about a moment — a
+    /// laptop that was offline, a runner not yet started — and storing it would greet the reader with a red
+    /// endpoint on next launch that nothing clears until something happens to retry it.
+    /// </summary>
+    [Fact]
+    public void Reachability_is_not_written_to_settings()
+    {
+        var (service, settings) = Make();
+        service.Add("box", Draft());
+        service.ReportReachability("box", reachable: false);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(settings);
+
+        Assert.DoesNotContain("Unreachable", json);
+        Assert.DoesNotContain("Reachab", json);
+    }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/AiEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiEndpointTests.cs
@@ -1,0 +1,77 @@
+using System;
+using CST.Avalonia.Services.Ai;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// #673: one first-event timeout served two situations with nothing in common. Ten minutes was earned by a
+/// local runner doing prompt evaluation on modest hardware; applied to a hosted endpoint it means a reader
+/// clicks a preset and the app is prepared to wait ten minutes before saying anything.
+/// </summary>
+public class AiEndpointTests
+{
+    [Theory]
+    [InlineData("http://localhost:11434/v1")]
+    [InlineData("http://127.0.0.1:1234/v1")]
+    [InlineData("http://[::1]:8080/v1")]
+    [InlineData("http://mac-studio.local:11434/v1")]
+    [InlineData("http://192.168.1.50:8000/v1")]
+    [InlineData("http://10.0.0.5:8000/v1")]
+    [InlineData("http://172.16.4.2:8000/v1")]
+    public void A_machine_on_this_desk_or_network_counts_as_local(string url)
+    {
+        Assert.True(AiEndpoint.IsLocal(url), url);
+    }
+
+    [Theory]
+    [InlineData("https://openrouter.ai/api/v1")]
+    [InlineData("https://api.openai.com/v1")]
+    [InlineData("https://api.anthropic.com/v1")]
+    [InlineData("https://acme.openai.azure.com/openai/v1")]
+    public void A_hosted_endpoint_does_not(string url)
+    {
+        Assert.False(AiEndpoint.IsLocal(url), url);
+    }
+
+    /// <summary>172.x is only private in 16–31; 172.15 and 172.32 are ordinary public space, and treating them
+    /// as local would hand a hosted endpoint the ten-minute allowance.</summary>
+    [Theory]
+    [InlineData("http://172.15.0.1:8000/v1")]
+    [InlineData("http://172.32.0.1:8000/v1")]
+    [InlineData("http://172.200.0.1:8000/v1")]
+    public void The_172_range_is_only_private_between_16_and_31(string url)
+    {
+        Assert.False(AiEndpoint.IsLocal(url), url);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a url")]
+    [InlineData("{resourceName}.example.com")]   // an unresolved template is not a usable address
+    public void Anything_unparseable_is_treated_as_hosted(string? url)
+    {
+        // Hosted is the safe default: it gives the SHORTER wait, so a misjudgement costs a premature timeout
+        // rather than ten minutes of silence.
+        Assert.False(AiEndpoint.IsLocal(url));
+    }
+
+    [Fact]
+    public void Local_keeps_the_long_allowance_it_earned()
+    {
+        Assert.Equal(SseReader.DefaultFirstEventTimeout,
+            AiEndpoint.FirstEventTimeoutFor("http://localhost:11434/v1"));
+    }
+
+    [Fact]
+    public void Hosted_gets_an_interactive_ceiling_instead()
+    {
+        var hosted = AiEndpoint.FirstEventTimeoutFor("https://openrouter.ai/api/v1");
+
+        Assert.Equal(AiEndpoint.HostedFirstEventTimeout, hosted);
+        Assert.True(hosted < SseReader.DefaultFirstEventTimeout);
+        Assert.True(hosted >= TimeSpan.FromMinutes(1), "too short to cover a slow hosted first token");
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -67,14 +67,23 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
         IAiContextBundler bundler,
         IPromptBuilder prompts,
         ISettingsService settings,
-        ILogger<AiChatOrchestrator> logger)
+        ILogger<AiChatOrchestrator> logger,
+        IAiConnectionService? connections = null)
     {
         _resolver = resolver;
         _bundler = bundler;
         _prompts = prompts;
         _settings = settings;
         _logger = logger;
+        _connections = connections;
     }
+
+    /// <summary>
+    /// Optional so the orchestrator stays constructible in tests that care about nothing else. Its only job
+    /// here is the reachability write-back (#673): a turn is the app's best evidence about whether an endpoint
+    /// answers, and without this the knowledge dies in the panel while Settings goes on saying "Connected".
+    /// </summary>
+    private readonly IAiConnectionService? _connections;
 
     public void Stop()
     {
@@ -309,6 +318,10 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
         if (inputTokens is not null || outputTokens is not null)
             yield return AiTurnEvent.ForUsage(new AiUsageReport(inputTokens, outputTokens));
 
+        // Anything that arrived at all proves the endpoint answered, whatever went wrong afterwards.
+        if (sawText || sawReasoning || inputTokens is not null || outputTokens is not null)
+            ReportReachability(true);
+
         if (failure is not null)
         {
             // The provider knows THAT the output limit was hit; only this loop knows what the user got for it.
@@ -317,6 +330,12 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
                 failure = failure with { Message = TruncationMessage(sawText, sawReasoning) };
 
             _logger.LogInformation("AI turn failed: {Kind} ({Code})", failure.Kind, failure.ProviderCode ?? "-");
+
+            // Only a NETWORK failure says anything about the endpoint. A 401, a rate limit or an over-long
+            // context all prove the endpoint answered - marking those unreachable would be wrong, and would
+            // put a red mark on a perfectly good connection whose key simply needs fixing.
+            if (failure.Kind == AiErrorKind.Network)
+                ReportReachability(false);
             yield return AiTurnEvent.ForError(failure);
             yield break;
         }
@@ -402,6 +421,21 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
             _ => "other",
         };
         return page.Volume > 0 ? $"{edition} {page.Volume}.{page.Number}" : $"{edition} {page.Number}";
+    }
+
+    /// <summary>Records what this turn learned about the active endpoint, so Settings and the assistant read
+    /// one fact rather than each guessing. Never throws: reporting is a courtesy, not part of the turn.</summary>
+    private void ReportReachability(bool reachable)
+    {
+        try
+        {
+            if (_connections?.Active is { } active)
+                _connections.ReportReachability(active.Id, reachable);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not record endpoint reachability (#673)");
+        }
     }
 
     private static string TruncationMessage(bool sawText, bool sawReasoning) =>

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -59,6 +59,15 @@ namespace CST.Avalonia.Services.Ai
 
         /// <summary>Turns one model on or off in the per-turn picker.</summary>
         AiConnectionResult SetModelEnabled(string connectionId, string modelId, bool enabled);
+
+        /// <summary>
+        /// Records what a real request just learned about an endpoint. (#673)
+        ///
+        /// <para>This is what stops Settings claiming "Connected" while the assistant reports it cannot
+        /// connect. The app already knows — it made the request — and the whole defect is that the knowledge
+        /// never reaches the surface a reader consults to diagnose. Both now read one fact.</para>
+        /// </summary>
+        void ReportReachability(string connectionId, bool reachable);
     }
 
     /// <summary>
@@ -76,6 +85,17 @@ namespace CST.Avalonia.Services.Ai
 
         private readonly ISettingsService _settings;
         private readonly IAiCredentialStore? _credentials;
+
+        /// <summary>
+        /// Last-known reachability, in memory only.
+        ///
+        /// <para><b>Deliberately not persisted.</b> "Unreachable" is a fact about a moment — a laptop that was
+        /// offline, a local runner that was not started yet — and writing it to settings would greet the reader
+        /// with a red endpoint on the next launch that no amount of fixing clears until something happens to
+        /// retry it. Every connection starts each session as <c>Configured</c>, which is the honest state:
+        /// not yet checked.</para>
+        /// </summary>
+        private readonly Dictionary<string, Reachability> _reachability = new(StringComparer.OrdinalIgnoreCase);
 
         /// <param name="credentials">Optional: a platform with nowhere safe to put a key still runs, and an
         /// endpoint needing no key still works. Resolved with <c>GetService</c> for that reason.</param>
@@ -206,6 +226,16 @@ namespace CST.Avalonia.Services.Ai
             return Saved(record);
         }
 
+        public void ReportReachability(string connectionId, bool reachable)
+        {
+            var state = reachable ? Reachability.Reachable : Reachability.Unreachable;
+
+            if (_reachability.TryGetValue(connectionId, out var current) && current == state) return;
+
+            _reachability[connectionId] = state;
+            ConnectionsChanged?.Invoke(this, EventArgs.Empty);
+        }
+
         public AiConnectionResult SetModelEnabled(string connectionId, string modelId, bool enabled)
         {
             if (Find(connectionId) is not { } record)
@@ -253,7 +283,8 @@ namespace CST.Avalonia.Services.Ai
             r.Models.Select(m => new AiModelEntry(m.Id, m.DisplayName, m.Enabled)).ToList(),
             new Dictionary<string, string>(r.Headers),
             new Dictionary<string, string>(r.Inputs),
-            SourceFor(r.Id));
+            SourceFor(r.Id),
+            _reachability.TryGetValue(r.Id, out var state) ? state : Reachability.Configured);
 
         /// <summary>
         /// Ids are the reserved namespace a custom connection may not take, and they become the credential's

--- a/src/CST.Avalonia/Services/Ai/AiEndpoint.cs
+++ b/src/CST.Avalonia/Services/Ai/AiEndpoint.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace CST.Avalonia.Services.Ai
+{
+    /// <summary>
+    /// Where an endpoint lives, and how long it is reasonable to wait for it. (#673)
+    ///
+    /// <para>One first-event timeout served two situations that have nothing in common. The ten-minute
+    /// allowance was earned by a <b>local runner</b>: a model doing prompt evaluation over an injected passage
+    /// on modest hardware can legitimately sit silent for minutes, and folding that into the ordinary idle
+    /// window would abandon the fully-local path exactly when it is working hardest. That argument is sound —
+    /// and it was then applied to every endpoint, including hosted ones, where it means a reader clicks a
+    /// preset and the app is prepared to wait ten minutes before saying anything.</para>
+    ///
+    /// <para>The base URL already distinguishes the two, so the split costs nothing.</para>
+    /// </summary>
+    internal static class AiEndpoint
+    {
+        /// <summary>
+        /// A hosted endpoint that produces nothing for this long is not thinking; it is queued behind someone
+        /// else or gone. Chosen to be longer than any realistic time-to-first-token on a hosted model while
+        /// still being a number a person will sit through.
+        /// </summary>
+        internal static readonly TimeSpan HostedFirstEventTimeout = TimeSpan.FromMinutes(2);
+
+        /// <summary>True when the endpoint is on this machine or this network — loopback, a private range, or
+        /// a <c>.local</c> name.</summary>
+        internal static bool IsLocal(string? baseUrl)
+        {
+            if (string.IsNullOrWhiteSpace(baseUrl)) return false;
+            if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri)) return false;
+
+            var host = uri.Host;
+            if (host.Length == 0) return false;
+
+            if (uri.IsLoopback) return true;
+            if (host.EndsWith(".local", StringComparison.OrdinalIgnoreCase)) return true;
+
+            // Private IPv4 ranges. A hosted model behind a LAN gateway is rare; a local runner on another
+            // machine on the desk is not, and it deserves the same patience as one on this machine.
+            //
+            // Parsed as an address rather than matched as a prefix: "172." is private only in 16-31, and a
+            // substring test gets 172.200.x wrong by reading two characters and finding "20".
+            if (!System.Net.IPAddress.TryParse(host, out var ip)) return false;
+            if (ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork) return false;
+
+            var octets = ip.GetAddressBytes();
+            return octets[0] switch
+            {
+                10 => true,
+                172 => octets[1] is >= 16 and <= 31,
+                192 => octets[1] == 168,
+                _ => false,
+            };
+        }
+
+        /// <summary>
+        /// How long to allow before the FIRST byte. Local keeps the long allowance it earned; hosted gets an
+        /// interactive ceiling.
+        /// </summary>
+        internal static TimeSpan FirstEventTimeoutFor(string? baseUrl) =>
+            IsLocal(baseUrl) ? SseReader.DefaultFirstEventTimeout : HostedFirstEventTimeout;
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -193,7 +193,8 @@ public sealed class ChatProviderResolver : IChatProviderResolver
                     new AnthropicMessagesProvider(
                         _http,
                         new AnthropicOptions(apiKey, NullIfBlank(baseUrl)),
-                        _loggerFactory.CreateLogger<AnthropicMessagesProvider>()),
+                        _loggerFactory.CreateLogger<AnthropicMessagesProvider>(),
+                        firstEventTimeout: AiEndpoint.FirstEventTimeoutFor(baseUrl)),
                     chat.ActiveModelId!.Trim());
 
             case ChatProviderKind.OpenAiCompatible when string.IsNullOrWhiteSpace(baseUrl):
@@ -209,7 +210,8 @@ public sealed class ChatProviderResolver : IChatProviderResolver
                     new OpenAiCompatibleProvider(
                         _http,
                         new OpenAiCompatibleOptions(baseUrl.Trim(), NullIfBlank(apiKey)),
-                        _loggerFactory.CreateLogger<OpenAiCompatibleProvider>()),
+                        _loggerFactory.CreateLogger<OpenAiCompatibleProvider>(),
+                        firstEventTimeout: AiEndpoint.FirstEventTimeoutFor(baseUrl)),
                     chat.ActiveModelId!.Trim());
 
             default:


### PR DESCRIPTION
Two of #673's three parts. The published-endpoint-health idea is left open on the issue.

## Reachability write-back

Settings could say **"Connected"** while the assistant reported it *could not connect*. Not because nothing checked — the app had just made the request and knew — but because the knowledge died in the panel and never reached the surface a reader consults to diagnose. That contradiction was observed in OpenCode; ours had the same shape.

`AiConnection.State` now moves: a turn that produces anything marks the endpoint **Reachable**, a `Network` failure marks it **Unreachable**, and both raise `ConnectionsChanged` so every bound screen agrees.

**Only a network failure says anything about the endpoint.** A 401, a rate limit, or an over-long context all prove it *answered* — marking those unreachable would put a red mark on a perfectly good connection whose key merely needs fixing.

**Reachability is per-session and deliberately not persisted.** "Unreachable" is a fact about a moment — a laptop that was offline, a runner not yet started — and storing it would greet the reader with a red endpoint on next launch that nothing clears until something happens to retry it. Every connection starts each session as `Configured`, which is the honest state: *not yet checked*. There's a test asserting it never reaches `settings.json`.

## The first-event timeout, split by locality

One ten-minute window served two situations with nothing in common.

It was earned by a **local runner**: a model doing prompt evaluation over an injected passage on modest hardware can legitimately sit silent for minutes, and folding that into the ordinary idle window would abandon the fully-local path exactly when it is working hardest. That reasoning is sound — and was then applied to *every* endpoint, so a reader clicking a preset against a hosted model got an app prepared to wait ten minutes before saying anything.

The base URL already distinguishes them, so the split costs nothing. **Local keeps ten minutes; hosted gets two.**

Loopback, `.local`, and the private IPv4 ranges all count as local — a runner on another machine on the desk deserves the same patience as one on this machine. Anything unparseable is treated as **hosted**, because hosted is the *shorter* wait: a misjudgement then costs a premature timeout rather than ten minutes of silence.

One thing the tests caught: the private-range check has to **parse the address**, not match a prefix. `172` is private only in 16–31, and a substring test gets `172.200.x` wrong by reading two characters and finding "20".

## Testing

29 tests across the two areas. Mutation-checked: removing the locality split fails 1; removing the no-churn guard on repeated reachability reports fails 1.

**1935 passing**, 0 warnings in both projects.

## Still open on #673

Published endpoint health — OpenRouter exposes per-backend `uptime_last_30m`, which would let the app say "this endpoint reported no uptime in the last half hour" while a reader watches a counter, instead of inferring anything from a timeout. Enrichment, not a dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)