### PR TITLE
Edit a named provider on the form it was added on (#691)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -604,14 +604,14 @@ public class AiConnectionEditorViewModelTests
 
     /// <summary>
     /// Azure sends its credential in `api-key` with no scheme, and expects `Authorization` to be ABSENT. That
-    /// shape is set by the preset and is not editable in this form — so a draft that omitted it silently reset
-    /// the connection to Bearer, and every request after the first rename came back 401.
+    /// shape is set by the preset and is not editable on either form — so a draft that omitted it silently
+    /// reset the connection to Bearer, and every request after the first edit came back 401.
     ///
     /// <para>The failure was invisible from the editor: nothing on screen shows the auth shape, so the
     /// connection looked untouched while it had stopped working.</para>
     /// </summary>
     [Fact]
-    public void Renaming_an_azure_connection_does_not_reset_its_auth_shape()
+    public void Editing_an_azure_connection_does_not_reset_its_auth_shape()
     {
         var h = new Harness();
         Save(h.Preset("azure").With(vm =>
@@ -625,31 +625,11 @@ public class AiConnectionEditorViewModelTests
         Assert.Null(before.AuthScheme);
 
         var edit = h.Existing("azure");
-        edit.DisplayName = "Work Azure";
+        edit.Inputs.Single().Value = "acme-2";
         Save(edit);
 
         var after = h.Service.Connections.Single();
-        Assert.Equal("Work Azure", after.DisplayName);
-        Assert.Equal("api-key", after.AuthHeaderName);
-        Assert.Null(after.AuthScheme);
-    }
-
-    /// <summary>Adding a model to a preset connection goes through Update too, so it is the same hazard.</summary>
-    [Fact]
-    public void Adding_a_model_does_not_reset_the_auth_shape()
-    {
-        var h = new Harness();
-        Save(h.Preset("azure").With(vm =>
-        {
-            vm.Inputs.Single().Value = "acme";
-            vm.ApiKeyEntry = "sk-test";   // required, and refused without one (#761)
-        }));
-
-        var edit = h.Existing("azure");
-        edit.Models.Add(new AiModelRowViewModel(edit.Models) { ModelId = "gpt-4o" });
-        Save(edit);
-
-        var after = h.Service.Connections.Single();
+        Assert.Contains("acme-2", after.ResolvedBaseUrl);
         Assert.Equal("api-key", after.AuthHeaderName);
         Assert.Null(after.AuthScheme);
     }
@@ -663,12 +643,148 @@ public class AiConnectionEditorViewModelTests
         Save(h.Preset("openrouter").With(vm => vm.ApiKeyEntry = "sk-test"));
 
         var edit = h.Existing("openrouter");
-        edit.DisplayName = "OR";
+        edit.ApiKeyEntry = "sk-replaced";
         Save(edit);
 
         var after = h.Service.Connections.Single();
         Assert.Equal("Authorization", after.AuthHeaderName);
         Assert.Equal("Bearer", after.AuthScheme);
+    }
+
+    // ---- an edit is the form the add was (#691) ----------------------------------------------------------
+
+    /// <summary>
+    /// Editing a connection added from the provider list opens the same form it was added on.
+    ///
+    /// <para>Reported as a surprise from use: the edit sheet offered protocol, address, models and headers,
+    /// none of which are the reader's to override on a named provider — and that form was load-bearing for
+    /// the auth-shape bug above. Where a provider stops behaving as its preset says, it can be added again as
+    /// a custom endpoint.</para>
+    /// </summary>
+    [Fact]
+    public void Editing_a_named_provider_shows_the_form_it_was_added_on()
+    {
+        var h = new Harness();
+        Save(h.Preset("openrouter").With(vm => vm.ApiKeyEntry = "sk-test"));
+
+        var edit = h.Existing("openrouter");
+
+        Assert.False(edit.IsFullForm);      // no protocol or address to override
+        Assert.False(edit.ShowModels);      // the Models tab owns those
+        Assert.False(edit.ShowHeaders);     // the preset carries whatever it needs
+        Assert.True(edit.ShowKeyField);
+        Assert.StartsWith("Edit", edit.Title);
+    }
+
+    /// <summary>
+    /// What the narrowed form no longer shows, it still carries.
+    ///
+    /// <para>The draft is built from the form, so hiding the model and header rows without carrying their
+    /// values would turn a key replacement into silent data loss — a model list built on the Models tab,
+    /// gone because the reader pasted a new key.</para>
+    /// </summary>
+    [Fact]
+    public void An_edit_keeps_what_the_form_no_longer_shows()
+    {
+        var h = new Harness();
+        Save(h.Preset("openrouter").With(vm => vm.ApiKeyEntry = "sk-test"));
+
+        var added = h.Service.Connections.Single();
+        h.Service.Update(added.Id, new AiConnectionDraft(
+            added.DisplayName, added.Kind, added.BaseUrl,
+            new[] { new AiModelEntry("nvidia/nemotron", "Nemotron") },
+            new Dictionary<string, string> { ["X-Gateway"] = "token" },
+            added.Inputs, added.AuthHeaderName, added.AuthScheme));
+
+        var edit = h.Existing("openrouter");
+        edit.ApiKeyEntry = "sk-replaced";
+        Save(edit);
+
+        var after = h.Service.Connections.Single();
+        Assert.Equal("nvidia/nemotron", after.Models.Single().Id);
+        Assert.Equal("token", after.Headers["X-Gateway"]);
+        Assert.Equal("https://openrouter.ai/api/v1", after.BaseUrl);
+        Assert.Equal("sk-replaced", h.Keys.Stored["openrouter"]);
+    }
+
+    /// <summary>An edit updates the connection rather than adding a second one — the id is already taken, and
+    /// the add path would be refused by its own collision check.</summary>
+    [Fact]
+    public void An_edit_updates_rather_than_adding_again()
+    {
+        var h = new Harness();
+        Save(h.Preset("openrouter").With(vm => vm.ApiKeyEntry = "sk-test"));
+
+        var edit = h.Existing("openrouter");
+        edit.ApiKeyEntry = "sk-replaced";
+        Save(edit);
+
+        Assert.Single(h.Service.Connections);
+        Assert.True(h.Closed);
+    }
+
+    /// <summary>An edit asks for the provider's inputs in the provider's own words, with the stored answer
+    /// filled in — not the raw key it happens to be stored under.</summary>
+    [Fact]
+    public void An_edit_asks_for_inputs_in_the_presets_own_words()
+    {
+        var h = new Harness();
+        Save(h.Preset("azure").With(vm =>
+        {
+            vm.Inputs.Single().Value = "acme";
+            vm.ApiKeyEntry = "sk-test";
+        }));
+
+        var input = h.Existing("azure").Inputs.Single();
+
+        Assert.Equal("acme", input.Value);
+        Assert.Equal(h.Service.Presets.Single(p => p.Id == "azure").Prompts!.Single().Message, input.Message);
+    }
+
+    /// <summary>A custom endpoint keeps the whole form: nothing about it comes from a preset.</summary>
+    [Fact]
+    public void Editing_a_custom_endpoint_still_shows_the_full_form()
+    {
+        var h = new Harness();
+        Save(h.Custom().With(vm =>
+        {
+            vm.Id = "my-box";
+            vm.BaseUrl = "http://localhost:1234/v1";
+        }));
+
+        var edit = h.Existing("my-box");
+
+        Assert.True(edit.IsFullForm);
+        Assert.True(edit.ShowModels);
+        Assert.True(edit.ShowHeaders);
+        Assert.False(edit.IsIdEditable);   // except the id, which the credential is filed under
+    }
+
+    /// <summary>A local runner from the provider list has nothing to edit — no key, no questions — so its row
+    /// offers no Edit rather than a sheet with a title and two buttons.</summary>
+    [Fact]
+    public void A_local_runner_has_nothing_to_edit()
+    {
+        var h = new Harness();
+        Save(h.Preset("ollama"));
+
+        Assert.False(AiConnectionEditorViewModel.CanEdit(h.Service, h.Service.Connections.Single()));
+    }
+
+    /// <summary>Everything else does: a hosted provider has its key, and a custom endpoint has all of it.</summary>
+    [Fact]
+    public void A_hosted_provider_and_a_custom_endpoint_can_both_be_edited()
+    {
+        var h = new Harness();
+        Save(h.Preset("openrouter").With(vm => vm.ApiKeyEntry = "sk-test"));
+        Save(h.Custom().With(vm =>
+        {
+            vm.Id = "my-box";
+            vm.BaseUrl = "http://localhost:1234/v1";
+        }));
+
+        foreach (var connection in h.Service.Connections)
+            Assert.True(AiConnectionEditorViewModel.CanEdit(h.Service, connection));
     }
 }
 

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -673,7 +673,7 @@ public class AiConnectionEditorViewModelTests
         Assert.False(edit.ShowModels);      // the Models tab owns those
         Assert.False(edit.ShowHeaders);     // the preset carries whatever it needs
         Assert.True(edit.ShowKeyField);
-        Assert.StartsWith("Edit", edit.Title);
+        Assert.Equal("Replace the OpenRouter API key", edit.Title);
     }
 
     /// <summary>
