### PR TITLE
Fix the startup crash from the model chip's x:Name (#693)

### DIFF
--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml.cs
@@ -1,6 +1,5 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
-using Avalonia.Markup.Xaml;
 using CST.Avalonia.ViewModels;
 
 namespace CST.Avalonia.Views;
@@ -22,6 +21,11 @@ public partial class AiAssistantPanel : UserControl
 
     public AiAssistantPanel()
     {
+        // The generated InitializeComponent, NOT a hand-written AvaloniaXamlLoader.Load(this). This file
+        // used to carry the hand-written one, which was harmless until a control here gained an x:Name:
+        // only the generated initializer assigns the fields those names produce, so a hand-written one
+        // loads the XAML and leaves ModelChip null. The result was a NullReferenceException three lines
+        // below, during the dock's layout pass, which presents as the app failing to start at all.
         InitializeComponent();
         DataContextChanged += OnDataContextChanged;
 
@@ -42,8 +46,6 @@ public partial class AiAssistantPanel : UserControl
         try { _picker.IsOpen = open; }
         finally { _syncingFlyout = false; }
     }
-
-    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
     private void OnDataContextChanged(object? sender, System.EventArgs e)
     {


### PR DESCRIPTION
**The app does not start on `main`.** `NullReferenceException` in `AiAssistantPanel`'s constructor, thrown
during the dock's layout pass, so nothing comes up at all. My regression, from #693.

```
System.NullReferenceException
   at CST.Avalonia.Views.AiAssistantPanel..ctor() … AiAssistantPanel.axaml.cs:line 31
   at Avalonia.Markup.Xaml.Templates.DataTemplate.Build(Object data)
   …
   at Avalonia.Layout.LayoutManager.ExecuteLayoutPass()
```

## Cause

`AiAssistantPanel` hand-wrote

```csharp
private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
```

which **shadows the initializer Avalonia generates**. Only the generated one assigns the backing fields that
`x:Name` produces.

That was harmless for as long as this view had no named control — and it had none until #693 added
`x:Name="ModelChip"` so the flyout could be closed after a model was picked. From that commit on, the
hand-written initializer loaded the XAML and left `ModelChip` null, and the constructor dereferenced it three
lines later.

Removed, so the generated initializer runs. Every other view in the tree that uses `x:Name` —
`BookDisplayView`, `OpenBookPanel`, `DictionaryPanel` — already relies on it; this file was the only one
carrying both.

## Deliberately not null-guarded

`ModelChip?.Flyout` would compile and would trade a loud crash for a flyout that silently never closes — the
exact failure mode this feature area has spent the day avoiding. The field being null means the view is not
wired, and that should be impossible rather than tolerated.

## What did not catch it

**2049 tests pass, and not one constructs a view.** A XAML/code-behind contract has no coverage at all here,
so the first thing to exercise it was launching the app. That is precisely the gap **#655** was filed for, and
this is the second time it has bitten — the first was the dead style selector in #646, which was invisible in
dark mode.

## Verification

Launched the built app: it starts, and the OpenRouter model listing returns **415 models** — which is also the
first time any of the #674 catalogue work has touched a real endpoint rather than a fake one.
