### PR TITLE
Mark a model the provider no longer lists (#728)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -412,4 +412,72 @@ public class AiConnectionServiceTests
         Assert.DoesNotContain("Unreachable", json);
         Assert.DoesNotContain("Reachab", json);
     }
+
+    private static AiConnectionDraft WithModels(params AiModelEntry[] models) =>
+        Draft() with { Models = models };
+
+    // ---- recording what a listing carried (#728) ---------------------------------------------------------
+
+    /// <summary>The mark follows the last good listing in both directions: set for what it dropped, cleared
+    /// for what it carries again.</summary>
+    [Fact]
+    public void Marking_a_listing_sets_and_clears_in_step_with_it()
+    {
+        var (service, _) = Make();
+        service.Add("box", WithModels(new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
+
+        service.MarkListing("box", new[] { "a" });
+        Assert.True(service.Connections.Single().Models.Single(m => m.Id == "b").Missing);
+
+        service.MarkListing("box", new[] { "a", "b" });
+        Assert.False(service.Connections.Single().Models.Single(m => m.Id == "b").Missing);
+    }
+
+    /// <summary>
+    /// Recording a listing that says nothing new writes nothing and tells nobody.
+    ///
+    /// <para>The Models tab records the listing on every successful fetch, which happens whenever the tab is
+    /// opened. Saving unconditionally would rewrite <c>settings.json</c> and rebuild the list the reader is
+    /// looking at, every time, to say exactly what it said before.</para>
+    /// </summary>
+    [Fact]
+    public void Recording_the_same_listing_twice_changes_nothing()
+    {
+        var (service, _) = Make();
+        service.Add("box", WithModels(new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
+        service.MarkListing("box", new[] { "a" });
+
+        var raised = 0;
+        service.ConnectionsChanged += (_, _) => raised++;
+        service.MarkListing("box", new[] { "a" });
+
+        Assert.Equal(0, raised);
+    }
+
+    /// <summary>An empty listing is no evidence, not total removal — a key without listing scope, or a
+    /// gateway with no upstream configured, would otherwise mark every model the reader has.</summary>
+    [Fact]
+    public void An_empty_listing_marks_nothing()
+    {
+        var (service, _) = Make();
+        service.Add("box", WithModels(new AiModelEntry("a", "A")));
+
+        service.MarkListing("box", Array.Empty<string>());
+
+        Assert.False(service.Connections.Single().Models.Single().Missing);
+    }
+
+    /// <summary>Promoting a model from a listing that carries it clears the mark too, so the two paths that
+    /// write it cannot disagree.</summary>
+    [Fact]
+    public void Promoting_a_model_from_the_listing_clears_its_mark()
+    {
+        var (service, _) = Make();
+        service.Add("box", WithModels(new AiModelEntry("a", "A")));
+        service.MarkListing("box", new[] { "other" });
+
+        service.EnableModel("box", "a", "A", true, new AiModelEntry("a", "A", ContextLength: 8192));
+
+        Assert.False(service.Connections.Single().Models.Single().Missing);
+    }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -231,4 +231,34 @@ public class AiModelCatalogTests
 
         Assert.Equal(expected, Assert.Single(models).SupportsReasoning);
     }
+
+    // ---- whether a listing is everything (#728) -----------------------------------------------------------
+
+    /// <summary>An ordinary listing we could read end to end is complete.</summary>
+    [Fact]
+    public void A_listing_read_end_to_end_is_complete()
+    {
+        Assert.False(AiModelCatalog.HasMore("""{"data":[{"id":"a"},{"id":"b"}]}"""));
+    }
+
+    /// <summary>
+    /// An endpoint that says there is another page is not complete.
+    ///
+    /// <para>Anthropic's <c>GET /v1/models</c> pages at twenty by default. We do not follow the pages yet, but
+    /// reading the flag is what stops a first page being mistaken for the whole catalogue — which would report
+    /// every model after the twentieth as retired (#728).</para>
+    /// </summary>
+    [Fact]
+    public void A_paged_listing_says_there_is_more()
+    {
+        Assert.True(AiModelCatalog.HasMore("""{"data":[{"id":"a"}],"has_more":true,"last_id":"a"}"""));
+    }
+
+    /// <summary>A body we cannot read is not evidence that there is nothing more. Guessing the other way is
+    /// the half of the answer that produces false alarms.</summary>
+    [Fact]
+    public void An_unreadable_body_is_not_taken_as_the_end()
+    {
+        Assert.True(AiModelCatalog.HasMore("{ this is not json"));
+    }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -741,6 +741,47 @@ public class AiConnectionEditorViewModelTests
         Assert.Equal(h.Service.Presets.Single(p => p.Id == "azure").Prompts!.Single().Message, input.Message);
     }
 
+    /// <summary>
+    /// Correcting a model id does not carry the old id's "no longer listed" mark. (#728)
+    ///
+    /// <para>The path this exists for: the provider renames a model, the reader sees the mark, opens the
+    /// editor and types the new id. Inheriting the mark would leave a corrected model still claiming to be
+    /// gone — across sessions, until the Models tab was next opened and fetched.</para>
+    /// </summary>
+    [Fact]
+    public void Retyping_a_marked_models_id_does_not_carry_the_mark()
+    {
+        var h = new Harness();
+        h.Service.Add("mine", Draft());
+        h.Service.EnableModel("mine", "old-name", "Old name", true);
+        h.Service.MarkListing("mine", new[] { "new-name" });
+
+        var vm = h.Existing("mine");
+        vm.Models.Single(m => m.ModelId == "old-name").ModelId = "new-name";
+        Save(vm);
+
+        var stored = Assert.Single(h.Service.Connections.Single().Models);
+        Assert.Equal("new-name", stored.Id);
+        Assert.False(stored.Missing);
+    }
+
+    /// <summary>A mark survives an edit that leaves the id alone — it is the listing's word about that id,
+    /// not a side effect of opening the sheet.</summary>
+    [Fact]
+    public void An_untouched_marked_model_keeps_its_mark_through_an_edit()
+    {
+        var h = new Harness();
+        h.Service.Add("mine", Draft());
+        h.Service.EnableModel("mine", "retired", "Retired", true);
+        h.Service.MarkListing("mine", new[] { "something-else" });
+
+        var vm = h.Existing("mine");
+        vm.DisplayName = "My box, renamed";
+        Save(vm);
+
+        Assert.True(h.Service.Connections.Single().Models.Single(m => m.Id == "retired").Missing);
+    }
+
     /// <summary>A custom endpoint keeps the whole form: nothing about it comes from a preset.</summary>
     [Fact]
     public void Editing_a_custom_endpoint_still_shows_the_full_form()

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -46,6 +46,66 @@ public class AiModelPickerViewModelTests
     private static IEnumerable<AiPickerModelViewModel> AllModels(AiModelPickerViewModel picker) =>
         picker.Groups.SelectMany(g => g.Models);
 
+    // ---- a model the provider dropped (#728) -------------------------------------------------------------
+
+    /// <summary>
+    /// A model the provider no longer lists is marked in the picker, and still pickable.
+    ///
+    /// <para>A listing is not authority over the reader's configuration, and the mark is only ever set from a
+    /// fetch that succeeded — so it is worth saying and not worth acting on. Whether the request works is
+    /// still the provider's answer to give.</para>
+    /// </summary>
+    [Fact]
+    public void A_model_the_provider_dropped_is_marked_and_still_pickable()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine", new AiModelEntry("retired", "Retired", Missing: true)));
+
+        var model = AllModels(picker).Single();
+
+        Assert.True(model.ShowMissingNote);
+        Assert.True(model.IsUsable);
+    }
+
+    /// <summary>
+    /// Its hover card stops describing it.
+    ///
+    /// <para>The published facts were cached (#726) so the card could show them without a fetch. Left in for
+    /// a retired model, the app would confidently state a context window and a reasoning flag for something
+    /// that no longer exists, in the same shape it describes real models — a worse failure than the silence
+    /// the cache replaced. The card says the one thing still true.</para>
+    /// </summary>
+    [Fact]
+    public void A_dropped_models_card_says_it_is_gone_rather_than_describing_it()
+    {
+        var (picker, service, _) = Make();
+        service.Add("mine", Draft("Mine", new AiModelEntry(
+            "retired", "Retired", true, ContextLength: 128_000, SupportsReasoning: true, Inputs: "text",
+            Missing: true)));
+
+        var facts = AllModels(picker).Single().Facts;
+
+        Assert.Contains(facts, f => f.Label == "Status" && f.Value.Contains("Mine"));
+        Assert.DoesNotContain(facts, f => f.Label is "Context" or "Reasoning" or "Inputs");
+    }
+
+    /// <summary>A reason it cannot be used at all outranks the mark: one message in that space, and the one
+    /// that stops the request is the one to read.</summary>
+    [Fact]
+    public void A_reason_it_cannot_be_used_outranks_the_mark()
+    {
+        var (picker, service, _) = Make();
+        service.AddFromPreset("openrouter", new Dictionary<string, string>());
+        service.EnableModel("openrouter", "retired", "Retired", true);
+        service.MarkListing("openrouter", new[] { "something-else" });
+
+        var model = AllModels(picker).Single(m => m.ModelId == "retired");
+
+        Assert.False(model.IsUsable);          // no key stored
+        Assert.True(model.Missing);
+        Assert.False(model.ShowMissingNote);   // so the mark stands down
+    }
+
     // ---- what the list contains ------------------------------------------------------------------------
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -193,13 +193,41 @@ public class AiModelsViewModelTests
     [Fact]
     public void A_failed_fetch_marks_nothing()
     {
-        var (vm, service) = Make(new FakeCatalog(AiCatalogResult.Fail("Could not connect to mine.")));
+        // Constructed rather than built with Fail(), which always carries an empty list: that would leave
+        // this passing on MarkListing's empty-listing guard while asserting nothing about the Ok check it
+        // names, and a future Fail that carried the models it got before dying would mark them all.
+        // (fable review, found by mutation)
+        var partial = new AiCatalogResult(
+            false, "Could not connect to mine.",
+            new[] { new AiCatalogModel("something-else", "Something else") }, Reachable: false);
+
+        var (vm, service) = Make(new FakeCatalog(partial));
         service.Add("mine", Draft(new AiModelEntry("mine-model", "Mine")));
 
         Group(vm).IsExpanded = true;
 
         Assert.False(Rows(vm).Single().Missing);
         Assert.False(service.Connections.Single().Models.Single().Missing);
+    }
+
+    /// <summary>
+    /// A listing the endpoint says is incomplete marks nothing.
+    ///
+    /// <para>A first page, or one whose entries we could only partly read, is a fine thing to show — every
+    /// model in it is real. What it cannot support is the inference in the other direction: that a model
+    /// absent from it has been retired. Anthropic's listing pages at twenty by default, so without this the
+    /// twenty-first model onwards would be reported as gone.</para>
+    /// </summary>
+    [Fact]
+    public void An_incomplete_listing_marks_nothing()
+    {
+        var (vm, service) = Make(new FakeCatalog(AiCatalogResult.Success(
+            new[] { new AiCatalogModel("page-one-model", "Page one") }, complete: false)));
+        service.Add("mine", Draft(new AiModelEntry("page-two-model", "Page two")));
+
+        Group(vm).IsExpanded = true;
+
+        Assert.False(service.Connections.Single().Models.Single(m => m.Id == "page-two-model").Missing);
     }
 
     /// <summary>An empty listing marks nothing either: endpoints answer 200 with an empty <c>data[]</c> for

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -159,6 +159,109 @@ public class AiModelsViewModelTests
         Assert.Empty(service.Connections.Single().Models);
     }
 
