### PR TITLE
Fetch provider logos, keeping the monogram as the fallback (#738)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiProviderLogosTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiProviderLogosTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
@@ -62,7 +63,8 @@ public class AiProviderLogosTests : IDisposable
         Assert.Equal(RealLogo, await File.ReadAllBytesAsync(first));
     }
 
-    /// <summary>Asked once per session, not per rebind — the connections list rebinds on every change.</summary>
+    /// <summary>Asked once per settled answer, not per rebind — the connections list rebinds on every
+    /// change.</summary>
     [Fact]
     public async Task A_second_request_does_not_hit_the_network()
     {
@@ -174,6 +176,8 @@ public class AiProviderLogosTests : IDisposable
     [InlineData("my/box")]
     [InlineData("my box")]
     [InlineData("-leading-dash")]
+    [InlineData("openai\n")]     // `$` would have matched before the newline, naming a file that contains one
+    [InlineData("OpenAI")]       // case-sensitive, like the id validators this mirrors
     public async Task An_id_that_is_not_a_slug_is_never_fetched(string id)
     {
         var stub = new Stub(() => Svg(RealLogo));
@@ -214,6 +218,112 @@ public class AiProviderLogosTests : IDisposable
         await logos.GetLogoPathAsync("ollama");
 
         Assert.Equal(1, stub.Calls);
+    }
+
+    /// <summary>
+    /// The one that would have shipped a permanent wrong answer.
+    ///
+    /// <para>A captive portal answers every request with 200 and a login page. Without a content check that
+    /// HTML is written into anthropic.svg and served from disk by every later session, turning a transient
+    /// network condition into a permanent bad cache — the exact failure this class refuses even to remember
+    /// for a session. A non-2xx cannot get this far, because GetByteArrayAsync throws on one.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_captive_portal_login_page_is_not_cached_as_a_logo()
+    {
+        var portal = Encoding.UTF8.GetBytes("<html><body>Sign in to Airport WiFi</body></html>");
+        var logos = Make(new Stub(() => Svg(portal)));
+
+        Assert.Null(await logos.GetLogoPathAsync("anthropic"));
+        Assert.False(File.Exists(Path.Combine(_dir, "anthropic.svg")));
+    }
+
+    /// <summary>And it is not remembered either: the portal is weather, so the next session — or the next
+    /// row — must be free to ask again.</summary>
+    [Fact]
+    public async Task A_non_svg_response_is_retried_rather_than_remembered()
+    {
+        var captive = true;
+        var logos = Make(new Stub(() => captive
+            ? Svg(Encoding.UTF8.GetBytes("<html>portal</html>"))
+            : Svg(RealLogo)));
+
+        Assert.Null(await logos.GetLogoPathAsync("anthropic"));
+
+        captive = false;
+        Assert.NotNull(await logos.GetLogoPathAsync("anthropic"));
+    }
+
+    /// <summary>
+    /// A cache already poisoned — by a release before the check existed, or by a placeholder hash that has
+    /// since drifted — heals rather than serving the bad copy forever.
+    /// </summary>
+    [Fact]
+    public async Task A_poisoned_cache_entry_is_replaced_rather_than_served()
+    {
+        Directory.CreateDirectory(_dir);
+        var poisoned = Path.Combine(_dir, "anthropic.svg");
+        await File.WriteAllBytesAsync(poisoned, Encoding.UTF8.GetBytes("<html>portal</html>"));
+
+        var path = await Make(new Stub(() => Svg(RealLogo))).GetLogoPathAsync("anthropic");
+
+        Assert.NotNull(path);
+        Assert.Equal(RealLogo, await File.ReadAllBytesAsync(path!));
+    }
+
+    /// <summary>Same, for a placeholder that reached the disk before it was recognised.</summary>
+    [Fact]
+    public async Task A_cached_placeholder_is_not_served_as_a_logo()
+    {
+        Directory.CreateDirectory(_dir);
+        await File.WriteAllBytesAsync(Path.Combine(_dir, "ollama.svg"), PlaceholderStandIn);
+
+        Assert.Null(await Make(new Stub(() => Svg(PlaceholderStandIn))).GetLogoPathAsync("ollama"));
+    }
+
+    /// <summary>An XML declaration or a licence comment ahead of the root element is ordinary in a real SVG
+    /// and must not read as "not an SVG".</summary>
+    [Theory]
+    [InlineData("<?xml version=\"1.0\"?><svg/>")]
+    [InlineData("<!-- Copyright --><svg/>")]
+    [InlineData("\n  <svg/>")]
+    [InlineData("<SVG/>")]
+    public async Task A_real_svg_is_recognised_however_it_opens(string body)
+    {
+        var logos = Make(new Stub(() => Svg(Encoding.UTF8.GetBytes(body))));
+
+        Assert.NotNull(await logos.GetLogoPathAsync("anthropic"));
+    }
+
+    /// <summary>The cache directory is documented as safe to delete. Deleting it must cost a refetch, not a
+    /// row bound to a file that has gone.</summary>
+    [Fact]
+    public async Task A_deleted_cache_is_refetched_rather_than_returned()
+    {
+        var logos = Make(new Stub(() => Svg(RealLogo)));
+
+        var first = await logos.GetLogoPathAsync("openrouter");
+        Directory.Delete(_dir, recursive: true);
+
+        var second = await logos.GetLogoPathAsync("openrouter");
+
+        Assert.NotNull(second);
+        Assert.True(File.Exists(second!));
+        Assert.Equal(first, second);
+    }
+
+    /// <summary>Two rows can carry the same id — a preset row and the connection added from it — and load at
+    /// the same moment. Neither may end up on a monogram because the other won a race to the same file.</summary>
+    [Fact]
+    public async Task Concurrent_loads_of_one_id_both_get_the_logo()
+    {
+        var logos = Make(new Stub(() => Svg(RealLogo)));
+
+        var results = await Task.WhenAll(
+            Enumerable.Range(0, 8).Select(_ => Task.Run(() => logos.GetLogoPathAsync("anthropic"))));
+
+        Assert.All(results, r => Assert.NotNull(r));
+        Assert.Empty(Directory.GetFiles(_dir, "*.tmp"));
     }
 
     /// <summary>The measured value, pinned. A wrong constant means placeholders get cached and displayed as

--- a/src/CST.Avalonia.Tests/Services/Ai/AiProviderLogosTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiProviderLogosTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Services.Ai;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// #738: logos are decoration, so every failure means "use the monogram" rather than an error. The subtle
+/// part is that models.dev answers 200 for an unknown provider with a shared placeholder, so status cannot
+/// distinguish a real logo from a stand-in.
+/// </summary>
+public class AiProviderLogosTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cst-738-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    private sealed class Stub : HttpMessageHandler
+    {
+        private readonly Func<HttpResponseMessage> _reply;
+        public int Calls { get; private set; }
+        public Stub(Func<HttpResponseMessage> reply) => _reply = reply;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage r, CancellationToken ct)
+        { Calls++; return Task.FromResult(_reply()); }
+    }
+
+    private static HttpResponseMessage Svg(byte[] body) =>
+        new(HttpStatusCode.OK) { Content = new ByteArrayContent(body) };
+
+    private static byte[] RealLogo => Encoding.UTF8.GetBytes("<svg><circle r='1'/></svg>");
+
+    /// <summary>Stands in for the real models.dev placeholder. Its hash is injected into the service rather
+    /// than the asset being reproduced, so the detection is exercised against bytes the test controls — the
+    /// real hash cannot be searched for, and a test that quietly failed to find it would pass anyway by
+    /// falling into the same null the fallback returns.</summary>
+    private static byte[] PlaceholderStandIn =>
+        Encoding.UTF8.GetBytes("<svg><!-- models.dev default --></svg>");
+
+    private static string Sha256Of(byte[] bytes) =>
+        Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+    private AiProviderLogos Make(HttpMessageHandler handler) =>
+        new(new HttpClient(handler), _dir, "https://example.invalid/logos", Sha256Of(PlaceholderStandIn));
+
+    [Fact]
+    public async Task A_real_logo_is_returned_and_cached()
+    {
+        var stub = new Stub(() => Svg(RealLogo));
+        var logos = Make(stub);
+
+        var first = await logos.GetLogoPathAsync("openrouter");
+
+        Assert.NotNull(first);
+        Assert.True(File.Exists(first!));
+        Assert.Equal(RealLogo, await File.ReadAllBytesAsync(first));
+    }
+
+    /// <summary>Asked once per session, not per rebind — the connections list rebinds on every change.</summary>
+    [Fact]
+    public async Task A_second_request_does_not_hit_the_network()
+    {
+        var stub = new Stub(() => Svg(RealLogo));
+        var logos = Make(stub);
+
+        await logos.GetLogoPathAsync("openrouter");
+        await logos.GetLogoPathAsync("openrouter");
+
+        Assert.Equal(1, stub.Calls);
+    }
+
+    /// <summary>
+    /// The case status codes cannot express. models.dev answers 200 with a shared placeholder for any
+    /// unknown id — Ollama among them, since local runners are not catalogue providers. A generic grey mark
+    /// says less than a coloured initial, so this must read as "no logo".
+    /// </summary>
+    [Fact]
+    public async Task The_shared_placeholder_reads_as_no_logo()
+    {
+        var logos = Make(new Stub(() => Svg(PlaceholderStandIn)));
+
+        Assert.Null(await logos.GetLogoPathAsync("ollama"));
+    }
+
+    /// <summary>And it is never written to disk: caching it would leave a provider that gains a logo next
+    /// month showing nothing until somebody cleared the directory.</summary>
+    [Fact]
+    public async Task The_placeholder_is_not_cached()
+    {
+        var logos = Make(new Stub(() => Svg(PlaceholderStandIn)));
+
+        await logos.GetLogoPathAsync("ollama");
+
+        Assert.False(Directory.Exists(_dir) && Directory.GetFiles(_dir).Length > 0,
+            "a placeholder was written to the cache");
+    }
+
+    [Fact]
+    public async Task A_network_failure_falls_back_to_the_monogram()
+    {
+        var logos = Make(new Stub(() => throw new HttpRequestException("offline")));
+
+        Assert.Null(await logos.GetLogoPathAsync("openrouter"));
+    }
+
+    [Fact]
+    public async Task A_server_error_falls_back_to_the_monogram()
+    {
+        var logos = Make(new Stub(() => new HttpResponseMessage(HttpStatusCode.InternalServerError)));
+
+        Assert.Null(await logos.GetLogoPathAsync("openrouter"));
+    }
+
+    /// <summary>A custom endpoint has no provider id at all, which is the commonest monogram case.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task No_provider_id_means_no_logo(string id)
+    {
+        var logos = Make(new Stub(() => Svg(RealLogo)));
+
+        Assert.Null(await logos.GetLogoPathAsync(id));
+    }
+
+    /// <summary>An already-cached file is served without a request, which is what makes an offline start
+    /// show logos at all.</summary>
+    [Fact]
+    public async Task A_cached_logo_is_used_without_a_request()
+    {
+        Directory.CreateDirectory(_dir);
+        await File.WriteAllBytesAsync(Path.Combine(_dir, "openrouter.svg"), RealLogo);
+        var stub = new Stub(() => throw new HttpRequestException("should not be called"));
+
+        var path = await Make(stub).GetLogoPathAsync("openrouter");
+
+        Assert.NotNull(path);
+        Assert.Equal(0, stub.Calls);
+    }
+
+    /// <summary>MIT asks that the notice accompany copies, and the cache holds copies — on the reader's disk,
+    /// outside the bundle, where nothing else records their origin.</summary>
+    [Fact]
+    public async Task The_licence_lands_beside_the_cached_logos()
+    {
+        await Make(new Stub(() => Svg(RealLogo))).GetLogoPathAsync("openrouter");
+
+        var notice = Path.Combine(_dir, "NOTICE.txt");
+        Assert.True(File.Exists(notice));
+        var text = await File.ReadAllTextAsync(notice);
+        Assert.Contains("MIT License", text);
+        Assert.Contains("models.dev", text);
+    }
+
+    /// <summary>No cached asset, no notice: an empty directory carrying a licence for nothing would be noise.</summary>
+    [Fact]
+    public async Task No_licence_is_written_when_nothing_is_cached()
+    {
+        await Make(new Stub(() => Svg(PlaceholderStandIn))).GetLogoPathAsync("ollama");
+
+        Assert.False(File.Exists(Path.Combine(_dir, "NOTICE.txt")));
+    }
+
+    /// <summary>A connection id is whatever its owner typed, and it becomes both a URL segment and a file
+    /// name. Nothing that is not a slug is asked for, which is what keeps a written file inside the cache.</summary>
+    [Theory]
+    [InlineData("../../etc/passwd")]
+    [InlineData("..")]
+    [InlineData("my/box")]
+    [InlineData("my box")]
+    [InlineData("-leading-dash")]
+    public async Task An_id_that_is_not_a_slug_is_never_fetched(string id)
+    {
+        var stub = new Stub(() => Svg(RealLogo));
+
+        Assert.Null(await Make(stub).GetLogoPathAsync(id));
+        Assert.Equal(0, stub.Calls);
+    }
+
+    /// <summary>
+    /// A failure is about this moment, not about this provider.
+    ///
+    /// <para>Remembering it would mean a reader who opened Settings before their wifi came up sees monograms
+    /// for the rest of the session with no way to ask again.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_failure_is_retried_rather_than_remembered()
+    {
+        var offline = true;
+        var logos = Make(new Stub(() => offline
+            ? throw new HttpRequestException("offline")
+            : Svg(RealLogo)));
+
+        Assert.Null(await logos.GetLogoPathAsync("openrouter"));
+
+        offline = false;
+        Assert.NotNull(await logos.GetLogoPathAsync("openrouter"));
+    }
+
+    /// <summary>Whereas "this provider has no mark" is settled, and asking again would be a request per
+    /// rebind that can only ever get the same answer.</summary>
+    [Fact]
+    public async Task A_definite_absence_is_only_asked_once()
+    {
+        var stub = new Stub(() => Svg(PlaceholderStandIn));
+        var logos = Make(stub);
+
+        await logos.GetLogoPathAsync("ollama");
+        await logos.GetLogoPathAsync("ollama");
+
+        Assert.Equal(1, stub.Calls);
+    }
+
+    /// <summary>The measured value, pinned. A wrong constant means placeholders get cached and displayed as
+    /// though they were logos — quiet, not loud — so only a deliberate edit should be able to change it.
+    /// Re-derive by requesting any provider id that cannot exist.</summary>
+    [Fact]
+    public void The_recorded_placeholder_hash_is_the_measured_one()
+    {
+        Assert.Equal(
+            "13bb0b37c627f6e5961487cd0159abc18dd87ff318668357c7c9990b42e7f32f",
+            AiProviderLogos.PlaceholderSha256);
+    }
+
+    /// <summary>A real logo must not read as the placeholder, or every provider would lose its mark.</summary>
+    [Fact]
+    public void A_real_logo_is_not_mistaken_for_the_placeholder()
+    {
+        Assert.False(AiProviderLogos.IsPlaceholder(RealLogo, Sha256Of(PlaceholderStandIn)));
+        Assert.True(AiProviderLogos.IsPlaceholder(PlaceholderStandIn, Sha256Of(PlaceholderStandIn)));
+    }
+
+    [Fact]
+    public async Task An_empty_body_reads_as_no_logo()
+    {
+        var logos = Make(new Stub(() => Svg(Array.Empty<byte>())));
+
+        Assert.Null(await logos.GetLogoPathAsync("openrouter"));
+    }
+}

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -77,7 +77,7 @@ public class AiConnectionsViewModelTests
             new AiCredentialMethod[] { new AiCredentialMethod.Key() });
 
     /// <summary>An in-memory keychain. The real one would need a Keychain prompt per test.</summary>
