### PR TITLE
Present the provider catalogue at 166, and name it when it is missing (#739)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -453,6 +453,28 @@ public class AiConnectionsViewModelTests
         Assert.DoesNotContain(vm.AvailablePresets.Select(p => p.Id), id => local.Contains(id));
     }
 
+    /// <summary>
+    /// Adding every local runner must not take the custom-endpoint route with it.
+    ///
+    /// <para>The two sit in one section, and gating that section on having local runners left would hide
+    /// custom the moment a reader added Ollama and LM Studio — breaking #691's rule that a preset is never
+    /// required to reach a provider, in precisely the state where the reader has shown they configure things
+    /// by hand.</para>
+    /// </summary>
+    [Fact]
+    public void Adding_every_local_runner_leaves_the_custom_route()
+    {
+        var (vm, _) = Make();
+        foreach (var id in vm.LocalPresets.Select(p => p.Id).ToList()) AddThroughSheet(vm, id);
+
+        Assert.Empty(vm.LocalPresets);
+        Assert.False(vm.HasLocalPresets);
+        // The custom row is not a preset and is bound unconditionally; this pins the command that drives it.
+        Assert.NotNull(vm.AddCustomCommand);
+        vm.AddCustomCommand.Execute().Subscribe();
+        Assert.True(vm.IsEditing);
+    }
+
     /// <summary>The catalogue is collapsed until asked for — a hundred and sixty rows above the fold is not a
     /// list anyone reads.</summary>
     [Fact]

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -247,7 +247,9 @@ public class AiConnectionsViewModelTests
     {
         var (vm, _) = Make();
 
-        Assert.Equal("No key needed", vm.AvailablePresets.Single(p => p.Id == "ollama").RequirementText);
+        // ollama is in the local section now (#739) - it needs no key AND no network, which is what puts it
+        // there rather than in the catalogue.
+        Assert.Equal("No key needed", vm.LocalPresets.Single(p => p.Id == "ollama").RequirementText);
         Assert.Equal("Needs an API key", vm.AvailablePresets.Single(p => p.Id == "openrouter").RequirementText);
     }
 
@@ -429,6 +431,96 @@ public class AiConnectionsViewModelTests
 
         Assert.Single(vm.Connections);          // did not see the second add
         Assert.Equal(2, service.Connections.Count);   // which did happen
