### PR TITLE
Say how long a rate limit lasts, instead of "wait a moment" (#673)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiRateLimitTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiRateLimitTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using CST.Avalonia.Services.Ai;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// #673: telling a rate-limited reader how long the limit lasts.
+///
+/// <para>Reported from use. A free OpenRouter key allows 50 requests a day; on hitting that the assistant
+/// said "Wait a moment and try again", so the reader retried, failed again, and had no way to tell a
+/// per-minute cap from one that lasts until tomorrow.</para>
+/// </summary>
+public class AiRateLimitTests
+{
+    private static HttpResponseMessage Response(params (string Name, string Value)[] headers)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        foreach (var (name, value) in headers)
+            response.Headers.TryAddWithoutValidation(name, value);
+        return response;
+    }
+
+    private static string Unix(DateTimeOffset moment, bool milliseconds) =>
+        (milliseconds ? moment.ToUnixTimeMilliseconds() : moment.ToUnixTimeSeconds()).ToString();
+
+    // ---- reading the headers ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// <c>X-RateLimit-Reset</c> is read when there is no <c>Retry-After</c>.
+    ///
+    /// <para>The case that produced the bad message: OpenRouter sends <c>Retry-After</c> only when every
+    /// upstream provider returned a retry hint, so an account-level daily cap arrives with the reset header
+    /// alone.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(true)]    // milliseconds
+    [InlineData(false)]   // seconds
+    public void The_reset_header_is_read_in_either_unit(bool milliseconds)
+    {
+        using var response = Response(
+            ("x-ratelimit-reset", Unix(DateTimeOffset.UtcNow.AddHours(7), milliseconds)));
+
+        var wait = AiHttp.RateLimitWait(response);
+
+        Assert.NotNull(wait);
+        Assert.InRange(wait!.Value.TotalHours, 6.9, 7.1);
+    }
+
+    /// <summary>
+    /// Told apart by magnitude, not by trusting a convention.
+    ///
+    /// <para>Providers disagree about the unit, and reading a millisecond timestamp as seconds puts the reset
+    /// tens of thousands of years out — which would be reported to the reader with a straight face.</para>
+    /// </summary>
+    [Fact]
+    public void An_absurd_reset_is_not_believed()
+    {
+        using var response = Response(("x-ratelimit-reset", "99999999999999999"));
+
+        Assert.Null(AiHttp.RateLimitWait(response));
+    }
+
+    /// <summary>A reset a moment ago reads as "now" rather than as nothing — clocks disagree by seconds.</summary>
+    [Fact]
+    public void A_reset_just_past_reads_as_now()
+    {
+        using var response = Response(
+            ("x-ratelimit-reset", Unix(DateTimeOffset.UtcNow.AddSeconds(-20), true)));
+
+        Assert.Equal(TimeSpan.Zero, AiHttp.RateLimitWait(response));
+    }
+
+    /// <summary>The standard header wins: it states a duration outright rather than a moment to subtract
+    /// from.</summary>
+    [Fact]
+    public void Retry_after_is_preferred_over_the_reset_header()
+    {
+        using var response = Response(
+            ("retry-after", "30"),
+            ("x-ratelimit-reset", Unix(DateTimeOffset.UtcNow.AddHours(7), true)));
+
+        Assert.Equal(TimeSpan.FromSeconds(30), AiHttp.RateLimitWait(response));
+    }
+
+    [Fact]
+    public void No_headers_means_no_wait() => Assert.Null(AiHttp.RateLimitWait(Response()));
+
+    // ---- what the reader is told -------------------------------------------------------------------------
+
+    /// <summary>A short wait is a minute, and says so.</summary>
+    [Fact]
+    public void A_short_wait_says_a_minute() =>
+        Assert.Contains("in a minute", AiHttp.RateLimitMessage(TimeSpan.FromSeconds(20)));
+
+    [Fact]
+    public void A_wait_of_minutes_counts_them() =>
+        Assert.Contains("about 12 minutes", AiHttp.RateLimitMessage(TimeSpan.FromMinutes(11.2)));
+
+    /// <summary>
+    /// A long wait names the hour it lifts, not just a duration.
+    ///
+    /// <para>"About 7 hours" invites arithmetic; the reader wants to know whether to wait or to come back
+    /// tomorrow, and a clock time answers that directly.</para>
+    /// </summary>
+    [Fact]
+    public void A_long_wait_names_the_time_it_resets()
+    {
+        var message = AiHttp.RateLimitMessage(TimeSpan.FromHours(7));
+
+        Assert.Contains("resets at", message);
+        Assert.Contains("about 7 hours", message);
+    }
+
+    /// <summary>
+    /// With no header the wording stays vague, because vague is what we know — but it no longer promises a
+    /// moment, and it names the possibility the reader cannot otherwise guess at.
+    /// </summary>
+    [Fact]
+    public void With_no_header_it_does_not_promise_a_moment()
+    {
+        var message = AiHttp.RateLimitMessage(null);
+
+        Assert.DoesNotContain("moment", message);
+        Assert.Contains("daily quota", message);
+    }
+
+    /// <summary>The message reaches the reader through the ordinary error path, not only from the helper.</summary>
+    [Fact]
+    public void The_rate_limit_message_is_what_a_429_reports() =>
+        Assert.Contains(
+            "in a minute",
+            AiHttp.MessageFor(AiErrorKind.RateLimited, HttpStatusCode.TooManyRequests, TimeSpan.FromSeconds(30)));
+}

