### PR TITLE
Store credentials by connection and name (#759)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -254,13 +254,20 @@ public class AiConnectionServiceTests
     /// <summary>An in-memory credential store, keyed by connection id exactly as the real one now is.</summary>
     private sealed class Keys : IAiCredentialStore
     {
-        private readonly Dictionary<string, string> _byConnection = new();
+        private readonly Dictionary<string, string> _byAccount = new();
+
+        /// <summary>The same joined spelling the real store uses, so a test that stores under one name and
+        /// reads under another sees a miss rather than a hit (#759).</summary>
+        private static string Account(string connectionId, string name) => connectionId + ":" + name;
+
         public bool IsAvailable => true;
         public string? Unavailable => null;
-        public string? GetApiKey(string connectionId) =>
-            _byConnection.TryGetValue(connectionId, out var k) ? k : null;
-        public bool SetApiKey(string connectionId, string apiKey) { _byConnection[connectionId] = apiKey; return true; }
-        public bool DeleteApiKey(string connectionId) { _byConnection.Remove(connectionId); return true; }
+        public string? Get(string connectionId, string name) =>
+            _byAccount.TryGetValue(Account(connectionId, name), out var k) ? k : null;
+        public bool Set(string connectionId, string name, string secret)
+        { _byAccount[Account(connectionId, name)] = secret; return true; }
+        public bool Delete(string connectionId, string name)
+        { _byAccount.Remove(Account(connectionId, name)); return true; }
     }
 
     private static (AiConnectionService Service, Settings Settings, Keys Keys) MakeWithKeys()
@@ -286,11 +293,11 @@ public class AiConnectionServiceTests
         service.Add("openrouter-box", Draft("OpenRouter", "https://openrouter.ai/api/v1"));
         service.Add("local-ollama", Draft("Ollama", "http://localhost:11434/v1"));
 
-        keys.SetApiKey("openrouter-box", "or-key");
-        keys.SetApiKey("local-ollama", "ollama-key");
+        keys.Set("openrouter-box", AiCredentialNames.Primary, "or-key");
+        keys.Set("local-ollama", AiCredentialNames.Primary, "ollama-key");
 
-        Assert.Equal("or-key", keys.GetApiKey("openrouter-box"));
-        Assert.Equal("ollama-key", keys.GetApiKey("local-ollama"));
+        Assert.Equal("or-key", keys.Get("openrouter-box", AiCredentialNames.Primary));
+        Assert.Equal("ollama-key", keys.Get("local-ollama", AiCredentialNames.Primary));
     }
 
     /// <summary>A connection reports where its credential came from, so the UI can name the source and — for
@@ -303,7 +310,7 @@ public class AiConnectionServiceTests
 
         Assert.Equal(CredentialSource.None, service.Connections.Single().KeySource);
 
-        keys.SetApiKey("box", "k");
+        keys.Set("box", AiCredentialNames.Primary, "k");
 
         Assert.Equal(CredentialSource.Keychain, service.Connections.Single().KeySource);
     }
@@ -317,11 +324,11 @@ public class AiConnectionServiceTests
     {
         var (service, _, keys) = MakeWithKeys();
         service.Add("box", Draft());
-        keys.SetApiKey("box", "k");
+        keys.Set("box", AiCredentialNames.Primary, "k");
 
         service.Remove("box");
 
-        Assert.Null(keys.GetApiKey("box"));
+        Assert.Null(keys.Get("box", AiCredentialNames.Primary));
     }
 
     // ---- reachability write-back (#673) ------------------------------------------------------------------

--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -251,7 +251,7 @@ public class AiConnectionServiceTests
         Assert.Equal("http://b/v1", result.Connection.BaseUrl);
     }
 
-    /// <summary>An in-memory credential store, keyed by connection id exactly as the real one now is.</summary>
+    /// <summary>An in-memory credential store, keyed by the joined account exactly as the real one is.</summary>
     private sealed class Keys : IAiCredentialStore
     {
         private readonly Dictionary<string, string> _byAccount = new();

--- a/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
@@ -295,6 +295,32 @@ public class AiCredentialStoreTests : IDisposable
     }
 
     [Fact]