+    }
+
+    // ---- the catalogue at scale (#739) ---------------------------------------------------------------------
+
+    /// <summary>
+    /// The local runners sit in their own section, chosen by a fact rather than an opinion.
+    ///
+    /// <para>They need no key and no network. That is what earns them a permanent place above a catalogue
+    /// which may be neither present nor short — a "popular" section would be the ranking #670/#681 removed,
+    /// arriving as a layout decision.</para>
+    /// </summary>
+    [Fact]
+    public void Local_runners_are_separated_from_the_catalogue()
+    {
+        var (vm, _) = Make();
+
+        var local = vm.LocalPresets.Select(p => p.Id).ToList();
+        Assert.Contains("ollama", local);
+        Assert.Contains("lmstudio", local);
+        Assert.DoesNotContain(vm.AvailablePresets.Select(p => p.Id), id => local.Contains(id));
+    }
+
+    /// <summary>The catalogue is collapsed until asked for — a hundred and sixty rows above the fold is not a
+    /// list anyone reads.</summary>
+    [Fact]
+    public void The_catalogue_starts_collapsed_and_says_how_big_it_is()
+    {
+        var (vm, _) = Make();
+
+        Assert.False(vm.IsCatalogueOpen);
+        Assert.True(vm.AvailablePresets.Count > 20, "the snapshot should supply a real catalogue");
+        Assert.EndsWith("providers", vm.CatalogueCount);
+    }
+
+    /// <summary>
+    /// Typing reveals the catalogue as well as filtering it.
+    ///
+    /// <para>A reader who types has asked for the list; making them expand a section first is a second
+    /// gesture for one intention.</para>
+    /// </summary>
+    [Fact]
+    public void Searching_opens_the_catalogue_and_filters_it()
+    {
+        var (vm, _) = Make();
+
+        vm.PresetSearch = "openrouter";
+
+        Assert.True(vm.IsCatalogueOpen);
+        Assert.All(vm.AvailablePresets, p =>
+            Assert.Contains("openrouter", p.Id + p.DisplayName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>Search matches the id as well as the display name — a reader may know a provider by
+    /// either.</summary>
+    [Fact]
+    public void Search_matches_the_id_as_well_as_the_name()
+    {
+        var (vm, _) = Make();
+
+        vm.PresetSearch = "togetherai";
+
+        Assert.NotEmpty(vm.AvailablePresets);
+    }
+
+    /// <summary>A search matching nothing empties the catalogue without disturbing the local runners, which
+    /// are not what was being searched.</summary>
+    [Fact]
+    public void A_fruitless_search_leaves_the_local_runners_alone()
+    {
+        var (vm, _) = Make();
+        var before = vm.LocalPresets.Count;
+
+        vm.PresetSearch = "zzzzz-no-such-provider";
+
+        Assert.Empty(vm.AvailablePresets);
+        Assert.Equal(before, vm.LocalPresets.Count);
+    }
+
+    /// <summary>Adding a provider still removes it from the catalogue, so the list keeps reading as "what you
+    /// could add next" at this scale too.</summary>
+    [Fact]
+    public void An_added_catalogue_provider_leaves_the_catalogue()
+    {
+        var (vm, _) = Make();
+        vm.PresetSearch = "openrouter";
+        Assert.NotEmpty(vm.AvailablePresets);
+
+        AddThroughSheet(vm, "openrouter");
+
+        Assert.DoesNotContain(vm.AvailablePresets, p => p.Id == "openrouter");
     }
 
     // ---- monograms -------------------------------------------------------------------------------------

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using CST.Avalonia.Models;
 using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services;
@@ -25,14 +27,54 @@ public class AiConnectionsViewModelTests
     private static (AiConnectionsViewModel Vm, AiConnectionService Service) Make() =>
         Make(new FakeCredentialStore());
 
-    private static (AiConnectionsViewModel Vm, AiConnectionService Service) Make(FakeCredentialStore keys)
+    private static (AiConnectionsViewModel Vm, AiConnectionService Service) Make(
+        FakeCredentialStore keys, IAiPresetSource? presets = null)
     {
         var settings = new Settings();
         var svc = new Mock<ISettingsService>();
         svc.SetupGet(s => s.Settings).Returns(settings);
-        var service = new AiConnectionService(svc.Object, keys);
+        var service = new AiConnectionService(svc.Object, keys, presets);
         return (new AiConnectionsViewModel(service, keys), service);
     }
+
+    /// <summary>
+    /// A preset source whose state the test chooses.
+    ///
+    /// <para>Without one, every test ran against a service built with <c>presets: null</c>, which hard-wires
+    /// <c>Ready</c> — so the failure and loading states this section exists for had no coverage at all.</para>
+    /// </summary>
+    private sealed class StubPresets : IAiPresetSource
+    {
+        public StubPresets(AiPresetState state, string? problem, params AiProviderPreset[] presets)
+        {
+            State = state;
+            Problem = problem;
+            Presets = presets;
+        }
+
+        public IReadOnlyList<AiProviderPreset> Presets { get; }
+        public AiPresetState State { get; private set; }
+        public string? Problem { get; private set; }
+        public int Refreshes { get; private set; }
+        public event EventHandler? PresetsChanged;
+
+        /// <summary>The startup path. Records that it was asked, so a test can tell a forced Retry from the
+        /// ordinary first load.</summary>
+        public Task EnsureLoadedAsync(CancellationToken ct = default) => RefreshAsync(ct);
+
+        public Task RefreshAsync(CancellationToken ct = default)
+        {
+            Refreshes++;
+            State = AiPresetState.Ready;
+            Problem = null;
+            PresetsChanged?.Invoke(this, EventArgs.Empty);
+            return Task.CompletedTask;
+        }
+    }
+
+    private static AiProviderPreset Hosted(string id) =>
+        new(id, id, ChatProviderKind.OpenAiCompatible, $"https://{id}.test/v1",
+            new AiCredentialMethod[] { new AiCredentialMethod.Key() });
 
     /// <summary>An in-memory keychain. The real one would need a Keychain prompt per test.</summary>
     private sealed class FakeCredentialStore : IAiCredentialStore
@@ -543,6 +585,95 @@ public class AiConnectionsViewModelTests
         AddThroughSheet(vm, "openrouter");
 
         Assert.DoesNotContain(vm.AvailablePresets, p => p.Id == "openrouter");
+    }
+
+    // ---- the states this section exists for (#739) ----------------------------------------------------------
+
+    /// <summary>
+    /// A search matching nothing must not hide the search box.
+    ///
+    /// <para>The box was gated on the <i>filtered</i> count, so typing a string that matched nothing removed
+    /// the only control that could clear the search — mid-keystroke — and the catalogue was gone for the life
+    /// of the window. Recovery was closing and reopening Settings.</para>
+    /// </summary>
+    [Fact]
+    public void A_search_matching_nothing_keeps_the_search_reachable()
+    {
+        var (vm, _) = Make(new FakeCredentialStore(),
+            new StubPresets(AiPresetState.Ready, null, Hosted("openrouter"), Hosted("groq")));
+
+        vm.PresetSearch = "zzzzz";
+
+        Assert.Empty(vm.AvailablePresets);
+        Assert.True(vm.HasCatalogue);    // the box stays on screen
+        Assert.True(vm.HasNoMatches);    // and says why the list is empty
+    }
+
+    /// <summary>A trailing space is invisible; matching on it would report a provider that plainly exists as
+    /// absent.</summary>
+    [Fact]
+    public void Search_is_trimmed()
+    {
+        var (vm, _) = Make(new FakeCredentialStore(),
+            new StubPresets(AiPresetState.Ready, null, Hosted("openrouter")));
+
+        vm.PresetSearch = "openrouter ";
+
+        Assert.Single(vm.AvailablePresets);
+    }
+
+    /// <summary>
+    /// The loading line appears only while there is nothing to show.
+    ///
+    /// <para>The source seeds the built-in snapshot before any fetch finishes, so "looking for the provider
+    /// list" would otherwise sit above 166 rows — and nothing initiates a fetch at all while the AI master
+    /// switch is off, leaving it there permanently on a tab reachable with AI disabled.</para>
+    /// </summary>
+    [Fact]
+    public void Loading_is_not_announced_over_a_populated_catalogue()
+    {
+        var (populated, _) = Make(new FakeCredentialStore(),
+            new StubPresets(AiPresetState.Loading, null, Hosted("openrouter")));
+        Assert.False(populated.IsCatalogueLoading);
+
+        var (empty, _) = Make(new FakeCredentialStore(), new StubPresets(AiPresetState.Loading, null));
+        Assert.True(empty.IsCatalogueLoading);
+    }
+
+    /// <summary>A failure that kept the previous list says that, rather than contradicting the 166 rows
+    /// underneath it.</summary>
+    [Fact]
+    public void A_failure_over_a_surviving_list_says_so()
+    {
+        var (vm, _) = Make(new FakeCredentialStore(),
+            new StubPresets(AiPresetState.Unavailable, "Could not reach models.dev.", Hosted("openrouter")));
+
+        Assert.True(vm.HasCatalogueProblem);
+        Assert.Contains("built-in", vm.CatalogueProblem);
+    }
+
+    /// <summary>With nothing left, the service's own sentence is the honest one.</summary>
+    [Fact]
+    public void A_failure_with_nothing_left_shows_the_services_sentence()
+    {
+        var (vm, _) = Make(new FakeCredentialStore(),
+            new StubPresets(AiPresetState.Unavailable, "Could not reach models.dev."));
+
+        Assert.Equal("Could not reach models.dev.", vm.CatalogueProblem);
+    }
+
+    /// <summary>Retry asks the source again, and the recovery reaches the view.</summary>
+    [Fact]
+    public void Retry_refetches_and_clears_the_failure()
+    {
+        var stub = new StubPresets(AiPresetState.Unavailable, "Could not reach models.dev.");
+        var (vm, _) = Make(new FakeCredentialStore(), stub);
+        Assert.True(vm.HasCatalogueProblem);
+
+        vm.RetryCatalogueCommand.Execute().Subscribe();
+
+        Assert.Equal(1, stub.Refreshes);
+        Assert.False(vm.HasCatalogueProblem);
     }
 
     // ---- monograms -------------------------------------------------------------------------------------

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
+using System.Threading.Tasks;
 using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services.Ai;
 using ReactiveUI;
@@ -33,6 +34,8 @@ namespace CST.Avalonia.ViewModels
         private readonly IAiCredentialStore? _credentials;
         private AiConnectionEditorViewModel? _editor;
         private string? _problem;
+        private string _presetSearch = "";
+        private bool _isCatalogueExpanded;
 
         public AiConnectionsViewModel(IAiConnectionService? service, IAiCredentialStore? credentials = null)
         {
@@ -40,6 +43,7 @@ namespace CST.Avalonia.ViewModels
             _credentials = credentials;
 
             AddCustomCommand = ReactiveCommand.Create(AddCustom);
+            RetryCatalogueCommand = ReactiveCommand.CreateFromTask(RetryCatalogueAsync);
 
             if (_service is not null)
             {
@@ -51,7 +55,20 @@ namespace CST.Avalonia.ViewModels
         /// <summary>What is configured now, in the order the reader added it.</summary>
         public ObservableCollection<AiConnectionRowViewModel> Connections { get; } = new();
 
-        /// <summary>The presets with no connection yet — "what you could add next".</summary>
+        /// <summary>
+        /// Presets that need no key and no network — the local runners. Always shown, never collapsed, and
+        /// still offered when the hosted catalogue is unreachable. (#739)
+        ///
+        /// <para><b>Not a "popular" section.</b> Its members are chosen by a fact — these work with no
+        /// credential and no internet — rather than by anyone's view of which providers are worth having,
+        /// which would be the ranking #670/#681 removed arriving as a layout decision.</para>
+        /// </summary>
+        public ObservableCollection<AiPresetRowViewModel> LocalPresets { get; } = new();
+
+        /// <summary>
+        /// Everything the catalogue offers, alphabetically. Collapsed until asked for, because ~166 rows
+        /// above the fold is not a list anyone reads.
+        /// </summary>
         public ObservableCollection<AiPresetRowViewModel> AvailablePresets { get; } = new();
 
         /// <summary>True while nothing is configured, so the empty state can say so rather than showing a
@@ -59,6 +76,58 @@ namespace CST.Avalonia.ViewModels
         public bool HasNoConnections => Connections.Count == 0;
 
         public bool HasAvailablePresets => AvailablePresets.Count > 0;
+
+        public bool HasLocalPresets => LocalPresets.Count > 0;
+
+        /// <summary>How many the catalogue offers, so the reader can judge whether to expand before they
+        /// do.</summary>
+        public string CatalogueCount => AvailablePresets.Count == 1
+            ? "1 provider"
+            : $"{AvailablePresets.Count} providers";
+
+        /// <summary>
+        /// Filters the catalogue. Searching also reveals it — a reader who types has asked for the list, and
+        /// making them expand a section first would be a second gesture for one intention.
+        /// </summary>
+        public string PresetSearch
+        {
+            get => _presetSearch;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _presetSearch, value);
+                this.RaisePropertyChanged(nameof(IsCatalogueOpen));
+                Rebind();
+            }
+        }
+
+        public bool IsCatalogueExpanded
+        {
+            get => _isCatalogueExpanded;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _isCatalogueExpanded, value);
+                this.RaisePropertyChanged(nameof(IsCatalogueOpen));
+            }
+        }
+
+        public bool IsCatalogueOpen => IsCatalogueExpanded || !string.IsNullOrWhiteSpace(PresetSearch);
+
+        /// <summary>No attempt has finished yet — said quietly, because it is the ordinary first second of a
+        /// fresh install rather than a problem.</summary>
+        public bool IsCatalogueLoading => _service?.PresetState == AiPresetState.Loading;
+
+        /// <summary>
+        /// The hosted catalogue is missing, and the reader is told so.
+        ///
+        /// <para>An empty section reads as a broken feature; a named failure with a retry reads as weather.
+        /// The local runners and the custom route stay on screen throughout — they need no network, which
+        /// makes them exactly the wrong thing to hide when the network is what failed.</para>
+        /// </summary>
+        public bool HasCatalogueProblem => _service?.PresetState == AiPresetState.Unavailable;
+
+        public string? CatalogueProblem => _service?.PresetProblem;
+
+        public ReactiveCommand<Unit, Unit> RetryCatalogueCommand { get; }
 
         /// <summary>
         /// The sheet, or null while the list is showing.