+    // ---- a model the provider dropped (#728) -----------------------------------------------------------
+
+    /// <summary>
+    /// A stored model the fetched listing does not carry is marked.
+    ///
+    /// <para>Providers retire and rename models routinely, free ones especially. Until this, the app went on
+    /// showing one as an ordinary row — enabled, pickable, indistinguishable — and the reader found out as a
+    /// 404 at the moment they asked a question.</para>
+    /// </summary>
+    [Fact]
+    public void A_stored_model_the_listing_no_longer_carries_is_marked()
+    {
+        var (vm, service) = Make(new FakeCatalog(new AiCatalogModel("kept", "Kept")));
+        service.Add("mine", Draft(
+            new AiModelEntry("kept", "Kept"),
+            new AiModelEntry("retired", "Retired")));
+
+        Group(vm).IsExpanded = true;
+
+        Assert.True(Rows(vm).Single(r => r.ModelId == "retired").Missing);
+        Assert.False(Rows(vm).Single(r => r.ModelId == "kept").Missing);
+        Assert.True(service.Connections.Single().Models.Single(m => m.Id == "retired").Missing);
+    }
+
+    /// <summary>
+    /// A fetch that failed marks nothing.
+    ///
+    /// <para>An offline moment, a local runner that is not started, a 401 — each would otherwise flag every
+    /// model the reader has, turning a transient problem into a screen of false alarms. Absence of evidence
+    /// is not evidence, which is the same reason <c>Reachability.Configured</c> is a third state.</para>
+    /// </summary>
+    [Fact]
+    public void A_failed_fetch_marks_nothing()
+    {
+        var (vm, service) = Make(new FakeCatalog(AiCatalogResult.Fail("Could not connect to mine.")));
+        service.Add("mine", Draft(new AiModelEntry("mine-model", "Mine")));
+
+        Group(vm).IsExpanded = true;
+
+        Assert.False(Rows(vm).Single().Missing);
+        Assert.False(service.Connections.Single().Models.Single().Missing);
+    }
+
+    /// <summary>An empty listing marks nothing either: endpoints answer 200 with an empty <c>data[]</c> for
+    /// reasons that have nothing to do with the reader's models, and that would be the loudest possible way
+    /// to say nothing.</summary>
+    [Fact]
+    public void An_empty_listing_marks_nothing()
+    {
+        var (vm, service) = Make(new FakeCatalog());
+        service.Add("mine", Draft(new AiModelEntry("mine-model", "Mine")));
+
+        Group(vm).IsExpanded = true;
+
+        Assert.False(service.Connections.Single().Models.Single().Missing);
+    }
+
+    /// <summary>A model that comes back — renamed away and restored, or a listing that was briefly partial —
+    /// loses the mark. The mark is a reading of the last good listing, not a verdict.</summary>
+    [Fact]
+    public void A_model_the_listing_carries_again_is_unmarked()
+    {
+        var (vm, service) = Make(new FakeCatalog(new AiCatalogModel("back", "Back")));
+        service.Add("mine", Draft(new AiModelEntry("back", "Back", Missing: true)));
+
+        Group(vm).IsExpanded = true;
+
+        Assert.False(service.Connections.Single().Models.Single().Missing);
+    }
+
+    /// <summary>Marked, never removed or switched off. The reader chose it, a listing is not authority over
+    /// their configuration, and an endpoint publishing an incomplete one would otherwise delete valid entries
+    /// on their behalf.</summary>
+    [Fact]
+    public void A_marked_model_is_neither_removed_nor_disabled()
+    {
+        var (vm, service) = Make(new FakeCatalog(new AiCatalogModel("kept", "Kept")));
+        service.Add("mine", Draft(new AiModelEntry("retired", "Retired", Enabled: true)));
+
+        Group(vm).IsExpanded = true;
+
+        var stored = Assert.Single(service.Connections.Single().Models);
+        Assert.Equal("retired", stored.Id);
+        Assert.True(stored.Enabled);
+        Assert.True(Rows(vm).Single(r => r.ModelId == "retired").Enabled);
+    }
+
+    /// <summary>The row stops repeating what the provider once published about it. A context window and a
+    /// price describe something on offer; this is not one.</summary>
+    [Fact]
+    public void A_marked_model_no_longer_carries_its_published_facts()
+    {
+        var (vm, service) = Make(new FakeCatalog(new AiCatalogModel("kept", "Kept")));
+        service.Add("mine", Draft(
+            new AiModelEntry("retired", "Retired", true, ContextLength: 128_000)));
+
+        Group(vm).IsExpanded = true;
+
+        var row = Rows(vm).Single(r => r.ModelId == "retired");
+        Assert.Equal("retired", row.Details);
+        Assert.DoesNotContain("context", row.Details, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>Promoting one adds it to the reader's stored list, with the provider's display name.</summary>
     [Fact]
     public void Promoting_a_fetched_model_stores_it()

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -57,13 +57,27 @@ namespace CST.Avalonia.Models.Ai
     /// <param name="ContextLength">What the provider published when this model was added, or null. Kept on
     /// the record because the listing is only fetched while the Models tab is open, and the per-turn picker
     /// (#693) has to be able to say it without asking again.</param>
+    /// <param name="Missing">
+    /// Set when the provider's own listing, fetched successfully, did not carry this model. (#728)
+    ///
+    /// <para><b>Only ever written from a listing we can trust</b>: a fetch that failed marks nothing, an empty
+    /// listing marks nothing, and an endpoint that publishes no listing at all can never mark anything. The
+    /// alternative — treating absence of evidence as evidence — turns one offline moment into a screen of
+    /// false alarms, which is the same reasoning that makes <see cref="Reachability.Configured"/> a third
+    /// state rather than a synonym for unreachable.</para>
+    ///
+    /// <para><b>A mark, never a removal.</b> The reader chose this model; a provider's listing is not
+    /// authority over their configuration, and an endpoint that publishes an incomplete one would otherwise
+    /// silently delete valid entries. It stays enabled, stays pickable, and says what it is.</para>
+    /// </param>
     public sealed record AiModelEntry(
         string Id,
         string DisplayName,
         bool Enabled = true,
         int? ContextLength = null,
         bool? SupportsReasoning = null,
-        string? Inputs = null);
+        string? Inputs = null,
+        bool Missing = false);
 
     /// <summary>
     /// One configured endpoint: where to send a request, how to authenticate, and which models it offers.

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -178,6 +178,15 @@ namespace CST.Avalonia.Models
         /// <summary>What the model accepts, as the provider words it — "text", "text, image". Null when it
         /// said nothing.</summary>
         public string? Inputs { get; set; }
+
+        /// <summary>
+        /// Whether the provider's listing no longer carries this model. (#728)
+        ///
+        /// <para>Written only from a successful, non-empty fetch, and cleared by the next one that carries it
+        /// again. False for every model on an endpoint that publishes no listing — silence is not a
+        /// removal.</para>
+        /// </summary>
+        public bool Missing { get; set; }
     }
 
     /// <summary>Permissions for the loopback API server that exposes the corpus tools to agents (surface C).</summary>

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -55,6 +55,18 @@ namespace CST.Avalonia.Services.Ai
         /// <summary>The model within <see cref="Active"/>, or null.</summary>
         string? ActiveModelId { get; }
 