+    public void The_account_spelling_is_stable()
+    {
+        // The same property ServiceName has, and for the same reason: change it and every credential already
+        // stored reads as "not configured", with no error anywhere. The round-trip tests above cannot hold
+        // this line - save and find share the value in-process, so they stay green across any reformatting of
+        // the account - and The_separator_cannot_occur_inside_either_part deliberately does not name the
+        // separator. So the exact spelling is pinned here, per platform.
+        //
+        // The concrete regression: someone "unifies" the two separators to one character (they look like an
+        // irregularity, and '.' is legal in a Keychain account too). Every macOS credential moves from
+        // anthropic:primary to anthropic.primary, every stored key silently disappears, and the whole suite
+        // passes. (fable review)
+        if (OperatingSystem.IsWindows())
+            Assert.Equal("anthropic.primary", AiCredentialStore.AccountFor("anthropic", AiCredentialNames.Primary));
+        else
+            Assert.Equal("anthropic:primary", AiCredentialStore.AccountFor("anthropic", AiCredentialNames.Primary));
+    }
+
+    /// <summary>
+    /// The two collision tests are load-bearing AS A PAIR, which is worth saying before someone deletes the
+    /// "redundant" one: a '_' separator leaves ("gw","header-x") and ("gw-header","x") distinct, so
+    /// An_id_ending_in_a_name_does_not_share_an_account_with_it stays green - and only
+    /// The_separator_cannot_occur_inside_either_part catches it, because '_' is a character Sanitize emits.
+    /// (fable review)
+    /// </summary>
+    [Fact]
     public void The_service_name_is_stable()
     {
         // Changing it orphans every key already stored, silently: the user is simply told they have not

--- a/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
@@ -49,11 +49,14 @@ public class AiCredentialStoreTests : IDisposable
 
     public void Dispose()
     {
-        // Connection ids now, not provider kinds (#678): keys are keyed per endpoint, so the cleanup list is
-        // whatever ids the tests in this class use rather than an enum's members.
-        if (_store.IsAvailable)
-            foreach (var id in new[] { "anthropic", "openai-compatible", "openrouter-box", "local-ollama" })
-                _store.DeleteApiKey(id);
+        // Connection ids, not provider kinds (#678), and every NAME each id is used with (#759): an account is
+        // the pair, so sweeping only the primary one would leave a test's second secret behind in the
+        // developer's own keychain.
+        if (!_store.IsAvailable) return;
+
+        foreach (var id in new[] { "anthropic", "openai-compatible", "openrouter-box", "local-ollama", "gw", "gw-header" })
+            foreach (var name in new[] { AiCredentialNames.Primary, "gateway", "header-x", "x" })
+                _store.Delete(id, name);
     }
 
     // ---- The acceptance test ------------------------------------------------------------------------------
@@ -66,9 +69,9 @@ public class AiCredentialStoreTests : IDisposable
         // is the easier one to introduce by accident.
         if (!_store.IsAvailable) return;
 
-        _store.SetApiKey("anthropic", Secret);
-        _store.GetApiKey("anthropic");
-        _store.DeleteApiKey("anthropic");
+        _store.Set("anthropic", AiCredentialNames.Primary, Secret);
+        _store.Get("anthropic", AiCredentialNames.Primary);
+        _store.Delete("anthropic", AiCredentialNames.Primary);
 
         Assert.NotEmpty(_log.Lines);   // the logger really was wired, so absence means absence
         foreach (var line in _log.Lines)
@@ -87,8 +90,8 @@ public class AiCredentialStoreTests : IDisposable
     {
         if (!_store.IsAvailable) return;
 
-        Assert.True(_store.SetApiKey("anthropic", Secret));
-        Assert.Equal(Secret, _store.GetApiKey("anthropic"));
+        Assert.True(_store.Set("anthropic", AiCredentialNames.Primary, Secret));
+        Assert.Equal(Secret, _store.Get("anthropic", AiCredentialNames.Primary));
     }
 
     [Fact]
@@ -98,10 +101,10 @@ public class AiCredentialStoreTests : IDisposable
         // a window with no key at all if the add failed.
         if (!_store.IsAvailable) return;
 
-        _store.SetApiKey("anthropic", Secret);
-        Assert.True(_store.SetApiKey("anthropic", "sk-ant-second-value"));
+        _store.Set("anthropic", AiCredentialNames.Primary, Secret);
+        Assert.True(_store.Set("anthropic", AiCredentialNames.Primary, "sk-ant-second-value"));
 
-        Assert.Equal("sk-ant-second-value", _store.GetApiKey("anthropic"));
+        Assert.Equal("sk-ant-second-value", _store.Get("anthropic", AiCredentialNames.Primary));
     }
 
     [Fact]
@@ -110,11 +113,11 @@ public class AiCredentialStoreTests : IDisposable
         // The ordinary case for someone comparing a hosted model against a local one.
         if (!_store.IsAvailable) return;
 
-        _store.SetApiKey("anthropic", "sk-ant-aaa");
-        _store.SetApiKey("openai-compatible", "sk-oai-bbb");
+        _store.Set("anthropic", AiCredentialNames.Primary, "sk-ant-aaa");
+        _store.Set("openai-compatible", AiCredentialNames.Primary, "sk-oai-bbb");
 
-        Assert.Equal("sk-ant-aaa", _store.GetApiKey("anthropic"));
-        Assert.Equal("sk-oai-bbb", _store.GetApiKey("openai-compatible"));
+        Assert.Equal("sk-ant-aaa", _store.Get("anthropic", AiCredentialNames.Primary));
+        Assert.Equal("sk-oai-bbb", _store.Get("openai-compatible", AiCredentialNames.Primary));
     }
 
     [Fact]
@@ -122,7 +125,7 @@ public class AiCredentialStoreTests : IDisposable
     {
         if (!_store.IsAvailable) return;
 
-        Assert.Null(_store.GetApiKey("anthropic"));
+        Assert.Null(_store.Get("anthropic", AiCredentialNames.Primary));
     }
 
     [Fact]
@@ -131,7 +134,7 @@ public class AiCredentialStoreTests : IDisposable
         // Idempotent: Settings should be able to offer "forget this key" without first checking.
         if (!_store.IsAvailable) return;
 
-        Assert.True(_store.DeleteApiKey("anthropic"));
+        Assert.True(_store.Delete("anthropic", AiCredentialNames.Primary));
     }
 
     [Fact]
@@ -139,10 +142,10 @@ public class AiCredentialStoreTests : IDisposable
     {
         if (!_store.IsAvailable) return;
 
-        _store.SetApiKey("anthropic", Secret);
-        Assert.True(_store.DeleteApiKey("anthropic"));
+        _store.Set("anthropic", AiCredentialNames.Primary, Secret);
+        Assert.True(_store.Delete("anthropic", AiCredentialNames.Primary));
 
-        Assert.Null(_store.GetApiKey("anthropic"));
+        Assert.Null(_store.Get("anthropic", AiCredentialNames.Primary));
     }
 
     [Fact]
@@ -152,9 +155,9 @@ public class AiCredentialStoreTests : IDisposable
         // a trailing newline, and storing that verbatim produces a 401 nobody can explain.
         if (!_store.IsAvailable) return;
 
-        _store.SetApiKey("anthropic", "  sk-ānt-ṃixed-42\n");
+        _store.Set("anthropic", AiCredentialNames.Primary, "  sk-ānt-ṃixed-42\n");
 
-        Assert.Equal("sk-ānt-ṃixed-42", _store.GetApiKey("anthropic"));
+        Assert.Equal("sk-ānt-ṃixed-42", _store.Get("anthropic", AiCredentialNames.Primary));
     }
 
     [Fact]
