### PR TITLE
Measure whether an endpoint takes /v1, instead of assuming (#742)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiBaseUrlVersionTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiBaseUrlVersionTests.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Tests.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// #742: a bare-host base URL always gained a <c>/v1</c>, which is wrong for at least one real provider.
+/// Perplexity documents <c>https://api.perplexity.ai</c> and serves <c>/chat/completions</c>, so every
+/// request 404'd against a URL the reader could not see us rewriting.
+///
+/// <para>The answer is measured, not configured: the model listing asks once, and what it learns is recorded
+/// on the connection so no later request has to guess. These tests pin the three parts of that — the guess,
+/// the probe, and the memory.</para>
+/// </summary>
+public class AiBaseUrlVersionTests
+{
+    private static AiConnection Connection(string baseUrl, bool? usesVersionSegment = null) => new(
+        Id: "custom",
+        DisplayName: "Custom",
+        Kind: ChatProviderKind.OpenAiCompatible,
+        BaseUrl: baseUrl,
+        Models: new List<AiModelEntry>(),
+        Headers: new Dictionary<string, string>(),
+        Inputs: new Dictionary<string, string>(),
+        UsesVersionSegment: usesVersionSegment);
+
+    private static (AiModelCatalog Catalog, List<string> Urls) Catalog(
+        params (HttpStatusCode Status, string Body)[] responses)
+    {
+        var urls = new List<string>();
+        var next = 0;
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            urls.Add(request.RequestUri!.ToString());
+            var (status, body) = responses[next < responses.Length ? next : responses.Length - 1];
+            next++;
+            return new HttpResponseMessage(status) { Content = new StringContent(body) };
+        });
+
+        return (new AiModelCatalog(new HttpClient(handler), null, NullLogger<AiModelCatalog>.Instance), urls);
+    }
+
+    private const string OneModel = """{"data":[{"id":"sonar-pro"}]}""";
+
+    // ---- the guess, unchanged where it was right ---------------------------------------------------------
+
+    [Fact]
+    public async Task A_bare_host_is_still_tried_with_the_version_segment_first()
+    {
+        var (catalog, urls) = Catalog((HttpStatusCode.OK, OneModel));
+
+        var result = await catalog.FetchAsync(Connection("https://api.deepseek.com"));
+
+        Assert.True(result.Ok);
+        Assert.Equal("https://api.deepseek.com/v1/models", Assert.Single(urls));
+        // Nothing was learned, because nothing needed to be: the guess was right on the first try.
+        Assert.Null(result.UsesVersionSegment);
+    }
+
+    // ---- the probe ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task A_404_on_the_guessed_url_asks_the_other_way_once_and_reports_what_worked()
+    {
+        var (catalog, urls) = Catalog(
+            (HttpStatusCode.NotFound, "not found"),
+            (HttpStatusCode.OK, OneModel));
+
+        var result = await catalog.FetchAsync(Connection("https://api.perplexity.ai"));
+
+        Assert.True(result.Ok);
+        Assert.Equal(
+            new[] { "https://api.perplexity.ai/v1/models", "https://api.perplexity.ai/models" },
+            urls);
+        Assert.False(result.UsesVersionSegment);
+    }
+
+    /// <summary>
+    /// The probe is for a URL we guessed at. A base that already carries its own version segment was not
+    /// guessed at, so a 404 there is the endpoint's answer and must not cost a second request.
+    /// </summary>
+    [Fact]
+    public async Task A_404_on_a_url_the_reader_fully_specified_is_not_second_guessed()
+    {
+        var (catalog, urls) = Catalog((HttpStatusCode.NotFound, "not found"));
+
+        var result = await catalog.FetchAsync(Connection("https://openrouter.ai/api/v1"));
+
+        Assert.False(result.Ok);
+        Assert.Equal("https://openrouter.ai/api/v1/models", Assert.Single(urls));
+    }
+
+    /// <summary>Asked once, never again — a connection that already knows does not re-probe.</summary>
+    [Fact]
+    public async Task A_connection_that_already_knows_does_not_probe_again()
+    {
+        var (catalog, urls) = Catalog((HttpStatusCode.NotFound, "not found"));
+
+        var result = await catalog.FetchAsync(
+            Connection("https://api.perplexity.ai", usesVersionSegment: false));
+
+        Assert.False(result.Ok);
+        Assert.Equal("https://api.perplexity.ai/models", Assert.Single(urls));
+    }
+
+    // ---- the memory, applied to the path that actually matters -------------------------------------------
+
+    /// <summary>
+    /// The whole point: the chat request is what was 404-ing, and it is not the request that can afford to
+    /// probe. A recorded answer moves the fix from the listing to the answer.
+    /// </summary>
+    [Fact]
+    public void A_recorded_answer_changes_where_a_chat_request_goes()
+    {
+        Assert.Equal(
+            "https://api.perplexity.ai/chat/completions",
+            AiHttp.ResolveEndpoint(
+                "https://api.perplexity.ai", "v1/chat/completions", "chat/completions",
+                BaseUrlConvention.IncludesVersion, usesVersionSegment: false).ToString());
+
+        Assert.Equal(
+            "https://api.deepseek.com/v1/chat/completions",
+            AiHttp.ResolveEndpoint(
+                "https://api.deepseek.com", "v1/chat/completions", "chat/completions",
+                BaseUrlConvention.IncludesVersion, usesVersionSegment: true).ToString());
+    }
+
+    /// <summary>
+    /// A measured answer replaces a GUESS, never a fact about the URL in hand. A base that already names its
+    /// version keeps it whatever was recorded, or a stale record would start mangling a correct URL.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void A_base_url_that_already_carries_a_version_is_left_alone_either_way(bool recorded)
+    {
+        Assert.Equal(
+            "https://openrouter.ai/api/v1/chat/completions",
+            AiHttp.ResolveEndpoint(
+                "https://openrouter.ai/api/v1", "v1/chat/completions", "chat/completions",
+                BaseUrlConvention.IncludesVersion, usesVersionSegment: recorded).ToString());
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -480,4 +480,67 @@ public class AiConnectionServiceTests
 
         Assert.False(service.Connections.Single().Models.Single().Missing);
     }
