### PR TITLE
Choose the model for the next message from the composer (#693)

### DIFF
--- a/docs/reference/OpenCode/opencode-provider-ux-notes.md
+++ b/docs/reference/OpenCode/opencode-provider-ux-notes.md
@@ -568,6 +568,13 @@ screenshot cannot show — and it is usually the thing that determines what the 
 
 ### ⚠ Correction 2 — NOT-list item 6 was wrong; revised in place
 
+> **⚠ SUPERSEDED 2026-08-18 by the source finding below** ("where the pre-enabled subset comes from"). The
+> rule stated here — that subsets are the verdict and all-on/all-off are both neutral — **stands and is
+> unchanged**. What is wrong below is the factual claim that OpenCode defaults a connected provider to
+> all-on. It does not: it enables the newest model per family released in the last six months, which is a
+> pre-enabled subset, i.e. the very thing this correction rules out. The Veo/Lyria evidence was consistent
+> with all-on but did not establish it.
+
 Batch 2's NOT-list said "Any model toggled on by default… **Default must be all-off**." **That is wrong as
 written**, and it is now revised in place (see NOT-list 6). The correct rule is about **subsets**, not about
 the on-state:
@@ -647,6 +654,111 @@ to us; `CST_AI_API_KEY` is.
 
 ---
 
+## Source finding (2026-08-18) — where the pre-enabled subset comes from
+
+Read from the source rather than the screen, at `anomalyco/opencode@0033bb3`. This **closes open question 1's
+tail and corrects Correction 2**, and it is the first case in this study where the falsified thing is a rule
+we had already built policy on.
+
+### What the maintainer observed
+
+Connecting OpenRouter with a real key produced a toast — *"OpenRouter connected. Select models."* — and a
+Models list of a couple of hundred entries under an OpenRouter group, of which **roughly 30 to 40 were on and
+the rest off**.
+
+That is neither of the two defaults this document had argued about. Batch 2's screenshot suggested all-off;
+Correction 2 reversed it to all-on from the Veo/Lyria evidence. The truth is a **pre-enabled subset**, which
+is the one outcome #689 names as forbidden — and which neither a screenshot nor a single live session could
+have explained, because the question is not what the toggles show but what computes them.
+
+### The rule, from source
+
+`packages/app/src/context/models.tsx`:
+
+```js
+const visible = (model) => {
+  const state = visibility().get(key)
+  if (state === "hide") return false      // the user turned it off
+  if (state === "show") return true       // the user turned it on
+  if (latestSet().has(key)) return true   // otherwise: is it "latest"?
+  const date = release().get(key)
+  if (!date?.isValid) return true         // no release date at all -> on
+  return false                            // dated, and not latest -> off
+}
+```
+
+and `latest` is, in the same file: take every available model, **keep only those released within the last six
+months**, group by provider, group again by `family`, and keep **the newest member of each family**.
+
+So the default-on set is *the newest model in each family, per provider, released in the last six months*,
+plus anything whose `release_date` is missing or unparseable. `family` and `release_date` come from
+models.dev. There is no hand-written list of model ids anywhere in it.
+
+### Why this matters to us, precisely
+
+**It is mechanical in implementation and a verdict in substance.** Nobody typed a list of good models; a rule
+computed one. But the rule encodes "newer is what you want", and #689 rejects exactly that in words:
+
+> even "newest first" editorializes, since a newer point release can be worse at Pāli.
+
+For a coding agent the assumption is defensible — capability there does track recency fairly well. For Pāli it
+is the assumption the model registry was deleted over (#670/#681), and adopting it because it arrived as
+`release_date` arithmetic rather than as a curated table would be the registry returning through the back
+door. **A mechanical computation of an editorial judgment is still the editorial judgment.**
+
+Note also what this does *not* settle: it is a recency rule, **not** the capability filter this document
+speculated about under steal 9. There is no modality or `supported_parameters` gate on the default at all —
+which is why a music model and a video model reached the picker in batch 5. The capability filter remains a
+good idea that upstream has not had.
+
+### The second finding: "Popular" is a literal list
+
+`packages/app/src/hooks/use-providers.ts:8`:
+
+```js
+export const popularProviders = [
+  "opencode", "opencode-go", "anthropic", "github-copilot",
+  "openai", "google", "openrouter", "vercel",
+]
+```
+
+Eight entries, hand-written, **their own two products first**. It is used three times: to sort provider
+groups in Settings → Models, to sort the groups in the composer's model picker, and as the *"Popular
+providers"* section on the Providers page.
+
+So batch 1's suspicion about OpenCode Zen's `Recommended` badge was right and understated. The curation is not
+a badge on one row — it is the ordering of every provider surface in the app, and it is a constant in a hooks
+file. Nothing in the UI says a choice was made.
+
+### Consequences for the ongoing sync
+
+The plan is to track upstream provider facts and fold in changes. This finding sharpens the do-not-take list,
+which now has two tiers:
+
+- **Never take as an input to any default or ordering:** `release_date`, `family`, `popularProviders` or any
+  successor, pricing, `status`, vendor `description`. Displaying `release_date` verbatim next to a model is
+  fine; letting it decide what is enabled is not.
+- **Take freely:** base URLs, env var names, auth shapes, wire protocol, prompts/inputs a provider needs.
+
+The general rule this produces, worth keeping in front of whoever does the next sync: **pull named fields,
+never "whatever the source says", and audit any field that reaches a default rather than a display.** A
+recency rule is easy to re-adopt by accident precisely because it looks like arithmetic rather than an
+opinion.
+
+### Consequence for our own defaults (#692, #674)
+
+The two cases separate, and conflating them is what made this argument go round twice:
+
+- **A hand-typed model list — what #691/#692 ship.** Typing a model id *is* the act of selecting it. All-on
+  is right, and all-off would mean typing a model and then hunting for a switch before it appears anywhere.
+- **A fetched catalogue — #674.** Hundreds of models nobody asked for. All-off is right there, and the
+  maintainer's instinct on seeing OpenRouter's list agrees. OpenCode's toast (*"Select models"*) reads as if
+  they had made that choice too; their code did something else.
+
+Neither case may use a pre-enabled subset, however it is computed.
+
+---
+
 ## Method note — what screenshots could not show
 
 Worth stating plainly for whoever reads these notes later, because the pattern repeated with unusual
@@ -662,6 +774,12 @@ screenshot was falsified by someone actually using the app:**
    determines the mechanism's meaning.
 3. **The finding above — the empty action slot.** It photographed as principled restraint. In use it is a
    dead end with no exit.
+4. **(added 2026-08-18) The pre-enabled subset.** Two screenshots and a live session produced three different
+   answers about the default toggle state — off, then all-on, then "about forty of two hundred". Only the
+   source settled it, and the answer was a *rule*, which is a thing no amount of looking at the UI can show.
+   The lesson extends the one below: use gives you behaviour, but where behaviour is computed from data you
+   cannot see, **the source is the only witness** — and it is worth reading before building policy on an
+   inference about it.
 
 The generalisation: **screenshots show structure, wording, hierarchy and affordances — the happy path, at
 rest. They do not show what happens when something goes wrong, or when the user changes their mind.**

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -1,0 +1,179 @@
+using System.Linq;
+using CST.Avalonia.Services.Ai;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// #674: reading a provider's model listing.
+///
+/// <para>The parser is the whole risk surface. One code path serves OpenRouter's richly annotated 414, the
+/// three fields Anthropic publishes, and the bare ids a local Ollama returns — so every test here is really
+/// asking the same question: does an absent field degrade, or break?</para>
+/// </summary>
+public class AiModelCatalogTests
+{
+    // ---- the three shapes one parser has to serve ------------------------------------------------------
+
+    /// <summary>OpenRouter: everything published at once. The fields are pulled by name — never "whatever
+    /// the source says" — because a listing can gain a ranking field in a release nobody read.</summary>
+    [Fact]
+    public void An_openrouter_entry_yields_every_published_field()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{
+          "id":"nvidia/nemotron-nano-9b-v2",
+          "name":"NVIDIA Nemotron Nano 9B V2",
+          "context_length":131072,
+          "pricing":{"prompt":"0.0000004","completion":"0.0000016"},
+          "architecture":{"input_modalities":["text"],"output_modalities":["text"]},
+          "supported_parameters":["temperature","reasoning"]
+        }]}
+        """);
+
+        var model = Assert.Single(models);
+        Assert.Equal("nvidia/nemotron-nano-9b-v2", model.Id);
+        Assert.Equal("NVIDIA Nemotron Nano 9B V2", model.DisplayName);
+        Assert.Equal(131072, model.ContextLength);
+        Assert.Equal(0.4m, model.PromptPricePerMillion);
+        Assert.Equal(1.6m, model.CompletionPricePerMillion);
+        Assert.True(model.SupportsReasoning);
+        Assert.True(model.IsTextToText);
+    }
+
+    /// <summary>Anthropic names the field differently and publishes nothing else.</summary>
+    [Fact]
+    public void An_anthropic_entry_uses_display_name()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"id":"claude-sonnet-4-5","display_name":"Claude Sonnet 4.5","type":"model"}]}
+        """);
+
+        var model = Assert.Single(models);
+        Assert.Equal("Claude Sonnet 4.5", model.DisplayName);
+        Assert.Null(model.ContextLength);
+        Assert.False(model.SupportsReasoning);
+    }
+
+    /// <summary>
+    /// A local runner publishes an id and nothing else — the ordinary case, not a degraded one.
+    ///
+    /// <para>It must still be usable, and in particular must survive the capability filter: a model with no
+    /// published modality has not said it cannot handle text, and filtering it away on a field the provider
+    /// never sent would make every local endpoint look empty.</para>
+    /// </summary>
+    [Fact]
+    public void An_ollama_entry_survives_on_its_id_alone()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"id":"gemma4:12b-mlx","object":"model","owned_by":"library"}]}
+        """);
+
+        var model = Assert.Single(models);
+        Assert.Equal("gemma4:12b-mlx", model.Id);
+        Assert.Equal("gemma4:12b-mlx", model.DisplayName);
+        Assert.True(model.IsTextToText);
+    }
+
+    // ---- the capability filter -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Mechanical, and built only from what the provider published: a model that cannot take text in and give
+    /// text out cannot answer a question at all. It is not a judgment about the models that remain — which is
+    /// the line #670/#681 draws, and the filter OpenCode omits, which is why a music model and a video model
+    /// reach their chat picker.
+    /// </summary>
+    [Theory]
+    [InlineData("""{"input_modalities":["text"],"output_modalities":["text"]}""", true)]
+    [InlineData("""{"input_modalities":["text","image"],"output_modalities":["text"]}""", true)]
+    [InlineData("""{"input_modalities":["text"],"output_modalities":["audio"]}""", false)]
+    [InlineData("""{"input_modalities":["text"],"output_modalities":["video"]}""", false)]
+    [InlineData("""{"modality":"text->text"}""", true)]
+    [InlineData("""{"modality":"text+image->text"}""", true)]
+    [InlineData("""{"modality":"text->image"}""", false)]
+    public void Only_models_that_answer_in_text_pass_the_capability_filter(string architecture, bool expected)
+    {
+        var models = AiModelCatalog.Parse($$"""{"data":[{"id":"m","architecture":{{architecture}}}]}""");
+
+        Assert.Equal(expected, Assert.Single(models).IsTextToText);
+    }
+
+    // ---- ordering and robustness -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Alphabetical, which is mechanical. The ordering upstream uses — newest first, computed from release
+    /// dates — is an editorial claim however arithmetically it is arrived at, since a newer point release can
+    /// be worse at Pāli (#689).
+    /// </summary>
+    [Fact]
+    public void Models_come_back_in_alphabetical_order()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"id":"c","name":"Zephyr"},{"id":"a","name":"Apollo"},{"id":"b","name":"mercury"}]}
+        """);
+
+        Assert.Equal(new[] { "Apollo", "mercury", "Zephyr" }, models.Select(m => m.DisplayName));
+    }
+
+    /// <summary>A price of zero is free and may be said so; an absent price is unknown and must not be
+    /// rendered as free.</summary>
+    [Fact]
+    public void An_absent_price_is_unknown_rather_than_free()
+    {
+        var models = AiModelCatalog.Parse("""{"data":[{"id":"m"}]}""");
+
+        Assert.Null(Assert.Single(models).PromptPricePerMillion);
+    }
+
+    [Fact]
+    public void A_zero_price_is_kept_as_zero()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"id":"m","pricing":{"prompt":"0","completion":"0"}}]}
+        """);
+
+        Assert.Equal(0m, Assert.Single(models).PromptPricePerMillion);
+    }
+
+    /// <summary>OpenRouter nests it under <c>top_provider</c> for some entries; the same list mixes both
+    /// shapes.</summary>
+    [Fact]
+    public void Context_length_is_read_from_either_place()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"id":"m","top_provider":{"context_length":8192}}]}
+        """);
+
+        Assert.Equal(8192, Assert.Single(models).ContextLength);
+    }
+
+    /// <summary>An entry with no id is not a model. Skipped rather than admitted as an empty row that would
+    /// send an empty string on the wire.</summary>
+    [Fact]
+    public void Entries_without_an_id_are_skipped()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"name":"No id here"},{"id":"real"},"a string",42]}
+        """);
+
+        Assert.Equal("real", Assert.Single(models).Id);
+    }
+
+    [Fact]
+    public void A_response_without_a_data_array_yields_nothing() =>
+        Assert.Empty(AiModelCatalog.Parse("""{"models":[{"id":"m"}]}"""));
+
+    /// <summary>Reasoning support is read from the provider's published parameters, never guessed from a
+    /// name — "thinking" in a model's title is marketing, `supported_parameters` is a fact.</summary>
+    [Theory]
+    [InlineData("""["reasoning"]""", true)]
+    [InlineData("""["include_reasoning"]""", true)]
+    [InlineData("""["thinking"]""", true)]
+    [InlineData("""["temperature","top_p"]""", false)]
+    public void Reasoning_support_comes_from_supported_parameters(string parameters, bool expected)
+    {
+        var models = AiModelCatalog.Parse($$"""{"data":[{"id":"m","supported_parameters":{{parameters}}}]}""");
+
+        Assert.Equal(expected, Assert.Single(models).SupportsReasoning);
+    }
+}

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -1,0 +1,413 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.ViewModels;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// #691: the connection sheet — a custom endpoint, a preset that needs more than a key, or an edit.
+/// </summary>
+public class AiConnectionEditorViewModelTests
+{
+    private sealed class Harness
+    {
+        public AiConnectionService Service { get; }
+        public FakeCredentialStore Keys { get; } = new();
+        public bool? Closed { get; private set; }
+
+        public Harness()
+        {
+            var settings = new Settings();
+            var svc = new Mock<ISettingsService>();
+            svc.SetupGet(s => s.Settings).Returns(settings);
+            Service = new AiConnectionService(svc.Object, Keys);
+        }
+
+        public void Close(bool saved) => Closed = saved;
+
+        public AiConnectionEditorViewModel Custom() =>
+            AiConnectionEditorViewModel.ForCustom(Service, Keys, Close);
+
+        public AiConnectionEditorViewModel Preset(string id) =>
+            AiConnectionEditorViewModel.ForPreset(
+                Service, Keys, Service.Presets.Single(p => p.Id == id), Close);
+
+        public AiConnectionEditorViewModel Existing(string id) =>
+            AiConnectionEditorViewModel.ForExisting(
+                Service, Keys, Service.Connections.Single(c => c.Id == id), Close);
+    }
+
+    /// <summary>An in-memory keychain, so no test prompts for a real one.</summary>
+    private sealed class FakeCredentialStore : IAiCredentialStore
+    {
+        public Dictionary<string, string> Stored { get; } = new(StringComparer.Ordinal);
+        public bool IsAvailable => true;
+        public string? Unavailable => null;
+        public string? GetApiKey(string connectionId) => Stored.GetValueOrDefault(connectionId);
+        public bool SetApiKey(string connectionId, string apiKey) { Stored[connectionId] = apiKey; return true; }
+        public bool DeleteApiKey(string connectionId) => Stored.Remove(connectionId);
+    }
+
+    private static void Save(AiConnectionEditorViewModel vm) => vm.SaveCommand.Execute().Subscribe();
+
+    // ---- identity --------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The id is defaulted from the host so a reader who does not care never has to invent one — but it stays
+    /// a default. Deriving it permanently is the mistake: a URL-derived key changes the moment a port does,
+    /// and the credential then looks rejected rather than lost.
+    /// </summary>
+    [Fact]
+    public void The_id_is_suggested_from_the_host_until_one_is_typed()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+
+        vm.BaseUrl = "http://localhost:11434/v1";
+
+        Assert.Equal("localhost", vm.Id);
+    }
+
+    [Fact]
+    public void A_typed_id_is_never_overwritten_by_a_later_url_edit()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+
+        vm.Id = "my-box";
+        vm.BaseUrl = "http://localhost:11434/v1";
+
+        Assert.Equal("my-box", vm.Id);
+    }
+
+    [Fact]
+    public void A_dotted_host_becomes_a_usable_slug()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+
+        vm.BaseUrl = "https://api.MyProvider.com/v1";
+
+        Assert.Equal("api-myprovider-com", vm.Id);
+    }
+
+    /// <summary>Immutable once the credential is filed under it. An editable id would mean migrating the
+    /// keychain account with every rename.</summary>
+    [Fact]
+    public void The_id_cannot_be_changed_once_the_connection_exists()
+    {
+        var h = new Harness();
+        h.Service.Add("mine", Draft());
+
+        var vm = h.Existing("mine");
+
+        Assert.False(vm.IsIdEditable);
+    }
+
+    // ---- refusals are shown, not swallowed -------------------------------------------------------------
+
+    /// <summary>A duplicate id would mean one connection inheriting another's credential, so the service's
+    /// refusal has to reach the reader and the sheet has to stay open on the field that caused it.</summary>
+    [Fact]
+    public void A_duplicate_id_keeps_the_sheet_open_and_says_why()
+    {
+        var h = new Harness();
+        h.Service.Add("mine", Draft());
+
+        var vm = h.Custom();
+        vm.Id = "mine";
+        vm.BaseUrl = "http://localhost:9000/v1";
+        Save(vm);
+
+        Assert.True(vm.HasProblem);
+        Assert.Contains("already", vm.Problem);
+        Assert.Null(h.Closed);
+        Assert.Single(h.Service.Connections);
+    }
+
+    /// <summary>A preset id is reserved, and taking it by hand collides with the built-in the reader might
+    /// add later.</summary>
+    [Fact]
+    public void A_reserved_id_is_refused_with_the_services_own_sentence()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+
+        vm.Id = "openrouter";
+        vm.BaseUrl = "http://localhost:9000/v1";
+        Save(vm);
+
+        Assert.True(vm.HasProblem);
+        Assert.Contains("built-in", vm.Problem);
+        Assert.Empty(h.Service.Connections);
+    }
+
+    /// <summary>An unanswered prompt means a base URL that keeps its placeholder, so the connection could
+    /// never send anything. Refused at the sheet rather than created unusable.</summary>
+    [Fact]
+    public void A_preset_missing_its_answer_is_refused()
+    {
+        var h = new Harness();
+        var vm = h.Preset("azure");
+
+        Save(vm);
+
+        Assert.True(vm.HasProblem);
+        Assert.Null(h.Closed);
+        Assert.Empty(h.Service.Connections);
+    }
+
+    // ---- saving ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_preset_with_its_answer_is_added_and_the_sheet_closes()
+    {
+        var h = new Harness();
+        var vm = h.Preset("azure");
+
+        vm.Inputs.Single(i => i.Key == "resourceName").Value = "my-resource";
+        Save(vm);
+
+        Assert.True(h.Closed);
+        var added = Assert.Single(h.Service.Connections);
+        Assert.Equal("https://my-resource.openai.azure.com/openai/v1", added.ResolvedBaseUrl);
+        Assert.False(added.IsIncomplete);
+    }
+
+    [Fact]
+    public void A_custom_endpoint_is_saved_with_its_models_and_headers()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+
+        vm.Id = "my-box";
+        vm.DisplayName = "My box";
+        vm.BaseUrl = "http://localhost:8000/v1";
+        vm.Models[0].ModelId = "gemma4:12b-mlx";
+        vm.Models[0].DisplayName = "Gemma4 12B MLX";
+        vm.AddHeaderCommand.Execute().Subscribe();
+        vm.Headers[0].Name = "X-Gateway";
+        vm.Headers[0].Value = "token";
+        Save(vm);
+
+        var added = Assert.Single(h.Service.Connections);
+        Assert.Equal("My box", added.DisplayName);
+        Assert.Equal("gemma4:12b-mlx", added.Models.Single().Id);
+        Assert.Equal("Gemma4 12B MLX", added.Models.Single().DisplayName);
+        Assert.Equal("token", added.Headers["X-Gateway"]);
+    }
+
+    /// <summary>Blank rows are the natural state of a repeating form — one is offered on open — so they must
+    /// be dropped rather than saved as a model whose id is the empty string.</summary>
+    [Fact]
+    public void Empty_rows_are_dropped_rather_than_saved()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+
+        vm.Id = "my-box";
+        vm.BaseUrl = "http://localhost:8000/v1";
+        vm.AddModelCommand.Execute().Subscribe();
+        vm.AddHeaderCommand.Execute().Subscribe();
+        Save(vm);
+
+        var added = Assert.Single(h.Service.Connections);
+        Assert.Empty(added.Models);
+        Assert.Empty(added.Headers);
+    }
+
+    /// <summary>The display name is for humans and the id is for the wire; when only one is given, showing
+    /// the id beats showing an empty row.</summary>
+    [Fact]
+    public void A_model_with_no_display_name_falls_back_to_its_id()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+
+        vm.Id = "my-box";
+        vm.BaseUrl = "http://localhost:8000/v1";
+        vm.Models[0].ModelId = "llama3.1:8b";
+        Save(vm);
+
+        Assert.Equal("llama3.1:8b", h.Service.Connections.Single().Models.Single().DisplayName);
+    }
+
+    /// <summary>
+    /// Editing must not quietly re-enable what the reader turned off.
+    ///
+    /// <para>The sheet has no control for <c>Enabled</c> — that belongs on the Models tab (#692) — so the flag
+    /// is carried through untouched. Rebuilding the model list from the form's visible fields alone would
+    /// silently reset it, and the reader would find their pruned short list restored by an unrelated rename.</para>
+    /// </summary>
+    [Fact]
+    public void An_edit_preserves_which_models_were_turned_off()
+    {
+        var h = new Harness();
+        h.Service.Add("mine", Draft() with
+        {
+            Models = new List<AiModelEntry>
+            {
+                new("a", "A", true),
+                new("b", "B", false),
+            },
+        });
+
+        var vm = h.Existing("mine");
+        vm.DisplayName = "Renamed";
+        Save(vm);
+
+        var saved = h.Service.Connections.Single();
+        Assert.Equal("Renamed", saved.DisplayName);
+        Assert.True(saved.Models.Single(m => m.Id == "a").Enabled);
+        Assert.False(saved.Models.Single(m => m.Id == "b").Enabled);
+    }
+
+    [Fact]
+    public void Cancelling_closes_without_saving()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+        vm.Id = "my-box";
+        vm.BaseUrl = "http://localhost:8000/v1";
+
+        vm.CancelCommand.Execute().Subscribe();
+
+        Assert.False(h.Closed);
+        Assert.Empty(h.Service.Connections);
+    }
+
+    // ---- what a named provider's sheet asks for --------------------------------------------------------
+
+    /// <summary>
+    /// A named provider's sheet asks for the key and nothing else.
+    ///
+    /// <para>Its model list is fetched once the connection exists (#674), so a model box here would make the
+    /// reader decide whether they need to type an id <i>before</i> seeing what the provider returns — and for
+    /// OpenRouter's four hundred it is a box nobody should ever fill in. The escape hatch for an id a listing
+    /// omits lives on the Models tab, beside the listing that omitted it.</para>
+    /// </summary>
+    [Fact]
+    public void A_named_providers_sheet_asks_for_the_key_and_nothing_else()
+    {
+        var vm = new Harness().Preset("openrouter");
+
+        Assert.False(vm.IsFullForm);        // no id, display name, protocol or base URL to fill in
+        Assert.False(vm.ShowHeaders);       // the preset carries whatever headers it needs
+        Assert.False(vm.ShowModels);        // fetched, not typed
+        Assert.Empty(vm.Models);
+        Assert.True(vm.ShowKeyField);
+        Assert.True(vm.ShowFixedEndpoint);  // shown, not asked - where the money goes
+        Assert.Equal("https://openrouter.ai/api/v1", vm.FixedEndpoint);
+    }
+
+    /// <summary>A custom endpoint still asks, and must: it may publish no listing at all, which is the
+    /// ordinary case for a local runner, and then typing is the only way in.</summary>
+    [Fact]
+    public void A_custom_endpoints_sheet_still_asks_for_models()
+    {
+        var vm = new Harness().Custom();
+
+        Assert.True(vm.ShowModels);
+        Assert.Single(vm.Models);
+    }
+
+    /// <summary>A local runner needs no key, and saying so beats an empty box the reader wonders about.</summary>
+    [Fact]
+    public void A_local_runner_is_not_asked_for_a_key()
+    {
+        var vm = new Harness().Preset("ollama");
+
+        Assert.False(vm.ShowKeyField);
+        Assert.True(vm.ShowFixedEndpoint);
+    }
+
+    /// <summary>The key reaches the store under the connection's own id, not under whichever one happened to
+    /// be active — which is #678 arriving by a different route.</summary>
+    [Fact]
+    public void A_key_typed_on_a_presets_sheet_is_filed_under_that_preset()
+    {
+        var h = new Harness();
+        var vm = h.Preset("openrouter");
+
+        vm.ApiKeyEntry = "sk-or-secret";
+        Save(vm);
+
+        Assert.Equal("sk-or-secret", h.Keys.GetApiKey("openrouter"));
+        Assert.Empty(h.Service.Connections.Single().Models);
+    }
+
+    /// <summary>The box exists to hand the key over, not to hold it.</summary>
+    [Fact]
+    public void The_key_box_is_cleared_once_the_key_is_stored()
+    {
+        var h = new Harness();
+        var vm = h.Preset("openrouter");
+
+        vm.ApiKeyEntry = "sk-or-secret";
+        Save(vm);
+
+        Assert.Equal("", vm.ApiKeyEntry);
+    }
+
+    /// <summary>Removing a stored key leaves the connection and its models untouched — the narrower of the
+    /// two destructive actions.</summary>
+    [Fact]
+    public void Removing_a_stored_key_keeps_the_connection()
+    {
+        var h = new Harness();
+        h.Service.Add("mine", Draft());
+        h.Keys.SetApiKey("mine", "sk-secret");
+
+        var vm = h.Existing("mine");
+        Assert.True(vm.HasStoredKey);
+
+        vm.RemoveKeyCommand.Execute().Subscribe();
+
+        Assert.False(vm.HasStoredKey);
+        Assert.Null(h.Keys.GetApiKey("mine"));
+        Assert.Single(h.Service.Connections);
+    }
+
+    // ---- conditional prompts ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// A prompt's <c>When</c> is re-evaluated as its trigger is typed, so a conditional field appears rather
+    /// than hides by default. Azure wants a resource name <i>or</i> an explicit URL, and asking for both at
+    /// once is wrong.
+    /// </summary>
+    [Fact]
+    public void A_conditional_prompt_hides_once_its_condition_stops_holding()
+    {
+        var h = new Harness();
+        var preset = new AiProviderPreset(
+            "conditional", "Conditional", ChatProviderKind.OpenAiCompatible,
+            "https://{host}/v1",
+            new AiCredentialMethod[] { new AiCredentialMethod.Key() },
+            new[]
+            {
+                new AiInputPrompt("mode", "Mode"),
+                new AiInputPrompt("host", "Host", When: new AiPromptCondition(
+                    "mode", AiConditionOperator.NotEquals, "auto")),
+            });
+
+        var vm = AiConnectionEditorViewModel.ForPreset(h.Service, h.Keys, preset, h.Close);
+        var host = vm.Inputs.Single(i => i.Key == "host");
+
+        Assert.True(host.IsVisible);
+
+        vm.Inputs.Single(i => i.Key == "mode").Value = "auto";
+
+        Assert.False(host.IsVisible);
+    }
+
+    private static AiConnectionDraft Draft(string name = "My box", string url = "http://localhost:8000/v1") =>
+        new(name, ChatProviderKind.OpenAiCompatible, url,
+            new List<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>());
+}

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -1,0 +1,438 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.ViewModels;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// #691: the Providers tab — configured connections above, a catalogue of named ones below.
+///
+/// <para>Driven through the real <see cref="AiConnectionService"/> over in-memory settings rather than a
+/// hand-written fake, so these exercise the binding surface the UI actually gets rather than a second
+/// opinion about it. The two rows the service cannot yet produce — an environment-sourced credential and a
+/// probed reachability — are built as records directly, which is the only way to reach that presentation
+/// code before the credential and probe plumbing land.</para>
+/// </summary>
+public class AiConnectionsViewModelTests
+{
+    private static (AiConnectionsViewModel Vm, AiConnectionService Service) Make() =>
+        Make(new FakeCredentialStore());
+
+    private static (AiConnectionsViewModel Vm, AiConnectionService Service) Make(FakeCredentialStore keys)
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object, keys);
+        return (new AiConnectionsViewModel(service, keys), service);
+    }
+
+    /// <summary>An in-memory keychain. The real one would need a Keychain prompt per test.</summary>
+    private sealed class FakeCredentialStore : IAiCredentialStore
+    {
+        public Dictionary<string, string> Keys { get; } = new(StringComparer.Ordinal);
+        public bool IsAvailable => true;
+        public string? Unavailable => null;
+        public string? GetApiKey(string connectionId) => Keys.GetValueOrDefault(connectionId);
+        public bool SetApiKey(string connectionId, string apiKey) { Keys[connectionId] = apiKey; return true; }
+        public bool DeleteApiKey(string connectionId) => Keys.Remove(connectionId);
+    }
+
+    /// <summary>Adds a preset the way a reader does — open the sheet, fill it in, save. There is no
+    /// add-without-a-sheet path any more, which is the point of the first test below.</summary>
+    private static void AddThroughSheet(
+        AiConnectionsViewModel vm, string presetId, string? key = null,
+        params (string Key, string Value)[] inputs)
+    {
+        vm.AddPreset(presetId);
+        var editor = vm.Editor!;
+
+        foreach (var (k, v) in inputs) editor.Inputs.Single(i => i.Key == k).Value = v;
+        if (key is not null) editor.ApiKeyEntry = key;
+
+        editor.SaveCommand.Execute().Subscribe();
+    }
+
+    private static AiConnectionDraft Draft(string name = "My box", string url = "http://localhost:8000/v1") =>
+        new(name, ChatProviderKind.OpenAiCompatible, url,
+            new List<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>());
+
+    // ---- the two sections ------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The whole point of the two-section layout: the catalogue reads as "what you could add next", so a
+    /// preset must leave it the moment a connection using it exists. A list where some rows are already
+    /// spoken for is the screen this replaces.
+    /// </summary>
+    [Fact]
+    public void An_added_preset_moves_from_the_catalogue_to_the_connections()
+    {
+        var (vm, _) = Make();
+        Assert.Contains(vm.AvailablePresets, p => p.Id == "openrouter");
+        Assert.Empty(vm.Connections);
+
+        AddThroughSheet(vm, "openrouter");
+
+        Assert.Contains(vm.Connections, c => c.Id == "openrouter");
+        Assert.DoesNotContain(vm.AvailablePresets, p => p.Id == "openrouter");
+    }
+
+    /// <summary>Deleting puts it back, so the reader can undo an add without knowing the URL by heart.</summary>
+    [Fact]
+    public void Deleting_a_connection_returns_its_preset_to_the_catalogue()
+    {
+        var (vm, _) = Make();
+        AddThroughSheet(vm, "openrouter");
+
+        vm.Delete("openrouter");
+
+        Assert.Empty(vm.Connections);
+        Assert.Contains(vm.AvailablePresets, p => p.Id == "openrouter");
+    }
+
+    /// <summary>The empty state is a real state, not an accident: on a fresh install the section below is
+    /// what the reader acts on, and the one above should say so rather than being blank.</summary>
+    [Fact]
+    public void The_empty_state_is_reported_until_something_is_configured()
+    {
+        var (vm, _) = Make();
+        Assert.True(vm.HasNoConnections);
+
+        AddThroughSheet(vm, "ollama");
+
+        Assert.False(vm.HasNoConnections);
+    }
+
+    // ---- keyed sync ------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Rows are updated in place, not rebuilt.
+    ///
+    /// <para><c>ConnectionsChanged</c> fires for state changes as well as add/remove — a reachability
+    /// write-back moves one connection's state — so rebuilding the collection would throw away scroll
+    /// position and focus every time a probe returned. Pinned because the cheap implementation (clear and
+    /// refill) passes every other test in this file.</para>
+    /// </summary>
+    [Fact]
+    public void An_unrelated_change_leaves_existing_rows_as_the_same_objects()
+    {
+        var (vm, service) = Make();
+        AddThroughSheet(vm, "ollama");
+        var original = vm.Connections.Single();
+
+        service.Add("second", Draft("Second"));
+
+        Assert.Same(original, vm.Connections.First(c => c.Id == "ollama"));
+        Assert.Equal(2, vm.Connections.Count);
+    }
+
+    /// <summary>An edit re-reads the row rather than replacing it, so a rename shows without the list
+    /// flickering.</summary>
+    [Fact]
+    public void Editing_a_connection_updates_the_row_in_place()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft("Old name"));
+        var row = vm.Connections.Single();
+
+        service.Update("mine", Draft("New name"));
+
+        Assert.Same(row, vm.Connections.Single());
+        Assert.Equal("New name", row.DisplayName);
+    }
+
+    /// <summary>Rows follow the service's order — the order the reader added them — which the in-place sync
+    /// has to maintain by moving rows rather than by luck.</summary>
+    [Fact]
+    public void Rows_follow_the_services_order_after_a_removal()
+    {
+        var (vm, service) = Make();
+        service.Add("a", Draft("A"));
+        service.Add("b", Draft("B"));
+        service.Add("c", Draft("C"));
+
+        service.Remove("a");
+
+        Assert.Equal(new[] { "b", "c" }, vm.Connections.Select(r => r.Id));
+    }
+
+    // ---- what a row says -------------------------------------------------------------------------------
+
+    private static AiConnectionRowViewModel Row(
+        CredentialSource source = CredentialSource.None,
+        Reachability state = Reachability.Configured,
+        string baseUrl = "http://localhost:11434/v1")
+    {
+        var connection = new AiConnection(
+            "local", "Local Ollama", ChatProviderKind.OpenAiCompatible, baseUrl,
+            new List<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>(),
+            source, state);
+        return new AiConnectionRowViewModel(new AiConnectionsViewModel(null, null), connection);
+    }
+
+    /// <summary>
+    /// Configured is not connected, and this is the sentence that must never drift.
+    ///
+    /// <para>A settings page that claims "Connected" while the assistant reports it cannot connect sends the
+    /// reader looking everywhere except the problem — observed in OpenCode, where the two surfaces contradict
+    /// each other and the one consulted to diagnose is the one that is wrong.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(Reachability.Configured, "Not checked yet")]
+    [InlineData(Reachability.Reachable, "Reachable")]
+    [InlineData(Reachability.Unreachable, "Not responding")]
+    public void Status_is_honest_about_what_has_actually_been_checked(Reachability state, string expected) =>
+        Assert.Equal(expected, Row(state: state).StatusText);
+
+    [Fact]
+    public void No_status_wording_ever_claims_a_connection()
+    {
+        foreach (var state in Enum.GetValues<Reachability>())
+            Assert.DoesNotContain("Connected", Row(state: state).StatusText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>One axis, applied to every row. OpenCode badges only the unusual row and overloads the slot
+    /// across two axes, which leaves the badge meaning nothing in particular.</summary>
+    [Theory]
+    [InlineData(CredentialSource.None, "No key")]
+    [InlineData(CredentialSource.Keychain, "Keychain")]
+    [InlineData(CredentialSource.Environment, "Environment")]
+    public void Every_row_names_where_its_credential_came_from(CredentialSource source, string expected) =>
+        Assert.Equal(expected, Row(source).KeySourceBadge);
+
+    /// <summary>
+    /// An environment-sourced row gets an empty action slot rather than a disabled button: the app cannot
+    /// delete a credential it never stored, and a control there would promise something it cannot do.
+    /// </summary>
+    [Fact]
+    public void Only_a_key_we_stored_ourselves_offers_to_be_removed()
+    {
+        Assert.False(Row(CredentialSource.Environment).CanRemoveKey);
+        Assert.False(Row(CredentialSource.None).CanRemoveKey);
+        Assert.True(Row(CredentialSource.Keychain).CanRemoveKey);
+    }
+
+    /// <summary>An unanswered <c>{placeholder}</c> is said on the row. Sent anyway it fails as a DNS error
+    /// naming nothing, which tells the reader neither what is wrong nor where to fix it.</summary>
+    [Fact]
+    public void A_connection_missing_an_input_says_what_it_still_needs()
+    {
+        var row = Row(baseUrl: "https://{resourceName}.openai.azure.com/openai/v1");
+
+        Assert.True(row.IsIncomplete);
+        Assert.Contains("resourceName", row.IncompleteText);
+    }
+
+    [Fact]
+    public void A_complete_connection_is_not_flagged() => Assert.False(Row().IsIncomplete);
+
+    // ---- the catalogue ---------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A catalogue row says what the preset knows and nothing more.
+    ///
+    /// <para>OpenCode's rows carry vendor blurbs — "GPT models for fast, capable general AI tasks" — which is
+    /// marketing presented as product information. Any line we wrote ourselves would be an opinion about a
+    /// provider, which is the registry removed in #670/#681 arriving as prose.</para>
+    /// </summary>
+    [Fact]
+    public void A_catalogue_row_says_only_whether_a_key_is_needed()
+    {
+        var (vm, _) = Make();
+
+        Assert.Equal("No key needed", vm.AvailablePresets.Single(p => p.Id == "ollama").RequirementText);
+        Assert.Equal("Needs an API key", vm.AvailablePresets.Single(p => p.Id == "openrouter").RequirementText);
+    }
+
+    /// <summary>
+    /// Every add opens the sheet, including a preset with nothing to ask.
+    ///
+    /// <para>Adding outright was tested and is wrong twice over: the new row lands at the top of a page the
+    /// reader has scrolled to the bottom of to reach the catalogue, so the click reads as having done
+    /// nothing — and a provider with neither a key nor a model id cannot answer a question, so the gap is
+    /// discovered later and has to be repaired through Edit.</para>
+    /// </summary>
+    [Fact]
+    public void Adding_a_provider_always_opens_the_sheet()
+    {
+        var (vm, _) = Make();
+
+        vm.AddPreset("openrouter");
+
+        Assert.NotNull(vm.Editor);
+        Assert.True(vm.Editor!.IsPreset);
+        Assert.Empty(vm.Connections);
+    }
+
+    /// <summary>Azure's address is a shape rather than a URL, so the sheet has a field for the part only the
+    /// reader knows.</summary>
+    [Fact]
+    public void A_preset_that_needs_an_answer_asks_for_it()
+    {
+        var (vm, _) = Make();
+
+        vm.AddPreset("azure");
+
+        Assert.Contains(vm.Editor!.Inputs, i => i.Key == "resourceName");
+    }
+
+    /// <summary>
+    /// The key is filed under the connection it was typed for.
+    ///
+    /// <para>The regression this pins is #678 arriving by a different route: a shared key box elsewhere in
+    /// Settings writes to whichever connection happens to be <i>active</i>, so a reader adding OpenRouter
+    /// second would file its key under the first endpoint and get a 401 naming neither.</para>
+    /// </summary>
+    [Fact]
+    public void A_key_typed_on_the_sheet_is_filed_under_that_connection()
+    {
+        var keys = new FakeCredentialStore();
+        var (vm, _) = Make(keys);
+
+        AddThroughSheet(vm, "ollama");
+        AddThroughSheet(vm, "openrouter", key: "sk-or-secret");
+
+        Assert.Equal("sk-or-secret", keys.GetApiKey("openrouter"));
+        Assert.Null(keys.GetApiKey("ollama"));
+    }
+
+    /// <summary>Where the credential came from is read off the store, so storing one moves the badge without
+    /// the row being rebuilt.</summary>
+    [Fact]
+    public void Storing_a_key_moves_the_rows_badge()
+    {
+        var keys = new FakeCredentialStore();
+        var (vm, _) = Make(keys);
+
+        AddThroughSheet(vm, "openrouter", key: "sk-or-secret");
+        var row = vm.Connections.Single();
+
+        Assert.Equal("Keychain", row.KeySourceBadge);
+        Assert.True(row.CanRemoveKey);
+
+        row.RemoveKeyCommand.Execute().Subscribe();
+
+        Assert.Equal("No key", vm.Connections.Single().KeySourceBadge);
+        Assert.Null(keys.GetApiKey("openrouter"));
+    }
+
+    /// <summary>Removing a key must not take the connection or its models with it — the whole reason the two
+    /// destructive actions are separate.</summary>
+    [Fact]
+    public void Removing_a_key_leaves_the_connection_and_its_models_alone()
+    {
+        var keys = new FakeCredentialStore();
+        var (vm, service) = Make(keys);
+        AddThroughSheet(vm, "openrouter", key: "sk-or-secret");
+
+        vm.Connections.Single().RemoveKeyCommand.Execute().Subscribe();
+
+        var still = service.Connections.Single();
+        Assert.Equal("openrouter", still.Id);
+    }
+
+    /// <summary>The generated form is the mechanism, so a preset added in a future upstream sync arrives with
+    /// its dialog already working rather than needing hand-written code.</summary>
+    [Fact]
+    public void The_sheet_for_a_preset_is_built_from_the_presets_own_prompts()
+    {
+        var (vm, _) = Make();
+
+        vm.AddPreset("cloudflare-workers-ai");
+        var input = Assert.Single(vm.Editor!.Inputs);
+
+        Assert.Equal("accountId", input.Key);
+        Assert.Equal("Cloudflare account ID", input.Message);
+        Assert.True(input.IsFreeText);
+    }
+
+    // ---- deleting asks first ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Delete destroys the hand-typed model list, which is real user-authored work — the same asymmetry that
+    /// makes "remove key" and "delete connection" two actions rather than one. So the first click asks.
+    /// </summary>
+    [Fact]
+    public void Deleting_asks_before_it_destroys_anything()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft());
+        var row = vm.Connections.Single();
+
+        row.DeleteCommand.Execute().Subscribe();
+
+        Assert.True(row.IsConfirmingDelete);
+        Assert.Single(vm.Connections);
+    }
+
+    [Fact]
+    public void Confirming_deletes_and_declining_does_not()
+    {
+        var (vm, service) = Make();
+        service.Add("keep", Draft());
+        service.Add("go", Draft());
+
+        var keep = vm.Connections.Single(r => r.Id == "keep");
+        keep.DeleteCommand.Execute().Subscribe();
+        keep.CancelDeleteCommand.Execute().Subscribe();
+
+        Assert.False(keep.IsConfirmingDelete);
+        Assert.Equal(2, vm.Connections.Count);
+
+        var go = vm.Connections.Single(r => r.Id == "go");
+        go.DeleteCommand.Execute().Subscribe();
+        go.ConfirmDeleteCommand.Execute().Subscribe();
+
+        Assert.Equal(new[] { "keep" }, vm.Connections.Select(r => r.Id));
+    }
+
+    /// <summary>The confirmation names the models, because that is the part a reader would not think to check
+    /// before clicking.</summary>
+    [Fact]
+    public void The_confirmation_says_what_goes_with_it()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft("My box") with
+        {
+            Models = new List<AiModelEntry> { new("a", "A"), new("b", "B") },
+        });
+
+        Assert.Equal("Delete My box and its 2 models?", vm.Connections.Single().DeleteConfirmText);
+    }
+
+    // ---- monograms -------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("OpenRouter", "O")]
+    [InlineData("xAI", "X")]
+    [InlineData("Z.ai", "Z")]
+    [InlineData("(unnamed)", "U")]
+    [InlineData("", "?")]
+    public void The_tile_shows_the_first_letter_there_is(string name, string expected) =>
+        Assert.Equal(expected, AiMonogram.For(name));
+
+    /// <summary>
+    /// The tone is a pure function of the id, not of this process.
+    ///
+    /// <para>.NET randomises string hashing per run, so <c>GetHashCode</c> here would repaint every row on
+    /// every launch — a list that looks different each time it is opened, for no reason the reader could
+    /// name.</para>
+    /// </summary>
+    [Fact]
+    public void A_tiles_tone_is_stable_and_within_range()
+    {
+        foreach (var id in new[] { "openrouter", "ollama", "my-box", "a" })
+        {
+            var tone = AiMonogram.ToneFor(id);
+            Assert.InRange(tone, 0, AiMonogram.ToneCount - 1);
+            Assert.Equal(tone, AiMonogram.ToneFor(id));
+        }
+    }
+}

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Models;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.ViewModels;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// #693: the per-turn model chip in the Assistant's composer.
+///
+/// <para>The primitive the provider rework exists for — comparing two models on the same passage, one click
+/// from the answer on screen rather than a trip to Settings.</para>
+/// </summary>
+public class AiModelPickerViewModelTests
+{
+    private sealed class FakeCredentialStore : IAiCredentialStore
+    {
+        public Dictionary<string, string> Keys { get; } = new(StringComparer.Ordinal);
+        public bool IsAvailable => true;
+        public string? Unavailable => null;
+        public string? GetApiKey(string connectionId) => Keys.GetValueOrDefault(connectionId);
+        public bool SetApiKey(string connectionId, string apiKey) { Keys[connectionId] = apiKey; return true; }
+        public bool DeleteApiKey(string connectionId) => Keys.Remove(connectionId);
+    }
+
+    private static (AiModelPickerViewModel Picker, AiConnectionService Service, FakeCredentialStore Keys) Make()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var keys = new FakeCredentialStore();
+        var service = new AiConnectionService(svc.Object, keys);
+        return (new AiModelPickerViewModel(service), service, keys);
+    }
+
+    private static AiConnectionDraft Draft(string name, params AiModelEntry[] models) =>
+        new(name, ChatProviderKind.OpenAiCompatible, "http://localhost:8000/v1",
+            models, new Dictionary<string, string>(), new Dictionary<string, string>());
+
+    private static IEnumerable<AiPickerModelViewModel> AllModels(AiModelPickerViewModel picker) =>
+        picker.Groups.SelectMany(g => g.Models);
+
+    // ---- what the list contains ------------------------------------------------------------------------
+
+    /// <summary>
+    /// Only the enabled subset. The full listing lives in Settings → Models; this is the short list the
+    /// reader built there, which is what lets it be a flat grouped list with no virtualization.
+    /// </summary>
+    [Fact]
+    public void Only_enabled_models_are_offered()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine",
+            new AiModelEntry("on", "On", true),
+            new AiModelEntry("off", "Off", false)));
+
+        Assert.Equal(new[] { "on" }, AllModels(picker).Select(m => m.ModelId));
+    }
+
+    /// <summary>Grouped by connection — what stops "the 8B I run locally" and "the hosted 70B" reading as
+    /// interchangeable rows once several endpoints are configured.</summary>
+    [Fact]
+    public void Models_are_grouped_by_connection()
+    {
+        var (picker, service, _) = Make();
+        service.Add("local", Draft("Local Ollama", new AiModelEntry("a", "A")));
+        service.Add("hosted", Draft("Hosted", new AiModelEntry("b", "B")));
+
+        Assert.Equal(new[] { "Local Ollama", "Hosted" }, picker.Groups.Select(g => g.DisplayName));
+    }
+
+    /// <summary>A connection with nothing enabled contributes no header — an empty group is a heading
+    /// promising rows it does not have.</summary>
+    [Fact]
+    public void A_connection_with_nothing_enabled_is_absent()
+    {
+        var (picker, service, _) = Make();
+        service.Add("empty", Draft("Empty", new AiModelEntry("x", "X", false)));
+        service.Add("full", Draft("Full", new AiModelEntry("y", "Y")));
+
+        Assert.Equal(new[] { "Full" }, picker.Groups.Select(g => g.DisplayName));
+    }
+
+    /// <summary>The chip is hidden until there is a choice to make. One model, or none, is a control that
+    /// cannot do anything.</summary>
+    [Fact]
+    public void The_chip_appears_only_when_there_is_something_to_choose()
+    {
+        var (picker, service, _) = Make();
+        Assert.False(picker.HasChoices);
+
+        service.Add("mine", Draft("Mine", new AiModelEntry("a", "A")));
+        Assert.False(picker.HasChoices);
+
+        service.Update("mine", Draft("Mine", new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
+        Assert.True(picker.HasChoices);
+    }
+
+    // ---- choosing ---------------------------------------------------------------------------------------
+
+    /// <summary>The chip shows the display name, not the wire id: nobody calls the thing they are talking to
+    /// <c>nvidia/nemotron-nano-9b-v2</c>.</summary>
+    [Fact]
+    public void The_chip_shows_the_current_models_display_name()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine",
+            new AiModelEntry("nvidia/nemotron-nano-9b-v2", "Nemotron Nano 9B"),
+            new AiModelEntry("other", "Other")));
+
+        AllModels(picker).Single(m => m.ModelId == "nvidia/nemotron-nano-9b-v2")
+            .SelectCommand.Execute().Subscribe();
+
+        Assert.Equal("Nemotron Nano 9B", picker.CurrentLabel);
+    }
+
+    /// <summary>
+    /// Choosing a model on another connection moves the connection with it.
+    ///
+    /// <para>Switching model across providers means switching base URL <i>and</i> credential; a picker that
+    /// moved only the model id would send the second provider's model to the first provider's endpoint and
+    /// fail confusingly.</para>
+    /// </summary>
+    [Fact]
+    public void Choosing_a_model_on_another_connection_switches_the_connection_too()
+    {
+        var (picker, service, _) = Make();
+        service.Add("local", Draft("Local", new AiModelEntry("a", "A")));
+        service.Add("hosted", Draft("Hosted", new AiModelEntry("b", "B")));
+
+        AllModels(picker).Single(m => m.ModelId == "b").SelectCommand.Execute().Subscribe();
+
+        Assert.Equal("hosted", service.Active?.Id);
+        Assert.Equal("b", service.ActiveModelId);
+    }
+
+    /// <summary>The current one is marked, so the reader can see what answered the last question without
+    /// opening anything else.</summary>
+    [Fact]
+    public void The_current_model_is_marked()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine", new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
+
+        AllModels(picker).Single(m => m.ModelId == "b").SelectCommand.Execute().Subscribe();
+
+        Assert.True(AllModels(picker).Single(m => m.ModelId == "b").IsCurrent);
+        Assert.False(AllModels(picker).Single(m => m.ModelId == "a").IsCurrent);
+    }
+
+    /// <summary>Choosing closes the popup and clears the search, so the next open starts from the whole
+    /// list rather than from whatever was typed last time.</summary>
+    [Fact]
+    public void Choosing_closes_the_popup_and_clears_the_search()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine", new AiModelEntry("a", "Alpha"), new AiModelEntry("b", "Beta")));
+        picker.IsOpen = true;
+        picker.Search = "alp";
+
+        AllModels(picker).Single().SelectCommand.Execute().Subscribe();
+
+        Assert.False(picker.IsOpen);
+        Assert.Equal("", picker.Search);
+    }
+
+    /// <summary>The panel is told, so a standing "not configured" notice reflects the new choice rather than
+    /// waiting to be contradicted at send time.</summary>
+    [Fact]
+    public void Choosing_notifies_the_panel()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object);
+        var told = 0;
+        var picker = new AiModelPickerViewModel(service, () => told++);
+
+        service.Add("mine", Draft("Mine", new AiModelEntry("a", "A")));
+        AllModels(picker).Single().SelectCommand.Execute().Subscribe();
+
+        Assert.Equal(1, told);
+    }
+
+    // ---- search ------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Search_matches_the_name_or_the_id()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine",
+            new AiModelEntry("nvidia/nemotron", "Nano"),
+            new AiModelEntry("meta/llama", "Llama")));
+
+        picker.Search = "nemotron";
+        Assert.Equal(new[] { "nvidia/nemotron" }, AllModels(picker).Select(m => m.ModelId));
+
+        picker.Search = "llama";
+        Assert.Equal(new[] { "meta/llama" }, AllModels(picker).Select(m => m.ModelId));
+    }
+
+    [Fact]
+    public void A_search_matching_nothing_says_so()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine", new AiModelEntry("a", "A")));
+
+        picker.Search = "zzz";
+
+        Assert.True(picker.HasNothingMatching);
+    }
+
+    // ---- what cannot be used, and why ---------------------------------------------------------------------
+
+    /// <summary>
+    /// A provider whose preset says it needs a key, with none stored, is shown disabled and says why.
+    ///
+    /// <para>Otherwise the send fails with a 401 that names neither the cause nor the connection — which is
+    /// the failure this is here to prevent.</para>
+    /// </summary>
+    [Fact]
+    public void A_provider_missing_a_required_key_is_disabled_with_the_reason()
+    {
+        var (picker, service, keys) = Make();
+        service.AddFromPreset("openrouter", new Dictionary<string, string>());
+        service.EnableModel("openrouter", "x/y", "X", true);
+
+        var model = AllModels(picker).Single();
+        Assert.False(model.IsUsable);
+        Assert.Equal("no API key stored", model.Unusable);
+
+        keys.SetApiKey("openrouter", "sk-or-secret");
+        picker.Refresh();
+
+        Assert.True(AllModels(picker).Single().IsUsable);
+    }
+
+    /// <summary>
+    /// A custom endpoint with no key is left alone.
+    ///
+    /// <para>Plenty need none — every local runner — and there is no fact saying otherwise, so nothing is
+    /// claimed. Disabling on a hunch would be worse than letting the request explain itself.</para>
+    /// </summary>
+    [Fact]
+    public void A_custom_endpoint_with_no_key_is_not_second_guessed()
+    {
+        var (picker, service, _) = Make();
+        service.Add("my-ollama", Draft("My Ollama", new AiModelEntry("a", "A")));
+
+        Assert.True(AllModels(picker).Single().IsUsable);
+    }
+
+    /// <summary>A connection whose URL still has an unanswered placeholder cannot send anything, which is a
+    /// fact rather than a guess.</summary>
+    [Fact]
+    public void An_unfinished_connection_is_disabled_with_the_reason()
+    {
+        var (picker, service, keys) = Make();
+        service.Add("azure-ish", new AiConnectionDraft(
+            "Half-built", ChatProviderKind.OpenAiCompatible,
+            "https://{resourceName}.openai.azure.com/openai/v1",
+            new[] { new AiModelEntry("a", "A") },
+            new Dictionary<string, string>(), new Dictionary<string, string>()));
+
+        var model = AllModels(picker).Single();
+        Assert.False(model.IsUsable);
+        Assert.Equal("not finished being set up", model.Unusable);
+    }
+
+    /// <summary>
+    /// An unreachable connection is marked, not hidden.
+    ///
+    /// <para>The reader may be about to start their local runner; a provider that vanished from the picker
+    /// because it was asleep would look like a lost configuration.</para>
+    /// </summary>
+    [Fact]
+    public void An_unreachable_connection_is_marked_rather_than_hidden()
+    {
+        var (picker, service, _) = Make();
+        service.Add("local", Draft("Local", new AiModelEntry("a", "A")));
+
+        service.ReportReachability("local", reachable: false);
+
+        var group = Assert.Single(picker.Groups);
+        Assert.True(group.HasNote);
+        Assert.Equal("not responding", group.Note);
+        Assert.Single(group.Models);
+    }
+}

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -1,0 +1,452 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.ViewModels;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// #692 and #674: the Models tab — the reader's short list, and the provider listing they build it from.
+/// </summary>
+public class AiModelsViewModelTests
+{
+    /// <summary>Returns a fixed listing without a network. Records how often it was asked, because "fetch
+    /// once, not on every keystroke" is a property worth pinning.</summary>
+    private sealed class FakeCatalog : IAiModelCatalog
+    {
+        private readonly AiCatalogResult _result;
+        public int Calls { get; private set; }
+
+        public FakeCatalog(params AiCatalogModel[] models)
+            : this(AiCatalogResult.Success(models)) { }
+
+        public FakeCatalog(AiCatalogResult result) => _result = result;
+
+        public Task<AiCatalogResult> FetchAsync(AiConnection connection, CancellationToken ct = default)
+        {
+            Calls++;
+            return Task.FromResult(_result);
+        }
+    }
+
+    private static (AiModelsViewModel Vm, AiConnectionService Service) Make(IAiModelCatalog? catalog = null)
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object);
+        return (new AiModelsViewModel(service, catalog), service);
+    }
+
+    private static AiConnectionDraft Draft(params AiModelEntry[] models) =>
+        new("My box", ChatProviderKind.OpenAiCompatible, "http://localhost:8000/v1",
+            models, new Dictionary<string, string>(), new Dictionary<string, string>());
+
+    private static AiModelGroupViewModel Group(AiModelsViewModel vm) => vm.Groups.Single();
+
+    private static IReadOnlyList<AiCatalogRowViewModel> Rows(AiModelsViewModel vm) =>
+        vm.Rows.OfType<AiCatalogRowViewModel>().ToList();
+
+    // ---- the hand-typed list (#692) --------------------------------------------------------------------
+
+    /// <summary>
+    /// A model the reader typed arrives on.
+    ///
+    /// <para>Typing an id <i>is</i> the act of choosing it — nobody types one they do not mean to use — so
+    /// all-off here would mean typing a model and then hunting for a switch on another tab before it appeared
+    /// anywhere.</para>
+    /// </summary>
+    [Fact]
+    public void A_typed_model_starts_enabled()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft(new AiModelEntry("llama3.1:8b", "Llama 3.1 8B")));
+
+        Group(vm).IsExpanded = true;
+
+        var row = Assert.Single(Rows(vm));
+        Assert.True(row.Enabled);
+        Assert.True(row.IsTyped);
+    }
+
+    /// <summary>Groups start collapsed with the count in the header — exactly the number a reader needs to
+    /// decide whether to expand, which OpenCode omits.</summary>
+    [Fact]
+    public void Groups_start_collapsed_and_carry_a_count()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft(
+            new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
+
+        Assert.False(Group(vm).IsExpanded);
+        Assert.Empty(Rows(vm));
+        Assert.Equal("2 models", Group(vm).CountText);
+    }
+
+    /// <summary>Several models under one connection must be on at once — the whole point of a short list you
+    /// switch between. A radio would cap it at one and destroy the design silently.</summary>
+    [Fact]
+    public void Several_models_can_be_on_at_once()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft(
+            new AiModelEntry("a", "A"), new AiModelEntry("b", "B"), new AiModelEntry("c", "C")));
+        Group(vm).IsExpanded = true;
+
+        Assert.All(Rows(vm), r => Assert.True(r.Enabled));
+        Assert.Equal(3, service.Connections.Single().Models.Count(m => m.Enabled));
+    }
+
+    /// <summary>Turning one off keeps the entry, so a display name the reader typed survives being switched
+    /// off and on again.</summary>
+    [Fact]
+    public void Turning_a_typed_model_off_keeps_it_in_the_list()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft(new AiModelEntry("a", "My name for it")));
+        Group(vm).IsExpanded = true;
+
+        Rows(vm).Single().Enabled = false;
+
+        var stored = Assert.Single(service.Connections.Single().Models);
+        Assert.False(stored.Enabled);
+        Assert.Equal("My name for it", stored.DisplayName);
+    }
+
+    // ---- the fetched catalogue (#674) ------------------------------------------------------------------
+
+    /// <summary>
+    /// A fetched model arrives OFF.
+    ///
+    /// <para>Four hundred entries turn up because a key was pasted, not because anyone asked for them. The
+    /// reader promotes the handful they will switch between — which is also the only way the per-turn picker
+    /// stays the single-digit list it needs to be.</para>
+    /// </summary>
+    [Fact]
+    public void A_fetched_model_starts_disabled()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("nvidia/nemotron-nano-9b-v2", "NVIDIA Nemotron Nano 9B V2")));
+        service.Add("mine", Draft());
+
+        Group(vm).IsExpanded = true;
+
+        var row = Assert.Single(Rows(vm));
+        Assert.False(row.Enabled);
+        Assert.False(row.IsTyped);
+    }
+
+    /// <summary>Nothing reaches <c>settings.json</c> until the reader chooses it — storing four hundred
+    /// entries so each could carry a <c>false</c> would bloat the file to state what its emptiness already
+    /// says.</summary>
+    [Fact]
+    public void An_untouched_catalogue_is_not_persisted()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B")));
+        service.Add("mine", Draft());
+
+        Group(vm).IsExpanded = true;
+
+        Assert.Empty(service.Connections.Single().Models);
+    }
+
+    /// <summary>Promoting one adds it to the reader's stored list, with the provider's display name.</summary>
+    [Fact]
+    public void Promoting_a_fetched_model_stores_it()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("nvidia/nemotron", "NVIDIA Nemotron")));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        Rows(vm).Single().Enabled = true;
+
+        var stored = Assert.Single(service.Connections.Single().Models);
+        Assert.Equal("nvidia/nemotron", stored.Id);
+        Assert.Equal("NVIDIA Nemotron", stored.DisplayName);
+        Assert.True(stored.Enabled);
+    }
+
+    /// <summary>A typed model that also appears in the listing is one row, not two — the reader's entry wins,
+    /// keeping the name they chose.</summary>
+    [Fact]
+    public void A_typed_model_is_not_duplicated_by_the_listing()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("shared", "Provider's name"),
+            new AiCatalogModel("other", "Other")));
+        service.Add("mine", Draft(new AiModelEntry("shared", "My name")));
+
+        Group(vm).IsExpanded = true;
+
+        var rows = Rows(vm);
+        Assert.Equal(2, rows.Count);
+        Assert.Single(rows, r => r.ModelId == "shared");
+        Assert.Equal("My name", rows.Single(r => r.ModelId == "shared").DisplayName);
+    }
+
+    /// <summary>The header says how much of a listing has been promoted, which is the number that matters
+    /// once a catalogue arrives.</summary>
+    [Fact]
+    public void The_header_counts_what_is_on_against_what_is_available()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B"), new AiCatalogModel("c", "C")));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        Rows(vm).Single(r => r.ModelId == "a").Enabled = true;
+
+        Assert.Equal("1 of 3 models on", Group(vm).CountText);
+    }
+
+    /// <summary>Fetched once, on first expand — not on every expand, and not on every keystroke in the search
+    /// box.</summary>
+    [Fact]
+    public void The_listing_is_fetched_once()
+    {
+        var catalog = new FakeCatalog(new AiCatalogModel("a", "A"));
+        var (vm, service) = Make(catalog);
+        service.Add("mine", Draft());
+
+        Group(vm).IsExpanded = true;
+        Group(vm).IsExpanded = false;
+        Group(vm).IsExpanded = true;
+        vm.Search = "a";
+
+        Assert.Equal(1, catalog.Calls);
+    }
+
+    /// <summary>
+    /// A failed fetch is reported and nothing else. The typed list stays exactly as it was — the listing is
+    /// additive, and an endpoint that publishes none is the ordinary case for a local runner rather than a
+    /// broken one.
+    /// </summary>
+    [Fact]
+    public void A_failed_fetch_leaves_the_typed_list_alone_and_says_why()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            AiCatalogResult.Fail("No response from http://localhost:8000/v1/models — is the endpoint running?")));
+        service.Add("mine", Draft(new AiModelEntry("typed", "Typed")));
+
+        Group(vm).IsExpanded = true;
+
+        Assert.True(Group(vm).HasFetchProblem);
+        Assert.Contains("localhost:8000", Group(vm).FetchProblem);
+        var row = Assert.Single(Rows(vm));
+        Assert.Equal("typed", row.ModelId);
+        Assert.True(row.Enabled);
+    }
+
+    /// <summary>
+    /// Toggling a model does not rebuild the list.
+    ///
+    /// <para>The rows are bound to an observable collection; clearing and refilling it sends the list box's
+    /// scroll position back to the top. At four hundred rows that means switching on a model near the bottom
+    /// throws the reader back to the first one — and they would then do it again, because the model they just
+    /// enabled is no longer on screen to confirm it worked.</para>
+    /// </summary>
+    [Fact]
+    public void Toggling_a_model_does_not_rebuild_the_list()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B")));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        var before = Rows(vm).ToList();
+        before.Single(r => r.ModelId == "a").Enabled = true;
+
+        Assert.Equal(before, Rows(vm));   // same row objects, same order, same collection contents
+    }
+
+    /// <summary>The header still keeps up, even though the list is not rebuilt.</summary>
+    [Fact]
+    public void Toggling_updates_the_count_without_a_rebuild()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B")));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        Rows(vm).Single(r => r.ModelId == "a").Enabled = true;
+
+        Assert.Equal("1 of 2 models on", Group(vm).CountText);
+    }
+
+    /// <summary>
+    /// A toggle survives a later rebuild.
+    ///
+    /// <para>Suppressing the rebuild means the group is holding a connection snapshot taken before the write.
+    /// If it is not refreshed, the next genuine rebuild — another connection added, a search typed — restores
+    /// the old value and the reader watches their choice undo itself.</para>
+    /// </summary>
+    [Fact]
+    public void A_toggle_survives_the_next_rebuild()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B")));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+        Rows(vm).Single(r => r.ModelId == "a").Enabled = true;
+
+        vm.Search = "a";
+        vm.Search = "";
+
+        Assert.True(Rows(vm).Single(r => r.ModelId == "a").Enabled);
+    }
+
+    // ---- search and the capability filter ---------------------------------------------------------------
+
+    /// <summary>Search filters across every group, not within the expanded one, and shows what it finds
+    /// without the reader expanding anything.</summary>
+    [Fact]
+    public void Search_reaches_into_collapsed_groups()
+    {
+        var (vm, service) = Make();
+        service.Add("one", Draft(new AiModelEntry("llama3.1:8b", "Llama 3.1 8B")));
+        service.Add("two", Draft(new AiModelEntry("qwen2.5:14b", "Qwen 2.5 14B")));
+
+        Assert.Empty(Rows(vm));   // both collapsed
+
+        vm.Search = "qwen";
+
+        var row = Assert.Single(Rows(vm));
+        Assert.Equal("qwen2.5:14b", row.ModelId);
+    }
+
+    /// <summary>A group with no match disappears rather than sitting there as a header promising results it
+    /// does not have.</summary>
+    [Fact]
+    public void A_group_with_no_matches_is_hidden_while_searching()
+    {
+        var (vm, service) = Make();
+        service.Add("one", Draft(new AiModelEntry("llama3.1:8b", "Llama 3.1 8B")));
+        service.Add("two", Draft(new AiModelEntry("qwen2.5:14b", "Qwen 2.5 14B")));
+
+        vm.Search = "qwen";
+
+        Assert.Single(vm.Rows.OfType<AiModelGroupViewModel>());
+    }
+
+    /// <summary>Searching matches the wire id as readily as the label — a reader thinking of "nemotron" may
+    /// have either in mind.</summary>
+    [Fact]
+    public void Search_matches_the_id_as_well_as_the_name()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft(new AiModelEntry("nvidia/nemotron-nano-9b-v2", "Nano")));
+
+        vm.Search = "nemotron";
+
+        Assert.Single(Rows(vm));
+    }
+
+    /// <summary>The capability filter drops models the provider publishes as unable to answer in text. It is
+    /// mechanical and reversible, and it makes no claim about the models that remain.</summary>
+    [Fact]
+    public void The_capability_filter_drops_models_that_cannot_answer_in_text()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("chat", "Chat",
+                InputModalities: new[] { "text" }, OutputModalities: new[] { "text" }),
+            new AiCatalogModel("tts", "Speech",
+                InputModalities: new[] { "text" }, OutputModalities: new[] { "audio" })));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        Assert.Equal(new[] { "chat" }, Rows(vm).Select(r => r.ModelId));
+
+        vm.TextOnly = false;
+
+        Assert.Equal(2, Rows(vm).Count);
+    }
+
+    /// <summary>
+    /// A model the reader typed is never filtered away.
+    ///
+    /// <para>They put it there; hiding it behind a filter would read as having lost it. The filter exists to
+    /// prune a listing nobody asked for, not to second-guess a choice already made.</para>
+    /// </summary>
+    [Fact]
+    public void A_typed_model_is_never_hidden_by_the_filter()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("odd", "Odd", InputModalities: new[] { "text" },
+                OutputModalities: new[] { "audio" })));
+        service.Add("mine", Draft(new AiModelEntry("odd", "Odd")));
+
+        Group(vm).IsExpanded = true;
+
+        Assert.Single(Rows(vm), r => r.ModelId == "odd");
+    }
+
+    // ---- what a row says ---------------------------------------------------------------------------------
+
+    /// <summary>The provider's own facts, verbatim and attributed — safe where a table we maintained would
+    /// not be.</summary>
+    [Fact]
+    public void A_row_shows_the_published_facts()
+    {
+        var (vm, service) = Make(new FakeCatalog(new AiCatalogModel(
+            "m", "M", ContextLength: 131072, PromptPricePerMillion: 0.4m,
+            CompletionPricePerMillion: 1.6m, SupportedParameters: new[] { "reasoning" })));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        var details = Rows(vm).Single().Details;
+        Assert.Contains("131K context", details);
+        Assert.Contains("$0.4/$1.6 per M", details);
+        Assert.Contains("reasoning", details);
+    }
+
+    /// <summary>An endpoint that publishes nothing degrades to the id rather than showing an empty
+    /// line.</summary>
+    [Fact]
+    public void A_row_with_no_published_facts_shows_its_id()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft(new AiModelEntry("gemma4:12b-mlx", "Gemma4 12B MLX")));
+        Group(vm).IsExpanded = true;
+
+        Assert.Equal("gemma4:12b-mlx", Rows(vm).Single().Details);
+    }
+
+    /// <summary>Zero is free and may be said so; unknown is not free and must never be rendered as it.</summary>
+    [Fact]
+    public void A_free_model_says_free_and_an_unpriced_one_says_nothing()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("free", "Free", PromptPricePerMillion: 0m, CompletionPricePerMillion: 0m),
+            new AiCatalogModel("quiet", "Quiet")));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        Assert.Contains("free", Rows(vm).Single(r => r.ModelId == "free").Details);
+        Assert.DoesNotContain("free", Rows(vm).Single(r => r.ModelId == "quiet").Details);
+    }
+
+    /// <summary>Alphabetical within a group. Nothing here may order by recency: that is what upstream does,
+    /// and it is an editorial claim however mechanically it is computed (#689).</summary>
+    [Fact]
+    public void Rows_are_alphabetical_within_a_group()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("c", "Zephyr"),
+            new AiCatalogModel("a", "Apollo"),
+            new AiCatalogModel("b", "mercury")));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        Assert.Equal(new[] { "Apollo", "mercury", "Zephyr" }, Rows(vm).Select(r => r.DisplayName));
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1311,6 +1311,14 @@ public partial class App : Application
         // event and every consumer must see the same list.
         services.AddSingleton<Services.Ai.IAiConnectionService, Services.Ai.AiConnectionService>();
 
+        // Asking a connection what models it offers (#674). Additive to the hand-typed list, never a
+        // prerequisite: an endpoint that publishes no listing stays fully usable, so a failure here is
+        // reported and nothing more.
+        services.AddSingleton<Services.Ai.IAiModelCatalog>(sp => new Services.Ai.AiModelCatalog(
+            new System.Net.Http.HttpClient(),
+            sp.GetService<Services.Ai.IAiCredentialStore>(),
+            sp.GetRequiredService<ILoggerFactory>().CreateLogger<Services.Ai.AiModelCatalog>()));
+
         // The fidelity advisory (#584). Data only — Settings (#585) and the panel (#586) surface it.
         services.AddSingleton<ILemmaReportService, LemmaReportService>();
 

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1370,7 +1370,8 @@ public partial class App : Application
             sp.GetService<Services.Ai.IAiChatOrchestrator>(),
             sp.GetService<Services.Ai.IReaderStateService>(),
             sp.GetService<Services.Ai.IChatProviderResolver>(),
-            sp.GetService<ISettingsService>()));
+            sp.GetService<ISettingsService>(),
+            sp.GetService<Services.Ai.IAiConnectionService>()));
         // services.AddTransient<MainWindowViewModel>();
     }
 

--- a/src/CST.Avalonia/Converters/ChevronConverter.cs
+++ b/src/CST.Avalonia/Converters/ChevronConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace CST.Avalonia.Converters
+{
+    /// <summary>The disclosure triangle for a collapsible group in the AI models list. (#692)</summary>
+    /// <remarks>
+    /// A glyph rather than two styled Path elements: the settings page has no icon set of its own, and one
+    /// character in the UI font renders identically on macOS, Windows and Linux without shipping an asset.
+    /// </remarks>
+    public class ChevronConverter : IValueConverter
+    {
+        public static readonly ChevronConverter Instance = new();
+
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            value is true ? "▼" : "▶";
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/CST.Avalonia/Converters/MonogramToneConverter.cs
+++ b/src/CST.Avalonia/Converters/MonogramToneConverter.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace CST.Avalonia.Converters
+{
+    /// <summary>
+    /// The tile colour behind a provider's initial in the AI connections list. (#691)
+    ///
+    /// <para>A stand-in until real vendor marks land. The tone is a hash of the connection id, so a row keeps
+    /// the same colour across launches and the eye can find it by something other than reading — which is the
+    /// job a logo does on this screen.</para>
+    ///
+    /// <para><b>The colour means nothing, deliberately.</b> It is not a status, a kind, or a quality: anything
+    /// that ranked or grouped providers by colour would be a judgment about them, which is what #670/#681
+    /// removed from this app. Muted enough to sit under either theme without a light and dark variant.</para>
+    /// </summary>
+    public class MonogramToneConverter : IValueConverter
+    {
+        public static readonly MonogramToneConverter Instance = new();
+
+        // Six, matching AiMonogram.ToneCount. Desaturated so white text reads on every one of them, in both
+        // themes, without the tile competing with the display name beside it.
+        private static readonly IBrush[] Tones =
+        {
+            new SolidColorBrush(Color.FromRgb(0x5B, 0x74, 0x9A)),
+            new SolidColorBrush(Color.FromRgb(0x6B, 0x8E, 0x7A)),
+            new SolidColorBrush(Color.FromRgb(0x8A, 0x6E, 0x9B)),
+            new SolidColorBrush(Color.FromRgb(0x9B, 0x7A, 0x5B)),
+            new SolidColorBrush(Color.FromRgb(0x5B, 0x8A, 0x9B)),
+            new SolidColorBrush(Color.FromRgb(0x9B, 0x6B, 0x6B)),
+        };
+
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            value is int tone && tone >= 0 ? Tones[tone % Tones.Length] : Tones[0];
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -61,6 +61,20 @@ namespace CST.Avalonia.Services.Ai
         AiConnectionResult SetModelEnabled(string connectionId, string modelId, bool enabled);
 
         /// <summary>
+        /// Turns a model on or off, adding it to the connection first if it is not there yet. (#674)
+        ///
+        /// <para>The verb a <i>fetched</i> listing needs. A provider's catalogue can run to hundreds of
+        /// models and none of them belongs in <c>settings.json</c> until the reader has chosen it — storing
+        /// all 414 so they can each carry a <c>false</c> would bloat the settings file to make a point the
+        /// file's emptiness already makes. So the stored list stays what it has always been: the models this
+        /// reader picked, whether they typed the id or promoted it from a listing.</para>
+        ///
+        /// <para>Turning one off keeps the entry rather than deleting it, so a display name the reader typed
+        /// survives being switched off and on again.</para>
+        /// </summary>
+        AiConnectionResult EnableModel(string connectionId, string modelId, string displayName, bool enabled);
+
+        /// <summary>
         /// Records what a real request just learned about an endpoint. (#673)
         ///
         /// <para>This is what stops Settings claiming "Connected" while the assistant reports it cannot
@@ -236,6 +250,32 @@ namespace CST.Avalonia.Services.Ai
 
             _reachability[connectionId] = state;
             ConnectionsChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public AiConnectionResult EnableModel(
+            string connectionId, string modelId, string displayName, bool enabled)
+        {
+            if (Find(connectionId) is not { } record)
+                return AiConnectionResult.Fail($"No connection called '{connectionId}'.");
+
+            if (string.IsNullOrWhiteSpace(modelId))
+                return AiConnectionResult.Fail("A model needs an id.");
+
+            var model = record.Models.FirstOrDefault(
+                m => string.Equals(m.Id, modelId, StringComparison.Ordinal));
+
+            if (model is null)
+            {
+                model = new AiModelRecord
+                {
+                    Id = modelId.Trim(),
+                    DisplayName = string.IsNullOrWhiteSpace(displayName) ? modelId.Trim() : displayName.Trim(),
+                };
+                record.Models.Add(model);
+            }
+
+            model.Enabled = enabled;
+            return Saved(record);
         }
 
         public AiConnectionResult SetModelEnabled(string connectionId, string modelId, bool enabled)

--- a/src/CST.Avalonia/Services/Ai/AiHttp.cs
+++ b/src/CST.Avalonia/Services/Ai/AiHttp.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -55,6 +56,51 @@ internal static class AiHttp
     /// </summary>
     internal static HttpClient CreateClient() =>
         new() { Timeout = System.Threading.Timeout.InfiniteTimeSpan };
+
+    /// <summary>
+    /// Attaches a connection's credential in whatever shape its endpoint expects, plus its extra headers.
+    /// (#689, #674)
+    ///
+    /// <para><b>Naming a non-standard auth header replaces <c>Authorization</c>; it does not add a second
+    /// one.</b> Azure rejects a request carrying both, which is why this cannot be expressed as an ordinary
+    /// extra header — an extra header is additive by definition, and the requirement there is an
+    /// absence.</para>
+    ///
+    /// <para>Extra headers are applied first so they can never overwrite the credential: a header named
+    /// <c>Authorization</c> mistyped into settings would otherwise silently replace the real key with whatever
+    /// the reader pasted.</para>
+    ///
+    /// <para><b>Shared deliberately.</b> Chat requests and model-listing requests go to the same endpoint with
+    /// the same credential, so they must authenticate identically — two implementations would eventually
+    /// disagree, and the symptom would be a provider whose model list loads while its answers 401, which is
+    /// exactly the sort of contradiction between two surfaces that #673 exists to prevent.</para>
+    /// </summary>
+    internal static void ApplyAuth(
+        HttpRequestMessage message,
+        string? apiKey,
+        string? authHeaderName,
+        string? authScheme,
+        IReadOnlyDictionary<string, string>? extraHeaders)
+    {
+        var header = string.IsNullOrWhiteSpace(authHeaderName) ? "Authorization" : authHeaderName;
+
+        if (extraHeaders is { Count: > 0 })
+        {
+            foreach (var extra in extraHeaders)
+            {
+                if (string.IsNullOrWhiteSpace(extra.Key)) continue;
+                if (extra.Key.Equals("Authorization", StringComparison.OrdinalIgnoreCase)) continue;
+                if (extra.Key.Equals(header, StringComparison.OrdinalIgnoreCase)) continue;
+                message.Headers.TryAddWithoutValidation(extra.Key, extra.Value);
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(apiKey)) return;   // a local runner needs none
+
+        message.Headers.TryAddWithoutValidation(
+            header,
+            string.IsNullOrWhiteSpace(authScheme) ? apiKey! : $"{authScheme} {apiKey}");
+    }
 
     /// <summary>
     /// Guard the invariant above at construction, because a finite timeout does not fail loudly — it truncates a

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -1,0 +1,331 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models.Ai;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Ai
+{
+    /// <summary>
+    /// One model as the provider describes it. (#674)
+    ///
+    /// <para><b>Everything here is the provider's own words, verbatim.</b> Nothing is scored, tiered, ranked or
+    /// recommended, and no field is ours — that is what makes a fetched listing safe where a table we
+    /// maintained would not be (#670/#681). Display it, attribute it, never re-rank on it.</para>
+    ///
+    /// <para>Providers publish wildly different amounts. OpenRouter gives context length, price and
+    /// <c>supported_parameters</c> per model; a local Ollama gives an id and nothing else. Every field beyond
+    /// <paramref name="Id"/> is therefore optional, and the UI degrades to a bare id rather than requiring
+    /// metadata that may not exist.</para>
+    /// </summary>
+    /// <param name="PromptPricePerMillion">USD per million prompt tokens, as published. Null when the provider
+    /// says nothing about price — which is not the same as free, and must not be rendered as free.</param>
+    public sealed record AiCatalogModel(
+        string Id,
+        string DisplayName,
+        int? ContextLength = null,
+        decimal? PromptPricePerMillion = null,
+        decimal? CompletionPricePerMillion = null,
+        IReadOnlyList<string>? InputModalities = null,
+        IReadOnlyList<string>? OutputModalities = null,
+        IReadOnlyList<string>? SupportedParameters = null)
+    {
+        /// <summary>
+        /// Whether this model can take text in and give text out — the only thing the assistant ever asks of
+        /// one.
+        ///
+        /// <para><b>A mechanical filter, not a judgment.</b> It reads the provider's own published modality
+        /// and removes models that cannot answer a question at all — a text-to-speech model, an image
+        /// generator, a video model. It says nothing about which of the remaining ones is better, which is the
+        /// line #670/#681 draws. OpenCode omits this filter, which is why a music model and a video model
+        /// reach their chat picker.</para>
+        ///
+        /// <para>Unknown counts as usable. A provider that publishes no modality — every local runner — must
+        /// not have its models filtered away by a field it never sent.</para>
+        /// </summary>
+        public bool IsTextToText =>
+            Handles(InputModalities, "text") && Handles(OutputModalities, "text");
+
+        /// <summary>Whether the provider says it accepts a reasoning-effort parameter (#671). Published, not
+        /// inferred from the name.</summary>
+        public bool SupportsReasoning =>
+            SupportedParameters?.Any(p =>
+                p.Contains("reasoning", StringComparison.OrdinalIgnoreCase) ||
+                p.Equals("thinking", StringComparison.OrdinalIgnoreCase)) == true;
+
+        private static bool Handles(IReadOnlyList<string>? modalities, string want) =>
+            modalities is null || modalities.Count == 0 ||
+            modalities.Any(m => m.Contains(want, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>What a fetch produced, or why it produced nothing.</summary>
+    /// <param name="Problem">A finished sentence for the reader. Never null when <paramref name="Ok"/> is
+    /// false, and it names the endpoint — "cannot connect" without saying to what is the message that sends
+    /// someone looking in the wrong place.</param>
+    public sealed record AiCatalogResult(bool Ok, string? Problem, IReadOnlyList<AiCatalogModel> Models)
+    {
+        public static AiCatalogResult Success(IReadOnlyList<AiCatalogModel> models) => new(true, null, models);
+
+        public static AiCatalogResult Fail(string problem) =>
+            new(false, problem, Array.Empty<AiCatalogModel>());
+    }
+
+    /// <summary>
+    /// Asks a connection what models it offers. (#674)
+    ///
+    /// <para><b>Additive, never load-bearing.</b> A failed fetch must never block anything: it reports why,
+    /// names the endpoint, and leaves the reader exactly where they were. For a custom endpoint the typed
+    /// model list is unaffected; for a named provider there is nothing to disturb.</para>
+    /// </summary>
+    public interface IAiModelCatalog
+    {
+        Task<AiCatalogResult> FetchAsync(AiConnection connection, CancellationToken ct = default);
+    }
+
+    /// <summary>
+    /// <c>GET {baseUrl}/models</c>, in whichever of the two protocols the connection speaks. (#674)
+    ///
+    /// <para>One parser serves both, because both answer with a <c>data[]</c> array of objects carrying an
+    /// <c>id</c>. Everything past that is optional and provider-specific: OpenRouter adds <c>name</c>,
+    /// <c>context_length</c>, <c>pricing</c>, <c>architecture</c> and <c>supported_parameters</c>; Anthropic
+    /// adds <c>display_name</c>; Ollama adds nothing at all. Reading them as optional is what lets one code
+    /// path serve a hosted gateway and a laptop daemon.</para>
+    /// </summary>
+    public sealed class AiModelCatalog : IAiModelCatalog
+    {
+        /// <summary>Long enough for a slow listing, short enough that a wrong URL is not a two-minute wait.
+        /// This is a directory lookup, not a generation — none of the patience #673 grants a local runner
+        /// applies.</summary>
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(20);
+
+        private readonly HttpClient _http;
+        private readonly IAiCredentialStore? _credentials;
+        private readonly ILogger<AiModelCatalog> _logger;
+
+        public AiModelCatalog(HttpClient http, IAiCredentialStore? credentials, ILogger<AiModelCatalog> logger)
+        {
+            _http = http;
+            _credentials = credentials;
+            _logger = logger;
+        }
+
+        public async Task<AiCatalogResult> FetchAsync(AiConnection connection, CancellationToken ct = default)
+        {
+            if (connection.IsIncomplete)
+                return AiCatalogResult.Fail(
+                    $"{connection.DisplayName} is not finished being set up, so it cannot be asked for a list.");
+
+            Uri url;
+            try
+            {
+                url = AiHttp.ResolveEndpoint(
+                    connection.ResolvedBaseUrl, "v1/models", "models",
+                    connection.Kind == ChatProviderKind.Anthropic
+                        ? BaseUrlConvention.ExcludesVersion
+                        : BaseUrlConvention.IncludesVersion);
+            }
+            catch (AiException ex)
+            {
+                return AiCatalogResult.Fail(ex.Error.Message);
+            }
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            Authenticate(request, connection);
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeout.CancelAfter(Timeout);
+
+            try
+            {
+                using var response = await _http.SendAsync(request, timeout.Token).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                    return AiCatalogResult.Fail(Explain(response.StatusCode, connection, url));
+
+                var body = await response.Content.ReadAsStringAsync(timeout.Token).ConfigureAwait(false);
+                var models = Parse(body);
+
+                // A 200 carrying no models is not an error, but it is not a success the UI should silently
+                // present as an empty list either - the reader would read it as "this provider has none".
+                if (models.Count == 0)
+                    return AiCatalogResult.Fail($"{url} answered, but listed no models.");
+
+                _logger.LogInformation(
+                    "Fetched {Count} models from {Connection}", models.Count, connection.Id);
+                return AiCatalogResult.Success(models);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                return AiCatalogResult.Fail($"No answer from {url} within {Timeout.TotalSeconds:0} seconds.");
+            }
+            catch (HttpRequestException ex)
+            {
+                // The endpoint is named on purpose. "Cannot connect to API" is the sentence OpenCode writes
+                // and the reason its users cannot diagnose a stopped local runner.
+                _logger.LogDebug(ex, "Model listing failed for {Connection}", connection.Id);
+                return AiCatalogResult.Fail($"No response from {url} — is the endpoint running?");
+            }
+            catch (JsonException)
+            {
+                return AiCatalogResult.Fail($"{url} answered, but not with a model listing.");
+            }
+        }
+
+        /// <summary>
+        /// Authenticates exactly as a chat request to the same endpoint would.
+        ///
+        /// <para>Routed through <see cref="AiHttp.ApplyAuth"/> rather than reimplemented: a listing and a
+        /// question go to the same host with the same credential, and two implementations would eventually
+        /// disagree. The visible symptom would be a provider whose model list loads while its answers 401 —
+        /// two surfaces contradicting each other, which is the failure #673 exists to prevent.</para>
+        ///
+        /// <para>Header values are templates like the base URL is: Azure and Cloudflare put reader-supplied
+        /// inputs in them.</para>
+        /// </summary>
+        private void Authenticate(HttpRequestMessage request, AiConnection connection)
+        {
+            var key = _credentials?.GetApiKey(connection.Id);
+            var headers = connection.Headers.ToDictionary(
+                h => h.Key, h => AiTemplate.Expand(h.Value, connection.Inputs));
+
+            if (connection.Kind == ChatProviderKind.Anthropic)
+            {
+                // Anthropic's shape is fixed by its own adapter rather than carried on the connection, so it
+                // is named here too. The version header is required on every request, key or no key.
+                AiHttp.ApplyAuth(request, key, "x-api-key", null, headers);
+                request.Headers.TryAddWithoutValidation("anthropic-version", "2023-06-01");
+                return;
+            }
+
+            AiHttp.ApplyAuth(request, key, connection.AuthHeaderName, connection.AuthScheme, headers);
+        }
+
+        /// <summary>A status code turned into something worth reading. The distinction that matters is
+        /// credential versus endpoint: a rejected key and a wrong URL are different problems and must never
+        /// produce the same sentence.</summary>
+        private static string Explain(
+            System.Net.HttpStatusCode status, AiConnection connection, Uri url) => (int)status switch
+        {
+            401 or 403 =>
+                $"{connection.DisplayName} rejected the stored key. Check it under Providers.",
+            404 =>
+                $"{url} is not a model listing — this endpoint may not publish one.",
+            429 =>
+                $"{connection.DisplayName} is rate-limiting requests. Try again shortly.",
+            >= 500 =>
+                $"{connection.DisplayName} returned an error ({(int)status}). That is the provider's end, not yours.",
+            _ =>
+                $"{url} answered {(int)status}.",
+        };
+
+        /// <summary>
+        /// Reads the fields we name, and only those.
+        ///
+        /// <para><b>Never "whatever the source says".</b> A listing can gain a field that ranks or scores
+        /// models in a release nobody read, and rendering it wholesale would adopt that judgment silently. So
+        /// each field is pulled by name, and adding one is a deliberate act.</para>
+        /// </summary>
+        internal static IReadOnlyList<AiCatalogModel> Parse(string json)
+        {
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("data", out var data) ||
+                data.ValueKind != JsonValueKind.Array)
+                return Array.Empty<AiCatalogModel>();
+
+            var models = new List<AiCatalogModel>(data.GetArrayLength());
+
+            foreach (var item in data.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Object) continue;
+                if (Text(item, "id") is not { Length: > 0 } id) continue;
+
+                var architecture = Object(item, "architecture");
+                var pricing = Object(item, "pricing");
+
+                models.Add(new AiCatalogModel(
+                    id,
+                    Text(item, "name") ?? Text(item, "display_name") ?? id,
+                    Int(item, "context_length") ?? Int(Object(item, "top_provider"), "context_length"),
+                    PerMillion(pricing, "prompt"),
+                    PerMillion(pricing, "completion"),
+                    Modalities(architecture, "input_modalities"),
+                    Modalities(architecture, "output_modalities"),
+                    Strings(item, "supported_parameters")));
+            }
+
+            // Alphabetical by the name the provider published. Mechanical, and the only ordering allowed:
+            // "newest first" is the rule upstream uses and is an editorial claim, since a newer point release
+            // can be worse at Pali (#689).
+            models.Sort((a, b) => string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase));
+            return models;
+        }
+
+        private static JsonElement? Object(JsonElement? parent, string name) =>
+            parent is { } p && p.ValueKind == JsonValueKind.Object &&
+            p.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.Object
+                ? value
+                : null;
+
+        private static string? Text(JsonElement? parent, string name) =>
+            parent is { } p && p.ValueKind == JsonValueKind.Object &&
+            p.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+                ? value.GetString()
+                : null;
+
+        private static int? Int(JsonElement? parent, string name) =>
+            parent is { } p && p.ValueKind == JsonValueKind.Object &&
+            p.TryGetProperty(name, out var value) && value.TryGetInt32(out var number)
+                ? number
+                : null;
+
+        /// <summary>
+        /// OpenRouter publishes price per <i>token</i>, as a decimal string. Per million is the unit anyone
+        /// actually compares in, and the conversion is arithmetic on the provider's own number rather than a
+        /// judgment about it.
+        /// </summary>
+        private static decimal? PerMillion(JsonElement? pricing, string name)
+        {
+            if (Text(pricing, name) is not { Length: > 0 } raw) return null;
+            if (!decimal.TryParse(raw, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var perToken)) return null;
+            return perToken * 1_000_000m;
+        }
+
+        /// <summary>Modalities, from either the list form or the older <c>"text-&gt;text"</c> string.</summary>
+        private static IReadOnlyList<string>? Modalities(JsonElement? architecture, string name)
+        {
+            if (Strings(architecture, name) is { Count: > 0 } list) return list;
+
+            if (Text(architecture, "modality") is not { Length: > 0 } modality) return null;
+
+            var halves = modality.Split("->", StringSplitOptions.TrimEntries);
+            if (halves.Length != 2) return null;
+
+            var half = name.StartsWith("input", StringComparison.Ordinal) ? halves[0] : halves[1];
+            return half.Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+
+        private static IReadOnlyList<string>? Strings(JsonElement? parent, string name)
+        {
+            if (parent is not { } p || p.ValueKind != JsonValueKind.Object) return null;
+            if (!p.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.Array) return null;
+
+            var items = new List<string>();
+            foreach (var element in value.EnumerateArray())
+                if (element.ValueKind == JsonValueKind.String && element.GetString() is { Length: > 0 } text)
+                    items.Add(text);
+
+            return items;
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -75,30 +75,8 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
     /// named <c>Authorization</c> in settings would otherwise silently replace the real key with whatever the
     /// reader pasted.</para>
     /// </summary>
-    private void ApplyAuth(HttpRequestMessage message)
-    {
-        if (_options.ExtraHeaders is { Count: > 0 })
-            foreach (var extra in _options.ExtraHeaders)
-                if (!string.IsNullOrWhiteSpace(extra.Key) && !IsAuthHeader(extra.Key))
-                    message.Headers.TryAddWithoutValidation(extra.Key, extra.Value);
-
-        if (string.IsNullOrWhiteSpace(_options.ApiKey)) return;   // a local runner needs none
-
-        var header = string.IsNullOrWhiteSpace(_options.AuthHeaderName)
-            ? "Authorization"
-            : _options.AuthHeaderName;
-
-        var credential = string.IsNullOrWhiteSpace(_options.AuthScheme)
-            ? _options.ApiKey!
-            : $"{_options.AuthScheme} {_options.ApiKey}";
-
-        message.Headers.TryAddWithoutValidation(header, credential);
-    }
-
-    /// <summary>Whether an extra header would collide with the credential, under either name.</summary>
-    private bool IsAuthHeader(string name) =>
-        string.Equals(name, "Authorization", StringComparison.OrdinalIgnoreCase)
-        || string.Equals(name, _options.AuthHeaderName, StringComparison.OrdinalIgnoreCase);
+    private void ApplyAuth(HttpRequestMessage message) => AiHttp.ApplyAuth(
+        message, _options.ApiKey, _options.AuthHeaderName, _options.AuthScheme, _options.ExtraHeaders);
 
     public async IAsyncEnumerable<ChatDelta> StreamAsync(
         ChatRequest request,

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -69,7 +69,7 @@ public class AiAssistantViewModel : ReactiveTool
     private bool _isBusy;
 
     public AiAssistantViewModel()
-        : this(null, null, null, null)
+        : this(null, null, null, null, null)
     {
     }
 
@@ -77,12 +77,18 @@ public class AiAssistantViewModel : ReactiveTool
         IAiChatOrchestrator? orchestrator,
         IReaderStateService? readerState,
         IChatProviderResolver? resolver,
-        ISettingsService? settings)
+        ISettingsService? settings,
+        IAiConnectionService? connections = null)
     {
         _orchestrator = orchestrator;
         _readerState = readerState;
         _resolver = resolver;
         _settings = settings;
+
+        // Changing model is the reason the provider rework exists, so it belongs here rather than in
+        // Settings (#693). Readiness is re-asked on every switch: picking a model on a connection with no
+        // key must change the standing notice, not wait to fail at send time.
+        ModelPicker = new AiModelPickerViewModel(connections, RefreshReadiness);
 
         Id = "AiAssistantTool";
         Title = "Assistant";
@@ -108,6 +114,9 @@ public class AiAssistantViewModel : ReactiveTool
         // Asked once at construction so the panel can say it is not configured before anything is pressed.
         RefreshReadiness();
     }
+
+    /// <summary>The per-turn model chip and its list. (#693)</summary>
+    public AiModelPickerViewModel ModelPicker { get; }
 
     public ReactiveCommand<Unit, Unit> ExplainCommand { get; }
     public ReactiveCommand<Unit, Unit> TranslateCommand { get; }

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -1,0 +1,574 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using ReactiveUI;
+
+namespace CST.Avalonia.ViewModels
+{
+    /// <summary>The wire protocol an endpoint speaks, as a dropdown entry. (#691)</summary>
+    /// <remarks>
+    /// Two entries, and neither is a brand. The OpenAI-compatible shape reaches OpenRouter, DeepSeek,
+    /// Together, Ollama and LM Studio alike, and what selects between them is the base URL. Deliberately kept
+    /// <b>independent of the base URL</b> in both directions: several providers serve the Anthropic Messages
+    /// protocol at their own hosts, so neither field may be inferred from the other.
+    /// </remarks>
+    public sealed record AiKindChoice(ChatProviderKind Kind, string Display);
+
+    /// <summary>
+    /// The connection sheet — adding a named provider, adding a custom endpoint, or editing one. (#691)
+    ///
+    /// <para><b>Every add opens this sheet, including a preset that asks nothing.</b> The first cut added
+    /// key-less presets outright, on the reasoning that there was nothing to ask. Tested, that is wrong twice
+    /// over: the new row lands at the top of a scrolled page where the reader cannot see it, so the click
+    /// reads as having done nothing at all — and adding OpenRouter without its key or a model id produces a
+    /// connection that cannot answer a question, which the reader then has to discover and go back to Edit.
+    /// OpenCode opens a sheet on every Connect, and it is right to.</para>
+    ///
+    /// <para>One view model for all three cases because they are the same form with different fields showing.
+    /// A preset already knows its address and protocol, so those are shown rather than asked.</para>
+    /// </summary>
+    public class AiConnectionEditorViewModel : ViewModelBase
+    {
+        private static readonly AiKindChoice[] KindChoices =
+        {
+            new(ChatProviderKind.OpenAiCompatible, "OpenAI-compatible endpoint"),
+            new(ChatProviderKind.Anthropic, "Claude (Anthropic)"),
+        };
+
+        private readonly IAiConnectionService _service;
+        private readonly IAiCredentialStore? _credentials;
+        private readonly Action<bool> _close;
+        private readonly AiProviderPreset? _preset;
+        private readonly string? _existingId;
+
+        private string _id = "";
+        private string _displayName = "";
+        private AiKindChoice _kind = KindChoices[0];
+        private string _baseUrl = "";
+        private string _apiKeyEntry = "";
+        private string? _problem;
+        private bool _idEdited;
+
+        private AiConnectionEditorViewModel(
+            IAiConnectionService service, IAiCredentialStore? credentials, Action<bool> close,
+            AiProviderPreset? preset, string? existingId)
+        {
+            _service = service;
+            _credentials = credentials;
+            _close = close;
+            _preset = preset;
+            _existingId = existingId;
+
+            SaveCommand = ReactiveCommand.Create(Save);
+            CancelCommand = ReactiveCommand.Create(() => _close(false));
+            AddModelCommand = ReactiveCommand.Create(() => Models.Add(new AiModelRowViewModel(Models)));
+            AddHeaderCommand = ReactiveCommand.Create(() => Headers.Add(new AiHeaderRowViewModel(Headers)));
+            RemoveKeyCommand = ReactiveCommand.Create(RemoveKey);
+        }
+
+        /// <summary>An endpoint in nobody's catalogue. The generic mechanism the named ones are a shortcut
+        /// for, and always available — a preset must never be required to reach a provider.</summary>
+        public static AiConnectionEditorViewModel ForCustom(
+            IAiConnectionService service, IAiCredentialStore? credentials, Action<bool> close)
+        {
+            var vm = new AiConnectionEditorViewModel(service, credentials, close, null, null);
+            vm.Models.Add(new AiModelRowViewModel(vm.Models));
+            return vm;
+        }
+
+        /// <summary>
+        /// A named provider: its address and protocol are known, so the sheet asks only for what is left —
+        /// whatever the preset declares it needs, a key if it takes one, and the models to start with.
+        ///
+        /// <para>The extra fields come from the preset's own <see cref="AiProviderPreset.Prompts"/>, so this
+        /// is one form driven by data rather than a hand-written dialog per provider. A provider arriving in a
+        /// later upstream sync needing a field we have never heard of gets a working dialog for free.</para>
+        /// </summary>
+        public static AiConnectionEditorViewModel ForPreset(
+            IAiConnectionService service, IAiCredentialStore? credentials, AiProviderPreset preset,
+            Action<bool> close)
+        {
+            var vm = new AiConnectionEditorViewModel(service, credentials, close, preset, null)
+            {
+                _id = preset.Id,
+                _displayName = preset.DisplayName,
+                _baseUrl = preset.BaseUrl,
+                _kind = KindChoices.First(k => k.Kind == preset.Kind),
+            };
+
+            foreach (var prompt in preset.Prompts ?? Array.Empty<AiInputPrompt>())
+                vm.Inputs.Add(new AiInputRowViewModel(prompt, vm.OnInputChanged));
+
+            vm.RefreshInputVisibility();
+            return vm;
+        }
+
+        /// <summary>Editing what is already configured. Everything is editable except the id, which is the
+        /// account the credential is filed under — changing it would orphan the key, and the failure would
+        /// read as a rejected key rather than a lost one.</summary>
+        public static AiConnectionEditorViewModel ForExisting(
+            IAiConnectionService service, IAiCredentialStore? credentials, AiConnection connection,
+            Action<bool> close)
+        {
+            var vm = new AiConnectionEditorViewModel(service, credentials, close, null, connection.Id)
+            {
+                _id = connection.Id,
+                _displayName = connection.DisplayName,
+                _baseUrl = connection.BaseUrl,
+                _kind = KindChoices.FirstOrDefault(k => k.Kind == connection.Kind) ?? KindChoices[0],
+                _idEdited = true,
+            };
+
+            foreach (var model in connection.Models)
+                vm.Models.Add(new AiModelRowViewModel(vm.Models)
+                {
+                    ModelId = model.Id,
+                    DisplayName = model.DisplayName,
+                    Enabled = model.Enabled,
+                });
+
+            foreach (var header in connection.Headers)
+                vm.Headers.Add(new AiHeaderRowViewModel(vm.Headers)
+                {
+                    Name = header.Key,
+                    Value = header.Value,
+                });
+
+            foreach (var input in connection.Inputs)
+                vm.Inputs.Add(new AiInputRowViewModel(
+                    new AiInputPrompt(input.Key, input.Key), vm.OnInputChanged) { Value = input.Value });
+
+            if (vm.Models.Count == 0) vm.Models.Add(new AiModelRowViewModel(vm.Models));
+            return vm;
+        }
+
+        // ---- what the sheet shows ----------------------------------------------------------------------
+
+        public bool IsPreset => _preset is not null;
+
+        /// <summary>Id, display name, protocol and address are asked for only where they are not already
+        /// known. A preset knows all four.</summary>
+        public bool IsFullForm => _preset is null;
+
+        public bool IsIdEditable => _existingId is null && _preset is null;
+
+        /// <summary>A preset's address, shown read-only. Not a field to fill in, but worth seeing: it is the
+        /// one fact that says where the reader's questions and money are about to go.</summary>
+        public bool ShowFixedEndpoint => _preset is not null;
+
+        public string FixedEndpoint => _preset?.BaseUrl ?? "";
+
+        public string Title => _preset is not null
+            ? $"Add {_preset.DisplayName}"
+            : _existingId is not null ? $"Edit {_displayName}" : "Add a custom endpoint";
+
+        /// <summary>
+        /// One sentence saying what this sheet is for, worded after OpenCode's — which says in a line what
+        /// our old screen took three stacked paragraphs to not quite say.
+        /// </summary>
+        public string Blurb
+        {
+            get
+            {
+                if (_preset is null)
+                    return _existingId is not null
+                        ? "Everything except the id can be changed."
+                        : "Any endpoint that speaks one of the two protocols below. This is the same mechanism the named providers use, with the address left to you.";
+
+                return _preset.RequiresKey
+                    ? $"Enter your {_preset.DisplayName} API key to use {_preset.DisplayName} models in CST Reader. Its model list is fetched afterwards, on the Models tab."
+                    : $"{_preset.DisplayName} runs on your own machine and needs no key. Its model list is fetched afterwards, on the Models tab.";
+            }
+        }
+
+        public AiKindChoice[] Kinds => KindChoices;
+
+        // ---- fields ------------------------------------------------------------------------------------
+
+        /// <summary>Lowercase slug, immutable once created, and the account the credential is filed under.
+        /// Defaulted from the host so a reader who does not care never has to invent one.</summary>
+        public string Id
+        {
+            get => _id;
+            set
+            {
+                _idEdited = true;
+                this.RaiseAndSetIfChanged(ref _id, value);
+            }
+        }
+
+        public string DisplayName
+        {
+            get => _displayName;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _displayName, value);
+                this.RaisePropertyChanged(nameof(Title));
+            }
+        }
+
+        public AiKindChoice Kind
+        {
+            get => _kind;
+            set => this.RaiseAndSetIfChanged(ref _kind, value);
+        }
+
+        public string BaseUrl
+        {
+            get => _baseUrl;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _baseUrl, value);
+                SuggestIdFromHost();
+            }
+        }
+
+        /// <summary>
+        /// The key, held only long enough to hand over.
+        ///
+        /// <para>Asked for <b>here</b> rather than on a shared field elsewhere in Settings, because a single
+        /// key box has no way to say which connection it belongs to — the reader pastes an OpenRouter key
+        /// while some other endpoint happens to be the active one, and it is filed under that. That is #678's
+        /// collision with a new cause, and a sheet that already knows whose key it is asking for cannot make
+        /// the mistake.</para>
+        /// </summary>
+        public string ApiKeyEntry
+        {
+            get => _apiKeyEntry;
+            set => this.RaiseAndSetIfChanged(ref _apiKeyEntry, value);
+        }
+
+        /// <summary>Whether to ask for a key at all. A local runner needs none, and saying so is better than
+        /// an empty box the reader wonders about.</summary>
+        public bool ShowKeyField => _preset is null || _preset.RequiresKey;
+
+        public bool CanStoreKeys => _credentials?.IsAvailable == true;
+
+        /// <summary>Why a key cannot be stored on this machine, in the platform's own words. Null when it
+        /// can.</summary>
+        public string? KeyUnavailable => CanStoreKeys ? null : _credentials?.Unavailable;
+
+        public bool HasKeyUnavailable => !string.IsNullOrEmpty(KeyUnavailable);
+
+        /// <summary>Whether a key is already filed under this id — only knowable for a connection that
+        /// exists.</summary>
+        public bool HasStoredKey =>
+            _existingId is not null && _credentials?.GetApiKey(_existingId) is not null;
+
+        public string KeyStatus => _existingId is null
+            ? "Stored in the operating system's credential store, never in settings."
+            : HasStoredKey
+                ? $"A key is stored for {_displayName}. Paste a new one to replace it."
+                : $"No key is stored for {_displayName}.";
+
+        public string KeyHint => "Optional — leave it empty if this endpoint needs no key, or if you authenticate with a header below.";
+
+        /// <summary>
+        /// Whether to ask for model ids at all.
+        ///
+        /// <para><b>A named provider is not asked.</b> Its listing is fetched once the connection exists, so a
+        /// model box here would make the reader decide whether they need to type an id <i>before</i> seeing
+        /// what asking the provider returns — which is the wrong moment, and for OpenRouter's four hundred it
+        /// is a box nobody should ever fill in. The escape hatch for an id a listing omits lives on the Models
+        /// tab, next to the listing that omitted it.</para>
+        ///
+        /// <para>A custom endpoint still asks, and must: it may publish no listing at all, which is the
+        /// ordinary case for a local runner, and then typing is the only way in.</para>
+        /// </summary>
+        public bool ShowModels => _preset is null;
+
+        public string ModelsHint =>
+            "This endpoint's own list is fetched on the Models tab if it publishes one. Type ids here for an "
+            + "endpoint that does not.";
+
+        /// <summary>The service's refusal, verbatim — a duplicate id, a reserved one, a missing input. Shown
+        /// rather than swallowed: a collision would mean one connection inheriting another's credential.</summary>
+        public string? Problem
+        {
+            get => _problem;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _problem, value);
+                this.RaisePropertyChanged(nameof(HasProblem));
+            }
+        }
+
+        public bool HasProblem => !string.IsNullOrEmpty(Problem);
+
+        /// <summary>The models this endpoint offers, typed by hand. Short by construction, works offline, and
+        /// needs no catalogue — a fetched listing is the upgrade for providers that publish one (#674), never
+        /// the mechanism this depends on.</summary>
+        public ObservableCollection<AiModelRowViewModel> Models { get; } = new();
+
+        /// <summary>The escape hatch that makes an absent API key coherent: Azure's <c>api-key</c>, gateway
+        /// tokens, anything that is not a bearer credential. A preset already carries whatever it needs.</summary>
+        public ObservableCollection<AiHeaderRowViewModel> Headers { get; } = new();
+
+        public bool ShowHeaders => _preset is null;
+
+        /// <summary>The preset's own questions, generated from its declared prompts.</summary>
+        public ObservableCollection<AiInputRowViewModel> Inputs { get; } = new();
+
+        public string SaveText => _existingId is null ? "Add" : "Save";
+
+        public ReactiveCommand<Unit, Unit> SaveCommand { get; }
+        public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+        public ReactiveCommand<Unit, Unit> AddModelCommand { get; }
+        public ReactiveCommand<Unit, Unit> AddHeaderCommand { get; }
+        public ReactiveCommand<Unit, Unit> RemoveKeyCommand { get; }
+
+        // ---- saving ------------------------------------------------------------------------------------
+
+        private void Save()
+        {
+            var inputs = Inputs
+                .Where(i => i.IsVisible && !string.IsNullOrWhiteSpace(i.Value))
+                .ToDictionary(i => i.Key, i => i.Value.Trim(), StringComparer.Ordinal);
+
+            var result = _preset is not null
+                ? AddPreset(inputs)
+                : _existingId is not null
+                    ? _service.Update(_existingId, BuildDraft(inputs))
+                    : _service.Add(Id.Trim(), BuildDraft(inputs));
+
+            if (!result.Ok)
+            {
+                Problem = result.Problem;
+                return;
+            }
+
+            StoreKey(result.Connection?.Id ?? _existingId ?? Id.Trim());
+            _close(true);
+        }
+
+        /// <summary>
+        /// Creates the connection from the preset, then applies the models typed on the sheet.
+        ///
+        /// <para>Two calls because <c>AddFromPreset</c> takes only the inputs — the update is built from the
+        /// connection the service just created rather than from this form, so the address, protocol and any
+        /// headers the preset set up are carried across exactly as the service wrote them and only the model
+        /// list comes from the reader.</para>
+        /// </summary>
+        private AiConnectionResult AddPreset(IReadOnlyDictionary<string, string> inputs)
+        {
+            var added = _service.AddFromPreset(_preset!.Id, inputs);
+            if (!added.Ok || added.Connection is not { } created) return added;
+
+            var models = TypedModels();
+            if (models.Count == 0) return added;
+
+            var updated = _service.Update(created.Id, new AiConnectionDraft(
+                created.DisplayName, created.Kind, created.BaseUrl, models, created.Headers, created.Inputs));
+
+            return updated.Ok ? updated : added;
+        }
+
+        /// <summary>Hands the key over once the connection it belongs to exists, so it is filed under an id
+        /// that is already real.</summary>
+        private void StoreKey(string connectionId)
+        {
+            if (_credentials is null || string.IsNullOrWhiteSpace(ApiKeyEntry)) return;
+
+            _credentials.SetApiKey(connectionId, ApiKeyEntry.Trim());
+            ApiKeyEntry = "";
+        }
+
+        /// <summary>
+        /// Forgets the stored key without touching the connection.
+        ///
+        /// <para>The narrower of the two destructive actions, and the reason they are separate: a hand-typed
+        /// model list is real user work, and destroying it on an action meant only to stop billing would be
+        /// data loss.</para>
+        /// </summary>
+        private void RemoveKey()
+        {
+            if (_credentials is null || _existingId is null) return;
+
+            _credentials.DeleteApiKey(_existingId);
+            ApiKeyEntry = "";
+            this.RaisePropertyChanged(nameof(HasStoredKey));
+            this.RaisePropertyChanged(nameof(KeyStatus));
+        }
+
+        private List<AiModelEntry> TypedModels() => Models
+            .Where(m => !string.IsNullOrWhiteSpace(m.ModelId))
+            .Select(m => new AiModelEntry(
+                m.ModelId.Trim(),
+                string.IsNullOrWhiteSpace(m.DisplayName) ? m.ModelId.Trim() : m.DisplayName.Trim(),
+                m.Enabled))
+            .ToList();
+
+        private AiConnectionDraft BuildDraft(IReadOnlyDictionary<string, string> inputs) => new(
+            string.IsNullOrWhiteSpace(DisplayName) ? Id.Trim() : DisplayName.Trim(),
+            Kind.Kind,
+            BaseUrl.Trim(),
+            TypedModels(),
+            Headers
+                .Where(h => !string.IsNullOrWhiteSpace(h.Name))
+                .ToDictionary(h => h.Name.Trim(), h => h.Value.Trim(), StringComparer.Ordinal),
+            inputs);
+
+        /// <summary>
+        /// Fills the id in from the host while the reader has not typed one of their own.
+        ///
+        /// <para>Only a default: the id is what the credential is filed under, so it must stay the reader's to
+        /// choose. Deriving it permanently is the mistake this avoids — a URL-derived key changes the moment a
+        /// port does, and the key appears to have been rejected rather than lost.</para>
+        /// </summary>
+        private void SuggestIdFromHost()
+        {
+            if (_idEdited || !IsIdEditable) return;
+            if (!Uri.TryCreate(BaseUrl.Trim(), UriKind.Absolute, out var uri)) return;
+
+            var slug = new string(uri.Host
+                .ToLowerInvariant()
+                .Select(c => char.IsLetterOrDigit(c) ? c : '-')
+                .ToArray())
+                .Trim('-');
+
+            if (slug.Length == 0) return;
+
+            this.RaiseAndSetIfChanged(ref _id, slug, nameof(Id));
+        }
+
+        private void OnInputChanged() => RefreshInputVisibility();
+
+        /// <summary>Re-evaluates each prompt's <c>When</c> condition against what has been answered so far, so
+        /// a conditional field appears as its trigger is typed. Azure wants a resource name <i>or</i> an
+        /// explicit URL, and asking for both at once is wrong.</summary>
+        private void RefreshInputVisibility()
+        {
+            var answered = Inputs.ToDictionary(i => i.Key, i => i.Value, StringComparer.Ordinal);
+            foreach (var input in Inputs) input.Evaluate(answered);
+        }
+    }
+
+    /// <summary>One <c>model-id</c> plus the name a human reads. Two strings on purpose: the id goes on the
+    /// wire, the name goes in the picker, and they are rarely the same.</summary>
+    public class AiModelRowViewModel : ViewModelBase
+    {
+        private readonly ObservableCollection<AiModelRowViewModel> _owner;
+        private string _modelId = "";
+        private string _displayName = "";
+        private bool _enabled = true;
+
+        public AiModelRowViewModel(ObservableCollection<AiModelRowViewModel> owner)
+        {
+            _owner = owner;
+            RemoveCommand = ReactiveCommand.Create(() => { _owner.Remove(this); });
+        }
+
+        public string ModelId
+        {
+            get => _modelId;
+            set => this.RaiseAndSetIfChanged(ref _modelId, value);
+        }
+
+        public string DisplayName
+        {
+            get => _displayName;
+            set => this.RaiseAndSetIfChanged(ref _displayName, value);
+        }
+
+        /// <summary>
+        /// On by default, and carried through an edit untouched.
+        ///
+        /// <para><b>A model is on because a person put it there.</b> Typing an id is putting it there — nobody
+        /// types one they do not mean to use, and nobody types two hundred — so a hand-entered list is
+        /// single-digit by construction and all-on gives the short per-turn picker (#693) that is the whole
+        /// point. The opposite default belongs to a <i>fetched</i> catalogue (#674), where hundreds arrive
+        /// because a key was pasted rather than because anyone asked.</para>
+        ///
+        /// <para>Untouched on edit so a rename cannot silently restore a list the reader pruned. Neither
+        /// default may become a pre-enabled <i>subset</i>, however mechanically it is computed — see
+        /// #689.</para>
+        /// </summary>
+        public bool Enabled
+        {
+            get => _enabled;
+            set => this.RaiseAndSetIfChanged(ref _enabled, value);
+        }
+
+        public ReactiveCommand<Unit, Unit> RemoveCommand { get; }
+    }
+
+    /// <summary>One extra request header. Never the credential — that lives in the OS credential store.</summary>
+    public class AiHeaderRowViewModel : ViewModelBase
+    {
+        private readonly ObservableCollection<AiHeaderRowViewModel> _owner;
+        private string _name = "";
+        private string _value = "";
+
+        public AiHeaderRowViewModel(ObservableCollection<AiHeaderRowViewModel> owner)
+        {
+            _owner = owner;
+            RemoveCommand = ReactiveCommand.Create(() => { _owner.Remove(this); });
+        }
+
+        public string Name
+        {
+            get => _name;
+            set => this.RaiseAndSetIfChanged(ref _name, value);
+        }
+
+        public string Value
+        {
+            get => _value;
+            set => this.RaiseAndSetIfChanged(ref _value, value);
+        }
+
+        public ReactiveCommand<Unit, Unit> RemoveCommand { get; }
+    }
+
+    /// <summary>One field a preset asked for, rendered from its own declaration. A closed list where the
+    /// preset supplies options, free text otherwise.</summary>
+    public class AiInputRowViewModel : ViewModelBase
+    {
+        private readonly AiInputPrompt _prompt;
+        private readonly Action _changed;
+        private string _value = "";
+        private bool _isVisible = true;
+
+        public AiInputRowViewModel(AiInputPrompt prompt, Action changed)
+        {
+            _prompt = prompt;
+            _changed = changed;
+        }
+
+        public string Key => _prompt.Key;
+
+        public string Message => _prompt.Message;
+
+        public string? Placeholder => _prompt.Placeholder;
+
+        public IReadOnlyList<AiPromptOption> Options => _prompt.Options ?? Array.Empty<AiPromptOption>();
+
+        public bool HasOptions => Options.Count > 0;
+
+        public bool IsFreeText => Options.Count == 0;
+
+        public string Value
+        {
+            get => _value;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _value, value);
+                _changed();
+            }
+        }
+
+        /// <summary>Whether this prompt applies, given what has been answered so far.</summary>
+        public bool IsVisible
+        {
+            get => _isVisible;
+            private set => this.RaiseAndSetIfChanged(ref _isVisible, value);
+        }
+
+        internal void Evaluate(IReadOnlyDictionary<string, string> answered) =>
+            IsVisible = _prompt.When is null || _prompt.When.IsSatisfiedBy(answered);
+    }
+}

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -1,0 +1,471 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using ReactiveUI;
+
+namespace CST.Avalonia.ViewModels
+{
+    /// <summary>
+    /// The Providers tab of the AI settings: the endpoints a reader has configured, and a catalogue of named
+    /// ones they could add. (#691)
+    ///
+    /// <para><b>Two stacked sections, not one list with an Add button.</b> "Your connections" is what is
+    /// configured now; "Add a provider" is what could be added next, and a preset leaves the lower section the
+    /// moment a connection using it exists. The screen this replaces could only ever report on whichever
+    /// provider a dropdown happened to be showing.</para>
+    ///
+    /// <para><b>Everything goes through <see cref="IAiConnectionService"/>.</b> This view model never reads or
+    /// writes <c>settings.json</c> and never touches the credential store — which also means it cannot
+    /// accidentally key a credential by wire format, the bug in #678.</para>
+    ///
+    /// <para><b>Nothing here ranks, scores or recommends.</b> Both sections are ordered mechanically —
+    /// connections in the order the reader added them, presets alphabetically by display name, which is the
+    /// order the service hands them over in. There is no "recommended" badge and no pre-selection anywhere,
+    /// because that is the model registry deleted in #670/#681 wearing different clothes.</para>
+    /// </summary>
+    public class AiConnectionsViewModel : ViewModelBase
+    {
+        private readonly IAiConnectionService? _service;
+        private readonly IAiCredentialStore? _credentials;
+        private AiConnectionEditorViewModel? _editor;
+        private string? _problem;
+
+        public AiConnectionsViewModel(IAiConnectionService? service, IAiCredentialStore? credentials = null)
+        {
+            _service = service;
+            _credentials = credentials;
+
+            AddCustomCommand = ReactiveCommand.Create(AddCustom);
+
+            if (_service is not null)
+            {
+                _service.ConnectionsChanged += OnConnectionsChanged;
+                Rebind();
+            }
+        }
+
+        /// <summary>What is configured now, in the order the reader added it.</summary>
+        public ObservableCollection<AiConnectionRowViewModel> Connections { get; } = new();
+
+        /// <summary>The presets with no connection yet — "what you could add next".</summary>
+        public ObservableCollection<AiPresetRowViewModel> AvailablePresets { get; } = new();
+
+        /// <summary>True while nothing is configured, so the empty state can say so rather than showing a
+        /// blank area above a catalogue and leaving the reader to infer it.</summary>
+        public bool HasNoConnections => Connections.Count == 0;
+
+        public bool HasAvailablePresets => AvailablePresets.Count > 0;
+
+        /// <summary>
+        /// The sheet, or null while the list is showing.
+        ///
+        /// <para>A sheet rather than an inline expansion, and it replaces the list rather than floating over
+        /// it: the form needs room for a second step later (validate, then fetch models), and a full-pane
+        /// swap gives it that without a scrim, a z-order, or a dialog window whose lifetime this view model
+        /// would have to own.</para>
+        /// </summary>
+        public AiConnectionEditorViewModel? Editor
+        {
+            get => _editor;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _editor, value);
+                this.RaisePropertyChanged(nameof(IsEditing));
+                this.RaisePropertyChanged(nameof(IsListing));
+            }
+        }
+
+        public bool IsEditing => Editor is not null;
+        public bool IsListing => Editor is null;
+
+        /// <summary>The service's own sentence when an operation was refused, shown verbatim. It already
+        /// names the connection and the reason; restating it here in our own words could only lose one.</summary>
+        public string? Problem
+        {
+            get => _problem;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _problem, value);
+                this.RaisePropertyChanged(nameof(HasProblem));
+            }
+        }
+
+        public bool HasProblem => !string.IsNullOrEmpty(Problem);
+
+        public ReactiveCommand<Unit, Unit> AddCustomCommand { get; }
+
+        /// <summary>Opens the full form for an endpoint that is in nobody's catalogue. Custom is first-class
+        /// and always available: a preset must never be <i>required</i> to reach a provider.</summary>
+        private void AddCustom()
+        {
+            if (_service is null) return;
+            Problem = null;
+            Editor = AiConnectionEditorViewModel.ForCustom(_service, _credentials, CloseEditor);
+        }
+
+        internal void BeginEdit(string id)
+        {
+            if (_service is null) return;
+            var connection = _service.Connections.FirstOrDefault(
+                c => string.Equals(c.Id, id, StringComparison.Ordinal));
+            if (connection is null) return;
+
+            Problem = null;
+            Editor = AiConnectionEditorViewModel.ForExisting(_service, _credentials, connection, CloseEditor);
+        }
+
+        /// <summary>
+        /// Opens the sheet for a named provider. <b>Always</b> the sheet, even for one that asks nothing.
+        ///
+        /// <para>The first cut added a key-less preset outright, reasoning that there was nothing to ask.
+        /// Testing killed that twice over. The new row lands at the <i>top</i> of a page the reader has
+        /// scrolled to the bottom of to reach the catalogue, so the click reads as having done nothing —
+        /// and a provider added with neither a key nor a model id cannot answer a question, so the reader
+        /// discovers the gap later and has to find Edit. OpenCode opens a sheet on every Connect.</para>
+        /// </summary>
+        internal void AddPreset(string presetId)
+        {
+            if (_service is null) return;
+            Problem = null;
+
+            var preset = _service.Presets.FirstOrDefault(
+                p => string.Equals(p.Id, presetId, StringComparison.Ordinal));
+            if (preset is null) return;
+
+            Editor = AiConnectionEditorViewModel.ForPreset(_service, _credentials, preset, CloseEditor);
+        }
+
+        /// <summary>
+        /// Deletes the connection and the models the reader typed into it.
+        ///
+        /// <para>Deliberately not paired with "stop billing me": those are two different intentions, and
+        /// collapsing them is how a hand-entered model list gets destroyed by someone who only meant to remove
+        /// a key. The narrower action needs a verb the service does not have yet — see the note on
+        /// <see cref="AiConnectionRowViewModel.KeySourceBadge"/>.</para>
+        /// </summary>
+        internal void Delete(string id)
+        {
+            if (_service is null) return;
+            var result = _service.Remove(id);
+            Problem = result.Ok ? null : result.Problem;
+        }
+
+        /// <summary>
+        /// Forgets one connection's key, leaving the connection and its models alone.
+        ///
+        /// <para>Reaches <see cref="IAiCredentialStore"/> directly, which is the one place this screen steps
+        /// outside <see cref="IAiConnectionService"/>. The seam's reason for forbidding it was that the store
+        /// was keyed by wire format, so the UI could not name a single connection's key without hitting
+        /// another's — #678 removed that, and the store is now keyed by the very id this method is handed. It
+        /// collapses to a one-line call the moment the service grows the verb.</para>
+        /// </summary>
+        internal void RemoveKey(string id)
+        {
+            if (_credentials is null) return;
+            _credentials.DeleteApiKey(id);
+            Rebind();
+        }
+
+        private void CloseEditor(bool saved)
+        {
+            Editor = null;
+            if (saved) Rebind();
+        }
+
+        private void OnConnectionsChanged(object? sender, EventArgs e) => Rebind();
+
+        /// <summary>
+        /// Syncs both lists in place, keyed by id, rather than rebuilding them.
+        ///
+        /// <para><c>ConnectionsChanged</c> fires for state changes as well as add/remove — a reachability
+        /// write-back moves one connection's <c>State</c> — so a wholesale rebuild would throw away scroll
+        /// position and any focus in the list every time a probe returned. Updating the matching row is the
+        /// difference between one row changing a word and the whole section flickering.</para>
+        /// </summary>
+        private void Rebind()
+        {
+            if (_service is null) return;
+
+            Sync(Connections, _service.Connections,
+                c => c.Id,
+                r => r.Id,
+                c => new AiConnectionRowViewModel(this, c),
+                (row, c) => row.Update(c));
+
+            Sync(AvailablePresets, _service.AvailablePresets,
+                p => p.Id,
+                r => r.Id,
+                p => new AiPresetRowViewModel(this, p),
+                (row, p) => row.Update(p));
+
+            this.RaisePropertyChanged(nameof(HasNoConnections));
+            this.RaisePropertyChanged(nameof(HasAvailablePresets));
+        }
+
+        /// <summary>Makes <paramref name="rows"/> match <paramref name="source"/> by key, reusing rows that
+        /// are still present so their bindings survive.</summary>
+        private static void Sync<TRow, TSource>(
+            ObservableCollection<TRow> rows,
+            IReadOnlyList<TSource> source,
+            Func<TSource, string> sourceKey,
+            Func<TRow, string> rowKey,
+            Func<TSource, TRow> create,
+            Action<TRow, TSource> update)
+        {
+            for (int i = rows.Count - 1; i >= 0; i--)
+                if (!source.Any(s => string.Equals(sourceKey(s), rowKey(rows[i]), StringComparison.Ordinal)))
+                    rows.RemoveAt(i);
+
+            for (int i = 0; i < source.Count; i++)
+            {
+                var key = sourceKey(source[i]);
+                var existing = rows.FirstOrDefault(r => string.Equals(rowKey(r), key, StringComparison.Ordinal));
+
+                if (existing is null)
+                {
+                    rows.Insert(Math.Min(i, rows.Count), create(source[i]));
+                    continue;
+                }
+
+                update(existing, source[i]);
+
+                var at = rows.IndexOf(existing);
+                if (at != i) rows.Move(at, i);
+            }
+        }
+    }
+
+    /// <summary>One configured endpoint, as a row in "Your connections". (#691)</summary>
+    public class AiConnectionRowViewModel : ViewModelBase
+    {
+        private readonly AiConnectionsViewModel _owner;
+        private AiConnection _connection;
+        private bool _isConfirmingDelete;
+
+        public AiConnectionRowViewModel(AiConnectionsViewModel owner, AiConnection connection)
+        {
+            _owner = owner;
+            _connection = connection;
+
+            EditCommand = ReactiveCommand.Create(() => _owner.BeginEdit(Id));
+            RemoveKeyCommand = ReactiveCommand.Create(() => _owner.RemoveKey(Id));
+            DeleteCommand = ReactiveCommand.Create(() => { IsConfirmingDelete = true; });
+            ConfirmDeleteCommand = ReactiveCommand.Create(() => _owner.Delete(Id));
+            CancelDeleteCommand = ReactiveCommand.Create(() => { IsConfirmingDelete = false; });
+        }
+
+        public string Id => _connection.Id;
+
+        public string DisplayName => _connection.DisplayName;
+
+        /// <summary>
+        /// The address, as a grey second line.
+        ///
+        /// <para>OpenCode shows the display name alone, which is opaque the moment a reader runs two local
+        /// endpoints — two rows, two names they chose, and no way to tell which is on which port. The URL is
+        /// already on screen in the editor and costs one line here.</para>
+        /// </summary>
+        public string Endpoint => _connection.ResolvedBaseUrl;
+
+        public string Monogram => AiMonogram.For(DisplayName);
+
+        public int MonogramTone => AiMonogram.ToneFor(Id);
+
+        public int ModelCount => _connection.Models.Count;
+
+        public string ModelSummary => ModelCount == 1 ? "1 model" : $"{ModelCount} models";
+
+        /// <summary>
+        /// Names where the credential came from, on <b>every</b> row.
+        ///
+        /// <para>OpenCode badges only the unusual row and overloads the slot across two different axes
+        /// (credential source on one row, connection kind on another), which leaves the badge meaning nothing
+        /// in particular. One axis, applied everywhere, is legible at a glance.</para>
+        ///
+        /// <para>"No key" is a legitimate resting state, not a warning: a local runner needs none, and a
+        /// connection may authenticate entirely through its headers.</para>
+        /// </summary>
+        public string KeySourceBadge => _connection.KeySource switch
+        {
+            CredentialSource.Keychain => "Keychain",
+            CredentialSource.Environment => "Environment",
+            _ => "No key",
+        };
+
+        /// <summary>
+        /// Whether this row offers to remove the stored key.
+        ///
+        /// <para>An environment-sourced credential gets an <b>empty action slot</b>, not a disabled button:
+        /// the app cannot delete a credential it never stored, and a control there would promise something it
+        /// cannot do. (A local "ignore this credential" flag is a separate affordance, and a better answer than
+        /// the dead end OpenCode leaves — but it is not this.)</para>
+        ///
+        /// <para>False for a key we did not store, and false when there is none — in both cases the slot is
+        /// simply empty. #678 made this reachable by filing keys under the connection's id.</para>
+        /// </summary>
+        public bool CanRemoveKey => _connection.KeySource == CredentialSource.Keychain;
+
+        /// <summary>
+        /// What we actually know about whether this works.
+        ///
+        /// <para><b>Never "Connected".</b> A configured endpoint is not a reachable one, and a settings page
+        /// that claims otherwise is the screen a reader consults to diagnose the failure it is lying about —
+        /// observed in OpenCode, where the assistant reported "cannot connect" while settings went on saying
+        /// Connected. "Not checked yet" is honest and costs nothing.</para>
+        /// </summary>
+        public string StatusText => _connection.State switch
+        {
+            Reachability.Reachable => "Reachable",
+            Reachability.Unreachable => "Not responding",
+            _ => "Not checked yet",
+        };
+
+        /// <summary>True when the base URL still has an unanswered <c>{placeholder}</c> in it — an Azure
+        /// connection with no resource name. Said here rather than discovered later as a DNS failure that
+        /// names nothing.</summary>
+        public bool IsIncomplete => _connection.IsIncomplete;
+
+        public string IncompleteText =>
+            "Not usable yet — still needs: " +
+            string.Join(", ", AiTemplate.PlaceholdersIn(_connection.ResolvedBaseUrl));
+
+        /// <summary>
+        /// Whether this row is asking before it destroys anything.
+        ///
+        /// <para>Delete takes the connection's hand-typed model list with it, which is real user-authored work
+        /// — the reason #691 wants "remove key" and "delete connection" kept apart in the first place. An
+        /// inline second click is the cheapest honest guard: it needs no dialog, it is undoable by looking
+        /// away, and the reversibility question is the one a mockup never asks.</para>
+        /// </summary>
+        public bool IsConfirmingDelete
+        {
+            get => _isConfirmingDelete;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _isConfirmingDelete, value);
+                this.RaisePropertyChanged(nameof(IsNotConfirmingDelete));
+            }
+        }
+
+        public bool IsNotConfirmingDelete => !IsConfirmingDelete;
+
+        /// <summary>Names what is about to go, because "3 models" is the part the reader would not think to
+        /// check before clicking.</summary>
+        public string DeleteConfirmText => ModelCount == 0
+            ? $"Delete {DisplayName}?"
+            : $"Delete {DisplayName} and its {ModelSummary}?";
+
+        public ReactiveCommand<Unit, Unit> EditCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> RemoveKeyCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> DeleteCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> ConfirmDeleteCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> CancelDeleteCommand { get; }
+
+        internal void Update(AiConnection connection)
+        {
+            _connection = connection;
+            this.RaisePropertyChanged(nameof(DisplayName));
+            this.RaisePropertyChanged(nameof(Endpoint));
+            this.RaisePropertyChanged(nameof(Monogram));
+            this.RaisePropertyChanged(nameof(MonogramTone));
+            this.RaisePropertyChanged(nameof(ModelCount));
+            this.RaisePropertyChanged(nameof(ModelSummary));
+            this.RaisePropertyChanged(nameof(KeySourceBadge));
+            this.RaisePropertyChanged(nameof(CanRemoveKey));
+            this.RaisePropertyChanged(nameof(StatusText));
+            this.RaisePropertyChanged(nameof(IsIncomplete));
+            this.RaisePropertyChanged(nameof(IncompleteText));
+            this.RaisePropertyChanged(nameof(DeleteConfirmText));
+        }
+    }
+
+    /// <summary>One named endpoint in "Add a provider". (#691)</summary>
+    public class AiPresetRowViewModel : ViewModelBase
+    {
+        private readonly AiConnectionsViewModel _owner;
+        private AiProviderPreset _preset;
+
+        public AiPresetRowViewModel(AiConnectionsViewModel owner, AiProviderPreset preset)
+        {
+            _owner = owner;
+            _preset = preset;
+
+            AddCommand = ReactiveCommand.Create(() => _owner.AddPreset(Id));
+        }
+
+        public string Id => _preset.Id;
+
+        public string DisplayName => _preset.DisplayName;
+
+        public string Monogram => AiMonogram.For(DisplayName);
+
+        public int MonogramTone => AiMonogram.ToneFor(Id);
+
+        /// <summary>
+        /// The only thing a row says beyond the provider's name.
+        ///
+        /// <para>Deliberately not a description. OpenCode's catalogue carries vendor blurbs — "GPT models for
+        /// fast, capable general AI tasks", "Unified access to AI models with smart routing" — which is
+        /// marketing copy presented as product information, and any line we wrote ourselves would be an
+        /// opinion about a provider. A preset carries a base URL and how it authenticates; that is all it
+        /// knows, so that is all this says.</para>
+        /// </summary>
+        public string RequirementText => _preset.RequiresKey ? "Needs an API key" : "No key needed";
+
+        public ReactiveCommand<Unit, Unit> AddCommand { get; }
+
+        internal void Update(AiProviderPreset preset)
+        {
+            _preset = preset;
+            this.RaisePropertyChanged(nameof(DisplayName));
+            this.RaisePropertyChanged(nameof(Monogram));
+            this.RaisePropertyChanged(nameof(MonogramTone));
+            this.RaisePropertyChanged(nameof(RequirementText));
+        }
+    }
+
+    /// <summary>
+    /// Stand-in provider marks: a letter on a coloured tile. (#691)
+    ///
+    /// <para>Real vendor logos are wanted here and are coming as their own change — 25 marks, each with its
+    /// own licence terms and several needing a separate dark-mode asset, which is a sourcing exercise rather
+    /// than a UI one. Until then a tile still does the job a logo does on this screen: give the eye something
+    /// other than left-aligned text to find a row by.</para>
+    ///
+    /// <para>The tone is a hash of the id, so it is stable across runs and carries no meaning — deliberately,
+    /// since a colour that meant something would be a judgment about a provider.</para>
+    /// </summary>
+    internal static class AiMonogram
+    {
+        /// <summary>How many tones the view defines. Kept here so the two cannot drift apart silently.</summary>
+        internal const int ToneCount = 6;
+
+        internal static string For(string displayName)
+        {
+            foreach (var c in displayName)
+                if (char.IsLetterOrDigit(c)) return char.ToUpperInvariant(c).ToString();
+            return "?";
+        }
+
+        internal static int ToneFor(string id)
+        {
+            // FNV-1a, so the tone is a pure function of the id rather than of this process's string hashing,
+            // which is randomised per run and would repaint the list on every launch.
+            uint hash = 2166136261;
+            foreach (var c in id)
+            {
+                hash ^= c;
+                hash *= 16777619;
+            }
+            return (int)(hash % ToneCount);
+        }
+    }
+}

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using ReactiveUI;
+
+namespace CST.Avalonia.ViewModels
+{
+    /// <summary>
+    /// The model chip in the Assistant's composer, and the list it opens. (#693)
+    ///
+    /// <para><b>This is the primitive the whole provider rework exists for.</b> Comparing two models on the
+    /// same passage is the actual task — not configuring one and reading — and it wants to be one click from
+    /// the answer on screen rather than a trip to Settings and back.</para>
+    ///
+    /// <para><b>Grouped by connection, not flat.</b> Claude Desktop's picker is flat, which works at four
+    /// models. Once several endpoints are configured, grouping is what stops "the 8B I run locally" and "the
+    /// hosted 70B" reading as interchangeable rows.</para>
+    ///
+    /// <para><b>The enabled subset only.</b> The full listing lives in Settings → Models; this is the short
+    /// list the reader built there, so it needs no virtualization and the search box is for comfort rather
+    /// than necessity.</para>
+    /// </summary>
+    public class AiModelPickerViewModel : ViewModelBase
+    {
+        private readonly IAiConnectionService? _service;
+        private readonly Action? _changed;
+        private string _search = "";
+        private bool _isOpen;
+
+        public AiModelPickerViewModel(IAiConnectionService? service, Action? changed = null)
+        {
+            _service = service;
+            _changed = changed;
+
+            ManageCommand = ReactiveCommand.Create(Manage);
+
+            if (_service is not null)
+            {
+                _service.ConnectionsChanged += (_, _) => Rebuild();
+                Rebuild();
+            }
+        }
+
+        public ObservableCollection<AiPickerGroupViewModel> Groups { get; } = new();
+
+        /// <summary>
+        /// What the chip says at rest — the current model's name, readable without opening anything.
+        ///
+        /// <para>The display name rather than the id: the reader typed or promoted a name for it, and
+        /// <c>nvidia/nemotron-nano-9b-v2</c> is not what anyone calls the thing they are talking to.</para>
+        /// </summary>
+        public string CurrentLabel
+        {
+            get
+            {
+                if (_service?.Active is not { } connection) return "No model";
+                if (_service.ActiveModelId is not { Length: > 0 } id) return "Choose a model";
+
+                return connection.Models.FirstOrDefault(
+                    m => string.Equals(m.Id, id, StringComparison.Ordinal))?.DisplayName ?? id;
+            }
+        }
+
+        /// <summary>Hidden entirely until there is a choice to make. A chip offering one model, or none, is a
+        /// control that cannot do anything.</summary>
+        public bool HasChoices => Groups.Sum(g => g.Models.Count) > 1;
+
+        public bool IsOpen
+        {
+            get => _isOpen;
+            set => this.RaiseAndSetIfChanged(ref _isOpen, value);
+        }
+
+        /// <summary>Present because the list can grow, focused on open. At a handful of models it is
+        /// unnecessary; it costs nothing and stops being unnecessary the moment someone enables twenty.</summary>
+        public string Search
+        {
+            get => _search;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _search, value);
+                Rebuild();
+            }
+        }
+
+        public bool HasNothingMatching => Groups.Count == 0;
+
+        public ReactiveCommand<Unit, Unit> ManageCommand { get; }
+
+        /// <summary>
+        /// Chooses what the next message uses.
+        ///
+        /// <para>Switching to a model on another connection changes the base URL and the credential with it —
+        /// the service's job, and the reason a picker that moved only the model id would fail confusingly.</para>
+        ///
+        /// <para>Persisted rather than session-only: the reader's last choice is the one they will most often
+        /// want again, and a picker that silently reverted on restart would make "which model answered this?"
+        /// a question they had to keep checking.</para>
+        /// </summary>
+        internal void Select(string connectionId, string modelId)
+        {
+            if (_service is null) return;
+
+            _service.SetActive(connectionId, modelId);
+            IsOpen = false;
+            Search = "";
+            _changed?.Invoke();
+        }
+
+        private void Manage()
+        {
+            IsOpen = false;
+            _ = App.ShowSettingsWindow();
+        }
+
+        private void Rebuild()
+        {
+            Groups.Clear();
+            if (_service is null) return;
+
+            foreach (var connection in _service.Connections)
+            {
+                var models = connection.Models
+                    .Where(m => m.Enabled)
+                    .Where(m => Matches(m))
+                    .OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
+                    .Select(m => new AiPickerModelViewModel(this, connection, m,
+                        isCurrent: IsCurrent(connection, m)))
+                    .ToList();
+
+                if (models.Count == 0) continue;
+
+                Groups.Add(new AiPickerGroupViewModel(connection, models));
+            }
+
+            this.RaisePropertyChanged(nameof(CurrentLabel));
+            this.RaisePropertyChanged(nameof(HasChoices));
+            this.RaisePropertyChanged(nameof(HasNothingMatching));
+        }
+
+        private bool Matches(AiModelEntry model) =>
+            string.IsNullOrWhiteSpace(Search) ||
+            model.DisplayName.Contains(Search, StringComparison.OrdinalIgnoreCase) ||
+            model.Id.Contains(Search, StringComparison.OrdinalIgnoreCase);
+
+        private bool IsCurrent(AiConnection connection, AiModelEntry model) =>
+            string.Equals(_service?.Active?.Id, connection.Id, StringComparison.Ordinal) &&
+            string.Equals(_service?.ActiveModelId, model.Id, StringComparison.Ordinal);
+
+        internal void Refresh() => Rebuild();
+    }
+
+    /// <summary>One connection's enabled models, under its name. (#693)</summary>
+    public class AiPickerGroupViewModel : ViewModelBase
+    {
+        public AiPickerGroupViewModel(AiConnection connection, IReadOnlyList<AiPickerModelViewModel> models)
+        {
+            DisplayName = connection.DisplayName;
+            Monogram = AiMonogram.For(connection.DisplayName);
+            MonogramTone = AiMonogram.ToneFor(connection.Id);
+            Models = models;
+
+            // Marked, never hidden: the reader may be about to start their local runner, and a provider that
+            // vanished from the picker because it was asleep would look like a lost configuration.
+            Note = connection.State == Reachability.Unreachable ? "not responding" : "";
+        }
+
+        public string DisplayName { get; }
+        public string Monogram { get; }
+        public int MonogramTone { get; }
+        public string Note { get; }
+        public bool HasNote => Note.Length > 0;
+        public IReadOnlyList<AiPickerModelViewModel> Models { get; }
+    }
+
+    /// <summary>One pickable model. (#693)</summary>
+    public class AiPickerModelViewModel : ViewModelBase
+    {
+        private readonly AiModelPickerViewModel _owner;
+        private readonly string _connectionId;
+
+        public AiPickerModelViewModel(
+            AiModelPickerViewModel owner, AiConnection connection, AiModelEntry model, bool isCurrent)
+        {
+            _owner = owner;
+            _connectionId = connection.Id;
+
+            ModelId = model.Id;
+            DisplayName = model.DisplayName;
+            IsCurrent = isCurrent;
+            Unusable = ReasonItCannotBeUsed(connection);
+
+            SelectCommand = ReactiveCommand.Create(() => _owner.Select(_connectionId, ModelId));
+        }
+
+        public string ModelId { get; }
+
+        public string DisplayName { get; }
+
+        /// <summary>Marked with a check, so the reader can see what answered the last question without
+        /// opening anything else.</summary>
+        public bool IsCurrent { get; }
+
+        /// <summary>
+        /// Why this model cannot be used, or empty when it can.
+        ///
+        /// <para>Said here rather than discovered as a 401 that names nothing — which is the failure this
+        /// exists to prevent.</para>
+        /// </summary>
+        public string Unusable { get; }
+
+        public bool IsUsable => Unusable.Length == 0;
+
+        public ReactiveCommand<Unit, Unit> SelectCommand { get; }
+
+        /// <summary>
+        /// Only reasons we can state as fact.
+        ///
+        /// <para>A missing key is a problem for a provider whose preset says it requires one, and that is a
+        /// provider fact from the extraction rather than a guess. For a custom endpoint nothing is claimed:
+        /// plenty of them need no key at all, and disabling a model on a hunch would be worse than letting
+        /// the request explain itself.</para>
+        /// </summary>
+        private static string ReasonItCannotBeUsed(AiConnection connection)
+        {
+            if (connection.IsIncomplete) return "not finished being set up";
+
+            var preset = AiProviderPresets.ById(connection.Id);
+            if (preset is { RequiresKey: true } && connection.KeySource == CredentialSource.None)
+                return "no API key stored";
+
+            return "";
+        }
+    }
+}

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -1,0 +1,446 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using System.Threading.Tasks;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using ReactiveUI;
+
+namespace CST.Avalonia.ViewModels
+{
+    /// <summary>
+    /// The Models tab: which of each connection's models the reader wants on their short list. (#692, #674)
+    ///
+    /// <para><b>Two sources, one list.</b> A connection's models are whatever the reader typed on the
+    /// connection sheet, plus — for a provider that publishes a listing — whatever asking it returns. The
+    /// typed ones are the floor and always work; the fetched ones are the upgrade, and a provider that
+    /// publishes nothing is not a degraded case but the ordinary one for a local runner.</para>
+    ///
+    /// <para><b>Defaults differ by source, for one reason.</b> A model is on because a person put it there.
+    /// Typing an id is putting it there, so a typed model arrives on. A fetched catalogue arrives because a
+    /// key was pasted — nobody asked for its four hundred entries — so every one of them starts off and the
+    /// reader promotes the handful they will switch between.</para>
+    ///
+    /// <para><b>Nothing here ranks anything.</b> Ordering is alphabetical within a group, groups follow the
+    /// order connections were added, and the only filter is a mechanical one built from the provider's own
+    /// published modality. No badge, no tier, no "recommended", and above all no pre-enabled subset — which
+    /// is what upstream ships, computed from release dates, and is still a verdict for being arithmetic
+    /// (#670/#681, #689).</para>
+    /// </summary>
+    public class AiModelsViewModel : ViewModelBase
+    {
+        private readonly IAiConnectionService? _service;
+        private readonly IAiModelCatalog? _catalog;
+        private string _search = "";
+        private bool _textOnly = true;
+        private bool _suppressRebind;
+
+        public AiModelsViewModel(IAiConnectionService? service, IAiModelCatalog? catalog = null)
+        {
+            _service = service;
+            _catalog = catalog;
+
+            if (_service is not null)
+            {
+                _service.ConnectionsChanged += (_, _) => Rebind();
+                Rebind();
+            }
+        }
+
+        /// <summary>
+        /// The flattened list the view renders: group headers and model rows in one sequence.
+        ///
+        /// <para>Flat so it can virtualize. A provider listing runs to hundreds of entries, and a nested
+        /// items control inside the settings page's scroll viewer would build a control for every one of
+        /// them.</para>
+        /// </summary>
+        public ObservableCollection<object> Rows { get; } = new();
+
+        public ObservableCollection<AiModelGroupViewModel> Groups { get; } = new();
+
+        public bool HasNoConnections => Groups.Count == 0;
+
+        /// <summary>Filters <b>across</b> groups, not within the expanded one — at four hundred models the
+        /// list is a search box with results, not a menu you scroll.</summary>
+        public string Search
+        {
+            get => _search;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _search, value);
+                Reflow();
+            }
+        }
+
+        public bool IsSearching => !string.IsNullOrWhiteSpace(Search);
+
+        /// <summary>
+        /// Hide models that cannot take text in and give text out.
+        ///
+        /// <para>Built entirely from the provider's published modality, so it removes models that cannot
+        /// answer a question at all — a text-to-speech model, an image generator — and says nothing about
+        /// which of the rest is better. Shown as a control and reversible, because a mechanical filter the
+        /// reader cannot see or turn off starts to look like a judgment even when it isn't.</para>
+        /// </summary>
+        public bool TextOnly
+        {
+            get => _textOnly;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _textOnly, value);
+                Reflow();
+            }
+        }
+
+        internal IAiConnectionService? Service => _service;
+
+        internal IAiModelCatalog? Catalog => _catalog;
+
+        /// <summary>
+        /// Runs a change that must not rebuild the list.
+        ///
+        /// <para>Flipping one model's switch raises <c>ConnectionsChanged</c> like any other edit, and
+        /// rebuilding <see cref="Rows"/> in response clears an <c>ObservableCollection</c> the list box is
+        /// bound to — which sends the scroll position back to the top. At four hundred rows that means
+        /// turning on a model near the bottom throws the reader back to the first one. The row updates
+        /// itself; nothing else about the list has changed.</para>
+        /// </summary>
+        internal void Suppressed(Action change)
+        {
+            _suppressRebind = true;
+            try { change(); }
+            finally { _suppressRebind = false; }
+        }
+
+        internal void Reflow()
+        {
+            Rows.Clear();
+
+            foreach (var group in Groups)
+            {
+                group.ApplyFilter(Search, TextOnly, IsSearching);
+
+                // A group with nothing matching disappears entirely while searching, rather than sitting
+                // there as a header promising results it does not have.
+                if (IsSearching && group.Visible.Count == 0) continue;
+
+                Rows.Add(group);
+                if (!group.IsExpanded && !IsSearching) continue;
+
+                foreach (var row in group.Visible) Rows.Add(row);
+            }
+
+            this.RaisePropertyChanged(nameof(HasNoConnections));
+        }
+
+        private void Rebind()
+        {
+            if (_service is null || _suppressRebind) return;
+
+            var connections = _service.Connections;
+
+            for (int i = Groups.Count - 1; i >= 0; i--)
+                if (!connections.Any(c => string.Equals(c.Id, Groups[i].Id, StringComparison.Ordinal)))
+                    Groups.RemoveAt(i);
+
+            for (int i = 0; i < connections.Count; i++)
+            {
+                var connection = connections[i];
+                var existing = Groups.FirstOrDefault(
+                    g => string.Equals(g.Id, connection.Id, StringComparison.Ordinal));
+
+                if (existing is null)
+                {
+                    Groups.Insert(Math.Min(i, Groups.Count), new AiModelGroupViewModel(this, connection));
+                    continue;
+                }
+
+                existing.Update(connection);
+                var at = Groups.IndexOf(existing);
+                if (at != i) Groups.Move(at, i);
+            }
+
+            Reflow();
+        }
+    }
+
+    /// <summary>One connection's models, as a collapsible group. (#692)</summary>
+    public class AiModelGroupViewModel : ViewModelBase
+    {
+        private readonly AiModelsViewModel _owner;
+        private AiConnection _connection;
+        private IReadOnlyList<AiCatalogModel> _fetched = Array.Empty<AiCatalogModel>();
+        private bool _isExpanded;
+        private bool _isFetching;
+        private bool _hasFetched;
+        private string? _fetchProblem;
+
+        public AiModelGroupViewModel(AiModelsViewModel owner, AiConnection connection)
+        {
+            _owner = owner;
+            _connection = connection;
+
+            ToggleCommand = ReactiveCommand.Create(() => { IsExpanded = !IsExpanded; });
+            FetchCommand = ReactiveCommand.CreateFromTask(FetchAsync);
+        }
+
+        public string Id => _connection.Id;
+
+        public string DisplayName => _connection.DisplayName;
+
+        public string Monogram => AiMonogram.For(DisplayName);
+
+        public int MonogramTone => AiMonogram.ToneFor(Id);
+
+        /// <summary>Every row this group could show, filtered and ordered.</summary>
+        public List<AiCatalogRowViewModel> Visible { get; } = new();
+
+        /// <summary>
+        /// Expanding fetches, once, if the connection has never been asked.
+        ///
+        /// <para>Cheaper than a button nobody finds, and it is the moment the reader has said they want to
+        /// see this provider's models. A failure leaves the typed list showing and reports why.</para>
+        /// </summary>
+        public bool IsExpanded
+        {
+            get => _isExpanded;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _isExpanded, value);
+                _owner.Reflow();
+                if (value && !_hasFetched && !_isFetching) _ = FetchAsync();
+            }
+        }
+
+        public bool IsFetching
+        {
+            get => _isFetching;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _isFetching, value);
+                this.RaisePropertyChanged(nameof(CanFetch));
+            }
+        }
+
+        public bool CanFetch => !IsFetching;
+
+        /// <summary>Why the last fetch produced nothing, in the service's own words — which name the endpoint
+        /// rather than saying "cannot connect" and leaving the reader to guess to what.</summary>
+        public string? FetchProblem
+        {
+            get => _fetchProblem;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _fetchProblem, value);
+                this.RaisePropertyChanged(nameof(HasFetchProblem));
+            }
+        }
+
+        public bool HasFetchProblem => !string.IsNullOrEmpty(FetchProblem);
+
+        /// <summary>
+        /// The number a reader needs to decide whether to expand — and, once a listing has been fetched, how
+        /// much of it they have promoted. OpenCode omits the count entirely.
+        /// </summary>
+        public string CountText
+        {
+            get
+            {
+                var total = Visible.Count;
+                var on = Visible.Count(r => r.Enabled);
+                if (total == 0) return "no models yet";
+                return on == total ? Plural(total) : $"{on} of {Plural(total)} on";
+            }
+        }
+
+        private static string Plural(int n) => n == 1 ? "1 model" : $"{n} models";
+
+        public ReactiveCommand<Unit, Unit> ToggleCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> FetchCommand { get; }
+
+        internal void Update(AiConnection connection)
+        {
+            _connection = connection;
+            this.RaisePropertyChanged(nameof(DisplayName));
+            this.RaisePropertyChanged(nameof(Monogram));
+            this.RaisePropertyChanged(nameof(MonogramTone));
+        }
+
+        /// <summary>
+        /// Merges the reader's stored list with anything fetched, then filters.
+        ///
+        /// <para>Stored models are always shown and never filtered out — the reader put them there, and
+        /// hiding one behind a capability filter would look like it had been lost. Fetched models the reader
+        /// has not touched are subject to both the search and the modality filter.</para>
+        /// </summary>
+        internal void ApplyFilter(string search, bool textOnly, bool searching)
+        {
+            var stored = _connection.Models.ToDictionary(m => m.Id, StringComparer.Ordinal);
+            var rows = new List<AiCatalogRowViewModel>();
+
+            foreach (var model in _connection.Models)
+                rows.Add(new AiCatalogRowViewModel(
+                    this, model.Id, model.DisplayName,
+                    _fetched.FirstOrDefault(f => string.Equals(f.Id, model.Id, StringComparison.Ordinal)),
+                    model.Enabled, typed: true));
+
+            foreach (var model in _fetched)
+            {
+                if (stored.ContainsKey(model.Id)) continue;
+                if (textOnly && !model.IsTextToText) continue;
+                rows.Add(new AiCatalogRowViewModel(
+                    this, model.Id, model.DisplayName, model, enabled: false, typed: false));
+            }
+
+            if (!string.IsNullOrWhiteSpace(search))
+                rows = rows.Where(r => r.Matches(search)).ToList();
+
+            rows.Sort((a, b) => string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase));
+
+            Visible.Clear();
+            Visible.AddRange(rows);
+            this.RaisePropertyChanged(nameof(CountText));
+        }
+
+        private async Task FetchAsync()
+        {
+            if (_owner.Catalog is null) return;
+
+            IsFetching = true;
+            FetchProblem = null;
+            try
+            {
+                var result = await _owner.Catalog.FetchAsync(_connection).ConfigureAwait(true);
+                _hasFetched = true;
+
+                if (result.Ok) _fetched = result.Models;
+                else FetchProblem = result.Problem;
+            }
+            catch (Exception ex)
+            {
+                // Started from a property setter, so nothing is awaiting this and an escaping exception would
+                // be an unobserved task rather than a message. The listing is additive; failing to get one is
+                // a sentence on the group header, never a crash.
+                _hasFetched = true;
+                FetchProblem = $"Could not read {DisplayName}'s model list: {ex.Message}";
+            }
+            finally
+            {
+                IsFetching = false;
+                _owner.Reflow();
+            }
+        }
+
+        /// <summary>
+        /// Promotes a model into the reader's stored list, or turns one off. Turning off keeps the entry, so
+        /// a display name typed by hand survives being switched off and on.
+        /// </summary>
+        /// <remarks>
+        /// The write is suppressed from rebuilding the list — see <see cref="AiModelsViewModel.Suppressed"/>
+        /// — so the connection snapshot is refreshed here instead. Without that, the next genuine rebuild
+        /// would rebuild from a record taken before the toggle and silently undo it on screen.
+        /// </remarks>
+        internal void SetEnabled(string modelId, string displayName, bool enabled)
+        {
+            if (_owner.Service is not { } service) return;
+
+            _owner.Suppressed(() => service.EnableModel(Id, modelId, displayName, enabled));
+
+            if (service.Connections.FirstOrDefault(
+                    c => string.Equals(c.Id, Id, StringComparison.Ordinal)) is { } fresh)
+                _connection = fresh;
+
+            this.RaisePropertyChanged(nameof(CountText));
+        }
+    }
+
+    /// <summary>One model, with whatever the provider published about it. (#674)</summary>
+    public class AiCatalogRowViewModel : ViewModelBase
+    {
+        private readonly AiModelGroupViewModel _group;
+        private readonly AiCatalogModel? _published;
+        private bool _enabled;
+
+        public AiCatalogRowViewModel(
+            AiModelGroupViewModel group, string id, string displayName, AiCatalogModel? published,
+            bool enabled, bool typed)
+        {
+            _group = group;
+            _published = published;
+            _enabled = enabled;
+
+            ModelId = id;
+            DisplayName = displayName;
+            IsTyped = typed;
+        }
+
+        public string ModelId { get; }
+
+        public string DisplayName { get; }
+
+        /// <summary>True for a model the reader typed rather than one that arrived in a listing. Shown,
+        /// because "I added this by hand" is the reason it appears even when the provider has never heard of
+        /// it.</summary>
+        public bool IsTyped { get; }
+
+        /// <summary>
+        /// The provider's own facts about the model, on one line: context window, price per million tokens,
+        /// and whether it accepts a reasoning parameter.
+        ///
+        /// <para>Verbatim and attributed to the provider — that is what makes it safe where a table we
+        /// maintained would not be. Empty for an endpoint that publishes nothing, which is most local
+        /// runners, and the row degrades to a bare id rather than demanding metadata that does not exist.</para>
+        /// </summary>
+        public string Details
+        {
+            get
+            {
+                if (_published is null) return ModelId;
+
+                var parts = new List<string> { ModelId };
+
+                if (_published.ContextLength is { } context)
+                    parts.Add($"{context / 1000:N0}K context");
+
+                if (_published.PromptPricePerMillion is { } prompt &&
+                    _published.CompletionPricePerMillion is { } completion)
+                    parts.Add(prompt == 0 && completion == 0
+                        ? "free"
+                        : $"${Money(prompt)}/${Money(completion)} per M");
+
+                if (_published.SupportsReasoning) parts.Add("reasoning");
+
+                return string.Join("  ·  ", parts);
+            }
+        }
+
+        private static string Money(decimal perMillion) =>
+            perMillion >= 1m ? perMillion.ToString("0.##") : perMillion.ToString("0.###");
+
+        /// <summary>
+        /// Whether this model appears in the per-turn picker.
+        ///
+        /// <para>Off by default for anything that arrived in a listing, on for anything the reader typed. See
+        /// the note on <see cref="AiModelsViewModel"/>: a model is on because a person put it there.</para>
+        /// </summary>
+        public bool Enabled
+        {
+            get => _enabled;
+            set
+            {
+                if (_enabled == value) return;
+                this.RaiseAndSetIfChanged(ref _enabled, value);
+                _group.SetEnabled(ModelId, DisplayName, value);
+            }
+        }
+
+        /// <summary>Matches on both the id and the display name — a reader searching "nemotron" is as likely
+        /// to be thinking of the wire id as of the label.</summary>
+        internal bool Matches(string search) =>
+            DisplayName.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+            ModelId.Contains(search, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1342,8 +1342,31 @@ public class AiSettingsViewModel : ViewModelBase
             SaveApiKeyCommand = ReactiveCommand.Create(SaveApiKey);
             RemoveApiKeyCommand = ReactiveCommand.Create(RemoveApiKey);
 
+            // The Providers tab (#691). Resolved rather than injected because this view model is constructed
+            // by hand; a null service leaves the tab inert rather than throwing, which is what the
+            // parameterless constructor used by the designer needs.
+            var connectionService = App.TryGetService<Services.Ai.IAiConnectionService>();
+            Connections = new AiConnectionsViewModel(connectionService, credentials);
+            Models = new AiModelsViewModel(
+                connectionService, App.TryGetService<Services.Ai.IAiModelCatalog>());
+
             RefreshKeyStatus();
         }
+
+        /// <summary>
+        /// The Providers tab: configured endpoints, and the catalogue of named ones to add. (#691)
+        ///
+        /// <para>Owns everything about connections, and reaches them only through
+        /// <see cref="Services.Ai.IAiConnectionService"/> — this class keeps the settings it always had, and
+        /// none of the connection state moved into it.</para>
+        /// </summary>
+        public AiConnectionsViewModel Connections { get; }
+
+        /// <summary>
+        /// The Models tab: each connection's models and the toggles that decide what the Assistant offers.
+        /// (#692, #674)
+        /// </summary>
+        public AiModelsViewModel Models { get; }
 
         /// <summary>Master switch — "Enable AI Features". Everything AI-related is gated behind this (default OFF).</summary>
         public bool AiEnabled

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -83,6 +83,112 @@
                     </TextBox.KeyBindings>
                 </TextBox>
 
+                <!-- The per-turn model chip (#693). At the composer rather than in Settings: comparing two
+                     models on the same passage is the task the assistant exists for, and it wants to be one
+                     click from the answer on screen. Hidden until there is more than one model to choose
+                     between — a chip offering one thing is a control that cannot do anything. -->
+                <Button x:Name="ModelChip"
+                        IsVisible="{Binding ModelPicker.HasChoices}"
+                        HorizontalAlignment="Left"
+                        Padding="8,3"
+                        CornerRadius="12"
+                        FontSize="11"
+                        Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                        BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1">
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <TextBlock Text="{Binding ModelPicker.CurrentLabel}" VerticalAlignment="Center"/>
+                        <TextBlock Text="⌄" FontSize="10" VerticalAlignment="Center"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                    </StackPanel>
+
+                    <Button.Flyout>
+                        <Flyout Placement="Top" ShowMode="Standard">
+                            <Grid RowDefinitions="Auto,*,Auto" Width="330" MaxHeight="360">
+
+                                <!-- Pinned above a scrolling list, and it takes focus: the list can grow. -->
+                                <TextBox Grid.Row="0" Text="{Binding ModelPicker.Search}"
+                                         Watermark="Search models" Margin="0,0,0,6"/>
+
+                                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                                    <StackPanel>
+                                        <TextBlock IsVisible="{Binding ModelPicker.HasNothingMatching}"
+                                                   Text="No models match."
+                                                   FontSize="11" Margin="4,6"
+                                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+
+                                        <ItemsControl ItemsSource="{Binding ModelPicker.Groups}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:AiPickerGroupViewModel">
+                                                    <StackPanel Margin="0,0,0,6">
+                                                        <!-- Grouped by connection: it is what stops "the 8B I
+                                                             run locally" and "the hosted 70B" reading as
+                                                             interchangeable rows. -->
+                                                        <StackPanel Orientation="Horizontal" Spacing="6"
+                                                                    Margin="4,2">
+                                                            <TextBlock Text="{Binding DisplayName}"
+                                                                       FontSize="11" FontWeight="SemiBold"
+                                                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                            <!-- Marked, never hidden: the reader may be
+                                                                 about to start their local runner. -->
+                                                            <TextBlock Text="{Binding Note}"
+                                                                       IsVisible="{Binding HasNote}"
+                                                                       FontSize="11"
+                                                                       Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
+                                                        </StackPanel>
+
+                                                        <ItemsControl ItemsSource="{Binding Models}">
+                                                            <ItemsControl.ItemTemplate>
+                                                                <DataTemplate x:DataType="vm:AiPickerModelViewModel">
+                                                                    <Button Command="{Binding SelectCommand}"
+                                                                            IsEnabled="{Binding IsUsable}"
+                                                                            HorizontalAlignment="Stretch"
+                                                                            HorizontalContentAlignment="Left"
+                                                                            Background="Transparent"
+                                                                            BorderThickness="0"
+                                                                            Padding="8,4">
+                                                                        <Grid ColumnDefinitions="Auto,*,Auto">
+                                                                            <TextBlock Grid.Column="0"
+                                                                                       Text="✓"
+                                                                                       IsVisible="{Binding IsCurrent}"
+                                                                                       Margin="0,0,6,0"
+                                                                                       Foreground="{DynamicResource DockApplicationAccentBrushLow}"/>
+                                                                            <TextBlock Grid.Column="1"
+                                                                                       Text="{Binding DisplayName}"
+                                                                                       TextTrimming="CharacterEllipsis"/>
+                                                                            <!-- Said here rather than
+                                                                                 discovered as a 401 naming
+                                                                                 nothing. -->
+                                                                            <TextBlock Grid.Column="2"
+                                                                                       Text="{Binding Unusable}"
+                                                                                       IsVisible="{Binding !IsUsable}"
+                                                                                       FontSize="11"
+                                                                                       Margin="6,0,0,0"
+                                                                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                                        </Grid>
+                                                                    </Button>
+                                                                </DataTemplate>
+                                                            </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </ScrollViewer>
+
+                                <!-- Pinned at the bottom: the route back to the full listing. -->
+                                <Button Grid.Row="2" Content="Manage models…"
+                                        Command="{Binding ModelPicker.ManageCommand}"
+                                        HorizontalAlignment="Left"
+                                        Background="Transparent" BorderThickness="0"
+                                        FontSize="11" Padding="4,4,4,0"
+                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                            </Grid>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+
                 <WrapPanel Orientation="Horizontal">
                     <!-- First, and disabled until something is typed: the other four are complete without a
                          question, and this one IS the question. -->

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml.cs
@@ -16,9 +16,60 @@ namespace CST.Avalonia.Views;
 /// </summary>
 public partial class AiAssistantPanel : UserControl
 {
-    public AiAssistantPanel() => InitializeComponent();
+    private AiModelPickerViewModel? _picker;
+
+    private bool _syncingFlyout;
+
+    public AiAssistantPanel()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+
+        // Mirror the flyout's own state into the view model. Needed in both directions: the view model has
+        // to KNOW it is open for its later close to register as a change, and a reader who dismisses the
+        // list by clicking away must not leave it believing otherwise.
+        if (ModelChip.Flyout is { } flyout)
+        {
+            flyout.Opened += (_, _) => SetOpen(true);
+            flyout.Closed += (_, _) => SetOpen(false);
+        }
+    }
+
+    private void SetOpen(bool open)
+    {
+        if (_picker is null) return;
+        _syncingFlyout = true;
+        try { _picker.IsOpen = open; }
+        finally { _syncingFlyout = false; }
+    }
 
     private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void OnDataContextChanged(object? sender, System.EventArgs e)
+    {
+        if (_picker is not null) _picker.PropertyChanged -= OnPickerChanged;
+        _picker = (DataContext as AiAssistantViewModel)?.ModelPicker;
+        if (_picker is not null) _picker.PropertyChanged += OnPickerChanged;
+    }
+
+    /// <summary>
+    /// Closes the model flyout once a choice is made. (#693)
+    ///
+    /// <para>Code-behind because a <c>Flyout</c> owns its own open state: it opens itself when the chip is
+    /// clicked and there is no bindable property to close it through. Without this, picking a model leaves
+    /// the list sitting over the composer — and the reader's next act is to dismiss a popup rather than to
+    /// ask the question they opened it for.</para>
+    ///
+    /// <para>Driven from the view model's own <c>IsOpen</c> rather than from each row's click handler, so
+    /// every route that ends the choice — picking a model, or leaving for Settings — closes it the same
+    /// way.</para>
+    /// </summary>
+    private void OnPickerChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (_syncingFlyout) return;   // the flyout told us; do not tell it back
+        if (e.PropertyName != nameof(AiModelPickerViewModel.IsOpen)) return;
+        if (_picker?.IsOpen == false) ModelChip.Flyout?.Hide();
+    }
 
     /// <summary>
     /// Drag the reasoning panel taller or shorter. The one piece of code-behind here, because

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -1,0 +1,176 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:CST.Avalonia.ViewModels"
+             xmlns:conv="using:CST.Avalonia.Converters"
+             x:Class="CST.Avalonia.Views.AiModelsView"
+             x:DataType="vm:AiModelsViewModel">
+
+    <!-- The Models tab (#692, #674).
+
+         One flat, virtualized list of group headers and model rows. Flat because a provider listing runs to
+         hundreds of entries and a nested items control would build a control for every one; a single
+         ListBox lets the virtualizing panel do its job.
+
+         Search filters ACROSS groups rather than within the expanded one, and expands what matches — at four
+         hundred models this is a search box with results, not a menu you scroll. -->
+
+    <UserControl.Styles>
+        <Style Selector="Border.Tile">
+            <Setter Property="Width" Value="22"/>
+            <Setter Property="Height" Value="22"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="0,0,8,0"/>
+        </Style>
+
+        <Style Selector="Border.Tile > TextBlock">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+
+        <Style Selector="TextBlock.Secondary">
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+        </Style>
+
+        <Style Selector="Button.Link">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="6,2"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+        </Style>
+
+        <!-- The list is a container for rows, not a thing you select from: every row's action is its own
+             toggle. Selection chrome here would suggest a row-level choice that does not exist. -->
+        <Style Selector="ListBoxItem">
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="MinHeight" Value="0"/>
+        </Style>
+        <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
+            <Setter Property="Background" Value="Transparent"/>
+        </Style>
+        <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}"/>
+        </Style>
+    </UserControl.Styles>
+
+    <StackPanel>
+        <TextBlock Text="Choose the models you want to switch between. They are what the Assistant offers when you ask a question."
+                   Classes="SettingDescription"/>
+
+        <TextBlock IsVisible="{Binding HasNoConnections}"
+                   Text="No providers are configured yet. Add one on the Providers tab first."
+                   Classes="SettingDescription"/>
+
+        <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,10"
+              IsVisible="{Binding !HasNoConnections}">
+            <TextBox Grid.Column="0" Text="{Binding Search}"
+                     Watermark="Search models"/>
+            <!-- Mechanical and reversible: it drops models that cannot take text in and give text out, using
+                 the provider's own published modality, and says nothing about which of the rest is better. -->
+            <CheckBox Grid.Column="1" IsChecked="{Binding TextOnly}"
+                      Content="Text models only"
+                      Margin="10,0,0,0" VerticalAlignment="Center"
+                      ToolTip.Tip="Hides models the provider publishes as image, audio or video only. Nothing is judged — these cannot answer a question at all."/>
+        </Grid>
+
+        <Border Classes="SettingGroup" Padding="0"
+                IsVisible="{Binding !HasNoConnections}">
+            <ListBox ItemsSource="{Binding Rows}"
+                     MaxHeight="460"
+                     Background="Transparent"
+                     BorderThickness="0"
+                     SelectionMode="Single">
+                <ListBox.DataTemplates>
+
+                    <!-- Group header: one connection -->
+                    <DataTemplate DataType="vm:AiModelGroupViewModel">
+                        <Border Padding="10,8"
+                                Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="0,0,0,1">
+                            <StackPanel Spacing="4">
+                                <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+                                    <Button Grid.Column="0" Classes="Link"
+                                            Command="{Binding ToggleCommand}"
+                                            Padding="2,0" Margin="0,0,4,0">
+                                        <TextBlock Text="{Binding IsExpanded, Converter={x:Static conv:ChevronConverter.Instance}}"
+                                                   FontSize="10"/>
+                                    </Button>
+
+                                    <Border Grid.Column="1" Classes="Tile"
+                                            Background="{Binding MonogramTone,
+                                                Converter={x:Static conv:MonogramToneConverter.Instance}}">
+                                        <TextBlock Text="{Binding Monogram}"/>
+                                    </Border>
+
+                                    <TextBlock Grid.Column="2" Text="{Binding DisplayName}"
+                                               FontWeight="SemiBold" VerticalAlignment="Center"/>
+
+                                    <TextBlock Grid.Column="3" Text="{Binding CountText}"
+                                               Classes="Secondary" VerticalAlignment="Center"
+                                               Margin="0,0,8,0"/>
+
+                                    <Button Grid.Column="4" Classes="Link"
+                                            Content="Refresh"
+                                            IsEnabled="{Binding CanFetch}"
+                                            Command="{Binding FetchCommand}"/>
+                                </Grid>
+
+                                <TextBlock Text="Asking the provider for its models…"
+                                           IsVisible="{Binding IsFetching}"
+                                           Classes="Secondary"/>
+
+                                <!-- Named endpoint, named reason. "Cannot connect" without saying to what is
+                                     the sentence that sends a reader looking in the wrong place. -->
+                                <TextBlock Text="{Binding FetchProblem}"
+                                           IsVisible="{Binding HasFetchProblem}"
+                                           Classes="Secondary"
+                                           TextWrapping="Wrap"
+                                           Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
+
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+
+                    <!-- One model -->
+                    <DataTemplate DataType="vm:AiCatalogRowViewModel">
+                        <Border Padding="34,6,10,6"
+                                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="0,0,0,1">
+                            <Grid ColumnDefinitions="*,Auto,Auto">
+                                <StackPanel Grid.Column="0" Spacing="1" VerticalAlignment="Center">
+                                    <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
+                                    <!-- The provider's own facts, verbatim. Empty for an endpoint that
+                                         publishes none, and the row degrades to its id. -->
+                                    <TextBlock Text="{Binding Details}" Classes="Secondary"
+                                               TextTrimming="CharacterEllipsis"/>
+                                </StackPanel>
+
+                                <Border Grid.Column="1" IsVisible="{Binding IsTyped}"
+                                        Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                                        BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                        BorderThickness="1" CornerRadius="9" Padding="7,1"
+                                        VerticalAlignment="Center" Margin="8,0">
+                                    <TextBlock Text="Typed" FontSize="10"
+                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                </Border>
+
+                                <!-- A switch, never a radio: several models under one connection must be
+                                     on at once, which is the entire point of a short list. -->
+                                <ToggleSwitch Grid.Column="2" IsChecked="{Binding Enabled}"
+                                              OnContent="" OffContent=""
+                                              VerticalAlignment="Center"/>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+
+                </ListBox.DataTemplates>
+            </ListBox>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/src/CST.Avalonia/Views/AiModelsView.axaml.cs
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace CST.Avalonia.Views
+{
+    /// <summary>The Models tab of the AI settings — each connection's models, with the toggles that decide
+    /// what the Assistant offers. (#692, #674)</summary>
+    public partial class AiModelsView : UserControl
+    {
+        public AiModelsView()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -1,0 +1,404 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:CST.Avalonia.ViewModels"
+             xmlns:conv="using:CST.Avalonia.Converters"
+             xmlns:ai="using:CST.Avalonia.Models.Ai"
+             x:Class="CST.Avalonia.Views.AiProvidersView"
+             x:DataType="vm:AiConnectionsViewModel">
+
+    <!-- The Providers tab of the AI settings (#691).
+
+         Two stacked sections: what is configured now, then a catalogue of what could be added. A preset
+         leaves the lower section once a connection using it exists, so the catalogue always reads as "what
+         you could add next" rather than a list where some rows are already spoken for.
+
+         The editor replaces the list rather than floating over it — a sheet, not an inline expansion, so
+         there is room for a second step later (validate, then fetch models) without a scrim or a z-order. -->
+
+    <UserControl.Styles>
+        <!-- The letter tile standing in for a provider mark until real vendor assets land. -->
+        <Style Selector="Border.Tile">
+            <Setter Property="Width" Value="28"/>
+            <Setter Property="Height" Value="28"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="VerticalAlignment" Value="Top"/>
+            <Setter Property="Margin" Value="0,1,12,0"/>
+        </Style>
+
+        <Style Selector="Border.Tile > TextBlock">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+
+        <!-- The credential-source badge. Every row carries one, on one axis. -->
+        <Style Selector="Border.Pill">
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundFillColorSecondaryBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="10"/>
+            <Setter Property="Padding" Value="8,1"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+
+        <Style Selector="Border.Pill > TextBlock">
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+        </Style>
+
+        <!-- Undoing is quieter than the invitation: bordered Add, plain-text Edit and Delete. -->
+        <Style Selector="Button.Link">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="6,2"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+        </Style>
+
+        <Style Selector="Button.Link:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}"/>
+        </Style>
+
+        <Style Selector="Border.Row">
+            <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}"/>
+            <Setter Property="BorderThickness" Value="0,0,0,1"/>
+            <Setter Property="Padding" Value="12,10"/>
+        </Style>
+
+        <Style Selector="TextBlock.Secondary">
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Grid>
+
+        <!-- THE LIST -->
+        <StackPanel IsVisible="{Binding IsListing}">
+
+            <TextBlock Text="{Binding Problem}"
+                       IsVisible="{Binding HasProblem}"
+                       Classes="SettingDescription"
+                       Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
+
+            <!-- Your connections -->
+            <TextBlock Text="Your connections" Classes="SettingLabel" FontWeight="SemiBold"/>
+
+            <TextBlock IsVisible="{Binding HasNoConnections}"
+                       Text="Nothing is configured yet. Add one from the list below, or add an endpoint of your own."
+                       Classes="SettingDescription"/>
+
+            <Border Classes="SettingGroup" Padding="0"
+                    IsVisible="{Binding !HasNoConnections}">
+                <ItemsControl ItemsSource="{Binding Connections}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:AiConnectionRowViewModel">
+                            <Border Classes="Row">
+                                <Grid ColumnDefinitions="Auto,*,Auto,Auto">
+
+                                    <Border Grid.Column="0" Classes="Tile"
+                                            Background="{Binding MonogramTone,
+                                                Converter={x:Static conv:MonogramToneConverter.Instance}}">
+                                        <TextBlock Text="{Binding Monogram}"/>
+                                    </Border>
+
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
+                                        <!-- The address, which OpenCode omits. Two local endpoints are two
+                                             names the reader chose and nothing else to tell them apart. -->
+                                        <TextBlock Text="{Binding Endpoint}" Classes="Secondary"/>
+                                        <TextBlock Text="{Binding IncompleteText}"
+                                                   IsVisible="{Binding IsIncomplete}"
+                                                   Classes="Secondary"
+                                                   Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Column="2" VerticalAlignment="Center"
+                                                HorizontalAlignment="Right" Spacing="3" Margin="12,0">
+                                        <Border Classes="Pill" HorizontalAlignment="Right">
+                                            <TextBlock Text="{Binding KeySourceBadge}"/>
+                                        </Border>
+                                        <!-- Never "Connected": configured is not reachable, and the screen a
+                                             reader consults to diagnose a failure must not be the one lying
+                                             about it. -->
+                                        <TextBlock Text="{Binding StatusText}" Classes="Secondary"
+                                                   HorizontalAlignment="Right"/>
+                                        <TextBlock Text="{Binding ModelSummary}" Classes="Secondary"
+                                                   HorizontalAlignment="Right"/>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Column="3" Orientation="Horizontal"
+                                                VerticalAlignment="Center"
+                                                IsVisible="{Binding IsNotConfirmingDelete}">
+                                        <Button Content="Edit" Classes="Link"
+                                                Command="{Binding EditCommand}"/>
+                                        <!-- Two destructive actions, not one: stopping the billing and
+                                             throwing away a hand-typed model list are different intentions.
+                                             An environment-sourced row gets an EMPTY slot here rather than a
+                                             disabled button — the app cannot delete a key it never stored,
+                                             and a control there would lie about what it can do. -->
+                                        <Button Content="Remove key" Classes="Link"
+                                                IsVisible="{Binding CanRemoveKey}"
+                                                Command="{Binding RemoveKeyCommand}"/>
+                                        <Button Content="Delete" Classes="Link"
+                                                Command="{Binding DeleteCommand}"/>
+                                    </StackPanel>
+
+                                    <!-- Delete takes the hand-typed model list with it, so it asks. An inline
+                                         second click rather than a dialog: nothing to dismiss, and looking
+                                         away is a valid answer. -->
+                                    <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="4"
+                                                VerticalAlignment="Center"
+                                                IsVisible="{Binding IsConfirmingDelete}">
+                                        <TextBlock Text="{Binding DeleteConfirmText}"
+                                                   Classes="Secondary" VerticalAlignment="Center"/>
+                                        <Button Content="Delete" Classes="Link"
+                                                Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+                                                Command="{Binding ConfirmDeleteCommand}"/>
+                                        <Button Content="Keep" Classes="Link"
+                                                Command="{Binding CancelDeleteCommand}"/>
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Border>
+
+            <!-- Add a provider -->
+            <TextBlock Text="Add a provider" Classes="SettingLabel" FontWeight="SemiBold"/>
+            <TextBlock Text="A named provider fills in the address for you. Nothing here is a recommendation — every entry is the same mechanism as a custom endpoint, with its URL already known."
+                       Classes="SettingDescription"/>
+
+            <Border Classes="SettingGroup" Padding="0">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding AvailablePresets}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:AiPresetRowViewModel">
+                                <Border Classes="Row">
+                                    <Grid ColumnDefinitions="Auto,*,Auto">
+
+                                        <Border Grid.Column="0" Classes="Tile"
+                                                Background="{Binding MonogramTone,
+                                                    Converter={x:Static conv:MonogramToneConverter.Instance}}">
+                                            <TextBlock Text="{Binding Monogram}"/>
+                                        </Border>
+
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                            <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{Binding RequirementText}" Classes="Secondary"/>
+                                        </StackPanel>
+
+                                        <Button Grid.Column="2" Content="+ Add"
+                                                Command="{Binding AddCommand}"
+                                                VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Custom last, as OpenCode has it, and always present. The named rows above are this
+                         same row with the address filled in; a preset must never be required to reach a
+                         provider that never appears in anyone's catalogue. -->
+                    <Border Classes="Row" BorderThickness="0">
+                        <Grid ColumnDefinitions="Auto,*,Auto">
+                            <Border Grid.Column="0" Classes="Tile"
+                                    Background="{DynamicResource DockApplicationAccentBrushLow}">
+                                <TextBlock Text="+"/>
+                            </Border>
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                <TextBlock Text="Custom endpoint" FontWeight="SemiBold"/>
+                                <TextBlock Text="Any OpenAI-compatible or Anthropic address, by URL."
+                                           Classes="Secondary"/>
+                            </StackPanel>
+                            <Button Grid.Column="2" Content="+ Add"
+                                    Command="{Binding AddCustomCommand}"
+                                    VerticalAlignment="Center"/>
+                        </Grid>
+                    </Border>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+
+        <!-- THE SHEET -->
+        <ContentControl IsVisible="{Binding IsEditing}" Content="{Binding Editor}">
+            <ContentControl.DataTemplates>
+                <DataTemplate DataType="vm:AiConnectionEditorViewModel">
+                    <StackPanel>
+                        <TextBlock Text="{Binding Title}" Classes="SectionTitle"/>
+                        <TextBlock Text="{Binding Blurb}" Classes="SettingDescription"/>
+
+                        <TextBlock Text="{Binding Problem}"
+                                   IsVisible="{Binding HasProblem}"
+                                   Classes="SettingDescription"
+                                   Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
+
+                        <!-- The full form: a custom endpoint, or one being edited. -->
+                        <StackPanel IsVisible="{Binding IsFullForm}" Spacing="0">
+
+                            <TextBlock Text="Id" Classes="SettingLabel"/>
+                            <TextBox Text="{Binding Id}"
+                                     IsEnabled="{Binding IsIdEditable}"
+                                     Watermark="myprovider"
+                                     Width="320" HorizontalAlignment="Left"/>
+                            <!-- Immutable after creation because it is the account the credential is filed
+                                 under. A URL-derived id would change with a port and the key would look
+                                 rejected rather than lost. -->
+                            <TextBlock Text="Lowercase letters, numbers, hyphens and underscores. Fixed once the connection exists — it is what the saved key is filed under."
+                                       Classes="SettingDescription"/>
+
+                            <TextBlock Text="Display name" Classes="SettingLabel"/>
+                            <TextBox Text="{Binding DisplayName}"
+                                     Watermark="My provider"
+                                     Width="320" HorizontalAlignment="Left"/>
+                            <TextBlock Text="What this endpoint is called on screen. Rename it whenever you like."
+                                       Classes="SettingDescription"/>
+
+                            <TextBlock Text="Protocol" Classes="SettingLabel"/>
+                            <ComboBox ItemsSource="{Binding Kinds}"
+                                      SelectedItem="{Binding Kind}"
+                                      Width="320" HorizontalAlignment="Left">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:AiKindChoice">
+                                        <TextBlock Text="{Binding Display}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                            <TextBlock Text="Which HTTP shape this endpoint speaks — not who runs it. Several providers serve the Anthropic protocol at their own address."
+                                       Classes="SettingDescription"/>
+
+                            <TextBlock Text="Endpoint address" Classes="SettingLabel"/>
+                            <TextBox Text="{Binding BaseUrl}"
+                                     Watermark="https://api.myprovider.com/v1"
+                                     Width="480" HorizontalAlignment="Left"/>
+                            <TextBlock Text="Required. For an OpenAI-compatible endpoint this is what selects the provider."
+                                       Classes="SettingDescription"/>
+
+                            <TextBlock Text="Headers (optional)" Classes="SettingLabel"
+                                       IsVisible="{Binding ShowHeaders}"/>
+                            <ItemsControl ItemsSource="{Binding Headers}" Margin="0,0,0,4">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:AiHeaderRowViewModel">
+                                        <Grid ColumnDefinitions="240,240,Auto" Margin="0,0,0,4">
+                                            <TextBox Grid.Column="0" Text="{Binding Name}"
+                                                     Watermark="Header-Name" Margin="0,0,6,0"/>
+                                            <TextBox Grid.Column="1" Text="{Binding Value}"
+                                                     Watermark="value" Margin="0,0,6,0"/>
+                                            <Button Grid.Column="2" Content="Remove" Classes="Link"
+                                                    Command="{Binding RemoveCommand}"
+                                                    VerticalAlignment="Center"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <Button Content="+ Add header" Classes="Link"
+                                    Command="{Binding AddHeaderCommand}"
+                                    HorizontalAlignment="Left"/>
+                            <TextBlock Text="For endpoints that authenticate with something other than a bearer key — a gateway token, or a provider's own key header."
+                                       Classes="SettingDescription" Margin="0,6,0,15"/>
+                        </StackPanel>
+
+                        <!-- The key is asked for HERE, on the sheet that already knows whose it is. A single
+                             shared key box elsewhere in Settings cannot say which connection it belongs to,
+                             so a reader pasting an OpenRouter key while some other endpoint happens to be
+                             active files it under that one — #678's collision with a new cause. -->
+                        <StackPanel IsVisible="{Binding ShowKeyField}">
+                            <TextBlock Text="API key" Classes="SettingLabel"/>
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <TextBox Text="{Binding ApiKeyEntry}"
+                                         PasswordChar="●"
+                                         IsEnabled="{Binding CanStoreKeys}"
+                                         Watermark="Paste a key"
+                                         Width="320"/>
+                                <Button Content="Remove stored key" Classes="Link"
+                                        IsVisible="{Binding HasStoredKey}"
+                                        Command="{Binding RemoveKeyCommand}"
+                                        VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <TextBlock Text="{Binding KeyStatus}" Classes="SettingDescription" Margin="0,4,0,0"/>
+                            <TextBlock Text="{Binding KeyUnavailable}"
+                                       IsVisible="{Binding HasKeyUnavailable}"
+                                       Classes="SettingDescription"
+                                       Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
+                            <TextBlock Text="{Binding KeyHint}" Classes="SettingDescription"/>
+                        </StackPanel>
+
+                        <!-- Only for an endpoint we cannot ask. A named provider's listing is fetched on the
+                             Models tab, so putting a model box here would make the reader decide whether they
+                             need to type an id before seeing what the provider returns. -->
+                        <StackPanel IsVisible="{Binding ShowModels}">
+                        <TextBlock Text="Models" Classes="SettingLabel"/>
+                        <ItemsControl ItemsSource="{Binding Models}" Margin="0,0,0,4">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="vm:AiModelRowViewModel">
+                                    <Grid ColumnDefinitions="240,240,Auto" Margin="0,0,0,4">
+                                        <TextBox Grid.Column="0" Text="{Binding ModelId}"
+                                                 Watermark="model-id" Margin="0,0,6,0"/>
+                                        <TextBox Grid.Column="1" Text="{Binding DisplayName}"
+                                                 Watermark="Display name" Margin="0,0,6,0"/>
+                                        <Button Grid.Column="2" Content="Remove" Classes="Link"
+                                                Command="{Binding RemoveCommand}"
+                                                VerticalAlignment="Center"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <Button Content="+ Add model" Classes="Link"
+                                Command="{Binding AddModelCommand}"
+                                HorizontalAlignment="Left"/>
+                        <TextBlock Text="{Binding ModelsHint}"
+                                   Classes="SettingDescription" Margin="0,6,0,0"/>
+                        <TextBlock Text="The id goes on the wire, exactly as the provider spells it. The display name is yours, and is what the model picker shows."
+                                   Classes="SettingDescription" Margin="0,2,0,15"/>
+                        </StackPanel>
+
+                        <!-- A preset's address, read-only. Not a field to fill in, but the one fact that
+                             says where the reader's questions and money are about to go. -->
+                        <StackPanel IsVisible="{Binding ShowFixedEndpoint}">
+                            <TextBlock Text="Endpoint address" Classes="SettingLabel"/>
+                            <SelectableTextBlock Text="{Binding FixedEndpoint}"
+                                                 Classes="Secondary" Margin="0,0,0,15"/>
+                        </StackPanel>
+
+                        <!-- Whatever the preset says it still needs, generated from its own prompts. -->
+                        <ItemsControl ItemsSource="{Binding Inputs}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="vm:AiInputRowViewModel">
+                                    <StackPanel IsVisible="{Binding IsVisible}">
+                                        <TextBlock Text="{Binding Message}" Classes="SettingLabel"/>
+                                        <TextBox Text="{Binding Value}"
+                                                 IsVisible="{Binding IsFreeText}"
+                                                 Watermark="{Binding Placeholder}"
+                                                 Width="320" HorizontalAlignment="Left"
+                                                 Margin="0,0,0,15"/>
+                                        <ComboBox ItemsSource="{Binding Options}"
+                                                  IsVisible="{Binding HasOptions}"
+                                                  SelectedValue="{Binding Value}"
+                                                  SelectedValueBinding="{Binding Value}"
+                                                  Width="320" HorizontalAlignment="Left"
+                                                  Margin="0,0,0,15">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate x:DataType="ai:AiPromptOption">
+                                                    <TextBlock Text="{Binding Label}"/>
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
+                            <Button Content="{Binding SaveText}" Command="{Binding SaveCommand}"/>
+                            <Button Content="Cancel" Classes="Link" Command="{Binding CancelCommand}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </DataTemplate>
+            </ContentControl.DataTemplates>
+        </ContentControl>
+    </Grid>
+</UserControl>

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml.cs
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.VisualTree;
+using CST.Avalonia.ViewModels;
+
+namespace CST.Avalonia.Views
+{
+    /// <summary>
+    /// The Providers tab of the AI settings — configured connections above, a catalogue of named endpoints
+    /// below. (#691)
+    /// </summary>
+    public partial class AiProvidersView : UserControl
+    {
+        private AiConnectionsViewModel? _bound;
+
+        public AiProvidersView()
+        {
+            InitializeComponent();
+            DataContextChanged += OnDataContextChanged;
+        }
+
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+        private void OnDataContextChanged(object? sender, System.EventArgs e)
+        {
+            if (_bound is not null) _bound.PropertyChanged -= OnViewModelChanged;
+            _bound = DataContext as AiConnectionsViewModel;
+            if (_bound is not null) _bound.PropertyChanged += OnViewModelChanged;
+        }
+
+        /// <summary>
+        /// Puts the top of the tab back in view when the sheet closes.
+        ///
+        /// <para>Without this, saving leaves the settings pane scrolled to wherever the reader was when they
+        /// reached the catalogue — the bottom — while the connection they just added is a row at the very
+        /// top. The add then reads as having done nothing, which is exactly the confusion that made every
+        /// add open a sheet in the first place.</para>
+        /// </summary>
+        private void OnViewModelChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(AiConnectionsViewModel.IsListing)) return;
+            if (_bound?.IsListing != true) return;
+            if (this.FindAncestorOfType<ScrollViewer>() is { } scroll) scroll.Offset = default;
+        }
+    }
+}

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:CST.Avalonia.ViewModels"
+        xmlns:views="using:CST.Avalonia.Views"
         x:Class="CST.Avalonia.Views.SettingsWindow"
         x:DataType="vm:SettingsViewModel"
         Title="Settings"
@@ -496,9 +497,16 @@
                             </StackPanel>
                         </DataTemplate>
 
-                        <!-- AI Settings Template (#186) -->
+                        <!-- AI Settings Template (#186).
+
+                             Sub-tabs rather than one long scroll (#691): connections, a catalogue of ~25
+                             named providers, and per-connection model lists do not fit under the switches
+                             they belong to. The master switch stays on the first tab, adjacent to what it
+                             gates, rather than becoming a left-nav row of its own. -->
                         <DataTemplate DataType="vm:AiSettingsViewModel">
-                            <StackPanel>
+                            <TabControl>
+                              <TabItem Header="General">
+                                <StackPanel Margin="0,12,0,0">
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
                                         <TextBlock Text="AI Features" Classes="SettingLabel"/>
@@ -575,25 +583,9 @@
                                                  Content="Enable the assistant"
                                                  Margin="0,10,0,0"/>
 
-                                        <TextBlock Text="Provider" Classes="SettingLabel" Margin="0,14,0,0"/>
-                                        <ComboBox ItemsSource="{Binding ProviderChoices}"
-                                                 SelectedItem="{Binding SelectedProvider}"
-                                                 IsEnabled="{Binding AssistantFieldsEnabled}"
-                                                 Width="320" HorizontalAlignment="Left">
-                                            <ComboBox.ItemTemplate>
-                                                <DataTemplate x:DataType="vm:AiProviderChoice">
-                                                    <TextBlock Text="{Binding Display}"/>
-                                                </DataTemplate>
-                                            </ComboBox.ItemTemplate>
-                                        </ComboBox>
-
-                                        <TextBlock Text="Endpoint address" Classes="SettingLabel" Margin="0,14,0,0"/>
-                                        <TextBox Text="{Binding BaseUrl}"
-                                                IsEnabled="{Binding AssistantFieldsEnabled}"
-                                                Watermark="https://…"
-                                                Width="480" HorizontalAlignment="Left"/>
-                                        <TextBlock Text="{Binding BaseUrlDescription}" Classes="SettingDescription"/>
-
+                                        <!-- The protocol and the address moved to the Providers tab, where
+                                             they belong to a connection rather than to the app (#691). What
+                                             is left here is what is still genuinely one-per-app. -->
                                         <TextBlock Text="Model" Classes="SettingLabel" Margin="0,14,0,0"/>
                                         <TextBox Text="{Binding Model}"
                                                 IsEnabled="{Binding AssistantFieldsEnabled}"
@@ -648,7 +640,19 @@
                                                   Margin="0,12,0,0"/>
                                     </StackPanel>
                                 </Border>
-                            </StackPanel>
+                                </StackPanel>
+                              </TabItem>
+
+                              <TabItem Header="Providers">
+                                <views:AiProvidersView DataContext="{Binding Connections}"
+                                                       Margin="0,12,0,0"/>
+                              </TabItem>
+
+                              <TabItem Header="Models">
+                                <views:AiModelsView DataContext="{Binding Models}"
+                                                    Margin="0,12,0,0"/>
+                              </TabItem>
+                            </TabControl>
                         </DataTemplate>
 
                         <!-- Developer Settings Template -->


### PR DESCRIPTION
Replaces #715, which GitHub auto-closed when its base branch (`feat/691-connections-ui`, from #713) was deleted on merge. **Same branch, same commits — reopened against `main`.** My error for merging the parent with `--delete-branch` while a stacked PR pointed at it; a closed PR's base cannot be changed and it cannot be reopened once the base is gone.

---

Closes #693. **Stacked on #713** — targets `feat/691-connections-ui`, because the picker offers the enabled
models that PR's Models tab produces. Merge #713 first and this rebases onto main cleanly.

Switching model meant opening Settings, changing a field, and coming back. That is the wrong shape for the
thing this feature exists to do: comparing two models on the same passage is the actual task, and it wants to
be one click from the answer on screen.

## Shape

A chip at the composer shows the current model **by its display name** — nobody calls the thing they are
talking to `nvidia/nemotron-nano-9b-v2` — and opens a list with a pinned search box, the enabled models
**grouped by connection**, the current one checked, and **Manage models…** pinned at the bottom.

Grouped rather than flat: Claude Desktop's picker is flat, which works at four models. Once several endpoints
are configured, grouping is what stops *"the 8B I run locally"* and *"the hosted 70B"* reading as
interchangeable rows.

It offers the **enabled subset only**. The full listing lives in Settings → Models, so this is the short list
the reader built there — which is what lets it be a plain grouped list with no virtualization, and makes
search a comfort rather than a necessity.

**Choosing a model on another connection moves the connection with it.** Switching across providers means
switching base URL *and* credential; a picker carrying only the model id would send one provider's model to
another's endpoint and fail confusingly.

## Said rather than discovered

A model whose connection cannot be used is shown **disabled with the reason**, so the failure is read before
the send rather than as a 401 naming neither cause nor connection.

**Only reasons we can state as fact.** A missing key disqualifies a provider whose *preset* says it requires
one — a provider fact from the #682 extraction. For a custom endpoint nothing is claimed: plenty need no key
at all, and disabling on a hunch would be worse than letting the request explain itself.

An **unreachable connection is marked, never hidden**. The reader may be about to start their local runner,
and a provider that vanished from the picker because it was asleep would look like a lost configuration.

The chip is hidden until there is more than one model — a chip offering one thing is a control that cannot do
anything.

## One piece of code-behind

The flyout's open state is mirrored into the view model **in both directions**: the view model has to know it
is open for its later close to register as a change, and a reader who dismisses the list by clicking away must
not leave it believing otherwise. A `Flyout` owns its own open state and exposes no bindable property to close
it through.

Without this, picking a model left the list sitting over the composer, and the reader's next act was to
dismiss a popup rather than ask the question they had opened it for. Worth naming because it is invisible to
the view-model tests — they were green while the flyout stayed stubbornly open.

## Testing

**2052 passing, 0 warnings in both projects.** 15 new tests. Manual pass worth doing once #713 is in:

1. Configure two connections with a couple of enabled models each — the chip appears at the composer.
2. Open it: models grouped under each connection, current one checked, search filters name and id.
3. Pick a model on the *other* connection and ask something — the answer must come from that provider.
4. Add a preset without a key, enable a model on it: that row should be **disabled**, reading "no API key
   stored".
5. Stop a local runner and use it once so it is marked unreachable — its group keeps its models and gains a
   "not responding" note.
6. **Manage models…** opens Settings.