+        /// <summary>
+        /// Records which of a connection's stored models the provider's listing still carries. (#728)
+        ///
+        /// <para>Call it <b>only</b> with the models of a fetch that succeeded. A failed fetch, or one from an
+        /// endpoint that publishes no listing, must not call this at all: there is nothing to conclude, and
+        /// concluding anyway would mark every model on a laptop whose runner is simply not started.</para>
+        ///
+        /// <para>An empty list is treated as no evidence rather than as total removal, and nothing is written
+        /// unless a mark actually changed.</para>
+        /// </summary>
+        AiConnectionResult MarkListing(string connectionId, IReadOnlyList<string> listedIds);
+
         /// <summary>Raised when the list, or any connection's state, changes. Rebind on this.</summary>
         event EventHandler? ConnectionsChanged;
 
@@ -328,6 +340,33 @@ namespace CST.Avalonia.Services.Ai
                 Dispatcher.UIThread.Post(() => handler(this, EventArgs.Empty));
         }
 
+        public AiConnectionResult MarkListing(string connectionId, IReadOnlyList<string> listedIds)
+        {
+            if (Find(connectionId) is not { } record)
+                return AiConnectionResult.Fail($"No connection called '{connectionId}'.");
+
+            // An empty listing is not a report that everything is gone. Endpoints answer 200 with an empty
+            // data[] for reasons that have nothing to do with the reader's models - a key without listing
+            // scope, a gateway with no upstream configured - and marking every stored model on that basis
+            // would be the loudest possible way to say nothing. (#728)
+            if (listedIds.Count == 0) return AiConnectionResult.Success(ToRuntime(record));
+
+            var listed = new HashSet<string>(listedIds, StringComparer.Ordinal);
+            var changed = false;
+
+            foreach (var model in record.Models)
+            {
+                var missing = !listed.Contains(model.Id);
+                if (missing == model.Missing) continue;
+                model.Missing = missing;
+                changed = true;
+            }
+
+            // Saving unconditionally would write settings.json and raise ConnectionsChanged every time the
+            // Models tab is opened, rebuilding a list the reader is looking at to say nothing new.
+            return changed ? Saved(record) : AiConnectionResult.Success(ToRuntime(record));
+        }
+
         public AiConnectionResult EnableModel(
             string connectionId, string modelId, string displayName, bool enabled,
             AiModelEntry? facts = null)
