### PR TITLE
Drop the status line from the connection rows (#739)

### DIFF
--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -550,14 +550,6 @@ namespace CST.Avalonia.ViewModels
         public string ModelSummary => ModelCount == 1 ? "1 model" : $"{ModelCount} models";
 
         /// <summary>
-        /// Status and model count on one line rather than two.
-        ///
-        /// <para>Both are secondary text, and stacking them made a four-line row out of a fact and a
-        /// number.</para>
-        /// </summary>
-        public string StatusSummary => $"{StatusText} · {ModelSummary}";
-
-        /// <summary>
         /// The address, on hover.
         ///
         /// <para>It was a permanent second line, and against a row that already carried a badge, a status, a
@@ -618,6 +610,17 @@ namespace CST.Avalonia.ViewModels
         /// that claims otherwise is the screen a reader consults to diagnose the failure it is lying about —
         /// observed in OpenCode, where the assistant reported "cannot connect" while settings went on saying
         /// Connected. "Not checked yet" is honest and costs nothing.</para>
+        /// </summary>
+        /// <summary>
+        /// What we actually know about whether this works.
+        ///
+        /// <para><b>No longer shown on the row.</b> Every connection reads "Not checked yet" until something
+        /// contacts it, so in practice the line said the same thing on every row and carried no information
+        /// at all — reported from use. Kept because the wording is the honest one and the per-turn picker
+        /// still marks an unreachable connection, which is the case that was worth saying.</para>
+        ///
+        /// <para><b>Never "Connected".</b> A configured endpoint is not a reachable one, and the screen a
+        /// reader consults to diagnose a failure must not be the one lying about it (#673).</para>
         /// </summary>
         public string StatusText => _connection.State switch
         {
@@ -682,12 +685,10 @@ namespace CST.Avalonia.ViewModels
             this.RaisePropertyChanged(nameof(MonogramTone));
             this.RaisePropertyChanged(nameof(ModelCount));
             this.RaisePropertyChanged(nameof(ModelSummary));
-            this.RaisePropertyChanged(nameof(StatusSummary));
             this.RaisePropertyChanged(nameof(RowTooltip));
             this.RaisePropertyChanged(nameof(KeySourceBadge));
             this.RaisePropertyChanged(nameof(CanRemoveKey));
             this.RaisePropertyChanged(nameof(StatusText));
-            this.RaisePropertyChanged(nameof(StatusSummary));
             this.RaisePropertyChanged(nameof(IsIncomplete));
             this.RaisePropertyChanged(nameof(IncompleteText));
             this.RaisePropertyChanged(nameof(DeleteConfirmText));

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -130,17 +130,10 @@
                                                    Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
                                     </StackPanel>
 
-                                    <StackPanel Grid.Column="2" VerticalAlignment="Center"
-                                                HorizontalAlignment="Right" Spacing="3" Margin="12,0">
-                                        <Border Classes="Pill" HorizontalAlignment="Right">
-                                            <TextBlock Text="{Binding KeySourceBadge}"/>
-                                        </Border>
-                                        <!-- Never "Connected": configured is not reachable, and the screen a
-                                             reader consults to diagnose a failure must not be the one lying
-                                             about it. -->
-                                        <TextBlock Text="{Binding StatusSummary}" Classes="Secondary"
-                                                   HorizontalAlignment="Right"/>
-                                    </StackPanel>
+                                    <Border Grid.Column="2" Classes="Pill" VerticalAlignment="Center"
+                                            HorizontalAlignment="Right" Margin="12,0">
+                                        <TextBlock Text="{Binding KeySourceBadge}"/>
+                                    </Border>
 
                                     <StackPanel Grid.Column="3" Orientation="Horizontal"
                                                 VerticalAlignment="Center"


### PR DESCRIPTION
Every row read *"Not checked yet · N models"*.

The status is only informative once something has contacted the endpoint, and nothing does until the reader
asks a question or opens the Models tab — so in practice the line said the same thing on every row. **A line
that always says the same thing says nothing.**

## This reverses an argument I made at length

It was right about the **wording** — "Connected" computed from stored configuration is a lie, and #673 exists
because OpenCode's settings page contradicts its own assistant. It was wrong about the **prominence**. Being
honest about what we do not know did not require saying it on every row, permanently, in the place a reader
scans to find a provider.

`StatusText` stays, and so does its reasoning, because the wording is still the honest one wherever it does
appear. **The case actually worth surfacing — an endpoint that failed — is still marked in the per-turn
picker**, which is where a reader meets the consequence.

The model count goes with it: it shared the line, and the Models tab is where a reader goes to think about
models.

## Also

The badge is now the only thing in that column, so it is a `Border` rather than a `StackPanel` of one with a
spacing between nothing.

## Testing

821 targeted tests, 0 warnings in both projects. No test changes — the properties and their assertions are
untouched; only the row stopped binding to one of them.

## One thing you may want to weigh after testing

With this, an unreachable connection is silent on the Providers tab. If a stopped local runner turns out to be
worth marking *there* as well as in the picker, the honest version is a badge that appears only in the failure
state — not a line present always and blank in meaning most of the time.