-    private sealed class FakeCredentialStore : IAiCredentialStore
+    internal sealed class FakeCredentialStore : IAiCredentialStore
     {
         public Dictionary<string, string> Keys { get; } = new(StringComparer.Ordinal);
         public bool IsAvailable => true;
@@ -703,5 +703,145 @@ public class AiConnectionsViewModelTests
             Assert.InRange(tone, 0, AiMonogram.ToneCount - 1);
             Assert.Equal(tone, AiMonogram.ToneFor(id));
         }
+    }
+}
+
+/// <summary>
+/// #738: a row asks for its provider's logo and falls back to the monogram. The monogram is never removed —
+/// this adds a better first choice on top of a mechanism that has to keep working for custom endpoints,
+/// local runners, and anyone offline.
+/// </summary>
+public class AiConnectionRowLogoTests
+{
+    private sealed class FakeLogos : IAiProviderLogos
+    {
+        private readonly Dictionary<string, string?> _paths;
+        public List<string> Asked { get; } = new();
+
+        public FakeLogos(Dictionary<string, string?>? paths = null) =>
+            _paths = paths ?? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+        public Task<string?> GetLogoPathAsync(string providerId, CancellationToken ct = default)
+        {
+            Asked.Add(providerId);
+            return Task.FromResult(_paths.TryGetValue(providerId, out var p) ? p : null);
+        }
+    }
+
+    private static (AiConnectionsViewModel Vm, AiConnectionService Service) Make(IAiProviderLogos logos)
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var keys = new AiConnectionsViewModelTests.FakeCredentialStore();
+        var service = new AiConnectionService(svc.Object, keys);
+        return (new AiConnectionsViewModel(service, keys, logos), service);
+    }
+
+    /// <summary>Adds through the sheet, which is the only path that produces a connection carrying a preset's
+    /// id — the editor seeds the id from the preset, and the reader may then change it.</summary>
+    private static void AddThroughSheet(AiConnectionsViewModel vm, string presetId, string? id = null)
+    {
+        vm.AddPreset(presetId);
+        var editor = vm.Editor!;
+        if (id is not null) editor.Id = id;
+        editor.ApiKeyEntry = "sk-test";
+        editor.SaveCommand.Execute().Subscribe();
+    }
+
+    /// <summary>The catalogue is the screen where logos matter most, and every row there has a real
+    /// provider id.</summary>
+    [Fact]
+    public async Task A_catalogue_row_shows_the_logo_when_there_is_one()
+    {
+        var logos = new FakeLogos(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            { ["anthropic"] = "/cache/anthropic.svg" });
+        var (vm, _) = Make(logos);
+
+        var row = vm.AvailablePresets.First(p => p.Id == "anthropic");
+        await row.LogoLoad!;
+
+        Assert.Equal("/cache/anthropic.svg", row.LogoPath);
+        Assert.True(row.HasLogo);
+    }
+
+    /// <summary>The fallback, and the ordinary case for a local runner: models.dev has no mark for Ollama, so
+    /// the coloured initial stays.</summary>
+    [Fact]
+    public async Task A_provider_with_no_logo_keeps_its_monogram()
+    {
+        var (vm, _) = Make(new FakeLogos());
+
+        var row = vm.AvailablePresets.First(p => p.Id == "ollama");
+        await row.LogoLoad!;
+
+        Assert.Null(row.LogoPath);
+        Assert.False(row.HasLogo);
+        Assert.False(string.IsNullOrWhiteSpace(row.Monogram));
+    }
+
+    /// <summary>A row must be drawable the instant it is created — the logo arriving later is the design, not
+    /// a race to wait out.</summary>
+    [Fact]
+    public void A_row_starts_on_its_monogram_before_anything_is_fetched()
+    {
+        var (vm, _) = Make(new FakeLogos(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            { ["anthropic"] = "/cache/anthropic.svg" }));
+
+        var row = new AiPresetRowViewModel(vm, AiProviderPresets.All.First(p => p.Id == "anthropic"));
+
+        Assert.False(string.IsNullOrWhiteSpace(row.Monogram));
+    }
+
+    /// <summary>A connection added from the catalogue keeps the preset's id, so its row resolves too.</summary>
+    [Fact]
+    public async Task A_configured_connection_resolves_by_its_id()
+    {
+        var logos = new FakeLogos(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            { ["anthropic"] = "/cache/anthropic.svg" });
+        var (vm, _) = Make(logos);
+
+        AddThroughSheet(vm, "anthropic");
+        var row = vm.Connections.Single();
+        await row.LogoLoad!;
+
+        Assert.Equal("/cache/anthropic.svg", row.LogoPath);
+    }
+
+    /// <summary>A custom endpoint has an id its owner invented, which is no provider's. Nothing is guessed
+    /// from it: showing one vendor's mark on another's row would be worse than showing a letter.</summary>
+    [Fact]
+    public async Task A_custom_connection_falls_back_rather_than_guessing()
+    {
+        var logos = new FakeLogos(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            { ["anthropic"] = "/cache/anthropic.svg" });
+        var (vm, service) = Make(logos);
+
+        service.Add("anthropic-work", new AiConnectionDraft(
+            "Anthropic (work)", ChatProviderKind.OpenAiCompatible, "http://localhost:8000/v1",
+            Array.Empty<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>()));
+        var row = vm.Connections.Single();
+        await row.LogoLoad!;
+
+        Assert.Equal("anthropic-work", row.Id);
+        Assert.Null(row.LogoPath);
+    }
+
+    /// <summary>Constructed without a resolver — the designer, and every test that predates this — must still
+    /// work rather than throw.</summary>
+    [Fact]
+    public void With_no_resolver_a_row_is_simply_a_monogram()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object, new AiConnectionsViewModelTests.FakeCredentialStore());
+
+        var vm = new AiConnectionsViewModel(service);
+        var row = vm.AvailablePresets.First();
+
+        Assert.Null(row.LogoLoad);
+        Assert.Null(row.LogoPath);
+        Assert.False(string.IsNullOrWhiteSpace(row.Monogram));
     }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -772,7 +772,9 @@ public class AiConnectionRowLogoTests
     {
         var (vm, _) = Make(new FakeLogos());
 
-        var row = vm.AvailablePresets.First(p => p.Id == "ollama");
+        // In LocalPresets, not the catalogue: #739 split the local runners out, and they are exactly the rows
+        // models.dev has no mark for.
+        var row = vm.LocalPresets.First(p => p.Id == "ollama");
         await row.LogoLoad!;
 
         Assert.Null(row.LogoPath);
@@ -780,17 +782,56 @@ public class AiConnectionRowLogoTests
         Assert.False(string.IsNullOrWhiteSpace(row.Monogram));
     }
 
