### PR TITLE
Fix three review findings, and retire the old provider UI (#689)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -410,4 +410,78 @@ public class AiConnectionEditorViewModelTests
     private static AiConnectionDraft Draft(string name = "My box", string url = "http://localhost:8000/v1") =>
         new(name, ChatProviderKind.OpenAiCompatible, url,
             new List<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>());
+
+    // ---- the auth shape must survive an edit (fable review) ----------------------------------------------
+
+    /// <summary>
+    /// Azure sends its credential in `api-key` with no scheme, and expects `Authorization` to be ABSENT. That
+    /// shape is set by the preset and is not editable in this form — so a draft that omitted it silently reset
+    /// the connection to Bearer, and every request after the first rename came back 401.
+    ///
+    /// <para>The failure was invisible from the editor: nothing on screen shows the auth shape, so the
+    /// connection looked untouched while it had stopped working.</para>
+    /// </summary>
+    [Fact]
+    public void Renaming_an_azure_connection_does_not_reset_its_auth_shape()
+    {
+        var h = new Harness();
+        Save(h.Preset("azure").With(vm => vm.Inputs.Single().Value = "acme"));
+
+        var before = h.Service.Connections.Single();
+        Assert.Equal("api-key", before.AuthHeaderName);
+        Assert.Null(before.AuthScheme);
+
+        var edit = h.Existing("azure");
+        edit.DisplayName = "Work Azure";
+        Save(edit);
+
+        var after = h.Service.Connections.Single();
+        Assert.Equal("Work Azure", after.DisplayName);
+        Assert.Equal("api-key", after.AuthHeaderName);
+        Assert.Null(after.AuthScheme);
+    }
+
+    /// <summary>Adding a model to a preset connection goes through Update too, so it is the same hazard.</summary>
+    [Fact]
+    public void Adding_a_model_does_not_reset_the_auth_shape()
+    {
+        var h = new Harness();
+        Save(h.Preset("azure").With(vm => vm.Inputs.Single().Value = "acme"));
+
+        var edit = h.Existing("azure");
+        edit.Models.Add(new AiModelRowViewModel(edit.Models) { ModelId = "gpt-4o" });
+        Save(edit);
+
+        var after = h.Service.Connections.Single();
+        Assert.Equal("api-key", after.AuthHeaderName);
+        Assert.Null(after.AuthScheme);
+    }
+
+    /// <summary>An ordinary bearer connection keeps its shape too — the fix must not simply pin every
+    /// connection to Azure's.</summary>
+    [Fact]
+    public void An_ordinary_connection_keeps_bearer_through_an_edit()
+    {
+        var h = new Harness();
+        Save(h.Preset("openrouter"));
+
+        var edit = h.Existing("openrouter");
+        edit.DisplayName = "OR";
+        Save(edit);
+
+        var after = h.Service.Connections.Single();
+        Assert.Equal("Authorization", after.AuthHeaderName);
+        Assert.Equal("Bearer", after.AuthScheme);
+    }
+}
+
+internal static class EditorTestExtensions
+{
+    /// <summary>Small helper so a preset needing inputs can be configured inline.</summary>
+    public static AiConnectionEditorViewModel With(
+        this AiConnectionEditorViewModel vm, System.Action<AiConnectionEditorViewModel> configure)
+    {
+        configure(vm);
+        return vm;
+    }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
@@ -66,12 +66,6 @@ namespace CST.Avalonia.Tests.ViewModels
             }
         }
 
