### PR TITLE
Generate the provider presets from the catalogue (#737)

### DIFF
--- a/src/CST.Avalonia.Tests/Models/Ai/AiProviderPresetsTests.cs
+++ b/src/CST.Avalonia.Tests/Models/Ai/AiProviderPresetsTests.cs
@@ -61,7 +61,9 @@ public class AiProviderPresetsTests
     [Fact]
     public void A_preset_that_needs_a_key_says_where_one_might_already_be()
     {
-        foreach (var p in AiProviderPresets.All.Where(p => p.RequiresKey))
+        // Asserted of the HAND-KEPT entries only. Build treats the catalogue's `env` as optional, so a
+        // future snapshot carrying an env-less provider would break this suite rather than the app.
+        foreach (var p in AiProviderPresets.HandKept.Where(p => p.RequiresKey))
             Assert.NotEmpty(p.EnvironmentVariables);
     }
 

--- a/src/CST.Avalonia.Tests/Models/Ai/AiProviderPresetsTests.cs
+++ b/src/CST.Avalonia.Tests/Models/Ai/AiProviderPresetsTests.cs
@@ -70,7 +70,10 @@ public class AiProviderPresetsTests
     [Fact]
     public void Local_runners_do_not_require_a_key()
     {
-        var local = AiProviderPresets.All.Where(p => p.BaseUrl.Contains("localhost")).ToList();
+        // Keyed off OUR local presets rather than "any URL containing localhost": the catalogue lists at
+        // least one hosted provider (privatemode-ai) that advertises a loopback address, and it is not a
+        // local runner in the sense this rule is about.
+        var local = AiProviderPresets.LocalOnly;
 
         Assert.NotEmpty(local);
         Assert.All(local, p => Assert.False(p.RequiresKey, $"{p.Id} is local but demands a key"));
@@ -146,7 +149,7 @@ public class AiProviderPresetsTests
     [Fact]
     public void Local_runners_declare_no_credential_method()
     {
-        foreach (var p in AiProviderPresets.All.Where(p => p.BaseUrl.Contains("localhost")))
+        foreach (var p in AiProviderPresets.LocalOnly)
         {
             Assert.Empty(p.Methods);
             Assert.False(p.RequiresKey);

--- a/src/CST.Avalonia.Tests/Services/Ai/AiPresetSourceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiPresetSourceTests.cs
@@ -232,4 +232,86 @@ public class AiPresetSourceTests
         Assert.Equal(1, catalog.Refreshes);
         Assert.Equal(1, raised);
     }
+
+    // ---- the wire protocol comes from the catalogue, not from an assumption (fable review) -------------
+
+    /// <summary>
+    /// The finding that would have shipped eight broken presets. Eight catalogue providers carry a perfectly
+    /// valid `api` URL and declare `@ai-sdk/anthropic` — minimax, thinkingmachines, kimi-for-coding and
+    /// others — so that URL serves Anthropic Messages, not `/chat/completions`. Probed live:
+    /// `/anthropic/v1/chat/completions` returns 404 while `/anthropic/v1/messages` returns 401.
+    /// </summary>
+    [Fact]
+    public void A_provider_declaring_the_anthropic_sdk_is_emitted_as_anthropic()
+    {
+        var built = AiPresetSource.Build(Catalogue(
+            new CatalogProvider("minimax", "MiniMax", "https://api.minimax.io/anthropic/v1",
+                Npm: "@ai-sdk/anthropic")));
+
+        var minimax = Assert.Single(built.Where(p => p.Id == "minimax"));
+        Assert.Equal(ChatProviderKind.Anthropic, minimax.Kind);
+    }
+
+    /// <summary>Deliberately not a general package-to-kind mapping: OpenRouter ships its own provider package
+    /// and is genuinely OpenAI-compatible, so only the one package whose protocol we can name is special.</summary>
+    [Fact]
+    public void Another_vendors_own_sdk_package_does_not_change_the_protocol()
+    {
+        var built = AiPresetSource.Build(Catalogue(
+            new CatalogProvider("openrouter", "OpenRouter", "https://openrouter.ai/api/v1",
+                Npm: "@openrouter/ai-sdk-provider")));
+
+        Assert.Equal(ChatProviderKind.OpenAiCompatible,
+            built.Single(p => p.Id == "openrouter").Kind);
+    }
+
+    /// <summary>Endpoints whose URL parses fine but which our resolution addresses wrongly. Both were
+    /// confirmed by probing rather than reasoned about; revisit when #742 lands.</summary>
+    [Theory]
+    [InlineData("github-copilot", "https://api.githubcopilot.com")]
+    [InlineData("perplexity-agent", "https://api.perplexity.ai/v1")]
+    public void An_endpoint_we_would_address_wrongly_is_not_emitted(string id, string api)
+    {
+        var built = AiPresetSource.Build(Catalogue(new CatalogProvider(id, id, api)));
+
+        Assert.DoesNotContain(built, p => p.Id == id);
+    }
+
+    /// <summary>
+    /// The guard was dead code: subtracting only the local runners left the count permanently above zero,
+    /// because Build always seeds the whole hand-kept table. A models.dev reshape leaving every record
+    /// templated would then have reported Ready with a dozen presets and no Problem — a silent collapse.
+    /// </summary>
+    [Fact]
+    public async Task A_catalogue_that_yields_no_hosted_presets_reports_unavailable()
+    {
+        var catalog = new FakeCatalog
+        {
+            // Parses fine, plenty of records, every one unusable: templated against host-expanded variables.
+            Result = new CatalogResult(
+                Catalogue(Enumerable.Range(0, 60)
+                    .Select(i => new CatalogProvider($"p{i}", $"P{i}", "https://${HOST}/v1"))
+                    .ToArray()),
+                CatalogSource.Network),
+        };
+        var source = new AiPresetSource(catalog);
+
+        await source.EnsureLoadedAsync();
+
+        Assert.Equal(AiPresetState.Unavailable, source.State);
+        Assert.NotNull(source.Problem);
+        Assert.Contains(source.Presets, p => p.Id == "ollama");
+    }
+
+    /// <summary>Before the first load, a caller WITH the service must not see fewer providers than one
+    /// without it — that window is an HTTP timeout long when the cache is stale and the host is hung.</summary>
+    [Fact]
+    public void Presets_are_seeded_from_the_snapshot_before_any_load()
+    {
+        var source = new AiPresetSource(new FakeCatalog());
+
+        Assert.Equal(AiPresetState.Loading, source.State);
+        Assert.True(source.Presets.Count > 100,
+            $"seeded with only {source.Presets.Count}; AddFromPreset would refuse known providers");
+    }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/AiPresetSourceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiPresetSourceTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// #737: presets come from the catalogue plus a small hand-kept table, and carry a STATE — because two of
+/// the three outcomes otherwise arrive as an empty list, and the loud one reads as a broken feature (#739).
+/// </summary>
+public class AiPresetSourceTests
+{
+    private sealed class FakeCatalog : IModelsDevCatalog
+    {
+        public CatalogResult Result { get; set; } =
+            new(new Dictionary<string, CatalogProvider>(), CatalogSource.Network);
+        public int Refreshes { get; private set; }
+
+        public Task<CatalogResult> GetAsync(CancellationToken ct = default) => Task.FromResult(Result);
+        public Task RefreshAsync(bool force = false, CancellationToken ct = default)
+        { Refreshes++; return Task.CompletedTask; }
+    }
+
+    private static Dictionary<string, CatalogProvider> Catalogue(params CatalogProvider[] p) =>
+        p.ToDictionary(x => x.Id, x => x);
+
+    // ---- the inclusion rule ---------------------------------------------------------------------------
+
+    [Fact]
+    public void A_catalogue_provider_with_a_base_url_becomes_a_preset()
+    {
+        var built = AiPresetSource.Build(Catalogue(
+            new CatalogProvider("acme", "Acme", "https://api.acme.test/v1", Env: new[] { "ACME_API_KEY" })));
+
+        var acme = Assert.Single(built.Where(p => p.Id == "acme"));
+        Assert.Equal("https://api.acme.test/v1", acme.BaseUrl);
+        Assert.Equal(ChatProviderKind.OpenAiCompatible, acme.Kind);
+        Assert.Contains("ACME_API_KEY", acme.EnvironmentVariables);
+    }
+
+    /// <summary>
+    /// A provider with no base URL is skipped, not emitted broken. Recording a URL we do not have would
+    /// produce a row that looks configured and fails at send time — the failure shape #728 and #735 removed.
+    /// </summary>
+    [Fact]
+    public void A_catalogue_provider_without_a_base_url_is_skipped()
+    {
+        var built = AiPresetSource.Build(Catalogue(
+            new CatalogProvider("sdk-only", "SDK Only", Api: null, Npm: "@ai-sdk/sdk-only")));
+
+        Assert.DoesNotContain(built, p => p.Id == "sdk-only");
+    }
+
+    /// <summary>
+    /// The case that would have dropped OpenAI and Anthropic. models.dev omits their `api` field because a
+    /// dedicated package carries the URL — so the hand-kept table supplies it, and must win.
+    /// </summary>
+    [Fact]
+    public void The_hand_kept_table_supplies_providers_the_catalogue_leaves_without_a_url()
+    {
+        var built = AiPresetSource.Build(Catalogue(
+            new CatalogProvider("openai", "OpenAI", Api: null, Npm: "@ai-sdk/openai"),
+            new CatalogProvider("anthropic", "Anthropic", Api: null, Npm: "@ai-sdk/anthropic")));
+
+        var openai = Assert.Single(built.Where(p => p.Id == "openai"));
+        Assert.Equal("https://api.openai.com/v1", openai.BaseUrl);
+
+        var anthropic = Assert.Single(built.Where(p => p.Id == "anthropic"));
+        Assert.Equal(ChatProviderKind.Anthropic, anthropic.Kind);
+    }
+
+    /// <summary>A hand-kept entry wins over a catalogue entry of the same id: it carries an auth shape the
+    /// catalogue cannot describe. Azure is the case — `api-key`, no scheme.</summary>
+    [Fact]
+    public void A_hand_kept_entry_wins_over_the_catalogue()
+    {
+        var built = AiPresetSource.Build(Catalogue(
+            new CatalogProvider("azure", "Azure", "https://wrong.example/v1")));
+
+        var azure = Assert.Single(built.Where(p => p.Id == "azure"));
+        Assert.Equal("api-key", azure.AuthHeaderName);
+        Assert.Null(azure.AuthScheme);
+        Assert.Contains("{resourceName}", azure.BaseUrl);
+    }
+
+    /// <summary>
+    /// Cohere posts to `/chat` on its own protocol. It must not appear, and structurally cannot: every
+    /// hand-kept entry carries an explicit Kind and the enum has two members, so there is no value to write.
+    /// </summary>
+    [Fact]
+    public void A_provider_speaking_a_third_protocol_is_not_emitted()
+    {
+        var built = AiPresetSource.Build(Catalogue(
+            new CatalogProvider("cohere", "Cohere", Api: null, Npm: "@ai-sdk/cohere")));
+
+        Assert.DoesNotContain(built, p => p.Id == "cohere");
+    }
+
+    // ---- local runners --------------------------------------------------------------------------------
+
+    /// <summary>Ollama is not in models.dev at all, and never will be — its models are whatever the reader
+    /// pulled onto that machine.</summary>
+    [Fact]
+    public void Local_runners_appear_even_with_an_empty_catalogue()
+    {
+        var built = AiPresetSource.Build(new Dictionary<string, CatalogProvider>());
+
+        Assert.Contains(built, p => p.Id == "ollama");
+        Assert.Contains(built, p => p.Id == "lmstudio");
+        Assert.All(built.Where(p => p.BaseUrl.Contains("localhost")), p => Assert.False(p.RequiresKey));
+    }
+
+    // ---- ordering -------------------------------------------------------------------------------------
+
+    /// <summary>Alphabetical, and only alphabetical. A reader reads "first" as "best", so any hand-arranged
+    /// order would be a claim we refuse to make (#670/#681).</summary>
+    [Fact]
+    public void Presets_are_ordered_alphabetically()
+    {
+        var built = AiPresetSource.Build(Catalogue(
+            new CatalogProvider("zeta", "Zeta", "https://z.test/v1"),
+            new CatalogProvider("alpha", "Alpha", "https://a.test/v1")));
+
+        var names = built.Select(p => p.DisplayName).ToList();
+        Assert.Equal(names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase), names);
+    }
+
+    // ---- state ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task A_loaded_catalogue_reports_ready()
+    {
+        var catalog = new FakeCatalog
+        {
+            Result = new CatalogResult(
+                Catalogue(new CatalogProvider("acme", "Acme", "https://api.acme.test/v1")),
+                CatalogSource.Network),
+        };
+        var source = new AiPresetSource(catalog);
+
+        await source.EnsureLoadedAsync();
+
+        Assert.Equal(AiPresetState.Ready, source.State);
+        Assert.Null(source.Problem);
+    }
+
+    /// <summary>The snapshot is a legitimate source: a fresh offline install genuinely has those providers
+    /// and can add them. Reporting it as a failure would put a retry button in front of a working list.</summary>
+    [Fact]
+    public async Task The_build_time_snapshot_reports_ready_not_unavailable()
+    {
+        var catalog = new FakeCatalog
+        {
+            Result = new CatalogResult(
+                Catalogue(new CatalogProvider("acme", "Acme", "https://api.acme.test/v1")),
+                CatalogSource.Snapshot),
+        };
+        var source = new AiPresetSource(catalog);
+
+        await source.EnsureLoadedAsync();
+
+        Assert.Equal(AiPresetState.Ready, source.State);
+    }
+
+    /// <summary>
+    /// The rider that is easy to get wrong: "Unavailable" names the HOSTED catalogue as missing, not the
+    /// section as empty. Ollama and LM Studio need no network to be useful, which makes them exactly the
+    /// wrong thing to hide when the network is down.
+    /// </summary>
+    [Fact]
+    public async Task Unavailable_still_returns_the_local_runners()
+    {
+        var catalog = new FakeCatalog
+        {
+            Result = new CatalogResult(
+                new Dictionary<string, CatalogProvider>(), CatalogSource.None,
+                Problem: "Couldn't reach the provider list."),
+        };
+        var source = new AiPresetSource(catalog);
+
+        await source.EnsureLoadedAsync();
+
+        Assert.Equal(AiPresetState.Unavailable, source.State);
+        Assert.NotNull(source.Problem);
+        Assert.Contains(source.Presets, p => p.Id == "ollama");
+        Assert.Contains(source.Presets, p => p.Id == "lmstudio");
+    }
+
+    [Fact]
+    public async Task Nothing_loaded_yet_reports_loading()
+    {
+        var source = new AiPresetSource(new FakeCatalog());
+
+        Assert.Equal(AiPresetState.Loading, source.State);
+        Assert.NotEmpty(source.Presets);   // local runners are available before any load
+        await Task.CompletedTask;
+    }
+
+    /// <summary>A stale-but-usable list is Ready with a sentence — not a retry-me failure.</summary>
+    [Fact]
+    public async Task A_stale_copy_is_ready_and_still_says_so()
+    {
+        var catalog = new FakeCatalog
+        {
+            Result = new CatalogResult(
+                Catalogue(new CatalogProvider("acme", "Acme", "https://api.acme.test/v1")),
+                CatalogSource.Cache, Problem: "Couldn't reach the provider list. Showing the last copy."),
+        };
+        var source = new AiPresetSource(catalog);
+
+        await source.EnsureLoadedAsync();
+
+        Assert.Equal(AiPresetState.Ready, source.State);
+        Assert.NotNull(source.Problem);
+    }
+
+    [Fact]
+    public async Task Refresh_forces_a_fetch_and_announces_the_change()
+    {
+        var catalog = new FakeCatalog();
+        var source = new AiPresetSource(catalog);
+        int raised = 0;
+        source.PresetsChanged += (_, _) => raised++;
+
+        await source.RefreshAsync();
+
+        Assert.Equal(1, catalog.Refreshes);
+        Assert.Equal(1, raised);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/AiPresetSourceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiPresetSourceTests.cs
@@ -299,8 +299,25 @@ public class AiPresetSourceTests
         await source.EnsureLoadedAsync();
 
         Assert.Equal(AiPresetState.Unavailable, source.State);
-        Assert.NotNull(source.Problem);
         Assert.Contains(source.Presets, p => p.Id == "ollama");
+
+        // Reached and unusable is not the same situation as unreachable, and must not borrow its sentence -
+        // that would send a reader to check their network over a problem that is ours.
+        Assert.NotNull(source.Problem);
+        Assert.DoesNotContain("reach", source.Problem!, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Ties fall back to insertion order, which is the source document's order — the last path by
+    /// which models.dev's own ordering could decide what a reader sees first (#670/#681).</summary>
+    [Fact]
+    public void A_shared_display_name_is_ordered_by_id_not_by_document_order()
+    {
+        var forward = AiPresetSource.Build(Catalogue(
+            new CatalogProvider("zzz", "Same Name", "https://z.test/v1"),
+            new CatalogProvider("aaa", "Same Name", "https://a.test/v1")));
+
+        var tied = forward.Where(p => p.DisplayName == "Same Name").Select(p => p.Id).ToList();
+        Assert.Equal(new[] { "aaa", "zzz" }, tied);
     }
 
     /// <summary>Before the first load, a caller WITH the service must not see fewer providers than one

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -492,9 +492,18 @@ public partial class App : Application
 
             if (ServiceProvider?.GetService<Services.Ai.IModelsDevCatalog>() is not { } catalogue) return;
 
+            var presets = ServiceProvider?.GetService<Services.Ai.IAiPresetSource>();
+
             _ = Task.Run(async () =>
             {
-                try { await catalogue.RefreshAsync().ConfigureAwait(false); }
+                try
+                {
+                    await catalogue.RefreshAsync().ConfigureAwait(false);
+
+                    // Rebuild after the fetch, so the list the reader sees reflects what just arrived rather
+                    // than what was cached when the app started.
+                    if (presets is not null) await presets.EnsureLoadedAsync().ConfigureAwait(false);
+                }
                 catch (Exception ex) { Log.Debug(ex, "Provider catalogue refresh failed (#736)"); }
             });
         }
@@ -1351,6 +1360,10 @@ public partial class App : Application
         // The models.dev provider catalogue (#736). Singleton because it caches the document in memory and
         // holds the fetch gate; nothing user-visible depends on it yet (#737 turns it into presets).
         services.AddSingleton<Services.Ai.IModelsDevCatalog>(_ => new Services.Ai.ModelsDevCatalog());
+
+        // Presets built from the catalogue plus the hand-kept table (#737). Singleton: it holds the built
+        // list and the load gate, and the connection service subscribes to its change event.
+        services.AddSingleton<Services.Ai.IAiPresetSource, Services.Ai.AiPresetSource>();
 
         // Asking a connection what models it offers (#674). Additive to the hand-typed list, never a
         // prerequisite: an endpoint that publishes no listing stays fully usable, so a failure here is

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Avalonia.Threading;
 using CST.Avalonia.Models;
 using CST.Avalonia.Models.Ai;
@@ -26,6 +28,22 @@ namespace CST.Avalonia.Services.Ai
 
         /// <summary>Named endpoints a reader can add. Facts only — no model lists, no rankings.</summary>
         IReadOnlyList<AiProviderPreset> Presets { get; }
+
+        /// <summary>
+        /// Whether the preset list is available, and why not. (#737, requested by #739)
+        ///
+        /// <para>Needed because two of the three outcomes arrive as an empty list — "all added" is a quiet
+        /// end state, "couldn't reach the catalogue" needs a sentence and a retry, and "not fetched yet"
+        /// wants "loading". A bare list cannot tell them apart, and the loud case reads as a broken
+        /// feature.</para>
+        /// </summary>
+        AiPresetState PresetState { get; }
+
+        /// <summary>A finished sentence to show, or null.</summary>
+        string? PresetProblem { get; }
+
+        /// <summary>What a Retry button calls.</summary>
+        Task RefreshPresetsAsync(CancellationToken ct = default);
 
         /// <summary>Presets with no connection yet, i.e. what an "add a provider" list should show. A preset
         /// drops out once added, so the catalogue always reads as "what you could add next".</summary>
@@ -102,6 +120,7 @@ namespace CST.Avalonia.Services.Ai
 
         private readonly ISettingsService _settings;
         private readonly IAiCredentialStore? _credentials;
+        private readonly IAiPresetSource? _presets;
 
         /// <summary>
         /// Last-known reachability, in memory only.
@@ -119,10 +138,19 @@ namespace CST.Avalonia.Services.Ai
 
         /// <param name="credentials">Optional: a platform with nowhere safe to put a key still runs, and an
         /// endpoint needing no key still works. Resolved with <c>GetService</c> for that reason.</param>
-        public AiConnectionService(ISettingsService settings, IAiCredentialStore? credentials = null)
+        public AiConnectionService(
+            ISettingsService settings,
+            IAiCredentialStore? credentials = null,
+            IAiPresetSource? presets = null)
         {
             _settings = settings;
             _credentials = credentials;
+            _presets = presets;
+
+            // The preset list changing is a change to what this service reports, so it reaches the UI on the
+            // one event it already binds to rather than through a second channel.
+            if (_presets is not null)
+                _presets.PresetsChanged += (_, _) => RaiseChanged();
         }
 
         public event EventHandler? ConnectionsChanged;
@@ -152,10 +180,18 @@ namespace CST.Avalonia.Services.Ai
                 ? CredentialSource.Keychain
                 : CredentialSource.None;
 
-        public IReadOnlyList<AiProviderPreset> Presets => AiProviderPresets.All;
+        public IReadOnlyList<AiProviderPreset> Presets =>
+            _presets?.Presets ?? AiPresetSource.SnapshotDefaults;
+
+        public AiPresetState PresetState => _presets?.State ?? AiPresetState.Ready;
+
+        public string? PresetProblem => _presets?.Problem;
+
+        public Task RefreshPresetsAsync(CancellationToken ct = default) =>
+            _presets?.RefreshAsync(ct) ?? Task.CompletedTask;
 
         public IReadOnlyList<AiProviderPreset> AvailablePresets =>
-            AiProviderPresets.All
+            Presets
                 .Where(p => !Chat.Connections.Any(c => IdMatches(c.Id, p.Id)))
                 .ToList();
 
@@ -179,7 +215,7 @@ namespace CST.Avalonia.Services.Ai
 
         public AiConnectionResult AddFromPreset(string presetId, IReadOnlyDictionary<string, string> inputs)
         {
-            var preset = AiProviderPresets.ById(presetId);
+            var preset = Presets.FirstOrDefault(p => IdMatches(p.Id, presetId));
             if (preset is null) return AiConnectionResult.Fail($"'{presetId}' is not a known provider.");
 
             if (Find(preset.Id) is not null)
@@ -438,7 +474,7 @@ namespace CST.Avalonia.Services.Ai
             if (string.IsNullOrWhiteSpace(id)) return "A connection needs an id.";
             if (!SlugPattern.IsMatch(id))
                 return "An id may use only lowercase letters, numbers, hyphens and underscores.";
-            if (AiProviderPresets.IsReservedId(id))
+            if (Presets.Any(p => IdMatches(p.Id, id)))
                 return $"'{id}' is the id of a built-in provider. Add it from the provider list instead.";
             if (!existingAllowed && Find(id) is not null)
                 return $"There is already a connection called '{id}'.";

--- a/src/CST.Avalonia/Services/Ai/AiPresetSource.cs
+++ b/src/CST.Avalonia/Services/Ai/AiPresetSource.cs
@@ -135,7 +135,15 @@ namespace CST.Avalonia.Services.Ai
                     // missing, not the section as empty - a reader with Ollama on this machine can still add
                     // it, and needs no network to do so.
                     State = AiPresetState.Unavailable;
-                    Problem = result.Problem ?? "Couldn't reach the provider list.";
+
+                    // Two different situations reach this branch and they deserve different sentences: the
+                    // catalogue was unreachable, or it was read and held nothing we can serve. Saying
+                    // "couldn't reach" for the second is simply untrue, and sends a reader to check their
+                    // network over a problem that is ours. (fable review)
+                    Problem = result.Problem
+                              ?? (result.Source == CatalogSource.None
+                                  ? "Couldn't reach the provider list."
+                                  : "The provider list held nothing this version can use.");
                 }
                 else
                 {
@@ -279,6 +287,12 @@ namespace CST.Avalonia.Services.Ai
             // "best", and any hand-arranged order would be a claim we refuse to make (#670/#681).
             return built.Values
                 .OrderBy(p => p.DisplayName, StringComparer.OrdinalIgnoreCase)
+                // Tie-broken on id, and this is the anti-registry rule rather than tidiness. OrderBy is
+                // stable, so two providers sharing a display name would fall back to insertion order - which
+                // is the SOURCE DOCUMENT's order, the one remaining path by which models.dev's own ordering
+                // could decide what a reader sees first. No such pair exists today; the input is no longer
+                // ours to control. (fable review)
+                .ThenBy(p => p.Id, StringComparer.Ordinal)
                 .ToList();
         }
     }

--- a/src/CST.Avalonia/Services/Ai/AiPresetSource.cs
+++ b/src/CST.Avalonia/Services/Ai/AiPresetSource.cs
@@ -78,7 +78,12 @@ namespace CST.Avalonia.Services.Ai
         public AiPresetSource(IModelsDevCatalog catalog)
         {
             _catalog = catalog;
-            Presets = AiProviderPresets.LocalOnly;
+
+            // Seeded from the snapshot, not the local runners. Before the first load completes, a caller WITH
+            // this service would otherwise see fewer providers than one without it - and with a stale cache
+            // and a hung models.dev that window is the length of an HTTP timeout, during which
+            // AddFromPreset("openai") answers "not a known provider". (fable review)
+            Presets = SnapshotDefaults;
         }
 
         /// <summary>
@@ -116,7 +121,11 @@ namespace CST.Avalonia.Services.Ai
                 var result = await _catalog.GetAsync(ct).ConfigureAwait(false);
 
                 var built = Build(result.Providers);
-                var hosted = built.Count - AiProviderPresets.LocalOnly.Count;
+                // Catalogue-DERIVED count. Subtracting only the local runners left this permanently >= 10,
+                // because Build always seeds the whole hand-kept table - so the guard below could never fire,
+                // and a models.dev reshape that left every record templated or URL-less would have reported
+                // Ready with 12 presets and no Problem. A silent collapse from 171 to 12. (fable review)
+                var hosted = built.Count - AiProviderPresets.HandKept.Count;
 
                 Presets = built;
 
@@ -137,7 +146,9 @@ namespace CST.Avalonia.Services.Ai
             catch (Exception ex) when (!ct.IsCancellationRequested)
             {
                 Log.Warning(ex, "Could not build the provider presets (#737)");
-                Presets = AiProviderPresets.LocalOnly;
+
+                // Whatever was already built stays. Resetting to the local runners would be this feature's
+                // one rule - a failure never destroys what we had - broken in its own error handler.
                 State = AiPresetState.Unavailable;
                 Problem = "Couldn't reach the provider list.";
             }
@@ -158,6 +169,12 @@ namespace CST.Avalonia.Services.Ai
         /// </summary>
         internal static string? SkipReason(CatalogProvider provider)
         {
+            // Endpoints whose URL parses fine and whose protocol we speak, but which our endpoint
+            // resolution would still address wrongly. Each was confirmed by probing the live endpoint, not
+            // reasoned about, and each would otherwise be a preset that looks configured and 404s.
+            if (DeniedIds.Contains(provider.Id))
+                return "endpoint path does not match how we resolve it (#742)";
+
             // The id becomes the credential's keychain account name, so it has to be a safe segment.
             // `wafer.ai` is the real case: a dot in the id.
             if (!SlugPattern.IsMatch(provider.Id)) return "id is not a slug";
@@ -178,6 +195,36 @@ namespace CST.Avalonia.Services.Ai
 
             return null;
         }
+
+        /// <summary>
+        /// <c>github-copilot</c> publishes a bare host and serves <c>/chat/completions</c>, so our
+        /// bare-host rule builds <c>/v1/chat/completions</c> — a 404 — and it cannot authenticate with a
+        /// pasted key regardless. <c>perplexity-agent</c> is the sibling of the <c>perplexity</c> case
+        /// already skipped by hand: <c>/v1</c> in the base plus our versioned path yields
+        /// <c>/v1/chat/completions</c> against an endpoint serving <c>/chat/completions</c>. Both revisit
+        /// when #742 lands.
+        /// </summary>
+        private static readonly HashSet<string> DeniedIds =
+            new(StringComparer.OrdinalIgnoreCase) { "github-copilot", "perplexity-agent" };
+
+        /// <summary>
+        /// The wire protocol a catalogue record implies. (fable review)
+        ///
+        /// <para><b>The <c>npm</c> field names the protocol, and ignoring it shipped wrong endpoints.</b>
+        /// Eight providers with a perfectly valid <c>api</c> URL declare <c>@ai-sdk/anthropic</c> — minimax,
+        /// thinkingmachines, kimi-for-coding and others — meaning that URL serves Anthropic Messages, not
+        /// <c>/chat/completions</c>. Probed: <c>POST /anthropic/v1/chat/completions</c> returns 404 while
+        /// <c>/anthropic/v1/messages</c> returns 401, i.e. the route exists. Emitting them as
+        /// OpenAI-compatible produced presets that could only ever fail.</para>
+        ///
+        /// <para>Deliberately NOT a general mapping from package to kind: <c>openrouter</c> ships
+        /// <c>@openrouter/ai-sdk-provider</c> and is genuinely OpenAI-compatible. Only the one package whose
+        /// protocol we can name is special-cased; everything else keeps the default.</para>
+        /// </summary>
+        internal static ChatProviderKind KindFor(CatalogProvider provider) =>
+            string.Equals(provider.Npm, "@ai-sdk/anthropic", StringComparison.OrdinalIgnoreCase)
+                ? ChatProviderKind.Anthropic
+                : ChatProviderKind.OpenAiCompatible;
 
         private static readonly System.Text.RegularExpressions.Regex SlugPattern =
             new("^[a-z0-9][a-z0-9_-]*$", System.Text.RegularExpressions.RegexOptions.Compiled);
@@ -213,7 +260,7 @@ namespace CST.Avalonia.Services.Ai
                 built[provider.Id] = new AiProviderPreset(
                     provider.Id,
                     string.IsNullOrWhiteSpace(provider.Name) ? provider.Id : provider.Name!,
-                    ChatProviderKind.OpenAiCompatible,
+                    KindFor(provider),
                     provider.Api!,
                     methods);
             }

--- a/src/CST.Avalonia/Services/Ai/AiPresetSource.cs
+++ b/src/CST.Avalonia/Services/Ai/AiPresetSource.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models.Ai;
+using Serilog;
+
+namespace CST.Avalonia.Services.Ai
+{
+    /// <summary>
+    /// Whether a preset list is available, and why not. (#737, requested by #739)
+    ///
+    /// <para><b>Three outcomes, two of which used to arrive as an empty list.</b> "The reader has added them
+    /// all", "the catalogue could not be reached" and "not fetched yet" are different situations needing
+    /// different words, and the loud one — an unexplained empty catalogue on a fresh install — reads as a
+    /// broken feature. A bare <c>IReadOnlyList</c> cannot tell them apart.</para>
+    /// </summary>
+    public enum AiPresetState
+    {
+        /// <summary>No attempt has finished yet.</summary>
+        Loading,
+
+        /// <summary>A list is available. <b>Includes the build-time snapshot</b> — a fresh offline install
+        /// genuinely has those providers and can add them, so that is Ready, not a failure.</summary>
+        Ready,
+
+        /// <summary>The hosted catalogue is missing. <b>Not "there is nothing to add"</b>: the local runners
+        /// and the custom-endpoint route are still returned, because they need no network to be useful and
+        /// are therefore exactly the wrong thing to hide when the network is down.</summary>
+        Unavailable,
+    }
+
+    public interface IAiPresetSource
+    {
+        IReadOnlyList<AiProviderPreset> Presets { get; }
+
+        AiPresetState State { get; }
+
+        /// <summary>A finished sentence to show, or null. Set only when <see cref="State"/> is
+        /// <see cref="AiPresetState.Unavailable"/>.</summary>
+        string? Problem { get; }
+
+        /// <summary>What a Retry button calls. Forces a fetch regardless of the freshness window.</summary>
+        Task RefreshAsync(CancellationToken ct = default);
+
+        /// <summary>Loads from whatever is already available, without forcing a fetch.</summary>
+        Task EnsureLoadedAsync(CancellationToken ct = default);
+
+        event EventHandler? PresetsChanged;
+    }
+
+    /// <summary>
+    /// Builds the provider presets from the models.dev catalogue plus a small hand-kept table. (#733, #737)
+    ///
+    /// <para><b>Why this is not purely generated.</b> Of the catalogue's 192 providers, 166 carry an
+    /// <c>api</c> base URL and 26 do not — and the 26 are not unsupported. models.dev records a URL exactly
+    /// when a provider is served by the generic OpenAI-compatible adapter, and omits it when a dedicated
+    /// SDK package carries its own default. Eight of the 26 are providers we shipped and that worked:
+    /// Anthropic, OpenAI, Groq, Cerebras, DeepInfra, Together, xAI, Azure. Emitting only what has an
+    /// <c>api</c> field would drop OpenAI and Anthropic.</para>
+    ///
+    /// <para><b>The inclusion rule, stated here because its absence is what made the old list
+    /// undiscoverable.</b> A preset is emitted when we have a base URL — from the catalogue or from
+    /// <see cref="AiProviderPresets.HandKept"/> — AND its credential shape is one the resolver serves: a
+    /// bearer token, Anthropic's <c>x-api-key</c>, or Azure's <c>api-key</c>. Everything else is skipped and
+    /// <b>logged with its id</b>. The previous hand-picked list shrank from ~70 to 25 silently and nobody
+    /// could say why; a generated one must not repeat that.</para>
+    ///
+    /// <para><b>Nothing here ranks.</b> Order is alphabetical by display name, which is mechanical. No
+    /// field of the catalogue determines prominence — see #670/#681, and the tests that enforce it.</para>
+    /// </summary>
+    public sealed class AiPresetSource : IAiPresetSource
+    {
+        private readonly IModelsDevCatalog _catalog;
+        private readonly SemaphoreSlim _gate = new(1, 1);
+
+        public AiPresetSource(IModelsDevCatalog catalog)
+        {
+            _catalog = catalog;
+            Presets = AiProviderPresets.LocalOnly;
+        }
+
+        /// <summary>
+        /// The presets derivable with no catalogue service at all — built once from the snapshot compiled
+        /// into the app.
+        ///
+        /// <para>The fallback for a caller constructed without an <see cref="IAiPresetSource"/>. Deliberately
+        /// the snapshot rather than the hand-kept table alone: the hand-kept entries are the ones the
+        /// catalogue cannot supply, so on their own they are a strange, small list that includes OpenAI and
+        /// excludes OpenRouter. The snapshot is what production actually falls back to, so a caller without
+        /// the service should see the same thing.</para>
+        /// </summary>
+        public static IReadOnlyList<AiProviderPreset> SnapshotDefaults => LazySnapshot.Value;
+
+        private static readonly Lazy<IReadOnlyList<AiProviderPreset>> LazySnapshot = new(() =>
+            Build(ModelsDevCatalog.ReadSnapshot() ?? new Dictionary<string, CatalogProvider>()));
+
+        public IReadOnlyList<AiProviderPreset> Presets { get; private set; }
+        public AiPresetState State { get; private set; } = AiPresetState.Loading;
+        public string? Problem { get; private set; }
+
+        public event EventHandler? PresetsChanged;
+
+        public Task EnsureLoadedAsync(CancellationToken ct = default) => LoadAsync(force: false, ct);
+
+        public Task RefreshAsync(CancellationToken ct = default) => LoadAsync(force: true, ct);
+
+        private async Task LoadAsync(bool force, CancellationToken ct)
+        {
+            await _gate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (force) await _catalog.RefreshAsync(force: true, ct).ConfigureAwait(false);
+
+                var result = await _catalog.GetAsync(ct).ConfigureAwait(false);
+
+                var built = Build(result.Providers);
+                var hosted = built.Count - AiProviderPresets.LocalOnly.Count;
+
+                Presets = built;
+
+                if (result.Source == CatalogSource.None || hosted == 0)
+                {
+                    // The local runners are still in the list. "Unavailable" names the HOSTED catalogue as
+                    // missing, not the section as empty - a reader with Ollama on this machine can still add
+                    // it, and needs no network to do so.
+                    State = AiPresetState.Unavailable;
+                    Problem = result.Problem ?? "Couldn't reach the provider list.";
+                }
+                else
+                {
+                    State = AiPresetState.Ready;
+                    Problem = result.Problem;   // e.g. "showing the last copy" - Ready, but worth saying
+                }
+            }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                Log.Warning(ex, "Could not build the provider presets (#737)");
+                Presets = AiProviderPresets.LocalOnly;
+                State = AiPresetState.Unavailable;
+                Problem = "Couldn't reach the provider list.";
+            }
+            finally
+            {
+                _gate.Release();
+            }
+
+            PresetsChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Why a catalogue record cannot become a preset, or null if it can. (#737)
+        ///
+        /// <para>Every one of these was found in the real document rather than imagined — emitting any of
+        /// them would produce a row that looks configured and fails at send time, which is the shape #728
+        /// and #735 exist to remove.</para>
+        /// </summary>
+        internal static string? SkipReason(CatalogProvider provider)
+        {
+            // The id becomes the credential's keychain account name, so it has to be a safe segment.
+            // `wafer.ai` is the real case: a dot in the id.
+            if (!SlugPattern.IsMatch(provider.Id)) return "id is not a slug";
+
+            // No URL here and none hand-kept. Not "unsupported" - unreachable until someone resolves it from
+            // the vendor's docs and adds it to the table.
+            if (string.IsNullOrWhiteSpace(provider.Api)) return "no base URL";
+
+            // The catalogue templates some URLs against environment variables it expects the host to expand:
+            // `${DATABRICKS_HOST}`, `${SNOWFLAKE_ACCOUNT}`, `${NEON_AI_GATEWAY_BASE_URL}`. Our templating
+            // fills from reader-supplied Inputs declared by PROMPTS, which a catalogue record does not carry -
+            // so these can only be served from the hand-kept table, where the prompts live.
+            if (provider.Api!.Contains('$') || provider.Api.Contains('{')) return "URL needs values we cannot prompt for";
+
+            if (!Uri.TryCreate(provider.Api, UriKind.Absolute, out var uri) ||
+                (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+                return "base URL is not an absolute http(s) address";
+
+            return null;
+        }
+
+        private static readonly System.Text.RegularExpressions.Regex SlugPattern =
+            new("^[a-z0-9][a-z0-9_-]*$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        /// <summary>
+        /// Applies the inclusion rule. Hand-kept entries win over the catalogue for the same id: they carry
+        /// URLs the catalogue does not record and auth shapes it does not describe.
+        /// </summary>
+        internal static IReadOnlyList<AiProviderPreset> Build(
+            IReadOnlyDictionary<string, CatalogProvider> providers)
+        {
+            var built = new Dictionary<string, AiProviderPreset>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var preset in AiProviderPresets.HandKept)
+                built[preset.Id] = preset;
+
+            var skipped = new List<string>();
+
+            foreach (var (_, provider) in providers)
+            {
+                if (built.ContainsKey(provider.Id)) continue;      // hand-kept wins
+
+                if (SkipReason(provider) is { } reason)
+                {
+                    skipped.Add($"{provider.Id} ({reason})");
+                    continue;
+                }
+
+                var methods = new List<AiCredentialMethod> { new AiCredentialMethod.Key() };
+                if (provider.Env is { Count: > 0 } env)
+                    methods.Add(new AiCredentialMethod.Env(env.ToList()));
+
+                built[provider.Id] = new AiProviderPreset(
+                    provider.Id,
+                    string.IsNullOrWhiteSpace(provider.Name) ? provider.Id : provider.Name!,
+                    ChatProviderKind.OpenAiCompatible,
+                    provider.Api!,
+                    methods);
+            }
+
+            if (skipped.Count > 0)
+            {
+                // Logged, not silent. One skip is noise; forty after an upstream change is a signal, and the
+                // old hand-picked list lost ~45 providers without anyone being able to tell.
+                Log.Information(
+                    "Provider presets: skipped {Count} with no base URL (add to AiProviderPresets.HandKept " +
+                    "to support one): {Ids} (#737)",
+                    skipped.Count, string.Join(", ", skipped.OrderBy(x => x, StringComparer.Ordinal).Take(40)));
+            }
+
+            // Alphabetical by display name. Mechanical on purpose: a reader reasonably reads "first" as
+            // "best", and any hand-arranged order would be a claim we refuse to make (#670/#681).
+            return built.Values
+                .OrderBy(p => p.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/AiProviderPresets.cs
+++ b/src/CST.Avalonia/Services/Ai/AiProviderPresets.cs
@@ -19,10 +19,15 @@ namespace CST.Avalonia.Services.Ai
     /// "recommended", no model lists, no ordering by quality, no notes on which endpoint is better at Pāli.
     /// That is the registry removed in #670/#681, and the rule binds a mined table exactly as it binds a
     /// hand-written one — including on every future sync, because a ranking field can appear in an upstream
-    /// release nobody read. The order below is alphabetical by display name, which is mechanical.</para>
+    /// release nobody read.</para>
+    ///
+    /// <para><b>Order in this file is grouping, not ranking.</b> The arrays below are grouped by what they
+    /// are for; the order a reader sees is applied at read time — alphabetical by display name, with the id
+    /// as a tie-break — in <see cref="All"/> and <c>AiPresetSource.Build</c>. Nothing about a position here
+    /// reaches the UI.</para>
     ///
     /// <para><b>Presets are a convenience, never a gate.</b> A custom endpoint typed by hand is first-class and
-    /// always available; roughly 150 of 189 catalogued providers are plain
+    /// always available; most of the 192 catalogued providers are plain
     /// <c>POST {base}/chat/completions</c> with a bearer token, which is exactly what "custom" already is.</para>
     /// </summary>
     public static class AiProviderPresets
@@ -151,7 +156,6 @@ namespace CST.Avalonia.Services.Ai
         /// </summary>
         public static IReadOnlyList<AiProviderPreset> All => AiPresetSource.SnapshotDefaults;
 
-        /// <summary>The preset with this id, or null. Ids are reserved: a custom connection may not take one.</summary>
         /// <summary>The preset with this id, or null. Looks at the whole derivable set, not only the
         /// hand-kept part — an id like <c>openrouter</c> comes from the catalogue, and treating it as unknown
         /// would let a custom connection claim it and would lose the key-required flag.</summary>
@@ -162,7 +166,7 @@ namespace CST.Avalonia.Services.Ai
         public static bool IsReservedId(string id) => ById(id) is not null;
 
         /// <summary>The common case: a base URL, a bearer token, and the env vars that may already hold it.
-        /// Roughly 150 of 189 catalogued providers are exactly this.</summary>
+        /// Most of the 192 catalogued providers are exactly this.</summary>
         private static AiProviderPreset P(
             string id, string displayName, ChatProviderKind kind, string baseUrl, bool requiresKey,
             params string[] envVars)

--- a/src/CST.Avalonia/Services/Ai/AiProviderPresets.cs
+++ b/src/CST.Avalonia/Services/Ai/AiProviderPresets.cs
@@ -31,9 +31,55 @@ namespace CST.Avalonia.Services.Ai
         /// answerable and a refresh is a diff rather than an audit.</summary>
         public const string SourceCommit = "e14acea";
 
-        private static readonly AiProviderPreset[] Items =
+        /// <summary>
+        /// Endpoints that run on this machine. <b>Always present, catalogue or not</b> — models.dev
+        /// catalogues hosted providers and will never list Ollama; LM Studio appears with three models,
+        /// a number about nothing, since what either serves is whatever the reader has loaded.
+        ///
+        /// <para>Structurally the simplest presets possible: a fixed loopback URL, no credential method,
+        /// no prompts, nothing to template — which is why hardcoding them cannot rot, and why they are
+        /// exactly the wrong thing to hide when the network is down.</para>
+        /// </summary>
+        private static readonly AiProviderPreset[] Local =
         {
-            // Anthropic speaks its own protocol. Kind and BaseUrl stay independent: other providers serve the
+            P("lmstudio", "LM Studio (local)", ChatProviderKind.OpenAiCompatible,
+                "http://localhost:1234/v1", false),
+
+            P("ollama", "Ollama (local)", ChatProviderKind.OpenAiCompatible,
+                "http://localhost:11434/v1", false),
+        };
+
+        /// <summary>
+        /// Hosted endpoints whose base URL the catalogue does not record, or whose auth shape it does not
+        /// describe. (#737)
+        ///
+        /// <para><b>Why this table exists at all.</b> models.dev records an <c>api</c> URL exactly when a
+        /// provider is served by the generic OpenAI-compatible adapter, and omits it when a dedicated SDK
+        /// package carries its own default. 26 of its 192 providers are in that state — including OpenAI and
+        /// Anthropic — so "no <c>api</c> field" means "packaged differently", never "unsupported".</para>
+        ///
+        /// <para><b>The wire format is a column here, not an assumption.</b> Each entry carries an explicit
+        /// <see cref="ChatProviderKind"/>, and that enum has two members. So a provider speaking a third
+        /// protocol cannot be added even by accident: Cohere posts to <c>/chat</c> on
+        /// <c>api.cohere.com/v2</c> and would need a value that does not exist. Recording a base URL for it
+        /// would produce a preset that looks configured and 404s on every request.</para>
+        ///
+        /// <para><b>Deliberately absent, with reasons</b> — each is a skip the generator logs rather than a
+        /// silent omission:</para>
+        /// <list type="bullet">
+        /// <item><c>cohere</c> — a third wire protocol, not a missing URL.</item>
+        /// <item><c>perplexity</c> — <c>https://api.perplexity.ai</c> has no version segment, and
+        /// <c>AiHttp.ResolveEndpoint</c> adds one to a bare host, so it would build
+        /// <c>/v1/chat/completions</c> against an endpoint serving <c>/chat/completions</c>. Tracked as
+        /// <b>#742</b>; add it here once that lands.</item>
+        /// <item><c>google</c>, <c>amazon-bedrock</c>, <c>google-vertex</c> — protocol or credential work
+        /// (#700, #702, #703).</item>
+        /// <item><c>cloudflare-ai-gateway</c> — two credentials on one request (#701).</item>
+        /// </list>
+        /// </summary>
+        private static readonly AiProviderPreset[] Hosted =
+        {
+            // Anthropic's own protocol. Kind and BaseUrl stay independent: other providers serve the
             // Anthropic Messages shape at their own URLs, so Kind must never imply this host.
             P("anthropic", "Anthropic", ChatProviderKind.Anthropic,
                 "https://api.anthropic.com/v1", true, "ANTHROPIC_API_KEY"),
@@ -48,23 +94,33 @@ namespace CST.Avalonia.Services.Ai
                     new AiCredentialMethod.Key(),
                     new AiCredentialMethod.Env(new[] { "AZURE_API_KEY", "AZURE_OPENAI_API_KEY" }),
                 },
-                new[]
-                {
-                    new AiInputPrompt("resourceName", "Azure resource name", "my-resource"),
-                },
+                new[] { new AiInputPrompt("resourceName", "Azure resource name", "my-resource") },
                 AuthHeaderName: "api-key",
                 AuthScheme: null),
 
-            P("baseten", "Baseten", ChatProviderKind.OpenAiCompatible,
-                "https://inference.baseten.co/v1", true, "BASETEN_API_KEY"),
-
+            // The five below carry no `api` field but are ordinary bearer endpoints we already ship and
+            // whose URLs are proven in use. opencode's own openai-compatible-profile.ts agrees on all five,
+            // which is a cross-check rather than the source.
             P("cerebras", "Cerebras", ChatProviderKind.OpenAiCompatible,
                 "https://api.cerebras.ai/v1", true, "CEREBRAS_API_KEY"),
 
-            P("chutes", "Chutes", ChatProviderKind.OpenAiCompatible,
-                "https://llm.chutes.ai/v1", true, "CHUTES_API_KEY"),
+            P("deepinfra", "DeepInfra", ChatProviderKind.OpenAiCompatible,
+                "https://api.deepinfra.com/v1/openai", true, "DEEPINFRA_API_KEY"),
 
-            // Account id goes in the path; ordinary bearer auth otherwise.
+            P("groq", "Groq", ChatProviderKind.OpenAiCompatible,
+                "https://api.groq.com/openai/v1", true, "GROQ_API_KEY"),
+
+            P("togetherai", "Together AI", ChatProviderKind.OpenAiCompatible,
+                "https://api.together.xyz/v1", true, "TOGETHER_API_KEY"),
+
+            P("xai", "xAI", ChatProviderKind.OpenAiCompatible,
+                "https://api.x.ai/v1", true, "XAI_API_KEY"),
+
+            P("openai", "OpenAI", ChatProviderKind.OpenAiCompatible,
+                "https://api.openai.com/v1", true, "OPENAI_API_KEY"),
+
+            // Account id goes in the path, and the catalogue cannot express a prompt for it - which is
+            // precisely what this table is for. Ordinary bearer auth otherwise.
             new AiProviderPreset(
                 "cloudflare-workers-ai", "Cloudflare Workers AI", ChatProviderKind.OpenAiCompatible,
                 "https://api.cloudflare.com/client/v4/accounts/{accountId}/ai/v1",
@@ -73,70 +129,20 @@ namespace CST.Avalonia.Services.Ai
                     new AiCredentialMethod.Key(),
                     new AiCredentialMethod.Env(new[] { "CLOUDFLARE_API_KEY", "CLOUDFLARE_WORKERS_AI_TOKEN" }),
                 },
-                new[]
-                {
-                    new AiInputPrompt("accountId", "Cloudflare account ID", "0123456789abcdef"),
-                }),
+                new[] { new AiInputPrompt("accountId", "Cloudflare account ID", "0123456789abcdef") }),
 
-            P("deepinfra", "DeepInfra", ChatProviderKind.OpenAiCompatible,
-                "https://api.deepinfra.com/v1/openai", true, "DEEPINFRA_API_KEY"),
-
-            P("deepseek", "DeepSeek", ChatProviderKind.OpenAiCompatible,
-                "https://api.deepseek.com/v1", true, "DEEPSEEK_API_KEY"),
-
-            P("fireworks-ai", "Fireworks AI", ChatProviderKind.OpenAiCompatible,
-                "https://api.fireworks.ai/inference/v1", true, "FIREWORKS_API_KEY"),
-
-            P("groq", "Groq", ChatProviderKind.OpenAiCompatible,
-                "https://api.groq.com/openai/v1", true, "GROQ_API_KEY"),
-
-            P("huggingface", "Hugging Face", ChatProviderKind.OpenAiCompatible,
-                "https://router.huggingface.co/v1", true, "HF_TOKEN"),
-
-            // Local runners. No key by default - which is why an absent credential must be a valid state
-            // rather than an error, and why CredentialSource has a None member.
-            P("lmstudio", "LM Studio (local)", ChatProviderKind.OpenAiCompatible,
-                "http://localhost:1234/v1", false),
-
-            P("moonshotai", "Moonshot AI", ChatProviderKind.OpenAiCompatible,
-                "https://api.moonshot.ai/v1", true, "MOONSHOT_API_KEY"),
-
-            P("nebius", "Nebius Token Factory", ChatProviderKind.OpenAiCompatible,
-                "https://api.tokenfactory.nebius.com/v1", true, "NEBIUS_API_KEY"),
-
-            P("novita-ai", "Novita AI", ChatProviderKind.OpenAiCompatible,
-                "https://api.novita.ai/openai", true, "NOVITA_API_KEY"),
-
-            P("nvidia", "Nvidia", ChatProviderKind.OpenAiCompatible,
-                "https://integrate.api.nvidia.com/v1", true, "NVIDIA_API_KEY"),
-
-            P("ollama", "Ollama (local)", ChatProviderKind.OpenAiCompatible,
-                "http://localhost:11434/v1", false),
-
-            P("openai", "OpenAI", ChatProviderKind.OpenAiCompatible,
-                "https://api.openai.com/v1", true, "OPENAI_API_KEY"),
-
-            P("openrouter", "OpenRouter", ChatProviderKind.OpenAiCompatible,
-                "https://openrouter.ai/api/v1", true, "OPENROUTER_API_KEY"),
-
-            P("requesty", "Requesty", ChatProviderKind.OpenAiCompatible,
-                "https://router.requesty.ai/v1", true, "REQUESTY_API_KEY"),
-
-            P("siliconflow", "SiliconFlow", ChatProviderKind.OpenAiCompatible,
-                "https://api.siliconflow.com/v1", true, "SILICONFLOW_API_KEY"),
-
-            P("togetherai", "Together AI", ChatProviderKind.OpenAiCompatible,
-                "https://api.together.xyz/v1", true, "TOGETHER_API_KEY"),
-
-            P("xai", "xAI", ChatProviderKind.OpenAiCompatible,
-                "https://api.x.ai/v1", true, "XAI_API_KEY"),
-
-            P("zai", "Z.ai", ChatProviderKind.OpenAiCompatible,
-                "https://api.z.ai/api/paas/v4", true, "ZHIPU_API_KEY"),
-
-            P("zhipuai", "Zhipu AI", ChatProviderKind.OpenAiCompatible,
-                "https://open.bigmodel.cn/api/paas/v4", true, "ZHIPU_API_KEY"),
+            // Read out of @ai-sdk/mistral rather than assumed: base https://api.mistral.ai/v1, posts to
+            // /chat/completions.
+            P("mistral", "Mistral", ChatProviderKind.OpenAiCompatible,
+                "https://api.mistral.ai/v1", true, "MISTRAL_API_KEY"),
         };
+
+        /// <summary>Local runners only — what remains offerable when the hosted catalogue is unavailable.</summary>
+        public static IReadOnlyList<AiProviderPreset> LocalOnly => Local;
+
+        /// <summary>Everything not derived from the catalogue. Wins over a catalogue entry of the same id:
+        /// these carry URLs it does not record and auth shapes it does not describe.</summary>
+        public static IReadOnlyList<AiProviderPreset> HandKept => Local.Concat(Hosted).ToList();
 
         /// <summary>
         /// Every preset, ordered alphabetically by display name.
@@ -156,11 +162,19 @@ namespace CST.Avalonia.Services.Ai
         /// </list>
         /// <para>All remain reachable today by adding a custom endpoint by hand.</para>
         /// </summary>
-        public static IReadOnlyList<AiProviderPreset> All => Items;
+        /// <summary>
+        /// Every preset derivable without the catalogue service — the hand-kept table plus whatever the
+        /// build-time snapshot supplies. Callers holding an <c>IAiPresetSource</c> should use that instead;
+        /// this is the answer for code with no access to one.
+        /// </summary>
+        public static IReadOnlyList<AiProviderPreset> All => AiPresetSource.SnapshotDefaults;
 
         /// <summary>The preset with this id, or null. Ids are reserved: a custom connection may not take one.</summary>
+        /// <summary>The preset with this id, or null. Looks at the whole derivable set, not only the
+        /// hand-kept part — an id like <c>openrouter</c> comes from the catalogue, and treating it as unknown
+        /// would let a custom connection claim it and would lose the key-required flag.</summary>
         public static AiProviderPreset? ById(string id) =>
-            Items.FirstOrDefault(p => string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase));
+            All.FirstOrDefault(p => string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase));
 
         /// <summary>True when <paramref name="id"/> names a preset, so a custom connection cannot claim it.</summary>
         public static bool IsReservedId(string id) => ById(id) is not null;

--- a/src/CST.Avalonia/Services/Ai/AiProviderPresets.cs
+++ b/src/CST.Avalonia/Services/Ai/AiProviderPresets.cs
@@ -145,24 +145,6 @@ namespace CST.Avalonia.Services.Ai
         public static IReadOnlyList<AiProviderPreset> HandKept => Local.Concat(Hosted).ToList();
 
         /// <summary>
-        /// Every preset, ordered alphabetically by display name.
-        ///
-        /// <para><b>Deliberately absent, and why</b> — these need fields the connection record does not yet
-        /// model, and guessing at them would ship endpoints that cannot work:</para>
-        /// <list type="bullet">
-        /// <item>Azure OpenAI — needs a resource name, and uses an <c>api-key</c> header that requires
-        /// <i>removing</i> <c>authorization</c> rather than adding to it.</item>
-        /// <item>Amazon Bedrock — SigV4 request signing, or ambient AWS credentials with no environment
-        /// variable set at all.</item>
-        /// <item>Google Vertex — project plus location, authenticated by ADC rather than a key.</item>
-        /// <item>Cloudflare AI Gateway — an account id and <b>two</b> tokens on a single request.</item>
-        /// <item>Google Gemini — its native protocol is neither of our two kinds (<c>x-goog-api-key</c>, and
-        /// the model id embedded in the path). It does publish an OpenAI-compatible endpoint, but that was not
-        /// part of the extraction, so it is left out rather than asserted from memory.</item>
-        /// </list>
-        /// <para>All remain reachable today by adding a custom endpoint by hand.</para>
-        /// </summary>
-        /// <summary>
         /// Every preset derivable without the catalogue service — the hand-kept table plus whatever the
         /// build-time snapshot supplies. Callers holding an <c>IAiPresetSource</c> should use that instead;
         /// this is the answer for code with no access to one.

--- a/src/CST.Avalonia/Services/Ai/ModelsDevCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/ModelsDevCatalog.cs
@@ -231,7 +231,7 @@ namespace CST.Avalonia.Services.Ai
             }
         }
 