-    /// <summary>A row must be drawable the instant it is created — the logo arriving later is the design, not
-    /// a race to wait out.</summary>
+    /// <summary>
+    /// A row must be drawable the instant it is created — the logo arriving later is the design, not a race
+    /// to wait out.
+    ///
+    /// <para>The resolver here never completes, which is the point: with a fake that answers synchronously
+    /// there is no "before" to observe, and this test passed while asserting nothing. (fable review)</para>
+    /// </summary>
     [Fact]
-    public void A_row_starts_on_its_monogram_before_anything_is_fetched()
+    public void A_row_starts_on_its_monogram_while_the_logo_is_still_coming()
     {
-        var (vm, _) = Make(new FakeLogos(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
-            { ["anthropic"] = "/cache/anthropic.svg" }));
+        var pending = new TaskCompletionSource<string?>();
+        var (vm, _) = Make(new PendingLogos(pending.Task));
 
-        var row = new AiPresetRowViewModel(vm, AiProviderPresets.All.First(p => p.Id == "anthropic"));
+        var row = vm.AvailablePresets.First(p => p.Id == "anthropic");
 
+        Assert.False(row.LogoLoad!.IsCompleted);   // genuinely still in flight
+        Assert.Null(row.LogoPath);
+        Assert.False(row.HasLogo);
         Assert.False(string.IsNullOrWhiteSpace(row.Monogram));
+
+        pending.SetResult("/cache/anthropic.svg");
+    }
+
+    /// <summary>And it swaps once the logo does arrive, without the row being rebuilt.</summary>
+    [Fact]
+    public async Task The_logo_replaces_the_monogram_when_it_arrives()
+    {
+        var pending = new TaskCompletionSource<string?>();
+        var (vm, _) = Make(new PendingLogos(pending.Task));
+        var row = vm.AvailablePresets.First(p => p.Id == "anthropic");
+
+        var changed = new List<string>();
+        row.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        pending.SetResult("/cache/anthropic.svg");
+        await row.LogoLoad!;
+
+        Assert.Equal("/cache/anthropic.svg", row.LogoPath);
+        Assert.True(row.HasLogo);
+        Assert.Contains(nameof(AiLogoRowViewModel.LogoPath), changed);
+        Assert.Contains(nameof(AiLogoRowViewModel.HasLogo), changed);
+    }
+
+    /// <summary>A resolver that never answers must not leave the row bound to nothing — the monogram is
+    /// already what is on screen.</summary>
+    private sealed class PendingLogos : IAiProviderLogos
+    {
+        private readonly Task<string?> _pending;
+        public PendingLogos(Task<string?> pending) => _pending = pending;
+        public Task<string?> GetLogoPathAsync(string providerId, CancellationToken ct = default) => _pending;
     }
 
     /// <summary>A connection added from the catalogue keeps the preset's id, so its row resolves too.</summary>

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1365,6 +1365,10 @@ public partial class App : Application
         // list and the load gate, and the connection service subscribes to its change event.
         services.AddSingleton<Services.Ai.IAiPresetSource, Services.Ai.AiPresetSource>();
 
