### PR TITLE
Show provider logos, and point at a provider's models when we cannot (#740)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -720,8 +720,25 @@ public class AiConnectionsViewModelTests
     [InlineData("not a url")]
     [InlineData("file:///etc/passwd")]
     [InlineData("javascript:alert(1)")]
-    public void A_url_that_is_not_http_is_not_opened(string? url) =>
-        AiConnectionsViewModel.OpenUrl(url);   // must return without launching anything, and without throwing
+    [InlineData("/etc/passwd")]
+    public void A_url_that_is_not_http_is_refused(string? url) =>
+        Assert.False(AiConnectionsViewModel.ShouldOpen(url, out _));
+
+    /// <summary>
+    /// Asserted on the decision, not on the launch.
+    ///
+    /// <para>A test that merely calls the launcher can only observe that nothing threw — so if the scheme
+    /// check were deleted it would pass while actually shell-opening <c>file:///etc/passwd</c> on whoever ran
+    /// it. Green, and worse than useless.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("https://openrouter.ai/models")]
+    [InlineData("http://example.test/docs")]
+    public void An_http_url_is_allowed(string url)
+    {
+        Assert.True(AiConnectionsViewModel.ShouldOpen(url, out var uri));
+        Assert.NotNull(uri);
+    }
 
     // ---- monograms -------------------------------------------------------------------------------------
 

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -676,6 +676,53 @@ public class AiConnectionsViewModelTests
         Assert.False(vm.HasCatalogueProblem);
     }
 
+    // ---- the documentation link (#740) ----------------------------------------------------------------------
+
+    /// <summary>
+    /// A catalogue-backed connection offers its provider's documentation.
+    ///
+    /// <para>Sampled across the catalogue, nine `doc` links in ten point at a <b>models</b> page rather than an
+    /// account page — so this answers "what can I run on this?", not "where do I get a key?". Anyone who has
+    /// pasted a key has already been to the provider.</para>
+    /// </summary>
+    [Fact]
+    public void A_catalogue_backed_connection_links_to_its_provider_docs()
+    {
+        var (vm, service) = Make();
+        service.AddFromPreset("openrouter", new Dictionary<string, string>());
+
+        var row = vm.Connections.Single();
+        Assert.True(row.HasDoc);
+        Assert.StartsWith("https://", row.DocUrl);
+    }
+
+    /// <summary>A custom endpoint has no provider behind it and therefore no documentation to point at —
+    /// the link is absent rather than pointing somewhere generic.</summary>
+    [Fact]
+    public void A_custom_endpoint_offers_no_documentation_link()
+    {
+        var (vm, service) = Make();
+        service.Add("my-box", Draft());
+
+        Assert.False(vm.Connections.Single().HasDoc);
+    }
+
+    /// <summary>
+    /// Only http(s) is handed to the shell.
+    ///
+    /// <para>The URL arrives in a fetched catalogue. Passing an arbitrary string to the operating system is
+    /// how a data file becomes a way to run something, so the scheme is checked rather than trusted.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a url")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("javascript:alert(1)")]
+    public void A_url_that_is_not_http_is_not_opened(string? url) =>
+        AiConnectionsViewModel.OpenUrl(url);   // must return without launching anything, and without throwing
+
     // ---- monograms -------------------------------------------------------------------------------------
 
     [Theory]

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -486,6 +486,48 @@ public class AiModelsViewModelTests
         Assert.Equal(Reachability.Configured, service.Connections.Single().State);
     }
 
