### PR TITLE
Match OpenCode's model card, and tell "no" apart from "no answer" (#693)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -52,7 +52,9 @@ public class AiModelCatalogTests
         var model = Assert.Single(models);
         Assert.Equal("Claude Sonnet 4.5", model.DisplayName);
         Assert.Null(model.ContextLength);
-        Assert.False(model.SupportsReasoning);
+        // Anthropic publishes no parameter list, which is not the same as publishing one without
+        // reasoning in it — so this is unknown rather than false.
+        Assert.Null(model.SupportsReasoning);
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -315,7 +315,7 @@ public class AiConnectionEditorViewModelTests
         var saved = Assert.Single(h.Service.Connections.Single().Models);
         Assert.Null(saved.ContextLength);
         Assert.Null(saved.Inputs);
-        Assert.False(saved.SupportsReasoning);
+        Assert.Null(saved.SupportsReasoning);
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -271,10 +271,49 @@ public class AiModelPickerViewModelTests
 
         var facts = AllModels(picker).Single().Facts;
 
-        Assert.Equal("1,000K", facts.Single(f => f.Label == "Context").Value);
-        Assert.Equal("supported", facts.Single(f => f.Label == "Reasoning").Value);
+        Assert.Equal("1,000,000", facts.Single(f => f.Label == "Context").Value);
+        Assert.Equal("Allows reasoning", facts.Single(f => f.Label == "Reasoning").Value);
         Assert.Equal("text, image", facts.Single(f => f.Label == "Inputs").Value);
         Assert.Equal("nvidia/nemotron", facts.Single(f => f.Label == "Id").Value);
+    }
+
+    /// <summary>
+    /// A provider that published a parameter list without reasoning in it says so; one that published no list
+    /// at all says nothing.
+    ///
+    /// <para>Three states, not two. OpenCode renders both as "No reasoning", which turns a local runner's
+    /// silence into an assertion about the model.</para>
+    /// </summary>
+    [Fact]
+    public void Reasoning_distinguishes_published_no_from_no_answer()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine",
+            new AiModelEntry("said-yes", "Said yes", true, SupportsReasoning: true),
+            new AiModelEntry("said-no", "Said no", true, SupportsReasoning: false),
+            new AiModelEntry("said-nothing", "Said nothing", true)));
+
+        string? Reasoning(string id) => AllModels(picker).Single(m => m.ModelId == id)
+            .Facts.FirstOrDefault(f => f.Label == "Reasoning")?.Value;
+
+        Assert.Equal("Allows reasoning", Reasoning("said-yes"));
+        Assert.Equal("No reasoning", Reasoning("said-no"));
+        Assert.Null(Reasoning("said-nothing"));
+    }
+
+    /// <summary>Rows read in the order a reader scans them, with the wire id last — the card has room for the
+    /// context window in full rather than rounded to thousands.</summary>
+    [Fact]
+    public void The_card_reads_in_a_fixed_order()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine",
+            new AiModelEntry("nvidia/nemotron", "Nemotron", true,
+                ContextLength: 1_000_000, SupportsReasoning: true, Inputs: "text")));
+
+        Assert.Equal(
+            new[] { "Model", "Provider", "Inputs", "Reasoning", "Context", "Id" },
+            AllModels(picker).Single().Facts.Select(f => f.Label));
     }
 
     /// <summary>The wire id is shown only when it differs from the name — repeating the same string twice is

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -411,7 +411,7 @@ public class AiModelsViewModelTests
         var stored = Assert.Single(service.Connections.Single().Models);
         Assert.Null(stored.ContextLength);
         Assert.Null(stored.Inputs);
-        Assert.False(stored.SupportsReasoning);
+        Assert.Null(stored.SupportsReasoning);   // nothing published is not "published: no"
     }
 
     // ---- search and the capability filter ---------------------------------------------------------------

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -62,7 +62,7 @@ namespace CST.Avalonia.Models.Ai
         string DisplayName,
         bool Enabled = true,
         int? ContextLength = null,
-        bool SupportsReasoning = false,
+        bool? SupportsReasoning = null,
         string? Inputs = null);
 
     /// <summary>

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -171,7 +171,9 @@ namespace CST.Avalonia.Models
         /// </summary>
         public int? ContextLength { get; set; }
 
-        public bool SupportsReasoning { get; set; }
+        /// <summary>Null when the provider published no parameter list — not the same as publishing one
+        /// without reasoning in it.</summary>
+        public bool? SupportsReasoning { get; set; }
 
         /// <summary>What the model accepts, as the provider words it — "text", "text, image". Null when it
         /// said nothing.</summary>

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -50,12 +50,19 @@ namespace CST.Avalonia.Services.Ai
         public bool CostsMoney =>
             PromptPricePerMillion > 0m || CompletionPricePerMillion > 0m;
 
