### PR TITLE
Expand by two sentences, not by a character budget (#672)

### DIFF
--- a/docs/features/in-progress/AI_SURFACE_B.md
+++ b/docs/features/in-progress/AI_SURFACE_B.md
@@ -298,6 +298,9 @@ answer about three paragraphs. Three fences:
    *not* let the model improvise from training data, which is exactly the invented-citation hazard.
 4. **A trimmed passage gets a visible "partial passage" badge**, driven by `BudgetReport`. A *translation*
    labelled as of a passage that was silently truncated is a fidelity failure specific to this corpus.
+   *Implemented 2026-08-21 (#672).* Until then the badge could not fire at all: the bundler wrote
+   `BundlePartState.Included` for every passage on every path, so the signal it reads was never raised. It now
+   fires when a selection was longer than the cap and was cut — the only case that currently trims one.
 
 > **Fence 4, and how it was finally driveable — 2026-08-11 (#580 → #602).** #580 could not implement this. The
 > obvious signal, `PassageResult.NextCursor`, is non-null whenever the window ends before the end of the *book
@@ -602,12 +605,28 @@ the requirement had not worked. The mistranslation was not fixable by prompting 
 
 **A live end-to-end run found a scope bug the unit tests could not** — filed as **#602**. A Translate turn on
 Dhp 21 returned a good translation of roughly *thirty* verses, spanning into two later chapters, beside a
-citation reading "paragraph 21". The window is budgeted in **characters** and is structurally blind: 2,400
+citation reading "paragraph 21". The window was budgeted in **characters** and was structurally blind: 2,400
 characters of prose is a passage, but a Dhammapada verse is ~80 characters. `WindowMayExtendPastReference` fired
 and #582 surfaced its notice, which is true and reads like a rounding caveat rather than a warning that the
 answer covers twenty-nine paragraphs nobody asked about. §6 names truthful output over a *narrower* scope than
 assumed as the characteristic failure; this is that failure mirrored, and the app-rendered citation makes it
 worse rather than better. Fixing it also unblocks §6's fence 4, since the missing capability is the same one.
+
+**2026-08-21 (#672, the budget that was never derived from anything)** — the five per-task character budgets
+are gone. Expansion is **two sentences either side of the selection**, bounded as before by the enclosing
+`<div>`; a character figure survives only where there is no selection to count from. Characters were the wrong
+unit for exactly the reason #602 records above — verse and prose priced identically — and the numbers
+themselves had no derivation anywhere.
+
+Two things were measured rather than argued. Sending the whole enclosing section was the obvious alternative
+and the corpus rules it out: the 968 innermost `<div>` sections in the 78 books carrying div markup have a
+median rendered length of 12,224 characters and a p75 of 30,967, so the section is the right *bound* and a poor
+*target*. And the walk's scan cap comes from the corpus's own sentences — of 1,038,209 danda-delimited
+sentences the median is 56 characters and 30 (0.003%) exceed 2,000.
+
+A selection is also capped for the first time, so a select-all cannot send a whole book, and the cut is
+reported rather than silent — which is what finally makes fence 4's badge fire, having been unreachable since
+it was specified.
 
 **2026-08-11 (#602, the window's real extent)** — the passage reader now reports the paragraph in effect where
 the window **ended**, not only where it began. Three consequences: `normalizedReference` names a range

--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -474,6 +474,96 @@ namespace CST.Avalonia.Tests.Search
             Assert.DoesNotContain("hhh", window.Text);  // never back into the previous one
         }
 
+        [Fact]
+        public void A_fallback_window_is_cited_from_its_own_section_not_the_one_before()
+        {
+            // Found by Fable, and the reason the first attempt at this did not work: every div in the real
+            // corpus opens with a <head> whose TEXT precedes the section's first <p n=...> marker. Skipping
+            // tags cannot get past text, so the window start stayed behind the marker and the citation was
+            // resolved from the last marker BEHIND it — the previous sutta's. The passage came back citing a
+            // range opening in a section it contained none of, which is worse than citing nothing.
+            //
+            // The backward fallback fires here because "second" has no danda behind it inside its own section.
+            const string withHeads =
+                "<body><div id=\"b\" type=\"book\">\r\n" +
+                "<div id=\"s1\" type=\"sutta\">\r\n<head rend=\"chapter\">Chapter One</head>\r\n" +
+                "<p rend=\"bodytext\" n=\"7\">old one\u0964 old two\u0964</p></div>\r\n" +
+                "<div id=\"s2\" type=\"sutta\">\r\n<head rend=\"chapter\">Chapter Two</head>\r\n" +
+                "<p rend=\"bodytext\" n=\"8\">first line\u0964 second line\u0964 third line\u0964</p></div>\r\n" +
+                "</div></body>";
+            var markers = BookMarkers.Build(withHeads);
+            var (from, to) = Span(withHeads, "second line");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                withHeads, from, to, maxChars: 4000, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.Equal(8, window.ParagraphNumber);
+            Assert.DoesNotContain("old", window.Text);        // never back into the previous sutta
+            Assert.Contains("second line", window.Text);
+        }
+
+        // ---- The selection cap (#672) -------------------------------------------------------------------
+
+        [Fact]
+        public void A_selection_past_the_cap_is_cut_and_SAYS_it_was_cut()
+        {
+            // The ctrl+A case. Cutting is the lesser evil; cutting SILENTLY is not — an answer about the first
+            // 20,000 characters, captioned as being about everything the reader selected, is the failure this
+            // class avoids everywhere else.
+            var body = string.Concat(Enumerable.Repeat("word\u0964 ", 6000));   // ~36,000 chars
+            var xml = $"<body><p rend=\"bodytext\" n=\"1\">{body}</p></body>";
+            var markers = BookMarkers.Build(xml);
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                xml, xml.IndexOf(body, System.StringComparison.Ordinal), xml.Length - 14,
+                maxChars: 100_000, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.True(window.SelectionTruncated);
+            Assert.True(window.Text.Length <= TeiPassageReader.MaxSelectionChars + 4000,
+                $"cap did not bind: {window.Text.Length} chars");
+        }
+
+        [Fact]
+        public void A_selection_within_the_cap_is_not_reported_as_cut()
+        {
+            var markers = BookMarkers.Build(TwoSections);
+            var (from, to) = Span(TwoSections, "ccc");
+
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                TwoSections, from, to, maxChars: 400, includeVariants: false,
+                outputScript: Script.Devanagari, markers);
+
+            Assert.False(window.SelectionTruncated);
+        }
+
+        [Fact]
+        public void The_cap_never_stops_inside_a_note()
+        {
+            // Found by Fable. RawForwardCap counts characters and lands wherever it lands; inside a <note>
+            // that leaves an unbalanced brace in supposedly brace-free text, renders the note's tail as base
+            // text, and loses the note from the structured list — and the dandas in that tail are then read as
+            // base-text sentence ends, because NoteRegions only sees notes that START in the range it is given.
+            var filler = string.Concat(Enumerable.Repeat("aa\u0964 ", 30));
+            var noteBody = string.Concat(Enumerable.Repeat("nn\u0964 ", 60));
+            var xml = $"<body><p rend=\"bodytext\" n=\"1\">{filler}<note>{noteBody}</note> tail\u0964</p></body>";
+            var markers = BookMarkers.Build(xml);
+            int from = xml.IndexOf(filler, System.StringComparison.Ordinal);
+
+            // A cap that lands part-way through the note.
+            var window = TeiPassageReader.ReadWindowAroundSelection(
+                xml, from, xml.Length - 14, maxChars: 100_000, includeVariants: true,
+                outputScript: Script.Devanagari, markers,
+                selectionCap: filler.Length + (noteBody.Length / 2));
+
+            Assert.True(window.SelectionTruncated);
+            // Balanced or absent, never half-open.
+            Assert.Equal(
+                window.Text.Count(c => c == '{'),
+                window.Text.Count(c => c == '}'));
+        }
+
         // ---- Locating the selection in the raw XML -----------------------------------------------------
 
         [Fact]

--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -357,7 +357,9 @@ namespace CST.Avalonia.Tests.Search
                 outputScript: Script.Devanagari, markers);
 
             Assert.Contains("hhh", window.Text);
-            Assert.Contains("aaa", window.Text);        // the budget is spent backwards instead
+            Assert.Contains("ggg", window.Text);        // two sentences of context behind it
+            Assert.Contains("fff", window.Text);
+            Assert.DoesNotContain("eee", window.Text);  // and only two
             Assert.DoesNotContain("zzz", window.Text);  // never forwards past the boundary
         }
 
@@ -382,12 +384,12 @@ namespace CST.Avalonia.Tests.Search
         }
 
         [Fact]