@@ -162,8 +165,71 @@ public class AiCredentialStoreTests : IDisposable
     {
         if (!_store.IsAvailable) return;
 
-        Assert.False(_store.SetApiKey("anthropic", "   "));
-        Assert.Null(_store.GetApiKey("anthropic"));
+        Assert.False(_store.Set("anthropic", AiCredentialNames.Primary, "   "));
+        Assert.Null(_store.Get("anthropic", AiCredentialNames.Primary));
+    }
+
+    // ---- Named credentials (#759) -------------------------------------------------------------------------
+
+    [Fact]
+    public void Two_names_on_one_connection_are_two_secrets()
+    {
+        // The case the whole reshape exists for: Cloudflare's gateway wants a gateway token beside the
+        // upstream key (#701), and one opaque string per connection had nowhere to put the second.
+        if (!_store.IsAvailable) return;
+
+        _store.Set("gw", AiCredentialNames.Primary, "sk-upstream");
+        _store.Set("gw", "gateway", "cf-gateway-token");
+
+        Assert.Equal("sk-upstream", _store.Get("gw", AiCredentialNames.Primary));
+        Assert.Equal("cf-gateway-token", _store.Get("gw", "gateway"));
+    }
+
+    [Fact]
+    public void Deleting_one_name_leaves_the_others()
+    {
+        // Degrading one credential at a time is the reason for N accounts rather than one JSON blob per
+        // connection: losing the gateway token must not lose the upstream key with it.
+        if (!_store.IsAvailable) return;
+
+        _store.Set("gw", AiCredentialNames.Primary, "sk-upstream");
+        _store.Set("gw", "gateway", "cf-gateway-token");
+
+        Assert.True(_store.Delete("gw", "gateway"));
+
+        Assert.Null(_store.Get("gw", "gateway"));
+        Assert.Equal("sk-upstream", _store.Get("gw", AiCredentialNames.Primary));
+    }
+
+    [Fact]
+    public void A_name_that_was_never_stored_reads_as_null_even_when_another_name_was()
+    {
+        // Absence of one secret must not be answered with a different one — that would present as a 401 the
+        // reader cannot attribute, which is #678's symptom exactly.
+        if (!_store.IsAvailable) return;
+
+        _store.Set("gw", AiCredentialNames.Primary, "sk-upstream");
+
+        Assert.Null(_store.Get("gw", "gateway"));
+    }
+
+    [Fact]
+    public void An_id_ending_in_a_name_does_not_share_an_account_with_it()
+    {
+        // The regression this design exists to make unreachable. Sanitising the JOINED string folds the
+        // separator into '-', which ids may contain, so ("gw", "header-x") and ("gw-header", "x") both become
+        // "gw-header-x" and silently overwrite each other. Sanitising each part and joining afterwards cannot:
+        // the separator never occurs inside a part, so the split is unambiguous.
+        //
+        // Invisible if it regresses — the symptom is one connection answering with another's credential, i.e.
+        // a 401 naming neither cause — which is why it is pinned rather than left to the doc comment.
+        if (!_store.IsAvailable) return;
+
+        _store.Set("gw", "header-x", "secret-for-gw");
+        _store.Set("gw-header", "x", "secret-for-gw-header");
+
+        Assert.Equal("secret-for-gw", _store.Get("gw", "header-x"));
+        Assert.Equal("secret-for-gw-header", _store.Get("gw-header", "x"));
     }
 
     // ---- Platform behaviour -------------------------------------------------------------------------------
@@ -200,8 +266,32 @@ public class AiCredentialStoreTests : IDisposable
     public void Each_provider_gets_its_own_account_name()
     {
         Assert.NotEqual(
-            AiCredentialStore.AccountFor("anthropic"),
-            AiCredentialStore.AccountFor("openai-compatible"));
+            AiCredentialStore.AccountFor("anthropic", AiCredentialNames.Primary),
+            AiCredentialStore.AccountFor("openai-compatible", AiCredentialNames.Primary));
+    }
+
+    [Fact]
+    public void Each_name_gets_its_own_account_name()
+    {
+        Assert.NotEqual(
+            AiCredentialStore.AccountFor("gw", AiCredentialNames.Primary),
+            AiCredentialStore.AccountFor("gw", "gateway"));
+    }
+
+    [Fact]
+    public void The_separator_cannot_occur_inside_either_part()
+    {
+        // What makes the account string unambiguously splittable, and therefore collision-free. Asserted on the
+        // sanitiser's OUTPUT rather than on its allowed set, so widening that set trips this rather than
+        // silently reopening the collision An_id_ending_in_a_name_does_not_share_an_account_with_it pins.
+        //
+        // Deliberately does not name the separator: it differs by platform (':' on macOS, '.' on Windows,
+        // because a DPAPI account is a filename), and a test that named one would be vacuous on the other.
+        // What must hold on both is that exactly ONE character of the account lies outside what Sanitize
+        // emits — the join — so the parts cannot bleed into each other.
+        var account = AiCredentialStore.AccountFor("a:b.c", "d.e:f");
+
+        Assert.Equal(1, account.Count(c => !(char.IsAsciiLetterOrDigit(c) || c is '-' or '_')));
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -30,9 +30,9 @@ public class ChatProviderResolverTests
 
         public bool IsAvailable => Unavailable is null;
         public string? Unavailable { get; }
-        public string? GetApiKey(string connectionId) => _key;
-        public bool SetApiKey(string connectionId, string apiKey) => throw new NotSupportedException();
-        public bool DeleteApiKey(string connectionId) => throw new NotSupportedException();
+        public string? Get(string connectionId, string name) => _key;
+        public bool Set(string connectionId, string name, string secret) => throw new NotSupportedException();
+        public bool Delete(string connectionId, string name) => throw new NotSupportedException();
     }
 
     private static ChatProviderResolver Resolver(

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -47,12 +47,16 @@ public class AiConnectionEditorViewModelTests
     /// <summary>An in-memory keychain, so no test prompts for a real one.</summary>
     private sealed class FakeCredentialStore : IAiCredentialStore
     {
+        /// <summary>Keyed by the joined account, exactly as the real store files it (#759).</summary>
         public Dictionary<string, string> Stored { get; } = new(StringComparer.Ordinal);
+        private static string Account(string connectionId, string name) => connectionId + ":" + name;
         public bool IsAvailable => true;
         public string? Unavailable => null;
-        public string? GetApiKey(string connectionId) => Stored.GetValueOrDefault(connectionId);
-        public bool SetApiKey(string connectionId, string apiKey) { Stored[connectionId] = apiKey; return true; }
-        public bool DeleteApiKey(string connectionId) => Stored.Remove(connectionId);
+        public string? Get(string connectionId, string name) =>
+            Stored.GetValueOrDefault(Account(connectionId, name));
+        public bool Set(string connectionId, string name, string secret)
+        { Stored[Account(connectionId, name)] = secret; return true; }
+        public bool Delete(string connectionId, string name) => Stored.Remove(Account(connectionId, name));
     }
 
     private static void Save(AiConnectionEditorViewModel vm) => vm.SaveCommand.Execute().Subscribe();
@@ -450,7 +454,7 @@ public class AiConnectionEditorViewModelTests
         vm.ApiKeyEntry = "sk-or-secret";
         Save(vm);
 
-        Assert.Equal("sk-or-secret", h.Keys.GetApiKey("openrouter"));
+        Assert.Equal("sk-or-secret", h.Keys.Get("openrouter", AiCredentialNames.Primary));
         Assert.Empty(h.Service.Connections.Single().Models);
     }
 
