### PR TITLE
Count a listing, and a refusal, as contact with the endpoint (#673)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using CST;
 using CST.Avalonia.Models;
 using CST.Avalonia.Services;
+using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services.Ai;
 using CST.Navigation;
 using CST.Search;
@@ -140,7 +141,8 @@ public class AiChatOrchestratorTests
         IChatProvider? provider = null,
         string? notConfigured = null,
         IAiContextBundler? bundler = null,
-        string language = "English")
+        string language = "English",
+        IAiConnectionService? connections = null)
     {
         // A store pointed at a directory that does not exist: no user override can be picked up, so every test
         // runs against the shipped templates.
@@ -153,7 +155,8 @@ public class AiChatOrchestratorTests
             bundler ?? new StubBundler(),
             new PromptBuilder(templates),
             Settings(language),
-            NullLogger<AiChatOrchestrator>.Instance);
+            NullLogger<AiChatOrchestrator>.Instance,
+            connections);
     }
 
     private static AiTurnRequest Request(AiTask task = AiTask.Explain) =>
@@ -303,6 +306,72 @@ public class AiChatOrchestratorTests
 
         Assert.Equal(AiErrorKind.Unauthorized, events[^1].Error!.Kind);
         Assert.Equal(AiTurnEventKind.Started, events[0].Kind);   // the citation still rendered
+    }
+
+    // ---- what a turn teaches us about the endpoint (#673) --------------------------------------------------
+
+    private static (IAiConnectionService Service, string Id) Connected()
+    {
+        var settings = new CST.Avalonia.Models.Settings();
+        var mock = new Mock<ISettingsService>();
+        mock.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(mock.Object);
+        service.Add("mine", new AiConnectionDraft(
+            "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
+            new[] { new AiModelEntry("m", "M") },
+            new Dictionary<string, string>(), new Dictionary<string, string>()));
+        return (service, "mine");
+    }
+
+    /// <summary>
+    /// A refusal with a status code proves the endpoint answered.
+    ///
+    /// <para>Reported from use: a Cerebras connection returned HTTP 402 and was still described as never
+    /// checked. The old rule only ever recorded a NETWORK failure (unreachable) or a turn that produced
+    /// output (reachable), so every HTTP-level refusal taught the app nothing — though a status code is
+    /// precisely the evidence that something was there to send one.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(402)]
+    [InlineData(401)]
+    [InlineData(429)]
+    public async Task A_refusal_with_a_status_code_marks_the_endpoint_reachable(int status)
+    {
+        var (service, id) = Connected();
+        var provider = new FakeProvider(throwBeforeStreaming: new AiException(
+            new AiError(AiErrorKind.Provider, "refused", StatusCode: status)));
+
+        await CollectAsync(Orchestrator(provider, connections: service));
+
+        Assert.Equal(Reachability.Reachable, service.Connections.Single(c => c.Id == id).State);
+    }
+
+    /// <summary>A network failure is the one that means unreachable — nothing answered, so there is no status
+    /// code to have come from anywhere.</summary>
+    [Fact]
+    public async Task A_network_failure_marks_the_endpoint_unreachable()
+    {
+        var (service, id) = Connected();
+        var provider = new FakeProvider(throwBeforeStreaming: new AiException(
+            new AiError(AiErrorKind.Network, "The endpoint could not be reached.")));
+
+        await CollectAsync(Orchestrator(provider, connections: service));
+
+        Assert.Equal(Reachability.Unreachable, service.Connections.Single(c => c.Id == id).State);
+    }
+
+    /// <summary>A failure that never left the machine says nothing about the endpoint: no request was sent,
+    /// so there is nothing to have learned.</summary>
+    [Fact]
+    public async Task A_failure_with_no_status_code_teaches_nothing()
+    {
+        var (service, id) = Connected();
+        var provider = new FakeProvider(throwBeforeStreaming: new AiException(
+            new AiError(AiErrorKind.Provider, "something went wrong locally")));
+
+        await CollectAsync(Orchestrator(provider, connections: service));
+
+        Assert.Equal(Reachability.Configured, service.Connections.Single(c => c.Id == id).State);
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -28,11 +28,14 @@ public class AiModelsViewModelTests
         public FakeCatalog(params AiCatalogModel[] models)
             : this(AiCatalogResult.Success(models)) { }
 
+        public AiConnection? Asked { get; private set; }
+
         public FakeCatalog(AiCatalogResult result) => _result = result;
 
         public Task<AiCatalogResult> FetchAsync(AiConnection connection, CancellationToken ct = default)
         {
             Calls++;
+            Asked = connection;
             return Task.FromResult(_result);
         }
     }
