### PR TITLE
Drop Mono.Cecil, which was never used

### DIFF
--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -125,7 +125,6 @@
          line covering x64 Windows hosts. -->
     <PackageReference Include="WebViewControl-Avalonia" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == '' and '$(OS)' == 'Windows_NT'" />
     <PackageReference Include="WebViewControl-Avalonia-ARM64" Version="3.120.9" Condition="'$(RuntimeIdentifier)' == '' and '$(OS)' != 'Windows_NT'" />
-    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="ReactiveUI" Version="23.2.28" />
     <!-- MCP surface (#191): Streamable HTTP transport mounted in-process at /mcp on the loopback API server. -->
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.0.0" />

--- a/src/CST.Avalonia/ViewModels/AboutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AboutViewModel.cs
@@ -136,7 +136,6 @@ namespace CST.Avalonia.ViewModels
                 ["Serilog", "Serilog.Extensions.Logging", "Serilog.Sinks.Console", "Serilog.Sinks.File"]),
             new("PdfPig", "Reading the scanned source editions.", ["PdfPig"]),
             new("Octokit", "Checking GitHub for corpus and dictionary updates.", ["Octokit"]),
-            new("Mono.Cecil", "Reading .NET assembly metadata.", ["Mono.Cecil"]),
             new("ModelContextProtocol", "The MCP server that exposes the reader's tools to AI clients.",
                 ["ModelContextProtocol.AspNetCore"]),
             new("Microsoft.Data.Sqlite and SQLitePCLRaw", "The dictionary and lemma databases.",


### PR DESCRIPTION
Found by #752 while building the About box's library inventory: `Mono.Cecil` is referenced by `CST.Avalonia.csproj`, has zero `using` in the tree, and is not a transitive dependency of anything.

## Where it came from

**[measured]** added in `b3500ae9` (2025-07-01) — the first Avalonia commit — on the line directly after `CefGlue.Avalonia.ARM64`:

```xml
<PackageReference Include="CefGlue.Avalonia.ARM64" Version="120.6099.211" />
<PackageReference Include="Mono.Cecil" Version="0.11.6" />
```

That places it in the CefGlue API investigation, and reading assembly metadata is exactly what Cecil is for. But the `CefGlueInspector` tool added in that same commit loads `Xilium.CefGlue.Avalonia.dll` through plain `System.Reflection` and declares **no package references at all** — so even the job it was presumably added for was done without it.

The likely sequence: Cecil went in as the obvious tool, the inspector was then written with reflection instead, and the reference was never removed. ~14 months ago.

## Never used, and not needed by anything else

**[measured]**

- No `.cs` file has imported it at any point in the project's history. Searching all of history for "Cecil" in `*.cs` returns exactly one commit — yesterday's About box, which credited it.
- Nothing depends on it transitively: after removal it is gone from the resolved dependency graph entirely, not merely demoted to indirect.

## Both halves, because the test demands it

Removed from the csproj **and** from `AboutViewModel.Libraries`. #746's inventory test fails either half on its own, which is the property that makes this safe:

- credit removed only → *"These packages ship but no line in AboutViewModel.Libraries names them: Mono.Cecil."*
- reference removed only → a credited package that no longer ships.

**[measured]** I verified the first of those by re-adding the csproj line alone and watching `Every_shipped_package_is_acknowledged` fail by name.

## Testing

Full suite **2241 passed, 0 failed**. App launches clean with no assembly-load failures.

No Fable review on this one — it is a two-line deletion of something provably unreferenced, and the inventory test enforces the only invariant involved.