+        // Provider logos (#738). Singleton so the per-session "this provider has none" answers are shared;
+        // the disk cache lives under cache/provider-logos.
+        services.AddSingleton<Services.Ai.IAiProviderLogos>(_ => new Services.Ai.AiProviderLogos());
+
         // Asking a connection what models it offers (#674). Additive to the hand-typed list, never a
         // prerequisite: an endpoint that publishes no listing stays fully usable, so a failure here is
         // reported and nothing more.

--- a/src/CST.Avalonia/Services/Ai/AiProviderLogos.cs
+++ b/src/CST.Avalonia/Services/Ai/AiProviderLogos.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Constants;
+using Serilog;
+
+namespace CST.Avalonia.Services.Ai
+{
+    public interface IAiProviderLogos
+    {
+        /// <summary>
+        /// The path to a cached SVG for this provider, or null when it has none and the caller should fall
+        /// back to the monogram. Never throws.
+        /// </summary>
+        Task<string?> GetLogoPathAsync(string providerId, CancellationToken ct = default);
+    }
+
+    /// <summary>
+    /// Provider logos from models.dev, cached on disk, with the monogram as the fallback. (#738)
+    ///
+    /// <para><b>Why this exists.</b> Logos were deferred to coloured monogram tiles for want of an asset
+    /// source, and shipping third-party marks raised a licensing question. models.dev answers both:
+    /// per-provider SVGs at <c>/logos/{id}.svg</c>, keyed by the same id we already use, MIT.</para>
+    ///
+    /// <para><b>A missing logo returns 200, not 404.</b> models.dev serves a default placeholder for any
+    /// unknown id — measured byte-identical across ids (1,421 bytes, one hash) — so status cannot tell a real
+    /// logo from a stand-in. The placeholder is recognised by hash and reported as "no logo", because a
+    /// generic grey mark says less than a coloured initial does. Ollama returns the placeholder, which is the
+    /// case that matters: local runners are not catalogue providers and never will be.</para>
+    ///
+    /// <para><b>The placeholder is never cached.</b> Caching it would leave a provider that gains a logo
+    /// next month showing nothing until somebody cleared the directory.</para>
+    /// </summary>
+    public sealed class AiProviderLogos : IAiProviderLogos
+    {
+        internal const string DefaultSource = "https://models.dev/logos";
+
+        internal const string NoticeFile = "NOTICE.txt";
+
+        /// <summary>
+        /// Written beside the cached SVGs. MIT asks that the notice accompany copies, and these files are
+        /// copies — sitting on the reader's disk, outside the app bundle, where nothing else would say where
+        /// they came from or under what terms.
+        ///
+        /// <para>Each mark also remains its owner's; showing a company's logo to label that company's own
+        /// service is the ordinary use, and no other use is made of them here.</para>
+        /// </summary>
+        internal const string NoticeText = """
+            Provider logos in this directory are from models.dev (https://models.dev),
+            fetched on demand and cached here. They are re-fetched if deleted.
+
+            MIT License
+
+            Copyright (c) 2025 models.dev
+
+            Permission is hereby granted, free of charge, to any person obtaining a copy
+            of this software and associated documentation files (the "Software"), to deal
+            in the Software without restriction, including without limitation the rights
+            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+            copies of the Software, and to permit persons to whom the Software is
+            furnished to do so, subject to the following conditions:
+
+            The above copyright notice and this permission notice shall be included in all
+            copies or substantial portions of the Software.
+
+            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+            SOFTWARE.
+
+            Each provider's mark remains the property of its owner.
+            """;
+
+        /// <summary>
+        /// SHA-256 of the placeholder models.dev returns for an unknown provider, measured 2026-08-19
+        /// (1,421 bytes; identical for <c>ollama</c> and for ids that cannot exist).
+        ///
+        /// <para>If upstream changes it, the effect is a placeholder cached and shown as though it were a
+        /// logo — mildly wrong, not broken — and the hash is re-derivable by requesting any id that cannot
+        /// exist. Recorded rather than probed at runtime so no request is spent discovering it.</para>
+        /// </summary>
+        internal const string PlaceholderSha256 =
+            "13bb0b37c627f6e5961487cd0159abc18dd87ff318668357c7c9990b42e7f32f";
+
+        private readonly HttpClient _http;
+        private readonly string _cacheDirectory;
+        private readonly string _source;
+        private readonly string _placeholderHash;
+
+        /// <summary>Ids already looked up this session, so a provider with no logo is asked for once rather
+        /// than on every rebind.</summary>
+        private readonly ConcurrentDictionary<string, string?> _resolved = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <param name="placeholderSha256">The hash treated as "this provider has no logo". Overridable only
+        /// so tests can exercise the detection against bytes they control — no caller should pass it.</param>
+        public AiProviderLogos(
+            HttpClient? http = null,
+            string? cacheDirectory = null,
+            string? source = null,
+            string? placeholderSha256 = null)
+        {
+            _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+
+            // Under cache/, not beside application-state.json: these are purely derived and re-fetchable, so
+            // deleting the directory should cost a refetch and nothing else.
+            _cacheDirectory = cacheDirectory
+                ?? Path.Combine(AppConstants.DataDirectory, "cache", "provider-logos");
+            _source = source ?? DefaultSource;
+            _placeholderHash = placeholderSha256 ?? PlaceholderSha256;
+        }
+
+        public async Task<string?> GetLogoPathAsync(string providerId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(providerId)) return null;
+
+            // A connection id is whatever its owner typed, and it reaches here as both a URL segment and a
+            // file name. models.dev's own ids are slugs (#737 rejects anything else), so anything that is not
+            // one cannot have a logo anyway - and refusing it here is what stops "../../.." from naming a file
+            // outside the cache.
+            if (!SlugPattern.IsMatch(providerId)) return null;
+
+            if (_resolved.TryGetValue(providerId, out var known)) return known;
+
+            try
+            {
+                var path = Path.Combine(_cacheDirectory, providerId + ".svg");
+                if (File.Exists(path))
+                {
+                    _resolved[providerId] = path;
+                    return path;
+                }
+
+                var bytes = await _http.GetByteArrayAsync($"{_source}/{providerId}.svg", ct)
+                    .ConfigureAwait(false);
+
+                // A definite answer, unlike the catch below: this provider has no mark, so remember it and
+                // stop asking.
+                if (bytes.Length == 0 || IsPlaceholder(bytes, _placeholderHash))
+                {
+                    _resolved[providerId] = null;
+                    return null;
+                }
+
+                Directory.CreateDirectory(_cacheDirectory);
+                WriteNoticeOnce();
+
+                // Temp-then-rename: a process killed mid-write must not leave a truncated SVG that every
+                // later start reads as a valid cached logo.
+                var tmp = path + ".tmp";
+                await File.WriteAllBytesAsync(tmp, bytes, ct).ConfigureAwait(false);
+                File.Move(tmp, path, overwrite: true);
+
+                _resolved[providerId] = path;
+                return path;
+            }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                // A logo is decoration. Offline, a 500, an unwritable directory - all mean "use the
+                // monogram", which is what the UI already does for a custom endpoint with no provider id.
+                //
+                // Deliberately NOT remembered. A failure says nothing about whether this provider has a logo,
+                // only about this moment; recording it would mean a reader who opened Settings before their
+                // wifi came up sees monograms for the rest of the session, with no way to ask again. The
+                // retry cost is bounded by the rows themselves, which ask once each.
+                Log.Debug(ex, "No logo for {Provider} right now; falling back to the monogram (#738)", providerId);
+                return null;
+            }
+        }
+
+        private static readonly Regex SlugPattern =
+            new("^[a-z0-9][a-z0-9_-]*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>Puts the licence beside the first cached logo. Rewritten if deleted, never overwritten
+        /// when already present, and a failure to write it must not cost the reader a logo.</summary>
+        private void WriteNoticeOnce()
+        {
+            try
+            {
+                var notice = Path.Combine(_cacheDirectory, NoticeFile);
+                if (!File.Exists(notice)) File.WriteAllText(notice, NoticeText);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "Could not write the logo licence notice (#738)");
+            }
+        }
+
+        /// <summary>
+        /// Whether these bytes are the shared placeholder rather than a provider's own mark.
+        ///
+        /// <para>Compared by content hash rather than by byte count: two real logos could coincidentally
+        /// share a length, and the placeholder's own size is not a promise.</para>
+        /// </summary>
+        internal static bool IsPlaceholder(byte[] bytes, string? expectedSha256 = null)
+        {
+            var hash = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+            return string.Equals(hash, expectedSha256 ?? PlaceholderSha256, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/AiProviderLogos.cs
+++ b/src/CST.Avalonia/Services/Ai/AiProviderLogos.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,7 +16,11 @@ namespace CST.Avalonia.Services.Ai
     {
         /// <summary>
         /// The path to a cached SVG for this provider, or null when it has none and the caller should fall
-        /// back to the monogram. Never throws.
+        /// back to the monogram.
+        ///
+        /// <para>No failure surfaces as an exception — offline, a 500, an unwritable directory all return
+        /// null. The one exception that does escape is cancellation of <paramref name="ct"/>, which is the
+        /// caller's own doing rather than a fault to report.</para>
         /// </summary>
         Task<string?> GetLogoPathAsync(string providerId, CancellationToken ct = default);
     }
@@ -95,9 +100,15 @@ namespace CST.Avalonia.Services.Ai
         private readonly string _source;
         private readonly string _placeholderHash;
 
-        /// <summary>Ids already looked up this session, so a provider with no logo is asked for once rather
-        /// than on every rebind.</summary>
-        private readonly ConcurrentDictionary<string, string?> _resolved = new(StringComparer.OrdinalIgnoreCase);
+        /// <summary>
+        /// Ids already settled this session, so a provider with no mark is asked for once rather than on
+        /// every rebind.
+        ///
+        /// <para>Per row, not globally serialised: two rows carrying the same id can both be in flight before
+        /// either records an answer, which costs a duplicate request and nothing else. Not worth a lock —
+        /// the outcome is identical and the writers no longer collide.</para>
+        /// </summary>
+        private readonly ConcurrentDictionary<string, string?> _resolved = new(StringComparer.Ordinal);
 
         /// <param name="placeholderSha256">The hash treated as "this provider has no logo". Overridable only
         /// so tests can exercise the detection against bytes they control — no caller should pass it.</param>
@@ -107,7 +118,9 @@ namespace CST.Avalonia.Services.Ai
             string? source = null,
             string? placeholderSha256 = null)
         {
-            _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+            // 30s to match ModelsDevCatalog rather than pick a second number for the same host. Nothing waits
+            // on this - a row draws its monogram immediately and swaps only if a logo arrives.
+            _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
 
             // Under cache/, not beside application-state.json: these are purely derived and re-fetchable, so
             // deleting the directory should cost a refetch and nothing else.
@@ -127,25 +140,60 @@ namespace CST.Avalonia.Services.Ai
             // outside the cache.
             if (!SlugPattern.IsMatch(providerId)) return null;
 
-            if (_resolved.TryGetValue(providerId, out var known)) return known;
+            // A remembered absence is final; a remembered path is only good while the file is still there,
+            // since the cache directory is documented as safe to delete and a row would otherwise bind to a
+            // file that has gone.
+            if (_resolved.TryGetValue(providerId, out var known)
+                && (known is null || File.Exists(known)))
+            {
+                return known;
+            }
 
             try
             {
                 var path = Path.Combine(_cacheDirectory, providerId + ".svg");
                 if (File.Exists(path))
                 {
-                    _resolved[providerId] = path;
-                    return path;
+                    // Re-checked rather than trusted. A file already on disk may have been written by an
+                    // earlier release whose placeholder hash had drifted, or by a captive portal before the
+                    // sniff below existed; re-reading is what lets a later release heal a poisoned cache
+                    // instead of serving the bad copy forever. These are ~1 KB files.
+                    var cached = await File.ReadAllBytesAsync(path, ct).ConfigureAwait(false);
+                    if (LooksLikeSvg(cached) && !IsPlaceholder(cached, _placeholderHash))
+                    {
+                        _resolved[providerId] = path;
+                        return path;
+                    }
+
+                    File.Delete(path);
                 }
 
                 var bytes = await _http.GetByteArrayAsync($"{_source}/{providerId}.svg", ct)
                     .ConfigureAwait(false);
 
-                // A definite answer, unlike the catch below: this provider has no mark, so remember it and
-                // stop asking.
-                if (bytes.Length == 0 || IsPlaceholder(bytes, _placeholderHash))
+                // A definite answer, unlike the two below: models.dev says this provider has no mark, so
+                // remember it and stop asking.
+                if (IsPlaceholder(bytes, _placeholderHash))
                 {
                     _resolved[providerId] = null;
+                    return null;
+                }
+
+                // Not an answer at all, and NOT written to disk.
+                //
+                // GetByteArrayAsync throws on a non-2xx, so an error page with an error status can never get
+                // here - but a captive portal answers every request with 200 and a login page. Without this,
+                // one hotel wifi writes HTML into anthropic.svg and every later session serves it from disk
+                // without a request. That would make a transient network condition into a permanent wrong
+                // answer, which is precisely the failure this class refuses even to remember for a session.
+                //
+                // An empty body is treated the same way: at least as plausibly a proxy artefact as a
+                // deliberate "no mark", and models.dev states the latter with the placeholder.
+                if (!LooksLikeSvg(bytes))
+                {
+                    Log.Debug(
+                        "Ignoring a {Bytes}-byte non-SVG response for {Provider}'s logo (#738)",
+                        bytes.Length, providerId);
                     return null;
                 }
 
@@ -154,9 +202,23 @@ namespace CST.Avalonia.Services.Ai
 
                 // Temp-then-rename: a process killed mid-write must not leave a truncated SVG that every
                 // later start reads as a valid cached logo.
-                var tmp = path + ".tmp";
-                await File.WriteAllBytesAsync(tmp, bytes, ct).ConfigureAwait(false);
-                File.Move(tmp, path, overwrite: true);
+                //
+                // The temp name is unique PER CALL, not per process: a preset row and the connection added
+                // from it carry the same id and can load at the same moment, on two threads of one process.
+                // With any shared name the loser's Move finds its own file already gone, fails, and leaves
+                // that row on the monogram for the session - measured at 7 of 8 concurrent callers.
+                var tmp = $"{path}.{Guid.NewGuid():N}.tmp";
+                try
+                {
+                    await File.WriteAllBytesAsync(tmp, bytes, ct).ConfigureAwait(false);
+                    File.Move(tmp, path, overwrite: true);
+                }
+                catch
+                {
+                    // Litter outlives the process otherwise, and nothing sweeps the directory.
+                    try { File.Delete(tmp); } catch { /* nothing further to try */ }
+                    throw;
+                }
 
                 _resolved[providerId] = path;
                 return path;
@@ -175,8 +237,40 @@ namespace CST.Avalonia.Services.Ai
             }
         }
 
+        /// <summary>
+        /// The same rule as <c>AiPresetSource</c> and <c>AiConnectionService</c> — case-SENSITIVE, because
+        /// those are, and a resolver that accepted more than the id validators do would be the odd one out
+        /// for no reason. Case-insensitivity also let "OpenAI" record an absence that "openai" then read,
+        /// hiding a real provider's logo for the session.
+        ///
+        /// <para><c>\z</c> rather than <c>$</c>: <c>$</c> matches before a trailing newline, so "openai\n"
+        /// passed as a slug and named a file with a newline in it.</para>
+        /// </summary>
         private static readonly Regex SlugPattern =
-            new("^[a-z0-9][a-z0-9_-]*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            new(@"^[a-z0-9][a-z0-9_-]*\z", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Whether these bytes open like an SVG document.
+        ///
+        /// <para>A prefix sniff rather than a parse: the question is only "did a network answer this with
+        /// something that is not the file we asked for", and every real answer starts with an XML declaration,
+        /// a doctype, a comment, or the root element.</para>
+        /// </summary>
+        internal static bool LooksLikeSvg(byte[] bytes)
+        {
+            if (bytes.Length == 0) return false;
+
+            // Enough for a declaration and any leading whitespace; a BOM is skipped by the decoder.
+            var head = Encoding.UTF8.GetString(bytes, 0, Math.Min(bytes.Length, 200)).TrimStart('\uFEFF');
+            var i = 0;
+            while (i < head.Length && char.IsWhiteSpace(head[i])) i++;
+            head = head[i..];
+
+            return head.StartsWith("<svg", StringComparison.OrdinalIgnoreCase)
+                || head.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase)
+                || head.StartsWith("<!--", StringComparison.Ordinal)
+                || head.StartsWith("<!DOCTYPE svg", StringComparison.OrdinalIgnoreCase);
+        }
 
         /// <summary>Puts the licence beside the first cached logo. Rewritten if deleted, never overwritten
         /// when already present, and a failure to write it must not cost the reader a logo.</summary>

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
 using System.Threading.Tasks;
+using Avalonia.Threading;
 using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services.Ai;
 using ReactiveUI;
@@ -32,16 +33,21 @@ namespace CST.Avalonia.ViewModels
     {
         private readonly IAiConnectionService? _service;
         private readonly IAiCredentialStore? _credentials;
+        private readonly IAiProviderLogos? _logos;
         private AiConnectionEditorViewModel? _editor;
         private string? _problem;
         private string _presetSearch = "";
         private bool _isCatalogueExpanded;
         private int _catalogueTotal;
 
-        public AiConnectionsViewModel(IAiConnectionService? service, IAiCredentialStore? credentials = null)
+        public AiConnectionsViewModel(
+            IAiConnectionService? service,
+            IAiCredentialStore? credentials = null,
+            IAiProviderLogos? logos = null)
         {
             _service = service;
             _credentials = credentials;
+            _logos = logos;
 
             AddCustomCommand = ReactiveCommand.Create(AddCustom);
             RetryCatalogueCommand = ReactiveCommand.CreateFromTask(RetryCatalogueAsync);
@@ -52,6 +58,10 @@ namespace CST.Avalonia.ViewModels
                 Rebind();
             }
         }
+
+        /// <summary>The logo resolver the rows use, or null when logos are unavailable — in tests, and
+        /// wherever this view model is constructed without one. (#738)</summary>
+        internal IAiProviderLogos? Logos => _logos;
 
         /// <summary>What is configured now, in the order the reader added it.</summary>
         public ObservableCollection<AiConnectionRowViewModel> Connections { get; } = new();
@@ -402,8 +412,75 @@ namespace CST.Avalonia.ViewModels
         }
     }
 