@@ -761,30 +761,64 @@ public class AiConnectionEditorViewModelTests
     }
 
     /// <summary>A local runner from the provider list has nothing to edit — no key, no questions — so its row
-    /// offers no Edit rather than a sheet with a title and two buttons.</summary>
+    /// offers no button rather than a sheet with a title and two buttons.</summary>
     [Fact]
     public void A_local_runner_has_nothing_to_edit()
     {
         var h = new Harness();
         Save(h.Preset("ollama"));
 
-        Assert.False(AiConnectionEditorViewModel.CanEdit(h.Service, h.Service.Connections.Single()));
+        Assert.Null(AiConnectionEditorViewModel.EditAction(h.Service, h.Service.Connections.Single()));
     }
 
-    /// <summary>Everything else does: a hosted provider has its key, and a custom endpoint has all of it.</summary>
+    /// <summary>
+    /// A plain hosted provider says "Replace key", because that is the whole sheet and the thing readers
+    /// actually do — a key rotates, expires, or hits a daily cap.
+    ///
+    /// <para>Delete-and-re-add is not the substitute it is in OpenCode: deleting takes the reader's enabled
+    /// models with it, and a re-fetched catalogue comes back all-off (#674), so rotating a key would cost
+    /// them their short list.</para>
+    /// </summary>
     [Fact]