+
+    // ---- the endpoint's measured path convention (#742) --------------------------------------------------
+
+    [Fact]
+    public void A_measured_path_convention_is_recorded_on_the_connection()
+    {
+        var (service, settings) = Make();
+        service.Add("perplexity-custom", Draft(url: "https://api.perplexity.ai"));
+
+        service.ReportEndpointVersioning("perplexity-custom", false);
+
+        var record = settings.Ai.Chat.Connections.Single(c => c.Id == "perplexity-custom");
+        Assert.False(record.UsesVersionSegment);
+        Assert.False(service.Connections.Single(c => c.Id == "perplexity-custom").UsesVersionSegment);
+    }
+
+    /// <summary>
+    /// The Models tab records this on every successful fetch, so re-reporting the same answer must not
+    /// rewrite settings or raise ConnectionsChanged — a tab opened five times would otherwise churn both.
+    /// </summary>
+    [Fact]
+    public void Re_reporting_the_same_convention_raises_nothing()
+    {
+        var (service, _) = Make();
+        service.Add("my-box", Draft(url: "https://api.perplexity.ai"));
+        service.ReportEndpointVersioning("my-box", false);
+
+        var raised = 0;
+        service.ConnectionsChanged += (_, _) => raised++;
+        service.ReportEndpointVersioning("my-box", false);
+
+        Assert.Equal(0, raised);
+    }
+
+    /// <summary>
+    /// It is a fact about one URL. Retyping the base URL invalidates it, and keeping it would apply the old
+    /// endpoint's convention to a new host — the failure being silent is the whole reason #742 exists.
+    /// </summary>
+    [Fact]
+    public void Retyping_the_base_url_forgets_what_was_measured()
+    {
+        var (service, settings) = Make();
+        service.Add("my-box", Draft(url: "https://api.perplexity.ai"));
+        service.ReportEndpointVersioning("my-box", false);
+
+        service.Update("my-box", Draft(url: "https://api.deepseek.com"));
+
+        Assert.Null(settings.Ai.Chat.Connections.Single(c => c.Id == "my-box").UsesVersionSegment);
+    }
+
+    /// <summary>An edit that leaves the URL alone keeps it — renaming a connection is not a reason to
+    /// re-probe an endpoint that has not moved.</summary>
+    [Fact]
+    public void An_edit_that_leaves_the_url_alone_keeps_what_was_measured()
+    {
+        var (service, settings) = Make();
+        service.Add("my-box", Draft(url: "https://api.perplexity.ai"));
+        service.ReportEndpointVersioning("my-box", false);
+
+        service.Update("my-box", Draft(name: "Renamed", url: "https://api.perplexity.ai"));
+
+        Assert.False(settings.Ai.Chat.Connections.Single(c => c.Id == "my-box").UsesVersionSegment);
+    }
 }

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -108,7 +108,8 @@ namespace CST.Avalonia.Models.Ai
         CredentialSource KeySource = CredentialSource.None,
         Reachability State = Reachability.Configured,
         string AuthHeaderName = "Authorization",
