### PR TITLE
Make a model the reader switches on the one that answers (#674, #693)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -87,18 +87,22 @@ public class AiModelPickerViewModelTests
         Assert.Equal(new[] { "Full" }, picker.Groups.Select(g => g.DisplayName));
     }
 
-    /// <summary>The chip is hidden until there is a choice to make. One model, or none, is a control that
-    /// cannot do anything.</summary>
+    /// <summary>
+    /// The chip appears as soon as one model is enabled, not two.
+    ///
+    /// <para>It used to require two, on the reasoning that a chip offering a single model cannot do anything.
+    /// The chip is also the only place that says which model will answer — and while it was hidden at one
+    /// enabled model, a reader with exactly one had no control anywhere that could configure the
+    /// assistant.</para>
+    /// </summary>
     [Fact]
-    public void The_chip_appears_only_when_there_is_something_to_choose()
+    public void The_chip_appears_as_soon_as_one_model_is_enabled()
     {
         var (picker, service, _) = Make();
         Assert.False(picker.HasChoices);
 
         service.Add("mine", Draft("Mine", new AiModelEntry("a", "A")));
-        Assert.False(picker.HasChoices);
 
-        service.Update("mine", Draft("Mine", new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
         Assert.True(picker.HasChoices);
     }
 

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -305,6 +305,76 @@ public class AiModelsViewModelTests
         Assert.True(Rows(vm).Single(r => r.ModelId == "a").Enabled);
     }
 
+    // ---- the active model follows what is switched on ------------------------------------------------------
+
+    /// <summary>
+    /// Switching a model on, with nothing active, makes it the one that answers.
+    ///
+    /// <para>The defect this pins: enabling only ever set a flag, so a reader who connected OpenRouter and
+    /// switched on a single model was told "No model is configured" by the assistant while looking at the
+    /// model they had just enabled. With one model enabled the per-turn picker had nothing to choose between
+    /// either, so there was no control anywhere that could set it.</para>
+    /// </summary>
+    [Fact]
+    public void Switching_a_model_on_makes_it_active_when_nothing_is()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("nvidia/nemotron", "Nemotron"), new AiCatalogModel("other", "Other")));
+        service.Add("openrouter-ish", Draft());
+        Group(vm).IsExpanded = true;
+        Assert.Null(service.ActiveModelId);
+
+        Rows(vm).Single(r => r.ModelId == "nvidia/nemotron").Enabled = true;
+
+        Assert.Equal("nvidia/nemotron", service.ActiveModelId);
+        Assert.Equal("openrouter-ish", service.Active?.Id);
+    }
+
+    /// <summary>A later enable does not steal the choice — the reader picked one already.</summary>
+    [Fact]
+    public void A_later_enable_does_not_change_the_active_model()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("first", "First"), new AiCatalogModel("second", "Second")));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        Rows(vm).Single(r => r.ModelId == "first").Enabled = true;
+        Rows(vm).Single(r => r.ModelId == "second").Enabled = true;
+
+        Assert.Equal("first", service.ActiveModelId);
+    }
+
+    /// <summary>Switching the active model off moves the pointer to another enabled one, rather than leaving
+    /// requests aimed at a model the reader has just hidden.</summary>
+    [Fact]
+    public void Switching_the_active_model_off_moves_to_another_enabled_one()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft(new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
+        Group(vm).IsExpanded = true;
+        service.SetActive("mine", "a");
+
+        Rows(vm).Single(r => r.ModelId == "a").Enabled = false;
+
+        Assert.Equal("b", service.ActiveModelId);
+    }
+
+    /// <summary>With nothing else enabled it clears, which is honest — and the assistant's own message then
+    /// says so rather than the request failing at the endpoint.</summary>
+    [Fact]
+    public void Switching_the_last_enabled_model_off_clears_the_active_one()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft(new AiModelEntry("a", "A")));
+        Group(vm).IsExpanded = true;
+        service.SetActive("mine", "a");
+
+        Rows(vm).Single().Enabled = false;
+
+        Assert.Null(service.ActiveModelId);
+    }
+
     // ---- search and the capability filter ---------------------------------------------------------------
 
     /// <summary>Search filters across every group, not within the expanded one, and shows what it finds

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -313,6 +313,7 @@ namespace CST.Avalonia.Services.Ai
             }
 
             model.Enabled = enabled;
+            FollowTheChoice(record, model, enabled);
             return Saved(record);
         }
 
@@ -325,7 +326,38 @@ namespace CST.Avalonia.Services.Ai
             if (model is null) return AiConnectionResult.Fail($"'{modelId}' is not a model on {record.DisplayName}.");
 
             model.Enabled = enabled;
