### PR TITLE
Make answer tables fit the panel and wrap (#586)

### DIFF
--- a/src/CST.Avalonia.Tests/Views/AnswerTableWidthTests.cs
+++ b/src/CST.Avalonia.Tests/Views/AnswerTableWidthTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Views;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Views;
+
+/// <summary>
+/// #586: how an answer table divides the panel's width between its columns.
+///
+/// <para>Reported from use — wide tables never wrapped and had to be scrolled sideways to read, most often on
+/// Explain. The columns were Auto inside a horizontally scrolling viewer, which cannot wrap: Auto asks a cell
+/// how wide it wants to be and the viewer answers "as wide as you like", so a wrapping run reports its whole
+/// unwrapped line.</para>
+///
+/// <para>Only the width split is testable here; that the cells then wrap is a layout fact this project has no
+/// harness for (#655).</para>
+/// </summary>
+public class AnswerTableWidthTests
+{
+    private static AnswerCell Cell(string text) =>
+        new(new List<AnswerSpan> { new(text, AnswerStyle.None) }, AnswerAlign.Left);
+
+    private static IReadOnlyList<IReadOnlyList<AnswerCell>> Rows(params string[][] rows) =>
+        rows.Select(r => (IReadOnlyList<AnswerCell>)r.Select(Cell).ToList()).ToList();
+
+    /// <summary>
+    /// A column of glosses gets more room than a column of single words.
+    ///
+    /// <para>Equal shares would be simpler and worse: it wraps the glosses to a ribbon while the short column
+    /// sits mostly empty, which is the layout a word-analysis table exists to avoid.</para>
+    /// </summary>
+    [Fact]
+    public void A_column_holding_more_text_gets_more_width()
+    {
+        var weights = AnswerTableView.ColumnWeights(
+            Rows(
+                new[] { "Word", "Meaning" },
+                new[] { "dhamma", "the teaching, the truth, a phenomenon" }),
+            columns: 2);
+
+        Assert.True(weights[1] > weights[0]);
+    }
+
+    /// <summary>
+    /// One long sentence does not take the whole table.
+    ///
+    /// <para>Past a certain length a cell wraps regardless, so more width buys the reader nothing and costs
+    /// its neighbours everything — an unclamped weight would squeeze the other columns to a character
+    /// wide.</para>
+    /// </summary>
+    [Fact]
+    public void One_very_long_cell_does_not_starve_its_neighbours()
+    {
+        var weights = AnswerTableView.ColumnWeights(
+            Rows(
+                new[] { "Word", "Note" },
+                new[] { "dhamma", new string('x', 400) }),
+            columns: 2);
+
+        Assert.True(weights[1] / weights[0] < 10);
+    }
+
+    /// <summary>An empty column keeps a share rather than collapsing to nothing — a header with no body text
+    /// under it is still a column the reader can see.</summary>
+    [Fact]
+    public void An_empty_column_still_gets_a_share()
+    {
+        var weights = AnswerTableView.ColumnWeights(
+            Rows(new[] { "Word", "" }, new[] { "dhamma", "" }),
+            columns: 2);
+
+        Assert.All(weights, w => Assert.True(w > 0));
+    }
+
+    /// <summary>A ragged row — fewer cells than the widest — must not throw or skew the split.</summary>
+    [Fact]
+    public void A_short_row_does_not_break_the_split()
+    {
+        var weights = AnswerTableView.ColumnWeights(
+            Rows(new[] { "A", "B", "C" }, new[] { "only one" }),
+            columns: 3);
+
+        Assert.Equal(3, weights.Count);
+        Assert.All(weights, w => Assert.True(w > 0));
+    }
+
+    /// <summary>Every column is measured, so the split reflects the whole table rather than its first
+    /// row.</summary>
+    [Fact]
+    public void The_longest_cell_in_a_column_decides_it_not_the_header()
+    {
+        var weights = AnswerTableView.ColumnWeights(
+            Rows(
+                new[] { "A", "Long header here" },
+                new[] { "a much longer body cell than the header", "x" }),
+            columns: 2);
+
+        Assert.True(weights[0] > weights[1]);
+    }
+}

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -459,18 +459,17 @@
                                                                  TextWrapping="Wrap"/>
                                         </DataTemplate>
                                         <DataTemplate DataType="ai:AnswerTable">
-                                            <!-- Horizontal scroll rather than squeeze: a four-column word
-                                                 analysis in a narrow panel is worth scrolling to read, and
-                                                 the page body must never scroll sideways on its account. -->
-                                            <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                                                          VerticalScrollBarVisibility="Disabled"
-                                                          Margin="0,6,0,6">
-                                                <Border BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                                                        BorderThickness="1" CornerRadius="4"
-                                                        Padding="2">
-                                                    <Grid views:AnswerTableView.Table="{Binding}"/>
-                                                </Border>
-                                            </ScrollViewer>
+                                            <!-- No horizontal scroller. It was here on the reasoning that a
+                                                 four-column analysis is worth scrolling to read, but it is
+                                                 also what stopped the cells wrapping: it offers the grid
+                                                 infinite width, so Auto columns sized to their longest
+                                                 unwrapped line and the reader scrolled sideways through a
+                                                 sentence. The table now fits the panel and wraps. -->
+                                            <Border BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                                    BorderThickness="1" CornerRadius="4"
+                                                    Padding="2" Margin="0,6,0,6">
+                                                <Grid views:AnswerTableView.Table="{Binding}"/>
+                                            </Border>
                                         </DataTemplate>
                                     </ItemsControl.DataTemplates>
                                 </ItemsControl>

--- a/src/CST.Avalonia/Views/AnswerTableView.cs
+++ b/src/CST.Avalonia/Views/AnswerTableView.cs
@@ -13,8 +13,14 @@ namespace CST.Avalonia.Views;
 ///
 /// <para><b>Why a real grid and not aligned monospace.</b> The word-analysis table we hand the model is a
 /// Markdown table, so a word-by-word answer comes back as one — and in a 25%-wide panel, monospace pipes
-/// wrap and stop lining up at exactly the width where the table was supposed to help. Auto-sized columns
-/// wrap per cell instead, which is what a reader needs.</para>
+/// wrap and stop lining up at exactly the width where the table was supposed to help.</para>
+///
+/// <para><b>Columns share the panel's width rather than sizing to their content.</b> They were
+/// <see cref="GridLength.Auto"/> inside a horizontally scrolling viewer, and that combination cannot wrap:
+/// Auto asks a cell how wide it wants to be, the viewer offers infinite width, and a wrapping run's answer
+/// under infinite width is its whole unwrapped line. So every table grew as wide as its longest cell and the
+/// reader scrolled sideways to read a sentence — reported from use, most often on Explain, whose answers are
+/// prose-heavy and produce exactly the long cells that made the table widest.</para>
 ///
 /// <para><b>Cells are separate controls, so a drag cannot select across the whole answer.</b> That is the
 /// cost of rendering tables at all, and it is why each turn carries an explicit Copy control: copying is a
@@ -35,6 +41,44 @@ public static class AnswerTableView
         TableProperty.Changed.AddClassHandler<Grid>((grid, args) => Apply(grid, args.NewValue as AnswerTable));
     }
 
