### PR TITLE
Model picker: unindent the current row, and say what a model is on hover (#693)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -269,6 +269,55 @@ public class AiConnectionEditorViewModelTests
         Assert.False(saved.Models.Single(m => m.Id == "b").Enabled);
     }
 
+    /// <summary>
+    /// An edit preserves what the provider published about each model.
+    ///
+    /// <para>The form shows an id, a name and nothing else, so rebuilding entries from its visible fields
+    /// drops the context length, modalities and reasoning flag recorded when the model was promoted — and the
+    /// per-turn picker's hover card goes blank because the reader renamed a connection. Exactly the shape of
+    /// the auth-header reset found in the #689 review.</para>
+    /// </summary>
+    [Fact]
+    public void An_edit_preserves_what_the_provider_published()
+    {
+        var h = new Harness();
+        h.Service.Add("mine", Draft() with
+        {
+            Models = new List<AiModelEntry>
+            {
+                new("nvidia/nemotron", "Nemotron", true,
+                    ContextLength: 1_000_000, SupportsReasoning: true, Inputs: "text, image"),
+            },
+        });
+
+        var vm = h.Existing("mine");
+        vm.DisplayName = "Renamed";
+        Save(vm);
+
+        var saved = Assert.Single(h.Service.Connections.Single().Models);
+        Assert.Equal(1_000_000, saved.ContextLength);
+        Assert.True(saved.SupportsReasoning);
+        Assert.Equal("text, image", saved.Inputs);
+    }
+
+    /// <summary>A row the reader adds by hand has nothing published, and nothing is invented for it.</summary>
+    [Fact]
+    public void A_newly_typed_model_carries_no_published_facts()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+
+        vm.Id = "my-box";
+        vm.BaseUrl = "http://localhost:8000/v1";
+        vm.Models[0].ModelId = "typed";
+        Save(vm);
+
+        var saved = Assert.Single(h.Service.Connections.Single().Models);
+        Assert.Null(saved.ContextLength);
+        Assert.Null(saved.Inputs);
+        Assert.False(saved.SupportsReasoning);
+    }
+
     [Fact]
     public void Cancelling_closes_without_saving()
     {

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -220,6 +220,74 @@ public class AiModelPickerViewModelTests
         Assert.True(picker.HasNothingMatching);
     }
 
+    // ---- the hover card ----------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The card names the model and its provider, always.
+    ///
+    /// <para>With several endpoints configured, "Gemma 4" alone does not say whether it is the local one —
+    /// which is exactly the confusion the grouping exists to prevent, and the card should not undo it.</para>
+    /// </summary>
+    [Fact]
+    public void The_hover_card_names_the_model_and_its_provider()
+    {
+        var (picker, service, _) = Make();
+        service.Add("local", Draft("Local Ollama", new AiModelEntry("gemma4:12b-mlx", "Gemma4 12B MLX")));
+
+        var facts = AllModels(picker).Single().Facts;
+
+        Assert.Equal("Gemma4 12B MLX", facts.Single(f => f.Label == "Model").Value);
+        Assert.Equal("Local Ollama", facts.Single(f => f.Label == "Provider").Value);
+    }
+
+    /// <summary>
+    /// A field the provider never published gets no row.
+    ///
+    /// <para>OpenCode's equivalent card shows "Context 0" and "No reasoning" for a local model that published
+    /// neither. That reads as fact and is not one — an absent row is the honest rendering of an absent
+    /// field, and a local runner publishes nothing at all.</para>
+    /// </summary>
+    [Fact]
+    public void Unpublished_facts_get_no_row_rather_than_a_zero()
+    {
+        var (picker, service, _) = Make();
+        service.Add("local", Draft("Local Ollama", new AiModelEntry("gemma4:12b-mlx", "Gemma4 12B MLX")));
+
+        var labels = AllModels(picker).Single().Facts.Select(f => f.Label).ToList();
+
+        Assert.DoesNotContain("Context", labels);
+        Assert.DoesNotContain("Reasoning", labels);
+        Assert.DoesNotContain("Inputs", labels);
+    }
+
+    /// <summary>What the provider did publish is shown, in its own words.</summary>
+    [Fact]
+    public void Published_facts_become_rows()
+    {
+        var (picker, service, _) = Make();
+        service.Add("openrouter-ish", Draft("OpenRouter",
+            new AiModelEntry("nvidia/nemotron", "Nemotron", true,
+                ContextLength: 1_000_000, SupportsReasoning: true, Inputs: "text, image")));
+
+        var facts = AllModels(picker).Single().Facts;
+
+        Assert.Equal("1,000K", facts.Single(f => f.Label == "Context").Value);
+        Assert.Equal("supported", facts.Single(f => f.Label == "Reasoning").Value);
+        Assert.Equal("text, image", facts.Single(f => f.Label == "Inputs").Value);
+        Assert.Equal("nvidia/nemotron", facts.Single(f => f.Label == "Id").Value);
+    }
+
+    /// <summary>The wire id is shown only when it differs from the name — repeating the same string twice is
+    /// noise, and a hand-typed model usually has no separate name.</summary>
+    [Fact]
+    public void The_id_row_is_omitted_when_it_repeats_the_name()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine", new AiModelEntry("gemma4:12b", "gemma4:12b")));
+
+        Assert.DoesNotContain(AllModels(picker).Single().Facts, f => f.Label == "Id");
+    }
+
     // ---- what cannot be used, and why ---------------------------------------------------------------------
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -371,6 +371,49 @@ public class AiModelsViewModelTests
         Assert.Null(service.ActiveModelId);
     }
 
