### PR TITLE
One provider list, and a quieter connection row (#739, #740)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -291,7 +291,7 @@ public class AiConnectionsViewModelTests
 
         // ollama is in the local section now (#739) - it needs no key AND no network, which is what puts it
         // there rather than in the catalogue.
-        Assert.Equal("No key needed", vm.LocalPresets.Single(p => p.Id == "ollama").RequirementText);
+        Assert.Equal("No key needed", vm.AvailablePresets.Single(p => p.Id == "ollama").RequirementText);
         Assert.Equal("Needs an API key", vm.AvailablePresets.Single(p => p.Id == "openrouter").RequirementText);
     }
 
@@ -477,75 +477,9 @@ public class AiConnectionsViewModelTests
 
     // ---- the catalogue at scale (#739) ---------------------------------------------------------------------
 
-    /// <summary>
-    /// The local runners sit in their own section, chosen by a fact rather than an opinion.
-    ///
-    /// <para>They need no key and no network. That is what earns them a permanent place above a catalogue
-    /// which may be neither present nor short — a "popular" section would be the ranking #670/#681 removed,
-    /// arriving as a layout decision.</para>
-    /// </summary>
-    [Fact]
-    public void Local_runners_are_separated_from_the_catalogue()
-    {
-        var (vm, _) = Make();
 
-        var local = vm.LocalPresets.Select(p => p.Id).ToList();
-        Assert.Contains("ollama", local);
-        Assert.Contains("lmstudio", local);
-        Assert.DoesNotContain(vm.AvailablePresets.Select(p => p.Id), id => local.Contains(id));
-    }
 
-    /// <summary>
-    /// Adding every local runner must not take the custom-endpoint route with it.
-    ///
-    /// <para>The two sit in one section, and gating that section on having local runners left would hide
-    /// custom the moment a reader added Ollama and LM Studio — breaking #691's rule that a preset is never
-    /// required to reach a provider, in precisely the state where the reader has shown they configure things
-    /// by hand.</para>
-    /// </summary>
-    [Fact]
-    public void Adding_every_local_runner_leaves_the_custom_route()
-    {
-        var (vm, _) = Make();
-        foreach (var id in vm.LocalPresets.Select(p => p.Id).ToList()) AddThroughSheet(vm, id);
 
-        Assert.Empty(vm.LocalPresets);
-        Assert.False(vm.HasLocalPresets);
-        // The custom row is not a preset and is bound unconditionally; this pins the command that drives it.
-        Assert.NotNull(vm.AddCustomCommand);
-        vm.AddCustomCommand.Execute().Subscribe();
-        Assert.True(vm.IsEditing);
-    }
-
-    /// <summary>The catalogue is collapsed until asked for — a hundred and sixty rows above the fold is not a
-    /// list anyone reads.</summary>
-    [Fact]
-    public void The_catalogue_starts_collapsed_and_says_how_big_it_is()
-    {
-        var (vm, _) = Make();
-
-        Assert.False(vm.IsCatalogueOpen);
-        Assert.True(vm.AvailablePresets.Count > 20, "the snapshot should supply a real catalogue");
-        Assert.EndsWith("providers", vm.CatalogueCount);
-    }
-
-    /// <summary>
-    /// Typing reveals the catalogue as well as filtering it.
-    ///
-    /// <para>A reader who types has asked for the list; making them expand a section first is a second
-    /// gesture for one intention.</para>
-    /// </summary>
-    [Fact]
-    public void Searching_opens_the_catalogue_and_filters_it()
-    {
-        var (vm, _) = Make();
-
-        vm.PresetSearch = "openrouter";
-
-        Assert.True(vm.IsCatalogueOpen);
-        Assert.All(vm.AvailablePresets, p =>
-            Assert.Contains("openrouter", p.Id + p.DisplayName, StringComparison.OrdinalIgnoreCase));
-    }
 
     /// <summary>Search matches the id as well as the display name — a reader may know a provider by
     /// either.</summary>
@@ -559,19 +493,6 @@ public class AiConnectionsViewModelTests
         Assert.NotEmpty(vm.AvailablePresets);
     }
 
