### PR TITLE
Say how many models a listing offered, and record what Cerebras actually serves (#674)

### DIFF
--- a/docs/research/PROVIDER_ENV_VARS_AND_ENDPOINTS.md
+++ b/docs/research/PROVIDER_ENV_VARS_AND_ENDPOINTS.md
@@ -279,6 +279,20 @@ framing is SSE.
 No per-provider request-shape table is needed for the common case. That is a real, reassuring
 finding — the complexity we might have budgeted for does not exist.
 
+### Observed provider behaviour (from use, not from the extraction)
+
+Facts established by running CST Reader against a real key, recorded here because they look like bugs in our
+code until someone checks.
+
+- **Cerebras lists two models on the shared endpoint, and that is correct.** `GET
+  https://api.cerebras.ai/v1/models` returns two entries. Their other models are not on the shared inference
+  endpoint at all — they are provisioned on per-customer endpoints for corporate accounts, so no key on the
+  public endpoint will list them (confirmed against Cerebras' own documentation, 2026-08-18). A short model
+  list here is the provider's shape, not a parsing failure on our side.
+- **Both of those models require payment, so a Cerebras key with no credit gets HTTP 402**, not 401 and not
+  429. Cerebras has no free tier on the shared endpoint, so "switch to a model that costs nothing" is advice
+  about switching *provider*, not about finding a free model there. See the `PaymentRequired` error kind.
+
 ### Endpoint quirks
 
 Where per-endpoint adjustments *do* exist, they are isolated exceptions, not a matrix. The complete

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -77,6 +77,45 @@ public class AiModelCatalogTests
         Assert.False(model.CostsMoney);   // publishes no price; unknown is not costly
     }
 
+    // ---- telling "the provider sent few" from "we understood few" ------------------------------------------
+
+    /// <summary>
+    /// The listing's entry count is read separately from what we could parse.
+    ///
+    /// <para>Asked in earnest: a Cerebras connection offered two models and the maintainer knew the provider
+    /// supported more. "Fetched 2 models" reads as a fact about the provider and is equally consistent with
+    /// the provider having sent two and with our having understood two of nine — and nothing in the log could
+    /// tell them apart.</para>
+    /// </summary>
+    [Fact]
+    public void The_listing_count_is_independent_of_what_parsed()
+    {
+        const string json = """
+        {"data":[{"id":"a"},{"no-id":"here"},{"id":"c"},"a string"]}
+        """;
+
+        Assert.Equal(4, AiModelCatalog.CountEntries(json));
+        Assert.Equal(2, AiModelCatalog.Parse(json).Count);
+    }
+
+    /// <summary>When everything parses the two agree, which is what makes a disagreement worth logging.</summary>
+    [Fact]
+    public void A_listing_we_fully_understand_counts_the_same_both_ways()
+    {
+        const string json = """{"data":[{"id":"a"},{"id":"b"}]}""";
+
+        Assert.Equal(AiModelCatalog.Parse(json).Count, AiModelCatalog.CountEntries(json));
+    }
+
+    /// <summary>A body that is not a listing counts as nothing rather than throwing — this runs on the path
+    /// that is already reporting a problem.</summary>
+    [Theory]
+    [InlineData("not json at all")]
+    [InlineData("""{"models":[{"id":"a"}]}""")]
+    [InlineData("""{"data":"not an array"}""")]
+    public void An_unreadable_listing_counts_as_none(string json) =>
+        Assert.Equal(0, AiModelCatalog.CountEntries(json));
+
     // ---- price -------------------------------------------------------------------------------------------
 
     /// <summary>

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -158,8 +158,24 @@ namespace CST.Avalonia.Services.Ai
                 if (models.Count == 0)
                     return AiCatalogResult.Fail($"{url} answered, but listed no models.");
 
-                _logger.LogInformation(
-                    "Fetched {Count} models from {Connection}", models.Count, connection.Id);
+                // Both numbers, because one of them cannot answer the question that gets asked of this line.
+                // "Fetched 2 models from cerebras" reads as a fact about the provider, and is equally
+                // consistent with the provider having sent two and with our having understood two of nine -
+                // and the reader who says "but I know they support more" has no way to tell which, nor did
+                // we, from the log.
+                var listed = CountEntries(body);
+                if (listed == models.Count)
+                {
+                    _logger.LogInformation(
+                        "Fetched {Count} models from {Connection}", models.Count, connection.Id);
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Fetched {Count} models from {Connection}, but its listing had {Listed} entries - "
+                        + "{Skipped} had no usable id", models.Count, connection.Id, listed, listed - models.Count);
+                    _logger.LogDebug("{Connection} listing: {Body}", connection.Id, body);
+                }
                 return AiCatalogResult.Success(models);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -271,6 +287,29 @@ namespace CST.Avalonia.Services.Ai
             // can be worse at Pali (#689).
             models.Sort((a, b) => string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase));
             return models;
