### PR TITLE
Release the AI settings tabs' subscriptions when Settings closes (#689)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -407,6 +407,30 @@ public class AiConnectionsViewModelTests
         Assert.Equal("Delete My box and its 2 models?", vm.Connections.Single().DeleteConfirmText);
     }
 
+    // ---- lifetime ----------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Disposing stops the view model listening.
+    ///
+    /// <para>The connection service is a singleton and a fresh Settings window builds a fresh view model
+    /// every time it is opened. Without this, each visit leaves another subscriber alive — rebuilding
+    /// collections nobody can see, on every connection change, for the rest of the session — and the cost
+    /// grows with how often the reader visits a screen whose whole job is being visited.</para>
+    /// </summary>
+    [Fact]
+    public void A_disposed_view_model_stops_listening()
+    {
+        var (vm, service) = Make();
+        service.Add("first", Draft());
+        Assert.Single(vm.Connections);
+
+        vm.Dispose();
+        service.Add("second", Draft("Second"));
+
+        Assert.Single(vm.Connections);          // did not see the second add
+        Assert.Equal(2, service.Connections.Count);   // which did happen
+    }
+
     // ---- monograms -------------------------------------------------------------------------------------
 
     [Theory]

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -390,6 +390,24 @@ public class AiModelsViewModelTests
         Assert.Single(Rows(vm), r => r.ModelId == "odd");
     }
 
+    // ---- lifetime ----------------------------------------------------------------------------------------
+
+    /// <summary>Same reason as the Providers tab: the service is a singleton and this is rebuilt on every
+    /// Settings open.</summary>
+    [Fact]
+    public void A_disposed_view_model_stops_listening()
+    {
+        var (vm, service) = Make();
+        service.Add("first", Draft());
+        Assert.Single(vm.Groups);
+
+        vm.Dispose();
+        service.Add("second", Draft());
+
+        Assert.Single(vm.Groups);
+        Assert.Equal(2, service.Connections.Count);
+    }
+
     // ---- what a row says ---------------------------------------------------------------------------------
 
     /// <summary>The provider's own facts, verbatim and attributed — safe where a table we maintained would

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -27,7 +27,7 @@ namespace CST.Avalonia.ViewModels
     /// order the service hands them over in. There is no "recommended" badge and no pre-selection anywhere,
     /// because that is the model registry deleted in #670/#681 wearing different clothes.</para>
     /// </summary>
-    public class AiConnectionsViewModel : ViewModelBase
+    public class AiConnectionsViewModel : ViewModelBase, IDisposable
     {
         private readonly IAiConnectionService? _service;
         private readonly IAiCredentialStore? _credentials;
@@ -177,6 +177,20 @@ namespace CST.Avalonia.ViewModels
         }
 
         private void OnConnectionsChanged(object? sender, EventArgs e) => Rebind();
+
+        /// <summary>
+        /// Stops listening to the service.
+        ///
+        /// <para><b>Required, not tidiness.</b> The connection service is a singleton and a fresh Settings
+        /// window builds a fresh view model every time it is opened, so without this each open leaves another
+        /// subscriber alive — rebuilding collections nobody can see, on every connection change, for the rest
+        /// of the session. The cost grows with how often the reader visits Settings, which for a screen whose
+        /// whole job is being visited is the wrong direction.</para>
+        /// </summary>
+        public void Dispose()
+        {
+            if (_service is not null) _service.ConnectionsChanged -= OnConnectionsChanged;
+        }
 
         /// <summary>
         /// Syncs both lists in place, keyed by id, rather than rebuilding them.

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -24,7 +24,7 @@ namespace CST.Avalonia.ViewModels
     /// list the reader built there, so it needs no virtualization and the search box is for comfort rather
     /// than necessity.</para>
     /// </summary>
-    public class AiModelPickerViewModel : ViewModelBase
+    public class AiModelPickerViewModel : ViewModelBase, IDisposable
     {
         private readonly IAiConnectionService? _service;
         private readonly Action? _changed;
@@ -40,7 +40,7 @@ namespace CST.Avalonia.ViewModels
 
             if (_service is not null)
             {
-                _service.ConnectionsChanged += (_, _) => Rebuild();
+                _service.ConnectionsChanged += OnConnectionsChanged;
                 Rebuild();
             }
         }
@@ -150,6 +150,16 @@ namespace CST.Avalonia.ViewModels
         private bool IsCurrent(AiConnection connection, AiModelEntry model) =>
             string.Equals(_service?.Active?.Id, connection.Id, StringComparison.Ordinal) &&
             string.Equals(_service?.ActiveModelId, model.Id, StringComparison.Ordinal);
+
+        private void OnConnectionsChanged(object? sender, EventArgs e) => Rebuild();
+
+        /// <summary>Stops listening. This one lives on the singleton assistant rather than being rebuilt per
+        /// window, so it does not leak today — it is disposable so that stays true if the assistant is ever
+        /// made per-panel.</summary>
+        public void Dispose()
+        {
+            if (_service is not null) _service.ConnectionsChanged -= OnConnectionsChanged;
+        }
 
         internal void Refresh() => Rebuild();
     }

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -29,7 +29,7 @@ namespace CST.Avalonia.ViewModels
     /// is what upstream ships, computed from release dates, and is still a verdict for being arithmetic
     /// (#670/#681, #689).</para>
     /// </summary>
