### PR TITLE
Choose the model for the next message from the composer (#693)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.ViewModels;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// #693: the per-turn model chip in the Assistant's composer.
+///
+/// <para>The primitive the provider rework exists for — comparing two models on the same passage, one click
+/// from the answer on screen rather than a trip to Settings.</para>
+/// </summary>
+public class AiModelPickerViewModelTests
+{
+    private sealed class FakeCredentialStore : IAiCredentialStore
+    {
+        public Dictionary<string, string> Keys { get; } = new(StringComparer.Ordinal);
+        public bool IsAvailable => true;
+        public string? Unavailable => null;
+        public string? GetApiKey(string connectionId) => Keys.GetValueOrDefault(connectionId);
+        public bool SetApiKey(string connectionId, string apiKey) { Keys[connectionId] = apiKey; return true; }
+        public bool DeleteApiKey(string connectionId) => Keys.Remove(connectionId);
+    }
+
+    private static (AiModelPickerViewModel Picker, AiConnectionService Service, FakeCredentialStore Keys) Make()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var keys = new FakeCredentialStore();
+        var service = new AiConnectionService(svc.Object, keys);
+        return (new AiModelPickerViewModel(service), service, keys);
+    }
+
+    private static AiConnectionDraft Draft(string name, params AiModelEntry[] models) =>
+        new(name, ChatProviderKind.OpenAiCompatible, "http://localhost:8000/v1",
+            models, new Dictionary<string, string>(), new Dictionary<string, string>());
+
+    private static IEnumerable<AiPickerModelViewModel> AllModels(AiModelPickerViewModel picker) =>
+        picker.Groups.SelectMany(g => g.Models);
+
+    // ---- what the list contains ------------------------------------------------------------------------
+
+    /// <summary>
+    /// Only the enabled subset. The full listing lives in Settings → Models; this is the short list the
+    /// reader built there, which is what lets it be a flat grouped list with no virtualization.
+    /// </summary>
+    [Fact]
+    public void Only_enabled_models_are_offered()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine",
+            new AiModelEntry("on", "On", true),
+            new AiModelEntry("off", "Off", false)));
+
+        Assert.Equal(new[] { "on" }, AllModels(picker).Select(m => m.ModelId));
+    }
+
+    /// <summary>Grouped by connection — what stops "the 8B I run locally" and "the hosted 70B" reading as
+    /// interchangeable rows once several endpoints are configured.</summary>
+    [Fact]
+    public void Models_are_grouped_by_connection()
+    {
+        var (picker, service, _) = Make();
+        service.Add("local", Draft("Local Ollama", new AiModelEntry("a", "A")));
+        service.Add("hosted", Draft("Hosted", new AiModelEntry("b", "B")));
+
+        Assert.Equal(new[] { "Local Ollama", "Hosted" }, picker.Groups.Select(g => g.DisplayName));
+    }
+
+    /// <summary>A connection with nothing enabled contributes no header — an empty group is a heading
+    /// promising rows it does not have.</summary>
+    [Fact]
+    public void A_connection_with_nothing_enabled_is_absent()
+    {
+        var (picker, service, _) = Make();
+        service.Add("empty", Draft("Empty", new AiModelEntry("x", "X", false)));
+        service.Add("full", Draft("Full", new AiModelEntry("y", "Y")));
+
+        Assert.Equal(new[] { "Full" }, picker.Groups.Select(g => g.DisplayName));
+    }
+
+    /// <summary>The chip is hidden until there is a choice to make. One model, or none, is a control that
+    /// cannot do anything.</summary>
+    [Fact]
+    public void The_chip_appears_only_when_there_is_something_to_choose()
+    {
+        var (picker, service, _) = Make();
+        Assert.False(picker.HasChoices);
+
+        service.Add("mine", Draft("Mine", new AiModelEntry("a", "A")));
+        Assert.False(picker.HasChoices);
+
+        service.Update("mine", Draft("Mine", new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
+        Assert.True(picker.HasChoices);
+    }
+
+    // ---- choosing ---------------------------------------------------------------------------------------
+
+    /// <summary>The chip shows the display name, not the wire id: nobody calls the thing they are talking to
+    /// <c>nvidia/nemotron-nano-9b-v2</c>.</summary>
+    [Fact]
+    public void The_chip_shows_the_current_models_display_name()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine",
+            new AiModelEntry("nvidia/nemotron-nano-9b-v2", "Nemotron Nano 9B"),
+            new AiModelEntry("other", "Other")));
+
+        AllModels(picker).Single(m => m.ModelId == "nvidia/nemotron-nano-9b-v2")
+            .SelectCommand.Execute().Subscribe();
+
+        Assert.Equal("Nemotron Nano 9B", picker.CurrentLabel);
+    }
+
+    /// <summary>
+    /// Choosing a model on another connection moves the connection with it.
+    ///
+    /// <para>Switching model across providers means switching base URL <i>and</i> credential; a picker that
+    /// moved only the model id would send the second provider's model to the first provider's endpoint and
+    /// fail confusingly.</para>
+    /// </summary>
+    [Fact]
+    public void Choosing_a_model_on_another_connection_switches_the_connection_too()
+    {
+        var (picker, service, _) = Make();
+        service.Add("local", Draft("Local", new AiModelEntry("a", "A")));
+        service.Add("hosted", Draft("Hosted", new AiModelEntry("b", "B")));
+
+        AllModels(picker).Single(m => m.ModelId == "b").SelectCommand.Execute().Subscribe();
+
+        Assert.Equal("hosted", service.Active?.Id);
+        Assert.Equal("b", service.ActiveModelId);
+    }
+
+    /// <summary>The current one is marked, so the reader can see what answered the last question without
+    /// opening anything else.</summary>
+    [Fact]
+    public void The_current_model_is_marked()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine", new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
+
+        AllModels(picker).Single(m => m.ModelId == "b").SelectCommand.Execute().Subscribe();
+
+        Assert.True(AllModels(picker).Single(m => m.ModelId == "b").IsCurrent);
+        Assert.False(AllModels(picker).Single(m => m.ModelId == "a").IsCurrent);
+    }
+
+    /// <summary>Choosing closes the popup and clears the search, so the next open starts from the whole
+    /// list rather than from whatever was typed last time.</summary>
+    [Fact]
+    public void Choosing_closes_the_popup_and_clears_the_search()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine", new AiModelEntry("a", "Alpha"), new AiModelEntry("b", "Beta")));
+        picker.IsOpen = true;
+        picker.Search = "alp";
+
+        AllModels(picker).Single().SelectCommand.Execute().Subscribe();
+
+        Assert.False(picker.IsOpen);
+        Assert.Equal("", picker.Search);
+    }
+
+    /// <summary>The panel is told, so a standing "not configured" notice reflects the new choice rather than
+    /// waiting to be contradicted at send time.</summary>
+    [Fact]
+    public void Choosing_notifies_the_panel()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object);
+        var told = 0;
+        var picker = new AiModelPickerViewModel(service, () => told++);
+
+        service.Add("mine", Draft("Mine", new AiModelEntry("a", "A")));
+        AllModels(picker).Single().SelectCommand.Execute().Subscribe();
+
+        Assert.Equal(1, told);
+    }
+
+    // ---- search ------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Search_matches_the_name_or_the_id()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine",
+            new AiModelEntry("nvidia/nemotron", "Nano"),
+            new AiModelEntry("meta/llama", "Llama")));
+
+        picker.Search = "nemotron";
+        Assert.Equal(new[] { "nvidia/nemotron" }, AllModels(picker).Select(m => m.ModelId));
+
+        picker.Search = "llama";
+        Assert.Equal(new[] { "meta/llama" }, AllModels(picker).Select(m => m.ModelId));
+    }
+
+    [Fact]
+    public void A_search_matching_nothing_says_so()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine", new AiModelEntry("a", "A")));
+
+        picker.Search = "zzz";
+
+        Assert.True(picker.HasNothingMatching);
+    }
+
+    // ---- what cannot be used, and why ---------------------------------------------------------------------
+
+    /// <summary>
+    /// A provider whose preset says it needs a key, with none stored, is shown disabled and says why.
+    ///
+    /// <para>Otherwise the send fails with a 401 that names neither the cause nor the connection — which is
+    /// the failure this is here to prevent.</para>
+    /// </summary>
+    [Fact]
+    public void A_provider_missing_a_required_key_is_disabled_with_the_reason()
+    {
+        var (picker, service, keys) = Make();
+        service.AddFromPreset("openrouter", new Dictionary<string, string>());
+        service.EnableModel("openrouter", "x/y", "X", true);
+
+        var model = AllModels(picker).Single();
+        Assert.False(model.IsUsable);
+        Assert.Equal("no API key stored", model.Unusable);
+
+        keys.SetApiKey("openrouter", "sk-or-secret");
+        picker.Refresh();
+
+        Assert.True(AllModels(picker).Single().IsUsable);
+    }
+
+    /// <summary>
+    /// A custom endpoint with no key is left alone.
+    ///
+    /// <para>Plenty need none — every local runner — and there is no fact saying otherwise, so nothing is
+    /// claimed. Disabling on a hunch would be worse than letting the request explain itself.</para>
+    /// </summary>
+    [Fact]
+    public void A_custom_endpoint_with_no_key_is_not_second_guessed()
+    {
+        var (picker, service, _) = Make();
+        service.Add("my-ollama", Draft("My Ollama", new AiModelEntry("a", "A")));
+
+        Assert.True(AllModels(picker).Single().IsUsable);
+    }
+
+    /// <summary>A connection whose URL still has an unanswered placeholder cannot send anything, which is a
+    /// fact rather than a guess.</summary>
+    [Fact]
+    public void An_unfinished_connection_is_disabled_with_the_reason()
+    {
+        var (picker, service, keys) = Make();
+        service.Add("azure-ish", new AiConnectionDraft(
+            "Half-built", ChatProviderKind.OpenAiCompatible,
+            "https://{resourceName}.openai.azure.com/openai/v1",
+            new[] { new AiModelEntry("a", "A") },
+            new Dictionary<string, string>(), new Dictionary<string, string>()));
+
+        var model = AllModels(picker).Single();
+        Assert.False(model.IsUsable);
+        Assert.Equal("not finished being set up", model.Unusable);
+    }
+
+    /// <summary>
+    /// An unreachable connection is marked, not hidden.
+    ///
+    /// <para>The reader may be about to start their local runner; a provider that vanished from the picker
+    /// because it was asleep would look like a lost configuration.</para>
+    /// </summary>
+    [Fact]
+    public void An_unreachable_connection_is_marked_rather_than_hidden()
+    {
+        var (picker, service, _) = Make();
+        service.Add("local", Draft("Local", new AiModelEntry("a", "A")));
+
+        service.ReportReachability("local", reachable: false);
+
+        var group = Assert.Single(picker.Groups);
+        Assert.True(group.HasNote);
+        Assert.Equal("not responding", group.Note);
+        Assert.Single(group.Models);
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1370,7 +1370,8 @@ public partial class App : Application
             sp.GetService<Services.Ai.IAiChatOrchestrator>(),
             sp.GetService<Services.Ai.IReaderStateService>(),
             sp.GetService<Services.Ai.IChatProviderResolver>(),
-            sp.GetService<ISettingsService>()));
+            sp.GetService<ISettingsService>(),
+            sp.GetService<Services.Ai.IAiConnectionService>()));
         // services.AddTransient<MainWindowViewModel>();
     }
 

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -69,7 +69,7 @@ public class AiAssistantViewModel : ReactiveTool
     private bool _isBusy;
 
     public AiAssistantViewModel()