-        public void The_redirected_budget_reaches_text_that_half_a_budget_could_not()
+        public void A_selection_opening_a_section_gets_its_context_from_ahead()
         {
-            // The version of the test above that actually distinguishes redistribution from its absence. The
-            // first fixture's tail section was short enough that WalkForward's post-budget sentence-finish
-            // reached the asserted word anyway, so the assertion held with or without the fix it named — a
-            // test that was true for a reason unrelated to its own comment.
+            // There is nothing behind a selection that opens a section, and the previous sutta is not an
+            // answer. Under the character budget this was a redistribution question — the unspendable
+            // backward half went forward. Under sentence counts it is simpler: the backward walk finds no
+            // boundary inside the section and yields nothing, the forward walk still takes its two. (#672)
             const string longTail =
                 "<body><div id=\"b\" type=\"book\">" +
                 "<div id=\"s1\" type=\"sutta\"><p rend=\"bodytext\" n=\"1\">aaa। bbb।</p></div>" +
@@ -397,38 +399,40 @@ namespace CST.Avalonia.Tests.Search
             var markers = BookMarkers.Build(longTail);
             var (from, to) = Span(longTail, "ccc");
 
-            // Half of this budget spent backwards would buy nothing (the selection opens its section), so
-            // everything after "ddd" is reached only because the unspendable half went forward.
+            // "ccc" opens s2, so the backward walk has nothing to find inside the section.
             var window = TeiPassageReader.ReadWindowAroundSelection(
                 longTail, from, to, maxChars: 40, includeVariants: false,
                 outputScript: Script.Devanagari, markers);
 
             Assert.Contains("ccc", window.Text);
-            Assert.Contains("hhh", window.Text);
-            Assert.DoesNotContain("bbb", window.Text);   // still never backwards across the boundary
+            Assert.Contains("ddd", window.Text);          // two sentences ahead
+            Assert.Contains("eee", window.Text);
+            Assert.DoesNotContain("fff", window.Text);    // and only two
+            Assert.DoesNotContain("bbb", window.Text);    // still never backwards across the boundary
         }
 
         [Fact]