@@ -170,6 +239,19 @@ namespace CST.Avalonia.ViewModels
             Rebind();
         }
 
+        /// <summary>Matches on the display name and the id — a reader may know a provider by either.</summary>
+        private bool MatchesSearch(AiProviderPreset preset) =>
+            string.IsNullOrWhiteSpace(PresetSearch) ||
+            preset.DisplayName.Contains(PresetSearch, StringComparison.OrdinalIgnoreCase) ||
+            preset.Id.Contains(PresetSearch, StringComparison.OrdinalIgnoreCase);
+
+        private async Task RetryCatalogueAsync()
+        {
+            if (_service is null) return;
+            await _service.RefreshPresetsAsync().ConfigureAwait(true);
+            Rebind();
+        }
+
         private void CloseEditor(bool saved)
         {
             Editor = null;
@@ -210,7 +292,21 @@ namespace CST.Avalonia.ViewModels
                 c => new AiConnectionRowViewModel(this, c),
                 (row, c) => row.Update(c));
 
-            Sync(AvailablePresets, _service.AvailablePresets,
+            // Split by a fact, not by an opinion: a local runner needs no key and no network, which is what
+            // earns it a permanent place above a catalogue that may be neither present nor short.
+            var local = AiProviderPresets.LocalOnly.Select(p => p.Id).ToHashSet(StringComparer.Ordinal);
+
+            Sync(LocalPresets, _service.AvailablePresets.Where(p => local.Contains(p.Id)).ToList(),
+                p => p.Id,
+                r => r.Id,
+                p => new AiPresetRowViewModel(this, p),
+                (row, p) => row.Update(p));
+
+            Sync(AvailablePresets,
+                _service.AvailablePresets
+                    .Where(p => !local.Contains(p.Id))
+                    .Where(MatchesSearch)
+                    .ToList(),
                 p => p.Id,
                 r => r.Id,
                 p => new AiPresetRowViewModel(this, p),
@@ -218,6 +314,11 @@ namespace CST.Avalonia.ViewModels
 
             this.RaisePropertyChanged(nameof(HasNoConnections));
             this.RaisePropertyChanged(nameof(HasAvailablePresets));
+            this.RaisePropertyChanged(nameof(HasLocalPresets));
+            this.RaisePropertyChanged(nameof(CatalogueCount));
+            this.RaisePropertyChanged(nameof(IsCatalogueLoading));
+            this.RaisePropertyChanged(nameof(HasCatalogueProblem));
+            this.RaisePropertyChanged(nameof(CatalogueProblem));
         }
 
         /// <summary>Makes <paramref name="rows"/> match <paramref name="source"/> by key, reusing rows that

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -36,6 +36,7 @@ namespace CST.Avalonia.ViewModels
         private string? _problem;
         private string _presetSearch = "";
         private bool _isCatalogueExpanded;
+        private int _catalogueTotal;
 
         public AiConnectionsViewModel(IAiConnectionService? service, IAiCredentialStore? credentials = null)
         {
@@ -79,11 +80,25 @@ namespace CST.Avalonia.ViewModels
 
         public bool HasLocalPresets => LocalPresets.Count > 0;
 
-        /// <summary>How many the catalogue offers, so the reader can judge whether to expand before they
-        /// do.</summary>
+        /// <summary>
+        /// Whether the hosted catalogue has anything in it at all, <b>before</b> the search filter.
+        ///
+        /// <para>The search box is gated on this rather than on the filtered count, and the distinction is
+        /// not academic: gating on the filtered count meant that typing a string matching nothing hid the
+        /// search box itself, mid-keystroke, leaving no control on screen able to clear the search. The
+        /// catalogue was then gone for the life of the window.</para>
+        /// </summary>
+        public bool HasCatalogue => _catalogueTotal > 0;
+
+        /// <summary>How many the catalogue offers — the filtered count while searching, so the number always
+        /// describes the list beneath it.</summary>
         public string CatalogueCount => AvailablePresets.Count == 1
             ? "1 provider"
             : $"{AvailablePresets.Count} providers";
+
+        /// <summary>A search that matched nothing says so. An empty bordered box is the "broken feature"
+        /// reading this section exists to avoid.</summary>
+        public bool HasNoMatches => HasCatalogue && AvailablePresets.Count == 0;
 
         /// <summary>
         /// Filters the catalogue. Searching also reveals it — a reader who types has asked for the list, and
@@ -114,7 +129,17 @@ namespace CST.Avalonia.ViewModels
 
         /// <summary>No attempt has finished yet — said quietly, because it is the ordinary first second of a
         /// fresh install rather than a problem.</summary>
-        public bool IsCatalogueLoading => _service?.PresetState == AiPresetState.Loading;
+        /// <summary>
+        /// Said only while there is nothing to show.
+        ///
+        /// <para>The source seeds the built-in snapshot before any fetch finishes, so the state is
+        /// <c>Loading</c> over a fully populated list — and a "looking for the provider list" line above 166
+        /// rows contradicts itself. Worse, nothing ever initiates a fetch while the AI master switch is off,
+        /// so that line would otherwise sit there permanently on a tab that is reachable with AI
+        /// disabled.</para>
+        /// </summary>
+        public bool IsCatalogueLoading =>
+            _service?.PresetState == AiPresetState.Loading && !HasCatalogue;
 
         /// <summary>
         /// The hosted catalogue is missing, and the reader is told so.
@@ -125,7 +150,18 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public bool HasCatalogueProblem => _service?.PresetState == AiPresetState.Unavailable;
 
-        public string? CatalogueProblem => _service?.PresetProblem;
+        /// <summary>
+        /// The failure, worded for what is actually on screen.
+        ///
+        /// <para>A failed refresh keeps the previous list, so the service's sentence can end up above a
+        /// catalogue announcing 166 providers — two statements that contradict each other. When something
+        /// survived, this says so instead.</para>
+        /// </summary>
+        public string? CatalogueProblem => !HasCatalogueProblem
+            ? null
+            : HasCatalogue
+                ? "Couldn't refresh the provider list — showing the built-in one."
+                : _service?.PresetProblem;
 
         public ReactiveCommand<Unit, Unit> RetryCatalogueCommand { get; }
 
@@ -240,10 +276,15 @@ namespace CST.Avalonia.ViewModels
         }
 
         /// <summary>Matches on the display name and the id — a reader may know a provider by either.</summary>
-        private bool MatchesSearch(AiProviderPreset preset) =>
-            string.IsNullOrWhiteSpace(PresetSearch) ||
-            preset.DisplayName.Contains(PresetSearch, StringComparison.OrdinalIgnoreCase) ||
-            preset.Id.Contains(PresetSearch, StringComparison.OrdinalIgnoreCase);
+        private bool MatchesSearch(AiProviderPreset preset)
+        {
+            // Trimmed: a trailing space is invisible and would otherwise match nothing at all, which for a
+            // provider that plainly exists reads as the list being broken.
+            var needle = PresetSearch.Trim();
+            return needle.Length == 0 ||
+                preset.DisplayName.Contains(needle, StringComparison.OrdinalIgnoreCase) ||
+                preset.Id.Contains(needle, StringComparison.OrdinalIgnoreCase);
+        }
 
         private async Task RetryCatalogueAsync()
         {
@@ -294,7 +335,12 @@ namespace CST.Avalonia.ViewModels
 
             // Split by a fact, not by an opinion: a local runner needs no key and no network, which is what
             // earns it a permanent place above a catalogue that may be neither present nor short.
-            var local = AiProviderPresets.LocalOnly.Select(p => p.Id).ToHashSet(StringComparer.Ordinal);
+            var local = AiProviderPresets.LocalOnly
+                .Select(p => p.Id)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);   // as the service matches ids
+
+            // Counted BEFORE the search filter — see HasCatalogue.
+            _catalogueTotal = _service.AvailablePresets.Count(p => !local.Contains(p.Id));
 
             Sync(LocalPresets, _service.AvailablePresets.Where(p => local.Contains(p.Id)).ToList(),
                 p => p.Id,
@@ -316,6 +362,8 @@ namespace CST.Avalonia.ViewModels
             this.RaisePropertyChanged(nameof(HasAvailablePresets));
             this.RaisePropertyChanged(nameof(HasLocalPresets));
             this.RaisePropertyChanged(nameof(CatalogueCount));
+            this.RaisePropertyChanged(nameof(HasCatalogue));
+            this.RaisePropertyChanged(nameof(HasNoMatches));
             this.RaisePropertyChanged(nameof(IsCatalogueLoading));
             this.RaisePropertyChanged(nameof(HasCatalogueProblem));
             this.RaisePropertyChanged(nameof(CatalogueProblem));

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -240,8 +240,10 @@
                        IsVisible="{Binding IsCatalogueLoading}"
                        Classes="SettingDescription"/>
 
+            <!-- Gated on the UNFILTERED catalogue: gating on the filtered count hid this box mid-keystroke
+                 the moment a search matched nothing, leaving nothing on screen able to clear it. -->
             <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,8"
-                  IsVisible="{Binding HasAvailablePresets}">
+                  IsVisible="{Binding HasCatalogue}">
                 <TextBox Grid.Column="0" Text="{Binding PresetSearch}"
                          Watermark="Search providers"/>
                 <ToggleButton Grid.Column="1" IsChecked="{Binding IsCatalogueExpanded}"
@@ -252,6 +254,9 @@
             <Border Classes="SettingGroup" Padding="0"
                     IsVisible="{Binding IsCatalogueOpen}">
                 <StackPanel>
+                    <TextBlock Text="No provider matches that."
+                               IsVisible="{Binding HasNoMatches}"
+                               Classes="Secondary" Margin="12,10"/>
                     <ItemsControl ItemsSource="{Binding AvailablePresets}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="vm:AiPresetRowViewModel">

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -177,9 +177,10 @@
                  is unreachable. Chosen by that fact rather than by anyone's view of which providers are worth
                  having — a "popular" section would be the ranking #670/#681 removed, arriving as a layout
                  decision. -->
-            <Border Classes="SettingGroup" Padding="0" IsVisible="{Binding HasLocalPresets}">
+            <Border Classes="SettingGroup" Padding="0">
                 <StackPanel>
-                    <ItemsControl ItemsSource="{Binding LocalPresets}">
+                    <ItemsControl ItemsSource="{Binding LocalPresets}"
+                                  IsVisible="{Binding HasLocalPresets}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="vm:AiPresetRowViewModel">
                                 <Border Classes="Row">

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -173,7 +173,83 @@
             <TextBlock Text="A named provider fills in the address for you. Nothing here is a recommendation — every entry is the same mechanism as a custom endpoint, with its URL already known."
                        Classes="SettingDescription"/>
 
-            <Border Classes="SettingGroup" Padding="0">
+            <!-- These need no key and no network, which is why they sit above the catalogue and stay when it
+                 is unreachable. Chosen by that fact rather than by anyone's view of which providers are worth
+                 having — a "popular" section would be the ranking #670/#681 removed, arriving as a layout
+                 decision. -->
+            <Border Classes="SettingGroup" Padding="0" IsVisible="{Binding HasLocalPresets}">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding LocalPresets}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:AiPresetRowViewModel">
+                                <Border Classes="Row">
+                                    <Grid ColumnDefinitions="Auto,*,Auto">
+                                        <Border Grid.Column="0" Classes="Tile"
+                                                Background="{Binding MonogramTone,
+                                                    Converter={x:Static conv:MonogramToneConverter.Instance}}">
+                                            <TextBlock Text="{Binding Monogram}"/>
+                                        </Border>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                            <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{Binding RequirementText}" Classes="Secondary"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="+ Add"
+                                                Command="{Binding AddCommand}"
+                                                VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Custom last, as OpenCode has it, and always present. The named rows are this same row
+                         with the address filled in; a preset must never be required to reach a provider that
+                         never appears in anyone's catalogue. -->
+                    <Border Classes="Row" BorderThickness="0">
+                        <Grid ColumnDefinitions="Auto,*,Auto">
+                            <Border Grid.Column="0" Classes="Tile"
+                                    Background="{DynamicResource DockApplicationAccentBrushLow}">
+                                <TextBlock Text="+"/>
+                            </Border>
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                <TextBlock Text="Custom endpoint" FontWeight="SemiBold"/>
+                                <TextBlock Text="Any OpenAI-compatible or Anthropic address, by URL."
+                                           Classes="Secondary"/>
+                            </StackPanel>
+                            <Button Grid.Column="2" Content="+ Add"
+                                    Command="{Binding AddCustomCommand}"
+                                    VerticalAlignment="Center"/>
+                        </Grid>
+                    </Border>
+                </StackPanel>
+            </Border>
+
+            <!-- The hosted catalogue. Named when it is missing rather than rendered as an empty section: an
+                 empty list reads as a broken feature, a sentence with a Retry reads as weather. -->
+            <StackPanel IsVisible="{Binding HasCatalogueProblem}" Margin="0,0,0,16">
+                <TextBlock Text="{Binding CatalogueProblem}"
+                           Classes="SettingDescription"
+                           Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                           Margin="0,0,0,6"/>
+                <Button Content="Try again" Command="{Binding RetryCatalogueCommand}"
+                        HorizontalAlignment="Left"/>
+            </StackPanel>
+
+            <TextBlock Text="Looking for the provider list…"
+                       IsVisible="{Binding IsCatalogueLoading}"
+                       Classes="SettingDescription"/>
+
+            <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,8"
+                  IsVisible="{Binding HasAvailablePresets}">
+                <TextBox Grid.Column="0" Text="{Binding PresetSearch}"
+                         Watermark="Search providers"/>
+                <ToggleButton Grid.Column="1" IsChecked="{Binding IsCatalogueExpanded}"
+                              Content="{Binding CatalogueCount}"
+                              Margin="8,0,0,0" VerticalAlignment="Center"/>
+            </Grid>
+
+            <Border Classes="SettingGroup" Padding="0"
+                    IsVisible="{Binding IsCatalogueOpen}">
                 <StackPanel>
                     <ItemsControl ItemsSource="{Binding AvailablePresets}">
                         <ItemsControl.ItemTemplate>
