### PR TITLE
Support and expose reasoning effort (#671)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -128,10 +128,11 @@ public class AiChatOrchestratorTests
 
     // ---- Fixture ------------------------------------------------------------------------------------------
 
-    private static ISettingsService Settings(string language = "English")
+    private static ISettingsService Settings(string language = "English", string? reasoningEffort = null)
     {
         var settings = new Settings();
         settings.Ai.Chat.AnswerLanguage = language;
+        settings.Ai.Chat.ReasoningEffort = reasoningEffort;
         var mock = new Mock<ISettingsService>();
         mock.SetupGet(s => s.Settings).Returns(settings);
         return mock.Object;
@@ -142,7 +143,8 @@ public class AiChatOrchestratorTests
         string? notConfigured = null,
         IAiContextBundler? bundler = null,
         string language = "English",
-        IAiConnectionService? connections = null)
+        IAiConnectionService? connections = null,
+        string? reasoningEffort = null)
     {
         // A store pointed at a directory that does not exist: no user override can be picked up, so every test
         // runs against the shipped templates.
@@ -154,7 +156,7 @@ public class AiChatOrchestratorTests
             new FixedResolver(provider, notConfigured),
             bundler ?? new StubBundler(),
             new PromptBuilder(templates),
-            Settings(language),
+            Settings(language, reasoningEffort),
             NullLogger<AiChatOrchestrator>.Instance,
             connections);
     }
@@ -598,5 +600,76 @@ public class AiChatOrchestratorTests
         // Including every gathered part, present or absent: an absence is as much a part of what was sent as
         // a presence, and much harder to notice.
         Assert.Contains(sent.Fields, f => f.Name.StartsWith("Part: "));
+    }
+
+    // ---- reasoning effort (#671) ------------------------------------------------------------------------
+
+    /// <summary>A connection whose single model publishes the levels named.</summary>
+    private static (IAiConnectionService Service, string Id) ConnectedOffering(params string[] efforts)
+    {
+        var settings = new CST.Avalonia.Models.Settings();
+        var mock = new Mock<ISettingsService>();
+        mock.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(mock.Object);
+        service.Add("mine", new AiConnectionDraft(
+            "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
+            // The id the FixedResolver reports, deliberately: the guard matches the model the request is
+            // actually going to, so a fixture whose model is named anything else proves nothing.
+            new[] { new AiModelEntry("test-model", "M", ReasoningEfforts: efforts) },
+            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
+        service.SetActive("mine", "test-model");
+        return (service, "mine");
+    }
+
+    [Fact]
+    public async Task A_chosen_effort_the_model_publishes_is_sent()
+    {
+        var provider = new FakeProvider();
+        var (connections, _) = ConnectedOffering("low", "high");
+
+        await CollectAsync(Orchestrator(provider, connections: connections, reasoningEffort: "high"));
+
+        Assert.Equal("high", provider.LastRequest!.ReasoningEffort);
+    }
+
+    /// <summary>
+    /// The guard that makes the setting safe to keep. A reader chooses "high" on a model that offers it, then
+    /// switches to one that publishes nothing — the stale choice must not go out, because an unsupported
+    /// parameter can be a 400 rather than an ignored key. The picker hiding the control is presentation; this
+    /// is the part that has to be right, which is why it is checked at the last point before the wire.
+    /// </summary>
+    [Fact]
+    public async Task A_chosen_effort_the_model_does_not_publish_is_not_sent()
+    {
+        var provider = new FakeProvider();
+        var (connections, _) = ConnectedOffering();   // publishes no levels at all
+
+        await CollectAsync(Orchestrator(provider, connections: connections, reasoningEffort: "high"));
+
+        Assert.Null(provider.LastRequest!.ReasoningEffort);
+    }
+
+    /// <summary>A value outside the model's published vocabulary is not sent either — "medium" is real at
+    /// most providers and absent at DeepSeek, which offers low/high/max.</summary>
+    [Fact]
+    public async Task An_effort_outside_the_models_vocabulary_is_not_sent()
+    {
+        var provider = new FakeProvider();
+        var (connections, _) = ConnectedOffering("low", "high", "max");
+
+        await CollectAsync(Orchestrator(provider, connections: connections, reasoningEffort: "medium"));
+
+        Assert.Null(provider.LastRequest!.ReasoningEffort);
+    }
+
+    [Fact]
+    public async Task No_effort_chosen_sends_none()
+    {
+        var provider = new FakeProvider();
+        var (connections, _) = ConnectedOffering("low", "high");
+
+        await CollectAsync(Orchestrator(provider, connections: connections));
+
+        Assert.Null(provider.LastRequest!.ReasoningEffort);
     }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -615,7 +615,12 @@ public class AiChatOrchestratorTests
             "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
             // The id the FixedResolver reports, deliberately: the guard matches the model the request is
             // actually going to, so a fixture whose model is named anything else proves nothing.
-            new[] { new AiModelEntry("test-model", "M", ReasoningEfforts: efforts) },
+            // Empty maps to NULL, which is the state that actually occurs: a provider that published no
+            // parameter list at all - every local runner, and every hosted listing that carries only ids.
+            // The helper used to hand down an empty array instead, so the null branch of the guard was never
+            // exercised and the mutant `== true` -> `!= false` passed every test here. (fable review)
+            new[] { new AiModelEntry("test-model", "M",
+                                     ReasoningEfforts: efforts.Length == 0 ? null : efforts) },
             Array.Empty<AiHeader>(), new Dictionary<string, string>()));
         service.SetActive("mine", "test-model");
         return (service, "mine");
@@ -638,13 +643,43 @@ public class AiChatOrchestratorTests
     /// parameter can be a 400 rather than an ignored key. The picker hiding the control is presentation; this
     /// is the part that has to be right, which is why it is checked at the last point before the wire.
     /// </summary>
+    /// <summary>
+    /// The majority case: the provider published no parameter list at all, so <c>ReasoningEfforts</c> is
+    /// NULL rather than empty. Every local runner is this, and so is every hosted listing that carries only
+    /// ids. Silence is not permission.
+    /// </summary>
     [Fact]
-    public async Task A_chosen_effort_the_model_does_not_publish_is_not_sent()
+    public async Task A_chosen_effort_is_not_sent_to_a_model_whose_provider_published_nothing()
     {
         var provider = new FakeProvider();
-        var (connections, _) = ConnectedOffering();   // publishes no levels at all
+        var (connections, _) = ConnectedOffering();   // null, not empty
 
         await CollectAsync(Orchestrator(provider, connections: connections, reasoningEffort: "high"));
+
+        Assert.Null(provider.LastRequest!.ReasoningEffort);
+    }
+
+    /// <summary>
+    /// And the neighbouring state: a published reasoning capability carrying no levels. models.dev counts
+    /// 1,301 models like this — reasoning models with no knob. Distinct from null in the data and identical
+    /// in what it permits, which is nothing.
+    /// </summary>
+    [Fact]
+    public async Task A_chosen_effort_is_not_sent_to_a_model_publishing_an_empty_level_list()
+    {
+        var provider = new FakeProvider();
+
+        var settings = new CST.Avalonia.Models.Settings();
+        var mock = new Mock<ISettingsService>();
+        mock.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(mock.Object);
+        service.Add("mine", new AiConnectionDraft(
+            "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
+            new[] { new AiModelEntry("test-model", "M", ReasoningEfforts: Array.Empty<string>()) },
+            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
+        service.SetActive("mine", "test-model");
+
+        await CollectAsync(Orchestrator(provider, connections: service, reasoningEffort: "high"));
 
         Assert.Null(provider.LastRequest!.ReasoningEffort);
     }

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -445,4 +445,85 @@ public class AiModelCatalogTests
             new[] { "secret-only-credential" },
             handler.LastRequest!.Headers.GetValues("x-api-key"));
     }
