### PR TITLE
Surface B is in progress, not planned

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ Active work happening now:
 - [View Source PDF Implementation](features/in-progress/VIEW_SOURCE_PDF_IMPLEMENTATION.md) - Burmese PDF viewing
 - [Show Source PDF](features/in-progress/SHOW_SOURCE_PDF.md) - View Burmese CST PDFs (core ships; mapping model #76 deferred)
 - [Dictionaries](features/in-progress/DICTIONARIES.md) - Pali-English and Pali-Hindi dictionaries (core ships; #25/#109 open)
+- [AI Surface B](features/in-progress/AI_SURFACE_B.md) - The in-app Assistant (explain/translate/grammar over the open passage) — v1 by context injection; the beta 6 headline feature
 
 - **windows/** - Windows 11 port — planning now tracked in [GitHub issue #28](https://github.com/fsnow/cst/issues/28) (Windows epic + child issues), not docs. The `WindowsFontService` design is folded into [#29](https://github.com/fsnow/cst/issues/29).
 
@@ -82,7 +83,6 @@ Features planned for future implementation (from CST4 analysis):
 - [Vector Search](features/planned/VECTOR_SEARCH.md) - Semantic search (future exploration)
 - [App Intents / Siri & Apple Intelligence](features/planned/APP_INTENTS_SUPPORT.md) - macOS assistant integration (research/feasibility)
 - [AI Integration](features/planned/AI_INTEGRATION.md) - Claude & agent access to the corpus (local HTTP + llms.txt, MCP adapter, agent-driven navigation) — design of record
-- [AI Surface B](features/planned/AI_SURFACE_B.md) - The in-app model (explain/translate/grammar over the open passage) — v1 by context injection; implementation plan under AI_INTEGRATION §11.1
 
 ### 🔬 **research/** - Research & Exploration
 Exploratory research and investigations:

--- a/docs/features/in-progress/AI_SURFACE_B.md
+++ b/docs/features/in-progress/AI_SURFACE_B.md
@@ -1,12 +1,26 @@
-# Surface B — the in-app model, v1 by context injection (Planned)
+# Surface B — the in-app Assistant, v1 by context injection (In progress)
 
-**Status:** In progress. Shipped: B1 (#578, provider layer), B3 (#580, context bundler), B3a (#581, selection
-pipeline), B4 (#582, presets and the grounding contract), B5 (#583, orchestrator), B6 (#584, model registry),
-B9 (#587, evaluation harness), B2 (#579, key storage — **macOS only**), plus the reader-state read path and
-`POST /v1/ai/context-preview` (#593). **The chain now runs end to end** — a live Translate turn against the real
-corpus and a real model works — but nothing is user-visible until the Settings UI (B7, #585) and the panel
-(B8, #586) exist.
-**Parent:** [AI_INTEGRATION.md](AI_INTEGRATION.md) — the design of record for the A–E surface map. §11.1 there
+**Status:** In progress, and **the headline feature of beta 6**. The whole B1–B9 chain has shipped and is
+user-visible: provider layer (#578), key storage (#579, macOS **and** Windows), context bundler (#580),
+selection pipeline (#581), presets and the grounding contract (#582), orchestrator (#583), evaluation
+harness (#587), **Settings UI (#585)** and **the Assistant panel (#586)**, plus the reader-state read path
+and `POST /v1/ai/context-preview` (#593).
+
+**Two things this document's older status paragraph got wrong, kept here because they are easy to re-derive
+incorrectly from the section numbering below:**
+
+- **B6, the model registry (#584), was built and then deliberately removed** (#670). Pāli ability is
+  emergent and not predicted by benchmarks or model size, so a table of our own model judgements was the
+  wrong artifact at any level of care. Provider-published capability shown verbatim replaced it.
+- **The scalar provider model B7 shipped with is gone.** #689 replaced one provider / one base URL / one
+  model / one credential with a list of **connections**, a per-connection model list, and a per-turn picker
+  (#678, #691, #692, #693, #674), fed by the models.dev catalogue (#736, #737, #739, #740).
+
+**Open against this surface for beta 6:** #711 (connection headers), #742 (base-URL versioning), #728
+(models removed by a provider), #759 (credential storage format), #671 (reasoning effort), #672 (context
+budget). The verification gap — #676, #677, #675, #651 — is tracked separately and is not beta 6 scope.
+
+**Parent:** [AI_INTEGRATION.md](../planned/AI_INTEGRATION.md) — the design of record for the A–E surface map. §11.1 there
 states the decided model-access *policy*; this document is the *implementation plan* for B.
 **Tracker:** epic #186 → children #578–#587 (filed 2026-08-09; the per-item numbers are in §12).
 **Prompted by:** Antonio's July 2026 question — *"do you have any plans to support DeepSeek as an AI provider

--- a/docs/features/planned/AI_INTEGRATION.md
+++ b/docs/features/planned/AI_INTEGRATION.md
@@ -36,7 +36,7 @@ Neither user needs to know which spine they are standing on.
 > **Scope note on B.** The row above describes B as a companion "over the open text **or corpus**". **B v1 is the
 > open-text half only** — it assembles context around the passage the reader has open and sends one request; the
 > corpus half needs the model to choose its own searches and arrives with a later tool-calling tier. See
-> [AI_SURFACE_B.md](AI_SURFACE_B.md) (epic #186 → #578–#587).
+> [AI_SURFACE_B.md](../in-progress/AI_SURFACE_B.md) (epic #186 → #578–#587).
 
 ## 3. The organizing principle
 

--- a/docs/testing/PALI_FIDELITY_CASES.md
+++ b/docs/testing/PALI_FIDELITY_CASES.md
@@ -2,7 +2,7 @@
 
 **Status:** Living. Seeded 2026-08-10.
 **Owned by:** #587 (surface B evaluation harness). Cited by #584 (model registry and fidelity advisory).
-**Design context:** [AI_SURFACE_B.md](../features/planned/AI_SURFACE_B.md) §7, §13; AI_INTEGRATION.md §11.1.
+**Design context:** [AI_SURFACE_B.md](../features/in-progress/AI_SURFACE_B.md) §7, §13; AI_INTEGRATION.md §11.1.
 
 A set of Pāli questions with authoritative answers, used to evaluate what models actually produce over this
 corpus. It is the fixed eval set #587 runs across model releases, and the evidence base for #584's tier


### PR DESCRIPTION
`docs/features/planned/AI_SURFACE_B.md` → `docs/features/in-progress/AI_SURFACE_B.md`, per the planned → in-progress → implemented workflow in CLAUDE.md, with `docs/README.md` updated to match.

The move is the small part. The status paragraph was the stale part — it still read:

> nothing is user-visible until the Settings UI (B7, #585) and the panel (B8, #586) exist

Both closed on 2026-08-15, and everything since has been built on top of them.

Two claims in that paragraph are worth correcting explicitly rather than just deleting, because the section numbering further down the document would lead a reader to re-derive them:

- **B6, the model registry (#584), was built and then removed** (#670). The old text lists it as shipped.
- **The scalar provider model is gone.** #689 replaced one provider / one base URL / one model / one credential with connections, per-connection model lists, and a per-turn picker.

The new header also records what is still open against this surface for beta 6 — #711, #742, #728, #759, #671, #672 — and notes that the verification cluster (#676, #677, #675, #651) is tracked separately and is not beta 6 scope.

Three relative links would have broken on the move (`AI_INTEGRATION.md` from inside the doc, and inbound links from `AI_INTEGRATION.md` and `docs/testing/PALI_FIDELITY_CASES.md`); all three are fixed here. Docs only — no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)