@@ -201,25 +277,6 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <!-- Custom last, as OpenCode has it, and always present. The named rows above are this
-                         same row with the address filled in; a preset must never be required to reach a
-                         provider that never appears in anyone's catalogue. -->
-                    <Border Classes="Row" BorderThickness="0">
-                        <Grid ColumnDefinitions="Auto,*,Auto">
-                            <Border Grid.Column="0" Classes="Tile"
-                                    Background="{DynamicResource DockApplicationAccentBrushLow}">
-                                <TextBlock Text="+"/>
-                            </Border>
-                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
-                                <TextBlock Text="Custom endpoint" FontWeight="SemiBold"/>
-                                <TextBlock Text="Any OpenAI-compatible or Anthropic address, by URL."
-                                           Classes="Secondary"/>
-                            </StackPanel>
-                            <Button Grid.Column="2" Content="+ Add"
-                                    Command="{Binding AddCustomCommand}"
-                                    VerticalAlignment="Center"/>
-                        </Grid>
-                    </Border>
                 </StackPanel>
             </Border>
         </StackPanel>


### PR DESCRIPTION
Closes #739. Unblocked by #737 landing — the section goes from 25 hand-picked entries to ~166 from the
catalogue, and a flat list stops working well below that.

## Two sections, split by a fact rather than an opinion