-        : this(null, null, null, null)
+        : this(null, null, null, null, null)
     {
     }
 
@@ -77,12 +77,18 @@ public class AiAssistantViewModel : ReactiveTool
         IAiChatOrchestrator? orchestrator,
         IReaderStateService? readerState,
         IChatProviderResolver? resolver,
-        ISettingsService? settings)
+        ISettingsService? settings,
+        IAiConnectionService? connections = null)
     {
         _orchestrator = orchestrator;
         _readerState = readerState;
         _resolver = resolver;
         _settings = settings;
+
+        // Changing model is the reason the provider rework exists, so it belongs here rather than in
+        // Settings (#693). Readiness is re-asked on every switch: picking a model on a connection with no
+        // key must change the standing notice, not wait to fail at send time.
+        ModelPicker = new AiModelPickerViewModel(connections, RefreshReadiness);
 
         Id = "AiAssistantTool";
         Title = "Assistant";
@@ -108,6 +114,9 @@ public class AiAssistantViewModel : ReactiveTool
         // Asked once at construction so the panel can say it is not configured before anything is pressed.
         RefreshReadiness();
     }
+
+    /// <summary>The per-turn model chip and its list. (#693)</summary>
+    public AiModelPickerViewModel ModelPicker { get; }
 
     public ReactiveCommand<Unit, Unit> ExplainCommand { get; }
     public ReactiveCommand<Unit, Unit> TranslateCommand { get; }

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using ReactiveUI;
+
+namespace CST.Avalonia.ViewModels
+{
+    /// <summary>
+    /// The model chip in the Assistant's composer, and the list it opens. (#693)
+    ///
+    /// <para><b>This is the primitive the whole provider rework exists for.</b> Comparing two models on the
+    /// same passage is the actual task — not configuring one and reading — and it wants to be one click from
+    /// the answer on screen rather than a trip to Settings and back.</para>
+    ///
+    /// <para><b>Grouped by connection, not flat.</b> Claude Desktop's picker is flat, which works at four
+    /// models. Once several endpoints are configured, grouping is what stops "the 8B I run locally" and "the
+    /// hosted 70B" reading as interchangeable rows.</para>
+    ///
+    /// <para><b>The enabled subset only.</b> The full listing lives in Settings → Models; this is the short
+    /// list the reader built there, so it needs no virtualization and the search box is for comfort rather
+    /// than necessity.</para>
+    /// </summary>
+    public class AiModelPickerViewModel : ViewModelBase
+    {
+        private readonly IAiConnectionService? _service;
+        private readonly Action? _changed;
+        private string _search = "";
+        private bool _isOpen;
+
+        public AiModelPickerViewModel(IAiConnectionService? service, Action? changed = null)
+        {
+            _service = service;
+            _changed = changed;
+
+            ManageCommand = ReactiveCommand.Create(Manage);
+
+            if (_service is not null)
+            {
+                _service.ConnectionsChanged += (_, _) => Rebuild();
+                Rebuild();
+            }
+        }
+
+        public ObservableCollection<AiPickerGroupViewModel> Groups { get; } = new();
+
+        /// <summary>
+        /// What the chip says at rest — the current model's name, readable without opening anything.
+        ///
+        /// <para>The display name rather than the id: the reader typed or promoted a name for it, and
+        /// <c>nvidia/nemotron-nano-9b-v2</c> is not what anyone calls the thing they are talking to.</para>
+        /// </summary>
+        public string CurrentLabel
+        {
+            get
+            {
+                if (_service?.Active is not { } connection) return "No model";
+                if (_service.ActiveModelId is not { Length: > 0 } id) return "Choose a model";
+
+                return connection.Models.FirstOrDefault(
+                    m => string.Equals(m.Id, id, StringComparison.Ordinal))?.DisplayName ?? id;
+            }
+        }
+
+        /// <summary>Hidden entirely until there is a choice to make. A chip offering one model, or none, is a
+        /// control that cannot do anything.</summary>
+        public bool HasChoices => Groups.Sum(g => g.Models.Count) > 1;
+
+        public bool IsOpen
+        {
+            get => _isOpen;
+            set => this.RaiseAndSetIfChanged(ref _isOpen, value);
+        }
+
+        /// <summary>Present because the list can grow, focused on open. At a handful of models it is
+        /// unnecessary; it costs nothing and stops being unnecessary the moment someone enables twenty.</summary>
+        public string Search
+        {
+            get => _search;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _search, value);
+                Rebuild();
+            }
+        }
+
+        public bool HasNothingMatching => Groups.Count == 0;
+
+        public ReactiveCommand<Unit, Unit> ManageCommand { get; }
+
+        /// <summary>
+        /// Chooses what the next message uses.
+        ///
+        /// <para>Switching to a model on another connection changes the base URL and the credential with it —
+        /// the service's job, and the reason a picker that moved only the model id would fail confusingly.</para>
+        ///
+        /// <para>Persisted rather than session-only: the reader's last choice is the one they will most often
+        /// want again, and a picker that silently reverted on restart would make "which model answered this?"
+        /// a question they had to keep checking.</para>
+        /// </summary>
+        internal void Select(string connectionId, string modelId)
+        {
+            if (_service is null) return;
+
+            _service.SetActive(connectionId, modelId);
+            IsOpen = false;
+            Search = "";
+            _changed?.Invoke();
+        }
+
+        private void Manage()
+        {
+            IsOpen = false;
+            _ = App.ShowSettingsWindow();
+        }
+
+        private void Rebuild()
+        {
+            Groups.Clear();
+            if (_service is null) return;
+
+            foreach (var connection in _service.Connections)
+            {
+                var models = connection.Models
+                    .Where(m => m.Enabled)
+                    .Where(m => Matches(m))
+                    .OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
+                    .Select(m => new AiPickerModelViewModel(this, connection, m,
+                        isCurrent: IsCurrent(connection, m)))
+                    .ToList();
+
+                if (models.Count == 0) continue;
+
+                Groups.Add(new AiPickerGroupViewModel(connection, models));
+            }
+
+            this.RaisePropertyChanged(nameof(CurrentLabel));
+            this.RaisePropertyChanged(nameof(HasChoices));
+            this.RaisePropertyChanged(nameof(HasNothingMatching));
+        }
+
+        private bool Matches(AiModelEntry model) =>
+            string.IsNullOrWhiteSpace(Search) ||
+            model.DisplayName.Contains(Search, StringComparison.OrdinalIgnoreCase) ||
+            model.Id.Contains(Search, StringComparison.OrdinalIgnoreCase);
+
+        private bool IsCurrent(AiConnection connection, AiModelEntry model) =>
+            string.Equals(_service?.Active?.Id, connection.Id, StringComparison.Ordinal) &&
+            string.Equals(_service?.ActiveModelId, model.Id, StringComparison.Ordinal);
+
+        internal void Refresh() => Rebuild();
+    }
+
+    /// <summary>One connection's enabled models, under its name. (#693)</summary>
+    public class AiPickerGroupViewModel : ViewModelBase
+    {
+        public AiPickerGroupViewModel(AiConnection connection, IReadOnlyList<AiPickerModelViewModel> models)
+        {
+            DisplayName = connection.DisplayName;
+            Monogram = AiMonogram.For(connection.DisplayName);
+            MonogramTone = AiMonogram.ToneFor(connection.Id);
+            Models = models;
+
+            // Marked, never hidden: the reader may be about to start their local runner, and a provider that
+            // vanished from the picker because it was asleep would look like a lost configuration.
+            Note = connection.State == Reachability.Unreachable ? "not responding" : "";
+        }
+
+        public string DisplayName { get; }
+        public string Monogram { get; }
+        public int MonogramTone { get; }
+        public string Note { get; }
+        public bool HasNote => Note.Length > 0;
+        public IReadOnlyList<AiPickerModelViewModel> Models { get; }
+    }
+
+    /// <summary>One pickable model. (#693)</summary>
+    public class AiPickerModelViewModel : ViewModelBase
+    {
+        private readonly AiModelPickerViewModel _owner;
+        private readonly string _connectionId;
+
+        public AiPickerModelViewModel(
+            AiModelPickerViewModel owner, AiConnection connection, AiModelEntry model, bool isCurrent)
+        {
+            _owner = owner;
+            _connectionId = connection.Id;
+
+            ModelId = model.Id;
+            DisplayName = model.DisplayName;
+            IsCurrent = isCurrent;
+            Unusable = ReasonItCannotBeUsed(connection);
+
+            SelectCommand = ReactiveCommand.Create(() => _owner.Select(_connectionId, ModelId));
+        }
+
+        public string ModelId { get; }
+
+        public string DisplayName { get; }
+
+        /// <summary>Marked with a check, so the reader can see what answered the last question without
+        /// opening anything else.</summary>
+        public bool IsCurrent { get; }
+
+        /// <summary>
+        /// Why this model cannot be used, or empty when it can.
+        ///
+        /// <para>Said here rather than discovered as a 401 that names nothing — which is the failure this
+        /// exists to prevent.</para>
+        /// </summary>
+        public string Unusable { get; }
+
+        public bool IsUsable => Unusable.Length == 0;
+
+        public ReactiveCommand<Unit, Unit> SelectCommand { get; }
+
+        /// <summary>
+        /// Only reasons we can state as fact.
+        ///
+        /// <para>A missing key is a problem for a provider whose preset says it requires one, and that is a
+        /// provider fact from the extraction rather than a guess. For a custom endpoint nothing is claimed:
+        /// plenty of them need no key at all, and disabling a model on a hunch would be worse than letting
+        /// the request explain itself.</para>
+        /// </summary>
+        private static string ReasonItCannotBeUsed(AiConnection connection)
+        {
+            if (connection.IsIncomplete) return "not finished being set up";
+
+            var preset = AiProviderPresets.ById(connection.Id);
+            if (preset is { RequiresKey: true } && connection.KeySource == CredentialSource.None)
+                return "no API key stored";
+
+            return "";
+        }
+    }
+}

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -83,6 +83,112 @@
                     </TextBox.KeyBindings>
                 </TextBox>
 
