### PR TITLE
Tell a reader their provider account is out of credit (#673)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiRateLimitTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiRateLimitTests.cs
@@ -133,4 +133,41 @@ public class AiRateLimitTests
         Assert.Contains(
             "in a minute",
             AiHttp.MessageFor(AiErrorKind.RateLimited, HttpStatusCode.TooManyRequests, TimeSpan.FromSeconds(30)));
+
+    // ---- 402, which is not a rate limit and not a bad key --------------------------------------------------
+
+    /// <summary>
+    /// 402 is its own kind.
+    ///
+    /// <para>Observed against Cerebras: a valid key on an account with no credit produced HTTP 402, which
+    /// fell through to the catch-all and was reported as "The provider rejected the request (HTTP 402)".</para>
+    /// </summary>
+    [Fact]
+    public void A_402_is_payment_required() =>
+        Assert.Equal(AiErrorKind.PaymentRequired, AiHttp.KindFor(HttpStatusCode.PaymentRequired));
+
+    /// <summary>
+    /// And it must not read like a rejected key.
+    ///
+    /// <para>Nothing is wrong with the key, so "check the key" sends the reader to re-paste a working one and
+    /// conclude the app is broken when that changes nothing. Nor is waiting any use, which rules out the
+    /// rate-limit wording.</para>
+    /// </summary>
+    [Fact]
+    public void The_402_message_blames_the_balance_rather_than_the_key()
+    {
+        var message = AiHttp.MessageFor(AiErrorKind.PaymentRequired, HttpStatusCode.PaymentRequired);
+
+        Assert.Contains("out of credit", message);
+        Assert.DoesNotContain("key", message, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("try again", message, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Statuses we have no better word for still fall through to the generic sentence, which names
+    /// the code so a reader can search for it.</summary>
+    [Fact]
+    public void An_unrecognised_status_still_names_its_code() =>
+        Assert.Contains(
+            "418",
+            AiHttp.MessageFor(AiErrorKind.Provider, (HttpStatusCode)418));
 }

--- a/src/CST.Avalonia/Services/Ai/AiHttp.cs
+++ b/src/CST.Avalonia/Services/Ai/AiHttp.cs
@@ -318,6 +318,7 @@ internal static class AiHttp
     internal static AiErrorKind KindFor(HttpStatusCode status) => status switch
     {
         HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => AiErrorKind.Unauthorized,
+        HttpStatusCode.PaymentRequired => AiErrorKind.PaymentRequired,
         HttpStatusCode.TooManyRequests => AiErrorKind.RateLimited,
         _ => AiErrorKind.Provider,
     };
@@ -329,6 +330,11 @@ internal static class AiHttp
     {
         AiErrorKind.Unauthorized =>
             "The provider rejected the API key. Check the key and that it has access to this model.",
+        // Deliberately NOT "check your key": the key is fine, which is exactly why the rejected-key wording
+        // would send the reader to re-paste a working one and conclude the app is broken when that changes
+        // nothing.
+        AiErrorKind.PaymentRequired =>
+            "This provider account is out of credit. Add credit with the provider, or switch to a model that costs nothing.",
         AiErrorKind.RateLimited => RateLimitMessage(wait),
         AiErrorKind.ContextTooLong =>
             "The request was longer than the model's context window. Try a smaller passage or fewer glosses.",

--- a/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
@@ -295,6 +295,12 @@ public sealed class AnthropicMessagesProvider : IChatProvider
         _logger.LogWarning(
             "Anthropic request failed: HTTP {Status} {Code}", (int)response.StatusCode, code ?? "(no code)");
 
+        // The body, at Debug, because "(no code)" is otherwise a dead end: a provider that puts its reason in
+        // prose rather than in a machine-readable field leaves the log saying only that something failed.
+        // Already bounded by ReadBoundedBodyAsync, and it is the provider's own error text - a request body
+        // or a credential never reaches here.
+        if (body.Length > 0) _logger.LogDebug("Anthropic error body: {Body}", body);
+
         // Read once and used twice: the sentence the reader sees and the delay any retry honours must agree,
         // and computing them from separate reads of the same headers is how they drift.
         var wait = AiHttp.RateLimitWait(response);

--- a/src/CST.Avalonia/Services/Ai/ChatContracts.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatContracts.cs
@@ -117,6 +117,15 @@ public enum AiErrorKind
     /// <summary>429. <see cref="AiError.RetryAfter"/> is set when the provider said how long to wait.</summary>
     RateLimited,
 
+    /// <summary>
+    /// 402 — the key is valid but has nothing left to spend. (#673)
+    ///
+    /// <para>Separate from <see cref="Unauthorized"/> because the fix is different and the reader cannot
+    /// guess it from a rejected-key message: nothing is wrong with the key, the account behind it is out of
+    /// credit. Separate from <see cref="RateLimited"/> because no amount of waiting clears it.</para>
+    /// </summary>
+    PaymentRequired,
+
     /// <summary>The request exceeded the model's context window. Actionable: the caller can trim and retry.</summary>
     ContextTooLong,
 

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -363,6 +363,12 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
         _logger.LogWarning(
             "OpenAI-compatible request failed: HTTP {Status} {Code}", (int)response.StatusCode, code ?? "(no code)");
 
+        // The body, at Debug, because "(no code)" is otherwise a dead end: a provider that puts its reason in
+        // prose rather than in a machine-readable field leaves the log saying only that something failed.
+        // Already bounded by ReadBoundedBodyAsync, and it is the provider's own error text - a request body
+        // or a credential never reaches here.
+        if (body.Length > 0) _logger.LogDebug("OpenAI-compatible error body: {Body}", body);
+
         // Read once and used twice: the sentence the reader sees and the delay any retry honours must agree,
         // and computing them from separate reads of the same headers is how they drift.
         var wait = AiHttp.RateLimitWait(response);


### PR DESCRIPTION
From the log, a Translate request to Cerebras at 23:00:49:

```
[WRN] OpenAI-compatible request failed: HTTP 402 (no code)
[INF] AI turn failed: "Provider" (-)
```

**402 is Payment Required** — a valid key on an account with nothing left to spend. It had no kind of its own,
so it fell through to the catch-all and was reported as *"The provider rejected the request (HTTP 402)"*,
which tells the reader nothing they can act on.

## Its own kind, deliberately separate from both neighbours

| | why not that one |
|---|---|
| `Unauthorized` | The key is **fine**. "Check the key" sends the reader to re-paste a working one and conclude the app is broken when that changes nothing. |
| `RateLimited` | No amount of waiting clears it. |

The message names the balance and offers the way out that costs nothing:

> This provider account is out of credit. Add credit with the provider, or switch to a model that costs
> nothing.

The free/paid filter on the Models tab is exactly the tool for that second half.

## The other half of that log line

**`(no code)` is a dead end.** The error body is read — it has to be, to look for a code — and then discarded,
so a provider that puts its reason in prose rather than in a machine-readable field leaves the log saying only
that *something* failed. It is now logged at Debug.

Safe to log: already bounded by `ReadBoundedBodyAsync`, and it is the provider's own error text — no request
body and no credential reaches there.

## Testing

**4 new tests:** 402 classifies as `PaymentRequired`; its message says "out of credit" and contains neither
"key" nor "try again"; an unrecognised status still names its code so a reader can search for it.

694 targeted AI tests pass, 0 warnings in both projects.

## Noticed in the same log, not fixed here

`Credential lookup for cerebras: found` appears **20+ times in 40ms**, and again on every rebind. Each is a
Keychain round-trip: `AiConnectionService.Connections` derives `KeySource` per connection on every read, and
the Models tab and picker read it whenever anything changes. Harmless today at two connections, but it is a
per-connection Keychain call on a UI path. Worth a look if it grows — happy to file it.
