### PR TITLE
Read the model count plainly (#786)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -90,7 +90,7 @@ public class AiModelsViewModelTests
 
         Assert.False(Group(vm).IsExpanded);
         Assert.Empty(Rows(vm));
-        Assert.Equal("2 models", Group(vm).CountText);
+        Assert.Equal("2 models saved", Group(vm).CountText);   // collapsed: nothing fetched yet
     }
 
     /// <summary>Several models under one connection must be on at once — the whole point of a short list you
@@ -337,7 +337,7 @@ public class AiModelsViewModelTests
 
         Rows(vm).Single(r => r.ModelId == "a").Enabled = true;
 
-        Assert.Equal("1 of 3 models on", Group(vm).CountText);
+        Assert.Equal("1 of 3 models listed", Group(vm).CountText);
     }
 
     /// <summary>Fetched once, on first expand — not on every expand, and not on every keystroke in the search
@@ -411,7 +411,7 @@ public class AiModelsViewModelTests
 
         Rows(vm).Single(r => r.ModelId == "a").Enabled = true;
 
-        Assert.Equal("1 of 2 models on", Group(vm).CountText);
+        Assert.Equal("1 of 2 models listed", Group(vm).CountText);
     }
 
     /// <summary>
@@ -930,5 +930,55 @@ public class AiModelsViewModelTests
         Group(vm).IsExpanded = true;
 
         Assert.Equal(new[] { "Apollo", "mercury", "Zephyr" }, Rows(vm).Select(r => r.DisplayName));
+    }
+
+    // ---- what the count is counting (#785) --------------------------------------------------------------
+
+    /// <summary>
+    /// The listing is fetched only when the group is first expanded, so before that the rows are the reader's
+    /// OWN saved models. "2 of 3" then reads as "this provider has 3 models", which is a different claim from
+    /// the one the number supports — and it sent a reader looking for models that were never missing, three
+    /// times in one sitting.
+    /// </summary>
+    [Fact]
+    public void Before_a_fetch_the_count_says_the_models_are_the_readers_own()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B"), new AiCatalogModel("c", "C")));
+        service.Add("mine", Draft(
+            new AiModelEntry("a", "A"), new AiModelEntry("b", "B", Enabled: false)));
+
+        Assert.Equal("1 of 2 models saved", Group(vm).CountText);
+    }
+
+    /// <summary>And once the provider has answered, the same words would mean something else, so they change.</summary>
+    [Fact]
+    public void After_a_fetch_the_count_says_it_is_the_providers_listing()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B"), new AiCatalogModel("c", "C")));
+        service.Add("mine", Draft(
+            new AiModelEntry("a", "A"), new AiModelEntry("b", "B", Enabled: false)));
+
+        Group(vm).IsExpanded = true;
+
+        Assert.Equal("1 of 3 models listed", Group(vm).CountText);
+    }
+
+    /// <summary>A narrowed view is a third meaning again: neither what the reader has nor what the provider
+    /// offers, and indistinguishable from a short listing without saying so.</summary>
+    [Fact]
+    public void While_searching_the_count_says_it_is_showing_matches()
+    {
+        var (vm, service) = Make(new FakeCatalog(
+            new AiCatalogModel("alpha", "Alpha"),
+            new AiCatalogModel("beta", "Beta"),
+            new AiCatalogModel("alpine", "Alpine")));
+        service.Add("mine", Draft());
+        Group(vm).IsExpanded = true;
+
+        vm.Search = "alp";
+
+        Assert.Equal("0 of 2 models matching", Group(vm).CountText);
     }
 }

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -281,8 +281,23 @@ namespace CST.Avalonia.ViewModels
             {
                 var total = Visible.Count;
                 var on = Visible.Count(r => r.Enabled);
-                if (total == 0) return "no models yet";
-                return on == total ? Plural(total) : $"{on} of {Plural(total)} on";
+                if (total == 0) return _hasFetched ? "no models" : "no models yet";
+
+                // WHAT the number counts, not just the number. The same words meant three different things
+                // in one sitting: the reader's own saved models before the listing arrives, a subset while a
+                // search narrows the view, and the provider's full listing after a fetch. "2 of 3" read as
+                // "Groq has 3 models" every time, and sent them looking for models that were never missing.
+                //
+                // The listing is only fetched when the group is first expanded, so the pre-fetch state is
+                // ordinary rather than a corner: it is what every reader sees for the first second, and what
+                // they keep seeing if they never expand.
+                var noun = !_hasFetched ? "saved"
+                    : _filtered ? "matching"
+                    : "listed";
+
+                return on == total
+                    ? $"{Plural(total)} {noun}"
+                    : $"{on} of {Plural(total)} {noun}";
             }
         }
 
@@ -335,8 +350,14 @@ namespace CST.Avalonia.ViewModels
         /// hiding one behind a price filter would look like it had been lost. Fetched models the reader has
         /// not touched are subject to both the search and the price filter.</para>
         /// </summary>
+        /// <summary>True while the rows are a narrowed view rather than everything this group has, so the
+        /// count can say which it is showing.</summary>
+        private bool _filtered;
+
         internal void ApplyFilter(string search, bool freeOnly, bool searching)
         {
+            _filtered = !string.IsNullOrWhiteSpace(search) || freeOnly;
+
             var stored = _connection.Models.ToDictionary(m => m.Id, StringComparer.Ordinal);
             var rows = new List<AiCatalogRowViewModel>();
 


### PR DESCRIPTION
Closes #786.

The Models tab group header now reads **`2 models`**, or **`2 of 13 models`**.

The trailing `on` is gone: it said which of the two numbers was the enabled one, which the shape `2 of 13` already says.

## What this replaces, and why the first attempt was wrong

The reported problem was that the count meant different things at different moments and used identical words. `AiModelsViewModel.cs:244` starts a fetch only when a group is *first expanded*, and the listing lives in memory for that window only — so the rows are the reader's own saved models until then, the provider's listing after, and whatever matched while a search is active.

That ambiguity was real and it cost a wrong diagnosis. Observed, from a reader who had just lost their model list to the regression fixed in #784: Groq showed `0 of 5`, later `0 of 13`, later `2 of 3` — read as *"most of my models are gone"* — and only **Refresh** turning it into `2 of 13` revealed that nothing was missing. Every number was correct. It then misled me: having ruled out the price filter, I concluded a stale search term must be responsible, because search is the only *other* thing in `ApplyFilter` that shrinks the list. It was not; the fetch simply had not happened.

My first fix qualified the noun — `saved` / `listed` / `matching` — so the words said which set was on screen. **[fsnow]** asked for the plain form instead, and that is right for a reason worth recording: qualifying the noun treats the symptom. The reason a reader ever sees their saved count is that the listing is discarded when the window closes, so every launch starts over. **#790 caches it**, the number becomes the listing from the first paint, and a label explaining which set you are looking at is then explaining a distinction that no longer exists.

So this PR is now the small half — read the count plainly — and #790 is the half that makes it always the right number.

## Tests

The three tests pinning the three state names go with the wording they pinned. What remains pins that no state name and no trailing word appear, and that an all-enabled group reads as the bare count. The pre-fetch state still has coverage — it had none before — it simply no longer asserts a different label for it.

Full suite green, 0 build warnings.