+    // ---- what gets written down on promotion ---------------------------------------------------------------
+
+    /// <summary>
+    /// Promoting a model records what the provider published about it.
+    ///
+    /// <para>The listing lives only in this tab and only while the window is open, so the per-turn picker
+    /// (#693) can never ask again — whatever it is to show has to be written down here.</para>
+    /// </summary>
+    [Fact]
+    public void Promoting_a_model_records_what_the_provider_published()
+    {
+        var (vm, service) = Make(new FakeCatalog(new AiCatalogModel(
+            "nvidia/nemotron", "Nemotron", ContextLength: 1_000_000,
+            InputModalities: new[] { "text", "image" },
+            SupportedParameters: new[] { "reasoning" })));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        Rows(vm).Single().Enabled = true;
+
+        var stored = Assert.Single(service.Connections.Single().Models);
+        Assert.Equal(1_000_000, stored.ContextLength);
+        Assert.True(stored.SupportsReasoning);
+        Assert.Equal("text, image", stored.Inputs);
+    }
+
+    /// <summary>A hand-typed model has nothing published about it, and nothing is invented.</summary>
+    [Fact]
+    public void A_typed_model_records_no_published_facts()
+    {
+        var (vm, service) = Make();
+        service.Add("mine", Draft(new AiModelEntry("typed", "Typed")));
+        Group(vm).IsExpanded = true;
+
+        Rows(vm).Single().Enabled = false;
+        Rows(vm).Single().Enabled = true;
+
+        var stored = Assert.Single(service.Connections.Single().Models);
+        Assert.Null(stored.ContextLength);
+        Assert.Null(stored.Inputs);
+        Assert.False(stored.SupportsReasoning);
+    }
+
     // ---- search and the capability filter ---------------------------------------------------------------
 
     /// <summary>Search filters across every group, not within the expanded one, and shows what it finds

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -54,7 +54,16 @@ namespace CST.Avalonia.Models.Ai
     /// connection: all-on is neutral ("here is what this offers"), all-off is neutral but unusable, and a
     /// pre-selected <i>subset</i> is a verdict — which is the model registry deleted in #670/#681 wearing a
     /// toggle.</param>
-    public sealed record AiModelEntry(string Id, string DisplayName, bool Enabled = true);
+    /// <param name="ContextLength">What the provider published when this model was added, or null. Kept on
+    /// the record because the listing is only fetched while the Models tab is open, and the per-turn picker
+    /// (#693) has to be able to say it without asking again.</param>
+    public sealed record AiModelEntry(
+        string Id,
+        string DisplayName,
+        bool Enabled = true,
+        int? ContextLength = null,
+        bool SupportsReasoning = false,
+        string? Inputs = null);
 
     /// <summary>
     /// One configured endpoint: where to send a request, how to authenticate, and which models it offers.

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -159,6 +159,23 @@ namespace CST.Avalonia.Models
         /// <summary>Whether it appears in the per-turn picker. Defaults true: all-on is neutral, whereas a
         /// pre-selected subset would be a quality verdict (#670/#681).</summary>
         public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// What the provider published about this model when it was added, kept so the assistant can say it