-    /// <summary>A search matching nothing empties the catalogue without disturbing the local runners, which
-    /// are not what was being searched.</summary>
-    [Fact]
-    public void A_fruitless_search_leaves_the_local_runners_alone()
-    {
-        var (vm, _) = Make();
-        var before = vm.LocalPresets.Count;
-
-        vm.PresetSearch = "zzzzz-no-such-provider";
-
-        Assert.Empty(vm.AvailablePresets);
-        Assert.Equal(before, vm.LocalPresets.Count);
-    }
 
     /// <summary>Adding a provider still removes it from the catalogue, so the list keeps reading as "what you
     /// could add next" at this scale too.</summary>
@@ -585,6 +506,40 @@ public class AiConnectionsViewModelTests
         AddThroughSheet(vm, "openrouter");
 
         Assert.DoesNotContain(vm.AvailablePresets, p => p.Id == "openrouter");
+    }
+
+    /// <summary>
+    /// The list is populated without a search term.
+    ///
+    /// <para>It used to be collapsed behind a count, so a reader who opened the tab saw an empty box until
+    /// they typed something — a populated list that looked broken. Reported from use, and the reason the
+    /// expander is gone rather than merely defaulted open.</para>
+    /// </summary>
+    [Fact]
+    public void The_provider_list_is_populated_with_no_search_term()
+    {
+        var (vm, _) = Make();
+
+        Assert.Equal("", vm.PresetSearch);
+        Assert.True(vm.AvailablePresets.Count > 20, "the snapshot should supply a real catalogue");
+    }
+
+    /// <summary>
+    /// One list, with the local runners in it rather than pinned above it.
+    ///
+    /// <para>They had their own section on the reasoning that needing no key and no network is a fact rather
+    /// than a ranking. True, and beside the point: it still gave three providers a permanent position above a
+    /// hundred and sixty others, which is prominence however it is justified.</para>
+    /// </summary>
+    [Fact]
+    public void Local_runners_sit_in_the_one_list_like_everything_else()
+    {
+        var (vm, _) = Make();
+        var ids = vm.AvailablePresets.Select(p => p.Id).ToList();
+
+        Assert.Contains("ollama", ids);
+        Assert.Contains("lmstudio", ids);
+        Assert.Contains("openrouter", ids);
     }
 
     // ---- the states this section exists for (#739) ----------------------------------------------------------
