### PR TITLE
Honour the endpoint's own auth shape, so Azure is callable (#689)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleAuthTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleAuthTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using CST.Avalonia.Services.Ai;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// #689: not every OpenAI-compatible endpoint authenticates with a bearer token. Azure sends the credential
+/// in <c>api-key</c> and rejects a request that also carries <c>Authorization</c> — so the auth header has to
+/// be REPLACEABLE, not merely supplementable, which is why this cannot be expressed as an extra header.
+///
+/// <para>Exercises the header construction directly. Sending a real request would need a live endpoint, and
+/// the thing worth pinning is which headers are attached — the part a wrong guess makes invisible until a
+/// provider returns 401 naming nothing.</para>
+/// </summary>
+public class OpenAiCompatibleAuthTests
+{
+    private static HttpRequestMessage Build(OpenAiCompatibleOptions options)
+    {
+        var provider = new OpenAiCompatibleProvider(
+            // The provider refuses a finite-timeout client: liveness is the SSE reader's idle window, and a
+            // finite HttpClient.Timeout would truncate a long stream and report it as a cancellation.
+            new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan },
+            options,
+            NullLogger<OpenAiCompatibleProvider>.Instance);
+
+        var message = new HttpRequestMessage(HttpMethod.Post, "https://example.invalid/chat/completions");
+
+        typeof(OpenAiCompatibleProvider)
+            .GetMethod("ApplyAuth", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(provider, new object[] { message });
+
+        return message;
+    }
+
+    private static string? Header(HttpRequestMessage m, string name) =>
+        m.Headers.TryGetValues(name, out var values) ? string.Join(",", values) : null;
+
+    [Fact]
+    public void The_ordinary_case_is_a_bearer_token_in_authorization()
+    {
+        var m = Build(new OpenAiCompatibleOptions("https://api.openai.com/v1", "sk-test"));
+
+        Assert.Equal("Bearer sk-test", Header(m, "Authorization"));
+    }
+
+    /// <summary>
+    /// The Azure case, and the reason this mechanism exists. The credential goes in <c>api-key</c> with no
+    /// scheme prefix, and <c>Authorization</c> must NOT be present — Azure rejects a request carrying both.
+    /// </summary>
+    [Fact]
+    public void A_named_auth_header_replaces_authorization_rather_than_joining_it()
+    {
+        var m = Build(new OpenAiCompatibleOptions(
+            "https://acme.openai.azure.com/openai/v1", "azure-key",
+            AuthHeaderName: "api-key", AuthScheme: null));
+
+        Assert.Equal("azure-key", Header(m, "api-key"));
+        Assert.Null(Header(m, "Authorization"));
+    }
+
+    /// <summary>A local runner needs no credential, and an absent key must produce no auth header at all
+    /// rather than an empty one — which some servers reject outright.</summary>
+    [Fact]
+    public void No_key_means_no_auth_header()
+    {
+        var m = Build(new OpenAiCompatibleOptions("http://localhost:11434/v1"));
+
+        Assert.Null(Header(m, "Authorization"));
+        Assert.Empty(m.Headers);
+    }
+
+    [Fact]
+    public void Extra_headers_are_attached_alongside_the_credential()
+    {
+        var m = Build(new OpenAiCompatibleOptions(
+            "https://openrouter.ai/api/v1", "sk-or",
+            ExtraHeaders: new Dictionary<string, string> { ["X-Title"] = "CST Reader" }));
+
+        Assert.Equal("Bearer sk-or", Header(m, "Authorization"));
+        Assert.Equal("CST Reader", Header(m, "X-Title"));
+    }
+
+    /// <summary>
+    /// An extra header may never overwrite the credential. A stray "Authorization" typed into a settings field
+    /// would otherwise silently replace the stored key with whatever the reader pasted — a failure that
+    /// presents as a bad key while the key is fine.
+    /// </summary>
+    [Fact]
+    public void An_extra_header_cannot_overwrite_the_credential()
+    {
+        var m = Build(new OpenAiCompatibleOptions(
+            "https://api.openai.com/v1", "sk-real",
+            ExtraHeaders: new Dictionary<string, string> { ["Authorization"] = "Bearer sk-typed-by-hand" }));
+
+        Assert.Equal("Bearer sk-real", Header(m, "Authorization"));
+    }
+
+    /// <summary>Same guarantee under the endpoint's own auth header name, not just the standard one.</summary>
+    [Fact]
+    public void An_extra_header_cannot_overwrite_a_named_credential_either()
+    {
+        var m = Build(new OpenAiCompatibleOptions(
+            "https://acme.openai.azure.com/openai/v1", "azure-key",
+            AuthHeaderName: "api-key", AuthScheme: null,
+            ExtraHeaders: new Dictionary<string, string> { ["api-key"] = "wrong" }));
+
+        Assert.Equal("azure-key", Header(m, "api-key"));
+    }
+
+    /// <summary>Defensive: a blank header name falls back to the standard one rather than producing a request
+    /// with the credential attached to nothing.</summary>
+    [Fact]
+    public void A_blank_auth_header_name_falls_back_to_authorization()
+    {
+        var m = Build(new OpenAiCompatibleOptions(
+            "https://api.openai.com/v1", "sk-test", AuthHeaderName: "  "));
+
+        Assert.Equal("Bearer sk-test", Header(m, "Authorization"));
+    }
+}

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -83,7 +83,9 @@ namespace CST.Avalonia.Models.Ai
         IReadOnlyDictionary<string, string> Headers,
         IReadOnlyDictionary<string, string> Inputs,
         CredentialSource KeySource = CredentialSource.None,
