### PR TITLE
Render cached provider logos with Avalonia.Svg.Skia (#748)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiLogoImagesTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiLogoImagesTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.Text;
+using Avalonia.Media;
+using CST.Avalonia.Services.Ai;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// #748: what may be handed to the SVG renderer.
+///
+/// <para>Rendering itself is not covered here: it needs Avalonia's rendering stack, and building an
+/// <c>SvgImage</c> is thread-affine. The screening in front of it is plain file-and-string work, and is where
+/// the consequential decisions live, so that is what these cover. The render path was verified in the running
+/// app by rasterising to a bitmap and sampling pixels; see the PR.</para>
+///
+/// <para><b>The thread guard is not covered here, and cannot be.</b> With no Avalonia application running,
+/// <c>Dispatcher.UIThread</c> binds to whichever thread first touches it — in a test process that is a pool
+/// thread, so <c>CheckAccess()</c> returns true off-thread and the guard never trips. A test asserting it
+/// would pass whether or not the guard existed.</para>
+///
+/// <para>Why screening exists at all: these files arrive over the network. The renderer expands XML entities
+/// with no quota, so a few KB of nested declarations become gigabytes, and it fetches
+/// <c>&lt;image href="https://…"&gt;</c> synchronously on the calling thread — which must be the UI thread.
+/// Neither appears in any of today's logos. (fable review)</para>
+/// </summary>
+public class AiLogoImagesTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cst-748-" + Guid.NewGuid().ToString("N"));
+
+    public AiLogoImagesTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    private string Write(string name, string content)
+    {
+        var path = Path.Combine(_dir, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    /// <summary>The shape of a real logo: an SVG namespace whose value is itself an http URL, which must not
+    /// read as "references a remote resource".</summary>
+    [Fact]
+    public void A_real_logo_passes()
+    {
+        var path = Write("anthropic.svg", """
+            <svg width="24" height="24" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+            <path d="M26.9 9.8H22.1L30.7 31.7H35.4Z" fill="currentColor"/></svg>
+            """);
+
+        Assert.Null(AiLogoImages.Screen(path));
+    }
+
+    /// <summary>Billion laughs. A few KB of nested declarations expand to gigabytes, and the renderer sets no
+    /// quota — so the cost is a frozen window long before the failure.</summary>
+    [Fact]
+    public void A_document_declaring_entities_is_refused()
+    {
+        var path = Write("bomb.svg", """
+            <?xml version="1.0"?>
+            <!DOCTYPE svg [<!ENTITY a "aaaaaaaaaa"><!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">]>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="&b;"/></svg>
+            """);
+
+        Assert.Equal("declares XML entities", AiLogoImages.Screen(path));
+    }
+
+    /// <summary>Fetched synchronously, on the UI thread, with the default 100-second timeout. A decorative
+    /// icon has no business reaching the network at draw time.</summary>
+    [Theory]
+    [InlineData("""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><image href="https://evil.example/x.png"/></svg>""")]
+    [InlineData("""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><image xlink:href="http://evil.example/x.png"/></svg>""")]
+    [InlineData("""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><image href="file:///etc/passwd"/></svg>""")]
+    [InlineData("""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path fill="url(https://evil.example/g)" d="M0,0H1"/></svg>""")]
+    public void A_document_reaching_off_the_machine_is_refused(string svg)
+    {
+        Assert.Equal("references a remote resource", AiLogoImages.Screen(Write("remote.svg", svg)));
+    }
+
+    /// <summary>A fragment reference is internal and ordinary — one logo in the set uses one for a clip
+    /// path.</summary>
+    [Fact]
+    public void An_internal_fragment_reference_is_allowed()
+    {
+        var path = Write("novita.svg", """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+            <g clip-path="url(#clip0)"><path d="M0,0H1"/></g></svg>
+            """);
+
+        Assert.Null(AiLogoImages.Screen(path));
+    }
+
+    [Fact]
+    public void An_oversized_file_is_refused()
+    {
+        var path = Write("huge.svg", new string('x', AiLogoImages.MaxBytes + 1));
+
+        Assert.Contains("over the", AiLogoImages.Screen(path));
+    }
+
+    /// <summary>The largest real mark is under 3 KB, so the limit has to be far above anything genuine or it
+    /// would be rejecting logos rather than payloads.</summary>
+    [Fact]
+    public void The_limit_is_far_above_any_real_logo()
+    {
+        Assert.True(AiLogoImages.MaxBytes > 100 * 1024);
+    }
+
+    [Theory]
+    [InlineData("")]
+    public void An_empty_file_is_refused(string content)
+    {
+        Assert.Equal("empty", AiLogoImages.Screen(Write("empty.svg", content)));
+    }
+
+    [Fact]
+    public void A_missing_file_is_refused()
+    {
+        Assert.Equal("no such file", AiLogoImages.Screen(Path.Combine(_dir, "nope.svg")));
+    }
+
+    /// <summary>A logo naming its own colours must not be mistaken for something reaching off the machine.
+    /// Four of the set do — 302ai, evroc, novita-ai, zenmux — and they are the ones that will not theme.</summary>
+    [Fact]
+    public void A_logo_with_literal_colours_passes()
+    {
+        var path = Write("zenmux.svg", """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+            <path d="M0,0H1" fill="#F5F5F5"/><path d="M1,1H2" fill="black"/></svg>
+            """);
+
+        Assert.Null(AiLogoImages.Screen(path));
+    }
+
+    [Fact]
+    public void No_path_means_no_image()
+    {
+        var images = new AiLogoImages();
+
+        Assert.Null(images.Get(null, Color.FromRgb(0, 0, 0)));
+        Assert.Null(images.Get("", Color.FromRgb(0, 0, 0)));
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1369,6 +1369,10 @@ public partial class App : Application
         // the disk cache lives under cache/provider-logos.
         services.AddSingleton<Services.Ai.IAiProviderLogos>(_ => new Services.Ai.AiProviderLogos());
 
+        // Rendering those logos (#748). Singleton so a mark is rasterised once per theme colour rather than
+        // once per row.
+        services.AddSingleton<Services.Ai.IAiLogoImages, Services.Ai.AiLogoImages>();
+
         // Asking a connection what models it offers (#674). Additive to the hand-typed list, never a
         // prerequisite: an endpoint that publishes no listing stays fully usable, so a failure here is
         // reported and nothing more.

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1373,6 +1373,10 @@ public partial class App : Application
         // once per row.
         services.AddSingleton<Services.Ai.IAiLogoImages, Services.Ai.AiLogoImages>();
 
+        // Rendering those logos (#748). Singleton so a mark is rasterised once per theme colour rather than
+        // once per row.
+        services.AddSingleton<Services.Ai.IAiLogoImages, Services.Ai.AiLogoImages>();
+
         // Asking a connection what models it offers (#674). Additive to the hand-typed list, never a
         // prerequisite: an endpoint that publishes no listing stays fully usable, so a failure here is
         // reported and nothing more.

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -89,7 +89,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.6" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Svg.Skia" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.0.2" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.6" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.6" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -89,6 +89,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.6" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.6" />
+    <PackageReference Include="Avalonia.Svg.Skia" Version="11.3.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.6" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.6" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/src/CST.Avalonia/Services/Ai/AiLogoImages.cs
+++ b/src/CST.Avalonia/Services/Ai/AiLogoImages.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using Avalonia.Media;
+using Avalonia.Svg.Skia;
+using Serilog;
+
+namespace CST.Avalonia.Services.Ai
+{
+    /// <summary>
+    /// Turns a logo cached by <see cref="AiProviderLogos"/> into something a view can draw. (#748)
+    ///
+    /// <para><b>Why a stylesheet rather than a parser.</b> An earlier draft of this hand-rolled an SVG
+    /// subset so the marks could be drawn as Avalonia geometry with no dependency. That was the wrong trade:
+    /// it covered ~98 of the 105 logos, and since the logos are fetched at runtime rather than baked in at
+    /// build time (<b>[fsnow]</b>), models.dev can publish one using a feature the subset does not cover at
+    /// any moment, with no release of ours in between and nothing to say it happened. Avalonia.Svg.Skia is
+    /// MIT and binds SkiaSharp, which Avalonia already renders through.</para>
+    ///
+    /// <para><b>Measured, in the running app.</b> Every logo renders <c>#000000</c> by default — including the
+    /// 101 of 105 drawn in <c>currentColor</c>, which would be invisible on a dark ground. The renderer takes
+    /// a stylesheet, and <c>* { color: … }</c> repaints exactly those, leaving a logo's own brand colours
+    /// alone. <c>svg { color: … }</c> does <b>not</b> work — the declaration does not inherit — and
+    /// <c>* { fill: … }</c> is worse than useless: it fills the outline-drawn logos solid.</para>
+    /// </summary>
+    public interface IAiLogoImages
+    {
+        /// <summary>The logo at <paramref name="path"/> drawn for <paramref name="foreground"/>, or null when
+        /// it cannot be rendered and the caller should fall back to the monogram. Never throws.</summary>
+        IImage? Get(string? path, Color foreground);
+    }
+
+    /// <inheritdoc cref="IAiLogoImages"/>
+    public sealed class AiLogoImages : IAiLogoImages
+    {
+        /// <summary>
+        /// Keyed by file AND colour: the same mark is a different image in light and dark, and a reader can
+        /// switch themes without restarting.
+        /// </summary>
+        private readonly ConcurrentDictionary<(string Path, uint Colour), IImage?> _images = new();
+
+        public IImage? Get(string? path, Color foreground)
+        {
+            if (string.IsNullOrEmpty(path)) return null;
+
+            return _images.GetOrAdd((path, foreground.ToUInt32()), key =>
+            {
+                try
+                {
+                    // Only currentColor is redirected. A logo that names its own colours keeps them - four of
+                    // the set do, and repainting a brand mark would be a worse answer than leaving it.
+                    var css = string.Create(
+                        CultureInfo.InvariantCulture, $"* {{ color: #{foreground.R:X2}{foreground.G:X2}{foreground.B:X2}; }}");
+
+                    var source = SvgSource.Load(key.Path, null, new Svg.Model.SvgParameters(null, css));
+                    if (source is null) return null;
+
+                    var image = new SvgImage { Source = source };
+
+                    // A document that parsed but drew nothing is not a logo. Cheaper to catch here than as an
+                    // invisible row in the catalogue.
+                    return image.Size.Width > 0 && image.Size.Height > 0 ? image : null;
+                }
+                catch (Exception ex)
+                {
+                    // Same contract as the fetch: a logo is decoration, so anything unreadable means the
+                    // monogram, which is already what the row is showing.
+                    Log.Debug(ex, "Could not render the logo at {Path}; falling back to the monogram (#748)", key.Path);
+                    return null;
+                }
+            });
+        }
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/AiLogoImages.cs
+++ b/src/CST.Avalonia/Services/Ai/AiLogoImages.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
 using Avalonia.Media;
 using Avalonia.Svg.Skia;
+using Avalonia.Threading;
 using Serilog;
 
 namespace CST.Avalonia.Services.Ai
@@ -10,23 +13,29 @@ namespace CST.Avalonia.Services.Ai
     /// <summary>
     /// Turns a logo cached by <see cref="AiProviderLogos"/> into something a view can draw. (#748)
     ///
-    /// <para><b>Why a stylesheet rather than a parser.</b> An earlier draft of this hand-rolled an SVG
-    /// subset so the marks could be drawn as Avalonia geometry with no dependency. That was the wrong trade:
-    /// it covered ~98 of the 105 logos, and since the logos are fetched at runtime rather than baked in at
-    /// build time (<b>[fsnow]</b>), models.dev can publish one using a feature the subset does not cover at
-    /// any moment, with no release of ours in between and nothing to say it happened. Avalonia.Svg.Skia is
-    /// MIT and binds SkiaSharp, which Avalonia already renders through.</para>
+    /// <para><b>Why a library rather than a parser.</b> An earlier draft hand-rolled an SVG subset so the
+    /// marks could be drawn as Avalonia geometry with no dependency. That was the wrong trade: it covered ~98
+    /// of the 105 logos, and since the logos are fetched at runtime rather than baked in at build time
+    /// (<b>[fsnow]</b>), models.dev can publish one using a feature the subset does not cover at any moment,
+    /// with no release of ours in between and nothing to say it happened.</para>
     ///
-    /// <para><b>Measured, in the running app.</b> Every logo renders <c>#000000</c> by default — including the
-    /// 101 of 105 drawn in <c>currentColor</c>, which would be invisible on a dark ground. The renderer takes
-    /// a stylesheet, and <c>* { color: … }</c> repaints exactly those, leaving a logo's own brand colours
-    /// alone. <c>svg { color: … }</c> does <b>not</b> work — the declaration does not inherit — and
-    /// <c>* { fill: … }</c> is worse than useless: it fills the outline-drawn logos solid.</para>
+    /// <para><b>Theming, measured in the running app.</b> Every logo renders <c>#000000</c> by default —
+    /// including the 101 of 105 drawn in <c>currentColor</c>, which would be invisible on a dark ground. The
+    /// renderer takes a stylesheet, and <c>* { color: … }</c> repaints exactly those, leaving a logo's own
+    /// brand colours alone. <c>svg { color: … }</c> does <b>not</b> work — the declaration does not inherit —
+    /// and <c>* { fill: … }</c> is worse than useless: it fills the outline-drawn logos solid.</para>
     /// </summary>
     public interface IAiLogoImages
     {
-        /// <summary>The logo at <paramref name="path"/> drawn for <paramref name="foreground"/>, or null when
-        /// it cannot be rendered and the caller should fall back to the monogram. Never throws.</summary>
+        /// <summary>
+        /// The logo at <paramref name="path"/> drawn for <paramref name="foreground"/>, or null when it cannot
+        /// be rendered and the caller should fall back to the monogram. Does not throw.
+        /// </summary>
+        /// <remarks>
+        /// <b>Call this on the UI thread.</b> It builds an <c>SvgImage</c>, and every <c>AvaloniaObject</c>
+        /// verifies thread access in its constructor. Called from anywhere else it returns null rather than
+        /// throwing, and says so in the log. (fable review)
+        /// </remarks>
         IImage? Get(string? path, Color foreground);
     }
 
@@ -34,41 +43,119 @@ namespace CST.Avalonia.Services.Ai
     public sealed class AiLogoImages : IAiLogoImages
     {
         /// <summary>
+        /// Far above any real mark — the largest in the current set is under 3 KB — and low enough that a
+        /// file which is not really a logo cannot cost a visible pause. These arrive over the network, so
+        /// their size is not ours to assume. (fable review)
+        /// </summary>
+        internal const int MaxBytes = 256 * 1024;
+
+        /// <summary>
+        /// Any absolute URL, once the namespace declarations that legitimately contain one are removed.
+        /// </summary>
+        private static readonly Regex ExternalReference =
+            new(@"\b(?:https?|ftp|file)://", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex NamespaceDeclaration =
+            new(@"xmlns(:[\w-]+)?\s*=\s*""[^""]*""", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>
         /// Keyed by file AND colour: the same mark is a different image in light and dark, and a reader can
         /// switch themes without restarting.
+        ///
+        /// <para>Only successes are stored. A failure says nothing durable about the file — it may be
+        /// mid-rewrite by a concurrent fetch, since #738 deletes and re-fetches to the same path when it
+        /// heals a poisoned entry — and remembering one would leave that row on a monogram for the session.
+        /// That is the policy #738 already states for its own failures. (fable review)</para>
         /// </summary>
-        private readonly ConcurrentDictionary<(string Path, uint Colour), IImage?> _images = new();
+        private readonly ConcurrentDictionary<(string Path, uint Colour), IImage> _images = new();
 
         public IImage? Get(string? path, Color foreground)
         {
             if (string.IsNullOrEmpty(path)) return null;
 
-            return _images.GetOrAdd((path, foreground.ToUInt32()), key =>
+            if (!Dispatcher.UIThread.CheckAccess())
             {
-                try
+                // Not cached: caching this would poison the entry for every later, correct call.
+                Log.Warning("Logo images must be requested on the UI thread; {Path} was not (#748)", path);
+                return null;
+            }
+
+            // Alpha is deliberately not part of the key, because it is deliberately not part of the render:
+            // the stylesheet takes an opaque colour. A caller wanting a faded mark should set Opacity on the
+            // control, which is the only way it can match the text beside it. (fable review)
+            var key = (path, (uint)((foreground.R << 16) | (foreground.G << 8) | foreground.B));
+            if (_images.TryGetValue(key, out var cached)) return cached;
+
+            var image = Render(path, foreground);
+            if (image is null) return null;
+
+            _images[key] = image;
+            return image;
+        }
+
+        private static IImage? Render(string path, Color foreground)
+        {
+            try
+            {
+                if (Screen(path) is { } refused)
                 {
-                    // Only currentColor is redirected. A logo that names its own colours keeps them - four of
-                    // the set do, and repainting a brand mark would be a worse answer than leaving it.
-                    var css = string.Create(
-                        CultureInfo.InvariantCulture, $"* {{ color: #{foreground.R:X2}{foreground.G:X2}{foreground.B:X2}; }}");
-
-                    var source = SvgSource.Load(key.Path, null, new Svg.Model.SvgParameters(null, css));
-                    if (source is null) return null;
-
-                    var image = new SvgImage { Source = source };
-
-                    // A document that parsed but drew nothing is not a logo. Cheaper to catch here than as an
-                    // invisible row in the catalogue.
-                    return image.Size.Width > 0 && image.Size.Height > 0 ? image : null;
-                }
-                catch (Exception ex)
-                {
-                    // Same contract as the fetch: a logo is decoration, so anything unreadable means the
-                    // monogram, which is already what the row is showing.
-                    Log.Debug(ex, "Could not render the logo at {Path}; falling back to the monogram (#748)", key.Path);
+                    Log.Warning("Not rendering {Path} as a logo: {Reason} (#748)", path, refused);
                     return null;
                 }
-            });
+
+                // Only currentColor is redirected. A logo that names its own colours keeps them - four of the
+                // set do, and repainting a brand mark would be a worse answer than leaving it.
+                var css = string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"* {{ color: #{foreground.R:X2}{foreground.G:X2}{foreground.B:X2}; }}");
+
+                var source = SvgSource.Load(path, null, new Svg.Model.SvgParameters(null, css));
+                if (source is null) return null;
+
+                var image = new SvgImage { Source = source };
+
+                // A document that parsed but drew nothing is not a logo. Cheaper to catch here than as an
+                // invisible row in the catalogue.
+                return image.Size.Width > 0 && image.Size.Height > 0 ? image : null;
+            }
+            catch (Exception ex)
+            {
+                // Same contract as the fetch: a logo is decoration, so anything unreadable means the
+                // monogram, which is already what the row is showing.
+                Log.Debug(ex, "Could not render the logo at {Path}; falling back to the monogram (#748)", path);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Why this file should not be handed to the renderer, or null to go ahead.
+        ///
+        /// <para>These files come off the network, and the renderer does two things with a document that a
+        /// decorative icon has no business doing: it expands XML entities with no quota, so a few KB of
+        /// nested declarations become gigabytes; and it fetches <c>&lt;image href="https://…"&gt;</c>
+        /// synchronously, on the calling thread, which is the UI thread. Neither appears in any of today's
+        /// logos, and neither should ever be worth a frozen window. (fable review)</para>
+        ///
+        /// <para>Kept as plain file-and-string work so it can be tested without a render backend.</para>
+        /// </summary>
+        internal static string? Screen(string path)
+        {
+            var file = new FileInfo(path);
+            if (!file.Exists) return "no such file";
+            if (file.Length == 0) return "empty";
+            if (file.Length > MaxBytes)
+                return $"{file.Length} bytes, over the {MaxBytes} limit";
+
+            var text = File.ReadAllText(path);
+
+            if (text.Contains("<!ENTITY", StringComparison.OrdinalIgnoreCase))
+                return "declares XML entities";
+
+            // The SVG namespace is itself an http URL, so those have to come out before asking the question.
+            if (ExternalReference.IsMatch(NamespaceDeclaration.Replace(text, string.Empty)))
+                return "references a remote resource";
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Closes #748. Unblocks the logo half of #740.

## The decision

**[fsnow]** "Add the package" — after asking, correctly, whether I was writing an SVG parser. I was.

## What I had written, and why it went

A whitelist parser over an SVG subset — `path`/`polygon`/`rect`/`g`, viewBox, transforms, fill/stroke/fill-rule/opacity — so logos could be drawn as Avalonia geometry with **no dependency**. That part was real: **[measured]** `Geometry.Parse` takes SVG path data directly, and all 199 path strings in the current corpus parse (`PARSED_OK=199 PARSED_FAIL=0`, probed in the running app — it cannot run headless).

But the trade was bad, and worse *because* of **[fsnow]**'s "dynamic, not compile time" decision. With build-time assets I'd parse a set frozen at release and could see every file before shipping. Fetching at runtime, models.dev can publish a logo using a feature the subset misses at any moment, with no release of ours in between and nothing to signal it. The saving was one dependency; the cost was owning an SVG parser permanently. ~350 lines, deleted.

## The package

`Avalonia.Svg.Skia` **11.3.0**, MIT — same 11.3 line as our Avalonia 11.3.6. Binds SkiaSharp, which Avalonia already renders through, so it is a binding layer rather than a second engine. Brings `Svg.Skia`, `Svg.Model`, `Svg.Custom`, `ShimSkiaSharp`, `ExCSS`.

**[measured]** it draws every case the hand-rolled subset refused: `novita-ai`'s clipPath, `openrouter`'s transform, `dinference`'s missing viewBox, and the 15 files carrying `shape-rendering`.

**Worth stating:** its last release was 2025-05-04, ~15 months ago. That may only mean it tracks Avalonia 11.3 and is finished, but it is a maintenance signal rather than nothing.

## Theming had to be measured, not assumed

**[measured]** every logo renders `#000000` by default — including the **101 of 105** drawn in `currentColor`, which would be invisible on a dark ground.

The renderer accepts a stylesheet. Three candidates, rasterised and pixel-sampled in the app:

| Stylesheet | Result |
|---|---|
| `svg { color: … }` | **no effect** — the declaration does not inherit |
| `* { fill: … }` | **worse than nothing** — fills the outline-drawn logos solid |
| `* { color: … }` | **correct** — repaints `currentColor`, leaves brand colours alone |

Verified end to end: `currentColor` marks come back `#202020` against a light foreground and `#E8E8E8` against a dark one, while the four that name their own colours keep them.

**[measured]** exactly **4 of 105 will not theme** — `302ai`, `evroc`, `novita-ai`, `zenmux` — because they never mention `currentColor`. Two are black, so they will be dim on a dark ground. **[suggestion]** that is #740's to judge with the app in front of it; a tile behind the mark, as the monogram already has, would settle it.

## Testing

**No unit tests, deliberately.** `SvgSource.Load` needs a render backend — the same reason `Geometry.Parse` throws `Unable to locate 'Avalonia.Platform.IPlatformRenderInterface'` headless. Verified in the running app instead, by rendering to a `RenderTargetBitmap` and counting and sampling pixels; the null paths (missing file, null path) were checked the same way.

Full suite **2184 passed, 0 failed**. App launched clean.

## Not committed

The 105 vendor SVGs. I had staged them as test fixtures and removed them: putting the asset set in the repo is close to the compile-time shape **[fsnow]** rejected, even in a test project.