+        }
+
+        /// <summary>
+        /// How many entries the listing carried, whether or not we could read them.
+        ///
+        /// <para>Counted separately from parsing so the two can disagree in the log. A provider that offers
+        /// nine models and a parser that understands two produce the same "2" otherwise, and the difference
+        /// is the whole diagnosis.</para>
+        /// </summary>
+        internal static int CountEntries(string json)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                return doc.RootElement.TryGetProperty("data", out var data) &&
+                       data.ValueKind == JsonValueKind.Array
+                    ? data.GetArrayLength()
+                    : 0;
+            }
+            catch (JsonException)
+            {
+                return 0;
+            }
         }
 
         private static JsonElement? Object(JsonElement? parent, string name) =>


### PR DESCRIPTION
Reported from use: a Cerebras connection showed toggles for two models, and the maintainer knew the provider
supported more. The log said:

```
23:00:26 [INF] Fetched 2 models from cerebras
```

That settles one thing — nothing in the UI or the free/paid filter was hiding anything — and settles nothing
else. **The line reads as a fact about the provider, and it is equally consistent with two having been sent
and with nine having been sent and two understood.** Neither the reader nor I could tell which, because the
raw listing was parsed and discarded.

## What changes

The listing's entry count is now read **separately from** what parsed:

- when they agree, the line is unchanged;
- when they disagree, it is a **warning** naming both numbers and how many entries had no usable id, with the
  body at Debug.

Counting is deliberately not a by-product of parsing — a count derived from the parse could only ever confirm
itself.

## Not a silent repair

No fallback, no guessing at malformed entries. If a provider sends entries we cannot read, that is worth
someone knowing about; quietly rendering what we managed is exactly how it stays unknown, which is the
situation this PR exists to end.

## The Cerebras case is closed, and it was not a bug

The maintainer checked their documentation: **Cerebras serves only those two models on the shared inference
endpoint.** Everything else is provisioned on per-customer endpoints for corporate accounts, so no key on the
public endpoint will list them. Our fetch was faithful and the display was right.

My guess in the original description — that the listing was entitlement-limited and tied to the 402 — was
wrong in its specifics, though the conclusion holds: both of those models require payment, so the 402 in the
same session was also correct.

**Second commit** records both facts in `docs/research/PROVIDER_ENV_VARS_AND_ENDPOINTS.md`, under a heading
that marks them as established by use rather than mined from opencode. Neither is in the extraction that file
was built from, and both look like our bug until somebody reads a vendor's docs — which is exactly the work
this saves next time.

## Is the diagnostic still worth having?

It did not catch a bug here, so the fair question is whether it is surface for a case that did not occur. I
think it earns its place, but the call is not mine:

- the case *was* observed — a real question was asked and the log could not answer it;
- it is log-only, no UI, and silent when the numbers agree;
- the question generalises past Cerebras, and the next provider to answer oddly will raise it again.

Happy to drop the first commit and keep only the documentation if you would rather not carry it.

## Testing

**5 new tests:** the counts diverging on a listing with unusable entries, agreeing on a clean one, and an
unreadable body counting as none rather than throwing — that path already runs while reporting a problem.

696 targeted AI tests pass, 0 warnings in both projects.