+                <!-- The per-turn model chip (#693). At the composer rather than in Settings: comparing two
+                     models on the same passage is the task the assistant exists for, and it wants to be one
+                     click from the answer on screen. Hidden until there is more than one model to choose
+                     between — a chip offering one thing is a control that cannot do anything. -->
+                <Button x:Name="ModelChip"
+                        IsVisible="{Binding ModelPicker.HasChoices}"
+                        HorizontalAlignment="Left"
+                        Padding="8,3"
+                        CornerRadius="12"
+                        FontSize="11"
+                        Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                        BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1">
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <TextBlock Text="{Binding ModelPicker.CurrentLabel}" VerticalAlignment="Center"/>
+                        <TextBlock Text="⌄" FontSize="10" VerticalAlignment="Center"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                    </StackPanel>
+
+                    <Button.Flyout>
+                        <Flyout Placement="Top" ShowMode="Standard">
+                            <Grid RowDefinitions="Auto,*,Auto" Width="330" MaxHeight="360">
+
+                                <!-- Pinned above a scrolling list, and it takes focus: the list can grow. -->
+                                <TextBox Grid.Row="0" Text="{Binding ModelPicker.Search}"
+                                         Watermark="Search models" Margin="0,0,0,6"/>
+
+                                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                                    <StackPanel>
+                                        <TextBlock IsVisible="{Binding ModelPicker.HasNothingMatching}"
+                                                   Text="No models match."
+                                                   FontSize="11" Margin="4,6"
+                                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+
+                                        <ItemsControl ItemsSource="{Binding ModelPicker.Groups}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:AiPickerGroupViewModel">
+                                                    <StackPanel Margin="0,0,0,6">
+                                                        <!-- Grouped by connection: it is what stops "the 8B I
+                                                             run locally" and "the hosted 70B" reading as
+                                                             interchangeable rows. -->
+                                                        <StackPanel Orientation="Horizontal" Spacing="6"
+                                                                    Margin="4,2">
+                                                            <TextBlock Text="{Binding DisplayName}"
+                                                                       FontSize="11" FontWeight="SemiBold"
+                                                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                            <!-- Marked, never hidden: the reader may be
+                                                                 about to start their local runner. -->
+                                                            <TextBlock Text="{Binding Note}"
+                                                                       IsVisible="{Binding HasNote}"
+                                                                       FontSize="11"
+                                                                       Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
+                                                        </StackPanel>
+
+                                                        <ItemsControl ItemsSource="{Binding Models}">
+                                                            <ItemsControl.ItemTemplate>
+                                                                <DataTemplate x:DataType="vm:AiPickerModelViewModel">
+                                                                    <Button Command="{Binding SelectCommand}"
+                                                                            IsEnabled="{Binding IsUsable}"
+                                                                            HorizontalAlignment="Stretch"
+                                                                            HorizontalContentAlignment="Left"
+                                                                            Background="Transparent"
+                                                                            BorderThickness="0"
+                                                                            Padding="8,4">
+                                                                        <Grid ColumnDefinitions="Auto,*,Auto">
+                                                                            <TextBlock Grid.Column="0"
+                                                                                       Text="✓"
+                                                                                       IsVisible="{Binding IsCurrent}"
+                                                                                       Margin="0,0,6,0"
+                                                                                       Foreground="{DynamicResource DockApplicationAccentBrushLow}"/>
+                                                                            <TextBlock Grid.Column="1"
+                                                                                       Text="{Binding DisplayName}"
+                                                                                       TextTrimming="CharacterEllipsis"/>
+                                                                            <!-- Said here rather than
+                                                                                 discovered as a 401 naming
+                                                                                 nothing. -->
+                                                                            <TextBlock Grid.Column="2"
+                                                                                       Text="{Binding Unusable}"
+                                                                                       IsVisible="{Binding !IsUsable}"
+                                                                                       FontSize="11"
+                                                                                       Margin="6,0,0,0"
+                                                                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                                        </Grid>
+                                                                    </Button>
+                                                                </DataTemplate>
+                                                            </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </ScrollViewer>
+
+                                <!-- Pinned at the bottom: the route back to the full listing. -->
+                                <Button Grid.Row="2" Content="Manage models…"
+                                        Command="{Binding ModelPicker.ManageCommand}"
+                                        HorizontalAlignment="Left"
+                                        Background="Transparent" BorderThickness="0"
+                                        FontSize="11" Padding="4,4,4,0"
+                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                            </Grid>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+
                 <WrapPanel Orientation="Horizontal">
                     <!-- First, and disabled until something is typed: the other four are complete without a
                          question, and this one IS the question. -->

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml.cs
@@ -16,9 +16,60 @@ namespace CST.Avalonia.Views;
 /// </summary>
 public partial class AiAssistantPanel : UserControl
 {
-    public AiAssistantPanel() => InitializeComponent();
+    private AiModelPickerViewModel? _picker;
+
+    private bool _syncingFlyout;
+
+    public AiAssistantPanel()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+
+        // Mirror the flyout's own state into the view model. Needed in both directions: the view model has
+        // to KNOW it is open for its later close to register as a change, and a reader who dismisses the
+        // list by clicking away must not leave it believing otherwise.
+        if (ModelChip.Flyout is { } flyout)
+        {
+            flyout.Opened += (_, _) => SetOpen(true);
+            flyout.Closed += (_, _) => SetOpen(false);
+        }
+    }
+
+    private void SetOpen(bool open)
+    {
+        if (_picker is null) return;
+        _syncingFlyout = true;
+        try { _picker.IsOpen = open; }
+        finally { _syncingFlyout = false; }
+    }
 
     private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void OnDataContextChanged(object? sender, System.EventArgs e)
+    {
+        if (_picker is not null) _picker.PropertyChanged -= OnPickerChanged;
+        _picker = (DataContext as AiAssistantViewModel)?.ModelPicker;
+        if (_picker is not null) _picker.PropertyChanged += OnPickerChanged;
+    }
+
+    /// <summary>
+    /// Closes the model flyout once a choice is made. (#693)
+    ///
+    /// <para>Code-behind because a <c>Flyout</c> owns its own open state: it opens itself when the chip is
+    /// clicked and there is no bindable property to close it through. Without this, picking a model leaves
+    /// the list sitting over the composer — and the reader's next act is to dismiss a popup rather than to
+    /// ask the question they opened it for.</para>
+    ///
+    /// <para>Driven from the view model's own <c>IsOpen</c> rather than from each row's click handler, so
+    /// every route that ends the choice — picking a model, or leaving for Settings — closes it the same
+    /// way.</para>
+    /// </summary>
+    private void OnPickerChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (_syncingFlyout) return;   // the flyout told us; do not tell it back
+        if (e.PropertyName != nameof(AiModelPickerViewModel.IsOpen)) return;
+        if (_picker?.IsOpen == false) ModelChip.Flyout?.Hide();
+    }
 
     /// <summary>
     /// Drag the reasoning panel taller or shorter. The one piece of code-behind here, because