-        Reachability State = Reachability.Configured)
+        Reachability State = Reachability.Configured,
+        string AuthHeaderName = "Authorization",
+        string? AuthScheme = "Bearer")
     {
         /// <summary>The base URL with <see cref="Inputs"/> substituted in — what a request actually goes to.</summary>
         public string ResolvedBaseUrl => AiTemplate.Expand(BaseUrl, Inputs);
@@ -103,7 +105,9 @@ namespace CST.Avalonia.Models.Ai
         string BaseUrl,
         IReadOnlyList<AiModelEntry> Models,
         IReadOnlyDictionary<string, string> Headers,
-        IReadOnlyDictionary<string, string> Inputs);
+        IReadOnlyDictionary<string, string> Inputs,
+        string AuthHeaderName = "Authorization",
+        string? AuthScheme = "Bearer");
 
     /// <summary>
     /// A named endpoint a reader can add without knowing its URL. (#689, #691)

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -138,6 +138,16 @@ namespace CST.Avalonia.Models
         /// <summary>Answers to the preset's prompts — resource name, account id, region — substituted into
         /// <see cref="BaseUrl"/> and <see cref="Headers"/>.</summary>
         public Dictionary<string, string> Inputs { get; set; } = new();
+
+        /// <summary>
+        /// Which header carries the credential. Azure uses <c>api-key</c> and expects <c>Authorization</c> to
+        /// be ABSENT rather than also present, so this REPLACES the auth header rather than adding one.
+        /// </summary>
+        public string AuthHeaderName { get; set; } = "Authorization";
+
+        /// <summary>Prefix before the credential, or null for a bare value. Bearer for almost everything;
+        /// null for Azure.</summary>
+        public string? AuthScheme { get; set; } = "Bearer";
     }
 
     /// <summary>One model a connection offers, as persisted.</summary>

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -173,6 +173,8 @@ namespace CST.Avalonia.Services.Ai
                 BaseUrl = preset.BaseUrl,
                 Headers = new Dictionary<string, string>(preset.Headers ?? new Dictionary<string, string>()),
                 Inputs = new Dictionary<string, string>(inputs),
+                AuthHeaderName = preset.AuthHeaderName,
+                AuthScheme = preset.AuthScheme,
             };
             Chat.Connections.Add(record);
             Chat.ActiveConnectionId ??= record.Id;