+
+    // ---- reasoning effort (#671) ------------------------------------------------------------------------
+
+    /// <summary>
+    /// The published levels and the provider's own default, read from the richer object OpenRouter carries
+    /// beside the flat parameter list. That object is what answers "which values, and which is the default";
+    /// the flat list only answers "is the knob there".
+    /// </summary>
+    [Fact]
+    public void Published_effort_levels_and_default_are_read()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"id":"m","name":"M","supported_parameters":["reasoning_effort"],
+                  "reasoning":{"supported_efforts":["low","high","max"],"default_effort":"high","mandatory":false}}]}
+        """);
+
+        var model = Assert.Single(models);
+        Assert.Equal(new[] { "low", "high", "max" }, model.ReasoningEfforts);
+        Assert.Equal("high", model.DefaultReasoningEffort);
+        Assert.False(model.ReasoningIsMandatory);
+    }
+
+    /// <summary>
+    /// The correction this issue turned up. The old predicate matched any parameter containing "reasoning",
+    /// which catches `reasoning` and `include_reasoning` — both meaning the model RETURNS reasoning content,
+    /// not that it takes an effort knob. Measured against OpenRouter's live listing, 287 models matched and
+    /// only 142 list reasoning_effort: 51% false positives. Gating the effort chip on the loose test would
+    /// have put it on 145 models that publish no such parameter.
+    /// </summary>
+    [Fact]
+    public void Emitting_reasoning_is_not_the_same_as_accepting_an_effort_parameter()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"id":"m","name":"M","supported_parameters":["reasoning","include_reasoning"]}]}
+        """);
+
+        var model = Assert.Single(models);
+        Assert.True(model.SupportsReasoning);        // it does emit reasoning
+        Assert.False(model.AcceptsReasoningEffort);  // and it does NOT take the knob
+    }
+
+    [Fact]
+    public void A_model_that_lists_reasoning_effort_accepts_it()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"id":"m","name":"M","supported_parameters":["reasoning","reasoning_effort"]}]}
+        """);
+
+        Assert.True(Assert.Single(models).AcceptsReasoningEffort);
+    }
+
+    /// <summary>Silence stays silence. A provider that publishes no parameter list has not said no.</summary>
+    [Fact]
+    public void A_provider_that_publishes_no_parameters_says_nothing_about_effort()
+    {
+        var models = AiModelCatalog.Parse("""{"data":[{"id":"m","name":"M"}]}""");
+
+        var model = Assert.Single(models);
+        Assert.Null(model.AcceptsReasoningEffort);
+        Assert.Null(model.ReasoningEfforts);
+        Assert.Null(model.DefaultReasoningEffort);
+    }
+
+    /// <summary>
+    /// #670/#681: the same OpenRouter objects carry benchmark scores on 229 of 420 models. Provider-published,
+    /// so it passes the letter of "a published capability is fine" while being unambiguously a ranking. This
+    /// pins that the parser does not pick it up as one more fact when someone widens it.
+    /// </summary>
+    [Fact]
+    public void Published_benchmark_scores_are_not_read()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"id":"m","name":"M",
+                  "benchmarks":{"artificial_analysis":{"intelligence_index":59.5,"coding_index":74.8}}}]}
+        """);
+
+        var model = Assert.Single(models);
+        var serialised = System.Text.Json.JsonSerializer.Serialize(model);
+        Assert.DoesNotContain("59.5", serialised, StringComparison.Ordinal);
+        Assert.DoesNotContain("intelligence", serialised, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -464,7 +464,6 @@ public class AiModelCatalogTests
         var model = Assert.Single(models);
         Assert.Equal(new[] { "low", "high", "max" }, model.ReasoningEfforts);
         Assert.Equal("high", model.DefaultReasoningEffort);
-        Assert.False(model.ReasoningIsMandatory);
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
@@ -753,6 +753,86 @@ public class OpenAiCompatibleProviderTests
         Assert.Contains("reasoning effort", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>The code arm alone, with the field named nowhere in the prose.</summary>
+    [Fact]
+    public async Task A_rejection_is_recognised_from_the_code_without_naming_the_field()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            """{"error":{"code":"unsupported_value","message":"reasoning is not available on this model"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(
+            () => CollectAsync(Provider(handler), Request() with { ReasoningEffort = "high" }));
+
+        Assert.Equal(AiErrorKind.UnsupportedParameter, error.Error.Kind);
+    }
+
+    /// <summary>The prose arm alone, with a code we do not list — many compatible providers put their reason
+    /// in the message rather than in a machine-readable field.</summary>
+    [Fact]
+    public async Task A_rejection_is_recognised_from_prose_naming_the_field()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            """{"error":{"code":"invalid_params","message":"reasoning_effort must be one of low, high"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(
+            () => CollectAsync(Provider(handler), Request() with { ReasoningEffort = "medium" }));
+
+        Assert.Equal(AiErrorKind.UnsupportedParameter, error.Error.Kind);
+    }
+
+    /// <summary>
+    /// A listed code on a 400 about something else entirely. Without the reasoning conjunct the reader is
+    /// told to change the effort control because an unrelated parameter was rejected.
+    /// </summary>
+    [Fact]
+    public async Task A_rejection_of_some_other_parameter_is_not_blamed_on_effort()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            """{"error":{"code":"unsupported_parameter","message":"Unsupported parameter: 'temperature'"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(
+            () => CollectAsync(Provider(handler), Request() with { ReasoningEffort = "high" }));
+
+        Assert.NotEqual(AiErrorKind.UnsupportedParameter, error.Error.Kind);
+    }
+
+    /// <summary>
+    /// The generic type OpenAI puts on nearly every 400, on a body that mentions reasoning for an unrelated
+    /// reason — 32+ OpenRouter models publish mandatory reasoning, and such refusals say so in prose. Treating
+    /// this as an effort rejection sends the reader to change the one control they recently touched while the
+    /// real cause persists. (fable review)
+    /// </summary>
+    [Fact]
+    public async Task A_generic_bad_request_mentioning_reasoning_is_not_blamed_on_effort()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            """{"error":{"type":"invalid_request_error","message":"this reasoning model requires max_tokens above the thinking budget"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(
+            () => CollectAsync(Provider(handler), Request() with { ReasoningEffort = "high" }));
+
+        Assert.NotEqual(AiErrorKind.UnsupportedParameter, error.Error.Kind);
+    }
+
+    /// <summary>Not a 400 at all: a 429 whose body happens to name the field is a rate limit, and telling the
+    /// reader to change a setting would be wrong in a way that wastes their next hour.</summary>
+    [Fact]
+    public async Task A_rate_limit_mentioning_the_field_stays_a_rate_limit()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.TooManyRequests,
+            """{"error":{"code":"unsupported_parameter","message":"reasoning_effort quota exceeded"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(
+            () => CollectAsync(Provider(handler), Request() with { ReasoningEffort = "high" }));
+
+        Assert.Equal(AiErrorKind.RateLimited, error.Error.Kind);
+    }
+
     /// <summary>
     /// The same 400 on a request that carried no effort is NOT attributed to effort. Without the guard, every
     /// unrelated bad request would tell the reader to change a setting they never touched.

--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
@@ -700,4 +700,72 @@ public class OpenAiCompatibleProviderTests
         Assert.Equal("Appamada is heedfulness.", Text(deltas));
         Assert.Equal("The user asks.", Reasoning(deltas));
     }
+
+    // ---- reasoning effort (#671) ------------------------------------------------------------------------
+
+    /// <summary>
+    /// The default, and the one that matters most: nothing chosen means the field is absent, not sent as a
+    /// default value. Support is per-model, and an unknown field can be a 400 rather than an ignored key —
+    /// the same failure mode as the sampling parameters that are the reason there is no temperature control.
+    /// Every existing connection must keep working exactly as it did.
+    /// </summary>
+    [Fact]
+    public async Task No_effort_chosen_sends_no_reasoning_effort_field()
+    {
+        var handler = StubHttpMessageHandler.Sse("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n");
+
+        await CollectAsync(Provider(handler));
+
+        using var body = JsonDocument.Parse(handler.LastRequestBody);
+        Assert.False(body.RootElement.TryGetProperty("reasoning_effort", out _));
+    }
+
+    /// <summary>The reader's chosen value goes out verbatim — it came from a list the provider published for
+    /// this model, so translating it here could only make it wrong.</summary>
+    [Fact]
+    public async Task A_chosen_effort_is_sent_verbatim()
+    {
+        var handler = StubHttpMessageHandler.Sse("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n");
+
+        await CollectAsync(Provider(handler), Request() with { ReasoningEffort = "xhigh" });
+
+        using var body = JsonDocument.Parse(handler.LastRequestBody);
+        Assert.Equal("xhigh", body.RootElement.GetProperty("reasoning_effort").GetString());
+    }
+
+    /// <summary>
+    /// #671's stated alternative to predicting support: report a rejection rather than maintain a list of
+    /// which models will reject. Left as a bare Provider error the reader is told "the provider rejected the
+    /// request (HTTP 400)" about a request that worked yesterday, with nothing pointing at the control they
+    /// changed.
+    /// </summary>
+    [Fact]
+    public async Task A_rejected_effort_is_named_rather_than_reported_as_a_bare_400()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            """{"error":{"code":"unsupported_parameter","message":"Unsupported parameter: 'reasoning_effort'"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(
+            () => CollectAsync(Provider(handler), Request() with { ReasoningEffort = "high" }));
+
+        Assert.Equal(AiErrorKind.UnsupportedParameter, error.Error.Kind);
+        Assert.Contains("reasoning effort", error.Error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The same 400 on a request that carried no effort is NOT attributed to effort. Without the guard, every
+    /// unrelated bad request would tell the reader to change a setting they never touched.
+    /// </summary>
+    [Fact]
+    public async Task A_400_on_a_request_that_sent_no_effort_is_not_blamed_on_effort()
+    {
+        var handler = StubHttpMessageHandler.Error(
+            HttpStatusCode.BadRequest,
+            """{"error":{"code":"unsupported_parameter","message":"Unsupported parameter: 'reasoning_effort'"}}""");
+
+        var error = await Assert.ThrowsAsync<AiException>(() => CollectAsync(Provider(handler)));
+
+        Assert.NotEqual(AiErrorKind.UnsupportedParameter, error.Error.Kind);
+    }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -544,6 +544,80 @@ public class AiModelPickerViewModelTests
     }
 
     /// <summary>
+    /// A choice made on another model is outside this one's vocabulary, so the wire guard drops it and the
+    /// provider applies its own default. The flyout has to say that: keying the default row off "is anything
+    /// stored" left NO row ticked, showing an unmarked list for a setting that does have an effect. The chip
+    /// label and the flyout must agree, because they describe the same fact. (fable review)
+    /// </summary>
+    [Fact]
+    public void A_choice_from_another_models_vocabulary_leaves_provider_default_current()
+    {
+        var (picker, _, settings) = MakeEffort("low", "medium", "high");
+        settings.Ai.Chat.ReasoningEffort = "max";   // real at DeepSeek, absent here
+        picker.Rebuild();
+
+        Assert.True(picker.Choices.First().IsCurrent);
+        Assert.DoesNotContain(picker.Choices.Skip(1), c => c.IsCurrent);
+        Assert.Equal("Effort: default", picker.CurrentLabel);
+    }
+
+    /// <summary>
+    /// The one dynamic behaviour the chip exists for. Every other test here builds the picker after the world
+    /// is already set up, so removing the ConnectionsChanged subscription would leave them all green while
+    /// the chip went stale on every model switch — offering the previous model's levels. (fable review)
+    /// </summary>
+    [Fact]
+    public void The_chip_follows_a_switch_to_a_model_with_different_levels()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object, new FakeCredentialStore());
+        service.Add("mine", new AiConnectionDraft(
+            "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
+            new[]
+            {
+                new AiModelEntry("a", "A", ReasoningEfforts: new[] { "low", "high" }),
+                new AiModelEntry("b", "B", ReasoningEfforts: new[] { "minimal", "medium" }),
+            },
+            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
+        service.SetActive("mine", "a");
+
+        var picker = new AiEffortPickerViewModel(service, svc.Object);
+        Assert.Equal(new[] { "Provider default", "low", "high" }, picker.Choices.Select(c => c.Label));
+
+        service.SetActive("mine", "b");
+
+        Assert.Equal(new[] { "Provider default", "minimal", "medium" }, picker.Choices.Select(c => c.Label));
+    }
+
+    /// <summary>And it disappears entirely when the reader switches to a model that published nothing.</summary>
+    [Fact]
+    public void The_chip_hides_itself_on_a_switch_to_a_model_with_no_levels()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object, new FakeCredentialStore());
+        service.Add("mine", new AiConnectionDraft(
+            "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
+            new[]
+            {
+                new AiModelEntry("a", "A", ReasoningEfforts: new[] { "low", "high" }),
+                new AiModelEntry("b", "B"),
+            },
+            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
+        service.SetActive("mine", "a");
+
+        var picker = new AiEffortPickerViewModel(service, svc.Object);
+        Assert.True(picker.HasChoices);
+
+        service.SetActive("mine", "b");
+
+        Assert.False(picker.HasChoices);
+    }
+
+    /// <summary>
     /// The provider's own statement of its default is shown against that position rather than acted on: not
     /// sending the field already means exactly that, so preselecting a level would send something where
     /// nothing was asked for.

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -467,4 +467,105 @@ public class AiModelPickerViewModelTests
         Assert.Equal("not responding", group.Note);
         Assert.Single(group.Models);
     }
+
+    // ---- the effort chip (#671) -------------------------------------------------------------------------
+
+    private static (AiEffortPickerViewModel Picker, AiConnectionService Service, Settings Settings)
+        MakeEffort(params string[] efforts)
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object, new FakeCredentialStore());
+        service.Add("mine", new AiConnectionDraft(
+            "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
+            new[] { new AiModelEntry("m", "M", ReasoningEfforts: efforts.Length == 0 ? null : efforts) },
+            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
+        service.SetActive("mine", "m");
+        return (new AiEffortPickerViewModel(service, svc.Object), service, settings);
+    }
+
+    /// <summary>
+    /// Hidden where the model published no levels — which is most models. A chip that is always present but
+    /// empty would imply the app knows something about a model it knows nothing about, and #671 is explicit
+    /// that the alternative to publishing is not guessing: it is saying nothing.
+    /// </summary>
+    [Fact]
+    public void The_effort_chip_is_hidden_when_the_model_publishes_no_levels()
+    {
+        var (picker, _, _) = MakeEffort();
+
+        Assert.False(picker.HasChoices);
+    }
+
+    [Fact]
+    public void The_effort_chip_offers_the_models_own_levels_and_nothing_else()
+    {
+        var (picker, _, _) = MakeEffort("low", "high", "max");
+
+        Assert.True(picker.HasChoices);
+        Assert.Equal(
+            new[] { "Provider default", "low", "high", "max" },
+            picker.Choices.Select(c => c.Label));
+    }
+
+    /// <summary>Provider default is first, sends nothing, and is where an untouched setting sits.</summary>
+    [Fact]
+    public void Provider_default_is_first_and_current_until_something_is_chosen()
+    {
+        var (picker, _, _) = MakeEffort("low", "high");
+
+        var first = picker.Choices.First();
+        Assert.Null(first.Value);
+        Assert.True(first.IsCurrent);
+        Assert.Equal("Effort: default", picker.CurrentLabel);
+    }
+
+    [Fact]
+    public void Choosing_a_level_records_it_and_shows_it_on_the_chip()
+    {
+        var (picker, _, settings) = MakeEffort("low", "high");
+
+        picker.Choices.Single(c => c.Label == "high").ChooseCommand.Execute().Subscribe();
+
+        Assert.Equal("high", settings.Ai.Chat.ReasoningEffort);
+        Assert.Equal("Effort: high", picker.CurrentLabel);
+    }
+
+    [Fact]
+    public void Choosing_provider_default_again_clears_the_setting()
+    {
+        var (picker, _, settings) = MakeEffort("low", "high");
+        picker.Choices.Single(c => c.Label == "high").ChooseCommand.Execute().Subscribe();
+
+        picker.Choices.First().ChooseCommand.Execute().Subscribe();
+
+        Assert.Null(settings.Ai.Chat.ReasoningEffort);
+    }
+
+    /// <summary>
+    /// The provider's own statement of its default is shown against that position rather than acted on: not
+    /// sending the field already means exactly that, so preselecting a level would send something where
+    /// nothing was asked for.
+    /// </summary>
+    [Fact]
+    public void A_published_default_is_shown_as_a_hint_not_preselected()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object, new FakeCredentialStore());
+        service.Add("mine", new AiConnectionDraft(
+            "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
+            new[] { new AiModelEntry("m", "M", ReasoningEfforts: new[] { "low", "high" },
+                                     DefaultReasoningEffort: "high") },
+            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
+        service.SetActive("mine", "m");
+
+        var picker = new AiEffortPickerViewModel(service, svc.Object);
+
+        Assert.Contains("high", picker.Choices.First().Hint);
+        Assert.True(picker.Choices.First().IsCurrent);       // still the default position
+        Assert.Null(settings.Ai.Chat.ReasoningEffort);       // and still sends nothing
+    }
 }

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -77,7 +77,9 @@ namespace CST.Avalonia.Models.Ai
         int? ContextLength = null,
         bool? SupportsReasoning = null,
         string? Inputs = null,
-        bool Missing = false);
+        bool Missing = false,
+        IReadOnlyList<string>? ReasoningEfforts = null,
+        string? DefaultReasoningEffort = null);
 
     /// <summary>
     /// One extra request header on a connection. (#711, #771)

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -104,6 +104,18 @@ namespace CST.Avalonia.Models
         /// (AI_SURFACE_B.md §9). Not optional in the bundle: "translate" has to mean translate into something.
         /// </summary>
         public string AnswerLanguage { get; set; } = "English";
+
+        /// <summary>
+        /// The reasoning effort the reader has chosen, in the provider's own vocabulary, or null for "let the
+        /// provider apply its default". (#671)
+        ///
+        /// <para>One setting rather than one per model, because it is a preference about how the reader wants
+        /// to trade cost against depth, not a property of any particular model. It is <b>validated against the
+        /// active model's published list at the moment a request is built</b> — so a value left over from a
+        /// model that accepted it is simply not sent to one that did not publish it, rather than becoming a
+        /// 400 the reader cannot attribute.</para>
+        /// </summary>
+        public string? ReasoningEffort { get; set; }
     }
 
     /// <summary>
@@ -207,6 +219,24 @@ namespace CST.Avalonia.Models
         /// <summary>What the model accepts, as the provider words it — "text", "text, image". Null when it
         /// said nothing.</summary>
         public string? Inputs { get; set; }
+
+        /// <summary>
+        /// The reasoning-effort values this model published, in the provider's own words and order. (#671)
+        ///
+        /// <para>Stored for the same reason <see cref="ContextLength"/> is: the listing is fetched only on the
+        /// Models tab and only while that window is open, so anything the per-turn picker needs has to have
+        /// been written down when the reader promoted the model.</para>
+        ///
+        /// <para><b>Null and empty are different.</b> Null is a provider that said nothing — every local
+        /// runner, and every hosted provider whose listing carries only ids. Empty is a provider that
+        /// published a reasoning capability with no effort levels in it. Neither gets a control: there is
+        /// nothing to offer, and inventing low/medium/high would be this app deciding what the levels are.</para>
+        /// </summary>
+        public List<string>? ReasoningEfforts { get; set; }
+
+        /// <summary>The value the provider says it applies when none is sent, or null where it does not say.
+        /// Shown as a label on the "Provider default" position — its word, not a choice of ours. (#671)</summary>
+        public string? DefaultReasoningEffort { get; set; }
 
         /// <summary>
         /// Whether the provider's listing no longer carries this model. (#728)

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -88,6 +88,13 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
     /// <summary>
     /// The reasoning effort to send, or null to send none. (#671)
     ///
+    /// <para><b>Read at resolution time, not at send time.</b> Bundling the context is asynchronous and can
+    /// take seconds, and the active connection is mutable throughout — the chip is right there in the
+    /// composer. Reading it afterwards meant validating against whatever connection was active by then while
+    /// sending on the provider resolved at the start, so a reader who switched connections mid-turn could
+    /// have an effort validated against one model and sent to another. Two ordinary reads of mutable state
+    /// seconds apart is all it takes. (fable review)</para>
+    ///
     /// <para><b>Validated here rather than trusted from the setting</b>, because this is the last point before
     /// the wire and the only one that knows which model the request is actually going to. A reader who chooses
     /// "high" on a model that offers it and then switches to one that does not would otherwise send a field
@@ -182,6 +189,11 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
             yield break;
         }
 