-        string? AuthScheme = "Bearer")
+        string? AuthScheme = "Bearer",
+        bool? UsesVersionSegment = null)
     {
         /// <summary>The base URL with <see cref="Inputs"/> substituted in — what a request actually goes to.</summary>
         public string ResolvedBaseUrl => AiTemplate.Expand(BaseUrl, Inputs);

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -148,6 +148,18 @@ namespace CST.Avalonia.Models
         /// <summary>Prefix before the credential, or null for a bare value. Bearer for almost everything;
         /// null for Azure.</summary>
         public string? AuthScheme { get; set; } = "Bearer";
+
+        /// <summary>
+        /// Whether this endpoint takes a version segment on a base URL that has no path — learned from its
+        /// model listing, not configured. Null until learned. (#742)
+        ///
+        /// <para>Learned rather than typed because the reader cannot see the transformation: we turn
+        /// <c>https://api.perplexity.ai</c> into <c>…/v1/chat/completions</c>, Perplexity serves
+        /// <c>…/chat/completions</c>, and every request 404s with nothing on screen suggesting the URL was
+        /// altered. Asking the reader to know their provider's path convention would be asking them about
+        /// the one thing this bug hides from them.</para>
+        /// </summary>
+        public bool? UsesVersionSegment { get; set; }
     }
 
     /// <summary>One model a connection offers, as persisted.</summary>

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -115,6 +115,12 @@ namespace CST.Avalonia.Services.Ai
         /// never reaches the surface a reader consults to diagnose. Both now read one fact.</para>
         /// </summary>
         void ReportReachability(string connectionId, bool reachable);
+
+        /// <summary>
+        /// Records what a listing measured about this endpoint's path convention, so every later request
+        /// stops guessing. Written only when it changes. (#742)
+        /// </summary>
+        void ReportEndpointVersioning(string connectionId, bool usesVersionSegment);
     }
 
     /// <summary>
@@ -319,6 +325,24 @@ namespace CST.Avalonia.Services.Ai
         }
 
         /// <summary>