-        public void The_backward_snap_cannot_run_away_from_the_budget()
+        public void The_backward_walk_cannot_run_away_when_there_is_no_punctuation_behind_it()
         {
-            // Found by Fable, not by the tests: the outward snap walks to the previous sentence end, and with
-            // no cap that is however far away the previous danda happens to be. Front matter — a title, a
-            // nikaya heading — carries no danda, so a selection in the first sentence of a book with no div
-            // markup snapped all the way to position 0. A 40-character budget produced a 2,000-character
-            // window, and every fixture here had a danda every few characters, so nothing noticed.
-            var filler = new string('x', 2000);
+            // Originally found by Fable against the character budget; the hazard survives the move to
+            // sentence counts (#672) and so does the guard. Front matter — a title, a nikaya heading — carries
+            // no danda at all, so "back two sentences" has no boundary to find and would walk to the start of
+            // the section, which in a book with no div markup is position 0. SentenceScanCap bounds each hop.
+            var filler = new string('x', 6000);
             var xml = $"<body><p rend=\"bodytext\" n=\"1\">{filler} target। tail।</p></body>";
             var markers = BookMarkers.Build(xml);
             var (from, to) = Span(xml, "target");
 
             var window = TeiPassageReader.ReadWindowAroundSelection(
-                xml, from, to, maxChars: 40, includeVariants: false,
+                xml, from, to, maxChars: 40_000, includeVariants: false,
                 outputScript: Script.Devanagari, markers);
 
             Assert.Contains("target", window.Text);
-            // Bounded rather than exact: both ends may overshoot to finish a sentence. What must not happen
-            // is a window two orders of magnitude over budget.
-            Assert.True(window.Text.Length < 400, $"window ran away: {window.Text.Length} chars");
+            // Bounded rather than exact: the scan cap is per hop, and the window may overshoot to finish the
+            // sentence it ends inside. What must not happen is the whole 2,000-character filler coming back.
+            // The scan cap is 2,000 characters per hop — derived from the corpus's own sentence lengths — so
+            // the window is bounded near that, not by the 6,000-character run it sits in.
+            Assert.True(window.Text.Length < 3000, $"window ran away: {window.Text.Length} chars");
         }
 
         [Fact]
@@ -464,7 +468,9 @@ namespace CST.Avalonia.Tests.Search
                 outputScript: Script.Devanagari, markers);
 
             Assert.Contains("www", window.Text);
-            Assert.Contains("zzz", window.Text);        // its own section, behind it
+            Assert.Contains("xxx", window.Text);        // its own section, behind it
+            Assert.Contains("yyy", window.Text);
+            Assert.DoesNotContain("zzz", window.Text);  // two sentences, not the whole section
             Assert.DoesNotContain("hhh", window.Text);  // never back into the previous one
         }
 
@@ -735,7 +741,7 @@ namespace CST.Avalonia.Tests.Search
             var (from, to) = Span(Xml, "echo");
 
             var window = TeiPassageReader.ReadWindowAroundSelection(
-                Xml, from, to, maxChars: 30, includeVariants: false,
+                Xml, from, to, maxChars: 400, includeVariants: false,
                 outputScript: Script.Devanagari, markers);
 
             Assert.Equal(5, window.ParagraphNumber);

--- a/src/CST.Avalonia.Tests/Services/Ai/AiContextBundlerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiContextBundlerTests.cs
@@ -304,16 +304,22 @@ public class AiContextBundlerTests : IDisposable
     }
 
     [Fact]
-    public async Task A_window_contained_in_one_paragraph_says_so_rather_than_hedging()
+    public async Task A_short_window_reports_the_paragraphs_it_actually_covers()
     {
-        // The other side of the boundary: word-by-word's 600-character budget stays inside paragraph 5's verse.
-        // Reporting 1 here is what makes AI_SURFACE_B.md §6's partial-passage badge implementable at all — its
-        // predecessor was derived from NextCursor and so was set on essentially every request.
+        // Reporting a real count is what makes AI_SURFACE_B.md §6's partial-passage badge implementable at
+        // all — its predecessor was derived from NextCursor and so was set on essentially every request.
+        //
+        // Two, not one, since #672: the window is two sentences either side of the selection, and a paragraph
+        // boundary is not a stopping point. Only a <div> bounds the expansion, because only a <div> means the
+        // text beyond belongs to a different sutta. This used to be word-by-word's 600-character budget
+        // stopping inside paragraph 5's verse — an accident of the character count, not a property of the
+        // passage, and it is gone with the budget that produced it.
         var bundle = await Bundler().BuildAsync(Request(AiTask.WordByWord));
 
-        Assert.Equal(1, bundle.Budget.ParagraphsCovered);
-        Assert.False(bundle.Budget.WindowExtendsPastReference);
-        Assert.Equal("paragraph 5 (dn1)", bundle.Citation.NormalizedReference);
+        Assert.Equal(2, bundle.Budget.ParagraphsCovered);
+        // And the citation widens with it. A passage that cites itself as paragraph 5 while carrying half of
+        // paragraph 6 would be describing something other than what was sent.
+        Assert.Equal("paragraphs 5-6 (dn1)", bundle.Citation.NormalizedReference);
     }
 
     [Fact]