+    /// <summary>
+    /// The logo half of a row. (#738)
+    ///
+    /// <para>Shared by both row kinds because they want identical behaviour: start on the monogram, ask for a
+    /// logo once, and switch only if one arrives. Nothing here decides how a logo is drawn — size, shape and
+    /// placement are the view's.</para>
+    /// </summary>
+    public abstract class AiLogoRowViewModel : ViewModelBase
+    {
+        private string? _logoPath;
+        private bool _asked;
+
+        /// <summary>The models.dev provider id, or null for a row that has no provider behind it — a custom
+        /// endpoint, where the monogram is the only honest mark.</summary>
+        protected abstract string? ProviderId { get; }
+
+        /// <summary>A cached SVG on disk, or null while none is known. Null is the ordinary case, not a
+        /// failure: it means <see cref="Monogram"/> is what to draw.</summary>
+        public string? LogoPath
+        {
+            get => _logoPath;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _logoPath, value);
+                this.RaisePropertyChanged(nameof(HasLogo));
+            }
+        }
+
+        public bool HasLogo => !string.IsNullOrEmpty(LogoPath);
+
+        public abstract string Monogram { get; }
+
+        public abstract int MonogramTone { get; }
+
+        /// <summary>The in-flight lookup, so a test can await what the constructor started.</summary>
+        internal Task? LogoLoad { get; private set; }
+
+        /// <summary>
+        /// Asks for the logo, once per row.
+        ///
+        /// <para>Started and not awaited on purpose: a row must draw immediately with its monogram rather than
+        /// wait on a network call, and the logo replacing it a moment later is the intended sequence. Awaiting
+        /// it would put a settings pane behind an HTTP request.</para>
+        /// </summary>
+        protected void LoadLogo(IAiProviderLogos? logos)
+        {
+            if (_asked || logos is null) return;
+            _asked = true;
+
+            var id = ProviderId;
+            if (string.IsNullOrWhiteSpace(id)) return;
+
+            LogoLoad = ApplyLogoAsync(logos, id!);
+        }
+
+        private async Task ApplyLogoAsync(IAiProviderLogos logos, string id)
+        {
+            var path = await logos.GetLogoPathAsync(id);
+            if (path is null) return;   // no logo: the monogram already on screen is the answer
+
+            // Same shape as the service's change event: set directly when already on the UI thread, post when
+            // the fetch resumed on a pool thread. A property change raised off-thread reaches a binding.
+            if (Dispatcher.UIThread.CheckAccess()) LogoPath = path;
+            else Dispatcher.UIThread.Post(() => LogoPath = path);
+        }
+    }
+
     /// <summary>One configured endpoint, as a row in "Your connections". (#691)</summary>