@@ -359,6 +398,10 @@ namespace CST.Avalonia.Services.Ai
                 model.ContextLength = facts.ContextLength;
                 model.SupportsReasoning = facts.SupportsReasoning;
                 model.Inputs = facts.Inputs;
+
+                // Facts exist because the listing carried this model, so it is by definition not missing from
+                // it. Clearing here as well as in MarkListing keeps the two from disagreeing. (#728)
+                model.Missing = false;
             }
 
             model.Enabled = enabled;
@@ -441,6 +484,7 @@ namespace CST.Avalonia.Services.Ai
                     ContextLength = m.ContextLength,
                     SupportsReasoning = m.SupportsReasoning,
                     Inputs = m.Inputs,
+                    Missing = m.Missing,
                 })
                 .ToList();
             record.Headers = new Dictionary<string, string>(draft.Headers);
@@ -456,7 +500,8 @@ namespace CST.Avalonia.Services.Ai
             r.BaseUrl,
             r.Models
                 .Select(m => new AiModelEntry(
-                    m.Id, m.DisplayName, m.Enabled, m.ContextLength, m.SupportsReasoning, m.Inputs))
+                    m.Id, m.DisplayName, m.Enabled, m.ContextLength, m.SupportsReasoning, m.Inputs,
+                    m.Missing))
                 .ToList(),
             new Dictionary<string, string>(r.Headers),
             new Dictionary<string, string>(r.Inputs),

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -70,6 +70,15 @@ namespace CST.Avalonia.Services.Ai
     /// <param name="Problem">A finished sentence for the reader. Never null when <paramref name="Ok"/> is
     /// false, and it names the endpoint — "cannot connect" without saying to what is the message that sends
     /// someone looking in the wrong place.</param>