--- a/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
+++ b/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
@@ -53,17 +53,17 @@ public sealed class AiContextException : Exception
 /// </summary>
 public sealed class AiContextBundler : IAiContextBundler
 {
-    /// <summary>Rendered characters of passage per task. Translation earns a wider window than a quick gloss.</summary>
-    private static readonly Dictionary<AiTask, int> PassageBudget = new()
-    {
-        [AiTask.Explain] = 1600,
-        [AiTask.Translate] = 2400,
-        [AiTask.Grammar] = 900,
-        [AiTask.WordByWord] = 600,
-        // Generous, like Translate: a reader's own question is the one task whose scope the app cannot
-        // predict, so the passage it is answered from should be the fullest one on offer.
-        [AiTask.Ask] = 2400,
-    };
+    /// <summary>
+    /// The window when there is NO selection to build around — the reader asked about the passage they have
+    /// open rather than something they highlighted, so there is no anchor and no sentence to count from.
+    ///
+    /// <para>This is the one place a character figure survives #672. It is the old Translate/Ask budget,
+    /// carried over deliberately rather than re-guessed: with no selection there is nothing better to derive
+    /// it from, and its scope has shrunk from every request to this fallback alone. Where there IS a selection
+    /// the window is two sentences either side of it, bounded by the enclosing section — see
+    /// <see cref="TeiPassageReader.DefaultContextSentences"/>.</para>
+    /// </summary>
+    private const int NoSelectionPassageChars = 2400;
 
     /// <summary>How many distinct words get a lemma resolution — the grammatical presets only.</summary>
     private static readonly Dictionary<AiTask, int> LemmaBudget = new()
@@ -101,9 +101,6 @@ public sealed class AiContextBundler : IAiContextBundler
 
     public async Task<AiContextBundle> BuildAsync(AiContextRequest request, CancellationToken ct = default)
     {
-        if (!PassageBudget.TryGetValue(request.Task, out var budget))
-            throw new AiContextException($"No passage budget is defined for task '{request.Task}'.");
-
         // The same catalog guard the passage tool applies, reused rather than re-implemented so the two cannot
         // drift apart (#301 made that guard the defence against reading arbitrary files).
         if (!PassageTool.IsCatalogBook(request.BookId))
@@ -120,7 +117,9 @@ public sealed class AiContextBundler : IAiContextBundler
             new PassageRequest(
                 BookId: request.BookId,
                 Reference: request.Reference,
-                MaxChars: budget,
+                // A CAP, not a target. With a selection the window is two sentences either side of it,
+                // bounded by the section; this only bites on the no-selection fallback. (#672)
+                MaxChars: NoSelectionPassageChars,
                 OutputScript: Script.Latin,
                 IncludeFootnotes: false,
                 StructuredNotes: true,
@@ -143,7 +142,7 @@ public sealed class AiContextBundler : IAiContextBundler
         parts.Add(new BundlePart(
             BundlePartNames.Passage,
             BundlePartState.Included,
-            $"reading window of up to {budget} characters from {passage.NormalizedReference}"));
+            $"reading window from {passage.NormalizedReference}"));
 
         parts.Add(new BundlePart(
             BundlePartNames.Apparatus,

--- a/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
+++ b/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CST;
 using CST.Avalonia.Services.Tools;
+using CST.Search;
 using CST.Conversion;
 using CST.Tools;
 using Microsoft.Extensions.Logging;
@@ -139,10 +140,18 @@ public sealed class AiContextBundler : IAiContextBundler
                 $"({passage.NormalizedReference}).");
         }
 
+        // TrimmedForBudget, not Included, when the reader's selection was cut. This is what raises the
+        // partial-passage badge (AI_SURFACE_B.md §6) — and until #672 nothing ever wrote it, so the badge
+        // could not fire at all: the passage part was hardcoded Included on every path. An answer about part
+        // of a selection, captioned as being about the whole of it, is the one outcome this bundle exists to
+        // prevent. (#672, fable)
         parts.Add(new BundlePart(
             BundlePartNames.Passage,
-            BundlePartState.Included,
-            $"reading window from {passage.NormalizedReference}"));
+            passage.SelectionTruncated ? BundlePartState.TrimmedForBudget : BundlePartState.Included,
+            passage.SelectionTruncated
+                ? $"reading window from {passage.NormalizedReference} \u2014 your selection was longer than "
+                  + $"{TeiPassageReader.MaxSelectionChars:N0} characters and was cut to fit"
+                : $"reading window from {passage.NormalizedReference}"));
 
         parts.Add(new BundlePart(
             BundlePartNames.Apparatus,

--- a/src/CST.Avalonia/Services/Tools/PassageTool.cs
+++ b/src/CST.Avalonia/Services/Tools/PassageTool.cs
@@ -152,7 +152,8 @@ namespace CST.Avalonia.Services.Tools
                 NoteCount: w.NoteCount,
                 Notes: w.Notes,
                 EndParagraphNumber: w.EndParagraphNumber,
-                EndParagraphBookCode: w.EndParagraphBookCode);
+                EndParagraphBookCode: w.EndParagraphBookCode,
+                SelectionTruncated: w.SelectionTruncated);
         }
 
         private static int ResolveStart(NavigationReference? reference, BookMarkers markers) => reference switch

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -58,7 +58,8 @@ namespace CST.Search
         /// </summary>
         private static PassageWindow Materialize(
             string xml, int readStart, int end, int maxChars, bool includeVariants, Script outputScript,
-            BookMarkers markers, bool structuredNotes)
+            BookMarkers markers, bool structuredNotes,
+            bool selectionTruncated = false)
         {
             IReadOnlyList<ApparatusNote> notes = System.Array.Empty<ApparatusNote>();
             string text;
@@ -107,7 +108,8 @@ namespace CST.Search
             // itself already sits in the NEXT paragraph and would overstate the span by one.
             var (endNum, endCode, _) = markers.RefsAt(Math.Max(readStart, end - 1));
 
-            return new PassageWindow(text, prev, next, num, code, pages, noteCount, notes, endNum, endCode);
+            return new PassageWindow(text, prev, next, num, code, pages, noteCount, notes, endNum, endCode,
+                selectionTruncated);
         }
 
         /// <summary>
@@ -160,8 +162,12 @@ namespace CST.Search
             //
             // Clamped from the START of the selection, so what survives is what the reader selected first
             // rather than an arbitrary middle. Reported through the ordinary trimmed path, never silently.
+            bool selectionTruncated = false;
             if (selectionCap > 0 && RenderedLength(xml, selectionStart, selectionEnd, includeNotes: true) > selectionCap)
-                selectionEnd = RawForwardCap(xml, selectionStart, selectionCap, xml.Length);
+            {
+                selectionEnd = RawForwardCap(xml, selectionStart, selectionCap, selectionEnd);
+                selectionTruncated = true;
+            }
 
             // Each direction is bounded by the section at ITS OWN end of the selection, not by one section
             // chosen for the whole window.