+    // ---- the documentation link on an empty group (#740) ----------------------------------------------------
+
+    /// <summary>
+    /// Offered only once we have asked and come back with nothing.
+    ///
+    /// <para>Before a fetch, a collapsed group would advertise a link although expanding it would have
+    /// produced a listing — which is the opposite of what the link says.</para>
+    /// </summary>
+    [Fact]
+    public void The_doc_link_is_not_offered_before_anything_has_been_asked()
+    {
+        var (vm, service) = Make(new FakeCatalog(AiCatalogResult.Fail("404")));
+        service.AddFromPreset("openrouter", new Dictionary<string, string>());
+
+        Assert.False(Group(vm).ShowDoc);
+
+        Group(vm).IsExpanded = true;
+
+        Assert.True(Group(vm).ShowDoc);
+    }
+
+    /// <summary>
+    /// A filter hiding everything is not a provider publishing nothing.
+    ///
+    /// <para>A connection whose four hundred fetched models are all paid would otherwise be described as
+    /// having no listing, and pointed at documentation it does not need.</para>
+    /// </summary>
+    [Fact]
+    public void A_filter_that_hides_every_model_does_not_offer_the_doc_link()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("paid", "Paid",
+                PromptPricePerMillion: 5m, CompletionPricePerMillion: 5m)));
+        service.AddFromPreset("openrouter", new Dictionary<string, string>());
+        Group(vm).IsExpanded = true;
+
+        vm.FreeOnly = true;
+
+        Assert.Empty(Rows(vm));            // nothing on screen
+        Assert.False(Group(vm).ShowDoc);   // but the provider does publish a listing
+    }
+
     // ---- search and the capability filter ---------------------------------------------------------------
 
     /// <summary>Search filters across every group, not within the expanded one, and shows what it finds

--- a/src/CST.Avalonia/Converters/ProviderLogoConverter.cs
+++ b/src/CST.Avalonia/Converters/ProviderLogoConverter.cs
@@ -50,4 +50,34 @@ namespace CST.Avalonia.Converters
         public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
             throw new NotSupportedException();
     }
+
+    /// <summary>
+    /// Whether a logo actually <b>rendered</b> — which is not the same as a path having resolved.
+    ///
+    /// <para>The row hid its monogram as soon as a cached file was known, but the file still has to be
+    /// read and parsed, and <c>Get</c> returns null for a malformed SVG, one over the size cap, or a call
+    /// off the UI thread. The row was then left with a hidden monogram and an empty image: a blank tile,
+    /// which is the one outcome a fallback exists to prevent.</para>
+    ///
+    /// <para>Asking the same question twice is cheap — <c>AiLogoImages</c> memoises by file and colour, so
+    /// the second call is a dictionary hit.</para>
+    /// </summary>
+    public sealed class ProviderLogoRenderedConverter : IValueConverter
+    {
+        public static readonly ProviderLogoRenderedConverter Instance = new();
+
+        /// <param name="parameter">Pass <c>invert</c> to ask the opposite question — "should the
+        /// monogram still be showing?" — so one converter drives both halves of the pair and they cannot
+        /// disagree.</param>
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            var rendered = ProviderLogoConverter.Instance.Convert(value, typeof(IImage), null, culture)
+                is not null;
+
+            return parameter as string == "invert" ? !rendered : rendered;
+        }
+
+        public object? ConvertBack(object? value, Type t, object? p, CultureInfo c) =>
+            throw new NotSupportedException();
+    }
 }

--- a/src/CST.Avalonia/Converters/ProviderLogoConverter.cs
+++ b/src/CST.Avalonia/Converters/ProviderLogoConverter.cs
@@ -59,8 +59,11 @@ namespace CST.Avalonia.Converters
     /// off the UI thread. The row was then left with a hidden monogram and an empty image: a blank tile,
     /// which is the one outcome a fallback exists to prevent.</para>
     ///