--- a/src/CST.Avalonia/Services/Ai/AiHttp.cs
+++ b/src/CST.Avalonia/Services/Ai/AiHttp.cs
@@ -184,6 +184,52 @@ internal static class AiHttp
         segment.Length > 1 && segment[0] is 'v' or 'V' && char.IsAsciiDigit(segment[1]);
 
     /// <summary>The provider's requested backoff, when it sent one. Seconds and HTTP-date forms are both legal.</summary>
+    /// <summary>
+    /// How long until the limit lifts, from whichever header the provider sent. (#673)
+    ///
+    /// <para><c>Retry-After</c> first, because it is the standard and states a duration outright. OpenRouter
+    /// sends it only when <i>every</i> upstream provider returned a retry hint, so on a plain account-level
+    /// cap there is no <c>Retry-After</c> at all and <c>X-RateLimit-Reset</c> is the only thing available —
+    /// which is exactly the case that produced "wait a moment" for a limit that lasts until tomorrow.</para>
+    /// </summary>
+    internal static TimeSpan? RateLimitWait(HttpResponseMessage response) =>
+        RetryAfter(response) ?? RateLimitReset(response);
+
+    /// <summary>
+    /// <c>X-RateLimit-Reset</c> as a wait, or null.
+    ///
+    /// <para><b>Seconds and milliseconds are both accepted</b>, told apart by magnitude rather than by
+    /// trusting a convention: providers disagree about the unit, and reading a millisecond timestamp as
+    /// seconds puts the reset tens of thousands of years out, which would be reported to the reader with a
+    /// straight face. Anything that lands more than a day and a bit away is treated as not understood.</para>
+    /// </summary>
+    internal static TimeSpan? RateLimitReset(HttpResponseMessage response)
+    {
+        if (!response.Headers.TryGetValues("x-ratelimit-reset", out var values)) return null;
+
+        foreach (var value in values)
+        {
+            if (!long.TryParse(value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var raw))
+                continue;
+
+            var epochMs = raw > 100_000_000_000 ? raw : raw * 1000;
+
+            // FromUnixTimeMilliseconds throws outside its range, and a header is somebody else's input: a
+            // malformed value must produce no advice, never an exception on the error path.
+            if (epochMs < 0 || epochMs > 253_402_300_799_000) continue;
+
+            var moment = DateTimeOffset.FromUnixTimeMilliseconds(epochMs);
+            var wait = moment - DateTimeOffset.UtcNow;
+
+            // Just past is "now" - clocks disagree by seconds and a reset a moment ago is not a reason to
+            // say nothing.
+            if (wait <= TimeSpan.Zero) return wait > TimeSpan.FromMinutes(-5) ? TimeSpan.Zero : null;
+            if (wait < TimeSpan.FromHours(26)) return wait;
+        }
+
+        return null;
+    }
+
     internal static TimeSpan? RetryAfter(HttpResponseMessage response)
     {
         var header = response.Headers.RetryAfter;
@@ -277,16 +323,42 @@ internal static class AiHttp
     };
 
     /// <summary>The user-facing sentence for a kind. Never contains provider text — see <see cref="AiError"/>.</summary>