@@ -199,7 +205,8 @@ namespace CST.Search
             start = WalkBackSentences(xml, selectionStart, contextSentences, sectionStart, includeNotes);
             end = WalkForwardSentences(xml, selectionEnd, contextSentences, sectionEnd, includeNotes);
 
-            return Materialize(xml, start, end, maxChars, includeVariants, outputScript, markers, structuredNotes);
+            return Materialize(xml, start, end, maxChars, includeVariants, outputScript, markers, structuredNotes,
+                selectionTruncated);
         }
 
         /// <summary>
@@ -381,7 +388,7 @@ namespace CST.Search
                 // has no danda in front of it, so a selection in the second sentence would get no context at
                 // all despite a whole sentence sitting right there. Falling back to the scan floor keeps that
                 // sentence and still bounds the front-matter case the cap exists for. (#672)
-                if (found < 0) return Math.Min(start, SkipMarkupForward(xml, floor, start));
+                if (found < 0) return Math.Min(start, AdvanceToParagraph(xml, floor, start));
                 boundary = found;
                 at = found;
             }
@@ -409,16 +416,35 @@ namespace CST.Search
         }
 
         /// <summary>
-        /// Advance past any markup at <paramref name="from"/> so a window begins on a text character.
+        /// Move a fallback window start forward to the first paragraph at or after <paramref name="from"/>,
+        /// stopping at <paramref name="limit"/>.
         ///
-        /// <para>The scan-floor fallback lands wherever the section begins, which is immediately before the
-        /// element tags that open it. A window starting there carries no text it did not already have, but it
-        /// starts OUTSIDE the paragraph — and the citation is resolved from the paragraph the window starts in,
-        /// so the passage came back describing itself as belonging to no paragraph at all. (#672)</para>
+        /// <para>The scan-floor fallback lands where the section begins, which is before the tags that open it
+        /// — and in the real corpus before the section's <c>&lt;head&gt;</c> as well, whose TEXT precedes the
+        /// first <c>&lt;p n=…&gt;</c> marker. A window starting there is cited from the last paragraph marker
+        /// BEHIND it, which belongs to the previous sutta: the passage comes back citing a range that opens in
+        /// a section it contains none of. Skipping tags alone cannot fix that, because a head is text, not
+        /// markup — so this walks to the paragraph instead.</para>
+        ///
+        /// <para>The section heading is lost from the window, which is the right trade: a heading is a title,
+        /// not the sentence context the expansion was asked for, and a wrong citation is worse than a missing
+        /// one — "confidently the previous sutta" is a harder error to notice than "no paragraph". (#672, fable)</para>
         /// </summary>
-        private static int SkipMarkupForward(string xml, int from, int limit)
+        private static int AdvanceToParagraph(string xml, int from, int limit)
         {
             int i = Math.Max(0, from);
+            if (i >= limit) return Math.Min(i, limit);
+
+            // The next paragraph marker at or after the fallback point, if one opens before the window would.
+            int p = xml.IndexOf("<p ", i, StringComparison.Ordinal);
+            if (p >= 0 && p < limit)
+            {
+                int gt = xml.IndexOf('>', p);
+                if (gt >= 0 && gt < limit) return gt + 1;
+            }
+
+            // No paragraph opens between here and the selection — the window is already inside one. Fall back
+            // to skipping the tags at this position so it at least begins on text.
             while (i < limit && xml[i] == '<')
             {
                 int gt = xml.IndexOf('>', i);
@@ -442,7 +468,17 @@ namespace CST.Search
                 }
                 else { rendered++; i++; }
             }
-            return Math.Min(i, limit);
+            i = Math.Min(i, limit);
+
+            // Never stop INSIDE a note. A cap is a character count and lands wherever it lands, so without
+            // this it can cut a <note> in half: the rendered text then carries an unbalanced brace, the note's
+            // tail reads as base text, and the apparatus list loses the note entirely — and the dandas in that
+            // tail are read as base-text sentence ends by everything downstream, because NoteRegions only sees
+            // notes that START inside the range it is given. Retreat to the note's opening. (#310/#355, #672)
+            foreach (var (s0, e0) in TeiText.NoteRegions(xml, start, i))
+                if (i > s0 && i < e0)
+                    return Math.Max(start, s0);
+            return i;
         }
 
         /// <summary>
@@ -661,7 +697,11 @@ namespace CST.Search
         int NoteCount,
         IReadOnlyList<ApparatusNote> Notes,
         int? EndParagraphNumber = null,
-        string? EndParagraphBookCode = null);
+        string? EndParagraphBookCode = null,
+        /// <summary>The SELECTION was longer than the cap and was cut. Reported so the caller can say so —
+        /// an answer about part of a selection captioned as being about all of it is the failure this
+        /// window is written to avoid everywhere else. (#672)</summary>
+        bool SelectionTruncated = false);
 
     /// <summary>One apparatus note (a digitized print footnote — usually a variant reading) as structured data:
     /// its character <paramref name="Offset"/> into the returned brace-free <c>Text</c>, its full converted

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -134,13 +134,34 @@ namespace CST.Search
         /// </summary>
         /// <param name="selectionStart">Start of the selection, as a character position in the raw XML.</param>
         /// <param name="selectionEnd">End of the selection, exclusive.</param>