+        // Read here, beside the resolution it is validated against, rather than at send time - see
+        // ReasoningEffortFor. Bundling below is asynchronous, and the chip that changes this sits in the
+        // composer the reader is looking at. (#671)
+        var effort = ReasoningEffortFor(provider.Model);
+
         var language = _settings.Settings.Ai.Chat.AnswerLanguage;
         if (string.IsNullOrWhiteSpace(language)) language = "English";
 
@@ -265,7 +277,7 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
             prompt.MaxOutputTokens,
             prompt.System,
             new[] { new ChatMessage(ChatRole.User, prompt.UserContent) },
-            ReasoningEffortFor(provider.Model));
+            effort);
 
         var markers = new PaliQuoteFilter();
         int? inputTokens = null, outputTokens = null;

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -85,6 +85,32 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
     /// </summary>
     private readonly IAiConnectionService? _connections;
 
+    /// <summary>
+    /// The reasoning effort to send, or null to send none. (#671)
+    ///
+    /// <para><b>Validated here rather than trusted from the setting</b>, because this is the last point before
+    /// the wire and the only one that knows which model the request is actually going to. A reader who chooses
+    /// "high" on a model that offers it and then switches to one that does not would otherwise send a field
+    /// that model never published — and an unsupported parameter can be a 400 rather than an ignored key. The
+    /// picker not offering it is presentation; this is the part that has to be right.</para>
+    ///
+    /// <para>Matched against what the provider published for THIS model, ordinally: the vocabularies differ
+    /// between providers and a value is only meaningful in the list it came from.</para>
+    /// </summary>
+    private string? ReasoningEffortFor(string model)
+    {
+        var chosen = _settings.Settings.Ai.Chat.ReasoningEffort;
+        if (string.IsNullOrWhiteSpace(chosen)) return null;
+        if (_connections?.Active is not { } connection) return null;
+
+        var entry = connection.Models.FirstOrDefault(
+            m => string.Equals(m.Id, model, StringComparison.Ordinal));
+
+        return entry?.ReasoningEfforts?.Any(v => string.Equals(v, chosen, StringComparison.Ordinal)) == true
+            ? chosen
+            : null;
+    }
+
     public void Stop()
     {
         CancellationTokenSource? running;
@@ -238,7 +264,8 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
             provider.Model,
             prompt.MaxOutputTokens,
             prompt.System,
-            new[] { new ChatMessage(ChatRole.User, prompt.UserContent) });
+            new[] { new ChatMessage(ChatRole.User, prompt.UserContent) },
+            ReasoningEffortFor(provider.Model));
 
         var markers = new PaliQuoteFilter();
         int? inputTokens = null, outputTokens = null;

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -468,6 +468,8 @@ namespace CST.Avalonia.Services.Ai
                 model.ContextLength = facts.ContextLength;
                 model.SupportsReasoning = facts.SupportsReasoning;
                 model.Inputs = facts.Inputs;
