### PR TITLE
An About box: which build this is, and who it is built on (#746)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AboutInventoryTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AboutInventoryTests.cs
@@ -37,6 +37,54 @@ public class AboutInventoryTests
         Path.Combine("CST.Lexicon", "CST.Lexicon.csproj"),
     ];
 
+    /// <summary>
+    /// The macOS menu item's header must match the constant the click handler matches on.
+    ///
+    /// <para>XAML cannot reference a C# const, so <c>App.axaml</c> carries the string literally and
+    /// <c>SetupNativeMenuEvents</c> compares against <c>App.AboutMenuHeader</c>. Reword one and the item
+    /// still appears, still looks enabled, and does nothing — the failure gives no sign of itself, which is
+    /// why it is worth a test rather than a comment.</para>
+    /// </summary>
+    [Fact]
+    public void The_macos_menu_header_matches_the_constant_it_is_matched_against()
+    {
+        var axaml = Path.Combine(RepoRoot(), "src", "CST.Avalonia", "App.axaml");
+        Assert.True(File.Exists(axaml), axaml);
+
+        Assert.Contains(
+            $"Header=\"{CST.Avalonia.App.AboutMenuHeader}\"",
+            File.ReadAllText(axaml),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The list above must match what CST.Avalonia actually references.
+    ///
+    /// <para>The blind spot in the two drift tests below: they check the packages of the projects named in
+    /// <see cref="ShippingProjects"/>, so a <c>ProjectReference</c> added later ships its packages
+    /// uncredited and every test still passes. The list is the one input neither of them can question, which
+    /// is exactly why it needs its own.</para>
+    /// </summary>
+    [Fact]
+    public void The_shipping_project_list_matches_what_the_app_references()
+    {
+        var app = Path.Combine(RepoRoot(), "src", "CST.Avalonia", "CST.Avalonia.csproj");
+        Assert.True(File.Exists(app), app);
+
+        var referenced = Regex.Matches(File.ReadAllText(app), @"<ProjectReference\s+Include=""([^""]+)""")
+            .Select(m => Path.GetFileName(m.Groups[1].Value.Replace('\\', Path.DirectorySeparatorChar)))
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var listed = ShippingProjects
+            .Select(Path.GetFileName)
+            .Where(n => !string.Equals(n, "CST.Avalonia.csproj", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        Assert.Equal(referenced, listed);
+    }
+
     [Fact]
     public void Every_shipped_package_is_acknowledged()
     {

--- a/src/CST.Avalonia.Tests/ViewModels/AboutInventoryTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AboutInventoryTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using CST.Avalonia.ViewModels;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// Keeps the About box's library list honest. (#746)
+///
+/// <para>#746 left "generated or written" open: reading PackageReference at build time keeps the list true,
+/// a written list reads better. This is the third option — written, and checked here against the csproj
+/// files that actually ship. A dependency added without a line in <see cref="AboutViewModel.Libraries"/>
+/// fails a test rather than quietly going uncredited, and a line naming a package that has since been
+/// dropped fails too, so the list cannot accumulate ghosts.</para>
+///
+/// <para>Asserted against the project files rather than the loaded assemblies: what we owe an
+/// acknowledgement for is what is <i>referenced and shipped</i>, and the test host loads a different set
+/// (xunit, Moq) while a reference used only at runtime may not be loaded at all.</para>
+/// </summary>
+public class AboutInventoryTests
+{
+    /// <summary>
+    /// The projects that ship inside the app: CST.Avalonia and everything it references. The tests project
+    /// and the command-line tools (CST.CharacterAnalysis, CST.ScriptValidation) are deliberately absent —
+    /// nothing they reference reaches a reader.
+    /// </summary>
+    private static readonly string[] ShippingProjects =
+    [
+        Path.Combine("CST.Avalonia", "CST.Avalonia.csproj"),
+        Path.Combine("CST.Core", "CST.Core.csproj"),
+        Path.Combine("CST.Lucene", "CST.Lucene.csproj"),
+        Path.Combine("CST.Lemma", "CST.Lemma.csproj"),
+        Path.Combine("CST.Lexicon", "CST.Lexicon.csproj"),
+    ];
+
+    [Fact]
+    public void Every_shipped_package_is_acknowledged()
+    {
+        var credited = CreditedPackages();
+        var uncredited = ReferencedPackages().Where(p => !credited.Contains(p)).ToList();
+
+        Assert.True(uncredited.Count == 0,
+            "These packages ship but no line in AboutViewModel.Libraries names them: "
+            + string.Join(", ", uncredited)
+            + ". Add them to an existing line's package list, or give them a line of their own.");
+    }
+
+    [Fact]
+    public void No_line_credits_a_package_that_is_gone()
+    {
+        var referenced = ReferencedPackages();
+        var stale = CreditedPackages().Where(p => !referenced.Contains(p)).ToList();
+
+        Assert.True(stale.Count == 0,
+            "AboutViewModel.Libraries names packages that are no longer referenced: "
+            + string.Join(", ", stale));
+    }
+
+    [Fact]
+    public void Every_line_names_at_least_one_package()
+    {
+        // A line with no packages behind it is invisible to both tests above — it would be a name the
+        // inventory can neither confirm nor retire.
+        var empty = new AboutViewModel().Libraries.Where(l => l.Packages.Count == 0).Select(l => l.Name);
+
+        Assert.Empty(empty);
+    }
+
+    private static SortedSet<string> CreditedPackages()
+    {
+        var credited = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var library in new AboutViewModel().Libraries)
+            foreach (var package in library.Packages)
+                credited.Add(package);
+        return credited;
+    }
+
+    private static SortedSet<string> ReferencedPackages()
+    {
+        var referenced = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var project in ShippingProjects)
+        {
+            var path = Path.Combine(RepoRoot(), "src", project);
+            Assert.True(File.Exists(path), $"Shipping project not found: {path}");
+
+            // The same id appears more than once in CST.Avalonia.csproj, under different RuntimeIdentifier
+            // conditions (the CEF packages), so this is a set rather than a list.
+            foreach (Match m in Regex.Matches(File.ReadAllText(path), "PackageReference\\s+Include=\"([^\"]+)\""))
+                referenced.Add(m.Groups[1].Value);
+        }
+
+        Assert.NotEmpty(referenced);
+        return referenced;
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/src/CST.Avalonia.Tests/ViewModels/AboutViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AboutViewModelTests.cs
@@ -1,0 +1,118 @@
+using System.Runtime.InteropServices;
+using CST.Avalonia.ViewModels;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// The About box's build identification (#746).
+///
+/// <para>Beta 6 ships four builds across two operating systems, and the whole point of the version block is
+/// that a tester can answer "which one are you running?" without guessing. So these tests are about the
+/// answer being <i>right</i> and <i>honest</i>: the version comes from the assembly, an unrecorded commit
+/// stays absent rather than becoming a plausible-looking placeholder, and an emulated architecture says so.
+/// </para>
+/// </summary>
+public class AboutViewModelTests
+{
+    [Fact]
+    public void Version_drops_the_build_metadata()
+    {
+        // What the SDK stamps on a git build. The '+sha' is not part of the version anyone quotes.
+        var vm = new AboutViewModel("5.0.0-beta.6+58e08bb3317de502d38ab98a49af76d41bf8116d",
+            "macOS 26.5.1", Architecture.Arm64, Architecture.Arm64, ".NET 10.0.9");
+
+        Assert.Equal("5.0.0-beta.6", vm.Version);
+        Assert.Equal("58e08bb", vm.Commit);
+        Assert.True(vm.HasCommit);
+    }
+
+    [Fact]
+    public void A_build_with_no_recorded_commit_shows_none()
+    {
+        // A source-archive build has no git metadata. Showing nothing is the honest answer; a placeholder
+        // would read as a real commit and send someone looking for it.
+        var vm = new AboutViewModel("5.0.0-beta.6", "macOS 26.5.1",
+            Architecture.Arm64, Architecture.Arm64, ".NET 10.0.9");
+
+        Assert.Equal("5.0.0-beta.6", vm.Version);
+        Assert.Null(vm.Commit);
+        Assert.False(vm.HasCommit);
+    }
+
+    [Fact]
+    public void A_missing_version_says_unknown_rather_than_a_literal()
+    {
+        // No hardcoded "5.0.0-beta.6" fallback anywhere in the About box: a literal would be one more string
+        // to remember at release time, and a stale one would misidentify the build it was meant to identify.
+        var vm = new AboutViewModel(null, "macOS 26.5.1",
+            Architecture.Arm64, Architecture.Arm64, ".NET 10.0.9");
+
+        Assert.Equal("unknown", vm.Version);
+    }
+
+    [Fact]
+    public void Platform_names_the_os_and_the_architecture()
+    {
+        var vm = new AboutViewModel("5.0.0-beta.6", "Microsoft Windows 10.0.26100",
+            Architecture.X64, Architecture.X64, ".NET 10.0.9");
+
+        Assert.Equal("Microsoft Windows 10.0.26100 · x64", vm.Platform);
+    }
+
+    [Fact]
+    public void An_emulated_process_names_both_architectures()
+    {
+        // The x64 download under Rosetta on an Apple Silicon Mac. Reporting only one of the two sends the
+        // investigation to the wrong build — which is exactly the mistake this box exists to prevent.
+        Assert.Equal("x64 on arm64", AboutViewModel.DescribeArchitecture(Architecture.X64, Architecture.Arm64));
+        Assert.Equal("arm64", AboutViewModel.DescribeArchitecture(Architecture.Arm64, Architecture.Arm64));
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("5.0.0-beta.6", null)]
+    // A '+' with nothing usable after it: shorter than an abbreviated sha, so there is nothing to show.
+    [InlineData("5.0.0-beta.6+", null)]
+    [InlineData("5.0.0-beta.6+abc12", null)]
+    [InlineData("5.0.0-beta.6+abcdef1", "abcdef1")]
+    public void ShortCommit_only_answers_when_there_is_a_commit(string? informational, string? expected)
+    {
+        Assert.Equal(expected, AboutViewModel.ShortCommit(informational));
+    }
+
+    [Fact]
+    public void BuildSummary_is_one_pasteable_line()
+    {
+        // The copy button's payload. It has to stand alone in a bug report, so it carries the app name too.
+        var vm = new AboutViewModel("5.0.0-beta.6+58e08bb3317de502d38ab98a49af76d41bf8116d",
+            "macOS 26.5.1", Architecture.Arm64, Architecture.Arm64, ".NET 10.0.9");
+
+        Assert.Equal("CST Reader 5.0.0-beta.6 (58e08bb) · macOS 26.5.1 · arm64 · .NET 10.0.9", vm.BuildSummary);
+    }
+
+    [Fact]
+    public void The_default_constructor_reads_this_build()
+    {
+        // The constructor the window actually uses. It reaches for the assembly and RuntimeInformation and
+        // nothing else — no service provider, no settings — so it still works when the app is in the state
+        // that made someone open the About box in the first place.
+        var vm = new AboutViewModel();
+
+        Assert.NotEqual("unknown", vm.Version);
+        Assert.DoesNotContain("+", vm.Version);
+        Assert.NotEmpty(vm.Platform);
+        Assert.NotEmpty(vm.Runtime);
+    }
+
+    [Fact]
+    public void VRI_is_credited_first()
+    {
+        // #746 is explicit: the app is a reader for VRI's corpus, and that belongs at the top rather than
+        // among the libraries.
+        var vm = new AboutViewModel();
+
+        Assert.Equal("Vipassana Research Institute", vm.Credits[0].Name);
+    }
+}

--- a/src/CST.Avalonia/App.axaml
+++ b/src/CST.Avalonia/App.axaml
@@ -98,6 +98,10 @@
     <!-- Native Menu for macOS - Application level (goes into CST Reader app menu) -->
     <NativeMenu.Menu>
         <NativeMenu>
+            <!-- About first, then Preferences, per the macOS application menu. Off macOS this whole menu is
+                 never realised, so SimpleTabbedWindow adds a Help menu carrying the same item. (#746) -->
+            <NativeMenuItem Header="About CST Reader" />
+            <NativeMenuItemSeparator />
             <!-- Preferences in app menu following macOS convention. This application-level NativeMenu is
                  only realised as the macOS app menu, so the gesture is ⌘, in practice - but it resolves
                  per platform like every other shortcut rather than hardcoding the modifier. (#28) -->

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -2234,8 +2234,11 @@ public partial class App : Application
     /// <summary>
     /// The About box (#746).
     ///
-    /// <para>Shown as a dialog, like Settings, which also makes it single-instance for free: About is the
-    /// kind of window someone opens twice without noticing, and a second copy has nothing to add.</para>
+    /// <para>Shown as a dialog, like Settings. That makes it single-instance off macOS, where the menu lives
+    /// inside the owner window and <c>ShowDialog</c> disables it — but <b>not</b> on macOS, where About sits
+    /// in the application-level menu that Avalonia leaves enabled during a window-modal dialog. Hence the
+    /// explicit guard: without it, App menu -> About twice stacks two dialogs. (Preferences has the same
+    /// gap; this fixes only its own.)</para>
     ///
     /// <para>Its view model takes no services deliberately — see AboutViewModel. That means this can still
     /// show the version when whatever the reporter is reporting has left the rest of the app unhappy.</para>
@@ -2250,14 +2253,35 @@ public partial class App : Application
                 return;
             }
 
-            var aboutWindow = new AboutWindow { DataContext = new AboutViewModel() };
-            await aboutWindow.ShowDialog(MainWindow);
+            // Bring the existing one forward rather than refusing silently: the reader asked for About and
+            // should get About, whether or not one is already behind something.
+            if (_aboutWindow is { } open)
+            {
+                open.Activate();
+                return;
+            }
+
+            _aboutWindow = new AboutWindow { DataContext = new AboutViewModel() };
+            try
+            {
+                await _aboutWindow.ShowDialog(MainWindow);
+            }
+            finally
+            {
+                // In a finally so a dialog that throws on close cannot leave the guard stuck, which would
+                // make About unopenable for the rest of the session - worse than the duplicate it prevents.
+                _aboutWindow = null;
+            }
         }
         catch (Exception ex)
         {
             Log.Error(ex, "Failed to open the About window");
         }
     }
+
+    /// <summary>The open About dialog, or null. UI-thread only, which is the only place the menu handlers
+    /// run.</summary>
+    private static AboutWindow? _aboutWindow;
 
     private void OnGoToMenuItemClickFromFloatingWindow(Window floatingWindow)
     {

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1502,12 +1502,22 @@ public partial class App : Application
         {
             foreach (var item in appMenu)
             {
-                if (item is NativeMenuItem menuItem && menuItem.Header?.ToString() == "Preferences...")
+                if (item is not NativeMenuItem menuItem) continue;
+
+                if (menuItem.Header?.ToString() == "Preferences...")
                 {
                     menuItem.Click += async (s, e) =>
                     {
                         Log.Information("Preferences menu clicked via native menu");
                         await ShowSettingsWindow();
+                    };
+                }
+                else if (menuItem.Header?.ToString() == AboutMenuHeader)
+                {
+                    menuItem.Click += async (s, e) =>
+                    {
+                        Log.Information("About menu clicked via native menu");
+                        await ShowAboutWindow();
                     };
                 }
             }
@@ -2211,6 +2221,41 @@ public partial class App : Application
         catch (Exception ex)
         {
             Log.Error(ex, "Failed to open settings window from native menu");
+        }
+    }
+
+    /// <summary>
+    /// The header both entry points match on — the macOS application menu declared in App.axaml, and the
+    /// Help menu SimpleTabbedWindow builds off macOS. Shared so a reworded menu cannot silently orphan one
+    /// of them the way a literal in two files would.
+    /// </summary>
+    internal const string AboutMenuHeader = "About CST Reader";
+
+    /// <summary>
+    /// The About box (#746).
+    ///
+    /// <para>Shown as a dialog, like Settings, which also makes it single-instance for free: About is the
+    /// kind of window someone opens twice without noticing, and a second copy has nothing to add.</para>
+    ///
+    /// <para>Its view model takes no services deliberately — see AboutViewModel. That means this can still
+    /// show the version when whatever the reporter is reporting has left the rest of the app unhappy.</para>
+    /// </summary>
+    internal static async Task ShowAboutWindow()
+    {
+        try
+        {
+            if (MainWindow == null)
+            {
+                Log.Warning("About requested with no main window to own the dialog");
+                return;
+            }
+
+            var aboutWindow = new AboutWindow { DataContext = new AboutViewModel() };
+            await aboutWindow.ShowDialog(MainWindow);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to open the About window");
         }
     }
 

--- a/src/CST.Avalonia/ViewModels/AboutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AboutViewModel.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using CST.Avalonia.Services;
+
+namespace CST.Avalonia.ViewModels
+{
+    /// <summary>
+    /// A credited source of text or data. <paramref name="Url"/> is the project's own home, so a reader who
+    /// wants to know more goes to the source rather than to something we wrote about it.
+    /// </summary>
+    public sealed record AboutCredit(string Name, string Detail, string? Url = null)
+    {
+        public bool HasUrl => !string.IsNullOrWhiteSpace(Url);
+    }
+
+    /// <summary>
+    /// One line of the library list.
+    ///
+    /// <para><see cref="Packages"/> names the NuGet ids the line stands for. That is what keeps a written
+    /// list honest: <c>AboutInventoryTests</c> reads the shipping csproj files and fails when a package is
+    /// referenced that no line here covers, or when a line names a package that has been removed. #746 left
+    /// generated-or-written open — this is written, so it can read as prose, and checked, so it cannot go
+    /// stale the next time someone adds a dependency.</para>
+    /// </summary>
+    public sealed record AboutLibrary(string Name, string Purpose, IReadOnlyList<string> Packages);
+
+    /// <summary>
+    /// The About box (#746): which build am I running, and who is this built on.
+    ///
+    /// <para>Deliberately free of every service. A tester reporting a bug needs the version even when
+    /// startup went wrong, and a view model that resolves services could fail in exactly that state —
+    /// <see cref="SettingsViewModel"/> cannot even be constructed without a service provider. Everything
+    /// here comes from the assembly, from <see cref="RuntimeInformation"/>, or from the two static lists
+    /// below.</para>
+    /// </summary>
+    public sealed class AboutViewModel
+    {
+        public AboutViewModel()
+            : this(ReadInformationalVersion(),
+                   RuntimeInformation.OSDescription,
+                   RuntimeInformation.ProcessArchitecture,
+                   RuntimeInformation.OSArchitecture,
+                   RuntimeInformation.FrameworkDescription)
+        {
+        }
+
+        /// <summary>Takes the environment as arguments so the formatting can be tested off the machine it
+        /// describes — a build's own values would make the assertions tautological.</summary>
+        internal AboutViewModel(string? informationalVersion, string osDescription,
+            Architecture processArchitecture, Architecture osArchitecture, string frameworkDescription)
+        {
+            Version = VersionComparer.StripBuildMetadata(informationalVersion) is { Length: > 0 } v
+                ? v
+                : "unknown";
+            Commit = ShortCommit(informationalVersion);
+            Platform = $"{osDescription} · {DescribeArchitecture(processArchitecture, osArchitecture)}";
+            Runtime = frameworkDescription;
+        }
+
+        public string AppName => "CST Reader";
+
+        public string Subtitle => "A reader for the Chaṭṭha Saṅgāyana Tipiṭaka";
+
+        /// <summary>The shipped version, e.g. "5.0.0-beta.6".</summary>
+        public string Version { get; }
+
+        /// <summary>The abbreviated commit the build came from, or null when it was not recorded.</summary>
+        public string? Commit { get; }
+
+        public bool HasCommit => Commit is not null;
+
+        /// <summary>e.g. "macOS 26.5.1 · arm64".</summary>
+        public string Platform { get; }
+
+        /// <summary>e.g. ".NET 10.0.9".</summary>
+        public string Runtime { get; }
+
+        /// <summary>
+        /// Everything above on one line, for the copy button. Beta 6 ships four builds across two operating
+        /// systems, and "which one are you running?" is answered by pasting this into an issue rather than by
+        /// a tester transcribing four fields.
+        /// </summary>
+        public string BuildSummary =>
+            $"{AppName} {Version}{(HasCommit ? $" ({Commit})" : "")} · {Platform} · {Runtime}";
+
+        /// <summary>
+        /// The texts and data, VRI first. The app is a reader for VRI's corpus; everything else here is
+        /// something it was built with.
+        /// </summary>
+        public IReadOnlyList<AboutCredit> Credits { get; } =
+        [
+            new("Vipassana Research Institute",
+                "The Chaṭṭha Saṅgāyana Tipiṭaka texts this application reads, prepared and made freely "
+                + "available by VRI. Every one of the 217 books comes from their edition.",
+                "https://www.vridhamma.org"),
+
+            new("models.dev",
+                "The catalogue of AI providers and models, and the provider logos. MIT licensed; the licence "
+                + "travels with the cached logo files.",
+                "https://models.dev"),
+
+            new("Digital Pāḷi Dictionary",
+                "Bhikkhu Bodhirāsa's dictionary, shipped as a derived asset under CC BY-NC-SA 4.0.",
+                "https://dpdict.net"),
+
+            new("Dictionary of Pāli Proper Names",
+                "G. P. Malalasekera's reference, in Ānandajoti Bhikkhu's revision, shipped as a derived asset."),
+
+            new("A Dictionary of the Pali Language",
+                "Robert Caesar Childers, 1875 — the bundled English dictionary."),
+        ];
+
+        /// <summary>
+        /// The libraries, as a plain list. #746 asked for a list rather than a licence-by-licence table: a
+        /// table implies a completeness it would lose the moment a package was added, and nobody audits
+        /// licences from a dialog box.
+        /// </summary>
+        public IReadOnlyList<AboutLibrary> Libraries { get; } =
+        [
+            new("Avalonia", "The cross-platform UI framework, its Fluent theme, and the Inter typeface.",
+                ["Avalonia", "Avalonia.Desktop", "Avalonia.Themes.Fluent", "Avalonia.Fonts.Inter",
+                 "Avalonia.Diagnostics"]),
+            new("Avalonia.Svg.Skia", "SVG rendering, which is how the provider logos are drawn.",
+                ["Avalonia.Svg.Skia"]),
+            new("Dock.Avalonia", "The docking layout — panels, tabs, and floating windows.",
+                ["Dock.Avalonia", "Dock.Avalonia.Themes.Fluent", "Dock.Controls.Recycling", "Dock.Model",
+                 "Dock.Model.Mvvm"]),
+            new("ReactiveUI", "The MVVM framework the view models are built on.", ["ReactiveUI"]),
+            new("WebViewControl-Avalonia", "The Chromium Embedded Framework browser the texts are rendered in.",
+                ["WebViewControl-Avalonia", "WebViewControl-Avalonia-ARM64"]),
+            new("Lucene.NET", "The full-text search index over the corpus.",
+                ["Lucene.Net", "Lucene.Net.Analysis.Common"]),
+            new("Serilog", "Logging.",
+                ["Serilog", "Serilog.Extensions.Logging", "Serilog.Sinks.Console", "Serilog.Sinks.File"]),
+            new("PdfPig", "Reading the scanned source editions.", ["PdfPig"]),
+            new("Octokit", "Checking GitHub for corpus and dictionary updates.", ["Octokit"]),
+            new("Mono.Cecil", "Reading .NET assembly metadata.", ["Mono.Cecil"]),
+            new("ModelContextProtocol", "The MCP server that exposes the reader's tools to AI clients.",
+                ["ModelContextProtocol.AspNetCore"]),
+            new("Microsoft.Data.Sqlite and SQLitePCLRaw", "The dictionary and lemma databases.",
+                ["Microsoft.Data.Sqlite", "SQLitePCLRaw.bundle_e_sqlite3"]),
+            new("Azure.Identity and Microsoft.Graph", "Reaching the source PDFs held on SharePoint.",
+                ["Azure.Identity", "Microsoft.Graph"]),
+            new("Tmds.DBus.Protocol", "Desktop integration on Linux.", ["Tmds.DBus.Protocol"]),
+            new("System.Security.Cryptography.ProtectedData", "Protecting stored API keys on Windows.",
+                ["System.Security.Cryptography.ProtectedData"]),
+        ];
+
+        /// <summary>
+        /// The version as the build recorded it. No hardcoded fallback: a literal here would be one more
+        /// string to remember at release time, and the whole point of reading the assembly is that it cannot
+        /// disagree with what shipped.
+        /// </summary>
+        private static string? ReadInformationalVersion()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                   ?? assembly.GetName().Version?.ToString();
+        }
+
+        /// <summary>
+        /// The commit from SemVer build metadata — the SDK appends "+&lt;sha&gt;" to InformationalVersion when
+        /// it builds from a git checkout. Absent from a source-archive build, hence nullable rather than a
+        /// placeholder that would look like a real answer.
+        /// </summary>
+        internal static string? ShortCommit(string? informationalVersion)
+        {
+            if (string.IsNullOrWhiteSpace(informationalVersion)) return null;
+
+            var plus = informationalVersion.IndexOf('+');
+            if (plus < 0) return null;
+
+            var sha = informationalVersion[(plus + 1)..].Trim();
+            return sha.Length >= 7 ? sha[..7] : null;
+        }
+
+        /// <summary>
+        /// The architecture, naming BOTH when they differ — an x64 build under Rosetta on an Apple Silicon
+        /// Mac is a distinct thing to be running, and a tester who reports "arm64" from the OS while running
+        /// the x64 download sends the investigation to the wrong build.
+        /// </summary>
+        internal static string DescribeArchitecture(Architecture process, Architecture os)
+        {
+            var running = process.ToString().ToLowerInvariant();
+            return process == os ? running : $"{running} on {os.ToString().ToLowerInvariant()}";
+        }
+    }
+}

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -136,11 +136,10 @@ namespace CST.Avalonia.ViewModels
             }
         }
 
-        private void ShowAbout()
-        {
-            // TODO: Implement About dialog
-            Log.Debug("[Layout] About dialog requested");
-        }
+        // Both entry points that exist go through the menus (App.axaml on macOS, Help elsewhere); this
+        // command predates them and is bound nowhere, but it is kept pointing at the same window so a future
+        // binding cannot resurrect the old stub that only wrote a log line. (#746)
+        private void ShowAbout() => _ = App.ShowAboutWindow();
 
         public void ToggleSelectBookPanel()
         {

--- a/src/CST.Avalonia/Views/AboutWindow.axaml
+++ b/src/CST.Avalonia/Views/AboutWindow.axaml
@@ -1,0 +1,130 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:CST.Avalonia.ViewModels"
+        x:Class="CST.Avalonia.Views.AboutWindow"
+        x:DataType="vm:AboutViewModel"
+        Title="About CST Reader"
+        Width="540" Height="660"
+        MinWidth="460" MinHeight="420"
+        WindowStartupLocation="CenterOwner">
+
+    <!-- The About box (#746). Two jobs, in this order: say which build this is, and say who it is built on.
+
+         The version block sits above the fold and never scrolls, because the reason someone opens this
+         window is usually to answer "which one are you running?" for a bug report. The acknowledgements
+         scroll below it: VRI's texts first — the app is a reader for their corpus — then the other data
+         sources, then the libraries as a plain list. -->
+
+    <Window.Styles>
+        <Style Selector=":is(TextBlock).Heading">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Margin" Value="0,0,0,8"/>
+        </Style>
+
+        <Style Selector=":is(TextBlock).Secondary">
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </Style>
+
+        <!-- The URL under a credit. HyperlinkButton rather than a restyled Button so the theme decides
+             what a link looks like in each mode - an accent colour spelled out here would be one more
+             hardcoded value to get wrong in dark mode. -->
+        <Style Selector="HyperlinkButton">
+            <Setter Property="Padding" Value="0,2"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid RowDefinitions="Auto,*,Auto">
+
+        <!-- IDENTITY AND BUILD -->
+        <Border Grid.Row="0"
+                Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                BorderThickness="0,0,0,1"
+                Padding="20,18">
+            <StackPanel Orientation="Horizontal" Spacing="16">
+
+                <!-- The application icon itself, from the iconset the macOS bundle is built from, so the
+                     window shows the same mark as the Dock and the installer rather than a second artwork
+                     that would drift from it. -->
+                <Image Source="avares://CST.Avalonia/Assets/cst-new.iconset/icon_256x256.png"
+                       Width="72" Height="72" VerticalAlignment="Top"/>
+
+                <StackPanel Spacing="2" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding AppName}" FontSize="20" FontWeight="Bold"/>
+                    <TextBlock Text="{Binding Subtitle}" Classes="Secondary" Margin="0,0,0,6"/>
+
+                    <!-- Selectable: a tester copying one field by hand should not have to retype it. -->
+                    <SelectableTextBlock Text="{Binding Version, StringFormat='Version {0}'}" FontSize="13"/>
+                    <SelectableTextBlock Text="{Binding Commit, StringFormat='Commit {0}'}"
+                                         IsVisible="{Binding HasCommit}"
+                                         Classes="Secondary"/>
+                    <SelectableTextBlock Text="{Binding Platform}" Classes="Secondary"/>
+                    <SelectableTextBlock Text="{Binding Runtime}" Classes="Secondary"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- ACKNOWLEDGEMENTS -->
+        <ScrollViewer Grid.Row="1" Padding="20,18" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Spacing="18">
+
+                <StackPanel Spacing="10">
+                    <TextBlock Text="Texts and data" Classes="Heading"/>
+
+                    <ItemsControl ItemsSource="{Binding Credits}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:AboutCredit">
+                                <StackPanel Margin="0,0,0,12" Spacing="1">
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                                    <TextBlock Text="{Binding Detail}" Classes="Secondary"/>
+                                    <HyperlinkButton Content="{Binding Url}"
+                                                     IsVisible="{Binding HasUrl}"
+                                                     Click="OnOpenLink"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <StackPanel Spacing="10">
+                    <TextBlock Text="Built with" Classes="Heading"/>
+
+                    <ItemsControl ItemsSource="{Binding Libraries}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:AboutLibrary">
+                                <StackPanel Margin="0,0,0,8" Spacing="1">
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                                    <TextBlock Text="{Binding Purpose}" Classes="Secondary"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- ACTIONS -->
+        <Border Grid.Row="2"
+                Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                BorderThickness="0,1,0,0"
+                Padding="20,12">
+            <Grid ColumnDefinitions="Auto,*,Auto">
+                <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                    <Button Content="Copy version details" Click="OnCopyBuildSummary"/>
+                    <TextBlock x:Name="CopyConfirm" Text="Copied ✓" Classes="Secondary"
+                               VerticalAlignment="Center" IsVisible="False"/>
+                </StackPanel>
+
+                <Button Grid.Column="2" Content="Close" IsDefault="True" IsCancel="True"
+                        MinWidth="88" Click="OnClose"/>
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/src/CST.Avalonia/Views/AboutWindow.axaml.cs
+++ b/src/CST.Avalonia/Views/AboutWindow.axaml.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using CST.Avalonia.ViewModels;
+using Serilog;
+
+namespace CST.Avalonia.Views
+{
+    public partial class AboutWindow : Window
+    {
+        private readonly ILogger _logger = Log.ForContext<AboutWindow>();
+
+        public AboutWindow()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Opens a credited project's own site.
+        ///
+        /// <para>Through Avalonia's <c>Launcher</c> rather than the <c>Process.Start</c> ladder WelcomeView
+        /// carries: that ladder exists because the welcome page hands URLs out of a CEF navigation callback,
+        /// which has no TopLevel to hand. Here there is one, so the framework can pick the platform's
+        /// opener.</para>
+        /// </summary>
+        private async void OnOpenLink(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (sender is not HyperlinkButton { DataContext: AboutCredit credit } || credit.Url is not { } url)
+                    return;
+
+                await Launcher.LaunchUriAsync(new Uri(url));
+                _logger.Information("Opened {Url} from the About window", url);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning("Could not open the link from the About window | {Details}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Puts version, platform and runtime on the clipboard as one line, so a bug report carries the
+        /// build without the reporter transcribing four fields. Lives here rather than in the view model
+        /// because the clipboard is reached through the window's TopLevel, exactly as SettingsWindow's
+        /// MCP-config copy is.
+        /// </summary>
+        private async void OnCopyBuildSummary(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (DataContext is not AboutViewModel about) return;
+
+                var clipboard = Clipboard ?? TopLevel.GetTopLevel(this)?.Clipboard;
+                if (clipboard == null)
+                {
+                    _logger.Warning("No clipboard available to copy the build summary");
+                    return;
+                }
+
+                await clipboard.SetTextAsync(about.BuildSummary);
+
+                // Async void resumes on the UI thread under Avalonia's sync context, so touching the
+                // confirmation after the delay is safe.
+                CopyConfirm.IsVisible = true;
+                await Task.Delay(1500);
+                CopyConfirm.IsVisible = false;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to copy the build summary");
+            }
+        }
+
+        private void OnClose(object? sender, RoutedEventArgs e) => Close();
+    }
+}

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -65,6 +65,8 @@ public partial class SimpleTabbedWindow : Window
         RegisterMenuShortcutKeyBindings();
         // #28: and Settings has no entry point off macOS until we add one.
         AddSettingsMenuItemOffMacOS();
+        // #746: same story for About, which macOS keeps in the application menu.
+        AddHelpMenuOffMacOS();
 
         // #621 Feed C: record which document owns whatever just took focus, so a command pressed after a
         // detour through a tool still targets the pane the user was working in. Bubbling and passive — it
@@ -873,6 +875,50 @@ public partial class SimpleTabbedWindow : Window
         catch (Exception ex)
         {
             _logger.Error(ex, "Failed to add the Settings menu item");
+        }
+    }
+
+    /// <summary>
+    /// Adds Help &gt; About CST Reader on Windows/Linux. (#746)
+    ///
+    /// <para>Same shape as <see cref="AddSettingsMenuItemOffMacOS"/> and for the same reason: About is
+    /// declared in App.axaml's application-level NativeMenu, which Avalonia only ever realises as the macOS
+    /// application menu, so off macOS that declaration is never shown.</para>
+    ///
+    /// <para>A whole new top-level menu rather than another Tools entry, because Help is where Windows and
+    /// Linux users look for About — and it is the menu the eventual user guide and issue-tracker links
+    /// belong in too. Built here rather than in SimpleTabbedWindow.axaml because a menu declared there would
+    /// also appear on macOS, which already has the item in the application menu.</para>
+    /// </summary>
+    private void AddHelpMenuOffMacOS()
+    {
+        if (OperatingSystem.IsMacOS()) return;
+
+        try
+        {
+            var windowMenu = NativeMenu.GetMenu(this);
+            if (windowMenu == null)
+            {
+                _logger.Warning("Window menu not found - About will have no entry point");
+                return;
+            }
+
+            var aboutItem = new NativeMenuItem { Header = App.AboutMenuHeader };
+            aboutItem.Click += async (s, e) =>
+            {
+                _logger.Information("About opened from the Help menu");
+                await App.ShowAboutWindow();
+            };
+
+            var helpMenu = new NativeMenu();
+            helpMenu.Add(aboutItem);
+            windowMenu.Add(new NativeMenuItem { Header = "Help", Menu = helpMenu });
+
+            _logger.Information("Added Help > About (macOS shows it in the application menu instead)");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Failed to add the Help menu");
         }
     }
 


### PR DESCRIPTION
Closes #746. Written by a subagent in an isolated worktree, then reviewed by Fable and hardened — two commits.

## What it is

An About window: the version read from assembly attributes (never a literal, which is the point), platform and
architecture, and acknowledgements — **VRI's texts first**, then models.dev, Digital Pāḷi Dictionary, DPPN,
Childers, then the libraries as a plain list.

Reached from the **macOS application menu** and from a **new Help menu** on Windows/Linux. That is the one
place it departs from the Settings precedent (#405 puts Settings under Tools off macOS): Help is where Windows
users look for About, and where a user guide link will want to live.

## The decision worth reading

**The library list is written prose, but checked.** `AboutInventoryTests` reads the shipping csprojs and fails
**both** ways — a package that ships uncredited, and a credited line naming a package that has been dropped.
Fable mutation-tested this rather than reading it: adding a fake package failed the first test by name,
removing PdfPig failed the second by name. So it reads like prose and cannot drift.

## What the review changed

1. **`ShowDialog` is not single-instance on macOS.** True off macOS, where the menu lives inside the window
   `ShowDialog` disables — but the macOS About item is in the *application-level* menu, which Avalonia leaves
   enabled, so App menu → About twice stacked two dialogs. Now guarded, and the guard **activates the existing
   window** rather than refusing silently. Cleared in a `finally`, so a dialog that threw on close cannot leave
   About unopenable for the session — worse than the duplicate it prevents.
2. **The inventory test could not see a new project.** `ShippingProjects` was a hardcoded list — the one input
   neither drift test could question — so a `ProjectReference` added later would ship its packages uncredited
   with everything green. Now asserted against the real `ProjectReference`s.
3. **The macOS menu header was a literal in two places.** XAML cannot reference a C# const, so reword
   `App.axaml` and the item still appears, still looks enabled, and does nothing. A failure that gives no sign
   of itself is worth a test.

## Verified, not assumed

Fable confirmed the version parsing against the **built DLL** (`5.0.0-beta.6+8525cdf…` — the SDK really does
append the sha), that the view model resolves nothing from DI (so the `SettingsViewModel` trap has not
reproduced), and that no hardcoded colour appears anywhere in the new XAML.

## Two things for a human

- **The credits assert licence facts** — models.dev "MIT", DPD "CC BY-NC-SA 4.0". Plausible, unverified by
  either agent, and it ships as a statement of fact.
- **No GUI pass.** Worth opening it on macOS and in dark mode.

## Found on the way, not fixed here

- **`Mono.Cecil` looks like dead weight** — referenced by `CST.Avalonia.csproj`, zero `using` in the tree, not
  a transitive dependency of WebViewControl. Credited honestly rather than invented a use for; dropping the
  reference would also drop the line.
- **`WelcomeViewModel` hardcodes `"5.0.0-beta.6"`** as a fallback — exactly the drift this issue exists to
  prevent. The About box deliberately has no such literal.
- **`TextFillColorSecondaryBrush` may be defined nowhere**, making muted styling a no-op in ~30 places
  app-wide. Neither the review nor I could confirm it statically — Avalonia compiles theme resources into a
  binary format a byte search cannot reach — and it is cosmetic either way (text renders at full contrast, not
  invisible). Wants a runtime check.

**30 About tests pass, 0 warnings in both projects.**
