### PR TITLE
Keep a header's credential out of the settings file (#771)

### DIFF
--- a/src/CST.Avalonia.Tests/Models/Ai/AiTemplateTests.cs
+++ b/src/CST.Avalonia.Tests/Models/Ai/AiTemplateTests.cs
@@ -87,7 +87,7 @@ public class AiTemplateTests
         var incomplete = new AiConnection(
             "azure-prod", "Azure", ChatProviderKind.OpenAiCompatible,
             "https://{resourceName}.openai.azure.com/openai/v1",
-            new List<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>());
+            new List<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>());
 
         Assert.True(incomplete.IsIncomplete);
 

--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -319,7 +319,7 @@ public class AiChatOrchestratorTests
         service.Add("mine", new AiConnectionDraft(
             "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
             new[] { new AiModelEntry("m", "M") },
-            new Dictionary<string, string>(), new Dictionary<string, string>()));
+            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
         return (service, "mine");
     }
 

--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -25,7 +25,7 @@ public class AiConnectionServiceTests
 
     private static AiConnectionDraft Draft(string name = "My box", string url = "http://localhost:8000/v1") =>
         new(name, ChatProviderKind.OpenAiCompatible, url,
-            new List<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>());
+            new List<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>());
 
     // ---- ids ------------------------------------------------------------------------------------------
 
@@ -486,5 +486,77 @@ public class AiConnectionServiceTests
         service.EnableModel("box", "a", "A", true, new AiModelEntry("a", "A", ContextLength: 8192));
 
         Assert.False(service.Connections.Single().Models.Single().Missing);
+    }
+
+    // ---- secret headers (#771) --------------------------------------------------------------------------
+
+    /// <summary>
+    /// The delete sweep has to know every name, not just the primary one. A credential left behind is
+    /// invisible by definition - nothing reads it, so nothing reports it - and it would be silently re-adopted
+    /// if a connection with the same id were ever created again.
+    /// </summary>
+    [Fact]
+    public void Removing_a_connection_deletes_its_secret_header_credentials_too()
+    {
+        var (service, _, keys) = MakeWithKeys();
+        service.Add("gw", new AiConnectionDraft(
+            "Gateway", ChatProviderKind.OpenAiCompatible, "https://gateway.example/v1",
+            new List<AiModelEntry>(),
+            new[] { new AiHeader("cf-aig-authorization", null, Secret: true) },
+            new Dictionary<string, string>()));
+
+        keys.Set("gw", AiCredentialNames.Primary, "sk-upstream");
+        keys.Set("gw", AiCredentialNames.Header("cf-aig-authorization"), "cf-token-abc");
+
+        service.Remove("gw");
+
+        Assert.Null(keys.Get("gw", AiCredentialNames.Primary));
+        Assert.Null(keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
+    }
+
+    /// <summary>
+    /// Header names are richer than credential names: <c>x.y</c> and <c>x-y</c> are different headers that
+    /// fold to one account, so one would overwrite the other's secret and the endpoint would authenticate
+    /// with the wrong one - a 401 naming nothing, which is #678's symptom. Refused at the service because
+    /// settings.json is hand-edited and the sheet is not the only way in.
+    /// </summary>
+    [Fact]
+    public void Two_secret_headers_that_fold_to_one_credential_name_are_refused()
+    {
+        var (service, _, _) = MakeWithKeys();
+
+        var result = service.Add("gw", new AiConnectionDraft(
+            "Gateway", ChatProviderKind.OpenAiCompatible, "https://gateway.example/v1",
+            new List<AiModelEntry>(),
+            new[]
+            {
+                new AiHeader("x.y", null, Secret: true),
+                new AiHeader("x-y", null, Secret: true),
+            },
+            new Dictionary<string, string>()));
+
+        Assert.False(result.Ok);
+        Assert.Contains("cannot both be secret", result.Problem);
+        Assert.Empty(service.Connections);
+    }
+
+    /// <summary>The same two names are fine while only one is secret - they are different headers, and only
+    /// the credential namespace is narrower than the header one.</summary>
+    [Fact]
+    public void Header_names_that_fold_together_are_allowed_while_only_one_is_secret()
+    {
+        var (service, _, _) = MakeWithKeys();
+
+        var result = service.Add("gw", new AiConnectionDraft(
+            "Gateway", ChatProviderKind.OpenAiCompatible, "https://gateway.example/v1",
+            new List<AiModelEntry>(),
+            new[]
+            {
+                new AiHeader("x.y", null, Secret: true),
+                new AiHeader("x-y", "cosmetic", Secret: false),
+            },
+            new Dictionary<string, string>()));
+
+        Assert.True(result.Ok);
     }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -376,21 +376,23 @@ public class AiModelCatalogTests
             handler.LastRequest!.Headers.GetValues("cf-aig-authorization"));
     }
 
-    /// <summary>The listing must never send the credential NAME in place of a value it could not find. An
-    /// empty header is the honest outcome of nothing stored; the chat path turns the same state into a
-    /// message naming the header.</summary>
+    /// <summary>
+    /// A secret with nothing stored is refused here exactly as the chat path refuses it. A listing that loads
+    /// while the chat refuses is the surface split #673 exists to prevent, pointing the other way — and a
+    /// blank header dropped at the wire comes back as a 401 naming nothing.
+    /// </summary>
     [Fact]
-    public async Task A_listing_sends_no_value_for_a_secret_header_with_nothing_stored()
+    public async Task A_listing_refuses_a_secret_header_with_nothing_stored()
     {
         var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new StringContent("""{"data":[]}"""),
+            Content = new StringContent("""{"data":[{"id":"some-model"}]}"""),
         });
 
         var catalog = new AiModelCatalog(
             new HttpClient(handler), new NamedKeys(), NullLogger<AiModelCatalog>.Instance);
 