+                model.ReasoningEfforts = facts.ReasoningEfforts?.ToList();
+                model.DefaultReasoningEffort = facts.DefaultReasoningEffort;
 
                 // Facts exist because the listing carried this model, so it is by definition not missing from
                 // it. Clearing here as well as in MarkListing keeps the two from disagreeing. (#728)
@@ -555,6 +557,8 @@ namespace CST.Avalonia.Services.Ai
                     SupportsReasoning = m.SupportsReasoning,
                     Inputs = m.Inputs,
                     Missing = m.Missing,
+                    ReasoningEfforts = m.ReasoningEfforts?.ToList(),
+                    DefaultReasoningEffort = m.DefaultReasoningEffort,
                 })
                 .ToList();
             // A secret header's value is NOT carried through the draft - the editor puts it in the credential
@@ -582,7 +586,7 @@ namespace CST.Avalonia.Services.Ai
             r.Models
                 .Select(m => new AiModelEntry(
                     m.Id, m.DisplayName, m.Enabled, m.ContextLength, m.SupportsReasoning, m.Inputs,
-                    m.Missing))
+                    m.Missing, m.ReasoningEfforts, m.DefaultReasoningEffort))
                 .ToList(),
             r.Headers.Select(h => new AiHeader(h.Name, h.Secret ? null : h.Value, h.Secret)).ToList(),
             new Dictionary<string, string>(r.Inputs),

--- a/src/CST.Avalonia/Services/Ai/AiHttp.cs
+++ b/src/CST.Avalonia/Services/Ai/AiHttp.cs
@@ -353,6 +353,8 @@ internal static class AiHttp
         AiErrorKind.RateLimited => RateLimitMessage(wait),
         AiErrorKind.ContextTooLong =>
             "The request was longer than the model's context window. Try a smaller passage or fewer glosses.",
+        AiErrorKind.UnsupportedParameter =>
+            "This model did not accept the reasoning effort you chose. Set it back to Provider default.",
         _ => $"The provider rejected the request (HTTP {(int)status}).",
     };
 

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -33,7 +33,10 @@ namespace CST.Avalonia.Services.Ai
         decimal? CompletionPricePerMillion = null,
         IReadOnlyList<string>? InputModalities = null,
         IReadOnlyList<string>? OutputModalities = null,
-        IReadOnlyList<string>? SupportedParameters = null)
+        IReadOnlyList<string>? SupportedParameters = null,
+        IReadOnlyList<string>? ReasoningEfforts = null,
+        string? DefaultReasoningEffort = null,
+        bool? ReasoningIsMandatory = null)
     {
         /// <summary>
         /// Whether the provider publishes a price above zero for this model.
@@ -51,12 +54,21 @@ namespace CST.Avalonia.Services.Ai
             PromptPricePerMillion > 0m || CompletionPricePerMillion > 0m;
 
         /// <summary>
-        /// Whether the provider says it accepts a reasoning-effort parameter (#671). Published, never
-        /// inferred from the name.
+        /// Whether the provider says this model produces reasoning at all (#671). Published, never inferred
+        /// from the name.
         ///
         /// <para><b>Null means the provider said nothing</b>, which is a different fact from saying no — a
         /// local runner publishes no parameter list at all, and rendering its silence as "No reasoning" would
         /// state something about the model that nobody has established.</para>
+        ///
+        /// <para><b>This is "emits reasoning", NOT "takes an effort knob"</b>, and the distinction is not
+        /// pedantic. The first version matched any parameter containing "reasoning", which catches
+        /// <c>reasoning</c> and <c>include_reasoning</c> — both of which mean the model <i>returns</i>
+        /// reasoning content. Measured against OpenRouter's live listing: 287 models matched, 142 actually
+        /// list <c>reasoning_effort</c>, so <b>51% were false positives</b>. Gating an effort control on this
+        /// would put the control on 145 models that publish no such parameter. Use
+        /// <see cref="AcceptsReasoningEffort"/> for that. (The old predicate also had a dead arm: it tested
+        /// for <c>thinking</c>, which never appears in OpenRouter's vocabulary at all.)</para>
         /// </summary>
         public bool? SupportsReasoning => SupportedParameters is null
             ? null
@@ -64,6 +76,17 @@ namespace CST.Avalonia.Services.Ai
                 p.Contains("reasoning", StringComparison.OrdinalIgnoreCase) ||
                 p.Equals("thinking", StringComparison.OrdinalIgnoreCase));
 