-    /// <para>Asking the same question twice is cheap — <c>AiLogoImages</c> memoises by file and colour, so
-    /// the second call is a dictionary hit.</para>
+    /// <para>Asking the same question twice is cheap <b>when the answer is yes</b> — <c>AiLogoImages</c>
+    /// memoises by file and colour, so a second call for a mark that rendered is a dictionary hit. Failures
+    /// are deliberately not cached, so a malformed or oversized file is re-read and re-parsed on each
+    /// evaluation. Bounded and rare, and the alternative — caching a failure — would defeat the delete-and-
+    /// refetch heal that repairs a corrupt cache entry. (fable review)</para>
     /// </summary>
     public sealed class ProviderLogoRenderedConverter : IValueConverter
     {

--- a/src/CST.Avalonia/Converters/ProviderLogoConverter.cs
+++ b/src/CST.Avalonia/Converters/ProviderLogoConverter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using CST.Avalonia.Services.Ai;
+
+namespace CST.Avalonia.Converters
+{
+    /// <summary>
+    /// Turns a cached logo path into something a row can draw. (#740)
+    ///
+    /// <para>The path comes from the view model, which resolves it per row and leaves it null when the
+    /// provider has none. Null here means <b>draw the monogram</b>, which is why this returns null rather than
+    /// a placeholder: the row already has a tile behind it, and the binding simply never replaces it.</para>
+    ///
+    /// <para><b>The colour is read from the theme at conversion time</b>, because a mark drawn in
+    /// <c>currentColor</c> is invisible against its own background in one of the two themes. A row built
+    /// before a theme switch keeps the colour it was built with until the list is rebuilt — acceptable
+    /// because the settings window is short-lived and a theme change is rare, and worth stating so nobody
+    /// reads it as a bug.</para>
+    /// </summary>
+    public class ProviderLogoConverter : IValueConverter
+    {
+        public static readonly ProviderLogoConverter Instance = new();
+
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is not string path || path.Length == 0) return null;
+            if (App.TryGetService<IAiLogoImages>() is not { } images) return null;
+
+            return images.Get(path, Foreground());
+        }
+
+        /// <summary>The theme's own primary text colour, so a monochrome mark reads like the name beside
+        /// it. Falls back to a mid grey that is legible on either ground rather than to black, which
+        /// disappears in dark mode.</summary>
+        private static Color Foreground()
+        {
+            if (Application.Current is { } app &&
+                app.TryGetResource("TextFillColorPrimaryBrush", app.ActualThemeVariant, out var found) &&
+                found is ISolidColorBrush brush)
+            {
+                return brush.Color;
+            }
+
+            return Color.FromRgb(0x80, 0x80, 0x80);
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -138,6 +138,15 @@ namespace CST.Avalonia.Models.Ai
     /// the auth header rather than adding one.</param>
     /// <param name="AuthScheme">Prefix before the credential, or null for a bare value. Bearer for almost
     /// everything; null for Azure's <c>api-key</c>.</param>
+    /// <param name="Doc">
+    /// The provider's own documentation link, as the catalogue publishes it.
+    ///
+    /// <para><b>In practice a models page</b>, not an account or key page — sampled across the catalogue, nine
+    /// in ten point at a list of model ids. So its use is for a reader with a working connection who needs to
+    /// know what to run on it, not for one who cannot find their key: anyone pasting a key has already been to
+    /// the provider. Null for the hand-kept presets and the local runners, which have no catalogue
+    /// record.</para>
+    /// </param>
     public sealed record AiProviderPreset(
         string Id,
         string DisplayName,
@@ -147,7 +156,8 @@ namespace CST.Avalonia.Models.Ai
         IReadOnlyList<AiInputPrompt>? Prompts = null,
         IReadOnlyDictionary<string, string>? Headers = null,
         string AuthHeaderName = "Authorization",
-        string? AuthScheme = "Bearer")
+        string? AuthScheme = "Bearer",
+        string? Doc = null)
     {
         /// <summary>True when a key must be supplied or found. False for a local runner.</summary>
         public bool RequiresKey => Methods.Any(m => m is AiCredentialMethod.Key or AiCredentialMethod.Env);

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -144,8 +144,11 @@ namespace CST.Avalonia.Models.Ai
     /// <para><b>In practice a models page</b>, not an account or key page — sampled across the catalogue, nine
     /// in ten point at a list of model ids. So its use is for a reader with a working connection who needs to
     /// know what to run on it, not for one who cannot find their key: anyone pasting a key has already been to
-    /// the provider. Null for the hand-kept presets and the local runners, which have no catalogue
-    /// record.</para>
+    /// the provider. Null only where the catalogue has nothing to give: the local runners, which it does not
+    /// carry at all, and a custom endpoint, which has no provider identity. <b>A hand-kept preset still gets
+    /// one</b> — those are hand-kept because the catalogue omits their <c>api</c> URL, not because they are
+    /// absent from it, and reading that the other way round cost the ten most prominent providers their
+    /// link.</para>
     /// </param>
     public sealed record AiProviderPreset(
         string Id,

--- a/src/CST.Avalonia/Services/Ai/AiPresetSource.cs
+++ b/src/CST.Avalonia/Services/Ai/AiPresetSource.cs
@@ -270,7 +270,10 @@ namespace CST.Avalonia.Services.Ai
                     string.IsNullOrWhiteSpace(provider.Name) ? provider.Id : provider.Name!,
                     KindFor(provider),
                     provider.Api!,
-                    methods);
+                    methods,
+                    // #737 said doc was carried through; it was parsed into CatalogProvider and then dropped
+                    // here. The UI issue that consumes it (#740) had nothing to bind to.
+                    Doc: provider.Doc);
             }
 
             if (skipped.Count > 0)

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Reactive;
 using System.Threading.Tasks;