@@ -474,7 +478,7 @@ public class AiConnectionEditorViewModelTests
     {
         var h = new Harness();
         h.Service.Add("mine", Draft());
-        h.Keys.SetApiKey("mine", "sk-secret");
+        h.Keys.Set("mine", AiCredentialNames.Primary, "sk-secret");
 
         var vm = h.Existing("mine");
         Assert.True(vm.HasStoredKey);
@@ -482,7 +486,7 @@ public class AiConnectionEditorViewModelTests
         vm.RemoveKeyCommand.Execute().Subscribe();
 
         Assert.False(vm.HasStoredKey);
-        Assert.Null(h.Keys.GetApiKey("mine"));
+        Assert.Null(h.Keys.Get("mine", AiCredentialNames.Primary));
         Assert.Single(h.Service.Connections);
     }
 
@@ -553,7 +557,7 @@ public class AiConnectionEditorViewModelTests
         Save(h.Preset("deepseek").With(vm => vm.ApiKeyEntry = "sk-test"));
 
         Assert.Single(h.Service.Connections);
-        Assert.Equal("sk-test", h.Keys.Stored["deepseek"]);
+        Assert.Equal("sk-test", h.Keys.Get("deepseek", AiCredentialNames.Primary));
     }
 
     /// <summary>Editing a connection whose key is already stored does not demand it again — the box is empty
@@ -704,7 +708,7 @@ public class AiConnectionEditorViewModelTests
         Assert.Equal("nvidia/nemotron", after.Models.Single().Id);
         Assert.Equal("token", after.Headers["X-Gateway"]);
         Assert.Equal("https://openrouter.ai/api/v1", after.BaseUrl);
-        Assert.Equal("sk-replaced", h.Keys.Stored["openrouter"]);
+        Assert.Equal("sk-replaced", h.Keys.Get("openrouter", AiCredentialNames.Primary));
     }
 
     /// <summary>An edit updates the connection rather than adding a second one — the id is already taken, and

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -80,12 +80,16 @@ public class AiConnectionsViewModelTests
     /// <summary>An in-memory keychain. The real one would need a Keychain prompt per test.</summary>
     internal sealed class FakeCredentialStore : IAiCredentialStore
     {
+        /// <summary>Keyed by the joined account, exactly as the real store files it (#759).</summary>
         public Dictionary<string, string> Keys { get; } = new(StringComparer.Ordinal);
+        private static string Account(string connectionId, string name) => connectionId + ":" + name;
         public bool IsAvailable => true;
         public string? Unavailable => null;
-        public string? GetApiKey(string connectionId) => Keys.GetValueOrDefault(connectionId);
-        public bool SetApiKey(string connectionId, string apiKey) { Keys[connectionId] = apiKey; return true; }
-        public bool DeleteApiKey(string connectionId) => Keys.Remove(connectionId);
+        public string? Get(string connectionId, string name) =>
+            Keys.GetValueOrDefault(Account(connectionId, name));
+        public bool Set(string connectionId, string name, string secret)
+        { Keys[Account(connectionId, name)] = secret; return true; }
+        public bool Delete(string connectionId, string name) => Keys.Remove(Account(connectionId, name));
     }
 
     /// <summary>Adds a preset the way a reader does — open the sheet, fill it in, save. There is no
@@ -349,8 +353,8 @@ public class AiConnectionsViewModelTests
         AddThroughSheet(vm, "ollama");
         AddThroughSheet(vm, "openrouter", key: "sk-or-secret");
 
-        Assert.Equal("sk-or-secret", keys.GetApiKey("openrouter"));
-        Assert.Null(keys.GetApiKey("ollama"));
+        Assert.Equal("sk-or-secret", keys.Get("openrouter", AiCredentialNames.Primary));
+        Assert.Null(keys.Get("ollama", AiCredentialNames.Primary));
     }
 
     /// <summary>Where the credential came from is read off the store, so storing one moves the badge without
@@ -370,7 +374,7 @@ public class AiConnectionsViewModelTests
         row.RemoveKeyCommand.Execute().Subscribe();
 
         Assert.Equal("No key", vm.Connections.Single().KeySourceBadge);