@@ -412,6 +415,75 @@ public class AiModelsViewModelTests
         Assert.Null(stored.ContextLength);
         Assert.Null(stored.Inputs);
         Assert.Null(stored.SupportsReasoning);   // nothing published is not "published: no"
+    }
+
+    // ---- a listing is contact ------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Fetching a listing marks the connection reachable.
+    ///
+    /// <para>Asking a provider for its models <i>is</i> contacting it, and establishes the same fact a chat
+    /// turn does. Without this a reader who had just fetched four hundred models from OpenRouter was still
+    /// told the connection had never been checked — the app had contacted the endpoint and thrown the
+    /// knowledge away.</para>
+    /// </summary>
+    [Fact]
+    public void A_successful_listing_marks_the_connection_reachable()
+    {
+        var (vm, service) = Make(new FakeCatalog(new AiCatalogModel("a", "A")));
+        service.Add("mine", Draft());
+        Assert.Equal(Reachability.Configured, service.Connections.Single().State);
+
+        Group(vm).IsExpanded = true;
+
+        Assert.Equal(Reachability.Reachable, service.Connections.Single().State);
+    }
+
+    /// <summary>
+    /// An endpoint that refuses is still an endpoint that answered.
+    ///
+    /// <para>A rejected key or a missing listing proves something was there to say no. Marking that
+    /// unreachable would send the reader to check their network over what is a credential problem — the
+    /// confusion between "cannot reach" and "reached, and was refused" that #673 exists to keep apart.</para>
+    /// </summary>
+    [Fact]
+    public void A_refused_listing_still_counts_as_contact()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            AiCatalogResult.Fail("rejected the stored key", reachable: true)));
+        service.Add("mine", Draft());
+
+        Group(vm).IsExpanded = true;
+
+        Assert.Equal(Reachability.Reachable, service.Connections.Single().State);
+        Assert.True(Group(vm).HasFetchProblem);
+    }
+
+    /// <summary>A transport failure is the one case that means unreachable — nothing answered.</summary>
+    [Fact]
+    public void A_listing_that_never_arrived_marks_it_unreachable()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            AiCatalogResult.Fail("No response from http://localhost:8000/v1/models", reachable: false)));
+        service.Add("mine", Draft());
+
+        Group(vm).IsExpanded = true;
+
+        Assert.Equal(Reachability.Unreachable, service.Connections.Single().State);
+    }
+
+    /// <summary>Where nothing was sent, nothing is claimed — an unfinished connection is not evidence either
+    /// way.</summary>
+    [Fact]
+    public void A_listing_that_was_never_attempted_reports_nothing()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            AiCatalogResult.Fail("is not finished being set up")));
+        service.Add("mine", Draft());
+
+        Group(vm).IsExpanded = true;
+
+        Assert.Equal(Reachability.Configured, service.Connections.Single().State);
     }
 
     // ---- search and the capability filter ---------------------------------------------------------------

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -331,11 +331,17 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
 
             _logger.LogInformation("AI turn failed: {Kind} ({Code})", failure.Kind, failure.ProviderCode ?? "-");
 
