### PR TITLE
Drop the "Typed" badge, which said the opposite of the truth (#674)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -72,9 +72,7 @@ public class AiModelsViewModelTests
 
         Group(vm).IsExpanded = true;
 
-        var row = Assert.Single(Rows(vm));
-        Assert.True(row.Enabled);
-        Assert.True(row.IsTyped);
+        Assert.True(Assert.Single(Rows(vm)).Enabled);
     }
 
     /// <summary>Groups start collapsed with the count in the header — exactly the number a reader needs to
@@ -139,9 +137,7 @@ public class AiModelsViewModelTests
 
         Group(vm).IsExpanded = true;
 
-        var row = Assert.Single(Rows(vm));
-        Assert.False(row.Enabled);
-        Assert.False(row.IsTyped);
+        Assert.False(Assert.Single(Rows(vm)).Enabled);
     }
 
     /// <summary>Nothing reaches <c>settings.json</c> until the reader chooses it — storing four hundred

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -296,14 +296,14 @@ namespace CST.Avalonia.ViewModels
                 rows.Add(new AiCatalogRowViewModel(
                     this, model.Id, model.DisplayName,
                     _fetched.FirstOrDefault(f => string.Equals(f.Id, model.Id, StringComparison.Ordinal)),
-                    model.Enabled, typed: true));
+                    model.Enabled));
 
             foreach (var model in _fetched)
             {
                 if (stored.ContainsKey(model.Id)) continue;
                 if (freeOnly && model.CostsMoney) continue;
                 rows.Add(new AiCatalogRowViewModel(
-                    this, model.Id, model.DisplayName, model, enabled: false, typed: false));
+                    this, model.Id, model.DisplayName, model, enabled: false));
             }
 
             if (!string.IsNullOrWhiteSpace(search))
@@ -377,7 +377,7 @@ namespace CST.Avalonia.ViewModels
 
         public AiCatalogRowViewModel(
             AiModelGroupViewModel group, string id, string displayName, AiCatalogModel? published,
-            bool enabled, bool typed)
+            bool enabled)
         {
             _group = group;
             _published = published;
@@ -385,17 +385,11 @@ namespace CST.Avalonia.ViewModels
 
             ModelId = id;
             DisplayName = displayName;
-            IsTyped = typed;
         }
 
         public string ModelId { get; }
 
         public string DisplayName { get; }
-
-        /// <summary>True for a model the reader typed rather than one that arrived in a listing. Shown,
-        /// because "I added this by hand" is the reason it appears even when the provider has never heard of
-        /// it.</summary>
-        public bool IsTyped { get; }
 
         /// <summary>
         /// The provider's own facts about the model, on one line: context window, price per million tokens,

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -131,7 +131,7 @@
                         <Border Padding="34,6,10,6"
                                 BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
                                 BorderThickness="0,0,0,1">
-                            <Grid ColumnDefinitions="*,Auto,Auto">
+                            <Grid ColumnDefinitions="*,Auto">
                                 <StackPanel Grid.Column="0" Spacing="1" VerticalAlignment="Center">
                                     <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
                                     <!-- The provider's own facts, verbatim. Empty for an endpoint that
@@ -140,18 +140,9 @@
                                                TextTrimming="CharacterEllipsis"/>
                                 </StackPanel>
 
-                                <Border Grid.Column="1" IsVisible="{Binding IsTyped}"
-                                        Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
-                                        BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                                        BorderThickness="1" CornerRadius="9" Padding="7,1"
-                                        VerticalAlignment="Center" Margin="8,0">
-                                    <TextBlock Text="Typed" FontSize="10"
-                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                                </Border>
-
                                 <!-- A switch, never a radio: several models under one connection must be
                                      on at once, which is the entire point of a short list. -->
-                                <ToggleSwitch Grid.Column="2" IsChecked="{Binding Enabled}"
+                                <ToggleSwitch Grid.Column="1" IsChecked="{Binding Enabled}"
                                               OnContent="" OffContent=""
                                               VerticalAlignment="Center"/>
                             </Grid>


### PR DESCRIPTION
Spotted from use: the selected Nemotron model was badged **Typed**, having been promoted from OpenRouter's
fetched listing rather than typed by anyone.

The badge was set for every model in the connection's stored `Models[]`, on the assumption that *stored* meant
*hand-entered*. Promoting a model from the catalogue puts it in exactly that list, so it was badged too — and
since a named provider's sheet no longer accepts model ids at all, for an OpenRouter connection the badge was
wrong on **every row that carried it**. It could only have been right for a custom endpoint, where it would
then appear on every row and say nothing.

## Removed rather than repaired

The repair would be to badge a stored model that the provider's listing does *not* carry — a stale or renamed
id, which a listing genuinely can tell us and which would explain a 404 at send time. But nobody has hit that,
and building it now would be the third time in this session I shipped UI for a case I reasoned my way to
rather than saw. If a stale id turns up it will arrive with a provider and a model attached, and can be
designed for then.

## Provenance

This was pushed as a second commit to #722 while that PR was open, and did not make the merge — #722 went in
as the price filter alone. Cherry-picked onto current `main` and sent as its own PR, which is the right shape
anyway: adding commits to an open PR races the review.

## Testing

Clean build, 30 targeted tests on the Models tab. No full suite, per the integration-branch cadence.