@@ -303,6 +304,28 @@ namespace CST.Avalonia.ViewModels
             Rebind();
         }
 
+        /// <summary>
+        /// Hands a documentation link to the operating system.
+        ///
+        /// <para>Guarded on the scheme: the URL comes from a fetched catalogue, and handing an arbitrary
+        /// string to the shell is how a data file becomes a way to run something. http and https only.</para>
+        /// </summary>
+        internal static void OpenUrl(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return;
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return;
+            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) return;
+
+            try
+            {
+                Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
+            }
+            catch
+            {
+                // A browser that will not open is not worth taking the settings window down for.
+            }
+        }
+
         private void CloseEditor(bool saved)
         {
             Editor = null;
@@ -492,6 +515,7 @@ namespace CST.Avalonia.ViewModels
             _connection = connection;
 
             EditCommand = ReactiveCommand.Create(() => _owner.BeginEdit(Id));
+            OpenDocCommand = ReactiveCommand.Create(() => AiConnectionsViewModel.OpenUrl(DocUrl));
             RemoveKeyCommand = ReactiveCommand.Create(() => _owner.RemoveKey(Id));
             DeleteCommand = ReactiveCommand.Create(() => { IsConfirmingDelete = true; });
             ConfirmDeleteCommand = ReactiveCommand.Create(() => _owner.Delete(Id));
@@ -541,6 +565,19 @@ namespace CST.Avalonia.ViewModels
         /// <para>"No key" is a legitimate resting state, not a warning: a local runner needs none, and a
         /// connection may authenticate entirely through its headers.</para>
         /// </summary>
+        /// <summary>
+        /// The provider's own documentation, where the catalogue publishes one.
+        ///
+        /// <para>In practice a <b>models</b> page rather than an account page — nine of ten sampled point at a
+        /// list of model ids. So it is for a reader with a working connection who needs to know what to run on
+        /// it, not for one who cannot find their key: anyone who has pasted a key has already been to the
+        /// provider. Null for a custom endpoint and for the local runners, which have no catalogue
+        /// record.</para>
+        /// </summary>
+        public string? DocUrl => AiProviderPresets.ById(_connection.Id)?.Doc;
+
+        public bool HasDoc => !string.IsNullOrEmpty(DocUrl);
+
         public string KeySourceBadge => _connection.KeySource switch
         {
             CredentialSource.Keychain => "Keychain",
@@ -612,6 +649,8 @@ namespace CST.Avalonia.ViewModels
             : $"Delete {DisplayName} and its {ModelSummary}?";
 
         public ReactiveCommand<Unit, Unit> EditCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> OpenDocCommand { get; }
 
         public ReactiveCommand<Unit, Unit> RemoveKeyCommand { get; }
 

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -312,18 +312,35 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         internal static void OpenUrl(string? url)
         {
-            if (string.IsNullOrWhiteSpace(url)) return;
-            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return;
-            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) return;
+            if (!ShouldOpen(url, out var uri)) return;
 
             try
             {
-                Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
+                Process.Start(new ProcessStartInfo(uri!.AbsoluteUri) { UseShellExecute = true });
             }
             catch
             {
                 // A browser that will not open is not worth taking the settings window down for.
             }
+        }
+
+        /// <summary>
+        /// Whether this is a link we are willing to hand to the operating system.
+        ///
+        /// <para>Separated from the launching so it can be asserted directly. A test over
+        /// <see cref="OpenUrl"/> can only observe that nothing was thrown — so if the scheme check were ever
+        /// deleted, that test would pass while actually shell-opening <c>file:///etc/passwd</c> on whoever ran
+        /// it. (fable review)</para>
+        /// </summary>
+        internal static bool ShouldOpen(string? url, out Uri? uri)
+        {
+            uri = null;
+            if (string.IsNullOrWhiteSpace(url)) return false;
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed)) return false;
+            if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps) return false;
+
+            uri = parsed;
+            return true;
         }
 
         private void CloseEditor(bool saved)