+    /// <param name="Complete">
+    /// Whether this listing is everything the endpoint has, so far as we can tell. (#728)
+    ///
+    /// <para>False when entries were skipped for want of a usable id — observed in the wild, a listing whose
+    /// nine entries yielded two we could read — or when the endpoint says there is another page. <b>A short
+    /// listing is still a listing</b>: it is shown, and every model in it is real. What it cannot support is
+    /// the inference in the other direction, that a model absent from it has been retired, which is why the
+    /// flag exists rather than a failure.</para>
+    /// </param>
     /// <param name="Reachable">
     /// Whether the endpoint answered at all — <b>not</b> whether the listing was useful.
     ///
@@ -78,13 +87,14 @@ namespace CST.Avalonia.Services.Ai
     /// unfinished connection cannot be reported either way.</para>
     /// </param>
     public sealed record AiCatalogResult(
-        bool Ok, string? Problem, IReadOnlyList<AiCatalogModel> Models, bool? Reachable = null)
+        bool Ok, string? Problem, IReadOnlyList<AiCatalogModel> Models, bool? Reachable = null,
+        bool Complete = true)
     {
-        public static AiCatalogResult Success(IReadOnlyList<AiCatalogModel> models) =>
-            new(true, null, models, true);
+        public static AiCatalogResult Success(IReadOnlyList<AiCatalogModel> models, bool complete = true) =>
+            new(true, null, models, true, complete);
 
         public static AiCatalogResult Fail(string problem, bool? reachable = null) =>
-            new(false, problem, Array.Empty<AiCatalogModel>(), reachable);
+            new(false, problem, Array.Empty<AiCatalogModel>(), reachable, false);
     }
 
     /// <summary>
@@ -177,6 +187,7 @@ namespace CST.Avalonia.Services.Ai
                 // and the reader who says "but I know they support more" has no way to tell which, nor did
                 // we, from the log.
                 var listed = CountEntries(body);
+                var complete = listed == models.Count && !HasMore(body);
                 if (listed == models.Count)
                 {
                     _logger.LogInformation(
@@ -189,7 +200,7 @@ namespace CST.Avalonia.Services.Ai
                         + "{Skipped} had no usable id", models.Count, connection.Id, listed, listed - models.Count);
                     _logger.LogDebug("{Connection} listing: {Body}", connection.Id, body);
                 }
-                return AiCatalogResult.Success(models);
+                return AiCatalogResult.Success(models, complete);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -267,6 +278,29 @@ namespace CST.Avalonia.Services.Ai
         /// models in a release nobody read, and rendering it wholesale would adopt that judgment silently. So
         /// each field is pulled by name, and adding one is a deliberate act.</para>
         /// </summary>