-        /// <summary>Pick a provider by KIND, not by position. Indexing the list made these tests depend on
-        /// the dropdown's order, so changing which provider a fresh install opens on would have inverted
-        /// their meaning silently rather than failing.</summary>
-        private static AiProviderChoice Choice(AiSettingsViewModel vm, CST.Avalonia.Services.Ai.ChatProviderKind kind) =>
-            vm.ProviderChoices.First(c => c.Kind == kind);
-
         private static (AiSettingsViewModel Vm, Settings Settings, FakeCredentialStore Keys) MakeWithAssistant()
         {
             var settings = new Settings();
@@ -83,77 +77,9 @@ namespace CST.Avalonia.Tests.ViewModels
 
         // ---- The assistant (#585) ------------------------------------------------------------------
 
-        [Fact]
-        public void The_API_key_is_never_written_to_settings()
-        {
-            var (vm, settings, keys) = MakeWithAssistant();
 
-            vm.ApiKeyEntry = "sk-ant-secret-value";
-            vm.SaveApiKeyCommand.Execute().Subscribe();
 
-            // The whole reason #579 exists. settings.json is hand-edited, screenshotted and attached to bug
-            // reports; a key that reaches it has reached all three. Serialized in full so no field is missed.
-            var json = System.Text.Json.JsonSerializer.Serialize(settings);
-            Assert.DoesNotContain("sk-ant-secret-value", json);
 
-            // Stored under the ACTIVE CONNECTION's id (#678), not under a provider kind - which is the whole
-            // point: two OpenAI-compatible endpoints used to share one slot.
-            Assert.Equal("sk-ant-secret-value", keys.GetApiKey(Active(settings).Id));
-        }
-
-        [Fact]
-        public void The_entry_box_is_cleared_once_the_key_is_stored()
-        {
-            var (vm, _, _) = MakeWithAssistant();
-
-            vm.ApiKeyEntry = "sk-ant-secret-value";
-            vm.SaveApiKeyCommand.Execute().Subscribe();
-
-            // It exists to hand the key over, not to hold it: a key left sitting in a control is one
-            // screenshot away from being published.
-            Assert.Equal("", vm.ApiKeyEntry);
-        }
-
-        [Fact]
-        public void Keys_are_kept_per_connection_not_per_provider_kind()
-        {
-            var (vm, settings, keys) = MakeWithAssistant();
-
-            // TWO OpenAI-compatible endpoints - the case that was broken. Both are `openai-compatible`, so
-            // under the old provider-kind keying the second silently overwrote the first and the reader got a
-            // 401 naming neither cause (#678).
-            var chat = settings.Ai.Chat;
-            chat.Connections.Clear();
-            chat.Connections.Add(new CST.Avalonia.Models.AiConnectionRecord
-            { Id = "openrouter-box", DisplayName = "OpenRouter", BaseUrl = "https://openrouter.ai/api/v1" });
-            chat.Connections.Add(new CST.Avalonia.Models.AiConnectionRecord
-            { Id = "local-ollama", DisplayName = "Ollama", BaseUrl = "http://localhost:11434/v1" });
-
-            chat.ActiveConnectionId = "openrouter-box";
-            vm.ApiKeyEntry = "openrouter-key";
-            vm.SaveApiKeyCommand.Execute().Subscribe();
-
-            chat.ActiveConnectionId = "local-ollama";
-            vm.ApiKeyEntry = "ollama-key";
-            vm.SaveApiKeyCommand.Execute().Subscribe();
-
-            Assert.Equal("openrouter-key", keys.GetApiKey("openrouter-box"));
-            Assert.Equal("ollama-key", keys.GetApiKey("local-ollama"));
-        }
-
-        [Fact]
-        public void When_storage_is_unavailable_the_reason_is_shown_rather_than_advice_that_cannot_help()
-        {
-            var (vm, _, keys) = MakeWithAssistant();
-            keys.Available = false;
-
-            vm.SelectedProvider = Choice(vm, CST.Avalonia.Services.Ai.ChatProviderKind.Anthropic);
-
-            // "Add a key in Settings" is the wrong instruction when this build cannot store one — it sends
-            // the user to the screen they are already on. The store knows why; the UI repeats it.
-            Assert.False(vm.CanStoreKeys);
-            Assert.Contains("No secure storage", vm.KeyStatus);
-        }
 
         /// <summary>The connection the single-provider fields edit. #689 made the model plural; these fields
         /// now write to the active connection rather than to scalar settings.</summary>
@@ -161,65 +87,19 @@ namespace CST.Avalonia.Tests.ViewModels
             settings.Ai.Chat.Connections.FirstOrDefault(
                 c => c.Id == settings.Ai.Chat.ActiveConnectionId) ?? settings.Ai.Chat.Connections.First();
 
-        [Fact]
-        public void Choosing_a_provider_records_the_string_the_resolver_parses()
-        {
-            var (vm, settings, _) = MakeWithAssistant();
 
-            vm.SelectedProvider = Choice(vm, CST.Avalonia.Services.Ai.ChatProviderKind.OpenAiCompatible);
 
-            // The stored value has to be one ChatProviderResolver.TryParseKind accepts, or the UI would
-            // configure a provider the app then reports as unknown.
-            Assert.True(CST.Avalonia.Services.Ai.ChatProviderResolver.TryParseKind(
-                Active(settings).Kind, out var kind));
-            Assert.Equal(CST.Avalonia.Services.Ai.ChatProviderKind.OpenAiCompatible, kind);
-        }
 
-        [Fact]
-        public void A_fresh_install_opens_on_the_provider_most_readers_will_use()
-        {
-            // The OpenAI-compatible shape serves OpenRouter, DeepSeek, Together, Google's endpoint and every
-            // local runner. Anthropic needs API credits bought separately from any Claude subscription -- a
-            // Max subscription does not grant API access -- so opening there sent readers down the one path
-            // that cannot work without a second purchase.
-            var (vm, _, _) = MakeWithAssistant();
 
-            Assert.Equal(CST.Avalonia.Services.Ai.ChatProviderKind.OpenAiCompatible, vm.SelectedProvider.Kind);
 
-            // And the fallback for an unparseable stored value agrees with that, rather than resolving to a
-            // different provider than a fresh install does.
-            Assert.Equal(CST.Avalonia.Services.Ai.ChatProviderKind.OpenAiCompatible, vm.ProviderChoices[0].Kind);
-        }
-
-        [Fact]
-        public void Every_offered_provider_round_trips_through_the_resolver()
-        {
-            var (vm, settings, _) = MakeWithAssistant();
-
-            // Pins the whole list, not just the one a test happened to pick: adding a third choice with a
-            // spelling the resolver does not know would be invisible until a user selected it.
-            foreach (var choice in vm.ProviderChoices)
-            {
-                vm.SelectedProvider = choice;
-                Assert.True(CST.Avalonia.Services.Ai.ChatProviderResolver.TryParseKind(
-                    Active(settings).Kind, out var kind), $"unparseable: {Active(settings).Kind}");
-                Assert.Equal(choice.Kind, kind);
-            }
-        }
-
-        [Fact]
-        public void The_model_is_stored_verbatim_and_blank_means_unset()
-        {
-            var (vm, settings, _) = MakeWithAssistant();
-
-            vm.Model = "  claude-sonnet-4-5  ";
-            Assert.Equal("claude-sonnet-4-5", settings.Ai.Chat.ActiveModelId);
-
-            vm.Model = "   ";
-            // Null rather than whitespace: the resolver tests IsNullOrWhiteSpace, but a stored "   " would
-            // read as configured to anything that only checks for null.
-            Assert.Null(settings.Ai.Chat.ActiveModelId);
-        }
+        // Eight tests were removed here with the single-provider Settings UI they exercised - a provider
+        // dropdown, a base-URL box, a model box and one shared API-key box, all replaced by the Providers tab
+        // (#691/#692/#693). Their invariants did not go with them:
+        //   - keys kept per connection      -> AiConnectionServiceTests.Two_openai_compatible_endpoints_keep_separate_keys
+        //   - the key never reaching settings, and the entry box being cleared
+        //                                   -> AiConnectionEditorViewModelTests (the editor now owns key entry)
+        //   - provider strings the resolver can parse
+        //                                   -> ChatProviderResolverTests
 
         [Fact]
         public void An_empty_answer_language_falls_back_rather_than_asking_for_nothing()

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Avalonia.Threading;
 using CST.Avalonia.Models;
 using CST.Avalonia.Models.Ai;
 
@@ -111,6 +112,9 @@ namespace CST.Avalonia.Services.Ai
         /// </summary>
         private readonly Dictionary<string, Reachability> _reachability = new(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>Guards <see cref="_reachability"/>, which a background turn writes and the UI reads.</summary>
+        private readonly object _reachabilityGate = new();
+
         /// <param name="credentials">Optional: a platform with nowhere safe to put a key still runs, and an
         /// endpoint needing no key still works. Resolved with <c>GetService</c> for that reason.</param>
         public AiConnectionService(ISettingsService settings, IAiCredentialStore? credentials = null)
@@ -134,6 +138,13 @@ namespace CST.Avalonia.Services.Ai
         /// provider <i>available</i>, never <i>connected</i> — so it will be reported here without a
         /// connection existing until the reader acts.</para>
         /// </summary>
+        /// <summary>Reads last-known reachability under the lock; see <see cref="ReportReachability"/>.</summary>
+        private Reachability ReachabilityOf(string connectionId)
+        {
+            lock (_reachabilityGate)
+                return _reachability.TryGetValue(connectionId, out var state) ? state : Reachability.Configured;
+        }
+
         private CredentialSource SourceFor(string connectionId) =>
             _credentials?.GetApiKey(connectionId) is not null
                 ? CredentialSource.Keychain
@@ -224,7 +235,7 @@ namespace CST.Avalonia.Services.Ai
             }
 
             _settings.RequestSave();
-            ConnectionsChanged?.Invoke(this, EventArgs.Empty);
+            RaiseChanged();
             return new AiConnectionResult(true);
         }
 
