### PR TITLE
Put a model's published facts on hover, not under every name (#674)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -518,7 +518,7 @@ public class AiModelsViewModelTests
     // ---- what a row says ---------------------------------------------------------------------------------
 
     /// <summary>The provider's own facts, verbatim and attributed — safe where a table we maintained would
-    /// not be.</summary>
+    /// not be. Carried on the row's tooltip rather than a second line of text under every name.</summary>
     [Fact]
     public void A_row_shows_the_published_facts()
     {
@@ -532,6 +532,21 @@ public class AiModelsViewModelTests
         Assert.Contains("131K context", details);
         Assert.Contains("$0.4/$1.6 per M", details);
         Assert.Contains("reasoning", details);
+        // The id on its own line: it is the string a reader would copy, and burying it in a run of
+        // dot-separated facts makes it hard to pick out.
+        Assert.StartsWith("m\n", details);
+    }
+
+    /// <summary>With nothing published there is no second line to write — the tooltip is the bare id, not an
+    /// id followed by an empty run of separators.</summary>
+    [Fact]
+    public void A_row_with_no_facts_has_no_second_line()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft(new AiModelEntry("bare", "Bare")));
+        Group(vm).IsExpanded = true;
+
+        Assert.DoesNotContain("\n", Rows(vm).Single().Details);
     }
 
     /// <summary>An endpoint that publishes nothing degrades to the id rather than showing an empty

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -392,12 +392,17 @@ namespace CST.Avalonia.ViewModels
         public string DisplayName { get; }
 
         /// <summary>
-        /// The provider's own facts about the model, on one line: context window, price per million tokens,
+        /// The provider's own facts about the model — the wire id, context window, price per million tokens,
         /// and whether it accepts a reasoning parameter.
         ///
-        /// <para>Verbatim and attributed to the provider — that is what makes it safe where a table we
-        /// maintained would not be. Empty for an endpoint that publishes nothing, which is most local
-        /// runners, and the row degrades to a bare id rather than demanding metadata that does not exist.</para>
+        /// <para>Verbatim and attributed to the provider, which is what makes it safe where a table we
+        /// maintained would not be. An endpoint that publishes nothing leaves the id alone, rather than
+        /// demanding metadata that does not exist.</para>
+        ///
+        /// <para><b>Shown on hover rather than in the row.</b> It was a permanent second line, which at four
+        /// hundred rows is four hundred lines of small grey text between the reader and the names they came
+        /// to read. The facts matter when choosing between two models, which is a moment, not a state — so
+        /// they are a tooltip, and the list stays a list of names.</para>
         /// </summary>
         public string Details
         {
@@ -405,20 +410,22 @@ namespace CST.Avalonia.ViewModels
             {
                 if (_published is null) return ModelId;
 
-                var parts = new List<string> { ModelId };
+                var facts = new List<string>();
 
                 if (_published.ContextLength is { } context)
-                    parts.Add($"{context / 1000:N0}K context");
+                    facts.Add($"{context / 1000:N0}K context");
 
                 if (_published.PromptPricePerMillion is { } prompt &&
                     _published.CompletionPricePerMillion is { } completion)
-                    parts.Add(prompt == 0 && completion == 0
+                    facts.Add(prompt == 0 && completion == 0
                         ? "free"
                         : $"${Money(prompt)}/${Money(completion)} per M");
 
-                if (_published.SupportsReasoning) parts.Add("reasoning");
+                if (_published.SupportsReasoning) facts.Add("reasoning");
 
-                return string.Join("  ·  ", parts);
+                // The id on its own line: it is the string the reader would copy, and burying it in a run of
+                // facts separated by dots makes it hard to pick out.
+                return facts.Count == 0 ? ModelId : ModelId + "\n" + string.Join("  ·  ", facts);
             }
         }
 

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -128,17 +128,19 @@
 
                     <!-- One model -->
                     <DataTemplate DataType="vm:AiCatalogRowViewModel">
-                        <Border Padding="34,6,10,6"
+                        <!-- The provider's facts are on the tooltip, not in the row. As a permanent second
+                             line they were, at four hundred rows, four hundred lines of small grey text
+                             between the reader and the names they came to read. They matter when choosing
+                             between two models — a moment, not a state. -->
+                        <Border Padding="34,4,10,4"
                                 BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                                BorderThickness="0,0,0,1">
+                                BorderThickness="0,0,0,1"
+                                Background="Transparent"
+                                ToolTip.Tip="{Binding Details}">
                             <Grid ColumnDefinitions="*,Auto">
-                                <StackPanel Grid.Column="0" Spacing="1" VerticalAlignment="Center">
-                                    <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
-                                    <!-- The provider's own facts, verbatim. Empty for an endpoint that
-                                         publishes none, and the row degrades to its id. -->
-                                    <TextBlock Text="{Binding Details}" Classes="Secondary"
-                                               TextTrimming="CharacterEllipsis"/>
-                                </StackPanel>
+                                <TextBlock Grid.Column="0" Text="{Binding DisplayName}"
+                                           TextTrimming="CharacterEllipsis"
+                                           VerticalAlignment="Center"/>
 
                                 <!-- A switch, never a radio: several models under one connection must be
                                      on at once, which is the entire point of a short list. -->


### PR DESCRIPTION
The id, context window, price and *reasoning* flag sat on a permanent second line under every model. At four
hundred rows that is four hundred lines of small grey text between the reader and the names they came to read.

They are now the row's **tooltip**. Nothing is lost and nothing is judged — the same provider-published facts,
verbatim, shown when the reader is choosing between two models. That is a moment, not a state, which is what a
tooltip is for.

The row becomes a name and a switch, with half the vertical padding it had, which also puts noticeably more of
a long listing on screen.

The **id gets its own line** in the tooltip rather than joining a run of dot-separated facts. It is the string
a reader would copy, and it is hard to pick out of `id · 131K context · free · reasoning`.

## What this costs

A tooltip is invisible until hovered, so **price is no longer readable at a glance while scanning** — and
price is exactly what the free/paid filter exists to act on. If that turns out to matter in use, the answer is
probably a small "free" marker on the row rather than restoring the whole line. Not doing that now: the
complaint was clutter, and adding something back before anyone has missed it is how clutter returns.

Search is unaffected — it still matches the id as well as the display name, so a model whose id is no longer
on screen is still findable by it.

## Rebased onto #723

Both touched this row template, and rebasing produced exactly the conflict predicted here. Resolved by keeping
the single `DisplayName` TextBlock and the `ToolTip.Tip` from this branch, and **main's two-column grid** —
the third column existed only for the "Typed" badge that #723 removed, so the toggle moves to column 1.

Deliberately not stacked on #723, since a follow-up pushed onto an open PR is what left the badge removal
orphaned when #722 merged without it.

## Testing

Clean build, 31 targeted tests on the Models tab, including that an endpoint publishing nothing yields a bare
id with no empty second line.

