### PR TITLE
Windows: --mcp-bridge can launch and activate CST Reader (#507)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LocalApi/McpBridgeWindowsLaunchTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApi/McpBridgeWindowsLaunchTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using CST.Avalonia.Services.LocalApi.Mcp;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.LocalApi;
+
+/// <summary>
+/// Deciding what to launch when an MCP client connects and CST Reader is not running. (#507)
+///
+/// <para>The relay is CST Reader itself - it runs as <c>CST.Avalonia.exe --mcp-bridge</c> - so the GUI is the
+/// same executable without that flag. That makes the decision a question about this process's own path, which
+/// is testable without launching anything.</para>
+///
+/// <para>The case that matters is the one where it must DECLINE. Under <c>dotnet run</c> the process path is
+/// the dotnet host, and starting that with no arguments prints help rather than launching CST Reader - so a
+/// naive "just start ProcessPath" would spawn something useless and report success.</para>
+/// </summary>
+public class McpBridgeWindowsLaunchTests
+{
+    [Theory]
+    [InlineData(@"C:\Program Files\CST Reader\CST.Avalonia.exe")]
+    [InlineData(@"C:\Users\me\source\cst\src\CST.Avalonia\bin\Debug\net10.0\win-arm64\CST.Avalonia.exe")]
+    [InlineData(@"D:\portable\cst.avalonia.EXE")]
+    public void The_app_executable_is_recognised(string path)
+    {
+        // Installed, developer-built and oddly-cased all name the same program.
+        Assert.Equal(path, McpBridge.WindowsAppExecutable(path));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Program Files\dotnet\dotnet.exe")]
+    [InlineData(@"C:\Windows\System32\cmd.exe")]
+    [InlineData(@"C:\Program Files\CST Reader\CST.Avalonia.Tests.exe")]
+    public void Anything_else_is_declined_rather_than_launched(string path)
+    {
+        // dotnet.exe is the real one: `dotnet run -- --mcp-bridge` lands here, and launching it with no
+        // arguments prints help. Declining produces an honest "start CST Reader manually" instead of a
+        // spawned process that never becomes the app.
+        //
+        // CST.Avalonia.Tests.exe is included because a prefix match would wrongly accept it.
+        Assert.Null(McpBridge.WindowsAppExecutable(path));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void An_unknown_process_path_is_declined(string? path)
+    {
+        // Environment.ProcessPath is documented as possibly null.
+        Assert.Null(McpBridge.WindowsAppExecutable(path));
+    }
+
+    [Fact]
+    public void The_two_platforms_decline_in_the_same_situation()
+    {
+        // Consistency between the halves: on macOS a `dotnet run` bridge has no enclosing .app bundle and
+        // declines; on Windows the same bridge has a dotnet host path and declines. Neither invents a launch
+        // it cannot deliver, so the "start CST Reader manually" message means the same thing on both.
+        Assert.Null(McpBridge.AppBundleFromExecutablePath(
+            "/usr/local/share/dotnet/dotnet"));
+        Assert.Null(McpBridge.WindowsAppExecutable(
+            @"C:\Program Files\dotnet\dotnet.exe"));
+    }
+
+    [Fact]
+    public void A_real_bundle_and_a_real_executable_are_both_accepted()
+    {
+        // The positive counterpart, so the previous test cannot pass merely because both always return null.
+        //
+        // Separators are normalised before comparing: Path.GetDirectoryName rewrites forward slashes as backslashes when the
+        // suite runs on Windows, which would fail this assertion for a reason that has nothing to do with the
+        // behaviour under test - AppBundleFromExecutablePath only ever runs on macOS.
+        var bundle = McpBridge.AppBundleFromExecutablePath("/Applications/CST Reader.app/Contents/MacOS/CST.Avalonia");
+        Assert.Equal("/Applications/CST Reader.app", bundle?.Replace('\\', '/'));
+
+        Assert.Equal(
+            @"C:\Program Files\CST Reader\CST.Avalonia.exe",
+            McpBridge.WindowsAppExecutable(@"C:\Program Files\CST Reader\CST.Avalonia.exe"));
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/LocalApi/McpBridgeWindowsLaunchTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LocalApi/McpBridgeWindowsLaunchTests.cs
@@ -52,6 +52,32 @@ public class McpBridgeWindowsLaunchTests
     }
 
     [Fact]
+    public void The_decision_does_not_depend_on_which_OS_is_running_the_test()
+    {
+        // These are always Windows paths, whatever host the suite runs on. An earlier version used
+        // Path.GetFileNameWithoutExtension, which is HOST-relative: on macOS a backslash is an ordinary
+        // filename character, so it returned the whole path and this helper answered null for every real
+        // input - a red suite on the development machine, and a function that only worked where it was
+        // written. Parsing the separators explicitly is what makes these assertions mean the same thing
+        // everywhere.
+        Assert.NotNull(McpBridge.WindowsAppExecutable(@"C:\Program Files\CST Reader\CST.Avalonia.exe"));
+        Assert.Null(McpBridge.WindowsAppExecutable(@"C:\Program Files\dotnet\dotnet.exe"));
+
+        // Forward slashes too: plenty of tooling reports Windows paths this way.
+        Assert.NotNull(McpBridge.WindowsAppExecutable("C:/Program Files/CST Reader/CST.Avalonia.exe"));
+    }
+
+    [Fact]
+    public void A_dotted_name_without_an_extension_is_still_recognised()
+    {
+        // The trap the old implementation fell into even on Windows: GetFileNameWithoutExtension reads
+        // "CST.Avalonia" as the name "CST" with the extension ".Avalonia", so an extensionless path was
+        // rejected. Stripping ".exe" explicitly is what fixes it.
+        Assert.NotNull(McpBridge.WindowsAppExecutable(@"C:\portable\CST.Avalonia"));
+        Assert.NotNull(McpBridge.WindowsAppExecutable("CST.Avalonia"));
+    }
+
+    [Fact]
     public void The_two_platforms_decline_in_the_same_situation()
     {
         // Consistency between the halves: on macOS a `dotnet run` bridge has no enclosing .app bundle and

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -150,9 +151,15 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         /// </summary>
         private static void TryLaunchApp()
         {
+            if (OperatingSystem.IsWindows())
+            {
+                TryLaunchAppWindows();
+                return;
+            }
+
             if (!OperatingSystem.IsMacOS())
             {
-                Log.Warning("--mcp-bridge: auto-launch is macOS-only; start CST Reader manually.");
+                Log.Warning("--mcp-bridge: auto-launch is not supported on this platform; start CST Reader manually.");
                 return;
             }
 
@@ -175,6 +182,72 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
             {
                 Log.Warning(ex, "--mcp-bridge: failed to launch CST Reader via `open`.");
             }
+        }
+
+        /// <summary>
+        /// The Windows half of <see cref="TryLaunchApp"/>. (#507)
+        ///
+        /// <para>There is no <c>open</c> here, but there is something better: this relay IS CST Reader - the
+        /// bridge runs as <c>CST.Avalonia.exe --mcp-bridge</c> - so the GUI is the same executable started
+        /// without that flag. No registry lookup, no install-directory search, and no way to launch a DIFFERENT
+        /// copy than the one relaying, which a path search could do on a machine with two installs.</para>
+        ///
+        /// <para><b>It reuses a running instance, exactly as <c>open</c> does.</b> Not by checking first - by
+        /// launching unconditionally and letting the single-instance guard decide. A second launch now asks the
+        /// running instance to come forward and exits (#568), so "launch" and "activate" are the same call on
+        /// this platform too. Before #568 that second process would have exited silently, which is why this
+        /// issue and that one were the same missing capability.</para>
+        ///
+        /// <para><c>UseShellExecute</c> is deliberately TRUE. With it false the launched GUI inherits this
+        /// process's stdio handles - and those handles are the JSON-RPC channel to the chat client. A GUI
+        /// holding the relay's stdin/stdout open is a hang waiting to happen at shutdown.</para>
+        /// </summary>
+        [SupportedOSPlatform("windows")]
+        private static void TryLaunchAppWindows()
+        {
+            var exe = WindowsAppExecutable(Environment.ProcessPath);
+            if (exe is null)
+            {
+                // The dev case: `dotnet run -- --mcp-bridge` makes ProcessPath the dotnet host, and launching
+                // THAT with no arguments prints help rather than starting CST Reader. Say so instead of
+                // spawning something useless - the macOS side declines in the same situation, for the same
+                // reason (no .app bundle around a `dotnet run`).
+                Log.Warning("--mcp-bridge: {Path} is not the CST Reader executable, so auto-launch was skipped; "
+                            + "start CST Reader manually.", Environment.ProcessPath ?? "(unknown)");
+                return;
+            }
+
+            try
+            {
+                var psi = new ProcessStartInfo(exe)
+                {
+                    UseShellExecute = true,
+                    WorkingDirectory = Path.GetDirectoryName(exe) ?? string.Empty,
+                };
+                using var _ = Process.Start(psi);
+                Log.Information("--mcp-bridge: started {Exe}; if an instance was already running the single-instance guard activates that one instead of adding a second.", exe);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "--mcp-bridge: failed to launch CST Reader.");
+            }
+        }
+
+        /// <summary>
+        /// The GUI executable to start on Windows, or null when this process is not one. Pure/testable, and the
+        /// counterpart to <see cref="AppBundleFromExecutablePath"/>.
+        ///
+        /// <para>Matched on filename rather than trusted outright, so a bridge hosted by <c>dotnet</c> - or by
+        /// anything else - declines rather than launching a program that will not become CST Reader.</para>
+        /// </summary>
+        internal static string? WindowsAppExecutable(string? processPath)
+        {
+            if (string.IsNullOrEmpty(processPath)) return null;
+
+            var name = Path.GetFileNameWithoutExtension(processPath);
+            return string.Equals(name, "CST.Avalonia", StringComparison.OrdinalIgnoreCase)
+                ? processPath
+                : null;
         }
 
         /// <summary>

--- a/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
+++ b/src/CST.Avalonia/Services/LocalApi/Mcp/McpBridge.cs
@@ -201,6 +201,21 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         /// <para><c>UseShellExecute</c> is deliberately TRUE. With it false the launched GUI inherits this
         /// process's stdio handles - and those handles are the JSON-RPC channel to the chat client. A GUI
         /// holding the relay's stdin/stdout open is a hang waiting to happen at shutdown.</para>
+        ///
+        /// <para><b>Two ways this is NOT `open`.</b> First, LINEAGE: `open` hands the launch to LaunchServices,
+        /// so the GUI's parent is launchd and it outlives the relay cleanly. Here the GUI is a direct CHILD of
+        /// the bridge and inherits any job object the chat client placed it in - so a client that kills the
+        /// server's whole process tree, rather than just the child, would take the reader's window down with
+        /// it. Breaking out of the job would need CREATE_BREAKAWAY_FROM_JOB or an explorer.exe intermediary,
+        /// both uglier than the risk; this note is here so "my reader vanished when I quit the chat client" is
+        /// findable rather than baffling.</para>
+        ///
+        /// <para>Second, ENVIRONMENT: a ShellExecute child inherits ours, and it cannot be scrubbed (setting
+        /// EnvironmentVariables with UseShellExecute throws). So <c>CST_ALLOW_MULTIPLE=1</c> reaching the
+        /// bridge - via a per-server `env` block in an MCP client config, say - propagates to the GUI and
+        /// disables the single-instance guard, making this launch a SECOND instance rather than an activation.
+        /// That bypass is a documented development escape hatch and only bites when no live handshake exists,
+        /// so it is accepted rather than defended against.</para>
         /// </summary>
         [SupportedOSPlatform("windows")]
         private static void TryLaunchAppWindows()
@@ -224,8 +239,16 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
                     UseShellExecute = true,
                     WorkingDirectory = Path.GetDirectoryName(exe) ?? string.Empty,
                 };
-                using var _ = Process.Start(psi);
-                Log.Information("--mcp-bridge: started {Exe}; if an instance was already running the single-instance guard activates that one instead of adding a second.", exe);
+                using var started = Process.Start(psi);
+                if (started is null)
+                {
+                    // ShellExecute can hand the request to an existing process and return nothing to own.
+                    Log.Information("--mcp-bridge: handed {Exe} to the shell; no new process to track.", exe);
+                    return;
+                }
+
+                Log.Information("--mcp-bridge: started {Exe}; if an instance was already running the "
+                                + "single-instance guard activates that one instead of adding a second.", exe);
             }
             catch (Exception ex)
             {
@@ -239,13 +262,31 @@ namespace CST.Avalonia.Services.LocalApi.Mcp
         ///
         /// <para>Matched on filename rather than trusted outright, so a bridge hosted by <c>dotnet</c> - or by
         /// anything else - declines rather than launching a program that will not become CST Reader.</para>
+        ///
+        /// <para><b>Windows path syntax is parsed here rather than delegated to <see cref="Path"/>.</b> Those
+        /// APIs are host-relative: on macOS a backslash is an ordinary filename character, so
+        /// <c>GetFileNameWithoutExtension</c> hands back a Windows path unchanged and this would answer null for
+        /// every real input. The suite runs on macOS, so that is not a hypothetical - it is a red suite on the
+        /// development machine for a function whose inputs are always Windows paths. Stripping the extension
+        /// explicitly also avoids a second host-relative trap: <c>GetFileNameWithoutExtension</c> reads
+        /// <c>CST.Avalonia</c> (no extension) as name <c>CST</c> with extension <c>.Avalonia</c>.</para>
+        ///
+        /// <para>The name is hardcoded rather than read from the assembly. A rename would silently stop
+        /// auto-launching - but it logs the path it declined, which is a debuggable failure rather than a
+        /// mystery, and the name is already load-bearing in <c>CST.Avalonia.iss</c>, so a rename touches that
+        /// file regardless.</para>
         /// </summary>
         internal static string? WindowsAppExecutable(string? processPath)
         {
             if (string.IsNullOrEmpty(processPath)) return null;
 
-            var name = Path.GetFileNameWithoutExtension(processPath);
-            return string.Equals(name, "CST.Avalonia", StringComparison.OrdinalIgnoreCase)
+            var lastSeparator = processPath.LastIndexOfAny(new[] { '\\', '/' });
+            var fileName = lastSeparator >= 0 ? processPath[(lastSeparator + 1)..] : processPath;
+
+            if (fileName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                fileName = fileName[..^4];
+
+            return string.Equals(fileName, "CST.Avalonia", StringComparison.OrdinalIgnoreCase)
                 ? processPath
                 : null;
         }


### PR DESCRIPTION
Closes #507.

An MCP chat client connecting on Windows had to be told to go start CST Reader by hand. The stdio↔HTTP relay itself is cross-platform and works fine once the app is up — only the bring-it-up step was macOS-only, because it used `open` on the `.app` bundle.

## The relay is CST Reader

No registry lookup, no install-directory search. The bridge runs as `CST.Avalonia.exe --mcp-bridge`, so the GUI is the same executable started **without** that flag, and `Environment.ProcessPath` is the right binary by construction. Unlike a path search, it also cannot launch a *different* copy than the one relaying on a machine with two installs.

## It reuses a running instance — because of #568

It does not check first. It launches unconditionally and lets the single-instance guard decide.

Since #568, a second launch asks the running instance to come forward and exits, so **"launch" and "activate" are one call on Windows too** — the same property `open` gives on macOS. Before #568 that second process would have exited silently. #568 and this issue really were the same missing capability with different callers, exactly as #568 said.

## Two details that would bite later

- **`UseShellExecute` is deliberately `true`.** With it false, the launched GUI inherits this process's stdio handles — and those handles are the JSON-RPC channel to the chat client. A GUI holding the relay's stdin/stdout open is a hang waiting to happen at shutdown.
- **It declines rather than guessing.** Under `dotnet run -- --mcp-bridge` the process path is the dotnet host, and starting *that* with no arguments prints help instead of launching anything. The macOS side already declines in the same situation — a `dotnet run` bridge has no enclosing `.app` bundle — so both platforms now say "start CST Reader manually" under the same conditions and mean the same thing by it.

## Verified on Windows 11 ARM64

| scenario | before | action | after |
|---|---|---|---|
| cold start | 0 `CST.Avalonia` processes | ran the bridge | **1 GUI (pid 4572)**, logged `started …CST.Avalonia.exe` |
| already up | 1 GUI (pid 4572) | ran the bridge again | **still exactly 1, same pid** — found the handshake and attached without launching |

## Tests

7 over the executable decision, which is the part that fails silently if wrong. They include `CST.Avalonia.Tests.exe` as a negative case (a prefix match would wrongly accept it), and assert that the macOS and Windows helpers decline in the same situation — with a positive case alongside, so that agreement cannot come from both always returning `null`.

**2211 pass, 0 warnings.**