@@ -836,9 +791,8 @@ public class AiConnectionRowLogoTests
     {
         var (vm, _) = Make(new FakeLogos());
 
-        // In LocalPresets, not the catalogue: #739 split the local runners out, and they are exactly the rows
-        // models.dev has no mark for.
-        var row = vm.LocalPresets.First(p => p.Id == "ollama");
+        // Ollama is the row models.dev has no mark for, which is what makes it the case worth asserting.
+        var row = vm.AvailablePresets.First(p => p.Id == "ollama");
         await row.LogoLoad!;
 
         Assert.Null(row.LogoPath);

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -38,7 +38,6 @@ namespace CST.Avalonia.ViewModels
         private AiConnectionEditorViewModel? _editor;
         private string? _problem;
         private string _presetSearch = "";
-        private bool _isCatalogueExpanded;
         private int _catalogueTotal;
 
         public AiConnectionsViewModel(
@@ -68,18 +67,16 @@ namespace CST.Avalonia.ViewModels
         public ObservableCollection<AiConnectionRowViewModel> Connections { get; } = new();
 
         /// <summary>
-        /// Presets that need no key and no network — the local runners. Always shown, never collapsed, and
-        /// still offered when the hosted catalogue is unreachable. (#739)
+        /// Every provider that can still be added, alphabetically, in one list.
         ///
-        /// <para><b>Not a "popular" section.</b> Its members are chosen by a fact — these work with no
-        /// credential and no internet — rather than by anyone's view of which providers are worth having,
-        /// which would be the ranking #670/#681 removed arriving as a layout decision.</para>
-        /// </summary>
-        public ObservableCollection<AiPresetRowViewModel> LocalPresets { get; } = new();
-
-        /// <summary>
-        /// Everything the catalogue offers, alphabetically. Collapsed until asked for, because ~166 rows
-        /// above the fold is not a list anyone reads.
+        /// <para>It was two: local runners pinned above a catalogue collapsed behind a count. Both were
+        /// wrong in use. The collapse made a populated list look like a broken one — the reader saw nothing
+        /// until they typed — and the pinned section gave three providers a permanent position above a
+        /// hundred and sixty others, which is prominence however mechanically it was justified.</para>
+        ///
+        /// <para>One alphabetical list ranks nothing and needs no explanation. Search filters it; the custom
+        /// endpoint sits at the end, where OpenCode puts it, because it is the generic case rather than a
+        /// provider.</para>
         /// </summary>
         public ObservableCollection<AiPresetRowViewModel> AvailablePresets { get; } = new();
 
@@ -88,8 +85,6 @@ namespace CST.Avalonia.ViewModels
         public bool HasNoConnections => Connections.Count == 0;
 
         public bool HasAvailablePresets => AvailablePresets.Count > 0;
-
-        public bool HasLocalPresets => LocalPresets.Count > 0;
 
         /// <summary>
         /// Whether the hosted catalogue has anything in it at all, <b>before</b> the search filter.
@@ -121,22 +116,9 @@ namespace CST.Avalonia.ViewModels
             set
             {
                 this.RaiseAndSetIfChanged(ref _presetSearch, value);
-                this.RaisePropertyChanged(nameof(IsCatalogueOpen));
                 Rebind();
             }
         }
-
-        public bool IsCatalogueExpanded
-        {
-            get => _isCatalogueExpanded;
-            set
-            {
-                this.RaiseAndSetIfChanged(ref _isCatalogueExpanded, value);
-                this.RaisePropertyChanged(nameof(IsCatalogueOpen));
-            }
-        }
-
-        public bool IsCatalogueOpen => IsCatalogueExpanded || !string.IsNullOrWhiteSpace(PresetSearch);
 
         /// <summary>No attempt has finished yet — said quietly, because it is the ordinary first second of a
         /// fresh install rather than a problem.</summary>
@@ -383,24 +365,11 @@ namespace CST.Avalonia.ViewModels
                 c => new AiConnectionRowViewModel(this, c),
                 (row, c) => row.Update(c));
 
-            // Split by a fact, not by an opinion: a local runner needs no key and no network, which is what
-            // earns it a permanent place above a catalogue that may be neither present nor short.
-            var local = AiProviderPresets.LocalOnly
-                .Select(p => p.Id)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);   // as the service matches ids
-
             // Counted BEFORE the search filter — see HasCatalogue.
