### PR TITLE
Models tab: filter by price, and drop the misleading "Typed" badge (#674)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -38,7 +38,7 @@ public class AiModelCatalogTests
         Assert.Equal(0.4m, model.PromptPricePerMillion);
         Assert.Equal(1.6m, model.CompletionPricePerMillion);
         Assert.True(model.SupportsReasoning);
-        Assert.True(model.IsTextToText);
+        Assert.True(model.CostsMoney);
     }
 
     /// <summary>Anthropic names the field differently and publishes nothing else.</summary>
@@ -72,30 +72,44 @@ public class AiModelCatalogTests
         var model = Assert.Single(models);
         Assert.Equal("gemma4:12b-mlx", model.Id);
         Assert.Equal("gemma4:12b-mlx", model.DisplayName);
-        Assert.True(model.IsTextToText);
+        Assert.False(model.CostsMoney);   // publishes no price; unknown is not costly
     }
 
-    // ---- the capability filter -------------------------------------------------------------------------
+    // ---- price -------------------------------------------------------------------------------------------
 
     /// <summary>
-    /// Mechanical, and built only from what the provider published: a model that cannot take text in and give
-    /// text out cannot answer a question at all. It is not a judgment about the models that remain — which is
-    /// the line #670/#681 draws, and the filter OpenCode omits, which is why a music model and a video model
-    /// reach their chat picker.
+    /// What a provider charges is a fact it publishes, which is what makes filtering on it safe where a
+    /// judgment about quality would not be (#670/#681).
     /// </summary>
     [Theory]
-    [InlineData("""{"input_modalities":["text"],"output_modalities":["text"]}""", true)]
-    [InlineData("""{"input_modalities":["text","image"],"output_modalities":["text"]}""", true)]
-    [InlineData("""{"input_modalities":["text"],"output_modalities":["audio"]}""", false)]
-    [InlineData("""{"input_modalities":["text"],"output_modalities":["video"]}""", false)]
-    [InlineData("""{"modality":"text->text"}""", true)]
-    [InlineData("""{"modality":"text+image->text"}""", true)]
-    [InlineData("""{"modality":"text->image"}""", false)]
-    public void Only_models_that_answer_in_text_pass_the_capability_filter(string architecture, bool expected)
+    [InlineData("""{"prompt":"0","completion":"0"}""", false)]
+    [InlineData("""{"prompt":"0.0000004","completion":"0.0000016"}""", true)]
+    [InlineData("""{"prompt":"0","completion":"0.0000016"}""", true)]
+    public void Costing_money_is_read_from_the_published_price(string pricing, bool expected)
     {
-        var models = AiModelCatalog.Parse($$"""{"data":[{"id":"m","architecture":{{architecture}}}]}""");
+        var models = AiModelCatalog.Parse($$"""{"data":[{"id":"m","pricing":{{pricing}}}]}""");
 
-        Assert.Equal(expected, Assert.Single(models).IsTextToText);
+        Assert.Equal(expected, Assert.Single(models).CostsMoney);
+    }
+
+    /// <summary>Unknown is not costly. Every local runner publishes no price at all, and treating silence as
+    /// expensive would hide the models of a reader spending nothing.</summary>
+    [Fact]
+    public void A_model_with_no_published_price_does_not_count_as_costing_money() =>
+        Assert.False(Assert.Single(AiModelCatalog.Parse("""{"data":[{"id":"m"}]}""")).CostsMoney);
+
+    /// <summary>Modalities are still parsed and kept — they are provider-published facts worth showing, even
+    /// though they no longer drive a filter: on OpenRouter every one of 415 models can answer in text, so the
+    /// modality filter they used to drive excluded nothing.</summary>
+    [Fact]
+    public void Modalities_are_still_read()
+    {
+        var models = AiModelCatalog.Parse(
+            """{"data":[{"id":"m","architecture":{"input_modalities":["text","image"],"output_modalities":["text"]}}]}""");
+
+        var model = Assert.Single(models);
+        Assert.Equal(new[] { "text", "image" }, model.InputModalities);
+        Assert.Equal(new[] { "text" }, model.OutputModalities);
     }
 
     // ---- ordering and robustness -----------------------------------------------------------------------

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -421,24 +421,64 @@ public class AiModelsViewModelTests
         Assert.Single(Rows(vm));
     }
 
-    /// <summary>The capability filter drops models the provider publishes as unable to answer in text. It is
-    /// mechanical and reversible, and it makes no claim about the models that remain.</summary>
+    /// <summary>
+    /// The price filter hides what the provider charges for, and is off by default.
+    ///
+    /// <para>Off by default because on would be a claim about what the reader wants to spend — and on
+    /// OpenRouter it would hide 395 of 415 models the first time they looked.</para>
+    /// </summary>
     [Fact]