### PR DESCRIPTION
Closes #693. **Stacked on #713** — targets `feat/691-connections-ui`, because the picker offers the enabled
models that PR's Models tab produces. Merge #713 first and this rebases onto main cleanly.

Switching model meant opening Settings, changing a field, and coming back. That is the wrong shape for the
thing this feature exists to do: comparing two models on the same passage is the actual task, and it wants to
be one click from the answer on screen.

## Shape

A chip at the composer shows the current model **by its display name** — nobody calls the thing they are
talking to `nvidia/nemotron-nano-9b-v2` — and opens a list with a pinned search box, the enabled models
**grouped by connection**, the current one checked, and **Manage models…** pinned at the bottom.

Grouped rather than flat: Claude Desktop's picker is flat, which works at four models. Once several endpoints
are configured, grouping is what stops *"the 8B I run locally"* and *"the hosted 70B"* reading as
interchangeable rows.

It offers the **enabled subset only**. The full listing lives in Settings → Models, so this is the short list
the reader built there — which is what lets it be a plain grouped list with no virtualization, and makes
search a comfort rather than a necessity.

**Choosing a model on another connection moves the connection with it.** Switching across providers means
switching base URL *and* credential; a picker carrying only the model id would send one provider's model to
another's endpoint and fail confusingly.

