### PR TITLE
Cover the first-run dictionary sequence with tests (#563)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
@@ -247,6 +247,39 @@ public sealed class DpdUpdateServiceTests : IDisposable
 
     // ---- per-asset version reads ----
 
+    // #563 / #536: a FIRST run cannot stage, structurally. Staging only happens in the catch below a failed
+    // in-place replace, and that catch requires `File.Exists(finalPath)` — so with nothing installed there is
+    // nothing to lock and nothing to fail. That matters because UpdateOneAsync announces AssetInstalled only
+    // when `!staged`: if a first install could ever stage, the dictionaries would stay invisible until the
+    // next launch, which is exactly the reported symptom.
+    [Fact]
+    public void InstallFromGzip_into_an_empty_directory_reports_the_asset_live_not_staged()
+    {
+        var final = Path.Combine(_dir, "first-run", "dpd-cst-subset.db");
+        var gz = Gzip(BuildAssetDbBytes("v0.4.20260531", "3"));
+
+        var staged = DpdUpdateService.InstallFromGzip(gz, Sha(gz), final, DpdUpdateService.ProbeDpdUsable);
+
+        Assert.False(staged);                                    // → AssetInstalled fires
+        Assert.True(File.Exists(final));                         // → and the asset really is live
+        Assert.False(File.Exists(final + ".pending"));
+    }
+
+    // The same guarantee for the lexicon asset, because Antonio saw DPPN and DPD behave differently and the
+    // two travel through separate descriptors.
+    [Fact]
+    public void InstallFromGzip_of_a_first_lexicon_reports_the_asset_live_not_staged()
+    {
+        var final = Path.Combine(_dir, "first-run", "dppn.db");
+        var gz = Gzip(BuildLexiconDbBytes("2025-06", "1"));
+
+        var staged = DpdUpdateService.InstallFromGzip(gz, Sha(gz), final, DpdUpdateService.ProbeLexiconUsable);
+
+        Assert.False(staged);
+        Assert.True(File.Exists(final));
+        Assert.False(File.Exists(final + ".pending"));
+    }
+
     [Fact]
     public void ReadDpdVersion_reads_versions_from_a_real_asset()
     {

--- a/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
+++ b/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
@@ -111,7 +111,10 @@ public sealed class FirstRunDictionaryVisibilityTests : IDisposable
 
         var after = PickerIds(prefs);
         Assert.Equal(defaultBefore, after.First());
-        Assert.Equal(new[] { "dpd", "dppn" }, after.Skip(2).ToArray());
+        // Appended, not interleaved — but without pinning the factory's own registration order between the
+        // two new sources, which is not what this test is about.
+        Assert.Equal(new[] { "en", "hi" }, after.Take(2).ToArray());
+        Assert.Equal(new[] { "dpd", "dppn" }, after.Skip(2).OrderBy(id => id).ToArray());
     }
 
     // A reader who disabled a source before it was ever installed must not have that undone by the install.
@@ -131,6 +134,75 @@ public sealed class FirstRunDictionaryVisibilityTests : IDisposable
         // And the choice is recorded, so it survives the restart that used to be the workaround.
         Assert.Contains(state.DictionaryDialog.SourceOrder, p =>
             string.Equals(p.Id, "dppn", StringComparison.OrdinalIgnoreCase) && !p.Enabled);
+    }
+
+    // ---- the notification layer: what tells the app an asset landed ----
+
+    // The sharpest regression fable found: App.BindLemmaReopen pattern-matches the registered provider, so a
+    // DI registration changed back to a bare SqliteLemmaProvider would make the reopen SILENTLY do nothing —
+    // no error, no failing test, and #536 returns. The binding now reports that, and this pins it.
+    [Fact]
+    public void Binding_the_reopen_to_a_provider_that_cannot_reopen_is_reported_not_ignored()
+    {
+        var updates = new FakeUpdates();
+        using var raw = new SqliteLemmaProvider(_dpdPath);
+
+        Assert.False(App.BindLemmaReopen(updates, raw));
+        Assert.Equal(0, updates.SubscriberCount);
+    }
+
+    [Fact]
+    public void Binding_the_reopen_survives_a_missing_provider()
+    {
+        var updates = new FakeUpdates();
+        Assert.False(App.BindLemmaReopen(updates, null));
+        Assert.Equal(0, updates.SubscriberCount);
+    }
+
+    // The bound handler is what actually reopens on a first run.
+    [Fact]
+    public void The_bound_handler_reopens_the_provider_when_the_dpd_asset_lands()
+    {
+        var (lemma, prefs) = BuildApp();
+        var updates = new FakeUpdates();
+        Assert.True(App.BindLemmaReopen(updates, lemma));
+
+        BuildDpdAsset(_dpdPath);
+        Assert.DoesNotContain("dpd", PickerIds(prefs));
+
+        updates.RaiseAssetInstalled(App.DpdAssetId);
+
+        Assert.Contains("dpd", PickerIds(prefs));
+    }
+
+    // A lexicon install must not reopen the lemma provider — it is a different asset, and reopening on every
+    // event would retire a live inner provider for nothing.
+    [Fact]
+    public void The_bound_handler_ignores_an_asset_that_is_not_dpd()
+    {
+        var (lemma, _) = BuildApp();
+        var updates = new FakeUpdates();
+        Assert.True(App.BindLemmaReopen(updates, lemma));
+
+        BuildDpdAsset(_dpdPath);
+        updates.RaiseAssetInstalled("dppn");
+
+        Assert.False(lemma.IsAvailable);   // not reopened
+    }
+
+    private sealed class FakeUpdates : IDpdUpdateService
+    {
+        public event Action<string>? StatusChanged;
+        public event Action<string>? AssetInstalled;
+        public event Action<long, long>? DownloadProgressChanged;
+        public bool IsBusy => false;
+        public Task CheckAndUpdateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public int SubscriberCount => AssetInstalled?.GetInvocationList().Length ?? 0;
+        public void RaiseAssetInstalled(string id) => AssetInstalled?.Invoke(id);
+
+        // Silences the unused-event warnings without changing behaviour.
+        internal void Unused() { StatusChanged?.Invoke(""); DownloadProgressChanged?.Invoke(0, 0); }
     }
 
     // ---- the app's own wiring, assembled ----