-    public class AiConnectionRowViewModel : ViewModelBase
+    public class AiConnectionRowViewModel : AiLogoRowViewModel
     {
         private readonly AiConnectionsViewModel _owner;
         private AiConnection _connection;
@@ -419,7 +496,19 @@ namespace CST.Avalonia.ViewModels
             DeleteCommand = ReactiveCommand.Create(() => { IsConfirmingDelete = true; });
             ConfirmDeleteCommand = ReactiveCommand.Create(() => _owner.Delete(Id));
             CancelDeleteCommand = ReactiveCommand.Create(() => { IsConfirmingDelete = false; });
+
+            LoadLogo(owner.Logos);
         }
+
+        /// <summary>
+        /// The connection id, which is the provider id for a connection added from the catalogue — the editor
+        /// seeds it from the preset.
+        ///
+        /// <para>A reader who renames it, or adds a second connection to the same provider, gets the monogram
+        /// instead. The connection does not record which preset it came from, and guessing from a renamed id
+        /// would show one provider's mark on another's row — a wrong logo is worse than a letter.</para>
+        /// </summary>
+        protected override string? ProviderId => _connection.Id;
 
         public string Id => _connection.Id;
 
@@ -434,9 +523,9 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public string Endpoint => _connection.ResolvedBaseUrl;
 
