### PR TITLE
Mark the current model at the far edge, and in the accent colour (#693)

### DIFF
--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -143,7 +143,7 @@
                                                                     <Button Command="{Binding SelectCommand}"
                                                                             IsEnabled="{Binding IsUsable}"
                                                                             HorizontalAlignment="Stretch"
-                                                                            HorizontalContentAlignment="Left"
+                                                                            HorizontalContentAlignment="Stretch"
                                                                             Background="Transparent"
                                                                             BorderThickness="0"
                                                                             Padding="8,4">
@@ -152,11 +152,31 @@
                                                                              current one: a leading tick
                                                                              indents the one row the eye is
                                                                              most likely to be looking for.
-                                                                             So the tick goes last. -->
+                                                                             So the tick goes last - and at
+                                                                             the far edge, which is why the
+                                                                             button stretches its content:
+                                                                             left-aligned, the grid shrank
+                                                                             to the text and the tick
+                                                                             trailed the name at whatever x
+                                                                             that name happened to end. -->
                                                                         <Grid ColumnDefinitions="*,Auto,Auto">
+                                                                            <!-- The current model is named
+                                                                                 in the accent colour as well
+                                                                                 as ticked: two readings of
+                                                                                 the same fact, one of which
+                                                                                 survives a glance that never
+                                                                                 reaches the far edge. -->
                                                                             <TextBlock Grid.Column="0"
                                                                                        Text="{Binding DisplayName}"
-                                                                                       TextTrimming="CharacterEllipsis"/>
+                                                                                       TextTrimming="CharacterEllipsis"
+                                                                                       Classes.current="{Binding IsCurrent}">
+                                                                                <TextBlock.Styles>
+                                                                                    <Style Selector="TextBlock.current">
+                                                                                        <Setter Property="Foreground"
+                                                                                                Value="{DynamicResource DockApplicationAccentBrushLow}"/>
+                                                                                    </Style>
+                                                                                </TextBlock.Styles>
+                                                                            </TextBlock>
                                                                             <!-- Said here rather than
                                                                                  discovered as a 401 naming
                                                                                  nothing. -->


### PR DESCRIPTION
Two cosmetic changes to the per-turn model picker, following OpenCode's.

**The tick now sits at the far edge.** It was already last in the row — the comment there explains why, a leading tick indents the one row the eye is most likely to be looking for — but the button aligned its content `Left`, so the grid shrank to fit the text and the tick trailed the name at whatever x that name happened to end. Down a 330px popup that reads as a ragged column. `HorizontalContentAlignment="Stretch"` gives the `*` column the width it was always asking for.

**The current model's name is drawn in the accent colour**, the same brush as the tick, so the two agree. Two readings of one fact, and the colour survives a glance that never reaches the far edge.

No tests: both are properties of a rendered popup, which is #655's blind spot. Wants an eye in both themes — the accent brush is `DockApplicationAccentBrushLow`, already used for the tick, so a contrast problem would be a pre-existing one.
