### PR TITLE
Open Settings at the Models tab when the picker says "Manage models" (#693)

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -2119,7 +2119,9 @@ public partial class App : Application
     // #28: also invoked from the Windows/Linux Tools menu. The macOS Preferences item lives in the
     // application-level NativeMenu, which is only ever realised as the macOS app menu - off macOS the
     // in-window <NativeMenuBar/> renders the *window's* menu, so Settings had no entry point at all.
-    internal static async Task ShowSettingsWindow()
+    /// <param name="category">Category to open on, e.g. "AI". Null opens on the first, as before.</param>
+    /// <param name="tab">Sub-tab within that category, where it has any. (#693)</param>
+    internal static async Task ShowSettingsWindow(string? category = null, int tab = 0)
     {
         try
         {
@@ -2128,6 +2130,7 @@ public partial class App : Application
             {
                 var sourcePrefs = ServiceProvider!.GetRequiredService<Services.Dictionaries.DictionarySourcePreferenceService>();
                 var settingsViewModel = new SettingsViewModel(settingsService, sourcePrefs);
+                if (category is not null) settingsViewModel.OpenAt(category, tab);
                 var settingsWindow = new SettingsWindow
                 {
                     DataContext = settingsViewModel

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -118,10 +118,17 @@ namespace CST.Avalonia.ViewModels
             _changed?.Invoke();
         }
 
+        /// <summary>
+        /// Opens Settings on the Models tab — the screen this control's label names.
+        ///
+        /// <para>It used to open Settings at whatever came first, leaving the reader to find the AI category
+        /// and then the right tab: a link that says "Manage models" and lands somewhere else is a small lie
+        /// the reader pays for every time.</para>
+        /// </summary>
         private void Manage()
         {
             IsOpen = false;
-            _ = App.ShowSettingsWindow();
+            _ = App.ShowSettingsWindow("AI", AiSettingsViewModel.ModelsTab);
         }
 
         private void Rebuild()

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -87,6 +87,26 @@ namespace CST.Avalonia.ViewModels
 
         public ObservableCollection<SettingsCategoryViewModel> Categories { get; }
 
+        /// <summary>
+        /// Opens on a named category, and on a sub-tab within it where the category has any. (#693)
+        ///
+        /// <para>Unknown names are ignored rather than throwing: the caller is naming a screen, and a screen
+        /// that has been renamed should land the reader on the default one rather than take the window
+        /// down.</para>
+        /// </summary>
+        public void OpenAt(string categoryName, int tab = 0)
+        {
+            var match = Categories.FirstOrDefault(
+                c => string.Equals(c.Name, categoryName, StringComparison.Ordinal));
+            if (match is null) return;
+
+            SelectedCategory = match;
+
+            // Only the AI category has sub-tabs. A cast rather than an interface for exactly one
+            // implementor - if a second category gains tabs, that is the moment to generalise it.
+            if (match.Content is AiSettingsViewModel ai) ai.SelectedTab = tab;
+        }
+
         public SettingsCategoryViewModel? SelectedCategory
         {
             get => _selectedCategory;
@@ -1312,6 +1332,7 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
         private bool _localApiEnabled;
         private bool _mcpEnabled;
         private bool _allowRemoteControl;
+        private int _selectedTab;
 
         public AiSettingsViewModel(ISettingsService settingsService)
             : this(settingsService, null, null)
@@ -1368,6 +1389,25 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
         /// (#692, #674)
         /// </summary>
         public AiModelsViewModel Models { get; }
+
+        /// <summary>Which sub-tab the AI category opens on. Named rather than numbered at the call sites, so
+        /// reordering the tabs cannot silently send a caller somewhere else. (#693)</summary>
+        public const int GeneralTab = 0;
+        public const int ProvidersTab = 1;
+        public const int ModelsTab = 2;
+
+        /// <summary>
+        /// The selected sub-tab.
+        ///
+        /// <para>Bindable so somewhere else in the app can open Settings <i>at</i> a tab — the assistant's
+        /// "Manage models…" means the Models tab specifically, and landing the reader on the first category's
+        /// first tab makes them navigate to the thing they just asked for.</para>
+        /// </summary>
+        public int SelectedTab
+        {
+            get => _selectedTab;
+            set => this.RaiseAndSetIfChanged(ref _selectedTab, value);
+        }
 
         /// <summary>Releases the two tabs' subscriptions to the connection service. The service is a
         /// singleton and this view model is rebuilt on every Settings open, so without this each visit leaves

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -504,7 +504,7 @@
                              they belong to. The master switch stays on the first tab, adjacent to what it
                              gates, rather than becoming a left-nav row of its own. -->
                         <DataTemplate DataType="vm:AiSettingsViewModel">
-                            <TabControl>
+                            <TabControl SelectedIndex="{Binding SelectedTab}">
                               <TabItem Header="General">
                                 <StackPanel Margin="0,12,0,0">
                                 <Border Classes="SettingGroup">


### PR DESCRIPTION
The picker's **"Manage models…"** opened Settings at whatever category came first, leaving the reader to find
the AI category and then the right tab inside it. A control labelled *Manage models* that lands somewhere else
is a small lie paid for on every use.

`ShowSettingsWindow` takes an optional category name and sub-tab; `SettingsViewModel` gains
`OpenAt(category, tab)`; the AI category's `TabControl` binds its `SelectedIndex` so a caller can name the tab.
The picker asks for `"AI"` and `AiSettingsViewModel.ModelsTab` — **named rather than numbered**, so reordering
the tabs cannot silently send a caller somewhere else.

An unknown category name is ignored rather than throwing. The caller is naming a screen, and a screen that has
been renamed should land the reader on the default one rather than take the settings window down.

## Not tested, and why

I wrote two tests for `OpenAt` and then removed them. **`SettingsViewModel` cannot be constructed outside a
running app**: it builds every settings category, and `AppearanceSettingsViewModel` calls `GetRequiredService`
on `App.ServiceProvider`, which is null in a test host. Making it constructible is real work on the settings
shell — #655's territory rather than this change's.

So this one is verified by use, not by test:

1. Open the Assistant, click the model chip.
2. Click **Manage models…**
3. Settings should open on **AI → Models**, not on Pali Script Fonts.

## Testing

Clean build, 669 targeted AI tests pass. No full suite, per the integration-branch cadence.