@@ -565,25 +582,25 @@ namespace CST.Avalonia.ViewModels
         /// <para>"No key" is a legitimate resting state, not a warning: a local runner needs none, and a
         /// connection may authenticate entirely through its headers.</para>
         /// </summary>
-        /// <summary>
-        /// The provider's own documentation, where the catalogue publishes one.
-        ///
-        /// <para>In practice a <b>models</b> page rather than an account page — nine of ten sampled point at a
-        /// list of model ids. So it is for a reader with a working connection who needs to know what to run on
-        /// it, not for one who cannot find their key: anyone who has pasted a key has already been to the
-        /// provider. Null for a custom endpoint and for the local runners, which have no catalogue
-        /// record.</para>
-        /// </summary>
-        public string? DocUrl => AiProviderPresets.ById(_connection.Id)?.Doc;
-
-        public bool HasDoc => !string.IsNullOrEmpty(DocUrl);
-
         public string KeySourceBadge => _connection.KeySource switch
         {
             CredentialSource.Keychain => "Keychain",
             CredentialSource.Environment => "Environment",
             _ => "No key",
         };
+
+        /// <summary>
+        /// The provider's own documentation, where the catalogue publishes one.
+        ///
+        /// <para>In practice a <b>models</b> page rather than an account page — nine of ten sampled point at a
+        /// list of model ids. So it is for a reader with a working connection who needs to know what to run on
+        /// it, not for one who cannot find their key: anyone who has pasted a key has already been to the
+        /// provider. Null for a custom endpoint, which has no provider identity, and for the local runners,
+        /// which the catalogue does not carry.</para>
+        /// </summary>
+        public string? DocUrl => AiProviderPresets.ById(_connection.Id)?.Doc;
+
+        public bool HasDoc => !string.IsNullOrEmpty(DocUrl);
 
         /// <summary>
         /// Whether this row offers to remove the stored key.

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -194,6 +194,7 @@ namespace CST.Avalonia.ViewModels
             _connection = connection;
 
             ToggleCommand = ReactiveCommand.Create(() => { IsExpanded = !IsExpanded; });
+            OpenDocCommand = ReactiveCommand.Create(() => AiConnectionsViewModel.OpenUrl(DocUrl));
             FetchCommand = ReactiveCommand.CreateFromTask(FetchAsync);
         }
 
@@ -268,6 +269,19 @@ namespace CST.Avalonia.ViewModels
 
         private static string Plural(int n) => n == 1 ? "1 model" : $"{n} models";
 
+        /// <summary>
+        /// The provider's models page, offered when this group has nothing in it.
+        ///
+        /// <para>The case with no other answer today: an endpoint that publishes no listing, or whose listing
+        /// failed, leaves a reader needing a model id from somewhere. This is the somewhere. Hidden once the
+        /// group has models, where it would be a link to information already on screen.</para>
+        /// </summary>
+        public string? DocUrl => AiProviderPresets.ById(Id)?.Doc;
+
+        public bool ShowDoc => Visible.Count == 0 && !string.IsNullOrEmpty(DocUrl);
+
+        public ReactiveCommand<Unit, Unit> OpenDocCommand { get; }
+
         public ReactiveCommand<Unit, Unit> ToggleCommand { get; }
 
         public ReactiveCommand<Unit, Unit> FetchCommand { get; }