+        /// Records the endpoint's measured path convention. Written to settings, because the point is that the
+        /// NEXT launch does not have to rediscover it — and unlike reachability, which is a fact about right
+        /// now, this is a fact about the endpoint. (#742)
+        ///
+        /// <para>Writes only on a change, so a Models tab opened repeatedly does not rewrite settings or
+        /// raise <see cref="ConnectionsChanged"/> for nothing.</para>
+        /// </summary>
+        public void ReportEndpointVersioning(string connectionId, bool usesVersionSegment)
+        {
+            if (Find(connectionId) is not { } record) return;
+            if (record.UsesVersionSegment == usesVersionSegment) return;
+
+            record.UsesVersionSegment = usesVersionSegment;
+            _settings.RequestSave();
+            RaiseChanged();
+        }
+
+        /// <summary>
         /// Raises <see cref="ConnectionsChanged"/> on the UI thread. (fable review)
         ///
         /// <para><b>Why the hop lives here and not in each subscriber.</b> The only off-thread caller is
@@ -469,6 +493,14 @@ namespace CST.Avalonia.Services.Ai
 
         private static void Apply(AiConnectionRecord record, AiConnectionDraft draft)
         {
+            // BEFORE the assignment below, which is what makes this readable as a comparison at all.
+            //
+            // UsesVersionSegment is measured, not edited - there is no field for it on the editor and there
+            // should not be. But it is a fact about one URL, so a reader who retypes the base URL has
+            // invalidated it, and keeping it would apply the old endpoint's convention to a new host. (#742)
+            if (!string.Equals(record.BaseUrl, draft.BaseUrl, StringComparison.Ordinal))
+                record.UsesVersionSegment = null;
+
             record.DisplayName = draft.DisplayName;
             record.Kind = draft.Kind == ChatProviderKind.Anthropic ? "anthropic" : "openai-compatible";
             record.BaseUrl = draft.BaseUrl;
@@ -508,7 +540,8 @@ namespace CST.Avalonia.Services.Ai
             SourceFor(r.Id),
             ReachabilityOf(r.Id),
             r.AuthHeaderName,
-            r.AuthScheme);
+            r.AuthScheme,
+            r.UsesVersionSegment);
 
         /// <summary>
         /// Ids are the reserved namespace a custom connection may not take, and they become the credential's

--- a/src/CST.Avalonia/Services/Ai/AiHttp.cs
+++ b/src/CST.Avalonia/Services/Ai/AiHttp.cs
@@ -147,8 +147,14 @@ internal static class AiHttp
     /// <param name="versionedPath">Path used when the version segment must be added, e.g. <c>v1/chat/completions</c>.</param>
     /// <param name="path">Path used when the base already carries the version, e.g. <c>chat/completions</c>.</param>
     /// <param name="convention">Which convention the provider's own documentation follows.</param>