-        /// <summary>Whether the provider says it accepts a reasoning-effort parameter (#671). Published, not
-        /// inferred from the name.</summary>
-        public bool SupportsReasoning =>
-            SupportedParameters?.Any(p =>
+        /// <summary>
+        /// Whether the provider says it accepts a reasoning-effort parameter (#671). Published, never
+        /// inferred from the name.
+        ///
+        /// <para><b>Null means the provider said nothing</b>, which is a different fact from saying no — a
+        /// local runner publishes no parameter list at all, and rendering its silence as "No reasoning" would
+        /// state something about the model that nobody has established.</para>
+        /// </summary>
+        public bool? SupportsReasoning => SupportedParameters is null
+            ? null
+            : SupportedParameters.Any(p =>
                 p.Contains("reasoning", StringComparison.OrdinalIgnoreCase) ||
-                p.Equals("thinking", StringComparison.OrdinalIgnoreCase)) == true;
+                p.Equals("thinking", StringComparison.OrdinalIgnoreCase));
 
     }
 

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -274,15 +274,23 @@ namespace CST.Avalonia.ViewModels
                 new("Provider", connection.DisplayName),
             };
 
-            // The wire id, when it differs from the name - when they are the same string, repeating it is
-            // noise rather than information.
+            if (model.Inputs is { Length: > 0 } inputs) facts.Add(new AiPickerFact("Inputs", inputs));
+
+            // Three states, not two. Null is the provider having said nothing - a local runner publishes no
+            // parameter list at all - and "No reasoning" there would assert something about the model that
+            // nobody has established.
+            if (model.SupportsReasoning is { } reasoning)
+                facts.Add(new AiPickerFact("Reasoning", reasoning ? "Allows reasoning" : "No reasoning"));
+
+            // Written out in full rather than rounded to "1,000K": the card has the room, and a context
+            // window is a number readers compare exactly.
+            if (model.ContextLength is { } context)
+                facts.Add(new AiPickerFact("Context", context.ToString("N0")));
+
+            // The wire id last, and only when it differs from the name - it is the string a reader would
+            // copy, but it is not what they came to the card to read.
             if (!string.Equals(model.Id, model.DisplayName, StringComparison.Ordinal))
                 facts.Add(new AiPickerFact("Id", model.Id));
-
-            if (model.Inputs is { Length: > 0 } inputs) facts.Add(new AiPickerFact("Inputs", inputs));
-            if (model.ContextLength is { } context)
-                facts.Add(new AiPickerFact("Context", $"{context / 1000:N0}K"));
-            if (model.SupportsReasoning) facts.Add(new AiPickerFact("Reasoning", "supported"));
 
             return facts;
         }

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -443,7 +443,7 @@ namespace CST.Avalonia.ViewModels
                         ? "free"
                         : $"${Money(prompt)}/${Money(completion)} per M");
 
-                if (_published.SupportsReasoning) facts.Add("reasoning");
+                if (_published.SupportsReasoning == true) facts.Add("reasoning");
 
                 // The id on its own line: it is the string the reader would copy, and burying it in a run of
                 // facts separated by dots makes it hard to pick out.


### PR DESCRIPTION
Side by side with OpenCode's card for the same Nemotron model:

| | theirs | ours, before |
|---|---|---|
| order | Model, Provider, Inputs, Reasoning, Context | Context and Reasoning reversed, id third |
| context | `1,000,000` | `1,000K` |
| reasoning | `Allows reasoning` | `supported` |

All three taken. The context window is a number readers compare exactly and the card has room for it;
"supported" does not read as a sentence on its own. The id row stays, moved last and still only when it
differs from the display name — it is the string a reader would copy, but not what they came to the card to
read.

## The distinction their card exposed

Theirs shows **"No reasoning"** for a local Ollama model. Ours could not have done better:
`SupportsReasoning` was a `bool`, so a provider that published a parameter list *without* reasoning in it and
a provider that published *no list at all* collapsed to the same `false`.

Those are different facts. A local runner's silence is not a statement about the model, and rendering it as
"No reasoning" asserts something nobody established — the same class of claim as reading an absent price as
free, which this code already refuses to make.

So it is `bool?` end to end: **null** says nothing, **false** says the provider said no, **true** says it said
yes. A test covers all three, and the Anthropic parser case now asserts null rather than false, because
Anthropic publishes no parameter list.

## Testing

**679 targeted AI tests pass, 0 warnings in both projects.** New: the three-state reasoning, and the card's
row order.

Worth checking in use — hover Nemotron on OpenRouter (should read exactly like their card) and a local Ollama
model (should show Model and Provider only, with no Reasoning row at all).