-        public string Monogram => AiMonogram.For(DisplayName);
+        public override string Monogram => AiMonogram.For(DisplayName);
 
-        public int MonogramTone => AiMonogram.ToneFor(Id);
+        public override int MonogramTone => AiMonogram.ToneFor(Id);
 
         public int ModelCount => _connection.Models.Count;
 
@@ -551,7 +640,7 @@ namespace CST.Avalonia.ViewModels
     }
 
     /// <summary>One named endpoint in "Add a provider". (#691)</summary>
-    public class AiPresetRowViewModel : ViewModelBase
+    public class AiPresetRowViewModel : AiLogoRowViewModel
     {
         private readonly AiConnectionsViewModel _owner;
         private AiProviderPreset _preset;
@@ -562,15 +651,20 @@ namespace CST.Avalonia.ViewModels
             _preset = preset;
 
             AddCommand = ReactiveCommand.Create(() => _owner.AddPreset(Id));
+
+            LoadLogo(owner.Logos);
         }
 
         public string Id => _preset.Id;
 
+        /// <summary>Always a real provider id: the catalogue is built from models.dev.</summary>
+        protected override string? ProviderId => _preset.Id;
+
         public string DisplayName => _preset.DisplayName;
 
-        public string Monogram => AiMonogram.For(DisplayName);
+        public override string Monogram => AiMonogram.For(DisplayName);
 
