### PR TITLE
Read a connection's headers in either shape, so an old settings file is not discarded

### DIFF
--- a/src/CST.Avalonia.Tests/Models/AiHeaderRecordListConverterTests.cs
+++ b/src/CST.Avalonia.Tests/Models/AiHeaderRecordListConverterTests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using CST.Avalonia.Models;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Models;
+
+/// <summary>
+/// Reading a connection's headers from either shape. (#771, #784)
+///
+/// <para>These exist because the shape change shipped without them and cost a real settings file. The lesson
+/// is not "add a converter": it is that <c>SettingsService</c> reverts the ENTIRE file to defaults on any
+/// parse failure, so a type change in one property discards fonts, layout, the book directory and every AI
+/// connection. A round-trip test on the new shape would have passed throughout.</para>
+/// </summary>
+public class AiHeaderRecordListConverterTests
+{
+    private static Settings Load(string json) =>
+        JsonSerializer.Deserialize<Settings>(json)!;
+
+    /// <summary>The shape written before #771. This is the exact failure that discarded a settings file.</summary>
+    [Fact]
+    public void The_old_object_shape_still_loads()
+    {
+        var settings = Load("""
+        {"Ai":{"Chat":{"Connections":[
+            {"Id":"gw","Headers":{"X-Title":"CST Reader","cf-aig-authorization":"Bearer token"}}
+        ]}}}
+        """);
+
+        var headers = settings.Ai.Chat.Connections.Single().Headers;
+        Assert.Equal(2, headers.Count);
+        Assert.Equal("X-Title", headers[0].Name);
+        Assert.Equal("CST Reader", headers[0].Value);
+        Assert.Equal("Bearer token", headers[1].Value);
+    }
+
+    /// <summary>Nothing in the old shape could have been marked secret, because the mark did not exist.</summary>
+    [Fact]
+    public void Headers_from_the_old_shape_are_never_marked_secret()
+    {
+        var settings = Load("""
+        {"Ai":{"Chat":{"Connections":[{"Id":"gw","Headers":{"cf-aig-authorization":"Bearer token"}}]}}}
+        """);
+
+        Assert.All(settings.Ai.Chat.Connections.Single().Headers, h => Assert.False(h.Secret));
+    }
+
+    [Fact]
+    public void The_current_array_shape_round_trips_with_the_secret_mark()
+    {
+        var settings = Load("""
+        {"Ai":{"Chat":{"Connections":[{"Id":"gw","Headers":[
+            {"Name":"X-Title","Value":"CST Reader","Secret":false},
+            {"Name":"cf-aig-authorization","Value":null,"Secret":true}
+        ]}]}}}
+        """);
+
+        var headers = settings.Ai.Chat.Connections.Single().Headers;
+        Assert.Equal("CST Reader", headers[0].Value);
+        Assert.True(headers[1].Secret);
+        Assert.Null(headers[1].Value);
+
+        var again = Load(JsonSerializer.Serialize(settings));
+        var round = again.Ai.Chat.Connections.Single().Headers;
+        Assert.Equal("cf-aig-authorization", round[1].Name);
+        Assert.True(round[1].Secret);
+    }
+
+    [Fact]
+    public void An_absent_or_null_headers_property_is_an_empty_list_not_a_failure()
+    {
+        Assert.Empty(Load("""{"Ai":{"Chat":{"Connections":[{"Id":"gw"}]}}}""")
+            .Ai.Chat.Connections.Single().Headers);
+        Assert.Empty(Load("""{"Ai":{"Chat":{"Connections":[{"Id":"gw","Headers":null}]}}}""")
+            .Ai.Chat.Connections.Single().Headers);
+    }
+
+    /// <summary>
+    /// The point of the whole class: an unreadable headers value costs the headers, not the settings file.
+    /// Throwing here reverts fonts, layout, the book directory and every connection to defaults.
+    /// </summary>
+    [Fact]
+    public void An_unreadable_headers_value_does_not_take_the_whole_file_with_it()
+    {
+        var settings = Load("""
+        {"XmlBooksDirectory":"/books","Ai":{"Chat":{"Connections":[
+            {"Id":"gw","Headers":"nonsense"}
+        ]}}}
+        """);
+
+        Assert.Empty(settings.Ai.Chat.Connections.Single().Headers);
+        Assert.Equal("/books", settings.XmlBooksDirectory);   // the rest of the file survived
+        Assert.Equal("gw", settings.Ai.Chat.Connections.Single().Id);
+    }
+
+    /// <summary>
+    /// A whole settings file in the pre-#771 shape loads with everything else intact — the regression as the
+    /// reader met it, rather than a fragment.
+    /// </summary>
+    [Fact]
+    public void A_whole_settings_file_in_the_old_shape_keeps_its_models_and_its_other_settings()
+    {
+        var settings = Load("""
+        {"XmlBooksDirectory":"/books",
+         "Ai":{"Chat":{"ActiveConnectionId":"groq","ActiveModelId":"openai/gpt-oss-120b","Connections":[
+            {"Id":"groq","DisplayName":"Groq","BaseUrl":"https://api.groq.com/openai/v1",
+             "Headers":{"X-Title":"CST Reader"},
+             "Models":[{"Id":"openai/gpt-oss-120b","DisplayName":"GPT-OSS 120B","Enabled":true},
+                       {"Id":"llama-3.3-70b","DisplayName":"Llama 3.3 70B","Enabled":true}]}
+        ]}}}
+        """);
+
+        var connection = settings.Ai.Chat.Connections.Single();
+        Assert.Equal(2, connection.Models.Count);
+        Assert.Equal("groq", settings.Ai.Chat.ActiveConnectionId);
+        Assert.Equal("/books", settings.XmlBooksDirectory);
+        Assert.Equal("CST Reader", connection.Headers.Single().Value);
+    }
+
+    /// <summary>
+    /// The regression as the reader met it: a whole pre-#771 settings file, with two connections, headers in
+    /// the object shape and hand-built model lists. Before the converter this threw, SettingsService caught
+    /// it, and the ENTIRE file — book directory, both connections, every enabled model — was replaced with
+    /// defaults. (#784)
+    /// </summary>
+    [Fact]
+    public void The_file_that_was_discarded_now_loads_with_its_models_intact()
+    {
+        // Inlined rather than read from disk: a fixture behind a machine path is a test that passes here and
+        // fails everywhere else, which is its own kind of false coverage.
+        var settings = Load("""
+        {
+          "XmlBooksDirectory": "/books/xml",
+          "Ai": { "Chat": {
+            "ActiveConnectionId": "groq",
+            "ActiveModelId": "openai/gpt-oss-120b",
+            "Connections": [
+              { "Id": "openrouter", "DisplayName": "OpenRouter", "Kind": "openai-compatible",
+                "BaseUrl": "https://openrouter.ai/api/v1",
+                "Headers": { "HTTP-Referer": "https://cst.example", "X-Title": "CST Reader" },
+                "Inputs": {},
+                "Models": [ { "Id": "nvidia/nemotron", "DisplayName": "Nemotron", "Enabled": true } ] },
+              { "Id": "groq", "DisplayName": "Groq", "Kind": "openai-compatible",
+                "BaseUrl": "https://api.groq.com/openai/v1",
+                "Headers": {},
+                "Inputs": {},
+                "Models": [ { "Id": "openai/gpt-oss-120b", "DisplayName": "GPT-OSS 120B", "Enabled": true },
+                            { "Id": "llama-3.3-70b-versatile", "DisplayName": "Llama 3.3 70B", "Enabled": true } ] }
+            ] } }
+        }
+        """);
+
+        Assert.Equal(2, settings.Ai.Chat.Connections.Count);
+
+        var groq = settings.Ai.Chat.Connections.Single(c => c.Id == "groq");
+        Assert.Equal(2, groq.Models.Count);
+        Assert.Contains(groq.Models, m => m.Id == "openai/gpt-oss-120b" && m.Enabled);
+
+        var openrouter = settings.Ai.Chat.Connections.Single(c => c.Id == "openrouter");
+        Assert.Equal(2, openrouter.Headers.Count);
+        Assert.Equal("CST Reader", openrouter.Headers.Single(h => h.Name == "X-Title").Value);
+        Assert.All(openrouter.Headers, h => Assert.False(h.Secret));
+
+        Assert.Equal("groq", settings.Ai.Chat.ActiveConnectionId);
+        Assert.Equal("/books/xml", settings.XmlBooksDirectory);
+    }
+}