-        private static IReadOnlyDictionary<string, CatalogProvider>? ReadSnapshot()
+        internal static IReadOnlyDictionary<string, CatalogProvider>? ReadSnapshot()
         {
             try
             {


### PR DESCRIPTION
Closes #737. Closes #731. Depends on #736 (merged).

Replaces a hand-picked table of **25** with **~170** derived from the models.dev document, plus a small hand-kept table for what the catalogue cannot supply.

The maintainer's question — *"I don't know how we selected the providers that we do support"* — had no answer in the code, because I picked them and never wrote the rule down. **The rule is now in the file:** a preset is emitted when we have a base URL, from the catalogue or the hand-kept table, **and** its credential shape is one the resolver serves.

## Why the hand-kept table is not a leftover

models.dev records an `api` URL exactly when a provider is served by the generic OpenAI-compatible adapter, and omits it when a dedicated SDK package carries its own default — so **26 of 192 have none, including OpenAI and Anthropic**. Emitting only what has an `api` field would drop both.

**The wire format is a column there, not an assumption.** Each entry carries an explicit `ChatProviderKind`, and that enum has two members — so a provider speaking a third protocol cannot be added even by accident. Cohere posts to `/chat` on `api.cohere.com/v2` and would need a value that does not exist. Kestrel measured that from the SDK package; **I would have recorded a base URL for it and shipped a preset that 404s on every request.**

## Four skip filters, every one from a real record

Found by running the generator over the real document rather than by imagining failure modes:

| skipped | why |
|---|---|
| `wafer.ai` | id is not a slug — and the id becomes the credential's keychain account name |
| 26 providers | no base URL |
| `databricks`, `snowflake-cortex`, `neon`, `infomaniak` | URL templated against env vars the catalogue expects the *host* to expand (`${DATABRICKS_HOST}`) — our templating fills from reader-supplied Inputs declared by **prompts**, which a catalogue record has none of |
| — | URL not an absolute http(s) address |

**Every skip is logged with its id.** Verified in a real launch:

```
Provider presets: skipped 17 with no base URL (add to AiProviderPresets.HandKept
to support one): aihubmix, amazon-bedrock, ... perplexity, ... watsonx (#737)
```

The old hand-picked list lost ~45 providers silently and nobody could say why.

`perplexity` is skipped for a different reason and is now **#742**: its base URL has no version segment, and `ResolveEndpoint` adds one to a bare host, so it would post to `/v1/chat/completions` against an endpoint serving `/chat/completions`. Not papered over with a doctored URL.

## State, not a bare list

Requested by Kestrel from the UI side **before this was built**, and correctly. Two of three outcomes arrive as an empty list: "all added" is a quiet end state, "couldn't reach the catalogue" needs a sentence and a retry, "not fetched yet" wants "loading" — and the loud one reads as a broken feature.

`AiPresetState { Loading, Ready, Unavailable }` + `PresetProblem` + `RefreshPresetsAsync`, surfaced through `IAiConnectionService`.

Two mappings worth reviewing: **the snapshot is `Ready`**, not a failure — a fresh offline install genuinely has those providers. And **`Unavailable` still returns the local runners**, since they need no network to be useful and are exactly the wrong thing to hide when the network is down. Both pinned by tests.

## Regressions I caused and caught

Rebuilding the table dropped **Cloudflare Workers AI** (it needs an `accountId` prompt), and `ById`/`IsReservedId` were still consulting only the hand-kept part — so `openrouter` read as unknown, which would let a custom connection claim the id and lose its key-required flag. Both found by the existing suite.

**2124 passing**, 0 warnings, app verified starting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)