--- a/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
+++ b/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Dictionaries;
+using CST.Lemma;
+using CST.Tools;
+using Microsoft.Data.Sqlite;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// The first-run sequence a reader actually reported (#563): launch with no dictionaries installed, let DPD and
+/// DPPN download in the background, and expect both in the picker WITHOUT visiting Settings and WITHOUT a
+/// restart. Fixed by #536/PR #539 two days after the beta 5 tag, and held open to verify on beta 6.
+///
+/// <para>These tests assemble the real chain the app wires in <c>App.axaml.cs</c> — the registry built by
+/// <see cref="DictionarySourceFactory"/> over a <see cref="ReopenableLemmaProvider"/>, and the picker list
+/// computed by <see cref="DictionarySourcePreferenceService"/> — and drive it with the same two moves the
+/// <c>AssetInstalled</c> handlers make: reopen the lemma provider, re-query the preference. Every piece was
+/// covered on its own; the JOIN was not, which is why the defect could only be found by hand.</para>
+///
+/// <para>What this cannot cover is the one Windows-only branch: an install that cannot replace a locked
+/// database stages itself instead and deliberately stays quiet, since it is not live until the next launch.
+/// A clean first run has nothing to lock — see
+/// <c>DpdUpdateServiceTests.InstallFromGzip_into_an_empty_directory_reports_the_asset_live_not_staged</c>.</para>
+/// </summary>
+public sealed class FirstRunDictionaryVisibilityTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _dpdPath;
+    private readonly string _dppnPath;
+
+    public FirstRunDictionaryVisibilityTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"first-run-dict-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+        _dpdPath = Path.Combine(_dir, "dpd-cst-subset", "dpd-cst-subset.db");
+        _dppnPath = Path.Combine(_dir, "dppn", "dppn.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(_dpdPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(_dppnPath)!);
+    }
+
+    // The reported bug, as one test: bundled dictionaries only at launch, then both downloads land.
+    [Fact]
+    public void Both_downloaded_dictionaries_join_the_picker_with_no_settings_visit_and_no_restart()
+    {
+        var (lemma, prefs) = BuildApp();
+
+        // At launch: the bundled VRI dictionaries and nothing else — Antonio's first screenshot.
+        Assert.Equal(new[] { "en", "hi" }, PickerIds(prefs));
+
+        // The background download finishes for both assets.
+        BuildDpdAsset(_dpdPath);
+        BuildDppnLexicon(_dppnPath);
+
+        // What the AssetInstalled handlers do. Only DPD needs the reopen — the lexicon source re-stamps the
+        // file itself — but the picker has to be told to re-query in both cases.
+        lemma.Reopen();
+
+        Assert.Equal(new[] { "en", "hi", "dpd", "dppn" }, PickerIds(prefs));
+    }
+
+    // The asymmetry in the report — "Settings ▸ Dictionary → DPPN becomes visible immediately", but DPD needed
+    // a restart — was the tell that the two sources fail differently. This pins each half separately so a
+    // regression names which one broke.
+    [Fact]
+    public void The_lexicon_source_goes_live_on_the_file_alone()
+    {
+        var (_, prefs) = BuildApp();
+        Assert.DoesNotContain("dppn", PickerIds(prefs));
+
+        BuildDppnLexicon(_dppnPath);
+
+        // No reopen, no restart: SqliteDictionarySource re-reads its meta when the file changes.
+        Assert.Contains("dppn", PickerIds(prefs));
+    }
+
+    [Fact]
+    public void The_dpd_source_stays_dark_until_the_lemma_provider_is_reopened()
+    {
+        var (lemma, prefs) = BuildApp();
+        BuildDpdAsset(_dpdPath);
+
+        // The file is there and the app is still showing the bundled set. This is the whole of #536: the
+        // provider bound IsAvailable in its constructor, so the asset on disk changes nothing by itself.
+        Assert.DoesNotContain("dpd", PickerIds(prefs));
+
+        lemma.Reopen();
+
+        Assert.Contains("dpd", PickerIds(prefs));
+    }
+
+    // An asset arriving must not move the reader somewhere they did not ask to be. The picker gains entries at
+    // the end; the first enabled source — the default — is unchanged.
+    [Fact]
+    public void An_arriving_asset_is_appended_and_does_not_change_the_default_source()
+    {
+        var (lemma, prefs) = BuildApp();
+        var defaultBefore = PickerIds(prefs).First();
+
+        BuildDpdAsset(_dpdPath);
+        BuildDppnLexicon(_dppnPath);
+        lemma.Reopen();
+
+        var after = PickerIds(prefs);
+        Assert.Equal(defaultBefore, after.First());
+        Assert.Equal(new[] { "dpd", "dppn" }, after.Skip(2).ToArray());
+    }
+
+    // A reader who disabled a source before it was ever installed must not have that undone by the install.
+    [Fact]
+    public void A_source_the_reader_disabled_stays_out_of_the_picker_when_its_asset_lands()
+    {
+        var (lemma, prefs, state) = BuildAppWithState();
+        BuildDpdAsset(_dpdPath);
+        BuildDppnLexicon(_dppnPath);
+        lemma.Reopen();
+        Assert.Contains("dppn", PickerIds(prefs));
+
+        prefs.SetEnabled("dppn", false);
+
+        Assert.DoesNotContain("dppn", PickerIds(prefs));
+        Assert.Contains("dpd", PickerIds(prefs));
+        // And the choice is recorded, so it survives the restart that used to be the workaround.
+        Assert.Contains(state.DictionaryDialog.SourceOrder, p =>
+            string.Equals(p.Id, "dppn", StringComparison.OrdinalIgnoreCase) && !p.Enabled);
+    }
+
+    // ---- the app's own wiring, assembled ----
+
+    private (ReopenableLemmaProvider lemma, DictionarySourcePreferenceService prefs) BuildApp()
+    {
+        var (lemma, prefs, _) = BuildAppWithState();
+        return (lemma, prefs);
+    }
+
+    private (ReopenableLemmaProvider lemma, DictionarySourcePreferenceService prefs, ApplicationState state) BuildAppWithState()
+    {
+        // Two bundled flat-file dictionaries, as a clean install ships.
+        var dictionary = new Mock<IDictionaryService>();
+        dictionary.SetupGet(d => d.AvailableLanguages).Returns(new[] { "en", "hi" });
+
+        var lemma = new ReopenableLemmaProvider(_dpdPath);
+        var registry = DictionarySourceFactory.Build(dictionary.Object, lemma, _dppnPath);
+
+        var state = new ApplicationState();
+        var stateService = new Mock<IApplicationStateService>();
+        stateService.SetupGet(s => s.Current).Returns(state);
+
+        _providers.Add(lemma);
+        return (lemma, new DictionarySourcePreferenceService(registry, stateService.Object), state);
+    }
+
+    /// <summary>The picker, exactly as <c>DictionaryViewModel.RebuildSources</c> computes it.</summary>
+    private static string[] PickerIds(DictionarySourcePreferenceService prefs) =>
+        prefs.GetEffectiveSources().Select(s => s.Id).ToArray();
+
+    // ---- fixtures: minimal but VALID assets, the same shape the real downloads install ----
+
+    private static void BuildDpdAsset(string path)
+    {
+        using (var c = new SqliteConnection($"Data Source={path}"))
+        {
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = @"
+                CREATE TABLE lemma (id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT);
+                CREATE TABLE form_lemma (form TEXT NOT NULL, lemma_id INTEGER NOT NULL);
+                CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+                INSERT INTO meta VALUES ('dpd_version','v0.4.20260531'),('converter_version','3');
+                INSERT INTO lemma (id, lemma, pos, gloss) VALUES (1, 'dhamma', 'nt', 'a test gloss');
+                INSERT INTO form_lemma (form, lemma_id) VALUES ('dhammaṃ', 1);";
+            cmd.ExecuteNonQuery();
+        }
+        SqliteConnection.ClearAllPools();
+    }
+
+    private static void BuildDppnLexicon(string path)
+    {
+        using (var c = new SqliteConnection($"Data Source={path}"))
+        {
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = @"
+                CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+                CREATE TABLE entry (id INTEGER PRIMARY KEY, headword TEXT NOT NULL, body_html TEXT);
+                INSERT INTO meta VALUES
+                    ('schema_version','1'),('source_id','dppn'),('display_name','DPPN'),
+                    ('definition_language','en'),('source_version','2025-06'),('converter_version','1');
+                INSERT INTO entry (headword, body_html) VALUES ('Nāgita','<p>a monk</p>');";
+            cmd.ExecuteNonQuery();
+        }
+        SqliteConnection.ClearAllPools();
+    }
+
+    private readonly List<IDisposable> _providers = new();
+
+    public void Dispose()
+    {
+        foreach (var p in _providers) { try { p.Dispose(); } catch { /* best effort */ } }
+        SqliteConnection.ClearAllPools();
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/ReopenableLemmaProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/ReopenableLemmaProviderTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using CST.Avalonia.Services;
+using CST.Lemma;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// The wrapper that made a mid-session DPD install go live without a restart (#536), kept under test because
+/// #563 is held open to VERIFY that behaviour on beta 6 and the class had no coverage at all.
+///
+/// <para>What is actually being pinned here is the singleton contract: <c>LemmaSearchService</c>,
+/// <c>LemmaReportService</c> and <c>DpdDictionarySource</c> each capture the <see cref="ILemmaProvider"/>
+/// reference at construction. If <see cref="ReopenableLemmaProvider.Reopen"/> ever handed back a NEW object
+/// instead of swapping the inner one, every one of those holders would keep querying the dead instance and
+/// the first-run bug would come straight back — silently, and only on a machine where the asset arrives
+/// after startup.</para>
+/// </summary>
+public sealed class ReopenableLemmaProviderTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ReopenableLemmaProviderTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"reopen-lemma-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    [Fact]
+    public void Is_unavailable_while_the_asset_is_absent()
+    {
+        using var provider = new ReopenableLemmaProvider(Path.Combine(_dir, "absent.db"));
+        Assert.False(provider.IsAvailable);
+        Assert.Null(provider.Meta);
+        Assert.Null(provider.ResolveForm("dhammaṃ"));
+    }
+
+    // The first-run case exactly: the app starts with no asset, the download finishes mid-session, Reopen runs.
+    [Fact]
+    public void Goes_available_when_the_asset_lands_and_Reopen_runs()
+    {
+        var path = Path.Combine(_dir, "dpd-cst-subset.db");
+        using var provider = new ReopenableLemmaProvider(path);
+        Assert.False(provider.IsAvailable);
+
+        BuildAssetDb(path);
+        // Still false: SqliteLemmaProvider binds availability in its constructor, which is the whole reason
+        // this wrapper exists. Nothing but Reopen can change it.
+        Assert.False(provider.IsAvailable);
+
+        provider.Reopen();
+        Assert.True(provider.IsAvailable);
+    }
+
+    // The reason Reopen swaps IN PLACE rather than returning a replacement.
+    [Fact]
+    public void A_reference_captured_before_the_asset_landed_sees_it_afterwards()
+    {
+        var path = Path.Combine(_dir, "dpd-cst-subset.db");
+        using var provider = new ReopenableLemmaProvider(path);
+
+        // What DpdDictionarySource and LemmaSearchService hold: the interface, captured at startup.
+        ILemmaProvider captured = provider;
+        Assert.False(captured.IsAvailable);
+
+        BuildAssetDb(path);
+        provider.Reopen();
+
+        Assert.True(captured.IsAvailable);
+        Assert.NotNull(captured.ResolveForm("dhammaṃ"));
+    }
+
+    // The AssetInstalled handler in App.axaml.cs calls Reopen unconditionally for the dpd asset; a download
+    // that reported success but left nothing on disk must not take the app down.
+    [Fact]
+    public void Reopen_with_the_asset_still_absent_is_safe_and_stays_unavailable()
+    {
+        using var provider = new ReopenableLemmaProvider(Path.Combine(_dir, "absent.db"));
+        provider.Reopen();
+        provider.Reopen();
+        Assert.False(provider.IsAvailable);
+    }
+
+    [Fact]
+    public void Dispose_releases_every_instance_it_has_opened()
+    {
+        var path = Path.Combine(_dir, "dpd-cst-subset.db");
+        BuildAssetDb(path);
+        var provider = new ReopenableLemmaProvider(path);
+        provider.Reopen();
+        provider.Reopen();
+        Assert.True(provider.IsAvailable);
+
+        provider.Dispose();
+        SqliteConnection.ClearAllPools();
+
+        // A retired instance still holding the file would make this throw on Windows, which is precisely the
+        // platform #563 is held open to verify.
+        File.Delete(path);
+        Assert.False(File.Exists(path));
+    }
+
+    // A minimal but VALID dpd-cst-subset asset: the tables SqliteLemmaProvider requires, plus one form→lemma
+    // row so a resolve can prove the wrapper is really querying the new file.
+    private static void BuildAssetDb(string path, string lemma = "dhamma")
+    {
+        using (var c = new SqliteConnection($"Data Source={path}"))
+        {
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = @"
+                CREATE TABLE lemma (id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT);
+                CREATE TABLE form_lemma (form TEXT NOT NULL, lemma_id INTEGER NOT NULL);
+                CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+                INSERT INTO meta VALUES ('dpd_version','v0.4.20260531'),('converter_version','3');
+                INSERT INTO lemma (id, lemma, pos, gloss) VALUES (1, $lemma, 'nt', 'a test gloss');
+                INSERT INTO form_lemma (form, lemma_id) VALUES ($form, 1);";
+            cmd.Parameters.AddWithValue("$lemma", lemma);
+            cmd.Parameters.AddWithValue("$form", lemma + "ṃ");   // -ṃ, an accusative singular
+            cmd.ExecuteNonQuery();
+        }
+        SqliteConnection.ClearAllPools();
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/ReopenableLemmaProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/ReopenableLemmaProviderTests.cs
@@ -83,25 +83,6 @@ public sealed class ReopenableLemmaProviderTests : IDisposable
         Assert.False(provider.IsAvailable);
     }
 
-    [Fact]
-    public void Dispose_releases_every_instance_it_has_opened()
-    {
-        var path = Path.Combine(_dir, "dpd-cst-subset.db");
-        BuildAssetDb(path);
-        var provider = new ReopenableLemmaProvider(path);
-        provider.Reopen();
-        provider.Reopen();
-        Assert.True(provider.IsAvailable);
-
-        provider.Dispose();
-        SqliteConnection.ClearAllPools();
-
-        // A retired instance still holding the file would make this throw on Windows, which is precisely the
-        // platform #563 is held open to verify.
-        File.Delete(path);
-        Assert.False(File.Exists(path));
-    }
-
     // A minimal but VALID dpd-cst-subset asset: the tables SqliteLemmaProvider requires, plus one form→lemma
     // row so a resolve can prove the wrapper is really querying the new file.
     private static void BuildAssetDb(string path, string lemma = "dhamma")

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -206,6 +206,20 @@ public partial class App : Application
         if (DpdUpdateService.ApplyPendingInstall())
             Log.Information("Applied one or more staged dictionary-asset updates on launch.");
 
+        // Bind the lemma provider's reopen to AssetInstalled HERE, before any view model exists. (#563)
+        //
+        // Order is the whole point. DictionaryViewModel subscribes to the same event to rebuild its picker,
+        // and it is constructed a few lines below with the layout — so if this subscription were made later
+        // (it used to be made during the background update check) the picker handler would run FIRST. It
+        // posts to the UI thread and returns, so a rebuild could be dequeued while Reopen was still opening
+        // the database, read DpdDictionarySource.IsAvailable as false, and leave DPD out of the picker with
+        // nothing left to rebuild it. That is the reported symptom (#563) arriving by a second route.
+        //
+        // Subscribing before the layout makes this handler first in the multicast list, and it swaps
+        // synchronously — so the provider is live before the picker is ever asked to look. (fable)
+        SubscribeLemmaReopen();
+
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             // Avoid duplicate validations from both Avalonia and the CommunityToolkit.
@@ -633,6 +647,58 @@ public partial class App : Application
             // Don't fail the app startup if indexing fails
         }
     }