+        /// <summary>
+        /// Whether the provider says this model accepts <c>reasoning_effort</c> — the question the effort
+        /// control actually needs answered. (#671)
+        ///
+        /// <para>Named exactly, not matched loosely. Null keeps the same meaning as everywhere else here:
+        /// the provider published no parameter list, which is silence rather than a no.</para>
+        /// </summary>
+        public bool? AcceptsReasoningEffort => SupportedParameters is null
+            ? null
+            : SupportedParameters.Any(
+                p => p.Equals("reasoning_effort", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>What a fetch produced, or why it produced nothing.</summary>
@@ -353,6 +376,7 @@ namespace CST.Avalonia.Services.Ai
 
                 var architecture = Object(item, "architecture");
                 var pricing = Object(item, "pricing");
+                var reasoning = Object(item, "reasoning");
 
                 models.Add(new AiCatalogModel(
                     id,
@@ -362,7 +386,18 @@ namespace CST.Avalonia.Services.Ai
                     PerMillion(pricing, "completion"),
                     Modalities(architecture, "input_modalities"),
                     Modalities(architecture, "output_modalities"),
-                    Strings(item, "supported_parameters")));
+                    Strings(item, "supported_parameters"),
+                    // OpenRouter publishes a richer object beside the flat parameter list, and it is the one
+                    // that answers "which values, and which is the default" rather than merely "is the knob
+                    // there". Absent everywhere else, which reads as null. (#671)
+                    //
+                    // NOTE for anyone widening this parse: the same objects carry a `benchmarks` field with
+                    // intelligence_index / coding_index / agentic_index on 229 of 420 models. It is
+                    // provider-published, so it passes the letter of "a published capability is fine" while
+                    // being unambiguously a score. It is NOT read here and must not be: #670/#681.
+                    Strings(reasoning, "supported_efforts"),
+                    Text(reasoning, "default_effort"),
+                    Bool(reasoning, "mandatory")));
             }
 
             // Alphabetical by the name the provider published. Mechanical, and the only ordering allowed:
@@ -405,6 +440,14 @@ namespace CST.Avalonia.Services.Ai
             parent is { } p && p.ValueKind == JsonValueKind.Object &&
             p.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
                 ? value.GetString()
+                : null;
+
+        /// <summary>Null when the field is absent or is not a boolean — silence, not false. (#671)</summary>
+        private static bool? Bool(JsonElement? parent, string name) =>
+            parent is { } p && p.ValueKind == JsonValueKind.Object &&
+            p.TryGetProperty(name, out var value)
+            && value.ValueKind is JsonValueKind.True or JsonValueKind.False
+                ? value.GetBoolean()
                 : null;
 
         private static int? Int(JsonElement? parent, string name) =>

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -35,8 +35,7 @@ namespace CST.Avalonia.Services.Ai
         IReadOnlyList<string>? OutputModalities = null,
         IReadOnlyList<string>? SupportedParameters = null,
         IReadOnlyList<string>? ReasoningEfforts = null,
-        string? DefaultReasoningEffort = null,
-        bool? ReasoningIsMandatory = null)
+        string? DefaultReasoningEffort = null)
     {
         /// <summary>
         /// Whether the provider publishes a price above zero for this model.
@@ -396,8 +395,7 @@ namespace CST.Avalonia.Services.Ai
                     // provider-published, so it passes the letter of "a published capability is fine" while
                     // being unambiguously a score. It is NOT read here and must not be: #670/#681.
                     Strings(reasoning, "supported_efforts"),
-                    Text(reasoning, "default_effort"),
-                    Bool(reasoning, "mandatory")));
+                    Text(reasoning, "default_effort")));
             }
 
             // Alphabetical by the name the provider published. Mechanical, and the only ordering allowed:
@@ -440,14 +438,6 @@ namespace CST.Avalonia.Services.Ai
             parent is { } p && p.ValueKind == JsonValueKind.Object &&
             p.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
                 ? value.GetString()
-                : null;
-
-        /// <summary>Null when the field is absent or is not a boolean — silence, not false. (#671)</summary>
-        private static bool? Bool(JsonElement? parent, string name) =>
-            parent is { } p && p.ValueKind == JsonValueKind.Object &&
-            p.TryGetProperty(name, out var value)
-            && value.ValueKind is JsonValueKind.True or JsonValueKind.False
-                ? value.GetBoolean()
                 : null;
 
         private static int? Int(JsonElement? parent, string name) =>

--- a/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/AnthropicMessagesProvider.cs
@@ -153,6 +153,14 @@ public sealed class AnthropicMessagesProvider : IChatProvider
         {
             Content = new StringContent(BuildBody(request), Encoding.UTF8, "application/json"),
         };
+        // Not sent: this API takes a `thinking` budget rather than an effort string (#779). Logged rather
+        // than dropped in silence - nothing arms it here today, so if it ever arrives the log is the only
+        // thing that would say why a control the reader can see had no effect. The VALUE is never logged.
+        if (!string.IsNullOrWhiteSpace(request.ReasoningEffort))
+            _logger.LogDebug(
+                "Reasoning effort was set but this adapter does not send one; the Anthropic Messages API "
+                + "expresses it as a thinking budget (#779).");
+
         ApplyHeaders(message);
 
         HttpResponseMessage response;

--- a/src/CST.Avalonia/Services/Ai/ChatContracts.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatContracts.cs
@@ -63,6 +63,12 @@ public sealed record ChatMessage(ChatRole Role, string Content);
 /// is the shape #670 forbids, and it would be wrong within a month besides. What reaches this field came from
 /// a list the provider published for that model.</para>
 ///
+/// <para><b>Honoured by the OpenAI-compatible adapter only.</b> The Anthropic Messages API expresses this as
+/// a <c>thinking</c> object with a token budget rather than an effort string, and mapping one onto the other
+/// means choosing numbers — deferred to #779 rather than guessed. Nothing arms this field for an Anthropic
+/// connection today, because the levels come from a listing field that adapter's models do not publish; if one
+/// ever arrives non-null there it is logged rather than silently dropped.</para>
+///
 /// <para><b>This is the control that replaced the one #601 removed.</b> Output caps could not govern a
 /// reasoning model, because reasoning and answer share the budget; effort governs the reasoning itself, which
 /// is the quantity that actually varies by an order of magnitude between models.</para>

--- a/src/CST.Avalonia/Services/Ai/ChatContracts.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatContracts.cs
@@ -48,11 +48,31 @@ public sealed record ChatMessage(ChatRole Role, string Content);
 /// </param>
 /// <param name="System">System prompt, or null. Anthropic carries it in a top-level field; the
 /// OpenAI-compatible shape carries it as a leading message, which the adapter handles.</param>
+/// <param name="ReasoningEffort">
+/// How hard the model should think before answering, in the provider's own vocabulary, or null to say nothing
+/// and let the provider apply its default. (#671)
+///
+/// <para><b>Null is the ordinary case, and sending nothing is not the same as sending a default.</b> Support is
+/// per-model rather than per-provider, and an unknown field can be a 400 rather than an ignored key — the same
+/// failure mode as the sampling parameters that are the reason there is no temperature control. So this is
+/// written only when the reader has explicitly chosen a value.</para>
+///
+/// <para><b>A string, not an enum.</b> The vocabulary is the model's: <c>low/medium/high</c> at most providers,
+/// <c>minimal/low/medium/high</c> at OpenAI, <c>none/default</c> on Groq's Qwen3, <c>low/high/max</c> at
+/// DeepSeek — 130+ distinct published sets. An enum here would be this app deciding what the levels are, which
+/// is the shape #670 forbids, and it would be wrong within a month besides. What reaches this field came from
+/// a list the provider published for that model.</para>
+///
+/// <para><b>This is the control that replaced the one #601 removed.</b> Output caps could not govern a
+/// reasoning model, because reasoning and answer share the budget; effort governs the reasoning itself, which
+/// is the quantity that actually varies by an order of magnitude between models.</para>
+/// </param>
 public sealed record ChatRequest(
     string Model,
     int? MaxTokens,
     string? System,
-    IReadOnlyList<ChatMessage> Messages);
+    IReadOnlyList<ChatMessage> Messages,
+    string? ReasoningEffort = null);
 
 /// <summary>What a <see cref="ChatDelta"/> carries.</summary>
 public enum ChatDeltaKind
@@ -128,6 +148,21 @@ public enum AiErrorKind
 
     /// <summary>The request exceeded the model's context window. Actionable: the caller can trim and retry.</summary>
     ContextTooLong,