+    /// <summary>
+    /// How to divide the width between columns, from how much text each holds.
+    ///
+    /// <para>Equal shares would be simpler and worse: a word-analysis table has a one-word column beside a
+    /// column of glosses, and giving them the same width wraps the glosses to a ribbon while the short column
+    /// sits mostly empty. Weighting by the longest cell keeps the split roughly proportional to the reading.</para>
+    ///
+    /// <para><b>Clamped at both ends.</b> A floor of one keeps an empty column from collapsing to nothing;
+    /// a ceiling stops one long sentence from taking the whole table and squeezing every other column into a
+    /// character-wide sliver — past a certain length a cell is going to wrap regardless, so more width buys
+    /// the reader nothing and costs its neighbours everything.</para>
+    /// </summary>
+    internal static IReadOnlyList<double> ColumnWeights(
+        IReadOnlyList<IReadOnlyList<AnswerCell>> rows, int columns)
+    {
+        const double floor = 1;
+        const double ceiling = 24;
+
+        var weights = new double[columns];
+
+        for (var c = 0; c < columns; c++)
+        {
+            double longest = 0;
+            foreach (var row in rows)
+            {
+                if (c >= row.Count) continue;
+
+                double length = 0;
+                foreach (var span in row[c].Spans) length += span.Text.Length;
+                if (length > longest) longest = length;
+            }
+
+            weights[c] = longest < floor ? floor : longest > ceiling ? ceiling : longest;
+        }
+
+        return weights;
+    }
+
     private static void Apply(Grid grid, AnswerTable? table)
     {
         grid.Children.Clear();
@@ -50,8 +94,8 @@ public static class AnswerTableView
         var columns = 0;
         foreach (var row in rows) columns = row.Count > columns ? row.Count : columns;
 
-        for (var c = 0; c < columns; c++)
-            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        foreach (var weight in ColumnWeights(rows, columns))
+            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(weight, GridUnitType.Star)));
         for (var r = 0; r < rows.Count; r++)
             grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 


### PR DESCRIPTION
Reported from use: tables in an answer never wrapped, so a wide one had to be scrolled far to the right to
read — most often on **Explain**, whose answers are prose-heavy and produce exactly the long cells that made a
table widest.

## Why they didn't wrap

The cells were already `TextWrapping.Wrap`. The reason it did nothing is the pairing they sat in: **`Auto`
columns inside a horizontally scrolling viewer.** Auto asks a cell how wide it wants to be, the viewer answers
*"as wide as you like"*, and a wrapping run's desired width under infinite width is its whole unwrapped line.
So every table grew to its longest cell and wrapping never engaged.

The class's own doc comment claimed the opposite — *"Auto-sized columns wrap per cell instead, which is what a
reader needs"*. It was wrong, and had been since tables went in.

**Both halves are fixed together, because either alone does nothing:** the scroller is gone so the grid is
bounded by the panel, and the columns are star-sized so they divide that width rather than demand their own.

## Width is split by content, not equally

Equal shares would be simpler and worse. A word-analysis table has a one-word column beside a column of
glosses; giving them the same width wraps the glosses to a ribbon while the short column sits mostly empty —
the layout the table exists to avoid.

Each column's weight is its longest cell, **clamped at both ends**. The floor keeps an empty column visible.
The ceiling stops one long sentence taking the whole table: past a certain length a cell wraps regardless, so
more width buys the reader nothing and costs its neighbours everything.

## Reversing a deliberate choice

The scroller was there on the stated reasoning that *"a four-column word analysis in a narrow panel is worth
scrolling to read"*. That is defensible in the abstract and wrong in use — which is the only place it could
have been settled.

## Testing

**Five tests on the width split** — longer column wins, one huge cell doesn't starve its neighbours, an empty
column keeps a share, a ragged row doesn't throw, and the longest *body* cell decides rather than the header.
699 targeted tests pass, 0 warnings in both projects.

The wrapping itself is a layout fact this project has no harness for (#655), so that half is verified by use:
ask **Explain** on a passage that produces a wide table and confirm it fits the panel with no sideways
scrolling.