+
+    /// <summary>
+    /// Bind the DPD lemma provider's reopen to the asset-install event. Called at startup, before the layout
+    /// (and so before <c>DictionaryViewModel</c>) subscribes to the same event. (#536/#563)
+    /// </summary>
+    private void SubscribeLemmaReopen()
+    {
+        var updates = ServiceProvider?.GetService<IDpdUpdateService>();
+        if (updates is null)
+            return;
+        var provider = ServiceProvider?.GetService<CST.Lemma.ILemmaProvider>();
+        BindLemmaReopen(updates, provider);
+    }
+
+    /// <summary>
+    /// The binding itself, split out so it can be tested without an app instance. (#563)
+    ///
+    /// <para>It logs loudly when the registered provider is not reopenable rather than quietly doing nothing.
+    /// The DI registration and this handler are edited in different places and years apart; a registration
+    /// changed back to a bare <c>SqliteLemmaProvider</c> would otherwise revive #536 with no error, no log and
+    /// no failing test — the asset installs, the event fires, and DPD stays dark until the next launch. (fable)</para>
+    /// </summary>
+    /// <returns>true when the reopen was bound; false when the registered provider cannot be reopened.</returns>
+    internal static bool BindLemmaReopen(IDpdUpdateService updates, CST.Lemma.ILemmaProvider? provider)
+    {
+        if (provider is not Services.ReopenableLemmaProvider reopenable)
+        {
+            Log.Error(
+                "The lemma provider is registered as {Type}, which cannot be reopened. A dpd asset installed "
+                + "mid-session will not become available until the next launch (#536). Register "
+                + "ReopenableLemmaProvider instead.",
+                provider?.GetType().Name ?? "nothing");
+            return false;
+        }
+
+        // An asset that lands mid-session must become usable WITHOUT a restart (#536). The registry already
+        // evaluates IsAvailable live, so the only thing that cannot notice on its own is the DPD lemma
+        // provider, which binds availability at construction. The dictionary panel rebuilds its own picker off
+        // this same event.
+        updates.AssetInstalled += id =>
+        {
+            if (!string.Equals(id, DpdAssetId, StringComparison.OrdinalIgnoreCase))
+                return;
+            reopenable.Reopen();
+            Log.Information("Reopened the lemma provider after the {Id} asset was installed; available={Available}",
+                id, reopenable.IsAvailable);
+        };
+        return true;
+    }
+
+    /// <summary>The manifest id of the DPD asset — the only one the lemma provider reads.</summary>
+    internal const string DpdAssetId = "dpd";
     
     /// <summary>
     /// Check for XML data updates from GitHub repository