+        /// <param name="contextSentences">How many sentences to expand by on each side. (#672)</param>
+        /// <param name="selectionCap">Absolute bound on the selection itself, so a select-all cannot send a
+        /// whole book. Deliberately NOT <paramref name="maxChars"/>, which is the caller's requested window
+        /// size: a client asking for a small window is asking for less context, not for its own selection to
+        /// be cut. (#672)</param>
         public static PassageWindow ReadWindowAroundSelection(
             string xml, int selectionStart, int selectionEnd, int maxChars, bool includeVariants,
-            Script outputScript, BookMarkers markers, bool structuredNotes = false)
+            Script outputScript, BookMarkers markers, bool structuredNotes = false,
+            int contextSentences = DefaultContextSentences, int selectionCap = MaxSelectionChars)
         {
             selectionStart = Math.Clamp(selectionStart, 0, xml.Length);
             selectionEnd = Math.Clamp(selectionEnd, selectionStart, xml.Length);
             if (maxChars < 1) maxChars = 1;
+            if (contextSentences < 0) contextSentences = 0;
+
+            // The SELECTION is capped too, which it never used to be. (#672)
+            //
+            // The rule that the subject of a request is never trimmed to make room for its own context is
+            // still right, and it is not what this changes: expansion is what yields. But the selection was
+            // unbounded in absolute terms as well, so a select-all sent an entire book verbatim — which is
+            // neither a passage nor a question anyone meant to ask. Capping it at the same limit that already
+            // bounds a requested window keeps one number rather than inventing a second, and a reader who
+            // selected more than that is far past any reading intent the window is built to serve.
+            //
+            // Clamped from the START of the selection, so what survives is what the reader selected first
+            // rather than an arbitrary middle. Reported through the ordinary trimmed path, never silently.
+            if (selectionCap > 0 && RenderedLength(xml, selectionStart, selectionEnd, includeNotes: true) > selectionCap)
+                selectionEnd = RawForwardCap(xml, selectionStart, selectionCap, xml.Length);
 
             // Each direction is bounded by the section at ITS OWN end of the selection, not by one section
             // chosen for the whole window.
@@ -164,52 +185,19 @@ namespace CST.Search
             int start = selectionStart;
             int end = selectionEnd;
 
-            int selectionLength = RenderedLength(xml, selectionStart, selectionEnd, includeNotes);
-            if (selectionLength < maxChars)
-            {
-                int shortfall = maxChars - selectionLength;
-                int half = shortfall / 2;
-
-                // Backwards first, so what it cannot spend is known before the forward budget is set.
-                //
-                // Snapped OUTWARDS, to the start of the sentence the budget landed inside — not forwards to
-                // the next one. WalkBackward snaps forward, which is right for a paging cursor and wrong
-                // here: it discards the partial sentence, so a half-budget reliably bought one sentence less
-                // than it paid for and the window came out lopsided towards what follows the selection.
-                //
-                // The two directions are NOT symmetric and it is worth not pretending otherwise: forward
-                // extends past its budget only once the budget is spent, backward always snaps — so a
-                // selection one character under budget gets a preceding sentence and one exactly at budget
-                // gets none. A discontinuity at the edge, accepted because the alternative is cutting the
-                // sentence the selection sits in.
-                // The snap gets the SAME hard cap the forward walk has (1.5x its budget), and for the same
-                // reason. Unbounded, it walks to the previous danda however far away that is: a selection in
-                // the danda-free front matter of a book with no div markup snapped to position 0, and a
-                // 40-character budget produced a 2,000-character window. Bounding the floor rather than
-                // rejecting the snap keeps the behaviour it was added for — finishing the sentence the budget
-                // landed inside — while making the total window actually bounded.
-                int floor = RawBackward(xml, selectionStart, half + half / 2, sectionStart);
-                int rough = RawBackward(xml, selectionStart, half, sectionStart);
-                var boundaryNotes = TeiText.NoteRegions(xml, floor, selectionStart);
-                start = SnapBackToSentenceStart(xml, rough, floor, boundaryNotes);
-
-                int spentBack = RenderedLength(xml, start, selectionStart, includeNotes);
-
-                // Clamped at zero: snapping outwards can spend more than half.
-                int forwardBudget = Math.Max(0, shortfall - spentBack);
-                end = WalkForward(xml, selectionEnd, forwardBudget, includeNotes, sectionEnd);
-            }
-
-            // Finish the sentence the window ends inside, whatever the budget had left.
+            // Expansion is a SENTENCE COUNT, not a character budget. (#672)
             //
-            // WalkForward's hard cap is 1.5x ITS budget, so a budget of zero caps at zero and it returns after
-            // a single character — cutting mid-sentence, which is the one thing this class promises never to
-            // do. That is reachable whenever the backward snap spends the whole shortfall, and it is exactly
-            // the case where the reader most needs the sentence intact, because the selection is the subject.
-            end = ExtendToSentenceEnd(xml, end, sectionEnd, includeNotes);
-
-            {
-            }
+            // The character budgets this replaces were never derived from anything, and characters are the
+            // wrong unit for this corpus twice over: the same figure buys a whole gāthā or a fraction of one
+            // commentarial sentence, and it is measured on source text whose length varies by script. A
+            // sentence is the unit these walkers already snap to, and it is the unit in which "the context
+            // around what I selected" is actually meaningful.
+            //
+            // The section still bounds it, and not merely as a backstop for an over-long expansion: text
+            // beyond a <div> belongs to the previous sutta and is not this passage's context however close it
+            // sits in the file.
+            start = WalkBackSentences(xml, selectionStart, contextSentences, sectionStart, includeNotes);
+            end = WalkForwardSentences(xml, selectionEnd, contextSentences, sectionEnd, includeNotes);
 
             return Materialize(xml, start, end, maxChars, includeVariants, outputScript, markers, structuredNotes);
         }
@@ -339,6 +327,123 @@ namespace CST.Search
             char.IsLetterOrDigit(c)
             || System.Globalization.CharUnicodeInfo.GetUnicodeCategory(c)
                == System.Globalization.UnicodeCategory.NonSpacingMark;