-        await catalog.FetchAsync(new AiConnection(
+        var result = await catalog.FetchAsync(new AiConnection(
             Id: "gw",
             DisplayName: "Gateway",
             Kind: ChatProviderKind.OpenAiCompatible,
@@ -399,10 +401,48 @@ public class AiModelCatalogTests
             Headers: new[] { new AiHeader("cf-aig-authorization", null, Secret: true) },
             Inputs: new Dictionary<string, string>()));
 
-        var values = handler.LastRequest!.Headers.TryGetValues("cf-aig-authorization", out var v)
-            ? v.ToArray()
-            : Array.Empty<string>();
+        Assert.False(result.Ok);
+        Assert.Contains("cf-aig-authorization", result.Problem);
+        Assert.Null(handler.LastRequest);   // refused before anything went out
+    }
 
-        Assert.DoesNotContain(values, value => value.Contains("header-", StringComparison.Ordinal));
+    /// <summary>
+    /// The case that could not exist before #771: the ONLY credential is a secret header. Anthropic, no API
+    /// key stored, authenticating entirely by a header whose value is in the credential store.
+    ///
+    /// <para>This is #689's "leave the key empty if you manage auth via headers" escape hatch, and it is the
+    /// one most at risk from this change — <c>IsSendableHeader</c> requires a non-blank VALUE (that was #764's
+    /// fix, after a cosmetic X-Title let a keyless connection through and its 401 surfaced as "the provider
+    /// rejected the API key"). A secret header is blank in settings.json, so if the value were fetched after
+    /// the credential check rather than before it, this connection would be refused by the very feature built
+    /// to make it safe. (raised in review by the session that landed #711/#764)</para>
+    /// </summary>
+    [Fact]
+    public async Task A_listing_authenticates_by_a_secret_header_alone()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"data":[{"id":"claude-opus-5"}]}"""),
+        });
+
+        var keys = new NamedKeys();
+        keys.Set("gw", AiCredentialNames.Header("x-api-key"), "secret-only-credential");
+
+        var catalog = new AiModelCatalog(
+            new HttpClient(handler), keys, NullLogger<AiModelCatalog>.Instance);
+
+        var result = await catalog.FetchAsync(new AiConnection(
+            Id: "gw",
+            DisplayName: "Gateway",
+            Kind: ChatProviderKind.Anthropic,
+            BaseUrl: "https://gateway.example",
+            Models: new List<AiModelEntry>(),
+            Headers: new[] { new AiHeader("x-api-key", null, Secret: true) },
+            Inputs: new Dictionary<string, string>()));
+
+        Assert.True(result.Ok);
+        Assert.Equal(
+            new[] { "secret-only-credential" },
+            handler.LastRequest!.Headers.GetValues("x-api-key"));
     }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -296,7 +296,7 @@ public class AiModelCatalogTests
             Kind: ChatProviderKind.Anthropic,
             BaseUrl: "https://gateway.example",
             Models: new List<AiModelEntry>(),
-            Headers: new Dictionary<string, string> { ["anthropic-version"] = "2026-01-01" },
+            Headers: new[] { new AiHeader("anthropic-version", "2026-01-01") },
             Inputs: new Dictionary<string, string>()));
 
         var sent = handler.LastRequest!;
@@ -321,9 +321,88 @@ public class AiModelCatalogTests
             Kind: ChatProviderKind.Anthropic,
             BaseUrl: "https://api.anthropic.com",
             Models: new List<AiModelEntry>(),
-            Headers: new Dictionary<string, string>(),
+            Headers: Array.Empty<AiHeader>(),
             Inputs: new Dictionary<string, string>()));
 
         Assert.Equal(new[] { "2023-06-01" }, handler.LastRequest!.Headers.GetValues("anthropic-version"));
+    }
+
+    /// <summary>An in-memory store keyed by the joined account, so a test that asks for the wrong name misses
+    /// rather than being handed the only secret there is.</summary>
+    private sealed class NamedKeys : IAiCredentialStore
+    {
+        private readonly Dictionary<string, string> _byAccount = new(StringComparer.Ordinal);
+        public bool IsAvailable => true;
+        public string? Unavailable => null;
+        public string? Get(string connectionId, string name) =>
+            _byAccount.GetValueOrDefault(connectionId + ":" + name);
+        public bool Set(string connectionId, string name, string secret)
+        { _byAccount[connectionId + ":" + name] = secret; return true; }
+        public bool Delete(string connectionId, string name) => _byAccount.Remove(connectionId + ":" + name);
+    }
+
+    /// <summary>
+    /// The listing sends a secret header exactly as the chat path does. (#771)
+    ///
+    /// <para>The two surfaces send the same credentials, so they have to authenticate identically — the
+    /// symptom of them diverging is a provider whose model list loads while its answers 401, which is the
+    /// contradiction #673 exists to prevent and is close to undiagnosable from a bug report.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_listing_sends_a_secret_header_from_the_credential_store()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"data":[{"id":"some-model"}]}"""),
+        });
+
+        var keys = new NamedKeys();
+        keys.Set("gw", AiCredentialNames.Header("cf-aig-authorization"), "cf-token-abc");
+
+        var catalog = new AiModelCatalog(
+            new HttpClient(handler), keys, NullLogger<AiModelCatalog>.Instance);
+
+        await catalog.FetchAsync(new AiConnection(
+            Id: "gw",
+            DisplayName: "Gateway",
+            Kind: ChatProviderKind.OpenAiCompatible,
+            BaseUrl: "https://gateway.example/v1",
+            Models: new List<AiModelEntry>(),
+            Headers: new[] { new AiHeader("cf-aig-authorization", null, Secret: true) },
+            Inputs: new Dictionary<string, string>()));
+
+        Assert.Equal(
+            new[] { "cf-token-abc" },
+            handler.LastRequest!.Headers.GetValues("cf-aig-authorization"));
+    }
+
+    /// <summary>The listing must never send the credential NAME in place of a value it could not find. An
+    /// empty header is the honest outcome of nothing stored; the chat path turns the same state into a
+    /// message naming the header.</summary>
+    [Fact]
+    public async Task A_listing_sends_no_value_for_a_secret_header_with_nothing_stored()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"data":[]}"""),
+        });
+
+        var catalog = new AiModelCatalog(
+            new HttpClient(handler), new NamedKeys(), NullLogger<AiModelCatalog>.Instance);
+
+        await catalog.FetchAsync(new AiConnection(
+            Id: "gw",
+            DisplayName: "Gateway",
+            Kind: ChatProviderKind.OpenAiCompatible,
+            BaseUrl: "https://gateway.example/v1",
+            Models: new List<AiModelEntry>(),
+            Headers: new[] { new AiHeader("cf-aig-authorization", null, Secret: true) },
+            Inputs: new Dictionary<string, string>()));
+
+        var values = handler.LastRequest!.Headers.TryGetValues("cf-aig-authorization", out var v)
+            ? v.ToArray()
+            : Array.Empty<string>();
+
+        Assert.DoesNotContain(values, value => value.Contains("header-", StringComparison.Ordinal));
     }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -336,4 +336,55 @@ public class ChatProviderResolverTests
         var options = Assert.IsType<OpenAiCompatibleProvider>(resolution!.Provider).Options;
         Assert.Equal("literal-{gatewayToken}-value", options.ExtraHeaders!["x-token"]);
     }
+
+    /// <summary>
+    /// The case that could not exist before #771, on the chat path: Anthropic with NO API key, authenticating
+    /// entirely by a secret header.
+    ///
+    /// <para><c>AnthropicMessagesProvider.HasCredential</c> counts only headers with a non-blank VALUE — which
+    /// was #764's fix, after a cosmetic <c>X-Title</c> let a keyless connection through and its 401 surfaced
+    /// as "the provider rejected the API key", naming a key that did not exist. A secret header is blank in
+    /// settings.json, so this resolves only because the value is pulled from the credential store BEFORE the
+    /// credential check runs. Reorder those two and #689's "leave the key empty if you manage auth via
+    /// headers" is defeated by the feature built to make it safe. (raised in review)</para>
+    /// </summary>
+    [Fact]
+    public void Anthropic_resolves_when_the_only_credential_is_a_secret_header()
+    {
+        var resolver = Resolver(c =>
+        {
+            var conn = Conn(c);
+            conn.Kind = "anthropic";
+            conn.BaseUrl = "https://gateway.example";
+            conn.Headers.Add(new AiHeaderRecord { Name = "x-api-key", Secret = true });
+            c.ActiveModelId = "claude-opus-5";
+        },
+        secrets: new Dictionary<string, string>
+        {
+            [AiCredentialNames.Header("x-api-key")] = "secret-only-credential",
+        });
+
+        var resolution = resolver.Resolve(out var problem);
+
+        Assert.Null(problem);
+        Assert.NotNull(resolution);
+    }
+
+    /// <summary>The mirror of the above: with the secret NOT stored, the same connection must be refused by
+    /// name rather than allowed through to send a blank header and 401.</summary>
+    [Fact]
+    public void Anthropic_is_refused_when_its_only_credential_is_a_secret_header_with_nothing_stored()
+    {
+        var resolver = Resolver(c =>
+        {
+            var conn = Conn(c);
+            conn.Kind = "anthropic";
+            conn.BaseUrl = "https://gateway.example";
+            conn.Headers.Add(new AiHeaderRecord { Name = "x-api-key", Secret = true });
+            c.ActiveModelId = "claude-opus-5";
+        });
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.Contains("x-api-key", problem);
+    }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -21,23 +21,32 @@ public class ChatProviderResolverTests
     private sealed class FixedKey : IAiCredentialStore
     {
         private readonly string? _key;
+        private readonly IReadOnlyDictionary<string, string>? _byName;
 
-        internal FixedKey(string? key, string? unavailable = null)
+        internal FixedKey(
+            string? key, string? unavailable = null, IReadOnlyDictionary<string, string>? byName = null)
         {
             _key = key;
             Unavailable = unavailable;
+            _byName = byName;
         }
 
         public bool IsAvailable => Unavailable is null;
         public string? Unavailable { get; }
-        public string? Get(string connectionId, string name) => _key;
+
+        /// <summary>Named secrets take precedence, so a test can store a gateway token without also standing in
+        /// for the primary key (#771).</summary>
+        public string? Get(string connectionId, string name) =>
+            _byName is not null && _byName.TryGetValue(name, out var named) ? named
+            : name == AiCredentialNames.Primary ? _key
+            : null;
         public bool Set(string connectionId, string name, string secret) => throw new NotSupportedException();
         public bool Delete(string connectionId, string name) => throw new NotSupportedException();
     }
 
     private static ChatProviderResolver Resolver(
         Action<ChatSettings> configure, string? apiKey = null, bool aiEnabled = true,
-        string? storageUnavailable = null)
+        string? storageUnavailable = null, IReadOnlyDictionary<string, string>? secrets = null)
     {
         var settings = new Settings();
         settings.Ai.Enabled = aiEnabled;
@@ -49,7 +58,9 @@ public class ChatProviderResolverTests
 
         return new ChatProviderResolver(
             service.Object,
-            apiKey is null && storageUnavailable is null ? null : new FixedKey(apiKey, storageUnavailable),
+            apiKey is null && storageUnavailable is null && secrets is null
+                ? null
+                : new FixedKey(apiKey, storageUnavailable, secrets),
             NullLoggerFactory.Instance,
             new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan });
     }
@@ -201,7 +212,7 @@ public class ChatProviderResolverTests
             var conn = Conn(c);
             conn.Kind = "openai-compatible";
             conn.BaseUrl = "https://gateway.example/v1";
-            conn.Headers["cf-aig-authorization"] = "Bearer {gatewayToken}";
+            conn.Headers.Add(new AiHeaderRecord { Name = "cf-aig-authorization", Value = "Bearer {gatewayToken}" });
             c.ActiveModelId = "some-model";
         }, apiKey: "sk-x");
 
@@ -219,7 +230,7 @@ public class ChatProviderResolverTests
             var conn = Conn(c);
             conn.Kind = "openai-compatible";
             conn.BaseUrl = "https://gateway.example/v1";
-            conn.Headers["cf-aig-authorization"] = "Bearer {gatewayToken}";
+            conn.Headers.Add(new AiHeaderRecord { Name = "cf-aig-authorization", Value = "Bearer {gatewayToken}" });
             conn.Inputs["gatewayToken"] = "real-token";
             c.ActiveModelId = "some-model";
         }, apiKey: "sk-x");
@@ -239,11 +250,90 @@ public class ChatProviderResolverTests
         {
             var conn = Conn(c);
             conn.Kind = "anthropic";
-            conn.Headers["X-Title"] = "  ";
+            conn.Headers.Add(new AiHeaderRecord { Name = "X-Title", Value = "  " });
             c.ActiveModelId = "claude-opus-5";
         });
 
         Assert.Null(resolver.Resolve(out var problem));
         Assert.Contains("API key", problem);
+    }
+
+    // ---- secret headers (#771) --------------------------------------------------------------------------
+
+    /// <summary>
+    /// A secret header's value is fetched at the moment the request is built rather than carried on the
+    /// connection, which is what keeps it out of settings.json, out of the UI types and out of a log line.
+    /// </summary>
+    [Fact]
+    public void A_secret_header_is_sent_with_its_stored_value()
+    {
+        var resolver = Resolver(c =>
+        {
+            var conn = Conn(c);
+            conn.Kind = "openai-compatible";
+            conn.BaseUrl = "https://gateway.example/v1";
+            conn.Headers.Add(new AiHeaderRecord { Name = "cf-aig-authorization", Secret = true });
+            c.ActiveModelId = "some-model";
+        },
+        apiKey: "sk-upstream",
+        secrets: new Dictionary<string, string>
+        {
+            [AiCredentialNames.Header("cf-aig-authorization")] = "cf-token-abc",
+        });
+
+        var resolution = resolver.Resolve(out var problem);
+
+        Assert.Null(problem);
+        var options = Assert.IsType<OpenAiCompatibleProvider>(resolution!.Provider).Options;
+        Assert.Equal("cf-token-abc", options.ExtraHeaders!["cf-aig-authorization"]);
+    }
+
+    /// <summary>
+    /// The store was unavailable when it was saved, or the reader deleted the item in Keychain Access. Sent
+    /// empty this comes back as a 401 that reads as a bad API key, sending them to re-paste the wrong thing.
+    /// </summary>
+    [Fact]
+    public void A_secret_header_with_nothing_stored_is_refused_by_name()
+    {
+        var resolver = Resolver(c =>
+        {
+            var conn = Conn(c);
+            conn.Kind = "openai-compatible";
+            conn.BaseUrl = "https://gateway.example/v1";
+            conn.Headers.Add(new AiHeaderRecord { Name = "cf-aig-authorization", Secret = true });
+            c.ActiveModelId = "some-model";
+        }, apiKey: "sk-upstream");
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.Contains("cf-aig-authorization", problem);
+    }
+
+    /// <summary>
+    /// A credential is a literal, never a template. Expanding one would mangle a key that happens to contain
+    /// braces, and there is no legitimate reason for a secret to reference an input.
+    /// </summary>
+    [Fact]
+    public void A_secret_header_value_is_not_expanded_as_a_template()
+    {
+        var resolver = Resolver(c =>
+        {
+            var conn = Conn(c);
+            conn.Kind = "openai-compatible";
+            conn.BaseUrl = "https://gateway.example/v1";
+            conn.Headers.Add(new AiHeaderRecord { Name = "x-token", Secret = true });
+            conn.Inputs["gatewayToken"] = "substituted";
+            c.ActiveModelId = "some-model";
+        },
+        apiKey: "sk-upstream",
+        secrets: new Dictionary<string, string>
+        {
+            [AiCredentialNames.Header("x-token")] = "literal-{gatewayToken}-value",
+        });
+
+        var resolution = resolver.Resolve(out var problem);
+
+        Assert.Null(problem);
+        var options = Assert.IsType<OpenAiCompatibleProvider>(resolution!.Provider).Options;
+        Assert.Equal("literal-{gatewayToken}-value", options.ExtraHeaders!["x-token"]);
     }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -50,8 +50,12 @@ public class AiConnectionEditorViewModelTests
         /// <summary>Keyed by the joined account, exactly as the real store files it (#759).</summary>
         public Dictionary<string, string> Stored { get; } = new(StringComparer.Ordinal);
         private static string Account(string connectionId, string name) => connectionId + ":" + name;
-        public bool IsAvailable => true;
-        public string? Unavailable => null;
+
+        /// <summary>Settable so a test can stand where there is nowhere to put a secret — Linux, or a Windows
+        /// profile whose data folder cannot be written.</summary>
+        public bool Available { get; set; } = true;
+        public bool IsAvailable => Available;
+        public string? Unavailable => Available ? null : "Nowhere to store a key in this build.";
         public string? Get(string connectionId, string name) =>
             Stored.GetValueOrDefault(Account(connectionId, name));
         public bool Set(string connectionId, string name, string secret)
@@ -207,7 +211,7 @@ public class AiConnectionEditorViewModelTests
         Assert.Equal("My box", added.DisplayName);
         Assert.Equal("gemma4:12b-mlx", added.Models.Single().Id);
         Assert.Equal("Gemma4 12B MLX", added.Models.Single().DisplayName);
-        Assert.Equal("token", added.Headers["X-Gateway"]);
+        Assert.Equal("token", added.Headers.Single(h => h.Name == "X-Gateway").Value);
     }
 
     /// <summary>Blank rows are the natural state of a repeating form — one is offered on open — so they must
@@ -524,7 +528,7 @@ public class AiConnectionEditorViewModelTests
 
     private static AiConnectionDraft Draft(string name = "My box", string url = "http://localhost:8000/v1") =>
         new(name, ChatProviderKind.OpenAiCompatible, url,
-            new List<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>());
+            new List<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>());
 
     // ---- a required key is required (#761) ---------------------------------------------------------------
 
@@ -697,7 +701,7 @@ public class AiConnectionEditorViewModelTests
         h.Service.Update(added.Id, new AiConnectionDraft(
             added.DisplayName, added.Kind, added.BaseUrl,
             new[] { new AiModelEntry("nvidia/nemotron", "Nemotron") },
-            new Dictionary<string, string> { ["X-Gateway"] = "token" },
+            new[] { new AiHeader("X-Gateway", "token") },
             added.Inputs, added.AuthHeaderName, added.AuthScheme));
 
         var edit = h.Existing("openrouter");
@@ -706,7 +710,7 @@ public class AiConnectionEditorViewModelTests
 
         var after = h.Service.Connections.Single();
         Assert.Equal("nvidia/nemotron", after.Models.Single().Id);
-        Assert.Equal("token", after.Headers["X-Gateway"]);
+        Assert.Equal("token", after.Headers.Single(h => h.Name == "X-Gateway").Value);
         Assert.Equal("https://openrouter.ai/api/v1", after.BaseUrl);
         Assert.Equal("sk-replaced", h.Keys.Get("openrouter", AiCredentialNames.Primary));
     }
@@ -864,6 +868,251 @@ public class AiConnectionEditorViewModelTests
         }));
 
         Assert.Equal("Edit", AiConnectionEditorViewModel.EditAction(h.Service, h.Service.Connections.Single()));
+    }
+
+    // ---- secret headers (#771) --------------------------------------------------------------------------
+
+    private static AiHeaderRowViewModel Header(
+        AiConnectionEditorViewModel vm, string name, string value, bool secret)
+    {
+        vm.AddHeaderCommand.Execute().Subscribe();
+        var row = vm.Headers.Last();
+        row.Name = name;
+        row.Value = value;
+        row.IsSecret = secret;
+        return row;
+    }
+
+    /// <summary>
+    /// The whole of #771 in one assertion. Before this, a reader following the sheet's own advice — "a gateway
+    /// token, or a provider's own key header" — wrote a credential to settings.json, a file the credential
+    /// store's doc comment describes as screenshotted and attached to bug reports.
+    /// </summary>
+    [Fact]
+    public void A_secret_header_value_never_reaches_the_connection_record()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+        vm.Id = "gw";
+        vm.BaseUrl = "https://gateway.example/v1";
+        Header(vm, "cf-aig-authorization", "cf-token-abc", secret: true);
+
+        Save(vm);
+
+        var stored = h.Service.Connections.Single().Headers.Single();
+        Assert.Equal("cf-aig-authorization", stored.Name);
+        Assert.True(stored.Secret);
+        Assert.Null(stored.Value);
+    }
+
+    [Fact]
+    public void A_secret_header_value_goes_to_the_credential_store()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+        vm.Id = "gw";
+        vm.BaseUrl = "https://gateway.example/v1";
+        Header(vm, "cf-aig-authorization", "cf-token-abc", secret: true);
+
+        Save(vm);
+
+        Assert.Equal(
+            "cf-token-abc",
+            h.Keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
+    }
+
+    /// <summary>The unmarked row is the ordinary case and must be untouched by any of this: a routing hint
+    /// belongs in the settings file, where the reader can see and edit it.</summary>
+    [Fact]
+    public void An_ordinary_header_still_keeps_its_value_in_the_record()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+        vm.Id = "gw";
+        vm.BaseUrl = "https://gateway.example/v1";
+        Header(vm, "X-Title", "CST Reader", secret: false);
+
+        Save(vm);
+
+        var stored = h.Service.Connections.Single().Headers.Single();
+        Assert.Equal("CST Reader", stored.Value);
+        Assert.False(stored.Secret);
+        Assert.Empty(h.Keys.Stored);
+    }
+
+    /// <summary>Same reasoning as #761's refusal on the key box: saved anyway, this is a connection that looks
+    /// configured and 401s on every request, discovered later and from the provider.</summary>
+    [Fact]
+    public void A_secret_header_with_no_value_is_refused()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+        vm.Id = "gw";
+        vm.BaseUrl = "https://gateway.example/v1";
+        Header(vm, "cf-aig-authorization", "", secret: true);
+
+        Save(vm);
+
+        Assert.Contains("cf-aig-authorization", vm.Problem);
+        Assert.Empty(h.Service.Connections);
+        Assert.Null(h.Closed);
+    }
+
+    /// <summary>A stored secret is never read back into a screen, so the box is empty on every edit. Treating
+    /// that as "cleared" would delete a working credential on an unrelated edit.</summary>
+    [Fact]
+    public void An_edit_that_leaves_the_box_empty_keeps_the_stored_secret()
+    {
+        var h = new Harness();
+        var add = h.Custom();
+        add.Id = "gw";
+        add.BaseUrl = "https://gateway.example/v1";
+        Header(add, "cf-aig-authorization", "cf-token-abc", secret: true);
+        Save(add);
+
+        var edit = h.Existing("gw");
+        edit.DisplayName = "Renamed";
+        Save(edit);
+
+        Assert.Equal(
+            "cf-token-abc",
+            h.Keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
+        Assert.True(h.Service.Connections.Single().Headers.Single().Secret);
+    }
+
+    [Fact]
+    public void Retyping_a_secret_header_replaces_the_stored_value()
+    {
+        var h = new Harness();
+        var add = h.Custom();
+        add.Id = "gw";
+        add.BaseUrl = "https://gateway.example/v1";
+        Header(add, "cf-aig-authorization", "cf-token-abc", secret: true);
+        Save(add);
+
+        var edit = h.Existing("gw");
+        edit.Headers.Single().Value = "cf-token-rotated";
+        Save(edit);
+
+        Assert.Equal(
+            "cf-token-rotated",
+            h.Keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
+    }
+
+    /// <summary>An orphaned credential is invisible by definition — nothing reads it, so nothing reports it.
+    /// The sheet is the only place that knows a header stopped being secret.</summary>
+    [Fact]
+    public void Clearing_the_secret_mark_deletes_the_stored_value()
+    {
+        var h = new Harness();
+        var add = h.Custom();
+        add.Id = "gw";
+        add.BaseUrl = "https://gateway.example/v1";
+        Header(add, "cf-aig-authorization", "cf-token-abc", secret: true);
+        Save(add);
+
+        var edit = h.Existing("gw");
+        var row = edit.Headers.Single();
+        row.IsSecret = false;
+        row.Value = "not-a-secret-any-more";
+        Save(edit);
+
+        Assert.Null(h.Keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
+        Assert.Equal("not-a-secret-any-more", h.Service.Connections.Single().Headers.Single().Value);
+    }
+
+    [Fact]
+    public void Removing_a_secret_header_row_deletes_the_stored_value()
+    {
+        var h = new Harness();
+        var add = h.Custom();
+        add.Id = "gw";
+        add.BaseUrl = "https://gateway.example/v1";
+        Header(add, "cf-aig-authorization", "cf-token-abc", secret: true);
+        Save(add);
+
+        var edit = h.Existing("gw");
+        edit.Headers.Single().RemoveCommand.Execute().Subscribe();
+        Save(edit);
+
+        Assert.Null(h.Keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
+        Assert.Empty(h.Service.Connections.Single().Headers);
+    }
+
+    /// <summary>Renaming moves the credential. Without the sweep the old name keeps a live secret in the
+    /// keychain that this app can never reach again and the reader has no reason to look for.</summary>
+    [Fact]
+    public void Renaming_a_secret_header_moves_its_stored_value()
+    {
+        var h = new Harness();
+        var add = h.Custom();
+        add.Id = "gw";
+        add.BaseUrl = "https://gateway.example/v1";
+        Header(add, "cf-aig-authorization", "cf-token-abc", secret: true);
+        Save(add);
+
+        var edit = h.Existing("gw");
+        var row = edit.Headers.Single();
+        row.Name = "x-gateway-token";
+        row.Value = "cf-token-abc";
+        Save(edit);
+
+        Assert.Null(h.Keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
+        Assert.Equal("cf-token-abc", h.Keys.Get("gw", AiCredentialNames.Header("x-gateway-token")));
+    }
+
+    /// <summary>
+    /// Where there is nowhere to store a secret, the row cannot be marked one — and the value stays in the
+    /// settings file rather than being dropped. Taking the header away instead would remove the only way to
+    /// configure an authenticated provider on a platform with no credential store, which is Linux today.
+    /// </summary>
+    [Fact]
+    public void With_no_credential_store_a_header_keeps_its_value_in_the_settings_file()
+    {
+        var h = new Harness();
+        h.Keys.Available = false;
+
+        var vm = h.Custom();
+        vm.Id = "gw";
+        vm.BaseUrl = "https://gateway.example/v1";
+        var row = Header(vm, "cf-aig-authorization", "cf-token-abc", secret: true);
+
+        Assert.False(row.CanBeSecret);
+
+        Save(vm);
+
+        var stored = h.Service.Connections.Single().Headers.Single();
+        Assert.False(stored.Secret);
+        Assert.Equal("cf-token-abc", stored.Value);
+    }
+
+    /// <summary>
+    /// The type refuses the state rather than each caller remembering to. Found by mutation: the sheet's own
+    /// drop of the value can be deleted with the whole suite still green, because the service drops it again
+    /// on the way to settings.json — two guards each relying on the other. (fable review method)
+    /// </summary>
+    [Fact]
+    public void A_header_marked_secret_cannot_carry_a_value_at_all()
+    {
+        var header = new AiHeader("cf-aig-authorization", "cf-token-abc", Secret: true);
+
+        Assert.Null(header.Value);
+    }
+
+    /// <summary>The mask is what stops a token standing on screen in a screenshot or over a shoulder; it is
+    /// derived rather than set, so it cannot fall out of step with the mark.</summary>
+    [Fact]
+    public void Marking_a_row_secret_masks_its_value_box()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+        var row = Header(vm, "cf-aig-authorization", "cf-token-abc", secret: false);
+
+        Assert.Equal('\0', row.ValueMask);
+
+        row.IsSecret = true;
+
+        Assert.NotEqual('\0', row.ValueMask);
     }
 }
 

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -1054,11 +1054,140 @@ public class AiConnectionEditorViewModelTests
         var edit = h.Existing("gw");
         var row = edit.Headers.Single();
         row.Name = "x-gateway-token";
-        row.Value = "cf-token-abc";
+        // Deliberately NOT retyping the value. The box is empty on every edit and says "stored - type to
+        // replace", so leaving it is what the screen tells the reader to do. Retyping here is what hid this:
+        // it turns the test into delete-plus-fresh-store and pins nothing about the rename. (fable review)
         Save(edit);
 
         Assert.Null(h.Keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
         Assert.Equal("cf-token-abc", h.Keys.Get("gw", AiCredentialNames.Header("x-gateway-token")));
+    }
+
+    /// <summary>Renaming and rotating in one edit does both: a typed value wins over the carried one.</summary>
+    [Fact]
+    public void Renaming_a_secret_header_and_retyping_it_stores_the_new_value_under_the_new_name()
+    {
+        var h = new Harness();
+        var add = h.Custom();
+        add.Id = "gw";
+        add.BaseUrl = "https://gateway.example/v1";
+        Header(add, "cf-aig-authorization", "cf-token-abc", secret: true);
+        Save(add);
+
+        var edit = h.Existing("gw");
+        var row = edit.Headers.Single();
+        row.Name = "x-gateway-token";
+        row.Value = "cf-token-rotated";
+        Save(edit);
+
+        Assert.Null(h.Keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
+        Assert.Equal("cf-token-rotated", h.Keys.Get("gw", AiCredentialNames.Header("x-gateway-token")));
+    }
+
+    /// <summary>
+    /// Unmarking reads as declassifying — moving the value out of the keychain into the settings file — and
+    /// for a row the reader just typed, it is. For one with a STORED secret it cannot be: the value was never
+    /// read back, so there is nothing to move, and the save would delete the credential and persist an empty
+    /// header that both request paths then send blank. (fable review)
+    /// </summary>
+    [Fact]
+    public void Unmarking_a_stored_secret_with_an_empty_box_is_refused_rather_than_destructive()
+    {
+        var h = new Harness();
+        var add = h.Custom();
+        add.Id = "gw";
+        add.BaseUrl = "https://gateway.example/v1";
+        Header(add, "cf-aig-authorization", "cf-token-abc", secret: true);
+        Save(add);
+
+        var edit = h.Existing("gw");
+        edit.Headers.Single().IsSecret = false;
+        Save(edit);
+
+        Assert.Contains("cf-aig-authorization", edit.Problem);
+        Assert.Equal("cf-token-abc", h.Keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
+        Assert.True(h.Service.Connections.Single().Headers.Single().Secret);
+    }
+
+    /// <summary>
+    /// The mark is data, not a capability of the machine doing the editing. A Windows profile whose data
+    /// folder is briefly unwritable — the state the store's own Unavailable message describes — must not turn
+    /// a stored-secret header into a blank plaintext one, which would orphan the credential beyond even the
+    /// delete sweep and remove the mark the missing-secret refusal fires on. (fable review)
+    /// </summary>
+    [Fact]
+    public void An_edit_where_no_store_is_available_keeps_a_secret_header_marked()
+    {
+        var h = new Harness();
+        var add = h.Custom();
+        add.Id = "gw";
+        add.BaseUrl = "https://gateway.example/v1";
+        Header(add, "cf-aig-authorization", "cf-token-abc", secret: true);
+        Save(add);
+
+        h.Keys.Available = false;
+
+        var edit = h.Existing("gw");
+        edit.DisplayName = "Renamed";
+        Save(edit);
+
+        var stored = h.Service.Connections.Single().Headers.Single();
+        Assert.True(stored.Secret);
+        Assert.Null(stored.Value);
+    }
+
+    /// <summary>
+    /// A duplicate name was unrepresentable while headers were a dictionary and is not any more. Both request
+    /// paths project back through a dictionary, so an unrefused duplicate reaches the reader as "Something
+    /// went wrong running that request" and "An item with the same key has already been added" — two dead ends
+    /// naming nothing, persisted across sessions. The natural way in: converting a plaintext header to a
+    /// secret one by adding a new row instead of ticking the box, and forgetting the old row. (fable review)
+    /// </summary>
+    [Fact]
+    public void Two_headers_with_the_same_name_are_refused()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+        vm.Id = "gw";
+        vm.BaseUrl = "https://gateway.example/v1";
+        Header(vm, "cf-aig-authorization", "plaintext", secret: false);
+        Header(vm, "cf-aig-authorization", "cf-token-abc", secret: true);
+
+        Save(vm);
+
+        Assert.Contains("cf-aig-authorization", vm.Problem);
+        Assert.Empty(h.Service.Connections);
+    }
+
+    /// <summary>Case-insensitively, because HTTP header names are.</summary>
+    [Fact]
+    public void Two_headers_differing_only_in_case_are_refused()
+    {
+        var h = new Harness();
+        var vm = h.Custom();
+        vm.Id = "gw";
+        vm.BaseUrl = "https://gateway.example/v1";
+        Header(vm, "X-Token", "a", secret: false);
+        Header(vm, "x-token", "b", secret: false);
+
+        Save(vm);
+
+        Assert.Contains("token", vm.Problem, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(h.Service.Connections);
+    }
+
+    /// <summary>
+    /// The invariant has to survive a <c>with</c>, not only the constructor. As a positional record the
+    /// generated init accessors let <c>header with { Secret = true }</c> produce a secret carrying a value —
+    /// the state the type's comment said could not exist. Get-only properties make that not compile; this
+    /// pins the construction half. (fable review)
+    /// </summary>
+    [Fact]
+    public void A_header_marked_secret_cannot_carry_a_value_at_all()
+    {
+        var header = new AiHeader("cf-aig-authorization", "cf-token-abc", Secret: true);
+
+        Assert.Null(header.Value);
     }
 
     /// <summary>
@@ -1084,19 +1213,6 @@ public class AiConnectionEditorViewModelTests
         var stored = h.Service.Connections.Single().Headers.Single();
         Assert.False(stored.Secret);
         Assert.Equal("cf-token-abc", stored.Value);
-    }
-
-    /// <summary>
-    /// The type refuses the state rather than each caller remembering to. Found by mutation: the sheet's own
-    /// drop of the value can be deleted with the whole suite still green, because the service drops it again
-    /// on the way to settings.json — two guards each relying on the other. (fable review method)
-    /// </summary>
-    [Fact]
-    public void A_header_marked_secret_cannot_carry_a_value_at_all()
-    {
-        var header = new AiHeader("cf-aig-authorization", "cf-token-abc", Secret: true);
-
-        Assert.Null(header.Value);
     }
 
     /// <summary>The mask is what stops a token standing on screen in a screenshot or over a shoulder; it is

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -114,7 +114,7 @@ public class AiConnectionsViewModelTests
 
     private static AiConnectionDraft Draft(string name = "My box", string url = "http://localhost:8000/v1") =>
         new(name, ChatProviderKind.OpenAiCompatible, url,
-            new List<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>());
+            new List<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>());
 
     // ---- the two sections ------------------------------------------------------------------------------
 
@@ -224,7 +224,7 @@ public class AiConnectionsViewModelTests
     {
         var connection = new AiConnection(
             "local", "Local Ollama", ChatProviderKind.OpenAiCompatible, baseUrl,
-            new List<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>(),
+            new List<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>(),
             source, state);
         return new AiConnectionRowViewModel(new AiConnectionsViewModel(null, null), connection);
     }
@@ -950,7 +950,7 @@ public class AiConnectionRowLogoTests
 
         service.Add("anthropic-work", new AiConnectionDraft(
             "Anthropic (work)", ChatProviderKind.OpenAiCompatible, "http://localhost:8000/v1",
-            Array.Empty<AiModelEntry>(), new Dictionary<string, string>(), new Dictionary<string, string>()));
+            Array.Empty<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>()));
         var row = vm.Connections.Single();
         await row.LogoLoad!;
 

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -45,7 +45,7 @@ public class AiModelPickerViewModelTests
 
     private static AiConnectionDraft Draft(string name, params AiModelEntry[] models) =>
         new(name, ChatProviderKind.OpenAiCompatible, "http://localhost:8000/v1",
-            models, new Dictionary<string, string>(), new Dictionary<string, string>());
+            models, Array.Empty<AiHeader>(), new Dictionary<string, string>());
 
     private static IEnumerable<AiPickerModelViewModel> AllModels(AiModelPickerViewModel picker) =>
         picker.Groups.SelectMany(g => g.Models);
@@ -441,7 +441,7 @@ public class AiModelPickerViewModelTests
             "Half-built", ChatProviderKind.OpenAiCompatible,
             "https://{resourceName}.openai.azure.com/openai/v1",
             new[] { new AiModelEntry("a", "A") },
-            new Dictionary<string, string>(), new Dictionary<string, string>()));
+            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
 
         var model = AllModels(picker).Single();
         Assert.False(model.IsUsable);

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -52,7 +52,7 @@ public class AiModelsViewModelTests
 
     private static AiConnectionDraft Draft(params AiModelEntry[] models) =>
         new("My box", ChatProviderKind.OpenAiCompatible, "http://localhost:8000/v1",
-            models, new Dictionary<string, string>(), new Dictionary<string, string>());
+            models, Array.Empty<AiHeader>(), new Dictionary<string, string>());
 
     private static AiModelGroupViewModel Group(AiModelsViewModel vm) => vm.Groups.Single();
 

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -80,6 +80,27 @@ namespace CST.Avalonia.Models.Ai
         bool Missing = false);
 
     /// <summary>
+    /// One extra request header on a connection. (#711, #771)
+    /// </summary>
+    /// <param name="Value">Null when <paramref name="Secret"/>: the value is in the credential store, and this
+    /// record is handed to the UI. Keeping it null here is what stops a secret reaching a screen, a log or a
+    /// settings file by simply being carried along — the request path fetches it at the moment it sends.</param>
+    /// <param name="Secret">Whether the value is a credential rather than a routing hint.</param>
+    public sealed record AiHeader(string Name, string? Value, bool Secret = false)
+    {
+        /// <summary>
+        /// Null whenever <see cref="Secret"/>, enforced here rather than trusted from each caller.
+        ///
+        /// <para>Two places already drop a secret's value on the way past — the sheet building this record and
+        /// the service writing the settings record — and a mutation test showed the first of them can be
+        /// removed with every test still green, because the second catches it. Two guards that each believe
+        /// the other is the belt is how a leak eventually gets through. Here the state simply cannot be
+        /// constructed: a secret header carries a name and a mark, never a value. (#771)</para>
+        /// </summary>
+        public string? Value { get; init; } = Secret ? null : Value;
+    }
+
+    /// <summary>
     /// One configured endpoint: where to send a request, how to authenticate, and which models it offers.
     /// Replaces the single scalar provider/base-URL/model/key that surface B shipped with. (#689)
     /// </summary>
@@ -103,7 +124,7 @@ namespace CST.Avalonia.Models.Ai
         ChatProviderKind Kind,
         string BaseUrl,
         IReadOnlyList<AiModelEntry> Models,
-        IReadOnlyDictionary<string, string> Headers,
+        IReadOnlyList<AiHeader> Headers,
         IReadOnlyDictionary<string, string> Inputs,
         CredentialSource KeySource = CredentialSource.None,
         Reachability State = Reachability.Configured,
@@ -127,7 +148,7 @@ namespace CST.Avalonia.Models.Ai
         ChatProviderKind Kind,
         string BaseUrl,
         IReadOnlyList<AiModelEntry> Models,
-        IReadOnlyDictionary<string, string> Headers,
+        IReadOnlyList<AiHeader> Headers,
         IReadOnlyDictionary<string, string> Inputs,
         string AuthHeaderName = "Authorization",
         string? AuthScheme = "Bearer");

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -86,18 +86,37 @@ namespace CST.Avalonia.Models.Ai
     /// record is handed to the UI. Keeping it null here is what stops a secret reaching a screen, a log or a
     /// settings file by simply being carried along — the request path fetches it at the moment it sends.</param>
     /// <param name="Secret">Whether the value is a credential rather than a routing hint.</param>
-    public sealed record AiHeader(string Name, string? Value, bool Secret = false)
+    public sealed record AiHeader
     {
         /// <summary>
-        /// Null whenever <see cref="Secret"/>, enforced here rather than trusted from each caller.
+        /// A secret header carries a name and a mark, never a value — normalised here rather than trusted from
+        /// each caller.
         ///
-        /// <para>Two places already drop a secret's value on the way past — the sheet building this record and
-        /// the service writing the settings record — and a mutation test showed the first of them can be
-        /// removed with every test still green, because the second catches it. Two guards that each believe
-        /// the other is the belt is how a leak eventually gets through. Here the state simply cannot be
-        /// constructed: a secret header carries a name and a mark, never a value. (#771)</para>
+        /// <para>Two places already drop a secret's value on the way past: the sheet building this record and
+        /// the service writing the settings record. A mutation showed the first can be deleted with every test
+        /// still green, because the second catches it — two guards each believing the other is the belt, which
+        /// is how a leak eventually gets through.</para>
+        ///
+        /// <para><b>Deliberately not a positional record.</b> As one, the generated <c>init</c> accessors made
+        /// <c>header with { Secret = true }</c> produce a secret carrying a value: the copy constructor copies
+        /// the backing fields and re-runs the initialiser only for members the <c>with</c> names. So the
+        /// invariant held at construction and nowhere else, while the comment claimed otherwise. Get-only
+        /// properties make <c>with</c> refuse to compile against any of them. (#771, fable review)</para>
         /// </summary>
-        public string? Value { get; init; } = Secret ? null : Value;
+        public AiHeader(string Name, string? Value, bool Secret = false)
+        {
+            this.Name = Name;
+            this.Secret = Secret;
+            this.Value = Secret ? null : Value;
+        }
+
+        public string Name { get; }
+
+        /// <summary>Null whenever <see cref="Secret"/> — the value is in the credential store, and the request
+        /// path fetches it at the moment it sends.</summary>
+        public string? Value { get; }
+
+        public bool Secret { get; }
     }
 
     /// <summary>

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -132,8 +132,11 @@ namespace CST.Avalonia.Models
 
         public List<AiModelRecord> Models { get; set; } = new();
 
-        /// <summary>Extra request headers. Never the credential, which lives in the OS credential store.</summary>
-        public Dictionary<string, string> Headers { get; set; } = new();
+        /// <summary>
+        /// Extra request headers. A value that IS a credential is marked secret and kept in the OS credential
+        /// store rather than here. (#771)
+        /// </summary>
+        public List<AiHeaderRecord> Headers { get; set; } = new();
 
         /// <summary>Answers to the preset's prompts — resource name, account id, region — substituted into
         /// <see cref="BaseUrl"/> and <see cref="Headers"/>.</summary>
@@ -148,6 +151,32 @@ namespace CST.Avalonia.Models
         /// <summary>Prefix before the credential, or null for a bare value. Bearer for almost everything;
         /// null for Azure.</summary>
         public string? AuthScheme { get; set; } = "Bearer";
+    }
+
+    /// <summary>
+    /// One extra request header, as persisted. (#711, #771)
+    ///
+    /// <para><b>Why a record and not a <c>Dictionary&lt;string, string&gt;</c>.</b> A secret header's value
+    /// does not live here, so the shape has to be able to say "this header has a name and no value in this
+    /// file". Expressed as a dictionary plus a parallel list of which names are secret, the two can disagree —
+    /// a name in both would have a plaintext value AND a stored secret, with nothing to say which wins. Here
+    /// that state cannot be written down.</para>
+    /// </summary>
+    public class AiHeaderRecord
+    {
+        public string Name { get; set; } = "";
+
+        /// <summary>
+        /// The header value, or null when <see cref="Secret"/> — in which case it is in the credential store
+        /// under <c>AiCredentialNames.Header(Name)</c> and is never written to this file at any point.
+        /// </summary>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Whether the value is a credential. Set by the reader on the row, because only they know: the same
+        /// header name is a routing hint at one provider and a token at another.
+        /// </summary>
+        public bool Secret { get; set; }
     }
 
     /// <summary>One model a connection offers, as persisted.</summary>

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -217,6 +217,8 @@ namespace CST.Avalonia.Services.Ai
             var problem = ValidateId(id, existingAllowed: false);
             if (problem is not null) return AiConnectionResult.Fail(problem);
 
+            if (CollidingSecretHeader(draft) is { } collision) return AiConnectionResult.Fail(collision);
+
             var record = new AiConnectionRecord { Id = id };
             Apply(record, draft);
             Chat.Connections.Add(record);
@@ -246,7 +248,11 @@ namespace CST.Avalonia.Services.Ai
                 DisplayName = preset.DisplayName,
                 Kind = preset.Kind == ChatProviderKind.Anthropic ? "anthropic" : "openai-compatible",
                 BaseUrl = preset.BaseUrl,
-                Headers = new Dictionary<string, string>(preset.Headers ?? new Dictionary<string, string>()),
+                // A preset's headers are never secret: they are routing hints the catalogue publishes, and a
+                // preset cannot carry a credential (#771).
+                Headers = (preset.Headers ?? new Dictionary<string, string>())
+                    .Select(h => new AiHeaderRecord { Name = h.Key, Value = h.Value })
+                    .ToList(),
                 Inputs = new Dictionary<string, string>(inputs),
                 AuthHeaderName = preset.AuthHeaderName,
                 AuthScheme = preset.AuthScheme,
@@ -261,8 +267,37 @@ namespace CST.Avalonia.Services.Ai
         {
             if (Find(id) is not { } record) return AiConnectionResult.Fail($"No connection called '{id}'.");
 
+            if (CollidingSecretHeader(draft) is { } collision) return AiConnectionResult.Fail(collision);
+
             Apply(record, draft);
             return Saved(record);
+        }
+
+        /// <summary>
+        /// Two secret headers whose names fold to one credential name, or null when there are none. (#771)
+        ///
+        /// <para>Header names are richer than credential names: <c>x.y</c> and <c>x-y</c> are different headers
+        /// and both fold to <c>header-x-y</c>, so one would silently overwrite the other's secret and the
+        /// endpoint would authenticate with the wrong one. Vanishingly rare - real header names are letters,
+        /// digits and hyphens - and refused rather than tolerated because the failure is a 401 that names
+        /// nothing, which is the same symptom #678 took a release to find.</para>
+        ///
+        /// <para>Checked here rather than in the sheet because this is the seam every write goes through, and
+        /// <c>settings.json</c> is hand-edited.</para>
+        /// </summary>
+        private static string? CollidingSecretHeader(AiConnectionDraft draft)
+        {
+            var seen = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var header in draft.Headers.Where(h => h.Secret && !string.IsNullOrWhiteSpace(h.Name)))
+            {
+                var name = AiCredentialNames.Header(header.Name);
+                if (seen.TryGetValue(name, out var first))
+                    return $"The {first} and {header.Name} headers cannot both be secret: "
+                           + "they would share one stored value.";
+                seen[name] = header.Name;
+            }
+
+            return null;
         }
 
         public AiConnectionResult Remove(string id)
@@ -492,7 +527,18 @@ namespace CST.Avalonia.Services.Ai
                     Missing = m.Missing,
                 })
                 .ToList();
-            record.Headers = new Dictionary<string, string>(draft.Headers);
+            // A secret header's value is NOT carried through the draft - the editor puts it in the credential
+            // store directly, exactly as it does the API key - so what is persisted is the name and the mark.
+            // Writing draft.Value here for a secret row is the one line that would put a credential in
+            // settings.json, which is why it cannot be reached: the draft's Value is null when Secret (#771).
+            record.Headers = draft.Headers
+                .Select(h => new AiHeaderRecord
+                {
+                    Name = h.Name,
+                    Value = h.Secret ? null : h.Value,
+                    Secret = h.Secret,
+                })
+                .ToList();
             record.Inputs = new Dictionary<string, string>(draft.Inputs);
             record.AuthHeaderName = draft.AuthHeaderName;
             record.AuthScheme = draft.AuthScheme;
@@ -508,7 +554,7 @@ namespace CST.Avalonia.Services.Ai
                     m.Id, m.DisplayName, m.Enabled, m.ContextLength, m.SupportsReasoning, m.Inputs,
                     m.Missing))
                 .ToList(),
-            new Dictionary<string, string>(r.Headers),
+            r.Headers.Select(h => new AiHeader(h.Name, h.Secret ? null : h.Value, h.Secret)).ToList(),
             new Dictionary<string, string>(r.Inputs),
             SourceFor(r.Id),
             ReachabilityOf(r.Id),
@@ -525,6 +571,9 @@ namespace CST.Avalonia.Services.Ai
         private static IEnumerable<string> CredentialNamesOf(AiConnectionRecord record)
         {
             yield return AiCredentialNames.Primary;
+
+            foreach (var header in record.Headers.Where(h => h.Secret))
+                yield return AiCredentialNames.Header(header.Name);
         }
 
         /// <summary>

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -217,6 +217,7 @@ namespace CST.Avalonia.Services.Ai
             var problem = ValidateId(id, existingAllowed: false);
             if (problem is not null) return AiConnectionResult.Fail(problem);
 
+            if (DuplicateHeader(draft) is { } duplicate) return AiConnectionResult.Fail(duplicate);
             if (CollidingSecretHeader(draft) is { } collision) return AiConnectionResult.Fail(collision);
 
             var record = new AiConnectionRecord { Id = id };
@@ -267,6 +268,7 @@ namespace CST.Avalonia.Services.Ai
         {
             if (Find(id) is not { } record) return AiConnectionResult.Fail($"No connection called '{id}'.");
 
+            if (DuplicateHeader(draft) is { } duplicate) return AiConnectionResult.Fail(duplicate);
             if (CollidingSecretHeader(draft) is { } collision) return AiConnectionResult.Fail(collision);
 
             Apply(record, draft);
@@ -285,6 +287,34 @@ namespace CST.Avalonia.Services.Ai
         /// <para>Checked here rather than in the sheet because this is the seam every write goes through, and
         /// <c>settings.json</c> is hand-edited.</para>
         /// </summary>
+        /// <summary>
+        /// Two header rows with the same name, or null when there are none. (#771, fable review)
+        ///
+        /// <para><b>A regression the shape change introduced.</b> While headers were a
+        /// <c>Dictionary&lt;string, string&gt;</c> a duplicate was unrepresentable; a list stores one happily,
+        /// and both request paths project back through <c>ToDictionary</c>, which throws. The reader gets
+        /// "Something went wrong running that request" from the chat and "An item with the same key has
+        /// already been added" from the Models tab — two dead ends naming nothing, persisted across sessions,
+        /// with no screen pointing at the row that caused it.</para>
+        ///
+        /// <para>The natural way in is not exotic: converting a plaintext header to a secret one by adding a
+        /// new row rather than ticking the box on the old one, and forgetting to delete the old row.</para>
+        ///
+        /// <para>Compared case-insensitively because HTTP header names are. HTTP does permit a repeated
+        /// header, so this refuses something the protocol allows — deliberately: the previous shape refused it
+        /// too, nothing in the app can express what a repeat would mean, and a refusal naming the header beats
+        /// an exception naming nothing.</para>
+        /// </summary>
+        private static string? DuplicateHeader(AiConnectionDraft draft)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var header in draft.Headers.Where(h => !string.IsNullOrWhiteSpace(h.Name)))
+                if (!seen.Add(header.Name.Trim()))
+                    return $"There are two {header.Name.Trim()} headers. Remove one.";
+
+            return null;
+        }
+
         private static string? CollidingSecretHeader(AiConnectionDraft draft)
         {
             var seen = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -238,8 +238,14 @@ namespace CST.Avalonia.Services.Ai
         private void Authenticate(HttpRequestMessage request, AiConnection connection)
         {
             var key = _credentials?.Get(connection.Id, AiCredentialNames.Primary);
+            // Same rule as the chat path, for the same reason the summary above gives: the two surfaces send
+            // the same credentials, so a secret header must resolve identically here or a provider's model
+            // list would load while its answers 401. A secret is a literal, never a template. (#771)
             var headers = connection.Headers.ToDictionary(
-                h => h.Key, h => AiTemplate.Expand(h.Value, connection.Inputs));
+                h => h.Name,
+                h => h.Secret
+                    ? _credentials?.Get(connection.Id, AiCredentialNames.Header(h.Name)) ?? string.Empty
+                    : AiTemplate.Expand(h.Value ?? string.Empty, connection.Inputs));
 
             if (connection.Kind == ChatProviderKind.Anthropic)
             {

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -142,6 +142,21 @@ namespace CST.Avalonia.Services.Ai
                 return AiCatalogResult.Fail(
                     $"{connection.DisplayName} is not finished being set up, so it cannot be asked for a list.");
 
+            // A header marked secret with nothing stored, refused here for the same reason the chat path
+            // refuses it: sent blank it is dropped at the wire and comes back as a 401 naming nothing, which
+            // is the #711 complaint arriving from a third direction. Refused in BOTH places or not at all -
+            // a listing that loads while the chat refuses is the surface split #673 exists to prevent, just
+            // pointing the other way. (#771)
+            var missingSecrets = connection.Headers
+                .Where(h => h.Secret
+                            && string.IsNullOrEmpty(_credentials?.Get(connection.Id, AiCredentialNames.Header(h.Name))))
+                .Select(h => h.Name)
+                .ToList();
+            if (missingSecrets.Count > 0)
+                return AiCatalogResult.Fail(
+                    $"No stored value for the {string.Join(", ", missingSecrets)} header. "
+                    + "Re-enter it under Settings \u2192 AI.");
+
             Uri url;
             try
             {

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -147,6 +147,14 @@ namespace CST.Avalonia.Services.Ai
             // is the #711 complaint arriving from a third direction. Refused in BOTH places or not at all -
             // a listing that loads while the chat refuses is the surface split #673 exists to prevent, just
             // pointing the other way. (#771)
+            var duplicate = connection.Headers
+                .Where(h => !string.IsNullOrWhiteSpace(h.Name))
+                .GroupBy(h => h.Name.Trim(), StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault(g => g.Count() > 1);
+            if (duplicate is not null)
+                return AiCatalogResult.Fail(
+                    $"This connection has two {duplicate.Key} headers. Remove one under Settings \u2192 AI.");
+
             var missingSecrets = connection.Headers
                 .Where(h => h.Secret
                             && string.IsNullOrEmpty(_credentials?.Get(connection.Id, AiCredentialNames.Header(h.Name))))
@@ -256,11 +264,11 @@ namespace CST.Avalonia.Services.Ai
             // Same rule as the chat path, for the same reason the summary above gives: the two surfaces send
             // the same credentials, so a secret header must resolve identically here or a provider's model
             // list would load while its answers 401. A secret is a literal, never a template. (#771)
-            var headers = connection.Headers.ToDictionary(
-                h => h.Name,
-                h => h.Secret
-                    ? _credentials?.Get(connection.Id, AiCredentialNames.Header(h.Name)) ?? string.Empty
-                    : AiTemplate.Expand(h.Value ?? string.Empty, connection.Inputs));
+            var headers = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var header in connection.Headers)
+                headers[header.Name] = header.Secret
+                    ? _credentials?.Get(connection.Id, AiCredentialNames.Header(header.Name)) ?? string.Empty
+                    : AiTemplate.Expand(header.Value ?? string.Empty, connection.Inputs);
 
             if (connection.Kind == ChatProviderKind.Anthropic)
             {

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -54,15 +54,47 @@ public interface IAiCredentialStore
 /// <summary>
 /// The names a connection files its secrets under. (#759)
 ///
-/// <para>These are ours, never the reader's: a name is part of the storage address, so a typo in one is a
-/// credential that cannot be found again rather than an error anyone sees. Presets declare which names they
-/// need; the reader only ever fills them in.</para>
+/// <para><b>A name is part of the storage address</b>, so a typo in one is a credential that cannot be found
+/// again rather than an error anyone sees. Most are constants: presets declare which names they need and the
+/// reader only ever fills them in. <see cref="Header"/> is the exception — it derives a name from a header
+/// name the reader typed — which is why it folds through <see cref="Slug"/> and why
+/// <c>AiConnectionService</c> refuses two secret headers that would fold together. (#771)</para>
 /// </summary>
 public static class AiCredentialNames
 {
     /// <summary>The credential the auth header carries — what every provider in the catalogue needs, and for
     /// almost all of them the only one.</summary>
     public const string Primary = "primary";
+
+    /// <summary>
+    /// The name a header's secret value is filed under. (#771)
+    ///
+    /// <para><b>Derived from the header rather than generated.</b> A serial number would be collision-proof
+    /// for free, but one of the stated reasons for N accounts over a single blob is that a reader can see in
+    /// Keychain Access what this app is holding and revoke one item — and <c>header-1</c> tells them nothing.
+    /// Derivation costs a uniqueness check instead, which <see cref="AiConnectionService"/> makes at the point
+    /// of save.</para>
+    /// </summary>
+    public static string Header(string headerName) => "header-" + Slug(headerName);
+
+    /// <summary>
+    /// The character folding every part of an account name goes through, defined here so that the code which
+    /// checks two names for collision and the code which stores under them cannot disagree.
+    ///
+    /// <para>Emits only <c>[a-z0-9-_]</c>. That is what makes an account string splittable — see
+    /// <c>AiCredentialStore.AccountFor</c>, whose separator is chosen to be a character this can never
+    /// produce. Widening this set reopens the collision documented there.</para>
+    /// </summary>
+    public static string Slug(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "default";
+
+        var chars = value.Trim().ToLowerInvariant().ToCharArray();
+        for (int i = 0; i < chars.Length; i++)
+            if (!(char.IsAsciiLetterOrDigit(chars[i]) || chars[i] is '-' or '_'))
+                chars[i] = '-';
+        return new string(chars);
+    }
 }
 
 /// <summary>
@@ -196,7 +228,17 @@ public sealed class ChatProviderResolver : IChatProviderResolver
         // reaches the wire verbatim and comes back as a 401 the reader would read as a bad key - the header
         // IS the credential in the gateway case, so an unfinished one is an unfinished credential. (#711)
         var headers = ExpandHeaders(connection);
+
+        // Secret values are excluded: they are literals, never templates, so a brace in one is part of the
+        // credential rather than an unfilled field. Scanning them refuses a perfectly good key for containing
+        // a character, with a message naming a placeholder that does not exist. (#771)
+        var secretHeaderNames = connection.Headers
+            .Where(h => h.Secret)
+            .Select(h => h.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         var unfinished = headers
+            .Where(h => !secretHeaderNames.Contains(h.Key))
             .Where(h => CST.Avalonia.Models.Ai.AiTemplate.HasUnresolvedPlaceholders(h.Value))
             .SelectMany(h => CST.Avalonia.Models.Ai.AiTemplate.PlaceholdersIn(h.Value))
             .Distinct()
@@ -205,6 +247,20 @@ public sealed class ChatProviderResolver : IChatProviderResolver
         {
             problem = $"This provider still needs: {string.Join(", ", unfinished)}. "
                       + "Fill it in under Settings \u2192 AI.";
+            return null;
+        }
+
+        // A header marked secret whose secret is not stored - the store was unavailable when it was saved, or
+        // the reader deleted the item in Keychain Access. Sending the header empty produces a 401 that reads
+        // as a bad key, so say which header is missing instead. (#771)
+        var missingSecrets = connection.Headers
+            .Where(h => h.Secret && string.IsNullOrEmpty(headers.GetValueOrDefault(h.Name)))
+            .Select(h => h.Name)
+            .ToList();
+        if (missingSecrets.Count > 0)
+        {
+            problem = $"No stored value for the {string.Join(", ", missingSecrets)} header. "
+                      + "Re-enter it under Settings \u2192 AI.";
             return null;
         }
 
@@ -289,8 +345,21 @@ public sealed class ChatProviderResolver : IChatProviderResolver
     /// reader-supplied input inside one. Shared by both provider kinds so that neither can quietly stop
     /// sending them, which is how the Anthropic adapter came to drop every header it was given. (#711)</para>
     /// </summary>
-    private static IReadOnlyDictionary<string, string> ExpandHeaders(AiConnectionRecord connection) =>
+    /// <summary>
+    /// The headers as they go on the wire: templated values filled in from the reader's inputs, and secret
+    /// values fetched from the credential store at this moment rather than carried around. (#711, #771)
+    ///
+    /// <para><b>A secret value is not expanded as a template.</b> A credential is a literal; running one
+    /// through <see cref="CST.Avalonia.Models.Ai.AiTemplate"/> would mean a key containing braces came out
+    /// mangled, and there is no legitimate reason for a secret to reference an input.</para>
+    ///
+    /// <para>A secret with nothing stored yields an empty string, which the caller treats as an unfinished
+    /// credential rather than sending a blank header — see the guard at the call site.</para>
+    /// </summary>
+    private IReadOnlyDictionary<string, string> ExpandHeaders(AiConnectionRecord connection) =>
         connection.Headers.ToDictionary(
-            h => h.Key,
-            h => CST.Avalonia.Models.Ai.AiTemplate.Expand(h.Value, connection.Inputs));
+            h => h.Name,
+            h => h.Secret
+                ? _credentials?.Get(connection.Id, AiCredentialNames.Header(h.Name)) ?? string.Empty
+                : CST.Avalonia.Models.Ai.AiTemplate.Expand(h.Value ?? string.Empty, connection.Inputs));
 }

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -213,6 +213,21 @@ public sealed class ChatProviderResolver : IChatProviderResolver
             return null;
         }
 
+        // Two headers with the same name. Refused at the service on every write path, so reaching here means
+        // a hand-edited settings.json - which is a supported way in, and used to be impossible to get wrong
+        // while headers were a dictionary. Named here rather than left to the projection below, which would
+        // otherwise surface as "An item with the same key has already been added" through a generic catch.
+        // (#771, fable review)
+        var duplicate = connection.Headers
+            .Where(h => !string.IsNullOrWhiteSpace(h.Name))
+            .GroupBy(h => h.Name.Trim(), StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(g => g.Count() > 1);
+        if (duplicate is not null)
+        {
+            problem = $"This connection has two {duplicate.Key} headers. Remove one under Settings \u2192 AI.";
+            return null;
+        }
+
         // A connection whose URL still contains an unfilled {placeholder} - Azure without its resource name -
         // must be refused HERE. Sent anyway it fails as a DNS error naming nothing, which tells the reader
         // neither what is wrong nor where to fix it. (#689)
@@ -356,10 +371,17 @@ public sealed class ChatProviderResolver : IChatProviderResolver
     /// <para>A secret with nothing stored yields an empty string, which the caller treats as an unfinished
     /// credential rather than sending a blank header — see the guard at the call site.</para>
     /// </summary>
-    private IReadOnlyDictionary<string, string> ExpandHeaders(AiConnectionRecord connection) =>
-        connection.Headers.ToDictionary(
-            h => h.Name,
-            h => h.Secret
-                ? _credentials?.Get(connection.Id, AiCredentialNames.Header(h.Name)) ?? string.Empty
-                : CST.Avalonia.Models.Ai.AiTemplate.Expand(h.Value ?? string.Empty, connection.Inputs));
+    private IReadOnlyDictionary<string, string> ExpandHeaders(AiConnectionRecord connection)
+    {
+        // Indexer assignment rather than ToDictionary: a duplicate name is refused before this runs, so this
+        // cannot be reached with one - and if a later edit moves the guard, the reader should get a wrong
+        // header rather than an exception surfacing as "Something went wrong running that request".
+        var headers = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var header in connection.Headers)
+            headers[header.Name] = header.Secret
+                ? _credentials?.Get(connection.Id, AiCredentialNames.Header(header.Name)) ?? string.Empty
+                : CST.Avalonia.Models.Ai.AiTemplate.Expand(header.Value ?? string.Empty, connection.Inputs);
+
+        return headers;
+    }
 }

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
@@ -1,4 +1,5 @@
 using System;
+using CST.Avalonia.Services.Ai;
 using Microsoft.Extensions.Logging;
 
 namespace CST.Avalonia.Services.Ai.Credentials;
@@ -87,9 +88,13 @@ public sealed class AiCredentialStore : IAiCredentialStore
             ? WindowsDpapiStore.Find(_service, account)
             : MacOsKeychain.Find(_service, account);
 
-        // The OUTCOME, never the value — and not its length either, which narrows a guess. The name is safe
-        // to log and worth logging: it is ours, and "which of this connection's secrets was missing" is the
-        // whole diagnosis when a two-credential provider 401s.
+        // The OUTCOME, never the value — and not its length either, which narrows a guess.
+        //
+        // The NAME is logged, and after #771 that is no longer simply "ours": a secret header's name is
+        // derived from a header name the reader typed. Logged anyway, deliberately — an HTTP header name
+        // travels on every request in the clear, so it is public in a way its value never is, and "which of
+        // this connection's secrets was missing" is the whole diagnosis when a two-credential provider 401s.
+        // The line to hold is the value, and it is held here and at every other call. (fable review)
         _logger.LogDebug("Credential lookup for {Connection}/{Name}: {Result}",
             connectionId, name, secret is null ? "none stored" : "found");
 
@@ -163,14 +168,5 @@ public sealed class AiCredentialStore : IAiCredentialStore
     /// <para>The allowed set is what <see cref="AccountFor"/> depends on. Widening it to admit <c>:</c> or
     /// <c>.</c> would reintroduce the collision documented there.</para>
     /// </summary>
-    private static string Sanitize(string id)
-    {
-        if (string.IsNullOrWhiteSpace(id)) return "default";
-
-        var chars = id.Trim().ToLowerInvariant().ToCharArray();
-        for (int i = 0; i < chars.Length; i++)
-            if (!(char.IsAsciiLetterOrDigit(chars[i]) || chars[i] is '-' or '_'))
-                chars[i] = '-';
-        return new string(chars);
-    }
+    private static string Sanitize(string id) => AiCredentialNames.Slug(id);
 }

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -43,6 +43,10 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
 {
     private readonly HttpClient _http;
     private readonly OpenAiCompatibleOptions _options;
+
+    /// <summary>Test seam: what the resolver actually built, so a test can assert that a secret header was
+    /// fetched and attached without standing up an HTTP stub for it (#771).</summary>
+    internal OpenAiCompatibleOptions Options => _options;
     private readonly ILogger<OpenAiCompatibleProvider> _logger;
     private readonly TimeSpan _idleTimeout;
     private readonly TimeSpan _firstEventTimeout;

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -46,6 +46,11 @@ namespace CST.Avalonia.ViewModels
         private readonly string? _existingId;
         private readonly bool _keyRequired;
 
+        /// <summary>The credential names this connection's secret headers occupied when the sheet opened, so a
+        /// header that is renamed, unmarked or removed takes its stored secret with it rather than leaving an
+        /// orphan nothing can reach. (#771)</summary>
+        private readonly List<string> _secretHeadersAtOpen = new();
+
         private string _id = "";
         private string _displayName = "";
         private AiKindChoice _kind = KindChoices[0];
@@ -68,7 +73,8 @@ namespace CST.Avalonia.ViewModels
             SaveCommand = ReactiveCommand.Create(Save);
             CancelCommand = ReactiveCommand.Create(() => _close(false));
             AddModelCommand = ReactiveCommand.Create(() => Models.Add(new AiModelRowViewModel(Models)));
-            AddHeaderCommand = ReactiveCommand.Create(() => Headers.Add(new AiHeaderRowViewModel(Headers)));
+            AddHeaderCommand = ReactiveCommand.Create(
+                () => Headers.Add(new AiHeaderRowViewModel(Headers, CanStoreKeys)));
             RemoveKeyCommand = ReactiveCommand.Create(RemoveKey);
         }
 
@@ -198,11 +204,21 @@ namespace CST.Avalonia.ViewModels
                 });
 
             foreach (var header in connection.Headers)
-                vm.Headers.Add(new AiHeaderRowViewModel(vm.Headers)
+                vm.Headers.Add(new AiHeaderRowViewModel(vm.Headers, vm.CanStoreKeys)
                 {
-                    Name = header.Key,
-                    Value = header.Value,
+                    Name = header.Name,
+                    // Null for a secret one, by construction - the runtime record does not carry it. What the
+                    // reader sees is an empty box and a "stored" note, the same shape as the API key.
+                    Value = header.Value ?? "",
+                    IsSecret = header.Secret,
+                    OriginalName = header.Name,
+                    HasStoredSecret = header.Secret
+                        && credentials?.Get(connection.Id, AiCredentialNames.Header(header.Name)) is not null,
                 });
+
+            vm._secretHeadersAtOpen.AddRange(connection.Headers
+                .Where(h => h.Secret)
+                .Select(h => AiCredentialNames.Header(h.Name)));
 
             foreach (var input in connection.Inputs)
                 vm.Inputs.Add(new AiInputRowViewModel(
@@ -368,6 +384,20 @@ namespace CST.Avalonia.ViewModels
         private bool MissingRequiredKey =>
             _keyRequired && CanStoreKeys && string.IsNullOrWhiteSpace(ApiKeyEntry) && !HasStoredKey;
 
+        /// <summary>
+        /// A header marked secret with nothing to store and nothing already stored. (#771)
+        ///
+        /// <para>Same reasoning as <see cref="MissingRequiredKey"/>: saved anyway it produces a connection that
+        /// looks configured and 401s on every request, and the reader finds out later, from the provider,
+        /// while trying to read something. Refusing needs no <see cref="CanStoreKeys"/> exemption because the
+        /// row cannot be marked secret at all where there is nowhere to put one.</para>
+        /// </summary>
+        private AiHeaderRowViewModel? UnstoredSecretHeader => Headers.FirstOrDefault(
+            h => h.IsSecret && h.CanBeSecret
+                 && !string.IsNullOrWhiteSpace(h.Name)
+                 && string.IsNullOrWhiteSpace(h.Value)
+                 && !h.HasStoredSecret);
+
         public string KeyHint => "Optional — leave it empty if this endpoint needs no key, or if you authenticate with a header below.";
 
         /// <summary>
@@ -434,6 +464,13 @@ namespace CST.Avalonia.ViewModels
                 return;
             }
 
+            if (UnstoredSecretHeader is { } unstored)
+            {
+                Problem = $"The {unstored.Name.Trim()} header is marked secret but has no value. "
+                          + "Paste one, or clear the mark to keep it in the settings file.";
+                return;
+            }
+
             var inputs = Inputs
                 .Where(i => i.IsVisible && !string.IsNullOrWhiteSpace(i.Value))
                 .ToDictionary(i => i.Key, i => i.Value.Trim(), StringComparer.Ordinal);
@@ -452,7 +489,9 @@ namespace CST.Avalonia.ViewModels
                 return;
             }
 
-            StoreKey(result.Connection?.Id ?? _existingId ?? Id.Trim());
+            var savedId = result.Connection?.Id ?? _existingId ?? Id.Trim();
+            StoreKey(savedId);
+            StoreHeaderSecrets(savedId);
             _close(true);
         }
 
@@ -489,6 +528,39 @@ namespace CST.Avalonia.ViewModels
 
             _credentials.Set(connectionId, AiCredentialNames.Primary, ApiKeyEntry.Trim());
             ApiKeyEntry = "";
+        }
+
+        /// <summary>
+        /// Files each secret header's value, and sweeps the ones that are no longer secret. (#771)
+        ///
+        /// <para><b>The sweep runs first and by name.</b> A header that was renamed, unmarked or deleted leaves
+        /// a credential under its old name, and an orphan in the keychain is invisible by definition — nothing
+        /// reads it, so nothing reports it. Comparing what the sheet opened with against what it is saving is
+        /// the only place that difference is known.</para>
+        ///
+        /// <para>A row whose value box is empty keeps what is stored rather than clearing it: the box is empty
+        /// on every edit, because a stored secret is never read back into a screen.</para>
+        /// </summary>
+        private void StoreHeaderSecrets(string connectionId)
+        {
+            if (_credentials is null) return;
+
+            var keeping = Headers
+                .Where(h => h.IsSecret && h.CanBeSecret && !string.IsNullOrWhiteSpace(h.Name))
+                .Select(h => AiCredentialNames.Header(h.Name.Trim()))
+                .ToHashSet(StringComparer.Ordinal);
+
+            foreach (var gone in _secretHeadersAtOpen.Where(name => !keeping.Contains(name)))
+                _credentials.Delete(connectionId, gone);
+
+            foreach (var row in Headers.Where(
+                         h => h.IsSecret && h.CanBeSecret
+                              && !string.IsNullOrWhiteSpace(h.Name)
+                              && !string.IsNullOrWhiteSpace(h.Value)))
+            {
+                _credentials.Set(connectionId, AiCredentialNames.Header(row.Name.Trim()), row.Value.Trim());
+                row.Value = "";
+            }
         }
 
         /// <summary>
@@ -551,7 +623,13 @@ namespace CST.Avalonia.ViewModels
             TypedModels(),
             Headers
                 .Where(h => !string.IsNullOrWhiteSpace(h.Name))
-                .ToDictionary(h => h.Name.Trim(), h => h.Value.Trim(), StringComparer.Ordinal),
+                // A secret row's value is deliberately dropped here rather than carried: the draft is what
+                // reaches settings.json, and the secret goes to the credential store on its own path (#771).
+                .Select(h => new AiHeader(
+                    h.Name.Trim(),
+                    h.IsSecret && h.CanBeSecret ? null : h.Value.Trim(),
+                    h.IsSecret && h.CanBeSecret))
+                .ToList(),
             inputs,
             _authHeaderName,
             _authScheme);
@@ -650,10 +728,12 @@ namespace CST.Avalonia.ViewModels
         private readonly ObservableCollection<AiHeaderRowViewModel> _owner;
         private string _name = "";
         private string _value = "";
+        private bool _isSecret;
 
-        public AiHeaderRowViewModel(ObservableCollection<AiHeaderRowViewModel> owner)
+        public AiHeaderRowViewModel(ObservableCollection<AiHeaderRowViewModel> owner, bool canStoreSecrets = true)
         {
             _owner = owner;
+            CanBeSecret = canStoreSecrets;
             RemoveCommand = ReactiveCommand.Create(() => { _owner.Remove(this); });
         }
 
@@ -668,6 +748,55 @@ namespace CST.Avalonia.ViewModels
             get => _value;
             set => this.RaiseAndSetIfChanged(ref _value, value);
         }
+
+        /// <summary>
+        /// Whether this value is a credential, and so belongs in the OS credential store rather than in
+        /// <c>settings.json</c>. (#771)
+        ///
+        /// <para><b>The reader's call, not ours.</b> The same header name is a routing hint at one provider
+        /// and a token at another, and a guess either way is wrong in a way they cannot see: guessing secret
+        /// hides a value they wanted to read back, and guessing not writes a token to a file that gets
+        /// screenshotted.</para>
+        /// </summary>
+        public bool IsSecret
+        {
+            get => _isSecret;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _isSecret, value);
+                this.RaisePropertyChanged(nameof(ShowStoredNote));
+                this.RaisePropertyChanged(nameof(ValueMask));
+                this.RaisePropertyChanged(nameof(ValueWatermark));
+            }
+        }
+
+        /// <summary>Masks the value box while the row is secret. Escaped rather than a literal bullet, per the
+        /// project rule against non-Latin glyphs in source.</summary>
+        public char ValueMask => IsSecret ? '\u2022' : '\0';
+
+        /// <summary>
+        /// What the empty value box says. A stored secret is never read back into a screen, so on an edit the
+        /// box is empty for a header that is in fact configured — without this it reads as missing, and the
+        /// reader retypes a credential they did not need to.
+        /// </summary>
+        public string ValueWatermark => ShowStoredNote ? "stored \u2014 type to replace" : "value";
+
+        /// <summary>False where there is nowhere to put a secret — Linux, or a Windows profile whose data
+        /// folder cannot be written. The row still works; its value simply stays in the settings file, which
+        /// the sheet says out loud rather than silently.</summary>
+        public bool CanBeSecret { get; }
+
+        /// <summary>Set when this row arrived with a secret already in the store. The value box stays empty —
+        /// a stored secret is never read back into a screen — so this is what tells the reader the row is
+        /// configured rather than blank.</summary>
+        public bool HasStoredSecret { get; init; }
+
+        /// <summary>The header name this row had when the sheet opened, or null for a row the reader added.
+        /// Renaming a secret header moves its credential, and without this the old one would be orphaned in
+        /// the keychain where nothing can ever reach it.</summary>
+        public string? OriginalName { get; init; }
+
+        public bool ShowStoredNote => IsSecret && HasStoredSecret;
 
         public ReactiveCommand<Unit, Unit> RemoveCommand { get; }
     }

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -211,6 +211,7 @@ namespace CST.Avalonia.ViewModels
                     // reader sees is an empty box and a "stored" note, the same shape as the API key.
                     Value = header.Value ?? "",
                     IsSecret = header.Secret,
+                    ArrivedSecret = header.Secret,
                     OriginalName = header.Name,
                     HasStoredSecret = header.Secret
                         && credentials?.Get(connection.Id, AiCredentialNames.Header(header.Name)) is not null,
@@ -393,10 +394,25 @@ namespace CST.Avalonia.ViewModels
         /// row cannot be marked secret at all where there is nowhere to put one.</para>
         /// </summary>
         private AiHeaderRowViewModel? UnstoredSecretHeader => Headers.FirstOrDefault(
-            h => h.IsSecret && h.CanBeSecret
+            h => h.KeepsSecret
                  && !string.IsNullOrWhiteSpace(h.Name)
                  && string.IsNullOrWhiteSpace(h.Value)
                  && !h.HasStoredSecret);
+
+        /// <summary>
+        /// A row that arrived with a stored secret, has been unmarked, and has nothing typed in its box.
+        /// (#771, fable review)
+        ///
+        /// <para>Unmarking reads as declassifying — moving the value from the keychain into the settings file
+        /// — and for a row the reader just typed, it is. For a row with a <i>stored</i> secret it cannot be:
+        /// the value was never read back into the box, so there is nothing to move, and the save would delete
+        /// the credential and persist an empty header that both request paths then send blank. That is the
+        /// anonymous 401 this whole feature exists to remove, arriving by the door marked exit.</para>
+        /// </summary>
+        private AiHeaderRowViewModel? EmptiedSecretHeader => Headers.FirstOrDefault(
+            h => !h.IsSecret && h.ArrivedSecret
+                 && !string.IsNullOrWhiteSpace(h.Name)
+                 && string.IsNullOrWhiteSpace(h.Value));
 
         public string KeyHint => "Optional — leave it empty if this endpoint needs no key, or if you authenticate with a header below.";
 
@@ -466,8 +482,17 @@ namespace CST.Avalonia.ViewModels
 
             if (UnstoredSecretHeader is { } unstored)
             {
+                // Not "clear the mark to keep it in the settings file": the box is empty, so there is nothing
+                // to keep, and for a renamed row clearing the mark would abandon the stored value too.
                 Problem = $"The {unstored.Name.Trim()} header is marked secret but has no value. "
-                          + "Paste one, or clear the mark to keep it in the settings file.";
+                          + "Paste one, or remove the row.";
+                return;
+            }
+
+            if (EmptiedSecretHeader is { } emptied)
+            {
+                Problem = $"The {emptied.Name.Trim()} header's value is stored in the keychain and cannot be "
+                          + "read back. Type it in to move it into the settings file, or mark it secret again.";
                 return;
             }
 
@@ -545,16 +570,37 @@ namespace CST.Avalonia.ViewModels
         {
             if (_credentials is null) return;
 
+            // FIRST, carry a renamed row's secret to its new name. (#771, fable review)
+            //
+            // A stored secret is never read back into the box, and the box says so - "stored, type to
+            // replace". A reader renaming a header because the provider renamed it therefore leaves it empty,
+            // which is what the screen tells them to do. Without this the sweep below would delete the old
+            // name and the store loop would skip the row for having no typed value: the credential is gone,
+            // the save reports success, and every request afterwards is refused for a secret the reader has
+            // no way to recover except from the provider.
+            foreach (var row in Headers.Where(h => h.KeepsSecret && !string.IsNullOrWhiteSpace(h.Name)))
+            {
+                if (row.OriginalName is not { } was) continue;
+
+                var from = AiCredentialNames.Header(was);
+                var to = AiCredentialNames.Header(row.Name.Trim());
+                if (string.Equals(from, to, StringComparison.Ordinal)) continue;
+
+                if (_credentials.Get(connectionId, from) is { } carried)
+                    _credentials.Set(connectionId, to, carried);
+            }
+
             var keeping = Headers
-                .Where(h => h.IsSecret && h.CanBeSecret && !string.IsNullOrWhiteSpace(h.Name))
+                .Where(h => h.KeepsSecret && !string.IsNullOrWhiteSpace(h.Name))
                 .Select(h => AiCredentialNames.Header(h.Name.Trim()))
                 .ToHashSet(StringComparer.Ordinal);
 
             foreach (var gone in _secretHeadersAtOpen.Where(name => !keeping.Contains(name)))
                 _credentials.Delete(connectionId, gone);
 
+            // A typed value wins over anything carried above, so renaming and rotating in one edit does both.
             foreach (var row in Headers.Where(
-                         h => h.IsSecret && h.CanBeSecret
+                         h => h.KeepsSecret
                               && !string.IsNullOrWhiteSpace(h.Name)
                               && !string.IsNullOrWhiteSpace(h.Value)))
             {
@@ -625,10 +671,7 @@ namespace CST.Avalonia.ViewModels
                 .Where(h => !string.IsNullOrWhiteSpace(h.Name))
                 // A secret row's value is deliberately dropped here rather than carried: the draft is what
                 // reaches settings.json, and the secret goes to the credential store on its own path (#771).
-                .Select(h => new AiHeader(
-                    h.Name.Trim(),
-                    h.IsSecret && h.CanBeSecret ? null : h.Value.Trim(),
-                    h.IsSecret && h.CanBeSecret))
+                .Select(h => new AiHeader(h.Name.Trim(), h.Value.Trim(), h.KeepsSecret))
                 .ToList(),
             inputs,
             _authHeaderName,
@@ -795,6 +838,23 @@ namespace CST.Avalonia.ViewModels
         /// Renaming a secret header moves its credential, and without this the old one would be orphaned in
         /// the keychain where nothing can ever reach it.</summary>
         public string? OriginalName { get; init; }
+
+        /// <summary>
+        /// Whether this row was already marked secret when the sheet opened. (#771, fable review)
+        ///
+        /// <para><b>The mark is data, not a capability of the machine doing the editing.</b> Without this, a
+        /// row that arrived secret is persisted unmarked wherever <see cref="CanBeSecret"/> is false — a
+        /// Windows profile whose data folder is briefly unwritable, or the settings file opened on Linux. The
+        /// value box is empty, because a stored secret is never read back, so what gets written is a blank
+        /// plaintext header: the credential is orphaned beyond even the delete sweep's reach, and the
+        /// missing-secret refusal can no longer fire because there is no longer a mark to fire on. The reader
+        /// renamed a connection and silently lost their gateway token.</para>
+        /// </summary>
+        public bool ArrivedSecret { get; init; }
+
+        /// <summary>Whether this row's mark survives a save here — either the store can take it, or it came
+        /// with one already and this machine has no business dropping it.</summary>
+        public bool KeepsSecret => IsSecret && (CanBeSecret || ArrivedSecret);
 
         public bool ShowStoredNote => IsSecret && HasStoredSecret;
 

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -362,7 +362,7 @@
                                     Command="{Binding AddHeaderCommand}"
                                     HorizontalAlignment="Left"/>
                             <TextBlock Text="For endpoints that authenticate with something other than a bearer key — a gateway token, or a provider's own key header. Mark such a value Secret: it then goes to the system keychain, and only the header's name is written to the settings file."
-                                       Classes="SettingDescription" Margin="0,6,0,0"/>
+                                       Classes="SettingDescription" Margin="0,6,0,15"/>
                             <!-- Where there is nowhere to store a secret the checkbox is disabled, so the
                                  reader is told what that means rather than left to wonder why (#771). -->
                             <TextBlock Text="{Binding KeyUnavailable}" IsVisible="{Binding !CanStoreKeys}"
@@ -371,7 +371,7 @@
                             <TextBlock Text="Until then a header value is stored in the settings file as typed."
                                        IsVisible="{Binding !CanStoreKeys}"
                                        Classes="SettingDescription Caution" TextWrapping="Wrap" MaxWidth="480"
-                                       HorizontalAlignment="Left" Margin="0,0,0,15"/>
+                                       HorizontalAlignment="Left" Margin="0,0,0,0"/>
                         </StackPanel>
 
                         <!-- The key is asked for HERE, on the sheet that already knows whose it is. A single

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -336,12 +336,22 @@
                             <ItemsControl ItemsSource="{Binding Headers}" Margin="0,0,0,4">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate x:DataType="vm:AiHeaderRowViewModel">
-                                        <Grid ColumnDefinitions="240,240,Auto" Margin="0,0,0,4">
+                                        <Grid ColumnDefinitions="240,240,Auto,Auto" Margin="0,0,0,4">
                                             <TextBox Grid.Column="0" Text="{Binding Name}"
                                                      Watermark="Header-Name" Margin="0,0,6,0"/>
+                                            <!-- PasswordChar rather than a separate control: the box has to
+                                                 stay the same box, or toggling Secret would lose what the
+                                                 reader has already typed into it. -->
                                             <TextBox Grid.Column="1" Text="{Binding Value}"
-                                                     Watermark="value" Margin="0,0,6,0"/>
-                                            <Button Grid.Column="2" Content="Remove" Classes="Link"
+                                                     PasswordChar="{Binding ValueMask}"
+                                                     Watermark="{Binding ValueWatermark}"
+                                                     Margin="0,0,6,0"/>
+                                            <CheckBox Grid.Column="2" Content="Secret"
+                                                      IsChecked="{Binding IsSecret}"
+                                                      IsEnabled="{Binding CanBeSecret}"
+                                                      ToolTip.Tip="Keep this value in the system keychain instead of the settings file."
+                                                      Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                            <Button Grid.Column="3" Content="Remove" Classes="Link"
                                                     Command="{Binding RemoveCommand}"
                                                     VerticalAlignment="Center"/>
                                         </Grid>
@@ -351,8 +361,17 @@
                             <Button Content="+ Add header" Classes="Link"
                                     Command="{Binding AddHeaderCommand}"
                                     HorizontalAlignment="Left"/>
-                            <TextBlock Text="For endpoints that authenticate with something other than a bearer key — a gateway token, or a provider's own key header."
-                                       Classes="SettingDescription" Margin="0,6,0,15"/>
+                            <TextBlock Text="For endpoints that authenticate with something other than a bearer key — a gateway token, or a provider's own key header. Mark such a value Secret: it then goes to the system keychain, and only the header's name is written to the settings file."
+                                       Classes="SettingDescription" Margin="0,6,0,0"/>
+                            <!-- Where there is nowhere to store a secret the checkbox is disabled, so the
+                                 reader is told what that means rather than left to wonder why (#771). -->
+                            <TextBlock Text="{Binding KeyUnavailable}" IsVisible="{Binding !CanStoreKeys}"
+                                       Classes="SettingDescription Caution" TextWrapping="Wrap" MaxWidth="480"
+                                       HorizontalAlignment="Left" Margin="0,4,0,0"/>
+                            <TextBlock Text="Until then a header value is stored in the settings file as typed."
+                                       IsVisible="{Binding !CanStoreKeys}"
+                                       Classes="SettingDescription Caution" TextWrapping="Wrap" MaxWidth="480"
+                                       HorizontalAlignment="Left" Margin="0,0,0,15"/>
                         </StackPanel>
 
                         <!-- The key is asked for HERE, on the sheet that already knows whose it is. A single


### PR DESCRIPTION
Closes #771. Builds on #774 — the second half of what #759's investigation recommended.

**The bug.** The sheet's own words under the Headers table are *"a gateway token, or a provider's own key header"* — both secrets — and the value went to `settings.json` as typed. `AiHttp.ApplyAuth` sends a reader-typed `Authorization` header verbatim whenever no key is stored, so that table is a complete, working way to configure a provider with its credential sitting in a file the credential store's own doc comment describes as "hand-edited, screenshotted, attached to bug reports and synced between machines". Two doc comments assert *never the credential* and nothing enforced either.

Nothing about it looked wrong to the reader. The row saves, the models list, and the failure — if it comes at all — arrives much later and from somewhere else.

**The fix.** A header row can be marked **Secret**. Its value goes to the credential store under `AiCredentialNames.Header(name)`; only the name and the mark are persisted. Both request paths fetch it at the moment they send — chat *and* the model listing, because a provider whose list loads while its answers 401 is the divergence #673 exists to prevent.

## The parts worth reviewing

**The persisted shape changed, and had to.** `AiConnectionRecord.Headers` goes from `Dictionary<string, string>` to `List<AiHeaderRecord>`. A secret header has a name and no value in that file; expressed as a dictionary plus a parallel list of which names are secret, the two can disagree — a name in both would carry a plaintext value *and* a stored secret, with nothing to say which wins. As a record list that state cannot be written down. No migration: the AI connection code postdates the beta 5 tag (`v5.0.0-beta.5` is `accd7c07`, 2026-07-28; `AiConnectionRecord` landed 2026-08-18 in #707), so there is no installed base to migrate.

**`AiHeader` nulls its own `Value` whenever `Secret`.** This came out of a mutation rather than a design instinct: I deleted the sheet's own drop of the value and *the whole suite stayed green*, because `AiConnectionService.Apply` drops it again on the way past. Two guards each believing the other is the belt is how a leak eventually gets through. Now the type refuses the state instead — a secret header carries a name and a mark, and a value cannot be constructed onto it.

**The sweep.** Renaming, unmarking or deleting a secret row moves or forgets its secret rather than stranding it, because the sheet compares what it opened with against what it is saving — the only place that difference is known. An orphaned credential is invisible by definition: nothing reads it, so nothing reports it, and it would be silently re-adopted if a connection with the same id were created again.

**Two smaller guards.** The service refuses two secret headers whose names fold to one credential name (`x.y` and `x-y` are different headers and one account — vanishingly rare, and the failure would be a 401 naming nothing, which is what #678 took a release to find). And secret values are excluded from the unresolved-`{placeholder}` scan: a credential is a literal, so a brace in one is part of the key. My own test caught that — without it, a key containing braces was refused with a message naming a placeholder that does not exist.

**Where there is nowhere to store a secret**, the mark is unavailable and the sheet says so, rather than dropping the value. The plaintext header is currently the only way to configure an authenticated provider on a platform with no credential store, which is Linux today, and taking it away in the name of security would remove the capability rather than protect it — the same exemption `CanStoreKeys == false` already earns from #761's refusal.

## What review changed

**From the session that landed #711/#764**, two points, both checked rather than taken on trust:

*The listing path was a real gap.* The chat path refused a header marked secret with nothing stored and named it; `AiModelCatalog` projected blank and sent, and the header was then dropped at the wire — a 401 naming nothing, which is the original #711 complaint arriving from a third direction. **Worse, the test I had written asserted that blank send**, so I had pinned the divergence rather than caught it. That is a worse failure than having no test, because it converts a bug into a documented contract and is invisible to a review that reads tests as evidence. Now refused pre-flight with the chat path's message, asserting nothing goes out at all.

*The keyless-Anthropic escape hatch.* `HasCredential` counts only headers with a non-blank **value** — #764's fix, after a cosmetic `X-Title` let a keyless connection through and its 401 surfaced as "the provider rejected the API key", naming a key that did not exist. A secret header is blank in `settings.json`, so #689's "leave the key empty if you manage auth via headers" survives only because `ExpandHeaders` pulls the value from the store *before* that check runs. It already did — but nothing pinned the ordering, and reversing it would defeat the escape hatch with the feature built to make it safe. Mutating `ExpandHeaders` to skip the store now fails three tests. The configuration is pinned on both surfaces and in both directions: authenticates by a secret header alone, and is refused by name when the secret is not there.

*And the flag, not just the value.* Of the seven consumers of `connection.Headers`, five are copies, and a copy is where a flag goes missing silently. Mutating `Apply` and `ToRuntime` each to drop `Secret` fails six tests apiece. Only `Add`, `AddFromPreset` and `Update` write `record.Headers`, only the editor calls them, and the model-list methods do not touch headers.

**From Fable**, four bugs — and they share a root worth stating, because it is a lesson about the tests rather than the code. My harness helper `Header(vm, name, value, secret)` always supplies a value, so **every destructive-edit test retyped it**. All three of the editing bugs below lived in the empty-value-box branch. One helper shaped three blind spots.

*Renaming a secret header destroyed the credential.* The sweep deleted the old name and the store loop skipped the row for having nothing typed, so the save reported success and every later request was refused for a secret the reader could only obtain again from the provider. The box had actively told them not to retype — it says *"stored — type to replace"*. `OriginalName` was dead code whose doc comment claimed the move was implemented; it is now.

*Unmarking with an empty box deleted the secret* and persisted an empty header that both paths then sent blank — the anonymous 401 this feature exists to remove, arriving by the door marked exit. Refused now, and the refusal text no longer says *"clear the mark to keep it in the settings file"*, which was impossible: a stored secret is never read back, so there is nothing to keep.

*Editing where there is no store stripped the mark.* A Windows profile whose data folder is briefly unwritable — the state the store's own `Unavailable` message describes — turned a stored-secret header into a blank plaintext one, orphaning the credential beyond even the delete sweep and removing the mark the missing-secret refusal fires on. The mark is data, not a capability of the machine doing the editing.

*Duplicate names became storable.* Unrepresentable as a dictionary, fine in a list, while both request paths still projected back through `ToDictionary`. The reader got "Something went wrong running that request" and "An item with the same key has already been added" — persisted across sessions with nothing pointing at the row, and reachable by the natural route of converting a plaintext header to a secret one by adding a row instead of ticking the box. Refused at the service, named on both paths, and neither projection can throw any more.

*And `AiHeader`'s invariant was narrower than its comment.* As a positional record, `header with { Secret = true }` produced a secret carrying a value — the copy constructor re-runs the initialiser only for members the `with` names. Get-only properties make that not compile.

Each fix was mutated back before being believed: exactly the five new tests fail, nothing else.

Full suite 2348 pass, 0 build warnings.