+        /// without asking again. (#693)
+        ///
+        /// <para>The listing is fetched only on the Models tab and only while that window is open, so
+        /// anything the per-turn picker wants to show has to have been written down at the moment the reader
+        /// promoted the model. Null throughout for a hand-typed id and for every endpoint that publishes no
+        /// listing — which the UI must render as silence rather than as zero.</para>
+        /// </summary>
+        public int? ContextLength { get; set; }
+
+        public bool SupportsReasoning { get; set; }
+
+        /// <summary>What the model accepts, as the provider words it — "text", "text, image". Null when it
+        /// said nothing.</summary>
+        public string? Inputs { get; set; }
     }
 
     /// <summary>Permissions for the loopback API server that exposes the corpus tools to agents (surface C).</summary>

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -73,7 +73,9 @@ namespace CST.Avalonia.Services.Ai
         /// <para>Turning one off keeps the entry rather than deleting it, so a display name the reader typed
         /// survives being switched off and on again.</para>
         /// </summary>
-        AiConnectionResult EnableModel(string connectionId, string modelId, string displayName, bool enabled);
+        AiConnectionResult EnableModel(
+            string connectionId, string modelId, string displayName, bool enabled,
+            AiModelEntry? facts = null);
 
         /// <summary>
         /// Records what a real request just learned about an endpoint. (#673)
@@ -291,7 +293,8 @@ namespace CST.Avalonia.Services.Ai
         }
 
         public AiConnectionResult EnableModel(
-            string connectionId, string modelId, string displayName, bool enabled)
+            string connectionId, string modelId, string displayName, bool enabled,
+            AiModelEntry? facts = null)
         {
             if (Find(connectionId) is not { } record)
                 return AiConnectionResult.Fail($"No connection called '{connectionId}'.");
@@ -310,6 +313,16 @@ namespace CST.Avalonia.Services.Ai
                     DisplayName = string.IsNullOrWhiteSpace(displayName) ? modelId.Trim() : displayName.Trim(),
                 };
                 record.Models.Add(model);
+            }
+
+            // Written on every call, not only on first add: a reader who turns a model off and on again after
+            // a catalogue refresh should end up with what the provider says now, not what it said in a
+            // session they have forgotten.
+            if (facts is not null)
+            {
+                model.ContextLength = facts.ContextLength;
+                model.SupportsReasoning = facts.SupportsReasoning;
+                model.Inputs = facts.Inputs;
             }
 
             model.Enabled = enabled;
@@ -380,8 +393,19 @@ namespace CST.Avalonia.Services.Ai
             record.DisplayName = draft.DisplayName;
             record.Kind = draft.Kind == ChatProviderKind.Anthropic ? "anthropic" : "openai-compatible";
             record.BaseUrl = draft.BaseUrl;
+            // Every field, not just the ones the editor shows. Rebuilding from the visible fields alone is
+            // how an edit silently drops what the provider published - the same shape of bug as the auth
+            // headers reset in the #689 review.
             record.Models = draft.Models
-                .Select(m => new AiModelRecord { Id = m.Id, DisplayName = m.DisplayName, Enabled = m.Enabled })
+                .Select(m => new AiModelRecord
+                {
+                    Id = m.Id,
+                    DisplayName = m.DisplayName,
+                    Enabled = m.Enabled,
+                    ContextLength = m.ContextLength,
+                    SupportsReasoning = m.SupportsReasoning,
+                    Inputs = m.Inputs,
+                })
                 .ToList();
             record.Headers = new Dictionary<string, string>(draft.Headers);
             record.Inputs = new Dictionary<string, string>(draft.Inputs);
@@ -394,7 +418,10 @@ namespace CST.Avalonia.Services.Ai
             r.DisplayName,
             ChatProviderResolver.TryParseKind(r.Kind, out var kind) ? kind : ChatProviderKind.OpenAiCompatible,
             r.BaseUrl,