@@ -314,6 +328,7 @@ namespace CST.Avalonia.ViewModels
             Visible.Clear();
             Visible.AddRange(rows);
             this.RaisePropertyChanged(nameof(CountText));
+            this.RaisePropertyChanged(nameof(ShowDoc));
         }
 
         /// <summary>What the provider published about one model, or null when it published nothing — which is

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -278,7 +278,22 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public string? DocUrl => AiProviderPresets.ById(Id)?.Doc;
 
-        public bool ShowDoc => Visible.Count == 0 && !string.IsNullOrEmpty(DocUrl);
+        /// <summary>
+        /// Offered only once we have asked and come back with nothing.
+        ///
+        /// <para>Three states looked empty but are not the case this answers: <b>mid-fetch</b>, where it
+        /// rendered beside "asking the provider for its models"; <b>before any fetch</b>, where a collapsed
+        /// group would advertise a link although expanding it would have produced a listing; and <b>when a
+        /// filter hid everything</b>, where a provider whose four hundred models are all paid would be
+        /// described as publishing none. Only the last of those is even visible today, and all three said
+        /// something untrue.</para>
+        /// </summary>
+        public bool ShowDoc =>
+            _hasFetched && !IsFetching && !HasAnyModels && !string.IsNullOrEmpty(DocUrl);
+
+        /// <summary>Whether this connection has any models at all, before the search and price filters — the
+        /// question "does this provider publish a listing?" rather than "did the filter leave anything?".</summary>
+        private bool HasAnyModels => _fetched.Count > 0 || _connection.Models.Count > 0;
 
         public ReactiveCommand<Unit, Unit> OpenDocCommand { get; }
 
@@ -380,6 +395,7 @@ namespace CST.Avalonia.ViewModels
             finally
             {
                 IsFetching = false;
+                this.RaisePropertyChanged(nameof(ShowDoc));
                 _owner.Reflow();
             }
         }

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -122,6 +122,15 @@
                                            TextWrapping="Wrap"
                                            Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
 
+                                <!-- Offered only when the group is empty. A reader whose endpoint publishes
+                                     no listing has to get a model id from somewhere, and this is the only
+                                     answer the app can give them. -->
+                                <Button Content="See this provider's models ↗" Classes="Link"
+                                        IsVisible="{Binding ShowDoc}"
+                                        Command="{Binding OpenDocCommand}"
+                                        ToolTip.Tip="{Binding DocUrl}"
+                                        HorizontalAlignment="Left" Margin="26,0,0,0"/>
+
                             </StackPanel>
                         </Border>
                     </DataTemplate>

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -99,11 +99,23 @@
                             <Border Classes="Row">
                                 <Grid ColumnDefinitions="Auto,*,Auto,Auto">
 
-                                    <Border Grid.Column="0" Classes="Tile"
-                                            Background="{Binding MonogramTone,
-                                                Converter={x:Static conv:MonogramToneConverter.Instance}}">
-                                        <TextBlock Text="{Binding Monogram}"/>
-                                    </Border>
+                                    <!-- The logo replaces the tile where one resolved; the monogram stays
+                                         for a provider with none, a custom endpoint (no provider id at all),
+                                         and any fetch that failed. It is a better first choice, not a
+                                         replacement mechanism. -->
+                                    <Panel Grid.Column="0" Width="28" Height="28" Margin="0,1,12,0"
+                                           VerticalAlignment="Top">
+                                        <Border Classes="Tile" Margin="0"
+                                                IsVisible="{Binding !HasLogo}"
+                                                Background="{Binding MonogramTone,
+                                                    Converter={x:Static conv:MonogramToneConverter.Instance}}">
+                                            <TextBlock Text="{Binding Monogram}"/>
+                                        </Border>
+                                        <Image IsVisible="{Binding HasLogo}"
+                                               Source="{Binding LogoPath,
+                                                   Converter={x:Static conv:ProviderLogoConverter.Instance}}"
+                                               Stretch="Uniform" Margin="2"/>
+                                    </Panel>
 
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
                                         <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