-            _catalogueTotal = _service.AvailablePresets.Count(p => !local.Contains(p.Id));
-
-            Sync(LocalPresets, _service.AvailablePresets.Where(p => local.Contains(p.Id)).ToList(),
-                p => p.Id,
-                r => r.Id,
-                p => new AiPresetRowViewModel(this, p),
-                (row, p) => row.Update(p));
+            _catalogueTotal = _service.AvailablePresets.Count;
 
             Sync(AvailablePresets,
                 _service.AvailablePresets
-                    .Where(p => !local.Contains(p.Id))
                     .Where(MatchesSearch)
                     .ToList(),
                 p => p.Id,
@@ -410,7 +379,6 @@ namespace CST.Avalonia.ViewModels
 
             this.RaisePropertyChanged(nameof(HasNoConnections));
             this.RaisePropertyChanged(nameof(HasAvailablePresets));
-            this.RaisePropertyChanged(nameof(HasLocalPresets));
             this.RaisePropertyChanged(nameof(CatalogueCount));
             this.RaisePropertyChanged(nameof(HasCatalogue));
             this.RaisePropertyChanged(nameof(HasNoMatches));
@@ -573,6 +541,25 @@ namespace CST.Avalonia.ViewModels
         public string ModelSummary => ModelCount == 1 ? "1 model" : $"{ModelCount} models";
 
         /// <summary>
+        /// Status and model count on one line rather than two.
+        ///
+        /// <para>Both are secondary text, and stacking them made a four-line row out of a fact and a
+        /// number.</para>
+        /// </summary>
+        public string StatusSummary => $"{StatusText} · {ModelSummary}";
+
+        /// <summary>
+        /// The address, on hover.
+        ///
+        /// <para>It was a permanent second line, and against a row that already carried a badge, a status, a
+        /// count and four buttons it was the thing making the list hard to read. The reason for showing it
+        /// stands — two local runners are two names the reader chose and nothing else tells them apart — so it
+        /// moves to the tooltip rather than going away. Same trade as the model metadata on the Models
+        /// tab.</para>
+        /// </summary>
+        public string RowTooltip => $"{DisplayName}\n{Endpoint}";
+
+        /// <summary>
         /// Names where the credential came from, on <b>every</b> row.
         ///
         /// <para>OpenCode badges only the unusual row and overloads the slot across two different axes
@@ -686,9 +673,12 @@ namespace CST.Avalonia.ViewModels
             this.RaisePropertyChanged(nameof(MonogramTone));
             this.RaisePropertyChanged(nameof(ModelCount));
             this.RaisePropertyChanged(nameof(ModelSummary));
+            this.RaisePropertyChanged(nameof(StatusSummary));
+            this.RaisePropertyChanged(nameof(RowTooltip));
             this.RaisePropertyChanged(nameof(KeySourceBadge));
             this.RaisePropertyChanged(nameof(CanRemoveKey));
             this.RaisePropertyChanged(nameof(StatusText));
+            this.RaisePropertyChanged(nameof(StatusSummary));
             this.RaisePropertyChanged(nameof(IsIncomplete));
             this.RaisePropertyChanged(nameof(IncompleteText));
             this.RaisePropertyChanged(nameof(DeleteConfirmText));

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -96,7 +96,8 @@
                 <ItemsControl ItemsSource="{Binding Connections}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="vm:AiConnectionRowViewModel">
-                            <Border Classes="Row">
+                            <Border Classes="Row" Background="Transparent"
+                                    ToolTip.Tip="{Binding RowTooltip}">
                                 <Grid ColumnDefinitions="Auto,*,Auto,Auto">
 
                                     <!-- The logo replaces the tile where one resolved; the monogram stays
@@ -119,9 +120,10 @@
 
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
                                         <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
-                                        <!-- The address, which OpenCode omits. Two local endpoints are two
-                                             names the reader chose and nothing else to tell them apart. -->
-                                        <TextBlock Text="{Binding Endpoint}" Classes="Secondary"/>
+                                        <!-- The address is on the row's tooltip, not a permanent second line.
+                                             The reason for having it stands - two local runners are two names
+                                             the reader chose - but it was the largest part of what made this
+                                             list hard to read. -->
                                         <TextBlock Text="{Binding IncompleteText}"
                                                    IsVisible="{Binding IsIncomplete}"
                                                    Classes="Secondary"
@@ -136,21 +138,17 @@
                                         <!-- Never "Connected": configured is not reachable, and the screen a
                                              reader consults to diagnose a failure must not be the one lying
                                              about it. -->
-                                        <TextBlock Text="{Binding StatusText}" Classes="Secondary"
-                                                   HorizontalAlignment="Right"/>
-                                        <TextBlock Text="{Binding ModelSummary}" Classes="Secondary"
+                                        <TextBlock Text="{Binding StatusSummary}" Classes="Secondary"
                                                    HorizontalAlignment="Right"/>
                                     </StackPanel>
 
                                     <StackPanel Grid.Column="3" Orientation="Horizontal"
                                                 VerticalAlignment="Center"
                                                 IsVisible="{Binding IsNotConfirmingDelete}">
-                                        <!-- Points at the provider's models page, which is the question a
-                                             configured connection actually raises: what can I run on it. -->
-                                        <Button Content="Models ↗" Classes="Link"
-                                                IsVisible="{Binding HasDoc}"
-                                                Command="{Binding OpenDocCommand}"
-                                                ToolTip.Tip="{Binding DocUrl}"/>
+                                        <!-- Two actions, not four. The provider's models page and Remove key
+                                             both live in the editor sheet, which is where a reader who wants
+                                             to change something is already going - and Remove key was a
+                                             straight duplicate of the sheet's own. -->
                                         <Button Content="Edit" Classes="Link"
                                                 Command="{Binding EditCommand}"/>
                                         <!-- Two destructive actions, not one: stopping the billing and
@@ -158,9 +156,6 @@
                                              An environment-sourced row gets an EMPTY slot here rather than a
                                              disabled button — the app cannot delete a key it never stored,
                                              and a control there would lie about what it can do. -->
-                                        <Button Content="Remove key" Classes="Link"
-                                                IsVisible="{Binding CanRemoveKey}"
-                                                Command="{Binding RemoveKeyCommand}"/>
                                         <Button Content="Delete" Classes="Link"
                                                 Command="{Binding DeleteCommand}"/>
                                     </StackPanel>
@@ -188,69 +183,6 @@
 
             <!-- Add a provider -->
             <TextBlock Text="Add a provider" Classes="SettingLabel" FontWeight="SemiBold"/>
-            <TextBlock Text="A named provider fills in the address for you. Nothing here is a recommendation — every entry is the same mechanism as a custom endpoint, with its URL already known."
-                       Classes="SettingDescription"/>
-
-            <!-- These need no key and no network, which is why they sit above the catalogue and stay when it
-                 is unreachable. Chosen by that fact rather than by anyone's view of which providers are worth
-                 having — a "popular" section would be the ranking #670/#681 removed, arriving as a layout
-                 decision. -->
-            <Border Classes="SettingGroup" Padding="0">
-                <StackPanel>
-                    <ItemsControl ItemsSource="{Binding LocalPresets}"
-                                  IsVisible="{Binding HasLocalPresets}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate x:DataType="vm:AiPresetRowViewModel">
-                                <Border Classes="Row">
-                                    <Grid ColumnDefinitions="Auto,*,Auto">
-                                        <Panel Grid.Column="0" Width="28" Height="28" Margin="0,1,12,0"
-                                               VerticalAlignment="Top">
-                                            <Border Classes="Tile" Margin="0"
-                                                    IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}, ConverterParameter=invert}"
-                                                    Background="{Binding MonogramTone,
-                                                        Converter={x:Static conv:MonogramToneConverter.Instance}}">
-                                                <TextBlock Text="{Binding Monogram}"/>
-                                            </Border>
-                                            <Image IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}}"
-                                                   Source="{Binding LogoPath,
-                                                       Converter={x:Static conv:ProviderLogoConverter.Instance}}"
-                                                   Stretch="Uniform" Margin="2"/>
-                                        </Panel>
-                                        <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
-                                            <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
-                                            <TextBlock Text="{Binding RequirementText}" Classes="Secondary"/>
-                                        </StackPanel>
-                                        <Button Grid.Column="2" Content="+ Add"
-                                                Command="{Binding AddCommand}"
-                                                VerticalAlignment="Center"/>
-                                    </Grid>
-                                </Border>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-
-                    <!-- Custom last, as OpenCode has it, and always present. The named rows are this same row
-                         with the address filled in; a preset must never be required to reach a provider that
-                         never appears in anyone's catalogue. -->
-                    <Border Classes="Row" BorderThickness="0">
-                        <Grid ColumnDefinitions="Auto,*,Auto">
-                            <Border Grid.Column="0" Classes="Tile"
-                                    Background="{DynamicResource DockApplicationAccentBrushLow}">
-                                <TextBlock Text="+"/>
-                            </Border>
-                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
-                                <TextBlock Text="Custom endpoint" FontWeight="SemiBold"/>
-                                <TextBlock Text="Any OpenAI-compatible or Anthropic address, by URL."
-                                           Classes="Secondary"/>
-                            </StackPanel>
-                            <Button Grid.Column="2" Content="+ Add"
-                                    Command="{Binding AddCustomCommand}"
-                                    VerticalAlignment="Center"/>
-                        </Grid>
-                    </Border>
-                </StackPanel>
-            </Border>
-
             <!-- The hosted catalogue. Named when it is missing rather than rendered as an empty section: an
                  empty list reads as a broken feature, a sentence with a Retry reads as weather. -->
             <StackPanel IsVisible="{Binding HasCatalogueProblem}" Margin="0,0,0,16">