+    /// <param name="usesVersionSegment">
+    /// What this endpoint was measured to want, overriding the guess. Null until something has actually
+    /// asked it. A base URL that already carries a version segment, or already names the endpoint, is left
+    /// alone either way — this decides only the cases where we would otherwise be guessing. (#742)
+    /// </param>
     internal static Uri ResolveEndpoint(
-        string baseUrl, string versionedPath, string path, BaseUrlConvention convention)
+        string baseUrl, string versionedPath, string path, BaseUrlConvention convention,
+        bool? usesVersionSegment = null)
     {
         var trimmed = (baseUrl ?? string.Empty).Trim();
         if (trimmed.Length == 0 || !Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ||
@@ -171,8 +177,11 @@ internal static class AiHttp
         var segments = existing.Length == 0 ? Array.Empty<string>() : existing.Split('/');
         var addVersion = segments.Length switch
         {
-            0 => true,                                   // bare host always needs the version segment
-            _ when IsVersionSegment(segments[^1]) => false,   // already versioned
+            _ when segments.Length > 0 && IsVersionSegment(segments[^1]) => false,   // already versioned
+            // A measured answer beats the guess, and only ever replaces a guess: the two branches above are
+            // facts about the URL in hand, not inferences about the provider.
+            _ when usesVersionSegment is { } measured => measured,
+            0 => true,                                   // bare host: assume it needs the version segment
             _ => convention == BaseUrlConvention.ExcludesVersion || segments.Length == 1,
         };
 

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -88,10 +88,12 @@ namespace CST.Avalonia.Services.Ai
     /// </param>
     public sealed record AiCatalogResult(
         bool Ok, string? Problem, IReadOnlyList<AiCatalogModel> Models, bool? Reachable = null,
-        bool Complete = true)
+        bool Complete = true,
+        bool? UsesVersionSegment = null)
     {
-        public static AiCatalogResult Success(IReadOnlyList<AiCatalogModel> models, bool complete = true) =>
-            new(true, null, models, true, complete);
+        public static AiCatalogResult Success(
+            IReadOnlyList<AiCatalogModel> models, bool complete = true, bool? usesVersionSegment = null) =>
+            new(true, null, models, true, complete, usesVersionSegment);
 
         public static AiCatalogResult Fail(string problem, bool? reachable = null) =>
             new(false, problem, Array.Empty<AiCatalogModel>(), reachable, false);
@@ -142,19 +144,32 @@ namespace CST.Avalonia.Services.Ai
                 return AiCatalogResult.Fail(
                     $"{connection.DisplayName} is not finished being set up, so it cannot be asked for a list.");
 
+            var convention = connection.Kind == ChatProviderKind.Anthropic
+                ? BaseUrlConvention.ExcludesVersion
+                : BaseUrlConvention.IncludesVersion;
+
             Uri url;
+            Uri? alternative;
             try
             {
                 url = AiHttp.ResolveEndpoint(
-                    connection.ResolvedBaseUrl, "v1/models", "models",
-                    connection.Kind == ChatProviderKind.Anthropic
-                        ? BaseUrlConvention.ExcludesVersion
-                        : BaseUrlConvention.IncludesVersion);
+                    connection.ResolvedBaseUrl, "v1/models", "models", convention,
+                    connection.UsesVersionSegment);
+
+                // The other reading of the same base URL. Null when there is no other reading — the base
+                // already carries a version segment, or already names the endpoint, in which case nothing
+                // was guessed and there is nothing to probe.
+                var other = AiHttp.ResolveEndpoint(
+                    connection.ResolvedBaseUrl, "v1/models", "models", convention,
+                    !(connection.UsesVersionSegment ?? true));
+                alternative = other == url ? null : other;
             }
             catch (AiException ex)
             {
                 return AiCatalogResult.Fail(ex.Error.Message);
             }
+
+            bool? learned = null;
 
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             Authenticate(request, connection);
@@ -164,7 +179,40 @@ namespace CST.Avalonia.Services.Ai
 
             try
             {
-                using var response = await _http.SendAsync(request, timeout.Token).ConfigureAwait(false);
+                var response = await _http.SendAsync(request, timeout.Token).ConfigureAwait(false);
+
+                // A 404 from a URL we GUESSED at is the one failure worth a second question, because the
+                // guess is invisible to the reader: they typed the base URL their provider documents, and
+                // we added or withheld a /v1 they never saw. Perplexity is the measured case - it documents
+                // https://api.perplexity.ai and serves /chat/completions, so our version segment 404s
+                // every request. Asked once, at a moment the reader is already waiting, and never again:
+                // the answer is recorded on the connection. (#742)
+                if (response.StatusCode == System.Net.HttpStatusCode.NotFound
+                    && alternative is not null
+                    && connection.UsesVersionSegment is null)
+                {
+                    response.Dispose();
+                    _logger.LogDebug(
+                        "{Connection}: {Url} answered 404; trying {Alternative}",
+                        connection.Id, url, alternative);
+
+                    using var retry = new HttpRequestMessage(HttpMethod.Get, alternative);
+                    Authenticate(retry, connection);
+                    response = await _http.SendAsync(retry, timeout.Token).ConfigureAwait(false);
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        // `alternative` is built with usesVersionSegment: false, so reaching here means the
+                        // endpoint answers WITHOUT the version segment. That is the fact to record.
+                        learned = false;
+                        url = alternative;
+                        _logger.LogInformation(
+                            "{Connection}: endpoint {Verb} a version segment; recorded",
+                            connection.Id, learned == true ? "takes" : "does not take");
+                    }
+                }
+
+                using var _held = response;
 
                 // Answered, even if the answer was no. A rejected key and a missing listing both prove the
                 // endpoint is there, which is the fact this reports - it says nothing about whether the
@@ -200,7 +248,7 @@ namespace CST.Avalonia.Services.Ai
                         + "{Skipped} had no usable id", models.Count, connection.Id, listed, listed - models.Count);
                     _logger.LogDebug("{Connection} listing: {Body}", connection.Id, body);
                 }