@@ -273,6 +275,8 @@ namespace CST.Avalonia.Services.Ai
                 .ToList();
             record.Headers = new Dictionary<string, string>(draft.Headers);
             record.Inputs = new Dictionary<string, string>(draft.Inputs);
+            record.AuthHeaderName = draft.AuthHeaderName;
+            record.AuthScheme = draft.AuthScheme;
         }
 
         private AiConnection ToRuntime(AiConnectionRecord r) => new(
@@ -284,7 +288,9 @@ namespace CST.Avalonia.Services.Ai
             new Dictionary<string, string>(r.Headers),
             new Dictionary<string, string>(r.Inputs),
             SourceFor(r.Id),
-            _reachability.TryGetValue(r.Id, out var state) ? state : Reachability.Configured);
+            _reachability.TryGetValue(r.Id, out var state) ? state : Reachability.Configured,
+            r.AuthHeaderName,
+            r.AuthScheme);
 
         /// <summary>
         /// Ids are the reserved namespace a custom connection may not take, and they become the credential's

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -209,7 +209,16 @@ public sealed class ChatProviderResolver : IChatProviderResolver
                 return new ChatProviderResolution(
                     new OpenAiCompatibleProvider(
                         _http,
-                        new OpenAiCompatibleOptions(baseUrl.Trim(), NullIfBlank(apiKey)),
+                        new OpenAiCompatibleOptions(
+                            baseUrl.Trim(),
+                            NullIfBlank(apiKey),
+                            connection.AuthHeaderName,
+                            connection.AuthScheme,
+                            // Header VALUES are templates too - Cloudflare and Azure put reader-supplied
+                            // inputs in them, exactly as the base URL does.
+                            connection.Headers.ToDictionary(
+                                h => h.Key,
+                                h => CST.Avalonia.Models.Ai.AiTemplate.Expand(h.Value, connection.Inputs))),
                         _loggerFactory.CreateLogger<OpenAiCompatibleProvider>(),
                         firstEventTimeout: AiEndpoint.FirstEventTimeoutFor(baseUrl)),
                     chat.ActiveModelId!.Trim());

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -17,7 +17,17 @@ namespace CST.Avalonia.Services.Ai;
 /// Together, Ollama and LM Studio.</param>
 /// <param name="ApiKey">Optional — local runners (Ollama, LM Studio) accept anonymous requests, so an empty key
 /// is a valid configuration rather than a misconfiguration. A remote provider will answer 401 on its own.</param>
-public sealed record OpenAiCompatibleOptions(string? BaseUrl, string? ApiKey = null);
+/// <param name="AuthHeaderName">Which header carries the credential. Almost always <c>Authorization</c>;
+/// Azure uses <c>api-key</c> and expects <c>Authorization</c> to be ABSENT, so naming a different header
+/// REPLACES the standard one rather than adding to it. (#689)</param>
+/// <param name="AuthScheme">Prefix before the credential, or null for a bare value.</param>
+/// <param name="ExtraHeaders">Static or templated headers the endpoint needs — never the credential itself.</param>
+public sealed record OpenAiCompatibleOptions(
+    string? BaseUrl,
+    string? ApiKey = null,
+    string AuthHeaderName = "Authorization",
+    string? AuthScheme = "Bearer",
+    IReadOnlyDictionary<string, string>? ExtraHeaders = null);
 
 /// <summary>
 /// The OpenAI-compatible Chat Completions shape (<c>POST {baseUrl}/chat/completions</c>, SSE). One adapter for
@@ -53,6 +63,43 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
 
     public string Id => "openai-compatible";
 