-        public int MonogramTone => AiMonogram.ToneFor(Id);
+        public override int MonogramTone => AiMonogram.ToneFor(Id);
 
         /// <summary>
         /// The only thing a row says beyond the provider's name.

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1369,7 +1369,8 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
             // by hand; a null service leaves the tab inert rather than throwing, which is what the
             // parameterless constructor used by the designer needs.
             var connectionService = App.TryGetService<Services.Ai.IAiConnectionService>();
-            Connections = new AiConnectionsViewModel(connectionService, credentials);
+            Connections = new AiConnectionsViewModel(
+                connectionService, credentials, App.TryGetService<Services.Ai.IAiProviderLogos>());
             Models = new AiModelsViewModel(
                 connectionService, App.TryGetService<Services.Ai.IAiModelCatalog>());
 


### PR DESCRIPTION
Closes #738. Last backend piece of #733; unblocks the logo half of #691.

## What

`AiProviderLogos` — fetch on demand per provider, cache to disk, and hand the UI a path or null. Null is the ordinary answer, not a failure: it means the monogram already on screen is what to draw.

## The part that is not obvious

**A missing logo returns 200, not 404.** models.dev serves a shared placeholder for any unknown id, so a status check would cache a grey stand-in for every provider without a mark. Measured byte-identical (1,421 bytes, sha256 `13bb0b37c627…`) across `definitely-not-a-provider`, `another-fake-xyz` and — the one that matters — `ollama`. It is recognised by content hash, and local runners keep their monogram exactly as #738 asked.

The hash is recorded as a pinned constant rather than probed at runtime, with a test pinning it. If upstream changes it the effect is a placeholder shown as though it were a logo — quiet rather than loud — which is why it is pinned.

## Two caching decisions

- **The placeholder is never written.** Caching it leaves a provider that gains a logo next month showing nothing until somebody clears the directory.
- **A failure is not remembered; a definite absence is.** A failed fetch says nothing about the provider, only about the moment. Remembering it would mean a reader who opened Settings before their wifi came up sees monograms for the rest of the session with no way to ask again. "This provider has no mark" is settled, so that one is remembered and stops asking.

## Where it caches

`~/Library/Application Support/CSTReader/cache/provider-logos/`, under `cache/` rather than beside `application-state.json` — these are purely derived, so deleting the directory should cost a refetch and nothing else. ~170 files at 355–1,421 bytes, fetched on demand rather than up front.

The MIT notice is written in beside the copies, which is where MIT asks for it. #746 (raised by @fsnow) tracks an About box, where a reader would actually see the acknowledgement.

## Hardening

Ids are slug-validated before use. A **connection** id is whatever its owner typed and it reaches the resolver as both a URL segment and a file name; the slug rule matches #737's and is what stops `../../..` from naming a file outside the cache.

## Binding surface

`LogoPath` and `HasLogo` on both row kinds, beside the existing `Monogram`/`MonogramTone`. Nothing here sizes, shapes or places a logo — that is the UI issues'.

A measured note that came out of writing the tests: **a connection added from the catalogue always carries the preset's id**, because `Save` routes preset adds through `AddFromPreset(_preset.Id, …)` and ignores the editor's id box. So those rows resolve reliably. A custom endpoint's id is no provider's; that row gets the monogram and nothing is guessed from it.

## ⚠️ The UI cannot consume this yet

**The app has no SVG renderer.** No `Avalonia.Svg.Skia`/`Svg.Skia` reference in any csproj, and Avalonia's `Image` takes a `Bitmap`. models.dev publishes only SVG, so displaying these means adding a rendering dependency — a dependency decision, so flagged rather than made here. Options and detail in https://github.com/fsnow/cst/issues/738#issuecomment-5346336212. The resolver degrades to the monogram on every path, so nothing is broken while this is undecided.

## Tests

21 new on the resolver, 6 on the rows. Full suite **2158 passed, 0 failed**.

The two placeholder tests were mutation-checked: with the detection removed they both fail. They needed it — a first draft that brute-forced the real hash passed while never finding it, because the resulting exception fell into the same `null` the fallback returns.