-            r.Models.Select(m => new AiModelEntry(m.Id, m.DisplayName, m.Enabled)).ToList(),
+            r.Models
+                .Select(m => new AiModelEntry(
+                    m.Id, m.DisplayName, m.Enabled, m.ContextLength, m.SupportsReasoning, m.Inputs))
+                .ToList(),
             new Dictionary<string, string>(r.Headers),
             new Dictionary<string, string>(r.Inputs),
             SourceFor(r.Id),

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -136,6 +136,7 @@ namespace CST.Avalonia.ViewModels
                     ModelId = model.Id,
                     DisplayName = model.DisplayName,
                     Enabled = model.Enabled,
+                    Published = model,
                 });
 
             foreach (var header in connection.Headers)
@@ -404,12 +405,24 @@ namespace CST.Avalonia.ViewModels
             this.RaisePropertyChanged(nameof(KeyStatus));
         }
 
+        /// <summary>
+        /// The model rows as entries, carrying through everything the form does not show.
+        ///
+        /// <para>Rebuilding from the visible fields alone is how an edit silently drops what the provider
+        /// published — the reader renames a connection and the per-turn picker's hover card goes blank. The
+        /// same shape as the auth-header reset found in the #689 review, which is why it is worth stating
+        /// rather than leaving to the reader of the expression.</para>
+        /// </summary>
         private List<AiModelEntry> TypedModels() => Models
             .Where(m => !string.IsNullOrWhiteSpace(m.ModelId))
-            .Select(m => new AiModelEntry(
-                m.ModelId.Trim(),
-                string.IsNullOrWhiteSpace(m.DisplayName) ? m.ModelId.Trim() : m.DisplayName.Trim(),
-                m.Enabled))
+            .Select(m => (m.Published ?? new AiModelEntry(m.ModelId.Trim(), m.ModelId.Trim())) with
+            {
+                Id = m.ModelId.Trim(),
+                DisplayName = string.IsNullOrWhiteSpace(m.DisplayName)
+                    ? m.ModelId.Trim()
+                    : m.DisplayName.Trim(),
+                Enabled = m.Enabled,
+            })
             .ToList();
 
         /// <summary>
@@ -512,6 +525,10 @@ namespace CST.Avalonia.ViewModels
             get => _enabled;
             set => this.RaiseAndSetIfChanged(ref _enabled, value);
         }
+
+        /// <summary>The entry this row was loaded from, so fields the form does not show — what the provider
+        /// published about the model — survive an edit. Null for a row the reader has just added.</summary>
+        public AiModelEntry? Published { get; set; }
 
         public ReactiveCommand<Unit, Unit> RemoveCommand { get; }
     }

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -201,6 +201,9 @@ namespace CST.Avalonia.ViewModels
         public IReadOnlyList<AiPickerModelViewModel> Models { get; }
     }
 
+    /// <summary>One label/value row on the model hover card. (#693)</summary>
+    public sealed record AiPickerFact(string Label, string Value);
+
     /// <summary>One pickable model. (#693)</summary>
     public class AiPickerModelViewModel : ViewModelBase
     {
@@ -215,8 +218,14 @@ namespace CST.Avalonia.ViewModels
 
             ModelId = model.Id;
             DisplayName = model.DisplayName;
+            ProviderName = connection.DisplayName;
             IsCurrent = isCurrent;
             Unusable = ReasonItCannotBeUsed(connection);
+
+            // Only what the provider actually said. A model that published no context length gets no context
+            // row - rendering the absence as "0" would state a falsehood about the model, which is worse
+            // than saying nothing.
+            Facts = BuildFacts(connection, model);
 
             SelectCommand = ReactiveCommand.Create(() => _owner.Select(_connectionId, ModelId));
         }
@@ -239,7 +248,44 @@ namespace CST.Avalonia.ViewModels
 
         public bool IsUsable => Unusable.Length == 0;
 
+        /// <summary>The connection this model belongs to. Named on the hover card because with several
+        /// endpoints configured, "Gemma 4" alone does not say whether it is the local one.</summary>
+        public string ProviderName { get; }
+
+        /// <summary>
+        /// The hover card's rows: what is known about this model, and nothing else.
+        ///
+        /// <para>Only ever what the provider published and we wrote down when the model was promoted.
+        /// OpenCode's equivalent card shows "Context 0" and "No reasoning" for a local model that published
+        /// neither, which reads as fact and is not one — an absent row is the honest rendering of an absent
+        /// field.</para>
+        /// </summary>
+        public IReadOnlyList<AiPickerFact> Facts { get; }
+
+        public bool HasFacts => Facts.Count > 0;
+
         public ReactiveCommand<Unit, Unit> SelectCommand { get; }