--- a/src/CST.Avalonia/Models/AiHeaderRecordListConverter.cs
+++ b/src/CST.Avalonia/Models/AiHeaderRecordListConverter.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CST.Avalonia.Models
+{
+    /// <summary>
+    /// Reads a connection's headers whether they were written as the current array of records or as the
+    /// object-of-name-to-value that preceded it. (#771, #784)
+    ///
+    /// <para><b>Why this exists.</b> #771 changed the persisted shape from
+    /// <c>Dictionary&lt;string, string&gt;</c> to <c>List&lt;AiHeaderRecord&gt;</c>, because a secret header
+    /// has a name and no value in this file and a dictionary cannot say that. The change was made on the
+    /// reasoning that no released build had ever written AI configuration, so there was no installed base to
+    /// migrate. That was true and it was not the whole question: <c>SettingsService</c> reverts the
+    /// <b>entire file</b> to defaults on any parse failure, so an older shape in one property discards every
+    /// setting the file holds — fonts, layout, book directory, and every AI connection with the model lists
+    /// the reader had built up by hand.</para>
+    ///
+    /// <para><b>An old value is not a corrupt file.</b> Deserialisation is the wrong place to be strict:
+    /// refusing a shape we ourselves wrote last week costs the reader everything and tells them nothing. The
+    /// old shape is unambiguous and maps exactly — a name and a plaintext value, never a secret, since the
+    /// mark did not exist when it was written.</para>
+    ///
+    /// <para>Deliberately permanent rather than a migration to delete later. It is a dozen lines, it cannot
+    /// misfire on a current file, and the alternative is that anyone restoring an old backup or moving a
+    /// profile between machines silently loses their settings.</para>
+    /// </summary>
+    public sealed class AiHeaderRecordListConverter : JsonConverter<List<AiHeaderRecord>>
+    {
+        /// <summary>
+        /// Without this, System.Text.Json assigns null for <c>"Headers": null</c> without consulting the
+        /// converter at all — so the list is null rather than empty and the next thing to enumerate it throws.
+        /// Found by the test for it, which is the shape of hole this whole class exists to close.
+        /// </summary>
+        public override bool HandleNull => true;
+
+        public override List<AiHeaderRecord> Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var headers = new List<AiHeaderRecord>();
+
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.Null:
+                    return headers;
+
+                // The shape before #771: {"X-Title":"CST Reader","cf-aig-authorization":"Bearer …"}.
+                case JsonTokenType.StartObject:
+                    while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+                    {
+                        if (reader.TokenType != JsonTokenType.PropertyName) continue;
+
+                        var name = reader.GetString() ?? "";
+                        if (!reader.Read()) break;
+
+                        headers.Add(new AiHeaderRecord
+                        {
+                            Name = name,
+                            // Secret is false by construction: nothing could have marked one when this shape
+                            // was written, so every value here is a plaintext value the reader can still see.
+                            Value = reader.TokenType == JsonTokenType.String ? reader.GetString() : null,
+                        });
+                    }
+                    return headers;
+
+                case JsonTokenType.StartArray:
+                    while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                    {
+                        if (reader.TokenType != JsonTokenType.StartObject) continue;
+
+                        // Read the element with the converter's own options minus this converter, which would
+                        // otherwise recurse on the element type.
+                        if (JsonSerializer.Deserialize<AiHeaderRecord>(ref reader, Inner(options)) is { } record)
+                            headers.Add(record);
+                    }
+                    return headers;
+
+                default:
+                    // Anything else is genuinely unreadable. Yielding no headers loses a routing hint the
+                    // reader can retype; throwing here would lose the whole settings file, which is the
+                    // failure this class exists to prevent.
+                    reader.Skip();
+                    return headers;
+            }
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer, List<AiHeaderRecord> value, JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+            foreach (var header in value)
+                JsonSerializer.Serialize(writer, header, Inner(options));
+            writer.WriteEndArray();
+        }
+
+        /// <summary>The same options without this converter, so serialising an element does not re-enter it.</summary>
+        private static JsonSerializerOptions Inner(JsonSerializerOptions options)
+        {
+            var inner = new JsonSerializerOptions(options);
+            for (int i = inner.Converters.Count - 1; i >= 0; i--)
+                if (inner.Converters[i] is AiHeaderRecordListConverter)
+                    inner.Converters.RemoveAt(i);
+            return inner;
+        }
+    }
+}

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -148,6 +148,7 @@ namespace CST.Avalonia.Models
         /// Extra request headers. A value that IS a credential is marked secret and kept in the OS credential
         /// store rather than here. (#771)
         /// </summary>
