### PR TITLE
Windows/Linux: add File > Exit (#778)

### DIFF
--- a/src/CST.Avalonia.Tests/Views/SimpleTabbedWindowMenuTests.cs
+++ b/src/CST.Avalonia.Tests/Views/SimpleTabbedWindowMenuTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using CST.Avalonia.Views;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Views;
+
+/// <summary>
+/// The window menu's markup and the code that reaches into it at runtime. (#778)
+///
+/// <para>Three items are added from C# rather than declared in <c>SimpleTabbedWindow.axaml</c>, because macOS
+/// supplies them in the application menu and an item declared in the window's markup would appear on both:
+/// Tools &gt; Settings (#28), Help &gt; About (#746), and File &gt; Exit (#778). Each one finds its parent menu
+/// by matching a header string against the markup.</para>
+///
+/// <para>That coupling is invisible when it breaks. Reword a header in the XAML and the lookup finds nothing:
+/// the item is simply never added, the menu still opens, everything still looks right, and the only trace is a
+/// warning in a log nobody reads. Same class of silent failure that earned
+/// <c>App.AboutMenuHeader</c> its test.</para>
+/// </summary>
+public class SimpleTabbedWindowMenuTests
+{
+    private static string WindowMarkup()
+    {
+        var path = Path.Combine(RepoRoot(), "src", "CST.Avalonia", "Views", "SimpleTabbedWindow.axaml");
+        Assert.True(File.Exists(path), path);
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void The_File_menu_header_matches_the_constant_the_code_looks_it_up_by()
+    {
+        // AddExitMenuItemOffMacOS walks the window's NativeMenu for this exact header. If the markup no longer
+        // carries it, Exit stops being added and Windows loses its only in-menu way to quit.
+        Assert.Contains(
+            $"Header=\"{SimpleTabbedWindow.FileMenuHeader}\"",
+            WindowMarkup(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Exit_is_not_declared_in_the_markup()
+    {
+        // It must be added from code, not XAML. An Exit declared here would also appear on macOS, where
+        // quitting belongs in the application menu as Quit - duplicating it and putting it somewhere the
+        // platform does not use. This is the assertion that would catch someone "simplifying" the code-side
+        // construction back into the markup.
+        Assert.DoesNotContain("Header=\"Exit\"", WindowMarkup(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_menus_the_code_reaches_into_are_all_present()
+    {
+        // The other two runtime-added items depend on the same kind of lookup, by "Tools" and "File". Pinning
+        // them here means a markup rename fails a test rather than quietly removing a menu item.
+        var markup = WindowMarkup();
+
+        Assert.Contains("Header=\"File\"", markup, StringComparison.Ordinal);
+        Assert.Contains("Header=\"Tools\"", markup, StringComparison.Ordinal);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.cs
@@ -67,6 +67,8 @@ public partial class SimpleTabbedWindow : Window
         AddSettingsMenuItemOffMacOS();
         // #746: same story for About, which macOS keeps in the application menu.
         AddHelpMenuOffMacOS();
+        // #778: and Exit, which macOS keeps there as Quit.
+        AddExitMenuItemOffMacOS();
 
         // #621 Feed C: record which document owns whatever just took focus, so a command pressed after a
         // detour through a tool still targets the pane the user was working in. Bubbling and passive — it
@@ -875,6 +877,81 @@ public partial class SimpleTabbedWindow : Window
         catch (Exception ex)
         {
             _logger.Error(ex, "Failed to add the Settings menu item");
+        }
+    }
+
+    /// <summary>
+    /// The File menu's header, as declared in <c>SimpleTabbedWindow.axaml</c>. (#778)
+    ///
+    /// <para>XAML cannot reference a C# const, so the markup carries the string literally and
+    /// <see cref="AddExitMenuItemOffMacOS"/> matches against this. Reword the markup and the lookup finds
+    /// nothing: Exit silently stops being added, and the only trace is a warning in a log nobody reads.
+    /// <c>SimpleTabbedWindowMenuTests</c> is what keeps the two in step - the same treatment
+    /// <c>App.AboutMenuHeader</c> gets for the same reason.</para>
+    /// </summary>
+    internal const string FileMenuHeader = "File";
+
+    /// <summary>
+    /// Adds File &gt; Exit on Windows/Linux. (#778)
+    ///
+    /// <para>Third in the family with <see cref="AddSettingsMenuItemOffMacOS"/> and
+    /// <see cref="AddHelpMenuOffMacOS"/>, for the same underlying reason: macOS keeps quitting in the
+    /// APPLICATION menu (CST Reader &gt; Quit, supplied by the OS), and Avalonia only ever realises that menu
+    /// on macOS. Off macOS the in-window menu bar shows the window's menu, where nothing offered a way out -
+    /// the File menu ended at Close Tab, which is an easy thing to reach for by mistake when what you wanted
+    /// was to leave.</para>
+    ///
+    /// <para>Built here rather than in SimpleTabbedWindow.axaml because an item declared there would also
+    /// appear on macOS, duplicating Quit and putting it somewhere the platform does not use.</para>
+    ///
+    /// <para><b>Routed through <c>TryShutdown</c>, never <c>Shutdown</c> or <c>Close</c>.</b> Only
+    /// TryShutdown raises ShutdownRequested, which is where the graceful sequence lives - await the state
+    /// save, then dispose services. App.axaml.cs records what the shortcut costs: the old path fired the save
+    /// and hard-shutdown on top of it, racing the write against process exit (XCUT-1). An Exit that skipped
+    /// that would drop layout, open tabs and reading positions intermittently, and would present as "it
+    /// sometimes forgets where I was" rather than as anything to do with this menu.</para>
+    /// </summary>
+    private void AddExitMenuItemOffMacOS()
+    {
+        if (OperatingSystem.IsMacOS()) return;
+
+        try
+        {
+            var fileMenu = NativeMenu.GetMenu(this)?
+                .Items.OfType<NativeMenuItem>()
+                .FirstOrDefault(i => i.Header?.ToString() == FileMenuHeader)?.Menu;
+
+            if (fileMenu == null)
+            {
+                _logger.Warning("File menu not found - Exit will be reachable only via the window close button");
+                return;
+            }
+
+            var exitItem = new NativeMenuItem
+            {
+                Header = "Exit",
+                // Display only, and true: the window manager provides Alt+F4, and this being the main window
+                // means closing it shuts the application down (ShutdownMode.OnMainWindowClose). Nothing is
+                // bound here - NativeMenuBar gestures are decorative off macOS anyway.
+                Gesture = new KeyGesture(Key.F4, KeyModifiers.Alt),
+            };
+            exitItem.Click += (_, _) =>
+            {
+                _logger.Information("Exit chosen from the File menu");
+                // Fully qualified to match the four other lifetime checks in this file, which avoid a
+                // using for it.
+                if (global::Avalonia.Application.Current?.ApplicationLifetime
+                    is global::Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
+                    desktop.TryShutdown();
+            };
+
+            fileMenu.Add(new NativeMenuItemSeparator());
+            fileMenu.Add(exitItem);
+            _logger.Information("Added File > Exit (macOS quits from the application menu instead)");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Failed to add the Exit menu item");
         }
     }
 


### PR DESCRIPTION
Closes #778.

The File menu had no way to quit — it ended at *Close Tab*, which is an easy thing to reach for by mistake when what you wanted was to leave. The only routes out were the title-bar X and Alt+F4: both work, neither is where a Windows user looks.

## Third in a family

Same shape and same cause as **Tools > Settings** (#28) and **Help > About** (#746). macOS keeps all three in the *application* menu, which Avalonia only ever realises on macOS — so off macOS the declaration is never shown and the item simply does not exist.

Built in code rather than in `SimpleTabbedWindow.axaml` for the same reason as its siblings: an item declared in the window's markup would also appear on macOS, duplicating Quit and putting it somewhere the platform does not use.

## `TryShutdown`, never `Shutdown` or `Close`

Only `TryShutdown` raises `ShutdownRequested`, which is where the graceful sequence lives — await the state save, then dispose services. `App.axaml.cs:355` records what the shortcut costs:

> The old path fired the save fire-and-forget and then hard-Shutdown()'d, racing the save against process exit. (XCUT-1)

An Exit that skipped that would drop layout, open tabs and reading positions **intermittently** — presenting as *"it sometimes forgets where I was"* rather than as anything to do with this menu.

## Alt+F4 as the accelerator

Display-only — `NativeMenuBar` gestures are decorative off macOS — but also **true**: this is the main window, and `ShutdownMode.OnMainWindowClose` means closing it shuts the application down. Matches VS Code, the reference application for this app's Windows UX.

## A constant instead of a literal

The lookup that finds the File menu now matches `SimpleTabbedWindow.FileMenuHeader`. Reword the header in the markup and the lookup finds nothing: Exit is never added, the menu still opens, everything still looks right, and the only trace is a warning in a log nobody reads.

That is the same silent-failure shape that earned `App.AboutMenuHeader` its test, so it gets the same treatment — 3 tests over the markup, including one asserting **Exit is not declared in XAML**, which is what would catch someone moving the code-side construction back into the markup.

## Verified on Windows 11 ARM64

All three builders log on startup:

```
Added Tools > Settings (macOS shows Preferences in the application menu instead)
Added Help > About (macOS shows it in the application menu instead)
Added File > Exit (macOS quits from the application menu instead)
```

And a graceful close runs the sequence `TryShutdown` enters:

```
SHUTDOWN: ShutdownRequested event triggered
Application state saved successfully to ...pplication-state.json
Disposing ApplicationStateService - performing final save
SHUTDOWN: All cleanup completed, proceeding with shutdown
```

One honest caveat: that last was exercised through the window-close trigger rather than by clicking the menu item — both converge on the same `ShutdownRequested` handler, but the click itself is the part I could not automate.

**2340 pass, 0 warnings.**