-    public void A_hosted_provider_and_a_custom_endpoint_can_both_be_edited()
+    public void A_plain_hosted_provider_offers_to_replace_its_key()
     {
         var h = new Harness();
         Save(h.Preset("openrouter").With(vm => vm.ApiKeyEntry = "sk-test"));
+
+        var connection = h.Service.Connections.Single();
+
+        Assert.Equal("Replace key", AiConnectionEditorViewModel.EditAction(h.Service, connection));
+        Assert.Equal("Replace the OpenRouter API key", h.Existing("openrouter").Title);
+    }
+
+    /// <summary>A provider that asks for something besides a key still says Edit — the sheet holds more than
+    /// the key, so naming it after the key would be a lie.</summary>
+    [Fact]
+    public void A_provider_that_asks_for_more_than_a_key_still_says_edit()
+    {
+        var h = new Harness();
+        Save(h.Preset("azure").With(vm =>
+        {
+            vm.Inputs.Single().Value = "acme";
+            vm.ApiKeyEntry = "sk-test";
+        }));
+
+        Assert.Equal("Edit", AiConnectionEditorViewModel.EditAction(h.Service, h.Service.Connections.Single()));
+        Assert.StartsWith("Edit", h.Existing("azure").Title);
+    }
+
+    /// <summary>A custom endpoint says Edit: every field on that form is the reader's.</summary>
+    [Fact]
+    public void A_custom_endpoint_says_edit()
+    {
+        var h = new Harness();
         Save(h.Custom().With(vm =>
         {
             vm.Id = "my-box";
             vm.BaseUrl = "http://localhost:1234/v1";
         }));
 
-        foreach (var connection in h.Service.Connections)
-            Assert.True(AiConnectionEditorViewModel.CanEdit(h.Service, connection));
+        Assert.Equal("Edit", AiConnectionEditorViewModel.EditAction(h.Service, h.Service.Connections.Single()));
     }
 }
 

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -87,20 +87,31 @@ namespace CST.Avalonia.ViewModels
                     p => string.Equals(p.Id, existingId, StringComparison.OrdinalIgnoreCase));
 
         /// <summary>