-    public void The_capability_filter_drops_models_that_cannot_answer_in_text()
+    public void The_price_filter_hides_models_that_cost_money()
     {
         var (vm, service) = Make(new FakeCatalog(
-            new AiCatalogModel("chat", "Chat",
-                InputModalities: new[] { "text" }, OutputModalities: new[] { "text" }),
-            new AiCatalogModel("tts", "Speech",
-                InputModalities: new[] { "text" }, OutputModalities: new[] { "audio" })));
+            new AiCatalogModel("free", "Free",
+                PromptPricePerMillion: 0m, CompletionPricePerMillion: 0m),
+            new AiCatalogModel("paid", "Paid",
+                PromptPricePerMillion: 0.4m, CompletionPricePerMillion: 1.6m)));
         service.Add("mine", Draft());
         Group(vm).IsExpanded = true;
 
-        Assert.Equal(new[] { "chat" }, Rows(vm).Select(r => r.ModelId));
-
-        vm.TextOnly = false;
-
+        Assert.False(vm.FreeOnly);
         Assert.Equal(2, Rows(vm).Count);
+
+        vm.FreeOnly = true;
+
+        Assert.Equal(new[] { "free" }, Rows(vm).Select(r => r.ModelId));
+    }
+
+    /// <summary>
+    /// An endpoint that publishes no price is unaffected.
+    ///
+    /// <para>Unknown is not costly. A local runner charges nothing and says nothing, and hiding its models
+    /// behind a filter for a field it never sent would empty the group for a reader who is not spending
+    /// anything at all.</para>
+    /// </summary>
+    [Fact]
+    public void A_model_with_no_published_price_survives_the_filter()
+    {
+        var (vm, service) = Make(new FakeCatalog(new AiCatalogModel("quiet", "Quiet")));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        vm.FreeOnly = true;
+
+        Assert.Single(Rows(vm), r => r.ModelId == "quiet");
+    }
+
+    /// <summary>A price of zero on only one side still counts as costing money — a model billed for output
+    /// alone is not free.</summary>
+    [Fact]
+    public void A_price_on_either_side_counts_as_costing_money()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("half", "Half",
+                PromptPricePerMillion: 0m, CompletionPricePerMillion: 1.6m)));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        vm.FreeOnly = true;
+
+        Assert.Empty(Rows(vm));
     }
 
     /// <summary>
@@ -451,11 +491,12 @@ public class AiModelsViewModelTests
     public void A_typed_model_is_never_hidden_by_the_filter()
     {
         var (vm, service) = Make(new FakeCatalog(
-            new AiCatalogModel("odd", "Odd", InputModalities: new[] { "text" },
-                OutputModalities: new[] { "audio" })));
+            new AiCatalogModel("odd", "Odd",
+                PromptPricePerMillion: 9m, CompletionPricePerMillion: 9m)));
         service.Add("mine", Draft(new AiModelEntry("odd", "Odd")));
-
         Group(vm).IsExpanded = true;
+
+        vm.FreeOnly = true;
 
         Assert.Single(Rows(vm), r => r.ModelId == "odd");
     }

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -36,20 +36,19 @@ namespace CST.Avalonia.Services.Ai
         IReadOnlyList<string>? SupportedParameters = null)
     {
         /// <summary>
-        /// Whether this model can take text in and give text out — the only thing the assistant ever asks of
-        /// one.
+        /// Whether the provider publishes a price above zero for this model.
         ///
-        /// <para><b>A mechanical filter, not a judgment.</b> It reads the provider's own published modality
-        /// and removes models that cannot answer a question at all — a text-to-speech model, an image
-        /// generator, a video model. It says nothing about which of the remaining ones is better, which is the
-        /// line #670/#681 draws. OpenCode omits this filter, which is why a music model and a video model
-        /// reach their chat picker.</para>
+        /// <para><b>A fact, not a judgment.</b> What a provider charges is something it states; filtering on
+        /// it removes nothing on the grounds of quality, which is the line #670/#681 draws. It replaced a
+        /// modality filter that was correct and useless: of OpenRouter's 415 models every single one outputs
+        /// text, so "can this answer in text?" excluded nothing at all, while 395 of them cost money.</para>
         ///
-        /// <para>Unknown counts as usable. A provider that publishes no modality — every local runner — must
-        /// not have its models filtered away by a field it never sent.</para>
+        /// <para><b>Unknown is not costly.</b> A provider that publishes no price — every local runner — must
+        /// not have its models hidden by a field it never sent. Only a price we can read and that is above
+        /// zero counts.</para>
         /// </summary>
-        public bool IsTextToText =>
-            Handles(InputModalities, "text") && Handles(OutputModalities, "text");
+        public bool CostsMoney =>
+            PromptPricePerMillion > 0m || CompletionPricePerMillion > 0m;
 
         /// <summary>Whether the provider says it accepts a reasoning-effort parameter (#671). Published, not
         /// inferred from the name.</summary>
@@ -58,9 +57,6 @@ namespace CST.Avalonia.Services.Ai
                 p.Contains("reasoning", StringComparison.OrdinalIgnoreCase) ||
                 p.Equals("thinking", StringComparison.OrdinalIgnoreCase)) == true;
 