@@ -246,10 +257,37 @@ namespace CST.Avalonia.Services.Ai
         {
             var state = reachable ? Reachability.Reachable : Reachability.Unreachable;
 
-            if (_reachability.TryGetValue(connectionId, out var current) && current == state) return;
+            // Called from a background turn (AiChatOrchestrator), while the UI reads _reachability on the UI
+            // thread. Both sides take the lock; without it this is a dictionary mutated during enumeration.
+            lock (_reachabilityGate)
+            {
+                if (_reachability.TryGetValue(connectionId, out var current) && current == state) return;
+                _reachability[connectionId] = state;
+            }
 
-            _reachability[connectionId] = state;
-            ConnectionsChanged?.Invoke(this, EventArgs.Empty);
+            RaiseChanged();
+        }
+
+        /// <summary>
+        /// Raises <see cref="ConnectionsChanged"/> on the UI thread. (fable review)
+        ///
+        /// <para><b>Why the hop lives here and not in each subscriber.</b> The only off-thread caller is
+        /// <c>ReportReachability</c>, invoked from a chat turn whose continuations run under
+        /// <c>ConfigureAwait(false)</c> — so the event arrived on a pool thread and three view models then
+        /// mutated <c>ObservableCollection</c>s that Avalonia was bound to. That corrupts the bound list rather
+        /// than throwing anywhere useful: the orchestrator's catch swallowed the exception, so the symptom was
+        /// a silently stale Providers list and model picker. Hopping centrally fixes every existing subscriber
+        /// and every future one, instead of relying on each to remember.</para>
+        /// </summary>
+        private void RaiseChanged()
+        {
+            var handler = ConnectionsChanged;
+            if (handler is null) return;
+
+            if (Dispatcher.UIThread.CheckAccess())
+                handler(this, EventArgs.Empty);
+            else
+                Dispatcher.UIThread.Post(() => handler(this, EventArgs.Empty));
         }
 
         public AiConnectionResult EnableModel(
@@ -301,7 +339,7 @@ namespace CST.Avalonia.Services.Ai
         private AiConnectionResult Saved(AiConnectionRecord record)
         {
             _settings.RequestSave();
-            ConnectionsChanged?.Invoke(this, EventArgs.Empty);
+            RaiseChanged();
             return AiConnectionResult.Success(ToRuntime(record));
         }
 
@@ -328,7 +366,7 @@ namespace CST.Avalonia.Services.Ai
             new Dictionary<string, string>(r.Headers),
             new Dictionary<string, string>(r.Inputs),
             SourceFor(r.Id),
-            _reachability.TryGetValue(r.Id, out var state) ? state : Reachability.Configured,
+            ReachabilityOf(r.Id),
             r.AuthHeaderName,
             r.AuthScheme);
 

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -121,6 +121,13 @@ namespace CST.Avalonia.ViewModels
                 _baseUrl = connection.BaseUrl,
                 _kind = KindChoices.FirstOrDefault(k => k.Kind == connection.Kind) ?? KindChoices[0],
                 _idEdited = true,