-        /// Whether an edit of this connection would have anything on it. (#691)
+        /// What the row's edit button should say, or null where it should not be there at all. (#691)
         ///
-        /// <para>False only for a local runner added from the provider list: it needs no key and asks nothing,
-        /// so the sheet would open with a title, a sentence and two buttons. The row hides Edit rather than
-        /// offering a dead end — a reader who needs that runner at another address adds it as a custom
-        /// endpoint, which is the same mechanism with the address left to them.</para>
+        /// <para>One function rather than a visibility flag beside a label, so the two cannot disagree — the
+        /// button that appears is the one whose word was chosen.</para>
+        ///
+        /// <para><b>"Replace key"</b> for the ~150 providers that are a base URL and a bearer token: that is
+        /// the entire sheet, and it is the thing readers actually do — a key rotates, expires, or hits a daily
+        /// cap. Naming it stops the button implying that a named provider's settings are the reader's to
+        /// change. <b>"Edit"</b> where the sheet holds more: a custom endpoint, whose every field is the
+        /// reader's, and a provider that asks something besides a key (Azure's resource name, Cloudflare's
+        /// account id). <b>Nothing</b> for a local runner from the provider list, which needs no key and asks
+        /// nothing, so the sheet would open with a title, a sentence and two buttons.</para>
+        ///
+        /// <para>Delete-and-re-add is <i>not</i> the substitute OpenCode can make it: deleting takes the
+        /// reader's enabled models with it, and a re-fetched catalogue comes back all-off by #674's rule, so
+        /// rotating a key would cost them their short list.</para>
         ///
         /// <para>Deliberately not symmetric with Add, which opens a sheet even for a provider that asks
         /// nothing: there the sheet is how the reader confirms an add they can see happen.</para>
         /// </summary>
-        public static bool CanEdit(IAiConnectionService service, AiConnection connection)
+        public static string? EditAction(IAiConnectionService service, AiConnection connection)
         {
             var preset = OriginPreset(service, connection.Id);
-            return preset is null || preset.RequiresKey || preset.Prompts?.Count > 0;
+            if (preset is null || preset.Prompts?.Count > 0) return "Edit";
+            return preset.RequiresKey ? "Replace key" : null;
         }
 
         /// <summary>An endpoint in nobody's catalogue. The generic mechanism the named ones are a shortcut
@@ -216,9 +227,12 @@ namespace CST.Avalonia.ViewModels
 
         public bool IsIdEditable => _existingId is null && _preset is null;
 
-        public string Title => _existingId is not null
-            ? $"Edit {_displayName}"
-            : _preset is not null ? $"Add {_preset.DisplayName}" : "Add a custom endpoint";
+        /// <summary>Says at the top of the sheet what the button that opened it said.</summary>
+        public string Title => _existingId is null
+            ? _preset is not null ? $"Add {_preset.DisplayName}" : "Add a custom endpoint"
+            : _preset is not null && !(_preset.Prompts?.Count > 0)
+                ? $"Replace the {_preset.DisplayName} API key"
+                : $"Edit {_displayName}";
 
         /// <summary>
         /// One sentence saying what this sheet is for, worded after OpenCode's — which says in a line what

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -63,7 +63,7 @@ namespace CST.Avalonia.ViewModels
             _close = close;
             _preset = preset;
             _existingId = existingId;