+        [System.Text.Json.Serialization.JsonConverter(typeof(AiHeaderRecordListConverter))]
         public List<AiHeaderRecord> Headers { get; set; } = new();
 
         /// <summary>Answers to the preset's prompts — resource name, account id, region — substituted into


### PR DESCRIPTION
Fixes a regression I introduced in #771 and that #775 merged. **It causes total settings loss**, and it has already cost one reader their model lists.

## What happens

A settings file written before #771 fails to parse, and `SettingsService` reverts the **entire file** to defaults:

```
[ERR] SettingsService  Failed to load settings from …/settings.json - reverting to defaults
JsonException: The JSON value could not be converted to List<AiHeaderRecord>.
Path: $.Ai.Chat.Connections[0].Headers
```

Not just the AI section — the book directory, fonts, layout, every connection and every hand-built model list. Reported from use: a Groq connection came back with zero models and had to be rebuilt from scratch.

## Why the reasoning failed

#771 changed persisted `Headers` from an object of name-to-value into a list of records, because a secret header has a name and *no value* in that file and a dictionary cannot express that. The change was argued on the grounds that **no released build had ever written AI configuration** — which is true, and I made it checkable rather than remembered: the credential code postdates the `v5.0.0-beta.5` tag, verifiable with one `git merge-base --is-ancestor`.