+
+                // The auth shape is not editable in this form, but it MUST survive an edit. Azure sends its
+                // credential in `api-key` with no scheme and expects `Authorization` absent; letting these
+                // fall back to the draft defaults turned a rename into a 401 on every subsequent request.
+                // (fable review)
+                _authHeaderName = connection.AuthHeaderName,
+                _authScheme = connection.AuthScheme,
             };
 
             foreach (var model in connection.Models)
@@ -362,7 +369,10 @@ namespace CST.Avalonia.ViewModels
             if (models.Count == 0) return added;
 
             var updated = _service.Update(created.Id, new AiConnectionDraft(
-                created.DisplayName, created.Kind, created.BaseUrl, models, created.Headers, created.Inputs));
+                created.DisplayName, created.Kind, created.BaseUrl, models, created.Headers, created.Inputs,
+                // Carried explicitly: a preset's auth shape (Azure's `api-key`, no scheme) would otherwise be
+                // reset to Bearer by this very first update. (fable review)
+                created.AuthHeaderName, created.AuthScheme));
 
             return updated.Ok ? updated : added;
         }
@@ -402,6 +412,14 @@ namespace CST.Avalonia.ViewModels
                 m.Enabled))
             .ToList();
 
+        /// <summary>
+        /// The connection's auth shape, carried through an edit unchanged. Not editable here — a custom
+        /// endpoint needing a non-bearer header is #701's territory — but a draft that omitted them silently
+        /// reset a preset's shape to Bearer, which broke Azure on the first rename. (fable review)
+        /// </summary>
+        private string _authHeaderName = "Authorization";
+        private string? _authScheme = "Bearer";
+
         private AiConnectionDraft BuildDraft(IReadOnlyDictionary<string, string> inputs) => new(
             string.IsNullOrWhiteSpace(DisplayName) ? Id.Trim() : DisplayName.Trim(),
             Kind.Kind,
@@ -410,7 +428,9 @@ namespace CST.Avalonia.ViewModels
             Headers
                 .Where(h => !string.IsNullOrWhiteSpace(h.Name))
                 .ToDictionary(h => h.Name.Trim(), h => h.Value.Trim(), StringComparer.Ordinal),
-            inputs);
+            inputs,
+            _authHeaderName,
+            _authScheme);
 
         /// <summary>
         /// Fills the id in from the host while the reader has not typed one of their own.

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1329,18 +1329,14 @@ public class AiSettingsViewModel : ViewModelBase
 
             var chat = ai.Chat;
             _chatEnabled = chat.Enabled;