+
+    /// <summary>
+    /// The model rejected a parameter the reader chose — today, reasoning effort. (#671)
+    ///
+    /// <para><b>Separate because the fix is a setting the reader can see, and no other kind points at it.</b>
+    /// Support for effort is per-model rather than per-provider, and an unsupported field can be a 400 rather
+    /// than an ignored key. Left as a bare <see cref="Provider"/> error the reader is told "the provider
+    /// rejected the request (HTTP 400)" about a request that worked yesterday on a different model, with
+    /// nothing connecting it to the control they changed.</para>
+    ///
+    /// <para>This is #671's stated alternative to predicting support: <i>report</i> a rejection rather than
+    /// maintain a list of which models will reject, which would be the curated capability table #670
+    /// forbids.</para>
+    /// </summary>
+    UnsupportedParameter,
 
     /// <summary>
     /// The app could not assemble what the model needs — no passage at the reference, a book whose XML never

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -118,7 +119,8 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
         using (response)
         {
             if (!response.IsSuccessStatusCode)
-                throw new AiException(await ClassifyAsync(response, ct).ConfigureAwait(false));
+                throw new AiException(
+                    await ClassifyAsync(response, request.ReasoningEffort, ct).ConfigureAwait(false));
 
             var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
             var think = new ThinkTagFilter();
@@ -206,6 +208,17 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
             // Optional here, unlike Anthropic — omitting it is the honest expression of "no cap", and it lets
             // a reasoning model spend what it needs on reasoning without starving the answer (#601).
             if (request.MaxTokens is { } maxTokens) json.WriteNumber("max_tokens", maxTokens);
+
+            // Written ONLY when the reader chose a value (#671). Omitted, the provider applies its own default,
+            // which is the honest meaning of "Provider default" in the picker - there is nothing to send for
+            // it, and inventing a value to send would be this app choosing a level on the model's behalf.
+            //
+            // Sent as the reader's chosen string, verbatim from a list the provider published for that model.
+            // A provider that does not know the field may 400 rather than ignore it, which is why nothing is
+            // sent unasked; a rejection is reported with the field named rather than surfacing as a bare 400.
+            if (!string.IsNullOrWhiteSpace(request.ReasoningEffort))
+                json.WriteString("reasoning_effort", request.ReasoningEffort);
+
             json.WriteBoolean("stream", true);
 
             // Ask for usage on the final chunk. Providers that do not know the option ignore it.
@@ -336,7 +349,13 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
     /// bounded: <c>error.code</c> is a short token and is kept (after sanitizing), while <c>error.message</c> can
     /// quote the request back and is discarded.
     /// </summary>
-    private async Task<AiError> ClassifyAsync(HttpResponseMessage response, CancellationToken ct)
+    /// <param name="sentEffort">
+    /// The reasoning effort this request carried, or null. Needed because a rejection of it is otherwise
+    /// indistinguishable from any other 400, and the reader is told "the provider rejected the request" about
+    /// a control they can see and change. (#671)
+    /// </param>
+    private async Task<AiError> ClassifyAsync(
+        HttpResponseMessage response, string? sentEffort, CancellationToken ct)
     {
         var kind = AiHttp.KindFor(response.StatusCode);
         string? code = null;
@@ -357,6 +376,17 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
 
                     if (string.Equals(code, "context_length_exceeded", StringComparison.OrdinalIgnoreCase))
                         kind = AiErrorKind.ContextTooLong;
+
+                    // Only when we actually sent one: a 400 naming the field on a request that did not carry
+                    // it would be about something else entirely. Codes first, since OpenAI publishes them;
+                    // the body-substring fallback covers providers that put the reason in prose, and it only
+                    // TESTS the text - provider prose never reaches AiError.Message. (#671)
+                    if (!string.IsNullOrWhiteSpace(sentEffort)
+                        && response.StatusCode == HttpStatusCode.BadRequest
+                        && (code is "unsupported_parameter" or "unsupported_value" or "invalid_request_error"
+                            || body.Contains("reasoning_effort", StringComparison.OrdinalIgnoreCase))
+                        && body.Contains("reasoning", StringComparison.OrdinalIgnoreCase))
+                        kind = AiErrorKind.UnsupportedParameter;
                 }
             }
             catch (JsonException)

--- a/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
+++ b/src/CST.Avalonia/Services/Ai/OpenAiCompatibleProvider.cs
@@ -381,9 +381,16 @@ public sealed class OpenAiCompatibleProvider : IChatProvider
                     // it would be about something else entirely. Codes first, since OpenAI publishes them;
                     // the body-substring fallback covers providers that put the reason in prose, and it only
                     // TESTS the text - provider prose never reaches AiError.Message. (#671)
+                    //
+                    // `invalid_request_error` deliberately NOT in the list, though it looks like a sibling.
+                    // It is OpenAI's generic TYPE for nearly every 400, and this method falls back to `type`
+                    // when `code` is absent - so including it collapsed the whole condition to "any 400 whose
+                    // body mentions reasoning". Mandatory-reasoning models and budget conflicts produce
+                    // exactly that prose, and the reader would be sent to change the one control they had
+                    // recently touched while the real cause persisted. (fable review)
                     if (!string.IsNullOrWhiteSpace(sentEffort)
                         && response.StatusCode == HttpStatusCode.BadRequest
-                        && (code is "unsupported_parameter" or "unsupported_value" or "invalid_request_error"
+                        && (code is "unsupported_parameter" or "unsupported_value"
                             || body.Contains("reasoning_effort", StringComparison.OrdinalIgnoreCase))
                         && body.Contains("reasoning", StringComparison.OrdinalIgnoreCase))
                         kind = AiErrorKind.UnsupportedParameter;

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -90,6 +90,11 @@ public class AiAssistantViewModel : ReactiveTool
         // key must change the standing notice, not wait to fail at send time.
         ModelPicker = new AiModelPickerViewModel(connections, RefreshReadiness);
 
+        // Beside the model chip rather than in Settings, and for the same reason (#671): effort is the lever
+        // that trades cost against depth on the turn about to be sent, and on a free tier it is the difference
+        // between a usable answer and a 504. It hides itself where the model published no levels.
+        EffortPicker = new AiEffortPickerViewModel(connections, settings);
+
         Id = "AiAssistantTool";
         Title = "Assistant";
         CanClose = false;
@@ -117,6 +122,8 @@ public class AiAssistantViewModel : ReactiveTool
 
     /// <summary>The per-turn model chip and its list. (#693)</summary>
     public AiModelPickerViewModel ModelPicker { get; }
+
+    public AiEffortPickerViewModel EffortPicker { get; }
 
     public ReactiveCommand<Unit, Unit> ExplainCommand { get; }
     public ReactiveCommand<Unit, Unit> TranslateCommand { get; }

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
 using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services;
 using CST.Avalonia.Services.Ai;
 using ReactiveUI;
 
@@ -339,5 +340,164 @@ namespace CST.Avalonia.ViewModels
 
             return "";
         }