**Local runners first** — Ollama, LM Studio and the custom-endpoint route — then the catalogue, collapsed
behind a count and a search box.

The split is deliberately **not "popular"**. Its members are chosen because they need **no key and no
network**, which is a property of the thing rather than a view about which providers are worth having. A
popular section would be the ranking deleted in #670/#681 arriving as a layout decision — and OpenCode's own
popular list leads with their first-party products, which is why that is worth saying out loud rather than
assuming nobody would do it.

It also satisfies **[fsnow]**'s requirement that the local runners stay first-class and reachable when the
catalogue is unavailable. They need no network, which makes them exactly the wrong thing to hide when the
network is what failed.

## Search opens the list as well as filtering it

A reader who types has asked for the catalogue; making them expand a section first is a second gesture for one
intention. Matching is on the **id as well as the display name**, since a provider may be known by either —
`togetherai` and "Together AI" both find it.

## A failure is said, not rendered as emptiness

`AiPresetState.Unavailable` shows the service's own sentence and a **Try again** that calls
`RefreshPresetsAsync`. `Loading` says so quietly — it is the ordinary first second of a fresh install, not a
problem. Through both, the local section stays on screen.

An empty section reads as a broken feature; a sentence with a retry reads as weather. The baked-in snapshot
should make this rare, and rare is exactly when an unexplained empty screen costs the most.

## Testing

**7 new tests** — the local/catalogue split, collapsed-by-default with a count, search revealing *and*
filtering, id-matching, a fruitless search leaving the local runners alone, and an added provider still
leaving the catalogue at this scale.

748 targeted AI tests pass, 0 warnings in both projects. One pre-existing test **moved rather than broke**: it
looked for `ollama` in the catalogue, which is now the local section.

## Worth a look in the app

The catalogue is real data from the snapshot, so this is the first time the section has had ~166 rows in it.
Worth checking the collapsed state reads well, and that searching for a provider you know by id rather than
name finds it.

## Not this issue

Logos and the `doc` link are #740, which is waiting on #738.