-        private static bool Handles(IReadOnlyList<string>? modalities, string want) =>
-            modalities is null || modalities.Count == 0 ||
-            modalities.Any(m => m.Contains(want, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>What a fetch produced, or why it produced nothing.</summary>

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -24,8 +24,8 @@ namespace CST.Avalonia.ViewModels
     /// reader promotes the handful they will switch between.</para>
     ///
     /// <para><b>Nothing here ranks anything.</b> Ordering is alphabetical within a group, groups follow the
-    /// order connections were added, and the only filter is a mechanical one built from the provider's own
-    /// published modality. No badge, no tier, no "recommended", and above all no pre-enabled subset — which
+    /// order connections were added, and the only filter is built from the provider's own published price.
+    /// No badge, no tier, no "recommended", and above all no pre-enabled subset — which
     /// is what upstream ships, computed from release dates, and is still a verdict for being arithmetic
     /// (#670/#681, #689).</para>
     /// </summary>
@@ -34,7 +34,7 @@ namespace CST.Avalonia.ViewModels
         private readonly IAiConnectionService? _service;
         private readonly IAiModelCatalog? _catalog;
         private string _search = "";
-        private bool _textOnly = true;
+        private bool _freeOnly;
         private bool _suppressRebind;
 
         public AiModelsViewModel(IAiConnectionService? service, IAiModelCatalog? catalog = null)
@@ -77,19 +77,21 @@ namespace CST.Avalonia.ViewModels
         public bool IsSearching => !string.IsNullOrWhiteSpace(Search);
 
         /// <summary>
-        /// Hide models that cannot take text in and give text out.
+        /// Hide models the provider charges for.
         ///
-        /// <para>Built entirely from the provider's published modality, so it removes models that cannot
-        /// answer a question at all — a text-to-speech model, an image generator — and says nothing about
-        /// which of the rest is better. Shown as a control and reversible, because a mechanical filter the
-        /// reader cannot see or turn off starts to look like a judgment even when it isn't.</para>
+        /// <para>Built from published price, so it states a fact rather than a preference — and unlike the
+        /// modality filter it replaced, it does something. Of OpenRouter's 415 models <b>every one</b> can
+        /// answer in text, so "text models only" excluded nothing at all; 395 of them cost money.</para>
+        ///
+        /// <para><b>Off by default.</b> On would be a claim about what the reader wants to spend, and it
+        /// would hide almost everything the first time they looked at their provider.</para>
         /// </summary>
-        public bool TextOnly
+        public bool FreeOnly
         {
-            get => _textOnly;
+            get => _freeOnly;
             set
             {
-                this.RaiseAndSetIfChanged(ref _textOnly, value);
+                this.RaiseAndSetIfChanged(ref _freeOnly, value);
                 Reflow();
             }
         }
@@ -120,7 +122,7 @@ namespace CST.Avalonia.ViewModels
 
             foreach (var group in Groups)
             {
-                group.ApplyFilter(Search, TextOnly, IsSearching);
+                group.ApplyFilter(Search, FreeOnly, IsSearching);
 
                 // A group with nothing matching disappears entirely while searching, rather than sitting
                 // there as a header promising results it does not have.
@@ -282,10 +284,10 @@ namespace CST.Avalonia.ViewModels
         /// Merges the reader's stored list with anything fetched, then filters.
         ///
         /// <para>Stored models are always shown and never filtered out — the reader put them there, and
-        /// hiding one behind a capability filter would look like it had been lost. Fetched models the reader
-        /// has not touched are subject to both the search and the modality filter.</para>
+        /// hiding one behind a price filter would look like it had been lost. Fetched models the reader has
+        /// not touched are subject to both the search and the price filter.</para>
         /// </summary>
-        internal void ApplyFilter(string search, bool textOnly, bool searching)
+        internal void ApplyFilter(string search, bool freeOnly, bool searching)
         {
             var stored = _connection.Models.ToDictionary(m => m.Id, StringComparer.Ordinal);
             var rows = new List<AiCatalogRowViewModel>();
@@ -299,7 +301,7 @@ namespace CST.Avalonia.ViewModels
             foreach (var model in _fetched)
             {
                 if (stored.ContainsKey(model.Id)) continue;
-                if (textOnly && !model.IsTextToText) continue;
+                if (freeOnly && model.CostsMoney) continue;
                 rows.Add(new AiCatalogRowViewModel(
                     this, model.Id, model.DisplayName, model, enabled: false, typed: false));
             }

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -63,12 +63,12 @@
               IsVisible="{Binding !HasNoConnections}">
             <TextBox Grid.Column="0" Text="{Binding Search}"
                      Watermark="Search models"/>
-            <!-- Mechanical and reversible: it drops models that cannot take text in and give text out, using
-                 the provider's own published modality, and says nothing about which of the rest is better. -->
-            <CheckBox Grid.Column="1" IsChecked="{Binding TextOnly}"
-                      Content="Text models only"
+            <!-- Built from published price, which is a fact the provider states rather than a preference of
+                 ours. Off by default: on would be a claim about what the reader wants to spend. -->
+            <CheckBox Grid.Column="1" IsChecked="{Binding FreeOnly}"
+                      Content="Free models only"
                       Margin="10,0,0,0" VerticalAlignment="Center"
-                      ToolTip.Tip="Hides models the provider publishes as image, audio or video only. Nothing is judged — these cannot answer a question at all."/>
+                      ToolTip.Tip="Hides models the provider publishes a price for. Endpoints that publish no price at all — a local runner — are unaffected."/>
         </Grid>
 
         <Border Classes="SettingGroup" Padding="0"


### PR DESCRIPTION
**Reported from use:** the "Text models only" checkbox did not appear to show or hide anything. It didn't.

I pulled OpenRouter's live listing to find out why. All 415 models:

| `output_modalities` | count |
|---|---|
| `text` | 400 |
| `image`, `text` | 11 |
| `audio`, `text` | 4 |

**Every single one outputs text.** None is image-only or audio-only, so a filter asking *"can this answer in
text?"* excludes nothing at all. The mechanism was fine — there was a passing test proving it drops an
audio-output model — the real data just has nothing for it to drop.

## Where I went wrong

The filter came from the OpenCode study, where a music model and a video model reached the chat picker. Those
were **Google's**, arriving through models.dev — a maintained catalogue, not a live `/v1/models`. I generalised
from one provider's curated listing to an endpoint that behaves differently, and shipped a control that does
nothing on the provider actually in use.

## Replaced with price

Of the same 415: **20 free, 395 paid.** That is a filter with something to do.

Note **3 of the 20 free models do not carry a `:free` suffix**, so matching on the id would miss them. The
published price is the only reliable signal, and it is what this reads.

**Unknown is not costly.** Only a price we can read *and* that is above zero counts. Every local runner
publishes no pricing at all, and treating silence as expensive would empty the group for a reader spending
nothing. A price on either side counts — a model billed for output alone is not free.

**Off by default.** On would be a claim about what the reader wants to spend, and would hide 395 of 415 the
first time they looked.

Still nothing here ranks. Price is a fact the provider states, not a judgment about which model is better, so
this stays on the right side of #670/#681. Modalities are still parsed and kept — provider-published facts
worth showing — they just no longer drive a filter.

## Testing

**2047 passing, 0 warnings in both projects.** Six tests on the new filter, including the two cases that would
otherwise be got wrong: no published price survives the filter, and a price on one side only still counts as
costing money.


---

## Second commit: drop the "Typed" badge

Spotted from use — the selected Nemotron model was badged **Typed**, having been promoted from OpenRouter's
fetched listing rather than typed by anyone.

The badge was set for every model in the connection's stored `Models[]`, on the assumption that *stored* meant
*hand-entered*. Promoting a model from the catalogue puts it in exactly that list, so it was badged too — and
since a named provider's sheet no longer accepts model ids at all, for an OpenRouter connection the badge was
wrong on **every row that carried it**. It could only have been right for a custom endpoint, where it would
then appear on every row and say nothing.

**Removed rather than repaired.** The repair would be to badge a stored model the provider's listing does *not*
carry — a stale or renamed id, which a listing genuinely can tell us and which would explain a 404 at send
time. But nobody has hit that, and building it now would be the third time today I shipped UI for a case I had
reasoned my way to rather than seen. If a stale id turns up it will arrive with a provider and a model
attached, and can be designed for then.