That was the right answer to the wrong question. The question neither I nor the reviewer asked was: **what does this app do when it cannot parse `settings.json`?** It throws all of it away, not just the part it could not read. So the cost was never "re-enter a key on a dev machine" as the PR body claimed — it was every setting in the file, including work that is not recoverable from anywhere.

Two people read that PR carefully and both of us checked the same fact.

## The fix

A converter that reads either shape. The old one maps exactly and unambiguously — a name, a plaintext value, and `Secret` false, because the mark did not exist when it was written.

**Deliberately permanent rather than a migration to delete later.** It is a dozen lines, it cannot misfire on a current file, and the alternative is that anyone restoring a backup or moving a profile between machines silently empties it. The failure mode it guards is total and silent; the code that guards it is trivial.

And deserialisation is the wrong place to be strict. Refusing a shape *we ourselves wrote last week* costs the reader everything and tells them nothing. An unreadable value now costs the headers — a routing hint they can retype — and nothing else.

## What writing the tests found

A second hole in the same place: **`"Headers": null` bypassed the converter entirely**, because `System.Text.Json` does not consult a converter for null unless it opts in via `HandleNull`. The list came back null rather than empty, for the next thing to enumerate. Covered now.

The tests include the regression as the reader met it — a whole pre-#771 file with two connections, headers in the object shape and hand-built model lists — asserting the models and the unrelated settings all survive. With the converter detached, all seven fail; that is the pin.

**A round-trip test on the new shape would have passed the entire time.** That is the lesson worth keeping: the missing test was never "does this shape serialise", it was **"does this load what the previous version wrote"**.

## Follow-up worth considering separately

`SettingsService` reverting the whole file on any parse failure is a large blast radius for a single bad property, and #319 already records a null section bricking the Settings window. Per-section tolerance — keep what parses, default only what does not — would have turned this incident into a lost header. Not done here, because this fix needs to land now and that one deserves its own argument.

Full suite green (2383 passed, 0 failed), 0 build warnings.