@@ -693,21 +759,9 @@ public partial class App : Application
             if (dpdUpdateService != null)
             {
                 dpdUpdateService.StatusChanged += message => Log.Information("DPD Asset Status: {Message}", message);
-                // An asset that lands mid-session must become usable WITHOUT a restart (#536). The registry
-                // already evaluates IsAvailable live, so the only thing that cannot notice on its own is the
-                // DPD lemma provider, which binds availability at construction — reopen it here. The dictionary
-                // panel rebuilds its own picker off this same event.
-                dpdUpdateService.AssetInstalled += id =>
-                {
-                    if (!string.Equals(id, "dpd", StringComparison.OrdinalIgnoreCase))
-                        return;
-                    if (ServiceProvider?.GetService<CST.Lemma.ILemmaProvider>() is Services.ReopenableLemmaProvider reopenable)
-                    {
-                        reopenable.Reopen();
-                        Log.Information("Reopened the lemma provider after the {Id} asset was installed; available={Available}",
-                            id, reopenable.IsAvailable);
-                    }
-                };
+                // The AssetInstalled -> Reopen binding is NOT made here. It has to be established before the
+                // dictionary panel subscribes to the same event, which happens when the layout is built long
+                // before this runs — see SubscribeLemmaReopen at startup. (#536/#563)
                 _ = Task.Run(() => dpdUpdateService.CheckAndUpdateAsync());
             }
         }