-                return AiCatalogResult.Success(models, complete);
+                return AiCatalogResult.Success(models, complete, learned);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {

--- a/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
@@ -27,7 +27,8 @@ namespace CST.Avalonia.Services.Ai;
 public sealed record AnthropicOptions(
     string? ApiKey,
     string? BaseUrl = null,
-    IReadOnlyDictionary<string, string>? ExtraHeaders = null)
+    IReadOnlyDictionary<string, string>? ExtraHeaders = null,
+    bool? UsesVersionSegment = null)
 {
     internal const string DefaultBaseUrl = "https://api.anthropic.com";
 
@@ -147,7 +148,8 @@ public sealed class AnthropicMessagesProvider : IChatProvider
             string.IsNullOrWhiteSpace(_options.BaseUrl) ? AnthropicOptions.DefaultBaseUrl : _options.BaseUrl!,
             versionedPath: "v1/messages",
             path: "messages",
-            convention: BaseUrlConvention.ExcludesVersion);
+            convention: BaseUrlConvention.ExcludesVersion,
+            usesVersionSegment: _options.UsesVersionSegment);
 
         using var message = new HttpRequestMessage(HttpMethod.Post, endpoint)
         {

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -214,7 +214,7 @@ public sealed class ChatProviderResolver : IChatProviderResolver
                 return new ChatProviderResolution(
                     new AnthropicMessagesProvider(
                         _http,
-                        new AnthropicOptions(apiKey, NullIfBlank(baseUrl), headers),
+                        new AnthropicOptions(apiKey, NullIfBlank(baseUrl), headers, connection.UsesVersionSegment),
                         _loggerFactory.CreateLogger<AnthropicMessagesProvider>(),
                         firstEventTimeout: AiEndpoint.FirstEventTimeoutFor(baseUrl)),
                     chat.ActiveModelId!.Trim());
@@ -236,7 +236,8 @@ public sealed class ChatProviderResolver : IChatProviderResolver
                             NullIfBlank(apiKey),
                             connection.AuthHeaderName,
                             connection.AuthScheme,
-                            headers),
+                            headers,
+                            connection.UsesVersionSegment),
                         _loggerFactory.CreateLogger<OpenAiCompatibleProvider>(),
                         firstEventTimeout: AiEndpoint.FirstEventTimeoutFor(baseUrl)),
                     chat.ActiveModelId!.Trim());

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -27,7 +27,8 @@ public sealed record OpenAiCompatibleOptions(
     string? ApiKey = null,
     string AuthHeaderName = "Authorization",
     string? AuthScheme = "Bearer",
-    IReadOnlyDictionary<string, string>? ExtraHeaders = null);
+    IReadOnlyDictionary<string, string>? ExtraHeaders = null,
+    bool? UsesVersionSegment = null);
 
 /// <summary>
 /// The OpenAI-compatible Chat Completions shape (<c>POST {baseUrl}/chat/completions</c>, SSE). One adapter for