-    internal static string MessageFor(AiErrorKind kind, HttpStatusCode status) => kind switch
+    /// <param name="wait">How long until the limit lifts, where the provider said. Turns "wait a moment" —
+    /// which is wrong by many hours for a daily cap — into something the reader can act on.</param>
+    internal static string MessageFor(AiErrorKind kind, HttpStatusCode status, TimeSpan? wait = null) => kind switch
     {
         AiErrorKind.Unauthorized =>
             "The provider rejected the API key. Check the key and that it has access to this model.",
-        AiErrorKind.RateLimited =>
-            "The provider is rate-limiting this key. Wait a moment and try again.",
+        AiErrorKind.RateLimited => RateLimitMessage(wait),
         AiErrorKind.ContextTooLong =>
             "The request was longer than the model's context window. Try a smaller passage or fewer glosses.",
         _ => $"The provider rejected the request (HTTP {(int)status}).",
     };
+
+    /// <summary>
+    /// What to tell a reader who has been rate-limited.
+    ///
+    /// <para>The old wording was "wait a moment and try again" for every 429. That is right for a
+    /// per-minute cap and badly wrong for a daily one — a free OpenRouter key allows 50 requests a day, and a
+    /// reader told to wait a moment will retry, fail, and reasonably conclude the app is broken.</para>
+    ///
+    /// <para>Where the provider said nothing the wording stays vague, because vague is what we know. It no
+    /// longer promises a moment.</para>
+    /// </summary>
+    internal static string RateLimitMessage(TimeSpan? wait)
+    {
+        const string prefix = "The provider is rate-limiting this key.";
+
+        if (wait is not { } left) return $"{prefix} It may be a per-minute limit or a daily quota — the provider did not say which.";
+        if (left <= TimeSpan.FromSeconds(90)) return $"{prefix} Try again in a minute.";
+        if (left < TimeSpan.FromHours(1)) return $"{prefix} Try again in about {Math.Ceiling(left.TotalMinutes):N0} minutes.";
+
+        // Beyond an hour, a duration alone is hard to act on - "about 7 hours" invites arithmetic, and the
+        // reader wants to know whether it is worth waiting or worth coming back tomorrow.
+        var hours = Math.Round(left.TotalHours, MidpointRounding.AwayFromZero);
+        var at = DateTime.Now.Add(left).ToString("t", CultureInfo.CurrentCulture);
+        return $"{prefix} The quota resets at {at}, about {hours:N0} hours from now.";
+    }
 
     /// <summary>The error for a 200 that carried nothing a provider stream could possibly be made of.</summary>
     internal static AiError EmptyResponse() => new(

--- a/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
@@ -295,12 +295,16 @@ public sealed class AnthropicMessagesProvider : IChatProvider
         _logger.LogWarning(
             "Anthropic request failed: HTTP {Status} {Code}", (int)response.StatusCode, code ?? "(no code)");
 
+        // Read once and used twice: the sentence the reader sees and the delay any retry honours must agree,
+        // and computing them from separate reads of the same headers is how they drift.
+        var wait = AiHttp.RateLimitWait(response);
+
         return new AiError(
             kind,
-            AiHttp.MessageFor(kind, response.StatusCode),
+            AiHttp.MessageFor(kind, response.StatusCode, wait),
             StatusCode: (int)response.StatusCode,
             ProviderCode: code,
-            RetryAfter: AiHttp.RetryAfter(response));
+            RetryAfter: wait);
     }
 
     /// <summary>

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -363,11 +363,15 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
         _logger.LogWarning(
             "OpenAI-compatible request failed: HTTP {Status} {Code}", (int)response.StatusCode, code ?? "(no code)");
 