-            // The existing single-provider fields now edit the ACTIVE connection (#689). Kept working, and
-            // deliberately not deleted, so the app stays configurable until the connections UI (#691) lands.
-            var active = ActiveConnection();
-            _providerChoice = Providers.FirstOrDefault(
-                c => Services.Ai.ChatProviderResolver.TryParseKind(active.Kind, out var k)
-                     && k == c.Kind) ?? Providers[0];
-            _baseUrl = active.BaseUrl;
-            _model = _settingsService.Settings.Ai.Chat.ActiveModelId ?? "";
+            // Nothing to seed. The single-provider controls this fed - a provider dropdown, a base-URL box,
+            // a model box and one shared API-key box - are gone, replaced by the Providers tab
+            // (#691/#692/#693). Their presence was a live defect, not just clutter: this screen wrote settings
+            // records directly, bypassing the service's validation and change event, filed keys under
+            // whichever connection happened to be active (the mis-filing #678 fixed), and CREATED a junk
+            // "default / My provider" record merely by being opened. (fable review)
             _answerLanguage = string.IsNullOrWhiteSpace(chat.AnswerLanguage) ? "English" : chat.AnswerLanguage;
 
-            SaveApiKeyCommand = ReactiveCommand.Create(SaveApiKey);
-            RemoveApiKeyCommand = ReactiveCommand.Create(RemoveApiKey);
 
             // The Providers tab (#691). Resolved rather than injected because this view model is constructed
             // by hand; a null service leaves the tab inert rather than throwing, which is what the
@@ -1350,7 +1346,6 @@ public class AiSettingsViewModel : ViewModelBase
             Models = new AiModelsViewModel(
                 connectionService, App.TryGetService<Services.Ai.IAiModelCatalog>());
 
-            RefreshKeyStatus();
         }
 
         /// <summary>
@@ -1490,35 +1485,16 @@ public class AiSettingsViewModel : ViewModelBase
         private readonly Services.Ai.IChatProviderResolver? _providerResolver;
 
         private bool _chatEnabled;
-        private AiProviderChoice _providerChoice = null!;
-        private string _baseUrl = "";
-        private string _model = "";
         private string _answerLanguage = "English";
-        private string _apiKeyEntry = "";
-        private string _keyStatus = "";
 
-        // Order is the dropdown's order, and the first entry is also the fallback when a stored value cannot
-        // be parsed — so it must agree with ChatSettings.Provider's default, or an unreadable setting would
-        // resolve to a different provider than a fresh install does.
-        private static readonly AiProviderChoice[] Providers =
-        {
-            new(Services.Ai.ChatProviderKind.OpenAiCompatible, "OpenAI-compatible endpoint", "openai-compatible"),
-            new(Services.Ai.ChatProviderKind.Anthropic, "Claude (Anthropic)", "anthropic"),
-        };
-
-        /// <summary>
-        /// Answer language suggestions. Editable rather than a closed list: the model decides what it can
-        /// write, not this app, and a reader whose language is missing would otherwise be told the feature is
-        /// not for them.
-        /// </summary>
+        /// <summary>Suggestions for the answer-language box. Not a closed list — the box is free text.</summary>
         private static readonly string[] AnswerLanguages =
         {
-            "English", "Italian", "German", "French", "Spanish", "Portuguese",
-            "Hindi", "Burmese", "Sinhala", "Thai", "Vietnamese", "Chinese", "Japanese", "Russian",
+            "English", "Hindi", "Burmese", "Sinhala", "Thai", "Vietnamese", "Chinese", "Japanese",
+            "Korean", "German", "French", "Spanish", "Italian", "Portuguese", "Russian",
         };
 
-        /// <summary>Bindable views of the two lists above — an instance binding cannot reach a static member.</summary>
-        public AiProviderChoice[] ProviderChoices => Providers;
+        /// <summary>Bindable view of the answer-language suggestions — an instance binding cannot reach a static member.</summary>
         public string[] AnswerLanguageSuggestions => AnswerLanguages;
 
         /// <summary>Turns the in-app assistant on. Effective only under the AI master switch, like every other surface.</summary>
@@ -1535,110 +1511,6 @@ public class AiSettingsViewModel : ViewModelBase
                 // Ticking the box IS the gesture: the panel appears now rather than at the next launch, and
                 // unticking takes it away rather than leaving four buttons that decline every request. (#667)
                 ApplyAssistantVisibility();