@@ -133,6 +145,12 @@
                                     <StackPanel Grid.Column="3" Orientation="Horizontal"
                                                 VerticalAlignment="Center"
                                                 IsVisible="{Binding IsNotConfirmingDelete}">
+                                        <!-- Points at the provider's models page, which is the question a
+                                             configured connection actually raises: what can I run on it. -->
+                                        <Button Content="Models ↗" Classes="Link"
+                                                IsVisible="{Binding HasDoc}"
+                                                Command="{Binding OpenDocCommand}"
+                                                ToolTip.Tip="{Binding DocUrl}"/>
                                         <Button Content="Edit" Classes="Link"
                                                 Command="{Binding EditCommand}"/>
                                         <!-- Two destructive actions, not one: stopping the billing and
@@ -185,11 +203,19 @@
                             <DataTemplate x:DataType="vm:AiPresetRowViewModel">
                                 <Border Classes="Row">
                                     <Grid ColumnDefinitions="Auto,*,Auto">
-                                        <Border Grid.Column="0" Classes="Tile"
-                                                Background="{Binding MonogramTone,
-                                                    Converter={x:Static conv:MonogramToneConverter.Instance}}">
-                                            <TextBlock Text="{Binding Monogram}"/>
-                                        </Border>
+                                        <Panel Grid.Column="0" Width="28" Height="28" Margin="0,1,12,0"
+                                               VerticalAlignment="Top">
+                                            <Border Classes="Tile" Margin="0"
+                                                    IsVisible="{Binding !HasLogo}"
+                                                    Background="{Binding MonogramTone,
+                                                        Converter={x:Static conv:MonogramToneConverter.Instance}}">
+                                                <TextBlock Text="{Binding Monogram}"/>
+                                            </Border>
+                                            <Image IsVisible="{Binding HasLogo}"
+                                                   Source="{Binding LogoPath,
+                                                       Converter={x:Static conv:ProviderLogoConverter.Instance}}"
+                                                   Stretch="Uniform" Margin="2"/>
+                                        </Panel>
                                         <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
                                             <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
                                             <TextBlock Text="{Binding RequirementText}" Classes="Secondary"/>
@@ -263,11 +289,19 @@
                                 <Border Classes="Row">
                                     <Grid ColumnDefinitions="Auto,*,Auto">
 
-                                        <Border Grid.Column="0" Classes="Tile"
-                                                Background="{Binding MonogramTone,
-                                                    Converter={x:Static conv:MonogramToneConverter.Instance}}">
-                                            <TextBlock Text="{Binding Monogram}"/>
-                                        </Border>
+                                        <Panel Grid.Column="0" Width="28" Height="28" Margin="0,1,12,0"
+                                               VerticalAlignment="Top">
+                                            <Border Classes="Tile" Margin="0"
+                                                    IsVisible="{Binding !HasLogo}"
+                                                    Background="{Binding MonogramTone,
+                                                        Converter={x:Static conv:MonogramToneConverter.Instance}}">
+                                                <TextBlock Text="{Binding Monogram}"/>
+                                            </Border>
+                                            <Image IsVisible="{Binding HasLogo}"
+                                                   Source="{Binding LogoPath,
+                                                       Converter={x:Static conv:ProviderLogoConverter.Instance}}"
+                                                   Stretch="Uniform" Margin="2"/>
+                                        </Panel>
 
                                         <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
                                             <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -106,12 +106,12 @@
                                     <Panel Grid.Column="0" Width="28" Height="28" Margin="0,1,12,0"
                                            VerticalAlignment="Top">
                                         <Border Classes="Tile" Margin="0"
-                                                IsVisible="{Binding !HasLogo}"
+                                                IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}, ConverterParameter=invert}"
                                                 Background="{Binding MonogramTone,
                                                     Converter={x:Static conv:MonogramToneConverter.Instance}}">
                                             <TextBlock Text="{Binding Monogram}"/>
                                         </Border>
-                                        <Image IsVisible="{Binding HasLogo}"
+                                        <Image IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}}"
                                                Source="{Binding LogoPath,
                                                    Converter={x:Static conv:ProviderLogoConverter.Instance}}"
                                                Stretch="Uniform" Margin="2"/>