+        /// <summary>
+        /// Whether the endpoint says it has another page. (#728)
+        ///
+        /// <para>Anthropic's listing is paged and defaults to twenty per page. We do not follow the pages yet
+        /// — that is its own work — but reading the flag is what stops a first page being mistaken for the
+        /// whole catalogue, which would mark every model after the twentieth as retired.</para>
+        /// </summary>
+        internal static bool HasMore(string json)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                return doc.RootElement.TryGetProperty("has_more", out var more) &&
+                       more.ValueKind == JsonValueKind.True;
+            }
+            catch (JsonException)
+            {
+                // Unparseable here means unparseable in Parse too, which already yields nothing. Saying "no
+                // more pages" about a body we cannot read would be the wrong half of the answer to guess.
+                return true;
+            }
+        }
+
         internal static IReadOnlyList<AiCatalogModel> Parse(string json)
         {
             using var doc = JsonDocument.Parse(json);

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -521,6 +521,14 @@ namespace CST.Avalonia.ViewModels
             .Select(m => (m.Published ?? new AiModelEntry(m.ModelId.Trim(), m.ModelId.Trim())) with
             {
                 Id = m.ModelId.Trim(),
+
+                // A retyped id is a different model, so it does not inherit the old one's mark. Without this,
+                // a reader who saw "no longer listed" and corrected the id to the provider's new name got a
+                // corrected model still claiming to be gone, across sessions, until the Models tab was next
+                // opened. (#728, fable review)
+                Missing = m.Published is { } published
+                    && string.Equals(published.Id, m.ModelId.Trim(), StringComparison.Ordinal)
+                    && published.Missing,
                 DisplayName = string.IsNullOrWhiteSpace(m.DisplayName)
                     ? m.ModelId.Trim()
                     : m.DisplayName.Trim(),

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -220,6 +220,7 @@ namespace CST.Avalonia.ViewModels
             DisplayName = model.DisplayName;
             ProviderName = connection.DisplayName;
             IsCurrent = isCurrent;
+            Missing = model.Missing;
             Unusable = ReasonItCannotBeUsed(connection);
 
             // Only what the provider actually said. A model that published no context length gets no context
@@ -248,6 +249,19 @@ namespace CST.Avalonia.ViewModels
 
         public bool IsUsable => Unusable.Length == 0;
 
+        /// <summary>
+        /// The provider's listing no longer carries this model. (#728)
+        ///
+        /// <para><b>Marked, not disabled.</b> A listing is not authority over the reader's configuration, and
+        /// the mark is only ever set from a fetch that succeeded — so it is worth saying and not worth acting
+        /// on. Whether the request works is still the provider's answer to give.</para>
+        /// </summary>
+        public bool Missing { get; }
+
+        /// <summary>Shown only where nothing more serious is already in that space: a model on a connection
+        /// with no key stored has a reason it cannot be used at all, and that is the one to read.</summary>
+        public bool ShowMissingNote => Missing && IsUsable;
+
         /// <summary>The connection this model belongs to. Named on the hover card because with several
         /// endpoints configured, "Gemma 4" alone does not say whether it is the local one.</summary>
         public string ProviderName { get; }
@@ -273,6 +287,18 @@ namespace CST.Avalonia.ViewModels
                 new("Model", model.DisplayName),
                 new("Provider", connection.DisplayName),
             };
+
+            // What the provider published about a model it no longer lists describes nothing it offers. Left
+            // in, the card would confidently state a context window and a reasoning flag for a model that has
+            // been retired, in the same shape it describes real ones - a worse failure than the silence that
+            // preceded the cache. So the card says the one thing that is still true. (#728)
+            if (model.Missing)
+            {
+                facts.Add(new AiPickerFact("Status", $"not in {connection.DisplayName}'s model list"));
+                if (!string.Equals(model.Id, model.DisplayName, StringComparison.Ordinal))
+                    facts.Add(new AiPickerFact("Id", model.Id));
+                return facts;
+            }
 
             if (model.Inputs is { Length: > 0 } inputs) facts.Add(new AiPickerFact("Inputs", inputs));
 

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -344,7 +344,7 @@ namespace CST.Avalonia.ViewModels
                 rows.Add(new AiCatalogRowViewModel(
                     this, model.Id, model.DisplayName,
                     _fetched.FirstOrDefault(f => string.Equals(f.Id, model.Id, StringComparison.Ordinal)),
-                    model.Enabled));
+                    model.Enabled, model.Missing));
 
             foreach (var model in _fetched)
             {
@@ -393,7 +393,21 @@ namespace CST.Avalonia.ViewModels
                 var result = await _owner.Catalog.FetchAsync(_connection).ConfigureAwait(true);
                 _hasFetched = true;
 
-                if (result.Ok) _fetched = result.Models;
+                if (result.Ok)
+                {
+                    _fetched = result.Models;
+
+                    // The listing is in memory only while this tab is open, so what it says about the
+                    // reader's stored models has to be written down now or the per-turn picker will go on
+                    // describing a model that no longer exists. Suppressed like the toggles, so recording it
+                    // does not rebuild the list under the reader. (#728)
+                    if (_owner.Service is { } service)
+                    {
+                        _owner.Suppressed(() => service.MarkListing(
+                            Id, _fetched.Select(m => m.Id).ToList()));
+                        Refresh();
+                    }
+                }
                 else FetchProblem = result.Problem;
 
                 // Asking a provider for its models IS contacting it, and the answer is the same fact a chat
@@ -438,12 +452,18 @@ namespace CST.Avalonia.ViewModels
             var facts = Facts(modelId);
 
             _owner.Suppressed(() => service.EnableModel(Id, modelId, displayName, enabled, facts));
-
-            if (service.Connections.FirstOrDefault(
-                    c => string.Equals(c.Id, Id, StringComparison.Ordinal)) is { } fresh)
-                _connection = fresh;
+            Refresh();
 
             this.RaisePropertyChanged(nameof(CountText));
+        }
+
+        /// <summary>Re-reads the connection after a suppressed write. Without it the next genuine rebuild
+        /// would rebuild from a record taken before the write and silently undo it on screen.</summary>
+        private void Refresh()
+        {
+            if (_owner.Service?.Connections.FirstOrDefault(
+                    c => string.Equals(c.Id, Id, StringComparison.Ordinal)) is { } fresh)
+                _connection = fresh;
         }
     }
 