+    }
+
+    /// <summary>
+    /// The per-turn reasoning-effort chip, beside the model chip. (#671)
+    ///
+    /// <para><b>Only the levels the provider published for the model in front of you.</b> Effort support is
+    /// per-model rather than per-provider, and the vocabularies genuinely differ — <c>low/medium/high</c> at
+    /// most providers, <c>minimal/low/medium/high</c> at OpenAI, <c>none/default</c> on Groq's Qwen3,
+    /// <c>low/high/max</c> at DeepSeek, and 130+ distinct published sets across models.dev. There is no
+    /// universal scale to offer, so this offers the model's own list or nothing at all. #671 is explicit that
+    /// the alternative — a table predicting which models take which values — is the curated capability
+    /// registry #670 forbids.</para>
+    ///
+    /// <para><b>"Provider default" is the first position and it is not a placeholder.</b> Omitting the field
+    /// IS the default: the provider then applies its own, so there is nothing to send for that position and
+    /// nothing we have to know. It is also the only correct answer for a reasoning model that publishes no
+    /// levels, and it keeps this app from choosing a level on a model's behalf. Where the provider publishes
+    /// what its default is, the position says so — its word, not our choice.</para>
+    /// </summary>
+    public class AiEffortPickerViewModel : ViewModelBase, IDisposable
+    {
+        private readonly IAiConnectionService? _service;
+        private readonly ISettingsService? _settings;
+        private bool _isOpen;
+
+        public AiEffortPickerViewModel(
+            IAiConnectionService? service, ISettingsService? settings)
+        {
+            _service = service;
+            _settings = settings;
+
+            if (_service is not null)
+            {
+                _service.ConnectionsChanged += OnConnectionsChanged;
+                Rebuild();
+            }
+        }
+
+        public ObservableCollection<AiEffortChoiceViewModel> Choices { get; } = new();
+
+        /// <summary>
+        /// Hidden unless the model in front of the reader published levels to choose between.
+        ///
+        /// <para>A chip that is always present but empty for most models would be worse than absent: it would
+        /// imply the app knows something about a model it knows nothing about.</para>
+        /// </summary>
+        public bool HasChoices => Choices.Count > 1;
+
+        public bool IsOpen
+        {
+            get => _isOpen;
+            set => this.RaiseAndSetIfChanged(ref _isOpen, value);
+        }
+
+        /// <summary>What the chip says at rest. Never bare — "Effort" alone would not say which way it is
+        /// set, and the default position is the one most readers will never move.</summary>
+        public string CurrentLabel =>
+            Choices.FirstOrDefault(c => c.IsCurrent)?.ChipLabel ?? "Effort: default";
+
+        private string? Chosen => _settings?.Settings.Ai.Chat.ReasoningEffort;
+
+        private AiModelEntry? ActiveModel
+        {
+            get
+            {
+                if (_service?.Active is not { } connection) return null;
+                if (_service.ActiveModelId is not { Length: > 0 } id) return null;
+
+                return connection.Models.FirstOrDefault(
+                    m => string.Equals(m.Id, id, StringComparison.Ordinal));
+            }
+        }
+
+        internal void Rebuild()
+        {
+            Choices.Clear();
+
+            var model = ActiveModel;
+            var published = model?.ReasoningEfforts;
+            if (published is not { Count: > 0 })
+            {
+                this.RaisePropertyChanged(nameof(HasChoices));
+                this.RaisePropertyChanged(nameof(CurrentLabel));
+                return;
+            }
+
+            var chosen = Chosen;
+
+            // The default sits first because it is the position that sends nothing, and because a reader
+            // scanning the list should meet "leave it alone" before any level.
+            Choices.Add(new AiEffortChoiceViewModel(
+                null,
+                "Provider default",
+                model!.DefaultReasoningEffort is { Length: > 0 } theirs ? $"the provider uses {theirs}" : null,
+                string.IsNullOrWhiteSpace(chosen),
+                Choose));
+
+            foreach (var value in published)
+                Choices.Add(new AiEffortChoiceViewModel(
+                    value,
+                    value,
+                    null,
+                    string.Equals(value, chosen, StringComparison.Ordinal),
+                    Choose));
+
+            this.RaisePropertyChanged(nameof(HasChoices));
+            this.RaisePropertyChanged(nameof(CurrentLabel));
+        }
+
+        private void Choose(string? value)
+        {
+            if (_settings is null) return;
+
+            _settings.Settings.Ai.Chat.ReasoningEffort = value;
+            _settings.RequestSave();
+
+            IsOpen = false;
+            Rebuild();
+        }
+
+        private void OnConnectionsChanged(object? sender, EventArgs e) => Rebuild();
+
+        public void Dispose()
+        {
+            if (_service is not null) _service.ConnectionsChanged -= OnConnectionsChanged;
+        }
+    }
+
+    /// <summary>One position in the effort chip.</summary>
+    /// <param name="Value">What goes on the wire, or null for the default position, which sends nothing.</param>
+    public class AiEffortChoiceViewModel : ViewModelBase
+    {
+        private readonly Action<string?> _choose;
+
+        public AiEffortChoiceViewModel(
+            string? value, string label, string? hint, bool isCurrent, Action<string?> choose)
+        {
+            Value = value;
+            Label = label;
+            Hint = hint;
+            IsCurrent = isCurrent;
+            _choose = choose;
+            ChooseCommand = ReactiveCommand.Create(() => _choose(Value));
+        }
+
+        public string? Value { get; }
+        public string Label { get; }
+
+        /// <summary>The provider's own statement of what it does by default, where it makes one. Shown rather
+        /// than acted on: we do not preselect it, because not sending the field already means exactly that.</summary>
+        public string? Hint { get; }
+
+        public bool HasHint => !string.IsNullOrWhiteSpace(Hint);
+        public bool IsCurrent { get; }
+
+        /// <summary>What the chip shows when this position is the current one.</summary>
+        public string ChipLabel => Value is null ? "Effort: default" : $"Effort: {Label}";
+
+        public ReactiveCommand<Unit, Unit> ChooseCommand { get; }
     }
 }

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -428,13 +428,22 @@ namespace CST.Avalonia.ViewModels
 
             var chosen = Chosen;
 
+            // Current when nothing WILL be sent, which is not the same as nothing being stored. A choice made
+            // on another model - "max" on DeepSeek, then a switch to a model offering low/medium/high - is
+            // outside this model's vocabulary, so the wire guard drops it and the provider applies its own
+            // default. Keying this off "is anything stored" left no row ticked at all, showing the reader an
+            // unmarked list for a setting that does in fact have an effect. This is the same fact the chip
+            // label already told them; the flyout has to agree with it. (fable review)
+            var willSend = !string.IsNullOrWhiteSpace(chosen)
+                           && published.Any(v => string.Equals(v, chosen, StringComparison.Ordinal));
+
             // The default sits first because it is the position that sends nothing, and because a reader
             // scanning the list should meet "leave it alone" before any level.
             Choices.Add(new AiEffortChoiceViewModel(
                 null,
                 "Provider default",
                 model!.DefaultReasoningEffort is { Length: > 0 } theirs ? $"the provider uses {theirs}" : null,
-                string.IsNullOrWhiteSpace(chosen),
+                !willSend,
                 Choose));
 
             foreach (var value in published)

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -549,6 +549,12 @@ namespace CST.Avalonia.ViewModels
 
                 if (_published.SupportsReasoning == true) facts.Add("reasoning");
 
+                // A separate fact from the one above, and the distinction is the whole point of #671's
+                // correction: "reasoning" means the model RETURNS reasoning content, "effort" means it takes
+                // the knob. 51% of the models that satisfy the first do not satisfy the second, so collapsing
+                // them would tell the reader something the provider never said.
+                if (_published.AcceptsReasoningEffort == true) facts.Add("effort");
+
                 // The id on its own line: it is the string the reader would copy, and burying it in a run of
                 // facts separated by dots makes it hard to pick out.
                 return facts.Count == 0 ? ModelId : ModelId + "\n" + string.Join("  ·  ", facts);

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -379,7 +379,13 @@ namespace CST.Avalonia.ViewModels
 
             return new AiModelEntry(
                 published.Id, published.DisplayName, true,
-                published.ContextLength, published.SupportsReasoning, inputs);
+                published.ContextLength, published.SupportsReasoning, inputs,
+                Missing: false,
+                // Captured at the moment the reader promotes the model, for the same reason the rest of these
+                // are: the listing is only fetched while the Models tab is open, and the per-turn picker has
+                // to be able to offer the levels without one. (#671)
+                ReasoningEfforts: published.ReasoningEfforts,
+                DefaultReasoningEffort: published.DefaultReasoningEffort);
         }
 
         private async Task FetchAsync()

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -83,6 +83,8 @@
                     </TextBox.KeyBindings>
                 </TextBox>
 