@@ -272,13 +204,11 @@
                   IsVisible="{Binding HasCatalogue}">
                 <TextBox Grid.Column="0" Text="{Binding PresetSearch}"
                          Watermark="Search providers"/>
-                <ToggleButton Grid.Column="1" IsChecked="{Binding IsCatalogueExpanded}"
-                              Content="{Binding CatalogueCount}"
-                              Margin="8,0,0,0" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="1" Text="{Binding CatalogueCount}" Classes="Secondary"
+                           Margin="10,0,2,0" VerticalAlignment="Center"/>
             </Grid>
 
-            <Border Classes="SettingGroup" Padding="0"
-                    IsVisible="{Binding IsCatalogueOpen}">
+            <Border Classes="SettingGroup" Padding="0">
                 <StackPanel>
                     <TextBlock Text="No provider matches that."
                                IsVisible="{Binding HasNoMatches}"
@@ -316,6 +246,26 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
+
+                    <!-- Last, as OpenCode has it, and always present: the named rows above are this same row
+                         with the address filled in. A preset must never be required to reach a provider that
+                         appears in nobody's catalogue. -->
+                    <Border Classes="Row" BorderThickness="0">
+                        <Grid ColumnDefinitions="Auto,*,Auto">
+                            <Border Grid.Column="0" Classes="Tile"
+                                    Background="{DynamicResource DockApplicationAccentBrushLow}">
+                                <TextBlock Text="+"/>
+                            </Border>
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                <TextBlock Text="Custom endpoint" FontWeight="SemiBold"/>
+                                <TextBlock Text="Any OpenAI-compatible or Anthropic address, by URL."
+                                           Classes="Secondary"/>
+                            </StackPanel>
+                            <Button Grid.Column="2" Content="+ Add"
+                                    Command="{Binding AddCustomCommand}"
+                                    VerticalAlignment="Center"/>
+                        </Grid>
+                    </Border>
 
                 </StackPanel>
             </Border>