-        Assert.Null(keys.GetApiKey("openrouter"));
+        Assert.Null(keys.Get("openrouter", AiCredentialNames.Primary));
     }
 
     /// <summary>Removing a key must not take the connection or its models with it — the whole reason the two

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -21,12 +21,16 @@ public class AiModelPickerViewModelTests
 {
     private sealed class FakeCredentialStore : IAiCredentialStore
     {
+        /// <summary>Keyed by the joined account, exactly as the real store files it (#759).</summary>
         public Dictionary<string, string> Keys { get; } = new(StringComparer.Ordinal);
+        private static string Account(string connectionId, string name) => connectionId + ":" + name;
         public bool IsAvailable => true;
         public string? Unavailable => null;
-        public string? GetApiKey(string connectionId) => Keys.GetValueOrDefault(connectionId);
-        public bool SetApiKey(string connectionId, string apiKey) { Keys[connectionId] = apiKey; return true; }
-        public bool DeleteApiKey(string connectionId) => Keys.Remove(connectionId);
+        public string? Get(string connectionId, string name) =>
+            Keys.GetValueOrDefault(Account(connectionId, name));
+        public bool Set(string connectionId, string name, string secret)
+        { Keys[Account(connectionId, name)] = secret; return true; }
+        public bool Delete(string connectionId, string name) => Keys.Remove(Account(connectionId, name));
     }
 
     private static (AiModelPickerViewModel Picker, AiConnectionService Service, FakeCredentialStore Keys) Make()
@@ -406,7 +410,7 @@ public class AiModelPickerViewModelTests
         Assert.False(model.IsUsable);
         Assert.Equal("no API key stored", model.Unusable);
 
-        keys.SetApiKey("openrouter", "sk-or-secret");
+        keys.Set("openrouter", AiCredentialNames.Primary, "sk-or-secret");
         picker.Refresh();
 
         Assert.True(AllModels(picker).Single().IsUsable);

--- a/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
@@ -49,19 +49,21 @@ namespace CST.Avalonia.Tests.ViewModels
             public bool IsAvailable => Available;
             public string? Unavailable => Available ? null : "No secure storage in this build.";
 
-            public string? GetApiKey(string connectionId) =>
-                Available && _keys.TryGetValue(connectionId, out var k) ? k : null;
+            private static string Account(string connectionId, string name) => connectionId + ":" + name;
 
-            public bool SetApiKey(string connectionId, string apiKey)
+            public string? Get(string connectionId, string name) =>
+                Available && _keys.TryGetValue(Account(connectionId, name), out var k) ? k : null;
+
+            public bool Set(string connectionId, string name, string secret)
             {
                 if (!Available) return false;
-                _keys[connectionId] = apiKey;
+                _keys[Account(connectionId, name)] = secret;
                 return true;
             }
 
-            public bool DeleteApiKey(string connectionId)
+            public bool Delete(string connectionId, string name)
             {
-                _keys.Remove(connectionId);
+                _keys.Remove(Account(connectionId, name));
                 return true;
             }
         }

--- a/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
@@ -63,6 +63,10 @@ namespace CST.Avalonia.Tests.ViewModels
 
             public bool Delete(string connectionId, string name)
             {
+                // Mirrors the real store, which refuses rather than reports success when there is nowhere to
+                // delete from - a fake that is more forgiving than the thing it stands for is how a bug gets
+                // through green. (fable review)
+                if (!Available) return false;
                 _keys.Remove(Account(connectionId, name));
                 return true;
             }

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -516,10 +516,6 @@ namespace CST.Avalonia.Services.Ai
             r.AuthScheme);
 
         /// <summary>
-        /// Ids are the reserved namespace a custom connection may not take, and they become the credential's
-        /// account name — so a collision would mean one connection quietly inheriting another's key.
-        /// </summary>
-        /// <summary>
         /// Every credential name this connection could have filed a secret under. (#759)
         ///
         /// <para>Derived rather than recorded, so it cannot drift out of step with what was actually stored:
@@ -531,6 +527,10 @@ namespace CST.Avalonia.Services.Ai
             yield return AiCredentialNames.Primary;
         }
 
+        /// <summary>
+        /// Ids are the reserved namespace a custom connection may not take, and they become the credential's
+        /// account name — so a collision would mean one connection quietly inheriting another's key.
+        /// </summary>
         private string? ValidateId(string id, bool existingAllowed)
         {
             if (string.IsNullOrWhiteSpace(id)) return "A connection needs an id.";

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -188,7 +188,7 @@ namespace CST.Avalonia.Services.Ai
         }
 
         private CredentialSource SourceFor(string connectionId) =>
-            _credentials?.GetApiKey(connectionId) is not null
+            _credentials?.Get(connectionId, AiCredentialNames.Primary) is not null
                 ? CredentialSource.Keychain
                 : CredentialSource.None;
 
@@ -271,10 +271,15 @@ namespace CST.Avalonia.Services.Ai
 
             Chat.Connections.Remove(record);
 
-            // The credential goes with the record. Removing a connection while leaving its key behind would
+            // The credentials go with the record. Removing a connection while leaving a secret behind would
             // leave an orphan in the keychain that nothing can ever reach or clean up - and that would be
             // silently re-adopted if someone later created a connection with the same id.
-            _credentials?.DeleteApiKey(record.Id);
+            //
+            // EVERY name, not just the primary one (#759): a connection may file more than one secret, and an
+            // orphan is invisible precisely because nothing reads it. This is the one place that has to know
+            // the full set, so it is the one place to extend when a provider adds a name.
+            foreach (var name in CredentialNamesOf(record))
+                _credentials?.Delete(record.Id, name);
 
             // Do not leave the active pointer dangling at something that no longer exists - a stale id reads
             // as "configured" to anything that only checks for null.
@@ -514,6 +519,18 @@ namespace CST.Avalonia.Services.Ai
         /// Ids are the reserved namespace a custom connection may not take, and they become the credential's
         /// account name — so a collision would mean one connection quietly inheriting another's key.
         /// </summary>