+                <!-- Both chips on one line, wrapping rather than clipping: the assistant docks narrow. -->
+                <WrapPanel Orientation="Horizontal">
                 <!-- The per-turn model chip (#693). At the composer rather than in Settings: comparing two
                      models on the same passage is the task the assistant exists for, and it wants to be one
                      click from the answer on screen. Hidden until there is more than one model to choose
@@ -255,6 +257,75 @@
                         </Flyout>
                     </Button.Flyout>
                 </Button>
+
+                <!-- The per-turn effort chip (#671), beside the model chip and in the same visual language.
+                     Hidden unless the model in front of the reader published levels to choose between: a chip
+                     that is always there but empty for most models would imply the app knows something about
+                     a model it knows nothing about. -->
+                <Button x:Name="EffortChip"
+                        IsVisible="{Binding EffortPicker.HasChoices}"
+                        HorizontalAlignment="Left"
+                        Margin="6,0,0,0"
+                        Padding="8,3"
+                        CornerRadius="12"
+                        FontSize="11"
+                        Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                        BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1">
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <TextBlock Text="{Binding EffortPicker.CurrentLabel}" VerticalAlignment="Center"/>
+                        <TextBlock Text="⌄" FontSize="10" VerticalAlignment="Center"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                    </StackPanel>
+
+                    <Button.Flyout>
+                        <Flyout Placement="Top" ShowMode="Standard">
+                            <StackPanel Width="240">
+                                <ItemsControl ItemsSource="{Binding EffortPicker.Choices}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="vm:AiEffortChoiceViewModel">
+                                            <Button Command="{Binding ChooseCommand}"
+                                                    HorizontalAlignment="Stretch"
+                                                    HorizontalContentAlignment="Stretch"
+                                                    Background="Transparent" BorderThickness="0"
+                                                    Padding="6,4">
+                                                <!-- Star column then the mark at the far edge, matching the
+                                                     model picker (#693). An Auto column would measure the
+                                                     label at infinite width and push the tick off the row. -->
+                                                <Grid ColumnDefinitions="*,Auto">
+                                                    <StackPanel Grid.Column="0">
+                                                        <TextBlock Text="{Binding Label}" FontSize="12"
+                                                                   Classes.current="{Binding IsCurrent}">
+                                                            <TextBlock.Styles>
+                                                                <Style Selector="TextBlock.current">
+                                                                    <Setter Property="Foreground"
+                                                                            Value="{DynamicResource SystemAccentColor}"/>
+                                                                </Style>
+                                                            </TextBlock.Styles>
+                                                        </TextBlock>
+                                                        <TextBlock Text="{Binding Hint}"
+                                                                   IsVisible="{Binding HasHint}"
+                                                                   FontSize="10" TextWrapping="Wrap"
+                                                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                    </StackPanel>
+                                                    <TextBlock Grid.Column="1" Text="✓" FontSize="11"
+                                                               IsVisible="{Binding IsCurrent}"
+                                                               VerticalAlignment="Center"
+                                                               Foreground="{DynamicResource SystemAccentColor}"/>
+                                                </Grid>
+                                            </Button>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+
+                                <TextBlock Text="Only the levels this model publishes. Provider default sends nothing, so the provider applies its own."
+                                           FontSize="10" TextWrapping="Wrap" Margin="6,6,6,2"
+                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                            </StackPanel>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+                </WrapPanel>
 
                 <WrapPanel Orientation="Horizontal">
                     <!-- First, and disabled until something is typed: the other four are complete without a

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml.cs
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml.cs
@@ -18,6 +18,8 @@ public partial class AiAssistantPanel : UserControl
     private AiModelPickerViewModel? _picker;
 
     private bool _syncingFlyout;
+    private AiEffortPickerViewModel? _effort;
+    private bool _syncingEffortFlyout;
 
     public AiAssistantPanel()
     {
@@ -37,6 +39,17 @@ public partial class AiAssistantPanel : UserControl
             flyout.Opened += (_, _) => SetOpen(true);
             flyout.Closed += (_, _) => SetOpen(false);
         }
+
+        // The same wiring for the effort chip (#671). It is not optional decoration: a Flyout owns its own
+        // open state, so without this, choosing a level leaves the list sitting over the composer and the
+        // reader's next act is to dismiss a popup rather than ask the question they opened it for. The effort
+        // picker had the IsOpen state and nothing observing it, which is the same bug this block already
+        // exists to prevent — it just had not been extended to the second chip. (fable review)
+        if (EffortChip.Flyout is { } effortFlyout)
+        {
+            effortFlyout.Opened += (_, _) => SetEffortOpen(true);
+            effortFlyout.Closed += (_, _) => SetEffortOpen(false);
+        }
     }
 
     private void SetOpen(bool open)
@@ -47,11 +60,32 @@ public partial class AiAssistantPanel : UserControl
         finally { _syncingFlyout = false; }
     }
 
+    private void SetEffortOpen(bool open)
+    {
+        if (_effort is null) return;
+        _syncingEffortFlyout = true;
+        try { _effort.IsOpen = open; }
+        finally { _syncingEffortFlyout = false; }
+    }
+
     private void OnDataContextChanged(object? sender, System.EventArgs e)
     {
         if (_picker is not null) _picker.PropertyChanged -= OnPickerChanged;
         _picker = (DataContext as AiAssistantViewModel)?.ModelPicker;
         if (_picker is not null) _picker.PropertyChanged += OnPickerChanged;
+
+        if (_effort is not null) _effort.PropertyChanged -= OnEffortChanged;
+        _effort = (DataContext as AiAssistantViewModel)?.EffortPicker;
+        if (_effort is not null) _effort.PropertyChanged += OnEffortChanged;
+    }
+
+    /// <summary>Closes the effort flyout once a level is chosen — see <see cref="OnPickerChanged"/> for why
+    /// this cannot be a binding. (#671)</summary>
+    private void OnEffortChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (_syncingEffortFlyout) return;
+        if (e.PropertyName != nameof(AiEffortPickerViewModel.IsOpen)) return;
+        if (_effort?.IsOpen == false) EffortChip.Flyout?.Hide();
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #671.

Several providers accept a reasoning-effort parameter; the app neither sent one nor exposed one. This adds the field, reads the levels providers publish, and puts a chip beside the model chip in the composer.

**It is the control that replaced the one #601 removed.** Output caps could not govern a reasoning model, because reasoning and answer share the budget and reasoning volume varies by an order of magnitude between models. Effort governs the reasoning itself, it is what the provider actually exposes, and on a free tier it is the difference between a usable turn and the 120-second wait and gateway 504 that prompted the issue.

## The constraint that shaped every decision

#671's *Care* section is binding: **"Do not reintroduce a curated per-model capability table for this — see #670. If a model rejects the field, report that; do not maintain a list predicting which will."**

So there is no table anywhere, and three things follow from that:

**The chip offers only what the provider published for the model in front of you**, and hides itself where that is nothing. There is no universal scale to fall back on — 130+ distinct published value-sets, `minimal/low/medium/high` at OpenAI, `low/high/max` at DeepSeek, `none/default` on Groq's Qwen3 — so offering `low/medium/high` everywhere would be this app deciding what the levels are.

**"Provider default" is first, and it is not a placeholder for data we lack.** Omitting the field *is* the default: the provider applies its own, so there is nothing to send for that position and nothing we have to know. It is also the only correct first position for a reasoning model that publishes no levels, of which models.dev counts 1,301. Where the provider states its own default, that position says so as a hint — its word, never preselected, because not sending already means exactly that.

**A rejection is reported rather than predicted.** A 400 that names the parameter, on a request that actually carried one, becomes `AiErrorKind.UnsupportedParameter` and reaches the reader as a setting they can change — instead of "the provider rejected the request (HTTP 400)" about a request that worked yesterday on a different model.

## Correctness lives at the wire, not in the picker

The chosen effort is validated against the active model's published list in the orchestrator, beside the resolution it is validated against. A value chosen on a model that offers it and left over when the reader switches to one that does not is simply never sent. The picker hiding the control is presentation; this is the part that has to be right — and it caught my own fixture, which named its model `m` while the resolver reported `test-model`.

## One fact corrected

`SupportsReasoning` matched any parameter containing "reasoning", which catches `reasoning` and `include_reasoning` — both meaning the model **returns** reasoning content, not that it accepts an effort knob. Measured against OpenRouter's live listing: **287 models matched, 142 actually list `reasoning_effort` — 51% false positives.** Gating the chip on it would have put the control on 145 models that publish no such parameter. The old predicate also had a dead arm, testing for `thinking`, which never appears in that vocabulary at all.

Both facts now exist separately and both are visible: the Models tab shows "reasoning" and "effort" as distinct chips.

## Anti-registry

OpenRouter's listing carries `benchmarks` — `intelligence_index`, `coding_index`, `agentic_index` — on 229 of 420 models. It is provider-published, so it passes the letter of "a published capability is fine" while being unambiguously a score. It is not read, there is a note beside the parse saying so, and a test pins it: otherwise a later widening picks it up as one more fact and #670/#681 is gone by accident.

Levels are offered in the order the provider published them. "Provider default" first is semantic, not a ranking.

## What review changed

Fable reviewed the branch adversarially and found five things.

**The flyout never closed.** A `Flyout` owns its own open state, so the model chip needed explicit code-behind to close it — and that wiring existed only for `ModelChip`. The new picker's `IsOpen` was written and observed by nothing: dead state. Choosing a level recorded the setting, moved the tick, and left the list sitting over the composer. The comment in that same file says why the mechanism exists: *"the reader's next act is to dismiss a popup rather than to ask the question they opened it for."* I extended the state and not the mechanism.

**The guard read the connection at send time**, seconds after the provider was resolved, across an async bundling gap — so a reader who switched connections mid-turn could have an effort validated against one model and sent to another. Now read beside the resolution.

**`invalid_request_error` was in the code list**, and it is not a sibling of `unsupported_parameter`: it is OpenAI's generic *type* for nearly every 400, which this method already falls back to reading when no code is present. Including it collapsed the condition to "any 400 whose body mentions reasoning" — and mandatory-reasoning models (32+ on OpenRouter publish `mandatory: true`) produce exactly that prose. The reader would have been sent to change the one control they had recently touched while the real cause persisted.

**A stale choice left no row ticked at all**, because the default row keyed off "is anything stored" rather than "will anything be sent". The chip label was already telling the truth; the flyout disagreed with it.

**The Anthropic adapter dropped the field in silence.** Nothing arms it there today, but hand-edited settings are a supported way in. It now logs, and the contract says which adapter honours it.

### And the test blind spot, in the same shape as yesterday's

`ConnectedOffering()` handed down an **empty array, never null** — so the majority case, a provider that published no parameter list at all, was never exercised. Every local runner is that case. Fable named the exact surviving mutant, `== true` → `!= false`, which sent the chosen effort to every model whose provider had published nothing while all four tests stayed green.

That is the second helper-shaped blind spot in two days, and it is the same lesson: **a harness that always supplies a value cannot test the absent-value branch.** Both states are now pinned separately — null (said nothing) and empty (published a capability with no levels) — the mutant dies, and only the new test catches it.

Also pinned, all previously unprotected: each conjunct of the error classification separately, and the picker following a model switch (every other picker test built the world before constructing the picker, so removing the subscription left them all green while the chip went stale on every switch — the one dynamic behaviour it exists for).

## Deliberately not in scope

- **Anthropic gets no chip** — #779. Its Messages API takes a `thinking` token budget rather than an effort string, the `capabilities.effort` listing claim is documentation that could not be verified without a key this project does not have, and mapping one onto the other means choosing numbers.
- **models.dev enrichment** — #780. Its `reasoning_options` covers 7,235 models, and the app currently discards that payload entirely. But it is a third-party aggregate, so using it to decide what the reader's own endpoint accepts is one step removed from the provider's word — which is the distinction #671's *Care* section turns on. Filed with the argument on both sides rather than settled quietly here.

Practically: the chip appears today for OpenRouter connections, which is where the issue's own first comment shows the maintainer working.

Full suite green, 0 build warnings.