-            // Only a NETWORK failure says anything about the endpoint. A 401, a rate limit or an over-long
-            // context all prove the endpoint answered - marking those unreachable would be wrong, and would
+            // Only a NETWORK failure says the endpoint could not be reached. A 401, a rate limit or an
+            // over-long context all prove it answered - marking those unreachable would be wrong, and would
             // put a red mark on a perfectly good connection whose key simply needs fixing.
+            //
+            // And they prove it POSITIVELY, which this used to leave on the table: a status code means
+            // something was there to send one, so it is contact and should be recorded as such. Reported
+            // from use - a connection that had just returned a 402 was still described as never checked.
             if (failure.Kind == AiErrorKind.Network)
                 ReportReachability(false);
+            else if (failure.StatusCode is not null)
+                ReportReachability(true);
             yield return AiTurnEvent.ForError(failure);
             yield break;
         }

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -70,12 +70,21 @@ namespace CST.Avalonia.Services.Ai
     /// <param name="Problem">A finished sentence for the reader. Never null when <paramref name="Ok"/> is
     /// false, and it names the endpoint — "cannot connect" without saying to what is the message that sends
     /// someone looking in the wrong place.</param>
-    public sealed record AiCatalogResult(bool Ok, string? Problem, IReadOnlyList<AiCatalogModel> Models)
+    /// <param name="Reachable">
+    /// Whether the endpoint answered at all — <b>not</b> whether the listing was useful.
+    ///
+    /// <para>An HTTP error is proof of contact: a 401, a 402, a 404 all mean something was there to say no.
+    /// Only a transport failure means the endpoint could not be reached. Null when nothing was sent, so an
+    /// unfinished connection cannot be reported either way.</para>
+    /// </param>
+    public sealed record AiCatalogResult(
+        bool Ok, string? Problem, IReadOnlyList<AiCatalogModel> Models, bool? Reachable = null)
     {
-        public static AiCatalogResult Success(IReadOnlyList<AiCatalogModel> models) => new(true, null, models);
+        public static AiCatalogResult Success(IReadOnlyList<AiCatalogModel> models) =>
+            new(true, null, models, true);
 
-        public static AiCatalogResult Fail(string problem) =>
-            new(false, problem, Array.Empty<AiCatalogModel>());
+        public static AiCatalogResult Fail(string problem, bool? reachable = null) =>
+            new(false, problem, Array.Empty<AiCatalogModel>(), reachable);
     }
 
     /// <summary>
@@ -147,8 +156,12 @@ namespace CST.Avalonia.Services.Ai
             {
                 using var response = await _http.SendAsync(request, timeout.Token).ConfigureAwait(false);
 
+                // Answered, even if the answer was no. A rejected key and a missing listing both prove the
+                // endpoint is there, which is the fact this reports - it says nothing about whether the
+                // listing was any use.
                 if (!response.IsSuccessStatusCode)
-                    return AiCatalogResult.Fail(Explain(response.StatusCode, connection, url));
+                    return AiCatalogResult.Fail(
+                        Explain(response.StatusCode, connection, url), reachable: true);
 
                 var body = await response.Content.ReadAsStringAsync(timeout.Token).ConfigureAwait(false);
                 var models = Parse(body);
@@ -156,7 +169,7 @@ namespace CST.Avalonia.Services.Ai
                 // A 200 carrying no models is not an error, but it is not a success the UI should silently
                 // present as an empty list either - the reader would read it as "this provider has none".
                 if (models.Count == 0)
-                    return AiCatalogResult.Fail($"{url} answered, but listed no models.");
+                    return AiCatalogResult.Fail($"{url} answered, but listed no models.", reachable: true);
 
                 _logger.LogInformation(
                     "Fetched {Count} models from {Connection}", models.Count, connection.Id);
@@ -168,18 +181,19 @@ namespace CST.Avalonia.Services.Ai
             }
             catch (OperationCanceledException)
             {
-                return AiCatalogResult.Fail($"No answer from {url} within {Timeout.TotalSeconds:0} seconds.");
+                return AiCatalogResult.Fail(
+                    $"No answer from {url} within {Timeout.TotalSeconds:0} seconds.", reachable: false);
             }
             catch (HttpRequestException ex)
             {
                 // The endpoint is named on purpose. "Cannot connect to API" is the sentence OpenCode writes
                 // and the reason its users cannot diagnose a stopped local runner.
                 _logger.LogDebug(ex, "Model listing failed for {Connection}", connection.Id);
-                return AiCatalogResult.Fail($"No response from {url} — is the endpoint running?");
+                return AiCatalogResult.Fail($"No response from {url} — is the endpoint running?", reachable: false);
             }
             catch (JsonException)
             {
-                return AiCatalogResult.Fail($"{url} answered, but not with a model listing.");
+                return AiCatalogResult.Fail($"{url} answered, but not with a model listing.", reachable: true);
             }
         }
 

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -346,6 +346,13 @@ namespace CST.Avalonia.ViewModels
 
                 if (result.Ok) _fetched = result.Models;
                 else FetchProblem = result.Problem;