-    public class AiModelsViewModel : ViewModelBase
+    public class AiModelsViewModel : ViewModelBase, IDisposable
     {
         private readonly IAiConnectionService? _service;
         private readonly IAiModelCatalog? _catalog;
@@ -44,7 +44,7 @@ namespace CST.Avalonia.ViewModels
 
             if (_service is not null)
             {
-                _service.ConnectionsChanged += (_, _) => Rebind();
+                _service.ConnectionsChanged += OnConnectionsChanged;
                 Rebind();
             }
         }
@@ -133,6 +133,15 @@ namespace CST.Avalonia.ViewModels
             }
 
             this.RaisePropertyChanged(nameof(HasNoConnections));
+        }
+
+        private void OnConnectionsChanged(object? sender, EventArgs e) => Rebind();
+
+        /// <summary>Stops listening. See the note on <see cref="AiConnectionsViewModel.Dispose"/> — the
+        /// service is a singleton and every Settings open builds one of these.</summary>
+        public void Dispose()
+        {
+            if (_service is not null) _service.ConnectionsChanged -= OnConnectionsChanged;
         }
 
         private void Rebind()

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -28,11 +28,16 @@ namespace CST.Avalonia.ViewModels
         private SettingsCategoryViewModel? _selectedCategory;
         private bool _hasUnsavedChanges;
 
-        // Held only so it can be disposed with the window; it also lives in Categories.
+        // Held only so they can be disposed with the window; both also live in Categories.
         private readonly AppearanceSettingsViewModel? _appearanceSettings;
+        private readonly AiSettingsViewModel? _aiSettings;
 
         /// <summary>Releases child subscriptions. Called from the window's Closed handler.</summary>
-        public void Dispose() => _appearanceSettings?.Dispose();
+        public void Dispose()
+        {
+            _appearanceSettings?.Dispose();
+            _aiSettings?.Dispose();
+        }
 
         public SettingsViewModel(ISettingsService settingsService, Services.Dictionaries.DictionarySourcePreferenceService sourcePrefs)
         {
@@ -61,6 +66,7 @@ namespace CST.Avalonia.ViewModels
                 _settingsService,
                 App.TryGetService<Services.Ai.IAiCredentialStore>(),
                 App.TryGetService<Services.Ai.IChatProviderResolver>());
+            _aiSettings = aiSettings;
             var loggingSettings = new DeveloperSettingsViewModel(_settingsService) { Parent = this };
 
             // Order: most-adjusted settings first, informational ones last (#100).
@@ -1299,7 +1305,7 @@ namespace CST.Avalonia.ViewModels
 /// </summary>
 public sealed record AiProviderChoice(Services.Ai.ChatProviderKind Kind, string Display, string Stored);
 
-public class AiSettingsViewModel : ViewModelBase
+public class AiSettingsViewModel : ViewModelBase, IDisposable
     {
         private readonly ISettingsService _settingsService;
         private bool _aiEnabled;
@@ -1362,6 +1368,15 @@ public class AiSettingsViewModel : ViewModelBase
         /// (#692, #674)
         /// </summary>
         public AiModelsViewModel Models { get; }
+
+        /// <summary>Releases the two tabs' subscriptions to the connection service. The service is a
+        /// singleton and this view model is rebuilt on every Settings open, so without this each visit leaves
+        /// another pair of listeners alive for the rest of the session.</summary>
+        public void Dispose()
+        {
+            Connections.Dispose();
+            Models.Dispose();
+        }
 
         /// <summary>Master switch — "Enable AI Features". Everything AI-related is gated behind this (default OFF).</summary>
         public bool AiEnabled


### PR DESCRIPTION
The **per-Settings-open view-model leak** from the Fable review, listed as not addressed by #717. Mine to fix
— it came in with #713.

## The defect

`IAiConnectionService` is a singleton. `SettingsViewModel` is built fresh by `App.ShowSettingsWindow()` on
every open, and with it a new `AiConnectionsViewModel` and `AiModelsViewModel`, each subscribing to
`ConnectionsChanged`. Nothing unsubscribed.

`SettingsViewModel.Dispose()` already existed and is already called from the window's `Closed` handler — it
just only released the appearance tab.

**Every visit to Settings left two more listeners alive for the rest of the session.** The retained objects are
the smaller half; each dead view model goes on *rebuilding its collections* on every connection change — a
probe result, a reachability write-back, a model toggled in the tab that is actually on screen. So the work
grows linearly with how often the reader has opened a screen whose entire job is being opened.

## The fix

Both are `IDisposable`; `AiSettingsViewModel` disposes the pair; `SettingsViewModel` holds it for exactly the
reason it already holds the appearance tab. The lambda handlers became named methods, since a lambda cannot be
unsubscribed.

`AiModelPickerViewModel` gets the same treatment **although it does not leak today** — it lives on the
singleton assistant and is constructed once. Disposable so that stays true if the assistant is ever made
per-panel, which is precisely the change that would reintroduce this without anyone noticing.

## Tests

One per tab: after `Dispose`, the view model does not see a connection the service *did* add. Mutation-checked
— dropping either unsubscribe fails its own test and nothing else, which is what makes them worth having.

**2049 passing, 0 warnings in both projects.**

## Still open from that review

Not in this PR, and not mine to guess at: unresolved placeholders in header values, and the `Remove`
doc/implementation contradiction.