-            _keyRequired = preset?.RequiresKey ?? OriginPreset(service, existingId)?.RequiresKey ?? false;
+            _keyRequired = preset?.RequiresKey ?? false;
 
             SaveCommand = ReactiveCommand.Create(Save);
             CancelCommand = ReactiveCommand.Create(() => _close(false));
@@ -85,6 +85,23 @@ namespace CST.Avalonia.ViewModels
                 ? null
                 : service.Presets.FirstOrDefault(
                     p => string.Equals(p.Id, existingId, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// Whether an edit of this connection would have anything on it. (#691)
+        ///
+        /// <para>False only for a local runner added from the provider list: it needs no key and asks nothing,
+        /// so the sheet would open with a title, a sentence and two buttons. The row hides Edit rather than
+        /// offering a dead end — a reader who needs that runner at another address adds it as a custom
+        /// endpoint, which is the same mechanism with the address left to them.</para>
+        ///
+        /// <para>Deliberately not symmetric with Add, which opens a sheet even for a provider that asks
+        /// nothing: there the sheet is how the reader confirms an add they can see happen.</para>
+        /// </summary>
+        public static bool CanEdit(IAiConnectionService service, AiConnection connection)
+        {
+            var preset = OriginPreset(service, connection.Id);
+            return preset is null || preset.RequiresKey || preset.Prompts?.Count > 0;
+        }
 
         /// <summary>An endpoint in nobody's catalogue. The generic mechanism the named ones are a shortcut
         /// for, and always available — a preset must never be required to reach a provider.</summary>
@@ -123,14 +140,28 @@ namespace CST.Avalonia.ViewModels
             return vm;
         }
 
-        /// <summary>Editing what is already configured. Everything is editable except the id, which is the
-        /// account the credential is filed under — changing it would orphan the key, and the failure would
-        /// read as a rejected key rather than a lost one.</summary>
+        /// <summary>
+        /// Editing what is already configured.
+        ///
+        /// <para><b>A connection added from a provider list is edited on the same form it was added on</b> —
+        /// the key, and whatever that provider asks for besides. Anything else about it belongs to the
+        /// preset: its address, its protocol and the auth shape those imply are not the reader's to override,
+        /// and offering them made a one-field form look like an infrastructure panel. It was also load-bearing
+        /// for a bug — a rename through that form silently reset Azure's auth shape to Bearer, and nothing on
+        /// screen showed the shape. Where a provider genuinely stops behaving as its preset says, the answer
+        /// is to add it as a custom endpoint, which is the same mechanism with the address left to the
+        /// reader.</para>
+        ///
+        /// <para>Only the id is never editable, on either form: it is the account the credential is filed
+        /// under, so changing it would orphan the key and the failure would read as a rejected key rather
+        /// than a lost one.</para>
+        /// </summary>
         public static AiConnectionEditorViewModel ForExisting(
             IAiConnectionService service, IAiCredentialStore? credentials, AiConnection connection,
             Action<bool> close)
         {
-            var vm = new AiConnectionEditorViewModel(service, credentials, close, null, connection.Id)
+            var preset = OriginPreset(service, connection.Id);
+            var vm = new AiConnectionEditorViewModel(service, credentials, close, preset, connection.Id)
             {
                 _id = connection.Id,
                 _displayName = connection.DisplayName,
@@ -164,9 +195,14 @@ namespace CST.Avalonia.ViewModels
 
             foreach (var input in connection.Inputs)
                 vm.Inputs.Add(new AiInputRowViewModel(
-                    new AiInputPrompt(input.Key, input.Key), vm.OnInputChanged) { Value = input.Value });
+                    // The preset's own wording where there is one, so an edit asks "Resource name" exactly as
+                    // the add did rather than falling back to the raw key.
+                    preset?.Prompts?.FirstOrDefault(p => p.Key == input.Key)
+                        ?? new AiInputPrompt(input.Key, input.Key),
+                    vm.OnInputChanged) { Value = input.Value });
 
             if (vm.Models.Count == 0) vm.Models.Add(new AiModelRowViewModel(vm.Models));
+            vm.RefreshInputVisibility();
             return vm;
         }
 