+
+        private static IReadOnlyList<AiPickerFact> BuildFacts(AiConnection connection, AiModelEntry model)
+        {
+            var facts = new List<AiPickerFact>
+            {
+                new("Model", model.DisplayName),
+                new("Provider", connection.DisplayName),
+            };
+
+            // The wire id, when it differs from the name - when they are the same string, repeating it is
+            // noise rather than information.
+            if (!string.Equals(model.Id, model.DisplayName, StringComparison.Ordinal))
+                facts.Add(new AiPickerFact("Id", model.Id));
+
+            if (model.Inputs is { Length: > 0 } inputs) facts.Add(new AiPickerFact("Inputs", inputs));
+            if (model.ContextLength is { } context)
+                facts.Add(new AiPickerFact("Context", $"{context / 1000:N0}K"));
+            if (model.SupportsReasoning) facts.Add(new AiPickerFact("Reasoning", "supported"));
+
+            return facts;
+        }
 
         /// <summary>
         /// Only reasons we can state as fact.

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -316,6 +316,23 @@ namespace CST.Avalonia.ViewModels
             this.RaisePropertyChanged(nameof(CountText));
         }
 
+        /// <summary>What the provider published about one model, or null when it published nothing — which is
+        /// every hand-typed id and every endpoint with no listing.</summary>
+        private AiModelEntry? Facts(string modelId)
+        {
+            var published = _fetched.FirstOrDefault(
+                f => string.Equals(f.Id, modelId, StringComparison.Ordinal));
+            if (published is null) return null;
+
+            var inputs = published.InputModalities is { Count: > 0 } modalities
+                ? string.Join(", ", modalities)
+                : null;
+
+            return new AiModelEntry(
+                published.Id, published.DisplayName, true,
+                published.ContextLength, published.SupportsReasoning, inputs);
+        }
+
         private async Task FetchAsync()
         {
             if (_owner.Catalog is null) return;
@@ -358,7 +375,12 @@ namespace CST.Avalonia.ViewModels
         {
             if (_owner.Service is not { } service) return;
 
-            _owner.Suppressed(() => service.EnableModel(Id, modelId, displayName, enabled));
+            // The listing is only in memory while this tab is open, so what the provider published has to be
+            // written down at the moment of promotion - otherwise the per-turn picker (#693) has nothing to
+            // show and no way to ask.
+            var facts = Facts(modelId);
+
+            _owner.Suppressed(() => service.EnableModel(Id, modelId, displayName, enabled, facts));
 
             if (service.Connections.FirstOrDefault(
                     c => string.Equals(c.Id, Id, StringComparison.Ordinal)) is { } fresh)

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -147,25 +147,60 @@
                                                                             Background="Transparent"
                                                                             BorderThickness="0"
                                                                             Padding="8,4">
-                                                                        <Grid ColumnDefinitions="Auto,*,Auto">
+                                                                        <!-- Names start at the same x
+                                                                             whether or not a row is the
+                                                                             current one: a leading tick
+                                                                             indents the one row the eye is
+                                                                             most likely to be looking for.
+                                                                             So the tick goes last. -->
+                                                                        <Grid ColumnDefinitions="*,Auto,Auto">
                                                                             <TextBlock Grid.Column="0"
-                                                                                       Text="✓"
-                                                                                       IsVisible="{Binding IsCurrent}"
-                                                                                       Margin="0,0,6,0"
-                                                                                       Foreground="{DynamicResource DockApplicationAccentBrushLow}"/>
-                                                                            <TextBlock Grid.Column="1"
                                                                                        Text="{Binding DisplayName}"
                                                                                        TextTrimming="CharacterEllipsis"/>
                                                                             <!-- Said here rather than
                                                                                  discovered as a 401 naming
                                                                                  nothing. -->
-                                                                            <TextBlock Grid.Column="2"
+                                                                            <TextBlock Grid.Column="1"
                                                                                        Text="{Binding Unusable}"
                                                                                        IsVisible="{Binding !IsUsable}"
                                                                                        FontSize="11"
                                                                                        Margin="6,0,0,0"
                                                                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                                            <TextBlock Grid.Column="2"
+                                                                                       Text="✓"
+                                                                                       IsVisible="{Binding IsCurrent}"
+                                                                                       Margin="6,0,0,0"
+                                                                                       Foreground="{DynamicResource DockApplicationAccentBrushLow}"/>
                                                                         </Grid>
+
+                                                                        <!-- What the provider published,
+                                                                             on hover. Only rows we actually
+                                                                             know: an absent field is shown
+                                                                             as an absent row rather than as
+                                                                             a zero, which would read as
+                                                                             fact and be none. -->
+                                                                        <ToolTip.Tip>
+                                                                            <ItemsControl ItemsSource="{Binding Facts}"
+                                                                                          IsVisible="{Binding HasFacts}">
+                                                                                <ItemsControl.ItemTemplate>
+                                                                                    <DataTemplate x:DataType="vm:AiPickerFact">
+                                                                                        <Grid ColumnDefinitions="Auto,*"
+                                                                                              Margin="0,1">
+                                                                                            <TextBlock Grid.Column="0"
+                                                                                                       Text="{Binding Label}"
+                                                                                                       FontSize="11"
+                                                                                                       MinWidth="70"
+                                                                                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                                                            <TextBlock Grid.Column="1"
+                                                                                                       Text="{Binding Value}"
+                                                                                                       FontSize="11"
+                                                                                                       Margin="12,0,0,0"
+                                                                                                       HorizontalAlignment="Right"/>
+                                                                                        </Grid>
+                                                                                    </DataTemplate>
+                                                                                </ItemsControl.ItemTemplate>
+                                                                            </ItemsControl>
+                                                                        </ToolTip.Tip>
                                                                     </Button>
                                                                 </DataTemplate>
                                                             </ItemsControl.ItemTemplate>


### PR DESCRIPTION
Both from the side-by-side with OpenCode's picker.

## 1. The tick no longer indents the name

The check sat in the first column, so the current model — the one row the eye goes to first — was the only one
pushed right. Names now start at the same x whatever their state, and the tick is at the trailing edge.

## 2. A hover card, with only what we actually know

Model, provider, wire id, inputs, context and reasoning, as label/value rows. Two deliberate differences from
theirs:

- **The provider is named.** With several endpoints configured, "Gemma 4" does not say whether it is the local
  one — which is the confusion the grouping exists to prevent, and the card should not undo it.
- **A field the provider never published gets no row.** OpenCode's card shows *"Context 0"* and *"No
  reasoning"* for a local model that published neither. That reads as fact and is not one. A local runner
  publishes nothing at all, so its card is two rows, honestly.

The id row appears only when the id differs from the display name — for a hand-typed model they are usually
the same string, and repeating it is noise.

## What made this more than a layout change

The picker had no access to any of it. A listing is fetched only on the Models tab and only while that window
is open, and `AiModelRecord` stored id, name and enabled — nothing else.

So the facts are **written down at the moment the reader promotes a model** — the one time we have both the
listing and the reader's intent — and carried on `AiModelEntry` thereafter. Written on every `EnableModel`
call rather than only on first add, so a model turned off and on after a catalogue refresh ends up with what
the provider says *now* rather than what it said in a session nobody remembers.

`AiModelRecord` gains three nullable fields. No migration concern: they are additive and absent means unknown,
which is exactly how an older record reads.

## A bug this turned up

Writing the tests found that **the connection editor rebuilt each `AiModelEntry` from the form's visible
fields**, so editing a connection would have wiped every persisted fact — rename a connection and the hover
card goes blank. The same shape as the auth-header reset in the #689 review. Fixed by carrying the loaded
entry through, and covered by a test that fails if the carry-through is removed.

## Testing

**677 targeted AI tests pass, 0 warnings in both projects.** Nine new: the card's contents, the absent-row
rule, the id-only-when-different rule, what promotion records, and the edit-preservation above.

Worth checking in use: hover a model on OpenRouter (should show context and reasoning) and one on a local
Ollama (should show just Model and Provider, with no zeroes).
