### PR TITLE
Give the custom-endpoint row the generic mark too (#740)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -696,6 +696,26 @@ public class AiConnectionsViewModelTests
         Assert.NotNull(uri);
     }
 
+    /// <summary>
+    /// The custom-endpoint row draws the same mark as everything else without a logo.
+    ///
+    /// <para>It is a fixed row in the view rather than a preset with a view model, so it inherits nothing —
+    /// which is how it ended up the one row in a list of icons showing a plus sign in a coloured tile. The
+    /// view model exposes the path the view binds to; a null means the bundled file could not be written and
+    /// the tile stays.</para>
+    /// </summary>
+    [Fact]
+    public void The_custom_row_is_offered_the_same_generic_mark()
+    {
+        var (vm, _) = Make();
+
+        // Null is legitimate here — extraction needs an Avalonia asset loader, which a plain test host has
+        // not started. What is asserted is that the view has somewhere to bind, not that a file appeared.
+        var path = vm.GenericLogoPath;
+
+        Assert.True(path is null || File.Exists(path));
+    }
+
     // ---- the generic model icon (#740) ------------------------------------------------------------------------
 
     /// <summary>

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -194,6 +194,18 @@ namespace CST.Avalonia.ViewModels
 
         public bool HasProblem => !string.IsNullOrEmpty(Problem);
 
+        /// <summary>
+        /// The generic mark, for the add-a-provider list's custom row. (#740)
+        ///
+        /// <para>That row is not a preset and has no view model of its own — it is a fixed row in the view —
+        /// so it cannot inherit the fallback the others get. Without this it was the one row in a list of
+        /// icons showing a plus sign in a coloured tile.</para>
+        ///
+        /// <para>Null when the bundled file cannot be written, which the view answers by keeping the
+        /// tile.</para>
+        /// </summary>
+        public string? GenericLogoPath => GenericModelIcon.Path();
+
         public ReactiveCommand<Unit, Unit> AddCustomCommand { get; }
 
         /// <summary>Opens the full form for an endpoint that is in nobody's catalogue. Custom is first-class

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -252,10 +252,22 @@
                          appears in nobody's catalogue. -->
                     <Border Classes="Row" BorderThickness="0">
                         <Grid ColumnDefinitions="Auto,*,Auto">
-                            <Border Grid.Column="0" Classes="Tile"
-                                    Background="{DynamicResource DockApplicationAccentBrushLow}">
-                                <TextBlock Text="+"/>
-                            </Border>
+                            <!-- The same generic mark every provider without a logo gets, so this row reads
+                                 as one of the list rather than as a control wedged into it. The plus tile
+                                 stays behind it for the case where the bundled file cannot be written. -->
+                            <Panel Grid.Column="0" Width="28" Height="28" Margin="0,1,12,0"
+                                   VerticalAlignment="Top">
+                                <Border Classes="Tile" Margin="0"
+                                        IsVisible="{Binding $parent[UserControl].((vm:AiConnectionsViewModel)DataContext).GenericLogoPath,
+                                            Converter={x:Static conv:ProviderLogoRenderedConverter.Instance},
+                                            ConverterParameter=invert}"
+                                        Background="{DynamicResource DockApplicationAccentBrushLow}">
+                                    <TextBlock Text="+"/>
+                                </Border>
+                                <Image Source="{Binding $parent[UserControl].((vm:AiConnectionsViewModel)DataContext).GenericLogoPath,
+                                           Converter={x:Static conv:ProviderLogoConverter.Instance}}"
+                                       Stretch="Uniform" Margin="2"/>
+                            </Panel>
                             <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
                                 <TextBlock Text="Custom endpoint" FontWeight="SemiBold"/>
                                 <TextBlock Text="Any OpenAI-compatible or Anthropic address, by URL."


### PR DESCRIPTION
#754 gave the sparkle to every provider models.dev has no logo for, and to a configured custom connection. It
missed the **"Custom endpoint" row in the add-a-provider list** — that one is a fixed row in the view rather
than a preset with a view model, so it inherits nothing, and stayed a plus sign in a coloured tile among a
hundred and sixty icons.

The view model exposes the bundled path; the row binds through the same converter pair the others use, so the
plus tile remains behind it for the case where the bundled file cannot be written. Same fallback discipline as
everywhere else — something is always drawn.

## Testing

57 tests on this screen, 0 warnings in both projects.

The new test asserts the view has somewhere to bind rather than that a file appeared: extraction needs an
Avalonia asset loader, which a plain test host has not started, so null is a legitimate result there and the
rendering itself remains untestable (#655).