+        /// <summary>
+        /// Every credential name this connection could have filed a secret under. (#759)
+        ///
+        /// <para>Derived rather than recorded, so it cannot drift out of step with what was actually stored:
+        /// a list in the settings file would be one more thing to keep true, and the failure mode of it being
+        /// stale is an orphaned credential nobody can see.</para>
+        /// </summary>
+        private static IEnumerable<string> CredentialNamesOf(AiConnectionRecord record)
+        {
+            yield return AiCredentialNames.Primary;
+        }
+
         private string? ValidateId(string id, bool existingAllowed)
         {
             if (string.IsNullOrWhiteSpace(id)) return "A connection needs an id.";

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -237,7 +237,7 @@ namespace CST.Avalonia.Services.Ai
         /// </summary>
         private void Authenticate(HttpRequestMessage request, AiConnection connection)
         {
-            var key = _credentials?.GetApiKey(connection.Id);
+            var key = _credentials?.Get(connection.Id, AiCredentialNames.Primary);
             var headers = connection.Headers.ToDictionary(
                 h => h.Key, h => AiTemplate.Expand(h.Value, connection.Inputs));
 

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -27,26 +27,42 @@ public enum ChatProviderKind
 /// </summary>
 public interface IAiCredentialStore
 {
-    /// <summary>Whether this platform has somewhere safe to put a key at all.</summary>
+    /// <summary>Whether this platform has somewhere safe to put a secret at all.</summary>
     bool IsAvailable { get; }
 
     /// <summary>Why not, phrased for the user to read. Null when storage is available.</summary>
     string? Unavailable { get; }
 
     /// <summary>
-    /// The stored key for a CONNECTION, or null when none is stored. (#678)
+    /// One stored secret, or null when none is stored.
     ///
-    /// <para>Keyed by connection id rather than by provider kind, which was a two-member enum — so every
-    /// OpenAI-compatible endpoint shared a single slot, and configuring a second one silently overwrote the
-    /// first.</para>
+    /// <para><b>Keyed by connection AND name</b> (#759). By connection because a two-member provider enum once
+    /// meant every OpenAI-compatible endpoint shared a slot (#678); by name because a single request can need
+    /// more than one secret — Cloudflare's gateway wants a gateway token beside the upstream key (#701),
+    /// Bedrock a secret access key beside an access key id (#702). A connection with one secret simply calls
+    /// it <see cref="AiCredentialNames.Primary"/>.</para>
     /// </summary>
-    string? GetApiKey(string connectionId);
+    string? Get(string connectionId, string name);
 
-    /// <summary>Store or replace a connection's key. False when the platform cannot.</summary>
-    bool SetApiKey(string connectionId, string apiKey);
+    /// <summary>Store or replace one named secret. False when the platform cannot.</summary>
+    bool Set(string connectionId, string name, string secret);
 
-    /// <summary>Forget a connection's key. Forgetting one never stored counts as success.</summary>
-    bool DeleteApiKey(string connectionId);
+    /// <summary>Forget one named secret. Forgetting one never stored counts as success.</summary>
+    bool Delete(string connectionId, string name);
+}
+
+/// <summary>
+/// The names a connection files its secrets under. (#759)
+///
+/// <para>These are ours, never the reader's: a name is part of the storage address, so a typo in one is a
+/// credential that cannot be found again rather than an error anyone sees. Presets declare which names they
+/// need; the reader only ever fills them in.</para>
+/// </summary>
+public static class AiCredentialNames
+{
+    /// <summary>The credential the auth header carries — what every provider in the catalogue needs, and for
+    /// almost all of them the only one.</summary>
+    public const string Primary = "primary";
 }
 
 /// <summary>
@@ -192,7 +208,7 @@ public sealed class ChatProviderResolver : IChatProviderResolver
             return null;
         }
 
-        var apiKey = _credentials?.GetApiKey(connection.Id);
+        var apiKey = _credentials?.Get(connection.Id, AiCredentialNames.Primary);
 
         switch (kind)
         {

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
@@ -78,70 +78,90 @@ public sealed class AiCredentialStore : IAiCredentialStore
         : "Secure key storage is not available on this platform. "
           + "An endpoint that needs no API key still works.";
 
-    public string? GetApiKey(string connectionId)
+    public string? Get(string connectionId, string name)
     {
         if (!IsAvailable) return null;
 
-        var key = OperatingSystem.IsWindows()
-            ? WindowsDpapiStore.Find(_service, AccountFor(connectionId))
-            : MacOsKeychain.Find(_service, AccountFor(connectionId));
+        var account = AccountFor(connectionId, name);
+        var secret = OperatingSystem.IsWindows()
+            ? WindowsDpapiStore.Find(_service, account)
+            : MacOsKeychain.Find(_service, account);
 
-        // The OUTCOME, never the value — and not its length either, which narrows a guess.
-        _logger.LogDebug("Credential lookup for {Connection}: {Result}",
-            connectionId, key is null ? "none stored" : "found");
+        // The OUTCOME, never the value — and not its length either, which narrows a guess. The name is safe
+        // to log and worth logging: it is ours, and "which of this connection's secrets was missing" is the
+        // whole diagnosis when a two-credential provider 401s.
+        _logger.LogDebug("Credential lookup for {Connection}/{Name}: {Result}",
+            connectionId, name, secret is null ? "none stored" : "found");
 
-        return key;
+        return secret;
     }
 
-    /// <summary>Store or replace the key for a provider. Returns false when the platform cannot.</summary>
-    public bool SetApiKey(string connectionId, string apiKey)
+    /// <summary>Store or replace one named secret. Returns false when the platform cannot.</summary>
+    public bool Set(string connectionId, string name, string secret)
     {
-        if (!IsAvailable || string.IsNullOrWhiteSpace(apiKey)) return false;
+        if (!IsAvailable || string.IsNullOrWhiteSpace(secret)) return false;
 
         var saved = OperatingSystem.IsWindows()
-            ? WindowsDpapiStore.Save(_service, AccountFor(connectionId), apiKey.Trim())
-            : MacOsKeychain.Save(_service, AccountFor(connectionId), apiKey.Trim());
-        _logger.LogInformation("Stored an API key for {Connection}: {Result}",
-            connectionId, saved ? "ok" : "failed");
+            ? WindowsDpapiStore.Save(_service, AccountFor(connectionId, name), secret.Trim())
+            : MacOsKeychain.Save(_service, AccountFor(connectionId, name), secret.Trim());
+        _logger.LogInformation("Stored a secret for {Connection}/{Name}: {Result}",
+            connectionId, name, saved ? "ok" : "failed");
         return saved;
     }
 
-    /// <summary>Forget the key for a provider. Forgetting one that was never stored counts as success.</summary>
-    public bool DeleteApiKey(string connectionId)
+    /// <summary>Forget one named secret. Forgetting one that was never stored counts as success.</summary>
+    public bool Delete(string connectionId, string name)
     {
         if (!IsAvailable) return false;
 
         var deleted = OperatingSystem.IsWindows()
-            ? WindowsDpapiStore.Delete(_service, AccountFor(connectionId))
-            : MacOsKeychain.Delete(_service, AccountFor(connectionId));
-        _logger.LogInformation("Removed the API key for {Connection}: {Result}",
-            connectionId, deleted ? "ok" : "failed");
+            ? WindowsDpapiStore.Delete(_service, AccountFor(connectionId, name))
+            : MacOsKeychain.Delete(_service, AccountFor(connectionId, name));
+        _logger.LogInformation("Removed a secret for {Connection}/{Name}: {Result}",
+            connectionId, name, deleted ? "ok" : "failed");
         return deleted;
     }
 
     /// <summary>
-    /// One item per provider, so a user can keep a Claude key and an OpenAI-compatible key at once — which is
-    /// the ordinary case for someone comparing a hosted model against a local one.
+    /// The character joining a connection id to a credential name in one account string.
+    ///
+    /// <para>It differs by platform because the two namespaces do. A Keychain account is an arbitrary string,
+    /// so <c>:</c> — the conventional spelling — survives. A DPAPI account is a <i>filename</i>
+    /// (<see cref="WindowsDpapiStore"/>), and <c>:</c> is an invalid filename character on Windows, so that
+    /// store would rewrite it to <c>_</c>: a character an id is allowed to contain, which is how the collision
+    /// below would come back on one platform only. <c>.</c> is legal in a filename and excluded from ids.</para>
     /// </summary>
+    private static char Separator => OperatingSystem.IsWindows() ? '.' : ':';
+
     /// <summary>
-    /// The credential-store account a connection's key is filed under. (#678)
+    /// The account one named secret of one connection is filed under. (#678, #759)
     ///
     /// <para><b>Was keyed by <c>ChatProviderKind</c>, a two-member enum</b> — so every OpenAI-compatible
     /// endpoint shared one slot. A reader who stored an OpenRouter key and then pointed the app at DeepSeek
-    /// silently sent the wrong key and got a 401 naming neither cause. That is the defect this issue exists
-    /// for, and it made comparing a hosted model against a local one impossible.</para>
+    /// silently sent the wrong key and got a 401 naming neither cause (#678).</para>
     ///
     /// <para><b>Why the connection id and not the base URL.</b> A URL-derived account orphans the credential
     /// the moment someone changes a port or swaps <c>localhost</c> for <c>127.0.0.1</c> — and the resulting
     /// failure presents as a bad key rather than a lost one, which sends the reader to re-paste a key that
     /// was fine. The id is immutable for exactly this reason.</para>
+    ///
+    /// <para><b>Each part is sanitised, then they are joined — never the other way round.</b> Sanitising the
+    /// joined string would fold the separator into <c>-</c>, which ids may contain: connection <c>gw</c> with
+    /// secret <c>primary</c> and a connection called <c>gw-primary</c> would land on one account and silently
+    /// overwrite each other. That is #678 again, one layer down, and it is invisible because the symptom is a
+    /// 401 rather than an error. Joining afterwards makes it unreachable instead of unlikely:
+    /// <see cref="Sanitize"/> emits only <c>[a-z0-9-_]</c>, so neither separator can occur inside a part.</para>
     /// </summary>
-    internal static string AccountFor(string connectionId) => Sanitize(connectionId);
+    internal static string AccountFor(string connectionId, string name) =>
+        Sanitize(connectionId) + Separator + Sanitize(name);
 
     /// <summary>
-    /// Ids are validated as slugs before they reach here, so this is a belt-and-braces guard rather than the
-    /// primary defence: a stray separator in an account name is the kind of thing that silently writes a
-    /// credential to a path nobody looks at again.
+    /// Ids are validated as slugs and names are our own constants, so this is a belt-and-braces guard rather
+    /// than the primary defence: a stray separator in an account name is the kind of thing that silently
+    /// writes a credential to a path nobody looks at again.
+    ///
+    /// <para>The allowed set is what <see cref="AccountFor"/> depends on. Widening it to admit <c>:</c> or
+    /// <c>.</c> would reintroduce the collision documented there.</para>
     /// </summary>
     private static string Sanitize(string id)
     {

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -329,7 +329,7 @@ namespace CST.Avalonia.ViewModels
         /// <summary>Whether a key is already filed under this id — only knowable for a connection that
         /// exists.</summary>
         public bool HasStoredKey =>
-            _existingId is not null && _credentials?.GetApiKey(_existingId) is not null;
+            _existingId is not null && _credentials?.Get(_existingId, AiCredentialNames.Primary) is not null;
 
         public string KeyStatus => _existingId is null
             ? "Stored in the operating system's credential store, never in settings."
@@ -487,7 +487,7 @@ namespace CST.Avalonia.ViewModels
         {
             if (_credentials is null || string.IsNullOrWhiteSpace(ApiKeyEntry)) return;
 
-            _credentials.SetApiKey(connectionId, ApiKeyEntry.Trim());
+            _credentials.Set(connectionId, AiCredentialNames.Primary, ApiKeyEntry.Trim());
             ApiKeyEntry = "";
         }
 
@@ -502,7 +502,7 @@ namespace CST.Avalonia.ViewModels
         {
             if (_credentials is null || _existingId is null) return;
 
-            _credentials.DeleteApiKey(_existingId);
+            _credentials.Delete(_existingId, AiCredentialNames.Primary);
             ApiKeyEntry = "";
             this.RaisePropertyChanged(nameof(HasStoredKey));
             this.RaisePropertyChanged(nameof(KeyStatus));

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -278,7 +278,7 @@ namespace CST.Avalonia.ViewModels
         internal void RemoveKey(string id)
         {
             if (_credentials is null) return;
-            _credentials.DeleteApiKey(id);
+            _credentials.Delete(id, AiCredentialNames.Primary);
             Rebind();
         }
 


### PR DESCRIPTION
Part of #759 — the storage layer. Step 1–2 of the four the investigation recommended; the secret-routing callers (#771, `AiInputPrompt.IsSecret`) follow in their own PR.

**The premise changed while investigating.** #759 asks what to do "before a second secret forces" plaintext. Nothing has to force it: a custom endpoint's **Headers** table already takes a credential into `settings.json` in the clear, `ApplyAuth` sends a reader-typed `Authorization` header verbatim whenever no key is stored, and the description under the box recommends exactly that — "a gateway token, or a provider's own key header." Filed as **#771**. Plaintext is not a future risk; it is the only slot a second secret has today, because the store held one opaque string per connection.

**What this changes.** `IAiCredentialStore` addresses a secret by `(connection, name)` rather than by connection alone, with `AiCredentialNames.Primary` for the connection that has only one. Three cases are already filed and waiting on it: Cloudflare's gateway token beside the upstream key (#701), Bedrock's secret access key beside an access key id (#702), Vertex's refreshing token (#703).

**N accounts, not one JSON blob per connection.** They degrade one credential at a time — a torn write or a bad byte loses one secret rather than all of them; they stay separately visible and revocable in Keychain Access, where a blob is one opaque item a reader can only inspect by pasting it somewhere; and the name *is* the schema, so there is nothing for a version marker to version. That last point is a better reason than "nothing has shipped": the shape that would need a marker is the one we are not choosing, and an inert marker is the same class of thing as the `kSecAttrAccessibleAfterFirstUnlock` #609 records being accepted and silently ignored.

## The part worth reviewing closely

The account is **sanitised per component and joined afterwards**, never joined and then sanitised.

Sanitising the join folds the separator into `-`, which ids may contain. So `("gw", "header-x")` and `("gw-header", "x")` would both become `gw-header-x` and silently overwrite each other — #678 again, one layer down, and invisible because the symptom is a 401 naming neither cause. Joining afterwards makes it unreachable rather than unlikely: `Sanitize` emits only `[a-z0-9-_]`, so the separator can never occur inside a part and the split is unambiguous.

**The separator differs by platform, and has to.** `:` survives a Keychain account, which is an arbitrary string. A DPAPI account is a *filename*, and `:` is invalid in one on Windows — that store would rewrite it to `_`, a character an id is allowed to contain, reopening the collision on one platform only. `.` is legal in a Windows filename and excluded from the slug pattern.

Removing a connection now sweeps every name it could have stored rather than one. An orphaned credential is invisible by definition: nothing reads it, so nothing reports it — and it would be silently re-adopted if a connection with the same id were ever created again.

## What the review changed

Fable reviewed the first commit adversarially and found nothing severe. It confirmed the collision argument on both platforms by reading further than I had: `MacOsKeychain` passes the account through as raw UTF-8 with no filtering or normalisation; nothing ever parses the DPAPI filename back, so multiple dots are inert; no trailing dot or space is reachable because both parts end in `[a-z0-9-_]`; and `AddFromPreset` skipping `ValidateId` is safe because `AiPresetSource.cs:188` rejects catalogue ids against the identical slug regex — with `wafer.ai` cited there as the live case.

Four things it did find, all fixed here:

**Nothing pinned the account spelling.** `ServiceName` is pinned exactly, for the stated reason that changing it orphans every stored credential with no error. The account string has that property too and had no equivalent test. The round-trip tests cannot hold the line — save and find share the value in-process — and the separator test deliberately does not name the separator. The concrete regression: someone unifies the two separators (they look like an irregularity, and `.` is legal in a Keychain account too), every macOS credential moves from `anthropic:primary` to `anthropic.primary`, every stored key silently reads as unconfigured, and 2304 tests stay green. Now pinned per platform.

**The two collision tests are load-bearing as a pair**, which is worth recording before someone deletes the redundant-looking one: a `_` separator leaves `("gw","header-x")` and `("gw-header","x")` distinct, so the collision test stays green — and only the character-set test catches it, because `_` is a character `Sanitize` emits. Noted in the source.

**`ValidateId` lost its doc comment.** Inserting `CredentialNamesOf` between a comment and its method left `ValidateId` undocumented and stacked two summaries on the new method — and the orphaned text is load-bearing, since it documents the id/credential-account coupling this whole change is about.

**One test fake was more forgiving than the real store** — `AiSettingsViewModelTests`'s `Delete` returned success where the real store returns false with no storage available.

Two advisory notes carried forward rather than fixed here: the resolver's `FixedKey` fake ignores both id and name, which masks nothing today (the resolver makes one hard-coded `Primary` call) but wants tightening when #771's routing lands; and `AiCredentialStore`'s "the name is ours, so it is safe to log" premise stops being true when #771 derives names from reader-typed header names — that argument gets re-made in that PR rather than grandfathered in from this one.

Full suite green, 0 build warnings.

**Note for whoever pulls this:** an existing stored key moves from account `{id}` to `{id}:primary`. That is a one-off re-entry of a key or two on a development machine, not a migration path in code — and the reason is checkable rather than remembered: **the credential code postdates the beta 5 tag entirely.** `v5.0.0-beta.5` is `accd7c07` (2026-07-28); the credential store first landed 2026-08-12 (#608) and `AiConnectionRecord` on 2026-08-18 (#707), and `git merge-base --is-ancestor` puts neither in the tag. So there is no installed base that could hold a key under the old account. (Framing suggested in review — "nothing has shipped to anyone" is hard to re-verify in six months; "postdates the tag" is one git command.)