@@ -89,7 +90,8 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
 
         var endpoint = AiHttp.ResolveEndpoint(
             _options.BaseUrl!, versionedPath: "v1/chat/completions", path: "chat/completions",
-            convention: BaseUrlConvention.IncludesVersion);
+            convention: BaseUrlConvention.IncludesVersion,
+            usesVersionSegment: _options.UsesVersionSegment);
 
         using var message = new HttpRequestMessage(HttpMethod.Post, endpoint)
         {

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -422,6 +422,13 @@ namespace CST.Avalonia.ViewModels
                 // the endpoint and thrown the knowledge away.
                 if (result.Reachable is { } reachable)
                     _owner.Service?.ReportReachability(Id, reachable);
+
+                // The listing also measures something the chat path has been guessing at: whether this
+                // endpoint takes a version segment on a bare base URL. Recorded here because this is the one
+                // request that can find out cheaply, and recording it is what stops every later chat turn
+                // from 404-ing against a URL the reader cannot see us rewriting. (#742)
+                if (result.UsesVersionSegment is { } usesVersion)
+                    _owner.Service?.ReportEndpointVersioning(Id, usesVersion);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Closes #742. **Stacked on #764** — base branch is `fix/711-anthropic-extra-headers`, because both touch `AiHttp`, `AiModelCatalog` and `ChatProviderResolver`. Merge #764 first and this retargets to main cleanly.

## The measurement that changed the plan

The issue leaned toward putting the convention on the connection and letting a preset set it. Checking the catalogue first says that would not have reached the reported bug:

- **models.dev carries no `api` URL for Perplexity at all** — which is exactly why #737 skipped it. A preset can never carry its convention because there is no preset.
- Of the 192 providers in the snapshot, **166 publish an `api` URL: 157 already carry a version segment, 7 have some other path, and exactly 2 are bare hosts** (DeepSeek, GitHub Copilot) — both of which do want `/v1`.

So the bare-host rule almost never fires for a preset. It fires for **hand-typed** URLs, which is precisely where there is no preset to consult. Hence: learn it.

## What it does

When a model listing 404s against a URL we guessed at, it asks the other way **once**. Whichever answers is recorded on the connection as `UsesVersionSegment`, and every later request — chat included — obeys it.

```
Add connection  →  GET https://api.perplexity.ai/v1/models   404
                →  GET https://api.perplexity.ai/models      200
                →  record UsesVersionSegment = false

Every later request:  POST https://api.perplexity.ai/chat/completions
```

One extra request, once per connection, at a moment the reader is already waiting on a listing. Nothing on the answer path pays for it.

## What it deliberately does not do

- **No retry on the chat path.** 404 is also what several OpenAI-shaped providers return for an unknown *model id*, so a retry there fires on a failure it cannot fix and makes a genuinely wrong URL slower to diagnose.
- **No editor field.** Asking readers whether their provider versions its path is asking about the one thing this bug hides from them. It is measured, not configured.
- **No second-guessing a URL the reader fully specified.** A base that already names its version was not a guess, so its 404 is the endpoint's answer and costs exactly one request.
- **A recorded answer replaces a guess, never a fact about the URL in hand.** A base carrying `/v1` keeps it whatever was recorded, so a stale record cannot start mangling a correct URL. Pinned by a `[Theory]` over both recorded values.

Retyping the base URL forgets the measurement — it is a fact about one host, and carrying it to a new one is the same silent-rewrite failure in reverse. Renaming the connection keeps it.

## Verification

11 new tests across two files. `ReportEndpointVersioning` writes only on change, so the Models tab recording this on every successful fetch does not churn settings or `ConnectionsChanged`.

One bug my own tests caught before review: `Apply` overwrote `record.BaseUrl` *before* my comparison against it, so the forget-on-retype reset never fired. Moved above the assignment.

Full suite: **2290 passed, 0 failed, 17 skipped**.

Not covered: no live Perplexity endpoint was exercised. The counterexample is the vendor SDK measurement recorded in the issue; the probe is asserted against a stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)