@@ -456,7 +476,7 @@ namespace CST.Avalonia.ViewModels
 
         public AiCatalogRowViewModel(
             AiModelGroupViewModel group, string id, string displayName, AiCatalogModel? published,
-            bool enabled)
+            bool enabled, bool missing = false)
         {
             _group = group;
             _published = published;
@@ -464,11 +484,22 @@ namespace CST.Avalonia.ViewModels
 
             ModelId = id;
             DisplayName = displayName;
+            Missing = missing;
         }
 
         public string ModelId { get; }
 
         public string DisplayName { get; }
+
+        /// <summary>
+        /// The provider's listing no longer carries this model. (#728)
+        ///
+        /// <para>Said in the row rather than left to be discovered as a 404 at send time. Marked, never
+        /// removed or switched off: the reader put it there, a listing is not authority over their
+        /// configuration, and a provider that publishes an incomplete one would otherwise delete valid
+        /// entries on their behalf.</para>
+        /// </summary>
+        public bool Missing { get; }
 
         /// <summary>
         /// The provider's own facts about the model — the wire id, context window, price per million tokens,
@@ -487,7 +518,11 @@ namespace CST.Avalonia.ViewModels
         {
             get
             {
-                if (_published is null) return ModelId;
+                // What was published about a model the listing has dropped is no longer a description of
+                // anything the provider offers. Showing a context window and a price for it would be the app
+                // describing something that does not exist - the specific harm in #728 - so the row falls
+                // back to the id.
+                if (_published is null || Missing) return ModelId;
 
                 var facts = new List<string>();
 

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -401,7 +401,13 @@ namespace CST.Avalonia.ViewModels
                     // reader's stored models has to be written down now or the per-turn picker will go on
                     // describing a model that no longer exists. Suppressed like the toggles, so recording it
                     // does not rebuild the list under the reader. (#728)
-                    if (_owner.Service is { } service)
+                    //
+                    // Only a listing that is complete as far as the endpoint told us. A first page of a paged
+                    // listing, or one whose entries we could only partly read, is a fine thing to SHOW - every
+                    // model in it is real - but it cannot support the inference in the other direction, that
+                    // what is absent has been retired. Marking from it would report a live model as gone,
+                    // which is the false alarm this feature was written to avoid. (fable review)
+                    if (result.Complete && _owner.Service is { } service)
                     {
                         _owner.Suppressed(() => service.MarkListing(
                             Id, _fetched.Select(m => m.Id).ToList()));

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -186,6 +186,18 @@
                                                                                        FontSize="11"
                                                                                        Margin="6,0,0,0"
                                                                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                                            <!-- Still selectable: a listing
+                                                                                 is not authority over the
+                                                                                 reader's configuration, and
+                                                                                 whether the request works
+                                                                                 is the provider's answer to
+                                                                                 give. (#728) -->
+                                                                            <TextBlock Grid.Column="1"
+                                                                                       Text="no longer listed"
+                                                                                       IsVisible="{Binding ShowMissingNote}"
+                                                                                       FontSize="11"
+                                                                                       Margin="6,0,0,0"
+                                                                                       Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
                                                                             <TextBlock Grid.Column="2"
                                                                                        Text="✓"
                                                                                        IsVisible="{Binding IsCurrent}"

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -159,7 +159,11 @@
                                 BorderThickness="0,0,0,1"
                                 Background="Transparent"
                                 ToolTip.Tip="{Binding Details}">
-                            <Grid ColumnDefinitions="Auto,Auto,*,Auto">
+                            <!-- The name in the STAR column, so it trims. In an Auto column the TextBlock
+                                 is measured at infinite width, TextTrimming never engages, and a long id
+                                 pushes the switch off the row - the same trap as the wide answer tables in
+                                 #586. (fable review) -->
+                            <Grid ColumnDefinitions="*,Auto,Auto">
                                 <TextBlock Grid.Column="0" Text="{Binding DisplayName}"
                                            TextTrimming="CharacterEllipsis"
                                            VerticalAlignment="Center"/>
@@ -178,7 +182,7 @@
 
                                 <!-- A switch, never a radio: several models under one connection must be
                                      on at once, which is the entire point of a short list. -->
-                                <ToggleSwitch Grid.Column="3" IsChecked="{Binding Enabled}"
+                                <ToggleSwitch Grid.Column="2" IsChecked="{Binding Enabled}"
                                               OnContent="" OffContent=""
                                               VerticalAlignment="Center"/>
                             </Grid>

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -159,14 +159,26 @@
                                 BorderThickness="0,0,0,1"
                                 Background="Transparent"
                                 ToolTip.Tip="{Binding Details}">
-                            <Grid ColumnDefinitions="*,Auto">
+                            <Grid ColumnDefinitions="Auto,Auto,*,Auto">
                                 <TextBlock Grid.Column="0" Text="{Binding DisplayName}"
                                            TextTrimming="CharacterEllipsis"
                                            VerticalAlignment="Center"/>
 
+                                <!-- Marked, never removed or switched off: the reader put this model there,
+                                     and a provider's listing is not authority over their configuration.
+                                     Caution rather than error - nothing has failed yet. (#728) -->
+                                <Border Grid.Column="1" IsVisible="{Binding Missing}"
+                                        Margin="8,0,0,0" Padding="6,1" CornerRadius="4"
+                                        VerticalAlignment="Center"
+                                        Background="{DynamicResource SystemFillColorCautionBackgroundBrush}"
+                                        ToolTip.Tip="The provider's model list no longer carries this id. It may have been renamed or retired. Requests to it will probably fail.">
+                                    <TextBlock Text="no longer listed" FontSize="11"
+                                               Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
+                                </Border>
+
                                 <!-- A switch, never a radio: several models under one connection must be
                                      on at once, which is the entire point of a short list. -->
-                                <ToggleSwitch Grid.Column="1" IsChecked="{Binding Enabled}"
+                                <ToggleSwitch Grid.Column="3" IsChecked="{Binding Enabled}"
                                               OnContent="" OffContent=""
                                               VerticalAlignment="Center"/>
                             </Grid>


### PR DESCRIPTION
Closes #728.

Providers retire and rename models routinely, free ones especially, and the app went on showing one as an ordinary row — enabled, pickable, indistinguishable. Since #726 cached the published facts it went further and *described* it: a context window and a reasoning flag for something that no longer exists, in the same shape it describes real models. That is a worse failure than the silence it replaced.

**What it does.** A fetch that succeeds, is non-empty, and is *complete* records which stored models the listing carried. The Models tab marks the rest "no longer listed" and falls back to the bare id instead of repeating stale facts; the per-turn picker marks them too and replaces the hover card's claims with the one thing still true — `Status: not in OpenRouter's model list`.

**What it deliberately does not do**, each pinned by a test:

- **A failed fetch marks nothing.** An offline moment or an unstarted local runner would otherwise flag every model the reader has. Absence of evidence is not evidence — the same reason `Reachability.Configured` is a third state.
- **An empty listing marks nothing.** Endpoints answer 200 with an empty `data[]` for reasons that have nothing to do with the reader's models.
- **An incomplete listing marks nothing.** See below.
- **Nothing is removed or switched off.** A listing is not authority over the reader's configuration, and an incomplete one would delete valid entries on their behalf.
- **Nothing is written when no mark changed**, so opening the Models tab does not rewrite `settings.json` and rebuild the list to say what it said before.

The resolver is untouched. Refusing to send to a marked model is #728's own open question, it belongs in the file #764 is rewriting, and the picker is deliberately not a gate — the provider's 404 stays the provider's to give.

## What the review changed

Fable reviewed the first commit adversarially; `9633d3a` is the response.

**A successful fetch is not a complete one.** Entries without a usable id are skipped and only logged — a listing whose nine entries yielded two we could read is on record in that log line — and Anthropic's listing is paged at twenty by default. Either way the first page or the readable subset would have marked every other stored model as retired: the exact false alarm this feature exists to avoid. `AiCatalogResult` now carries `Complete`, and the mark is only recorded from a listing that is. A short listing is still shown; it just cannot support the inference in the other direction. Following the pages is filed as #769.

**The row stopped trimming.** I had moved the model name into an `Auto` column, which measures its child at infinite width — so `TextTrimming` never engaged and a long id pushed the toggle off the row. Same trap as the wide answer tables in #586. The name is back in the star column.

**Retyping a marked id inherited the mark**, so a reader who saw "no longer listed" and corrected the id to the provider's new name got a corrected model still claiming to be gone, across sessions.

**One test passed for the wrong reason** — proved by mutation: `A_failed_fetch_marks_nothing` stayed green with `MarkListing` called from the failure branch, because `Fail` always carries an empty list and the empty-listing guard absorbed it. It now uses a failed result that carries models, so it pins the `Ok` check it names.

Two findings I did not act on, both noted in the issue: the mark only refreshes while the Models tab is open, so a re-listed model stays marked until that tab is next visited (#728 suggested dating the mark; not taken); and a fetch in flight while the connection's endpoint is edited can mark against the new configuration — the id is immutable and per-group, so it cannot cross connections.

Full suite 2279 pass, 0 build warnings.

**Merge note:** no overlap with #764 — Egret confirmed its file list. This branch does touch `AiModelCatalog.cs`, which #764 also touches, but in different members (`Parse`/`FetchAsync` here, `Authenticate` there).