+            FollowTheChoice(record, model, enabled);
             return Saved(record);
+        }
+
+        /// <summary>
+        /// Keeps the active model in step with what the reader just switched on or off.
+        ///
+        /// <para><b>Turning a model on when nothing is active makes it active.</b> Enabling is the reader
+        /// saying "this is one I want to use", and with a single enabled model there is nothing else it could
+        /// mean. Without this the assistant answered "No model is configured" to someone looking at the model
+        /// they had just switched on — and with only one enabled, the per-turn picker had nothing to choose
+        /// between and so offered no way out at all.</para>
+        ///
+        /// <para><b>Turning the active model off moves the pointer.</b> To another enabled model on the same
+        /// connection where there is one, and otherwise to nothing — leaving it pointing at a model the
+        /// reader has just hidden would send requests to something the picker no longer lists.</para>
+        /// </summary>
+        private void FollowTheChoice(AiConnectionRecord record, AiModelRecord model, bool enabled)
+        {
+            if (enabled)
+            {
+                if (!string.IsNullOrEmpty(Chat.ActiveModelId)) return;
+                Chat.ActiveConnectionId = record.Id;
+                Chat.ActiveModelId = model.Id;
+                return;
+            }
+
+            if (!IdMatches(Chat.ActiveConnectionId, record.Id)) return;
+            if (!string.Equals(Chat.ActiveModelId, model.Id, StringComparison.Ordinal)) return;
+
+            Chat.ActiveModelId = record.Models
+                .FirstOrDefault(m => m.Enabled && !string.Equals(m.Id, model.Id, StringComparison.Ordinal))?.Id;
         }
 
         // ---- internals -------------------------------------------------------------------------------

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -65,9 +65,16 @@ namespace CST.Avalonia.ViewModels
             }
         }
 
-        /// <summary>Hidden entirely until there is a choice to make. A chip offering one model, or none, is a
-        /// control that cannot do anything.</summary>
-        public bool HasChoices => Groups.Sum(g => g.Models.Count) > 1;
+        /// <summary>
+        /// Shown as soon as one model is enabled.
+        ///
+        /// <para>It used to require <i>two</i>, on the reasoning that a chip offering a single model cannot
+        /// do anything. That was wrong twice: the chip is also the only place that says which model will
+        /// answer, and — until the service learned to follow an enable — it was the only control that could
+        /// set the active model at all, so hiding it at one enabled model left no way to configure the
+        /// assistant.</para>
+        /// </summary>
+        public bool HasChoices => Groups.Sum(g => g.Models.Count) > 0;
 
         public bool IsOpen
         {


### PR DESCRIPTION
**Reported from use:** configure OpenRouter, switch on a model, ask a question — and the assistant says *"No
model is configured"*, while the reader is looking at the model they just enabled.

Reproduced from the maintainer's `settings.json`:

```json
"ActiveConnectionId": "openrouter",
"ActiveModelId": null,
"Models": [ { "Id": "nvidia/nemotron-3-ultra-550b-a55b:free", "Enabled": true } ]
```

Two of my defects, and they compound into a dead end.

## 1. Enabling never set the active model

`EnableModel` wrote `Models[].Enabled` and nothing else. Choosing which model *answers* was `SetActive`,
reachable only from the composer picker — so the Models tab could hand a reader a fully configured connection
that the resolver still read as unconfigured.

Enabling now claims the active slot **when it is empty**. That is what enabling means — the reader saying
"this is one I want to use" — and with a single enabled model there is nothing else it could mean. A later
enable does not steal it; they already chose.

The reverse too: switching **off** the active model moves the pointer to another enabled model on the same
connection, or clears it. Leaving it aimed at a model the reader has just hidden would send requests to
something the picker no longer lists.

## 2. The composer chip hid itself at one model

`HasChoices` required *more than one* model, on the reasoning that a chip offering a single model cannot do
anything. Wrong twice over: the chip is also the only place that says **which** model will answer, and while
it was hidden it was the only control that could set the active model — so a reader with exactly one enabled
model had no way to configure the assistant at all.

**Either fix alone leaves the trap half-open:** without (1) a reader must know to open the chip; without (2)
the one-model case has no chip to open.

## Tests

Four on the pointer-following, one on the chip. Mutation-checked — reverting either half fails its own tests
and nothing else.

**2051 passing, 0 warnings in both projects.**

## One manual step after merging

An already-stuck `settings.json` does not heal itself — the fix changes what *enabling* does, and the model is
already enabled. Switch the model off and back on once, and the active pointer is set. No migration is
warranted for this: `ChatSettings` postdates the beta 5 tag, so no reader outside this repo has connections at
all.