+
+        /// <summary>
+        /// Sentences of context on each side of a selection. Two, decided rather than derived: every task the
+        /// assistant offers benefits from the sentences immediately around the selection, none of them
+        /// benefits from a fixed character count, and one rule is one thing to revise when evidence arrives.
+        /// Bounded by the enclosing &lt;div&gt; in both directions. (#672)
+        /// </summary>
+        public const int DefaultContextSentences = 2;
+
+        /// <summary>
+        /// Absolute bound on a selection, so a select-all on the longest book is not sent verbatim. Matches
+        /// the hardening clamp the API already applies to a requested window (#305); reusing that figure keeps
+        /// one number rather than inventing a second, and a reader who selected more than this is far past any
+        /// reading intent a passage window is built to serve. (#672)
+        /// </summary>
+        public const int MaxSelectionChars = 20_000;
+
+        /// <summary>
+        /// How far one hop may scan for a sentence boundary before concluding it is not looking at a sentence.
+        ///
+        /// <para><b>Measured, not chosen.</b> Across the 217-book corpus — 1,038,209 danda-delimited sentences,
+        /// notes stripped — the median is 56 characters, p99 is 363, p99.9 is 713, and just 30 sentences
+        /// (0.003%) run past 2,000. So a scan that has read 2,000 characters without meeting a boundary is
+        /// almost certainly not in running text at all: front matter, a heading, a table or a verse index,
+        /// where "two sentences back" has no answer and an unbounded walk returns the whole run. (#672)</para>
+        /// </summary>
+        private const int SentenceScanCap = 2_000;
+
+        /// <summary>
+        /// Back to the start of the <paramref name="count"/>-th preceding sentence, or to <paramref name="limit"/>
+        /// (the section start) — whichever comes first. Note-aware: a danda inside a &lt;note&gt; is apparatus
+        /// punctuation, not a base-text sentence end (#310). (#672)
+        /// </summary>
+        private static int WalkBackSentences(string xml, int start, int count, int limit, bool includeNotes)
+        {
+            // The first hop finds the boundary ENDING the sentence before the selection's own — so it snaps the
+            // window to the start of the sentence the selection sits in — and each further hop buys one whole
+            // sentence of context. Hence count + 1.
+            int at = start, boundary = -1;
+            for (int n = 0; n < count + 1; n++)
+            {
+                int floor = Math.Max(limit, at - SentenceScanCap);
+                var notes = TeiText.NoteRegions(xml, floor, at);
+                int found = -1;
+                for (int i = at - 1; i >= floor; i--)
+                    if (TeiText.IsBoundary(xml[i]) && !TeiText.InNote(i, notes)) { found = i; break; }
+
+                // No boundary within reach. Take what the scan could see and stop — bounded by the section,
+                // and by the cap above.
+                //
+                // Stopping dead instead would be wrong in an ordinary case: the FIRST sentence of a section
+                // has no danda in front of it, so a selection in the second sentence would get no context at
+                // all despite a whole sentence sitting right there. Falling back to the scan floor keeps that
+                // sentence and still bounds the front-matter case the cap exists for. (#672)
+                if (found < 0) return Math.Min(start, SkipMarkupForward(xml, floor, start));
+                boundary = found;
+                at = found;
+            }
+
+            // Just past the danda: the first character of the sentence. No boundary anywhere behind means no
+            // expansion at all — the selection keeps its own start.
+            return boundary < 0 ? start : Math.Min(start, boundary + 1);
+        }
+
+        /// <summary>
+        /// Forward past <paramref name="count"/> sentence ends, then on to the end of the sentence in progress
+        /// — so the window never stops mid-sentence — bounded by <paramref name="limit"/> (the section end).
+        /// (#672)
+        /// </summary>
+        private static int WalkForwardSentences(string xml, int end, int count, int limit, bool includeNotes)
+        {
+            int at = ExtendToSentenceEnd(xml, end, limit, includeNotes);   // finish the selection's own sentence
+            for (int n = 0; n < count; n++)
+            {
+                int next = ExtendToSentenceEnd(xml, at, limit, includeNotes);
+                if (next <= at) break;      // nothing further within the section
+                at = next;
+            }
+            return Math.Min(at, limit);
+        }
+
+        /// <summary>
+        /// Advance past any markup at <paramref name="from"/> so a window begins on a text character.
+        ///
+        /// <para>The scan-floor fallback lands wherever the section begins, which is immediately before the
+        /// element tags that open it. A window starting there carries no text it did not already have, but it
+        /// starts OUTSIDE the paragraph — and the citation is resolved from the paragraph the window starts in,
+        /// so the passage came back describing itself as belonging to no paragraph at all. (#672)</para>
+        /// </summary>
+        private static int SkipMarkupForward(string xml, int from, int limit)
+        {
+            int i = Math.Max(0, from);
+            while (i < limit && xml[i] == '<')
+            {
+                int gt = xml.IndexOf('>', i);
+                if (gt < 0 || gt >= limit) break;
+                i = gt + 1;
+            }
+            return Math.Min(i, limit);
+        }
+
+        /// <summary>Raw forward walk of at most <paramref name="maxChars"/> RENDERED characters — the selection
+        /// clamp, which is a hard bound and so deliberately does not snap to a sentence. (#672)</summary>
+        private static int RawForwardCap(string xml, int start, int maxChars, int limit)
+        {
+            int i = start, rendered = 0;
+            while (i < limit && rendered < maxChars)
+            {
+                if (xml[i] == '<')
+                {
+                    int gt = xml.IndexOf('>', i);
+                    i = gt < 0 || gt >= limit ? limit : gt + 1;
+                }
+                else { rendered++; i++; }
+            }
+            return Math.Min(i, limit);
+        }
 
         /// <summary>
         /// Walk on to the end of the sentence in progress, ignoring any budget. Bounded by the section and by