### PR DESCRIPTION
Reported from use, side by side with OpenCode's Providers screen. Three things, all of them mine.

## The list looked empty

It was collapsed behind a count, so opening the tab showed a search box and nothing else until you typed — a
populated list that reads as a broken one.

**The expander is gone rather than defaulted open.** If the answer is always "open", it was never a control.

## Local runners are not above the list

They had their own section, on the reasoning that needing no key and no network is a *fact* rather than a
ranking. That is true and beside the point: it still gave three providers a permanent position above a hundred
and sixty others, which is prominence however it is justified.

One alphabetical list now, with the custom endpoint last — where OpenCode has it, and where the generic case
belongs.

## The row carried seven things

An address line, a badge, a status, a model count and **four** buttons, against OpenCode's badge and one
action.

| | |
|---|---|
| address | → the row's tooltip. The reason for having it stands — two local runners are two names the reader chose and nothing else tells them apart — but it was the largest part of what made the list hard to read |
| status + count | one line |
| **Remove key** | gone: a straight duplicate of the editor sheet's own *Remove stored key* |
| **Models ↗** | → the sheet, where a reader wanting to change something is already going |

Two actions left: **Edit** and **Delete**.

The explanatory paragraph under the heading is deleted too. It argued that nothing in the list is a
recommendation — true, and a list that needs to say so has already lost the argument.

## Testing

**819 targeted tests, 0 warnings.** Five tests describing the split-and-collapse design went with it; two new
ones pin exactly what was reported — that the list populates with no search term, and that the local runners
sit in it rather than above it.

Stacked-adjacent note: #754 (the generic model mark) is open against `main` and touches the same view model
but not this view. Whichever merges second will want a trivial rebase.