+    /// <summary>
+    /// Attaches the credential in whatever shape this endpoint expects, plus any extra headers. (#689)
+    ///
+    /// <para><b>Naming a non-standard auth header replaces <c>Authorization</c>; it does not add a second
+    /// one.</b> Azure rejects a request carrying both, which is why this cannot be expressed as an entry in
+    /// <see cref="OpenAiCompatibleOptions.ExtraHeaders"/> — an extra header is additive by definition, and the
+    /// requirement here is an absence.</para>
+    ///
+    /// <para>Extra headers are applied first so they can never overwrite the credential: a mis-typed header
+    /// named <c>Authorization</c> in settings would otherwise silently replace the real key with whatever the
+    /// reader pasted.</para>
+    /// </summary>
+    private void ApplyAuth(HttpRequestMessage message)
+    {
+        if (_options.ExtraHeaders is { Count: > 0 })
+            foreach (var extra in _options.ExtraHeaders)
+                if (!string.IsNullOrWhiteSpace(extra.Key) && !IsAuthHeader(extra.Key))
+                    message.Headers.TryAddWithoutValidation(extra.Key, extra.Value);
+
+        if (string.IsNullOrWhiteSpace(_options.ApiKey)) return;   // a local runner needs none
+
+        var header = string.IsNullOrWhiteSpace(_options.AuthHeaderName)
+            ? "Authorization"
+            : _options.AuthHeaderName;
+
+        var credential = string.IsNullOrWhiteSpace(_options.AuthScheme)
+            ? _options.ApiKey!
+            : $"{_options.AuthScheme} {_options.ApiKey}";
+
+        message.Headers.TryAddWithoutValidation(header, credential);
+    }
+
+    /// <summary>Whether an extra header would collide with the credential, under either name.</summary>
+    private bool IsAuthHeader(string name) =>
+        string.Equals(name, "Authorization", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(name, _options.AuthHeaderName, StringComparison.OrdinalIgnoreCase);
+
     public async IAsyncEnumerable<ChatDelta> StreamAsync(
         ChatRequest request,
         [EnumeratorCancellation] CancellationToken ct = default)
@@ -70,8 +117,7 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
         {
             Content = new StringContent(BuildBody(request), Encoding.UTF8, "application/json"),
         };
-        if (!string.IsNullOrWhiteSpace(_options.ApiKey))
-            message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.ApiKey);
+        ApplyAuth(message);
 
         HttpResponseMessage response;
         try


### PR DESCRIPTION
Part of #689.

The preset catalogue has declared Azure's auth shape since #698 — credential in `api-key`, no scheme — but the adapter always sent `Authorization: Bearer`. **Azure was configurable and not callable**, which is worse than absent: the app offered an endpoint that could only ever return 401.

## The shape travels on the connection

Not looked up from the preset, so a hand-added custom endpoint can use a non-bearer header too. Presets seed it; a custom connection can set it.

## The rule that makes this a mechanism rather than a header entry

**Naming a non-standard auth header *replaces* `Authorization`; it does not add a second one.** Azure rejects a request carrying both, and an extra header is additive by definition — the requirement here is an *absence*, which no additive mechanism can express. That's why this couldn't just be an entry in the headers dictionary.

## Extra headers can't overwrite the credential

They're applied first and skip any name colliding with the credential, under either the standard name or the endpoint's own. Without that, an `Authorization` typed by hand into a settings field would silently replace the stored key with whatever was pasted — a failure that presents as a *bad key* while the key is fine.

Header values are expanded through `AiTemplate` like the base URL, since Azure and Cloudflare put reader-supplied inputs in them too.

An absent key still produces **no** auth header rather than an empty one — some servers reject an empty `Authorization` outright, and a local runner needs none.

## Testing

7 tests exercising header construction directly. Sending a real request would need a live endpoint, and what's worth pinning is *which headers get attached* — the part a wrong guess makes invisible until a provider returns 401 naming nothing.

Mutation-checked: also emitting `Authorization` alongside a named header fails 1; letting an extra header overwrite the credential fails 2.

Anthropic's shape (`x-api-key` + `anthropic-version`) was already correct in its own adapter and is untouched.

**1942 passing**, 0 warnings in both projects.

## Remaining on #689

`CST_AI_*` environment overrides. After that the backend is done bar the four provider issues (#700–#703), and the UI (#691/#692/#693) is the long pole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)