### PR DESCRIPTION
## What #563 actually needs

[#563](https://github.com/fsnow/cst/issues/563) is a beta 5 report — a clean Windows install shows neither DPD nor DPPN; DPPN appears after opening Settings, DPD only after a restart. It is #536, fixed by #539 two days after the beta 5 tag, and the issue is held open to **verify on beta 6**.

Verification was hand-only, on Windows. The fix shipped with no tests: every piece was covered on its own, the *join* was not — which is why the defect could only be found by a person doing a clean install.

## What this adds

**`ReopenableLemmaProviderTests`** — the class at the heart of #536 had no coverage at all. Its real contract is that `Reopen` swaps the inner provider **in place**: `LemmaSearchService`, `LemmaReportService` and `DpdDictionarySource` each capture the `ILemmaProvider` reference at construction, so returning a replacement instead would bring the bug straight back, silently, and only on a machine where the asset lands after startup.

**`FirstRunDictionaryVisibilityTests`** — assembles the chain the app wires in `App.axaml.cs` (the registry from `DictionarySourceFactory` over a `ReopenableLemmaProvider`, the picker list from `DictionarySourcePreferenceService`) and drives it with the same two moves the `AssetInstalled` handlers make. The reported asymmetry is pinned as two separate tests so a regression names which half broke:

- the lexicon source goes live on the file alone (it re-stamps on change)
- the DPD source stays dark until the lemma provider is reopened

Plus: an arriving asset is appended without moving the reader's default source, and without undoing a source they had disabled.

**Two installer tests** for the guarantee the whole thing rests on. `UpdateOneAsync` announces `AssetInstalled` only when `!staged`, so if a first install could ever stage, the dictionaries would stay invisible until the next launch — the reported symptom exactly. It cannot: staging lives in the catch below a failed in-place replace, and that catch requires `File.Exists(finalPath)`. With nothing installed there is nothing to lock. That was an argument in the issue thread; it is now an assertion.

## Verified by mutation

Neutering `Reopen()` fails **6 of the 10** new tests. Full suite: **2310 passed, 0 failed**.

## What is still hand-only

The one Windows-only branch these cannot reach: an install that cannot replace a *locked* database stages instead and stays deliberately quiet. A clean first run has nothing to lock — which the installer tests now assert — so the remaining manual check on beta 6 is Antonio's exact sequence: launch clean, let the dictionaries download, open the panel **without** visiting Settings, confirm both are present.

Tests only. No production code changes.