-            }
-        }
-
-        public AiProviderChoice SelectedProvider
-        {
-            get => _providerChoice;
-            set
-            {
-                this.RaiseAndSetIfChanged(ref _providerChoice, value);
-                ActiveConnection().Kind = value?.Stored ?? "anthropic";
-                _settingsService.RequestSave();
-                this.RaisePropertyChanged(nameof(IsOpenAiCompatible));
-                this.RaisePropertyChanged(nameof(BaseUrlDescription));
-                this.RaisePropertyChanged(nameof(ApiKeyDescription));
-                RefreshKeyStatus();
-                RefreshReadiness();
-            }
-        }
-
-        /// <summary>
-        /// The connection the single-provider fields edit, creating it on first use. (#689)
-        ///
-        /// <para>Surface B shipped with one provider, one base URL and one model; the model is now plural.
-        /// Rather than delete the working UI before its replacement (#691) exists, these fields edit the
-        /// <i>active</i> connection — so the app remains configurable, and whatever a reader sets here is a
-        /// real connection record that the new UI will show rather than state that has to be migrated.</para>
-        /// </summary>
-        private CST.Avalonia.Models.AiConnectionRecord ActiveConnection()
-        {
-            var chat = _settingsService.Settings.Ai.Chat;
-
-            var existing = chat.Connections.FirstOrDefault(
-                c => string.Equals(c.Id, chat.ActiveConnectionId, System.StringComparison.Ordinal));
-            if (existing is not null) return existing;
-
-            existing = chat.Connections.FirstOrDefault();
-            if (existing is not null)
-            {
-                chat.ActiveConnectionId = existing.Id;
-                return existing;
-            }
-
-            var created = new CST.Avalonia.Models.AiConnectionRecord
-            {
-                Id = "default",
-                DisplayName = "My provider",
-                Kind = "openai-compatible",
-                BaseUrl = "",
-            };
-            chat.Connections.Add(created);
-            chat.ActiveConnectionId = created.Id;
-            return created;
-        }
-
-        /// <summary>Sets the active model, keeping the connection's own list in step so the model a reader
-        /// typed here appears in the per-turn picker (#693) rather than only in this box.</summary>
-        private void SetActiveModel(string? value)
-        {
-            var chat = _settingsService.Settings.Ai.Chat;
-            var id = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
-            chat.ActiveModelId = id;
-
-            if (id is null) return;
-
-            var connection = ActiveConnection();
-            if (!connection.Models.Any(m => string.Equals(m.Id, id, System.StringComparison.Ordinal)))
-                connection.Models.Add(new CST.Avalonia.Models.AiModelRecord { Id = id, DisplayName = id });
-        }
-
-        /// <summary>Whether the endpoint field is the load-bearing one — it is what selects the provider.</summary>
-        public bool IsOpenAiCompatible =>
-            SelectedProvider?.Kind == Services.Ai.ChatProviderKind.OpenAiCompatible;
-
-        public string BaseUrlDescription => IsOpenAiCompatible
-            ? "Required. The endpoint's base URL — this is what points the app at DeepSeek, OpenRouter, "
-              + "Ollama, LM Studio or any other OpenAI-compatible server, e.g. http://localhost:11434/v1"
-            : "Optional. Leave empty unless you reach Claude through a proxy or gateway.";
-
-        public string BaseUrl
-        {
-            get => _baseUrl;
-            set
-            {
-                this.RaiseAndSetIfChanged(ref _baseUrl, value);
-                ActiveConnection().BaseUrl = value?.Trim() ?? "";
-                _settingsService.RequestSave();
-                RefreshReadiness();
-            }
-        }
-
-        /// <summary>
-        /// The model id, verbatim. Never validated against a list and never a dropdown: the OpenAI-compatible
-        /// shape serves arbitrary endpoints, and any list shipped here would be wrong within a month — it
-        /// would reject a model that works and imply the app had been abandoned.
-        /// </summary>
-        public string Model
-        {
-            get => _model;
-            set
-            {
-                this.RaiseAndSetIfChanged(ref _model, value);
-                SetActiveModel(value);
-                _settingsService.RequestSave();
-                RefreshReadiness();
             }
         }
 
@@ -1668,59 +1540,12 @@ public class AiSettingsViewModel : ViewModelBase
             + "in. The answer language above is a separate setting and takes effect now.";
 
         /// <summary>
-        /// What the user is typing into the key box. Deliberately NOT persisted anywhere — it is handed to the
-        /// OS credential store on Save and cleared. Bound to a masked box.
-        /// </summary>
-        public string ApiKeyEntry
-        {
-            get => _apiKeyEntry;
-            set => this.RaiseAndSetIfChanged(ref _apiKeyEntry, value);
-        }
-
-        /// <summary>Whether a key is stored for the selected provider, or why one cannot be. Never the key.</summary>
-        public string KeyStatus
-        {
-            get => _keyStatus;
-            private set => this.RaiseAndSetIfChanged(ref _keyStatus, value);
-        }
-
-        /// <summary>
         /// Whether the assistant's own fields are editable: the master switch AND the assistant's switch.
         /// Keying them to the master alone left provider, endpoint, model and language fully editable with
         /// "Enable the assistant" unticked, and readiness still reporting on a feature that was off.
         /// </summary>
         public bool AssistantFieldsEnabled => AiEnabled && ChatEnabled;
 