## Said rather than discovered

A model whose connection cannot be used is shown **disabled with the reason**, so the failure is read before
the send rather than as a 401 naming neither cause nor connection.

**Only reasons we can state as fact.** A missing key disqualifies a provider whose *preset* says it requires
one — a provider fact from the #682 extraction. For a custom endpoint nothing is claimed: plenty need no key
at all, and disabling on a hunch would be worse than letting the request explain itself.

An **unreachable connection is marked, never hidden**. The reader may be about to start their local runner,
and a provider that vanished from the picker because it was asleep would look like a lost configuration.

The chip is hidden until there is more than one model — a chip offering one thing is a control that cannot do
anything.

## One piece of code-behind

The flyout's open state is mirrored into the view model **in both directions**: the view model has to know it
is open for its later close to register as a change, and a reader who dismisses the list by clicking away must
not leave it believing otherwise. A `Flyout` owns its own open state and exposes no bindable property to close
it through.

Without this, picking a model left the list sitting over the composer, and the reader's next act was to
dismiss a popup rather than ask the question they had opened it for. Worth naming because it is invisible to
the view-model tests — they were green while the flyout stayed stubbornly open.

## Testing

**2052 passing, 0 warnings in both projects.** 15 new tests. Manual pass worth doing once #713 is in:

1. Configure two connections with a couple of enabled models each — the chip appears at the composer.
2. Open it: models grouped under each connection, current one checked, search filters name and id.
3. Pick a model on the *other* connection and ask something — the answer must come from that provider.
4. Add a preset without a key, enable a model on it: that row should be **disabled**, reading "no API key
   stored".
5. Stop a local runner and use it once so it is marked unreachable — its group keeps its models and gains a
   "not responding" note.
6. **Manage models…** opens Settings.