+        // Read once and used twice: the sentence the reader sees and the delay any retry honours must agree,
+        // and computing them from separate reads of the same headers is how they drift.
+        var wait = AiHttp.RateLimitWait(response);
+
         return new AiError(
             kind,
-            AiHttp.MessageFor(kind, response.StatusCode),
+            AiHttp.MessageFor(kind, response.StatusCode, wait),
             StatusCode: (int)response.StatusCode,
             ProviderCode: code,
-            RetryAfter: AiHttp.RetryAfter(response));
+            RetryAfter: wait);
     }
 }


### PR DESCRIPTION
Reported from use: hitting OpenRouter's free-tier cap produced *"The provider is rate-limiting this key. Wait
a moment and try again."* — after which the maintainer had to go and Google what the limit actually was.

That wording is right for a per-minute cap and badly wrong for a daily one. Per OpenRouter's documentation a
free key allows **20 requests a minute *and* 50 a day** (1,000 with ≥10 credits purchased). Told to wait a
moment, a reader retries, fails again, and reasonably concludes the app is broken — when the honest answer was
"not until tomorrow".

**The information was already in the response and already being parsed.** `AiHttp.RetryAfter` has read
`Retry-After` since #673 and `AiError` carries it. It simply never reached the sentence, which was chosen from
the error *kind* alone.

## Why `Retry-After` was not enough

Per their docs, OpenRouter sends `Retry-After` **only when every attempted upstream provider returned a retry
hint**. A plain account-level cap arrives with `X-RateLimit-Reset` and no `Retry-After` — exactly the case
that produced the useless message. So the reset header is read as a fallback.

Its unit is not documented and providers disagree, so seconds and milliseconds are told apart **by magnitude**
rather than by trusting a convention: reading a millisecond timestamp as seconds puts the reset tens of
thousands of years out, and we would have reported that to the reader with a straight face. Anything landing
beyond a day and a bit is treated as not understood, and since a header is somebody else's input, a malformed
value produces no advice rather than an exception on the error path.

## What the reader now sees

| wait | message |
|---|---|
| under 90s | *Try again in a minute.* |
| under an hour | *Try again in about 12 minutes.* |
| beyond | *The quota resets at 09:14, about 7 hours from now.* |
| no header | *It may be a per-minute limit or a daily quota — the provider did not say which.* |

Past an hour it names the clock time as well as the duration: "about 7 hours" invites arithmetic, and what the
reader is deciding is whether to wait or come back tomorrow.

Where the provider said nothing the wording stays vague, because vague is what we know — but it no longer
promises a moment, and it names the possibility a reader cannot otherwise guess at.

The wait is read once and used twice — for the sentence and for `AiError.RetryAfter` — so the advice and any
retry delay cannot drift apart.

## Not addressed

The **"Try again" button** is still offered on a daily cap, where pressing it cannot succeed. Disabling or
relabelling it from `AiError.RetryAfter` is a reasonable follow-up, but it is panel behaviour rather than
error reporting, and the message was the thing actively misleading.

## Testing

**11 new tests** — both header units, the absurd-value guard, a reset just in the past, `Retry-After` winning,
and each wording band. 680 targeted AI tests pass, 0 warnings in both projects.