+
+                // Asking a provider for its models IS contacting it, and the answer is the same fact a chat
+                // turn establishes. Without this a reader who had just fetched four hundred models from
+                // OpenRouter was still told the connection had never been checked - the app had contacted
+                // the endpoint and thrown the knowledge away.
+                if (result.Reachable is { } reachable)
+                    _owner.Service?.ReportReachability(Id, reachable);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Asked from the screen: **why does OpenRouter say "Not checked yet" when it has plainly been used?**

"Not checked yet" means we have never successfully contacted that endpoint, so we decline to claim it works —
the honest default from #673, because "Connected" computed from stored configuration is exactly what lies when
a local runner is stopped. That part is working as designed.

What was wrong is how little counted as *contact*. Two gaps, both visible in one screenshot.

## 1. A model listing was not contact

Fetching a provider's models — 415 of them, from that endpoint, with that key — established reachability and
threw it away. Only a chat turn ever reported. So every connection whose models were sitting on screen,
fetched, was described as never checked.

A fetch now reports what it learned:

| outcome | reported |
|---|---|
| answered `200` | reachable |
| answered `401` / `402` / `404` | **reachable** — a refusal proves something was there to refuse |
| nothing answered | unreachable |
| nothing was sent | no claim — an unfinished connection is not evidence |

Reported by the view model rather than from inside the catalogue, so the catalogue keeps knowing nothing about
connections and cannot become a second writer of their state.

## 2. Nor was a refusal, on the chat path

The same gap in `AiChatOrchestrator`, and its comment already had half the reasoning: *"a 401, a rate limit or
an over-long context all prove the endpoint answered — marking those unreachable would be wrong."* True, and
one step short. They prove it **positively**: a status code means something was there to send one.

Observed in the log — Cerebras returned HTTP 402 at 23:00:49, in the session that was on screen, and was still
described as never checked.

A failure with **no** status code still teaches nothing, which keeps local assembly failures out of it:
nothing was sent, so there is nothing to have learned.

## Why OpenRouter specifically, since it *had* been used

The log settles it: last shutdown **22:48:47**, OpenRouter's last chat turn **22:41**. Reachability is held
per session, so the restart cleared it and nothing since had reported. Both fixes cover it — after this,
opening the Models tab marks it reachable without asking it a question.

## Not changed, deliberately

**Reachability is still per-session and still not persisted.** A stored "Reachable" from yesterday is the
stale green light this whole design refuses: restore it on a laptop that is now offline and the settings page
confidently contradicts the assistant. "Not checked yet" after a restart is correct — it will now just be
replaced by something better far sooner.

## Testing

**7 new tests**, one per branch of each rule. The orchestrator ones needed its test helper to accept a
connection service — it already took one, the helper simply never passed it. 700 targeted AI tests pass, 0
warnings in both projects.