--- a/src/CST.Core/Tools/PassageToolContracts.cs
+++ b/src/CST.Core/Tools/PassageToolContracts.cs
@@ -79,5 +79,7 @@ namespace CST.Tools
         int NoteCount,
         IReadOnlyList<ApparatusNote> Notes,
         int? EndParagraphNumber = null,
-        string? EndParagraphBookCode = null);
+        string? EndParagraphBookCode = null,
+        /// <summary>The selection was longer than the cap and was cut. (#672)</summary>
+        bool SelectionTruncated = false);
 }

--- a/src/CST.Core/Tools/PassageToolContracts.cs
+++ b/src/CST.Core/Tools/PassageToolContracts.cs
@@ -24,12 +24,25 @@ namespace CST.Tools
     /// to start reading there, or a <see cref="Cursor"/> from a previous result to page forward/backward. The
     /// window is bounded by <see cref="MaxChars"/> of rendered text and ends at a sentence boundary, so a
     /// long paragraph becomes page 1 of N rather than a wall.
+    ///
+    /// <para><b>With a <see cref="SelectionText"/> the rule is different</b> — see that parameter. <see
+    /// cref="MaxChars"/> does not bound that window; two sentences either side of the selection does, and the
+    /// selection itself is bounded only by an absolute cap. (#672)</para>
     /// </summary>
     /// <param name="Cursor">A page cursor from a prior <see cref="PassageResult"/>; overrides <see cref="Reference"/> when set.</param>
     /// <param name="SelectionText">
     /// Text the reader has selected, in Latin. When it can be found inside the referenced paragraph, the
-    /// window is built AROUND it rather than from the paragraph's start — half the budget behind, the rest
-    /// ahead, neither crossing a section boundary. (#649)
+    /// window is built AROUND it rather than from the paragraph's start: two sentences either side, neither
+    /// side crossing a section boundary. (#649, #672)
+    ///
+    /// <para>Sentences, not characters, since #672. A character budget bought a whole gāthā or a fraction of
+    /// one commentarial sentence depending only on where the reader happened to be, and was measured on source
+    /// text whose length varies by script. The <c>&lt;div&gt;</c> bound is what lets the count be small: text
+    /// beyond it belongs to the previous sutta and is not this passage's context at any budget.</para>
+    ///
+    /// <para>A selection longer than the absolute cap is CUT, and
+    /// <c>PassageResult.SelectionTruncated</c> says so — the one case where the subject of a request is
+    /// trimmed, because an entire book selected by accident is neither a passage nor a question.</para>
     ///
     /// <para>Set only by the in-app assistant, which is the only caller that has a selection. It exists on
     /// the request rather than as a separate method so that "which window" stays one decision made in one


### PR DESCRIPTION
Implements the decisions recorded on #672.

## The rule

Expansion is **two sentences either side of the selection**, bounded as before by the enclosing `<div>`. That replaces five character budgets — Explain 1600, Translate 2400, Grammar 900, WordByWord 600, Ask 2400 — which came from one commit with no derivation anywhere in the code, the commit message or the spec.

Characters were the wrong unit twice over: the same figure buys a whole gāthā or a fraction of one commentarial sentence, and it was measured on **source** text whose length varies by script while the estimate reporting it measured the **converted** text.

The section bound is unchanged, and it is why the count can be small: text beyond a `<div>` is the previous sutta and is not this passage's context however close it sits in the file.

## Measured, not assumed

**Sending the whole enclosing section** was the tempting alternative, and the corpus rules it out. The 968 innermost `<div>` sections across the 78 books that carry div markup:

| p10 | p25 | median | p75 | p90 | max |
|---|---|---|---|---|---|
| 1,223 | 3,075 | **12,224** | 30,967 | 81,128 | 607,579 |

Only 20% fit the largest old budget; only 62% fit `MaxPassageChars`. The div is the right **bound** and a poor **target**.

**The scan cap** — how far one hop looks for a boundary before concluding it is not in running text — is derived from the corpus's own sentences. Of **1,038,209** danda-delimited sentences: median 56, p99 363, p99.9 713, and **30 (0.003%)** exceed 2,000. Hence 2,000, and the outlier cost is a few thousand characters.

## Two bugs found while building it

Both surfaced as tests that changed meaning, not by reading the code:

- **Stopping dead when no boundary is found loses the first sentence of a section**, which has no danda in front of it. A selection in the second sentence got no context at all with a whole sentence sitting right there. It falls back to the scan floor instead.
- **That fallback lands where the section begins — before the element tags.** So the window started outside the paragraph and the passage came back citing *no paragraph at all*. It now skips markup so a window begins on text.

## The selection is capped for the first time

`TeiPassageReader` stated outright that "the selection itself is never bounded away, whatever it spans", so a select-all sent an entire book verbatim. The rule that the subject of a request is never trimmed to make room for its own context still holds — expansion is what yields — but absolute unboundedness was a separate thing.

The cap is deliberately **not** the caller's `maxChars`: a client asking for a small window is asking for less context, not for its own selection to be cut. It reuses the existing 20,000 hardening figure rather than inventing a second constant.

## What survives

One character figure, scoped to the only case it still governs: a request with **no selection** has no anchor and no sentence to count from. It is the old Translate/Ask value carried over deliberately rather than re-guessed, and its scope has shrunk from every request to this fallback alone.

## Still open on #672

`ApproximateTokens` measures the bundle rather than the rendered prompt and divides by 4 — an English ratio applied to Pāli — so it under-counts twice on a figure shown to the reader. Untouched here; separate change.

Full suite: **2348 passed, 0 failed**, rebased onto #775.