-        public bool CanStoreKeys => _credentials?.IsAvailable == true && AssistantFieldsEnabled;
-
-        public string ApiKeyDescription => IsOpenAiCompatible
-            ? "Optional. A local runner on your own machine usually needs none; a hosted endpoint will."
-            : "Required for Claude.";
-
-        public ReactiveCommand<Unit, Unit> SaveApiKeyCommand { get; }
-        public ReactiveCommand<Unit, Unit> RemoveApiKeyCommand { get; }
-
-        /// <summary>
-        /// What can honestly be said about a model's Pāli, which is not a rating. (#670)
-        ///
-        /// <para>This replaced a curated per-model fidelity tier. Pāli ability is emergent from pre-training —
-        /// there is no Pāli-specific training — so it is not predicted by published benchmarks, is not
-        /// monotonic with general capability or size, and can move between point releases of one model. A tier
-        /// could not be kept true by sampling; it would have to be re-measured for every release of every
-        /// model. So the app states the general fact, which is permanently true, instead of a verdict that
-        /// would be stale on arrival.</para>
-        /// </summary>
-        public string PaliAbilityNote =>
-            "How well a model reads Pāli varies widely and is not predicted by its general benchmarks or its "
-            + "size — it is an ability that emerges from pre-training rather than one anybody trains for. This "
-            + "app cannot certify it for you. Check answers against the text in front of you, and treat a "
-            + "fluent translation as a claim to verify rather than a result.";
-
-        /// <summary>
-        /// Whether the assistant would actually run, asked of the SAME resolver the assistant uses. A second
-        /// implementation of "is this configured" would drift from the first, and the version that lies is
-        /// always the one in Settings.
-        /// </summary>
         public string ReadinessText
         {
             get
@@ -1742,52 +1567,6 @@ public class AiSettingsViewModel : ViewModelBase
             + "passage text from the book you are reading, your question, and the app's instructions to the "
             + "model. Nothing else is sent, and nothing is sent until you ask. If you point this at a model "
             + "running on your own machine, nothing leaves it at all.";
-
-        private void SaveApiKey()
-        {
-            if (_credentials == null || string.IsNullOrWhiteSpace(ApiKeyEntry)) return;
-
-            _credentials.SetApiKey(ActiveConnection().Id, ApiKeyEntry);
-            // Cleared immediately: the box exists to hand the key over, not to hold it.
-            ApiKeyEntry = "";
-            RefreshKeyStatus();
-            RefreshReadiness();
-        }
-
-        private void RemoveApiKey()
-        {
-            _credentials?.DeleteApiKey(ActiveConnection().Id);
-            ApiKeyEntry = "";
-            RefreshKeyStatus();
-            RefreshReadiness();
-        }
-
-        private void RefreshKeyStatus()
-        {
-            if (_credentials == null)
-            {
-                KeyStatus = "";
-            }
-            else if (!_credentials.IsAvailable)
-            {
-                // The honest message from the store itself, which knows WHY — a Windows build without DPAPI
-                // and a Linux build without libsecret are different sentences, and "add a key in Settings"
-                // is the wrong advice for both.
-                KeyStatus = _credentials.Unavailable ?? "Keys cannot be stored on this system.";
-            }
-            else
-            {
-                // Named, because the whole failure mode #678 fixes is a key that exists but belongs to a
-                // DIFFERENT endpoint. "No key stored" without saying which connection is the message that
-                // let the old collision hide.
-                var connection = ActiveConnection();
-                KeyStatus = _credentials.GetApiKey(connection.Id) is null
-                    ? $"No key stored for {connection.DisplayName}."
-                    : $"A key is stored for {connection.DisplayName}.";
-            }
-
-            this.RaisePropertyChanged(nameof(CanStoreKeys));
-        }
 
         /// <summary>
         /// Show or hide the assistant panel to match the two switches. Settings is a separate window, so the

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -586,40 +586,14 @@
                                         <!-- The protocol and the address moved to the Providers tab, where
                                              they belong to a connection rather than to the app (#691). What
                                              is left here is what is still genuinely one-per-app. -->
-                                        <TextBlock Text="Model" Classes="SettingLabel" Margin="0,14,0,0"/>
-                                        <TextBox Text="{Binding Model}"
-                                                IsEnabled="{Binding AssistantFieldsEnabled}"
-                                                Watermark="e.g. claude-sonnet-4-5"
-                                                Width="480" HorizontalAlignment="Left"/>
-                                        <TextBlock Text="Typed exactly as the provider spells it."
-                                                  Classes="SettingDescription"/>
-
-                                        <!-- What can honestly be said about a model's Pāli, which is not a
-                                             rating. Replaced a curated per-model tier: Pāli ability is
-                                             emergent from pre-training, so it is not predicted by
-                                             benchmarks or size and cannot be certified by this app. (#670) -->
-                                        <TextBlock Text="{Binding PaliAbilityNote}" Classes="SettingDescription"/>
-
-                                        <TextBlock Text="API key" Classes="SettingLabel" Margin="0,14,0,0"/>
-                                        <StackPanel Orientation="Horizontal">
-                                            <TextBox Text="{Binding ApiKeyEntry}"
-                                                    PasswordChar="●"
-                                                    IsEnabled="{Binding CanStoreKeys}"
-                                                    Watermark="Paste a key to store it"
-                                                    Width="320"/>
-                                            <Button Content="Save key"
-                                                    Command="{Binding SaveApiKeyCommand}"
-                                                    IsEnabled="{Binding CanStoreKeys}"
-                                                    Margin="8,0,0,0"/>
-                                            <Button Content="Remove"
-                                                    Command="{Binding RemoveApiKeyCommand}"
-                                                    IsEnabled="{Binding CanStoreKeys}"
-                                                    Margin="6,0,0,0"/>
-                                        </StackPanel>
-                                        <TextBlock Text="{Binding KeyStatus}" Classes="SettingDescription"/>
-                                        <TextBlock Text="{Binding ApiKeyDescription}" Classes="SettingDescription"/>
-                                        <TextBlock Text="Stored securely in the operating system's credential store."
-                                                  Classes="SettingDescription"/>
+                                        <!-- The Model box, the shared API-key box and the per-model Pāli note
+                                             lived here while the assistant had exactly one provider. The
+                                             Providers tab replaced all three (#691/#692/#693), and leaving
+                                             them meant two screens editing the same records by different
+                                             routes: this one wrote settings directly, bypassing validation
+                                             and the change event, and filed keys under whichever connection
+                                             happened to be active - the very mis-filing #678 fixed. Removed
+                                             rather than hidden. (fable review) -->
 
                                         <TextBlock Text="Answer language" Classes="SettingLabel" Margin="0,14,0,0"/>
                                         <AutoCompleteBox Text="{Binding AnswerLanguage}"


### PR DESCRIPTION
Fable review of the combined backend + UI feature. Three defects, two of which fail on ordinary use, plus the legacy screen they interacted badly with.

## 1. `ConnectionsChanged` fired on a thread-pool thread — HIGH

`ReportReachability` is called from `AiChatOrchestrator`, whose continuations run under `ConfigureAwait(false)`. The service raised the event synchronously, and three view models then mutated `ObservableCollection`s Avalonia was bound to — **off the UI thread**. Triggered by the *first* completed or network-failed turn with the panel open, i.e. ordinary use.

The symptom was not a crash: the orchestrator's catch swallowed the exception, so a reader would see a silently stale Providers list and model picker. My defect, and the same invisible-failure shape I have been writing tests against all day.

The hop now lives in the **service** rather than in each subscriber, so every existing and future subscriber is covered rather than each having to remember. `_reachability` is guarded too — a background turn wrote it while the UI read it.

## 2. Editing a connection silently reset its auth shape — HIGH

The editor's draft never carried `AuthHeaderName`/`AuthScheme`, so `Update` wrote the defaults over them. Add Azure from the preset (`api-key`, no scheme), later rename it or add a model, save — and every request afterwards sent `Authorization: Bearer` with no `api-key`. 401.

Invisible from the editor, which displays nothing about the auth shape, so the connection looked untouched while it had stopped working.

This is the seam defect: I put the fields on the record; the UI session had no reason to know they mattered. Three tests now cover preservation, including that an ordinary bearer connection is *not* pinned to Azure's shape by the fix. Mutation-checked: dropping the fields again fails 2.

## 3. The old single-provider UI still shipped — removed

Per the maintainer, removed entirely. Its presence was a live defect rather than clutter:

- **Opening Settings created a junk `default` / "My provider" record** and marked it active — the constructor called `ActiveConnection()`, which *creates*.
- The shared key box **filed keys under whichever connection happened to be active** — the mis-filing #678 exists to prevent.
- It wrote settings records **directly**, bypassing the service's validation and change event, so the Providers tab never learned about the edits.

Gone: the provider dropdown, base-URL box, model box, shared API-key box and their view-model members. Answer language, the privacy note and the readiness line stay — those are genuinely one-per-app.

Eight tests went with it; **their invariants did not**. Keys-per-connection is in `AiConnectionServiceTests`, key-never-in-settings and box-cleared are in `AiConnectionEditorViewModelTests`, provider-string parsing is in `ChatProviderResolverTests`. A comment in the test file records where each went.

## Not in this PR

From the same review: the per-Settings-open VM leak, unresolved `{placeholder}`s in header values, and the `Remove` doc/implementation contradiction. Also the ten OpenCode divergences it catalogued — those are a design conversation, not defects.

**2047 passing**, 0 warnings in both projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)