@@ -180,9 +216,9 @@ namespace CST.Avalonia.ViewModels
 
         public bool IsIdEditable => _existingId is null && _preset is null;
 
-        public string Title => _preset is not null
-            ? $"Add {_preset.DisplayName}"
-            : _existingId is not null ? $"Edit {_displayName}" : "Add a custom endpoint";
+        public string Title => _existingId is not null
+            ? $"Edit {_displayName}"
+            : _preset is not null ? $"Add {_preset.DisplayName}" : "Add a custom endpoint";
 
         /// <summary>
         /// One sentence saying what this sheet is for, worded after OpenCode's — which says in a line what
@@ -196,6 +232,10 @@ namespace CST.Avalonia.ViewModels
                     return _existingId is not null
                         ? "Everything except the id can be changed."
                         : "Any endpoint that speaks one of the two protocols below. This is the same mechanism the named providers use, with the address left to you.";
+
+                if (_existingId is not null)
+                    return $"{_preset.DisplayName}'s address and protocol come from the provider list, and its "
+                        + "models are on the Models tab. What is left is what it asks you for.";
 
                 return _preset.RequiresKey
                     ? $"Enter your {_preset.DisplayName} API key to use {_preset.DisplayName} models in CST Reader. Its model list is fetched afterwards, on the Models tab."
@@ -384,10 +424,12 @@ namespace CST.Avalonia.ViewModels
                 .Where(i => i.IsVisible && !string.IsNullOrWhiteSpace(i.Value))
                 .ToDictionary(i => i.Key, i => i.Value.Trim(), StringComparer.Ordinal);
 
-            var result = _preset is not null
-                ? AddPreset(inputs)
-                : _existingId is not null
-                    ? _service.Update(_existingId, BuildDraft(inputs))
+            // Order matters: an edit updates even when it carries a preset, or saving one would try to add a
+            // second connection under an id that is already taken.
+            var result = _existingId is not null
+                ? _service.Update(_existingId, BuildDraft(inputs))
+                : _preset is not null
+                    ? AddPreset(inputs)
                     : _service.Add(Id.Trim(), BuildDraft(inputs));
 
             if (!result.Ok)

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -522,8 +522,9 @@ namespace CST.Avalonia.ViewModels
             _owner = owner;
             _connection = connection;
 
-            CanEdit = owner.Service is null
-                || AiConnectionEditorViewModel.CanEdit(owner.Service, connection);
+            EditLabel = owner.Service is null
+                ? "Edit"
+                : AiConnectionEditorViewModel.EditAction(owner.Service, connection);
 
             EditCommand = ReactiveCommand.Create(() => _owner.BeginEdit(Id));
             OpenDocCommand = ReactiveCommand.Create(() => AiConnectionsViewModel.OpenUrl(DocUrl));
@@ -681,10 +682,11 @@ namespace CST.Avalonia.ViewModels
             ? $"Delete {DisplayName}?"
             : $"Delete {DisplayName} and its {ModelSummary}?";
 
-        /// <summary>Whether the sheet would have anything on it. A local runner from the provider list asks
-        /// nothing and needs no key, so its row shows no Edit rather than a dead end.
-        /// (<see cref="AiConnectionEditorViewModel.CanEdit"/>)</summary>
-        public bool CanEdit { get; }
+        /// <summary>What the edit button says, or null where the sheet would be empty and the button is not
+        /// drawn at all. (<see cref="AiConnectionEditorViewModel.EditAction"/>)</summary>
+        public string? EditLabel { get; }
+
+        public bool CanEdit => EditLabel is not null;
 
         public ReactiveCommand<Unit, Unit> EditCommand { get; }
 

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -63,6 +63,8 @@ namespace CST.Avalonia.ViewModels
         /// wherever this view model is constructed without one. (#738)</summary>
         internal IAiProviderLogos? Logos => _logos;
 
+        internal IAiConnectionService? Service => _service;
+
         /// <summary>What is configured now, in the order the reader added it.</summary>
         public ObservableCollection<AiConnectionRowViewModel> Connections { get; } = new();
 