@@ -206,12 +206,12 @@
                                         <Panel Grid.Column="0" Width="28" Height="28" Margin="0,1,12,0"
                                                VerticalAlignment="Top">
                                             <Border Classes="Tile" Margin="0"
-                                                    IsVisible="{Binding !HasLogo}"
+                                                    IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}, ConverterParameter=invert}"
                                                     Background="{Binding MonogramTone,
                                                         Converter={x:Static conv:MonogramToneConverter.Instance}}">
                                                 <TextBlock Text="{Binding Monogram}"/>
                                             </Border>
-                                            <Image IsVisible="{Binding HasLogo}"
+                                            <Image IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}}"
                                                    Source="{Binding LogoPath,
                                                        Converter={x:Static conv:ProviderLogoConverter.Instance}}"
                                                    Stretch="Uniform" Margin="2"/>
@@ -292,12 +292,12 @@
                                         <Panel Grid.Column="0" Width="28" Height="28" Margin="0,1,12,0"
                                                VerticalAlignment="Top">
                                             <Border Classes="Tile" Margin="0"
-                                                    IsVisible="{Binding !HasLogo}"
+                                                    IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}, ConverterParameter=invert}"
                                                     Background="{Binding MonogramTone,
                                                         Converter={x:Static conv:MonogramToneConverter.Instance}}">
                                                 <TextBlock Text="{Binding Monogram}"/>
                                             </Border>
-                                            <Image IsVisible="{Binding HasLogo}"
+                                            <Image IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}}"
                                                    Source="{Binding LogoPath,
                                                        Converter={x:Static conv:ProviderLogoConverter.Instance}}"
                                                    Stretch="Uniform" Margin="2"/>


### PR DESCRIPTION
Closes #740. Unblocked by #738 and #749.

## Logos

Those two PRs built the resolver, the disk cache, the SVG renderer, and `AiLogoRowViewModel` already asks for
a logo per row. **Nothing drew it** — all three views were still monogram-only. This is that half.

The logo replaces the tile where one resolved. The **monogram stays** for a provider with none, for a custom
endpoint (no provider id at all), for the local runners, and for any fetch that failed. A better first choice,
not a replacement mechanism — every path still ends with something drawn.

The colour is read from the theme at conversion time, because a mark drawn in `currentColor` is invisible
against its own background in one of the two themes. A row built before a theme switch keeps the colour it was
built with until the list rebuilds; that is stated in the converter so it is not read later as a bug.

## The `doc` link — and a field that was not carried

**#737 said `doc` was carried through to the preset. It was not.** It is parsed into `CatalogProvider` and
then dropped at the generator boundary — the same shape as the `AuthHeaderName` drop the #689 review found,
and the reason this issue had nothing to bind to. `AiProviderPreset` now has `Doc` and the generator passes
it. One field, additive.

**Placement follows what the field actually is.** Sampled across the catalogue, nine `doc` links in ten point
at a *models* page rather than an account page — so it answers *"what can I run on this?"*, not *"where do I
get a key?"*. Anyone pasting a key has already been to the provider.

- a connection row gets **Models ↗** beside Edit;
- a Models-tab group gets **See this provider's models ↗** *only when it is empty*.

The second is the case with no other answer today: an endpoint that publishes no listing leaves a reader
needing a model id from somewhere. Hidden once the group has models, where it would link to information
already on screen.

**Only http and https reach the shell.** The URL arrives in a fetched catalogue, and handing an arbitrary
string to the operating system is how a data file becomes a way to run something. Covered by a theory over
`file://`, `javascript:`, empty and malformed input.

## Testing

816 targeted AI tests pass, 0 warnings in both projects.

The logo rendering itself has no automated coverage — it is a converter returning an Avalonia `IImage`, which
needs a UI thread and a real SVG (#655's gap). Worth a look in the app: OpenRouter, Groq and Cerebras should
show real marks in the connections list and the catalogue, while Ollama, LM Studio and any custom endpoint keep
their lettered tiles — and both themes, since that is where a `currentColor` mark goes wrong.
