### PR TITLE
Put the provider marks on the Models tab too (#740)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -40,13 +40,14 @@ public class AiModelsViewModelTests
         }
     }
 
-    private static (AiModelsViewModel Vm, AiConnectionService Service) Make(IAiModelCatalog? catalog = null)
+    private static (AiModelsViewModel Vm, AiConnectionService Service) Make(
+        IAiModelCatalog? catalog = null, IAiProviderLogos? logos = null)
     {
         var settings = new Settings();
         var svc = new Mock<ISettingsService>();
         svc.SetupGet(s => s.Settings).Returns(settings);
         var service = new AiConnectionService(svc.Object);
-        return (new AiModelsViewModel(service, catalog), service);
+        return (new AiModelsViewModel(service, catalog, logos), service);
     }
 
     private static AiConnectionDraft Draft(params AiModelEntry[] models) =>
@@ -670,6 +671,59 @@ public class AiModelsViewModelTests
 
         Assert.Single(vm.Groups);
         Assert.Equal(2, service.Connections.Count);
+    }
+
+    // ---- provider marks on the group headers (#740) -----------------------------------------------------------
+
+    /// <summary>
+    /// A group header asks for its provider's logo, keyed by the connection id.
+    ///
+    /// <para>The same id models.dev uses for anything added from the catalogue, so the mark on this tab is
+    /// the one on the Providers tab. A reader who has learnt to find OpenRouter by its logo should not have
+    /// to fall back to reading letters one tab over.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_group_asks_for_its_providers_logo()
+    {
+        var logos = new FakeLogos("openrouter");
+        var (vm, service) = Make(logos: logos);
+        service.AddFromPreset("openrouter", new Dictionary<string, string>());
+
+        var group = Group(vm);
+        if (group.LogoLoad is { } load) await load;
+
+        Assert.Equal("openrouter", logos.Asked);
+        Assert.True(group.HasLogo);
+    }
+
+    /// <summary>A provider with no mark keeps its lettered tile — the fallback is never removed, only covered
+    /// when something actually rendered.</summary>
+    [Fact]
+    public async Task A_group_with_no_logo_keeps_its_monogram()
+    {
+        var logos = new FakeLogos(null);
+        var (vm, service) = Make(logos: logos);
+        service.Add("my-box", Draft());
+
+        var group = Group(vm);
+        if (group.LogoLoad is { } load) await load;
+
+        Assert.False(group.HasLogo);
+        Assert.False(string.IsNullOrWhiteSpace(group.Monogram));
+    }
+
+    /// <summary>Hands back a path for one id and null for anything else, recording what it was asked.</summary>
+    private sealed class FakeLogos : IAiProviderLogos
+    {
+        private readonly string? _known;
+        public FakeLogos(string? known) => _known = known;
+        public string? Asked { get; private set; }
+
+        public Task<string?> GetLogoPathAsync(string providerId, CancellationToken ct = default)
+        {
+            Asked = providerId;
+            return Task.FromResult(providerId == _known ? "/tmp/cst-test-logo.svg" : null);
+        }
     }
 
     // ---- what a row says ---------------------------------------------------------------------------------

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -33,14 +33,19 @@ namespace CST.Avalonia.ViewModels
     {
         private readonly IAiConnectionService? _service;
         private readonly IAiModelCatalog? _catalog;
+        private readonly IAiProviderLogos? _logos;
         private string _search = "";
         private bool _freeOnly;
         private bool _suppressRebind;
 
-        public AiModelsViewModel(IAiConnectionService? service, IAiModelCatalog? catalog = null)
+        public AiModelsViewModel(
+            IAiConnectionService? service,
+            IAiModelCatalog? catalog = null,
+            IAiProviderLogos? logos = null)
         {
             _service = service;
             _catalog = catalog;
+            _logos = logos;
 
             if (_service is not null)
             {
@@ -99,6 +104,8 @@ namespace CST.Avalonia.ViewModels
         internal IAiConnectionService? Service => _service;
 
         internal IAiModelCatalog? Catalog => _catalog;
+
+        internal IAiProviderLogos? Logos => _logos;
 
         /// <summary>
         /// Runs a change that must not rebuild the list.
@@ -178,7 +185,12 @@ namespace CST.Avalonia.ViewModels
     }
 
     /// <summary>One connection's models, as a collapsible group. (#692)</summary>
-    public class AiModelGroupViewModel : ViewModelBase
+    /// <remarks>
+    /// Carries a logo for the same reason the Providers rows do: these headers name the same connections, and
+    /// a reader who has learnt to find OpenRouter by its mark on one tab should not have to fall back to
+    /// reading letters on the next.
+    /// </remarks>
+    public class AiModelGroupViewModel : AiLogoRowViewModel
     {
         private readonly AiModelsViewModel _owner;
         private AiConnection _connection;
@@ -193,6 +205,8 @@ namespace CST.Avalonia.ViewModels
             _owner = owner;
             _connection = connection;
 
+            LoadLogo(owner.Logos);
+
             ToggleCommand = ReactiveCommand.Create(() => { IsExpanded = !IsExpanded; });
             OpenDocCommand = ReactiveCommand.Create(() => AiConnectionsViewModel.OpenUrl(DocUrl));
             FetchCommand = ReactiveCommand.CreateFromTask(FetchAsync);
@@ -202,9 +216,14 @@ namespace CST.Avalonia.ViewModels
 
         public string DisplayName => _connection.DisplayName;
 
-        public string Monogram => AiMonogram.For(DisplayName);
+        public override string Monogram => AiMonogram.For(DisplayName);
 
-        public int MonogramTone => AiMonogram.ToneFor(Id);
+        public override int MonogramTone => AiMonogram.ToneFor(Id);
+
+        /// <summary>The connection id, which is the models.dev provider id for anything added from the
+        /// catalogue. A custom endpoint's own slug matches nothing, and falls back to the generic mark like
+        /// everywhere else.</summary>
+        protected override string? ProviderId => Id;
 
         /// <summary>Every row this group could show, filtered and ordered.</summary>
         public List<AiCatalogRowViewModel> Visible { get; } = new();

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1372,7 +1372,9 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
             Connections = new AiConnectionsViewModel(
                 connectionService, credentials, App.TryGetService<Services.Ai.IAiProviderLogos>());
             Models = new AiModelsViewModel(
-                connectionService, App.TryGetService<Services.Ai.IAiModelCatalog>());
+                connectionService,
+                App.TryGetService<Services.Ai.IAiModelCatalog>(),
+                App.TryGetService<Services.Ai.IAiProviderLogos>());
 
         }
 

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -91,11 +91,24 @@
                                                    FontSize="10"/>
                                     </Button>
 
-                                    <Border Grid.Column="1" Classes="Tile"
-                                            Background="{Binding MonogramTone,
-                                                Converter={x:Static conv:MonogramToneConverter.Instance}}">
-                                        <TextBlock Text="{Binding Monogram}"/>
-                                    </Border>
+                                    <!-- The provider's own mark, as on the Providers tab; the lettered tile
+                                         behind it for anything that has none or fails to render. -->
+                                    <Panel Grid.Column="1" Width="22" Height="22" Margin="0,0,8,0"
+                                           VerticalAlignment="Center">
+                                        <Border Classes="Tile" Margin="0"
+                                                IsVisible="{Binding LogoPath,
+                                                    Converter={x:Static conv:ProviderLogoRenderedConverter.Instance},
+                                                    ConverterParameter=invert}"
+                                                Background="{Binding MonogramTone,
+                                                    Converter={x:Static conv:MonogramToneConverter.Instance}}">
+                                            <TextBlock Text="{Binding Monogram}"/>
+                                        </Border>
+                                        <Image IsVisible="{Binding LogoPath,
+                                                   Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}}"
+                                               Source="{Binding LogoPath,
+                                                   Converter={x:Static conv:ProviderLogoConverter.Instance}}"
+                                               Stretch="Uniform" Margin="1"/>
+                                    </Panel>
 
                                     <TextBlock Grid.Column="2" Text="{Binding DisplayName}"
                                                FontWeight="SemiBold" VerticalAlignment="Center"/>


### PR DESCRIPTION
The Providers tab shows each provider's own logo; the Models tab still showed a lettered tile for the same connections, so a reader who had learnt to find OpenRouter by its mark had to fall back to reading letters one tab over.

- `AiModelGroupViewModel` now derives from `AiLogoRowViewModel`, keyed on the connection id — the models.dev provider id for anything added from the catalogue, so it resolves to the same mark the Providers tab drew. A custom endpoint's own slug matches nothing and falls back to the generic mark, as everywhere else.
- `AiModelsViewModel` takes an `IAiProviderLogos?`, injected in `SettingsViewModel` alongside the catalogue.
- The header draws the logo over the lettered tile, gated on `ProviderLogoRenderedConverter` (`invert` for the tile) so the monogram stays visible whenever nothing actually rendered — a provider models.dev has no mark for, a malformed SVG, an off-thread call. The 22x22 `Panel` matches the existing `Border.Tile` metrics, so nothing shifts.

Two tests: a group asks for its provider's logo by connection id, and a group with no logo keeps a non-empty monogram. Whether the pixels arrive is still untestable headlessly (#655) — that needs an eye on both themes.

The per-turn picker's group headers remain plain text.
