### PR TITLE
One scrolling region on the Models tab, not two (#674)

### DIFF
--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -7,12 +7,17 @@
 
     <!-- The Models tab (#692, #674).
 
-         One flat, virtualized list of group headers and model rows. Flat because a provider listing runs to
-         hundreds of entries and a nested items control would build a control for every one; a single
-         ListBox lets the virtualizing panel do its job.
+         One flat list of group headers and model rows, scrolled by the settings page's own scroll viewer.
+         It was a height-capped ListBox, which virtualized but put a second scrolling region inside the
+         first: two scrollbars, and a wheel whose effect depended on where the pointer happened to be.
 
-         Search filters ACROSS groups rather than within the expanded one, and expands what matches — at four
-         hundred models this is a search box with results, not a menu you scroll. -->
+         Flat is still the right shape - search filters ACROSS groups rather than within the expanded one,
+         so results from several connections interleave, and at four hundred models this is a search box
+         with results rather than a menu you scroll.
+
+         The cost of dropping the cap is that nothing virtualizes: expanding a group of OpenRouter's ~415
+         builds a control per row. Groups start collapsed and the search is the intended way in, so that is
+         a deliberate expand, not the resting state. -->
 
     <UserControl.Styles>
         <Style Selector="Border.Tile">
@@ -44,18 +49,6 @@
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
         </Style>
 
-        <!-- The list is a container for rows, not a thing you select from: every row's action is its own
-             toggle. Selection chrome here would suggest a row-level choice that does not exist. -->
-        <Style Selector="ListBoxItem">
-            <Setter Property="Padding" Value="0"/>
-            <Setter Property="MinHeight" Value="0"/>
-        </Style>
-        <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
-            <Setter Property="Background" Value="Transparent"/>
-        </Style>
-        <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}"/>
-        </Style>
     </UserControl.Styles>
 
     <StackPanel>
@@ -80,12 +73,8 @@
 
         <Border Classes="SettingGroup" Padding="0"
                 IsVisible="{Binding !HasNoConnections}">
-            <ListBox ItemsSource="{Binding Rows}"
-                     MaxHeight="460"
-                     Background="Transparent"
-                     BorderThickness="0"
-                     SelectionMode="Single">
-                <ListBox.DataTemplates>
+            <ItemsControl ItemsSource="{Binding Rows}">
+                <ItemsControl.DataTemplates>
 
                     <!-- Group header: one connection -->
                     <DataTemplate DataType="vm:AiModelGroupViewModel">
@@ -169,8 +158,8 @@
                         </Border>
                     </DataTemplate>
 
-                </ListBox.DataTemplates>
-            </ListBox>
+                </ItemsControl.DataTemplates>
+            </ItemsControl>
         </Border>
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
The model list was a `ListBox` capped at 460px sitting inside the settings page's own scroll viewer — two
scrollbars for one list, and a mouse wheel whose effect depended on which of them the pointer was over. Now an
`ItemsControl`, scrolled by the settings page like every other tab.

The `ListBoxItem` styles went with it. They existed only to suppress selection chrome on a list that was never
selectable, since every row's action is its own toggle.

## What this costs, plainly

The cap was not arbitrary: a virtualizing panel needs a bounded viewport, so removing it means **nothing
virtualizes**. Expanding OpenRouter's ~415 models now builds a control per row rather than only the visible
ones.

Taken deliberately, and here is the reasoning so it can be overruled on evidence rather than re-litigated:

- Groups **start collapsed**, and the search box filters **across** all of them. The intended path to a model
  is to search, not to expand four hundred rows.
- Expanding a large group is therefore something a reader does on purpose, occasionally.
- The nested scroll, by contrast, was in the way on **every** visit to the tab — including the ordinary one
  where a connection has three models and there was never anything to virtualize.

**If a large group does turn out to be slow in use, the fix is not to put the inner scrollbar back.** It is to
give the tab the window's height so the list owns the only scroll region — one scrollbar *and* virtualization.
That is a change to the settings shell rather than to this tab, which is why it is not in this PR.

## Testing

**2049 passing, 0 warnings in both projects.** No test changes: this is layout, and the view models are
untouched — which is also the honest caveat, since nothing here has automated coverage of the rendered result
(#655).

Worth a look with a real provider connected: expand OpenRouter's group and confirm one scrollbar, then judge
whether the expand itself is acceptably quick.