@@ -520,6 +522,9 @@ namespace CST.Avalonia.ViewModels
             _owner = owner;
             _connection = connection;
 
+            CanEdit = owner.Service is null
+                || AiConnectionEditorViewModel.CanEdit(owner.Service, connection);
+
             EditCommand = ReactiveCommand.Create(() => _owner.BeginEdit(Id));
             OpenDocCommand = ReactiveCommand.Create(() => AiConnectionsViewModel.OpenUrl(DocUrl));
             RemoveKeyCommand = ReactiveCommand.Create(() => _owner.RemoveKey(Id));
@@ -675,6 +680,11 @@ namespace CST.Avalonia.ViewModels
         public string DeleteConfirmText => ModelCount == 0
             ? $"Delete {DisplayName}?"
             : $"Delete {DisplayName} and its {ModelSummary}?";
+
+        /// <summary>Whether the sheet would have anything on it. A local runner from the provider list asks
+        /// nothing and needs no key, so its row shows no Edit rather than a dead end.
+        /// (<see cref="AiConnectionEditorViewModel.CanEdit"/>)</summary>
+        public bool CanEdit { get; }
 
         public ReactiveCommand<Unit, Unit> EditCommand { get; }
 

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -143,6 +143,7 @@
                                              to change something is already going - and Remove key was a
                                              straight duplicate of the sheet's own. -->
                                         <Button Content="Edit" Classes="Link"
+                                                IsVisible="{Binding CanEdit}"
                                                 Command="{Binding EditCommand}"/>
                                         <!-- Two destructive actions, not one: stopping the billing and
                                              throwing away a hand-typed model list are different intentions.

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -142,7 +142,7 @@
                                              both live in the editor sheet, which is where a reader who wants
                                              to change something is already going - and Remove key was a
                                              straight duplicate of the sheet's own. -->
-                                        <Button Content="Edit" Classes="Link"
+                                        <Button Content="{Binding EditLabel}" Classes="Link"
                                                 IsVisible="{Binding CanEdit}"
                                                 Command="{Binding EditCommand}"/>
                                         <!-- Two destructive actions, not one: stopping the billing and


### PR DESCRIPTION
Reported from use: the edit sheet for a named provider offered protocol, endpoint address, model list and headers — none of which are the reader's to override on a provider that came from a list.

It was a fallthrough rather than a decision. There are three factory methods but two forms: `ForExisting` passed no preset, and `IsFullForm => _preset is null`, so editing DeepSeek rendered the custom-endpoint form. That same form was load-bearing for an earlier bug — a rename through it silently reset Azure's auth shape to Bearer, with nothing on screen showing the shape.

**An edit is now the form the add was**: the key, plus whatever that provider asks for besides. Where a provider stops behaving as its preset says, it can be added again as a custom endpoint — the same mechanism with the address left to the reader.

**What the form no longer shows, it still carries.** The draft is built from the form, so hiding the model and header rows without carrying their values would turn a key replacement into silent data loss — a model list built on the Models tab, gone because the reader pasted a new key. Models, headers, address, protocol and auth shape are all read off the connection, and a test pins it.

**The button says what it does.** "Replace key" for the ~150 providers that are a base URL and a bearer token, since that is the whole sheet; "Edit" where the sheet holds more (a custom endpoint, or Azure with its resource name); nothing at all for a local runner from the provider list, which needs no key and asks nothing — its row would otherwise open a sheet with a title, a sentence and two buttons. One function returns the word or null, so the button that appears is the one whose word was chosen.

Delete-and-re-add was considered as the strict alternative and rejected: it is not the substitute OpenCode can make it, because deleting takes the reader's enabled models with it and a re-fetched catalogue comes back all-off by #674's rule — rotating a key would cost them their short list.

Also fixed here: an edit now asks for a provider's inputs in the preset's own words ("Resource name") rather than the raw key they are stored under, and `RefreshInputVisibility` runs on the edit path as it already did on the add path.

Full suite 2260 pass, 0 build warnings.
