### PR TITLE
Tick the level the provider says it uses, and drop the prose (#671)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -509,6 +509,15 @@ public class AiModelPickerViewModelTests
             picker.Choices.Select(c => c.Label));
     }
 
+    /// <summary>And with a published default, the levels alone.</summary>
+    [Fact]
+    public void The_effort_chip_offers_only_the_levels_when_the_default_is_known()
+    {
+        var (picker, _) = MakeEffortWithDefault("high", "low", "high", "max");
+
+        Assert.Equal(new[] { "low", "high", "max" }, picker.Choices.Select(c => c.Label));
+    }
+
     /// <summary>Provider default is first, sends nothing, and is where an untouched setting sits.</summary>
     [Fact]
     public void Provider_default_is_first_and_current_until_something_is_chosen()
@@ -541,6 +550,88 @@ public class AiModelPickerViewModelTests
         picker.Choices.First().ChooseCommand.Execute().Subscribe();
 
         Assert.Null(settings.Ai.Chat.ReasoningEffort);
+    }
+
+    private static (AiEffortPickerViewModel Picker, Settings Settings) MakeEffortWithDefault(
+        string theirDefault, params string[] efforts)
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object, new FakeCredentialStore());
+        service.Add("mine", new AiConnectionDraft(
+            "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
+            new[] { new AiModelEntry("m", "M", ReasoningEfforts: efforts,
+                                     DefaultReasoningEffort: theirDefault) },
+            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
+        service.SetActive("mine", "m");
+        return (new AiEffortPickerViewModel(service, svc.Object), settings);
+    }
+
+    /// <summary>
+    /// Where the provider says which level it applies, that level is ticked and there is no separate
+    /// "Provider default" row: the reader wants to know what will happen, and a row saying "default" above a
+    /// list containing the default says it twice and answers it once.
+    /// </summary>
+    [Fact]
+    public void A_published_default_is_ticked_and_needs_no_extra_row()
+    {
+        var (picker, settings) = MakeEffortWithDefault("high", "high", "medium");
+
+        Assert.Equal(new[] { "high", "medium" }, picker.Choices.Select(c => c.Label));
+        Assert.True(picker.Choices.Single(c => c.Label == "high").IsCurrent);
+        Assert.Equal("Effort: high", picker.CurrentLabel);
+        Assert.Null(settings.Ai.Chat.ReasoningEffort);   // ticked, and still sending nothing
+    }
+
+    /// <summary>The tick describes the outcome, not the payload: nothing is sent until the reader moves it.</summary>
+    [Fact]
+    public void Ticking_the_published_default_does_not_start_sending_a_field()
+    {
+        var (_, settings) = MakeEffortWithDefault("high", "high", "medium");
+
+        Assert.Null(settings.Ai.Chat.ReasoningEffort);
+    }
+
+    [Fact]
+    public void Choosing_a_level_beside_the_published_default_moves_the_tick()
+    {
+        var (picker, settings) = MakeEffortWithDefault("high", "high", "medium");
+
+        picker.Choices.Single(c => c.Label == "medium").ChooseCommand.Execute().Subscribe();
+
+        Assert.Equal("medium", settings.Ai.Chat.ReasoningEffort);
+        Assert.True(picker.Choices.Single(c => c.Label == "medium").IsCurrent);
+        Assert.False(picker.Choices.Single(c => c.Label == "high").IsCurrent);
+    }
+
+    /// <summary>
+    /// The same stale-choice case with a published default: the default level is ticked, not nothing — the
+    /// wire drops the stale value and the provider applies its own, so that is what the flyout must say.
+    /// </summary>
+    [Fact]
+    public void A_stale_choice_falls_back_to_the_published_default_being_ticked()
+    {
+        var (picker, settings) = MakeEffortWithDefault("high", "high", "medium");
+        settings.Ai.Chat.ReasoningEffort = "max";   // real elsewhere, absent here
+        picker.Rebuild();
+
+        Assert.True(picker.Choices.Single(c => c.Label == "high").IsCurrent);
+        Assert.False(picker.Choices.Single(c => c.Label == "medium").IsCurrent);
+        Assert.Equal("Effort: high", picker.CurrentLabel);
+    }
+
+    /// <summary>
+    /// Where the provider publishes no default there is no basis for ticking a level, so the extra row earns
+    /// its place: something has to be current.
+    /// </summary>
+    [Fact]
+    public void With_no_published_default_the_provider_default_row_remains()
+    {
+        var (picker, _, _) = MakeEffort("low", "high");
+
+        Assert.Equal(new[] { "Provider default", "low", "high" }, picker.Choices.Select(c => c.Label));
+        Assert.True(picker.Choices.First().IsCurrent);
     }
 
     /// <summary>
@@ -617,29 +708,4 @@ public class AiModelPickerViewModelTests
         Assert.False(picker.HasChoices);
     }
 
-    /// <summary>
-    /// The provider's own statement of its default is shown against that position rather than acted on: not
-    /// sending the field already means exactly that, so preselecting a level would send something where
-    /// nothing was asked for.
-    /// </summary>
-    [Fact]
-    public void A_published_default_is_shown_as_a_hint_not_preselected()
-    {
-        var settings = new Settings();
-        var svc = new Mock<ISettingsService>();
-        svc.SetupGet(s => s.Settings).Returns(settings);
-        var service = new AiConnectionService(svc.Object, new FakeCredentialStore());
-        service.Add("mine", new AiConnectionDraft(
-            "Mine", ChatProviderKind.OpenAiCompatible, "https://example.test/v1",
-            new[] { new AiModelEntry("m", "M", ReasoningEfforts: new[] { "low", "high" },
-                                     DefaultReasoningEffort: "high") },
-            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
-        service.SetActive("mine", "m");
-
-        var picker = new AiEffortPickerViewModel(service, svc.Object);
-
-        Assert.Contains("high", picker.Choices.First().Hint);
-        Assert.True(picker.Choices.First().IsCurrent);       // still the default position
-        Assert.Null(settings.Ai.Chat.ReasoningEffort);       // and still sends nothing
-    }
 }

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -427,32 +427,30 @@ namespace CST.Avalonia.ViewModels
             }
 
             var chosen = Chosen;
+            var theirs = model!.DefaultReasoningEffort;
+            var knowTheirDefault = theirs is { Length: > 0 } && published.Contains(theirs, StringComparer.Ordinal);
 
-            // Current when nothing WILL be sent, which is not the same as nothing being stored. A choice made
-            // on another model - "max" on DeepSeek, then a switch to a model offering low/medium/high - is
-            // outside this model's vocabulary, so the wire guard drops it and the provider applies its own
-            // default. Keying this off "is anything stored" left no row ticked at all, showing the reader an
-            // unmarked list for a setting that does in fact have an effect. This is the same fact the chip
-            // label already told them; the flyout has to agree with it. (fable review)
+            // What will actually happen on the next turn, which is what the tick has to describe.
+            //
+            // A stored choice only counts while it is in THIS model's vocabulary — the wire guard drops it
+            // otherwise, so "max" chosen on DeepSeek is inert on a model offering low/medium/high. Where the
+            // provider states its own default, that is what happens when nothing is sent, so that level is
+            // current. Where it does not, nothing here can say what happens, and the extra row carries it.
             var willSend = !string.IsNullOrWhiteSpace(chosen)
-                           && published.Any(v => string.Equals(v, chosen, StringComparison.Ordinal));
+                           && published.Contains(chosen!, StringComparer.Ordinal);
+            var current = willSend ? chosen : (knowTheirDefault ? theirs : null);
 
-            // The default sits first because it is the position that sends nothing, and because a reader
-            // scanning the list should meet "leave it alone" before any level.
-            Choices.Add(new AiEffortChoiceViewModel(
-                null,
-                "Provider default",
-                model!.DefaultReasoningEffort is { Length: > 0 } theirs ? $"the provider uses {theirs}" : null,
-                !willSend,
-                Choose));
+            // No separate "Provider default" row where the provider named its default: the reader wants to
+            // know what will happen, and a row saying "default" above a list containing that same default
+            // says it twice and answers it once. Nothing is sent while their choice matches it, exactly as
+            // before — the tick describes the outcome, not the payload.
+            if (!knowTheirDefault)
+                Choices.Add(new AiEffortChoiceViewModel(
+                    null, "Provider default", current is null, Choose));
 
             foreach (var value in published)
                 Choices.Add(new AiEffortChoiceViewModel(
-                    value,
-                    value,
-                    null,
-                    string.Equals(value, chosen, StringComparison.Ordinal),
-                    Choose));
+                    value, value, string.Equals(value, current, StringComparison.Ordinal), Choose));
 
             this.RaisePropertyChanged(nameof(HasChoices));
             this.RaisePropertyChanged(nameof(CurrentLabel));
@@ -484,11 +482,10 @@ namespace CST.Avalonia.ViewModels
         private readonly Action<string?> _choose;
 
         public AiEffortChoiceViewModel(
-            string? value, string label, string? hint, bool isCurrent, Action<string?> choose)
+            string? value, string label, bool isCurrent, Action<string?> choose)
         {
             Value = value;
             Label = label;
-            Hint = hint;
             IsCurrent = isCurrent;
             _choose = choose;
             ChooseCommand = ReactiveCommand.Create(() => _choose(Value));
@@ -497,11 +494,6 @@ namespace CST.Avalonia.ViewModels
         public string? Value { get; }
         public string Label { get; }
 
-        /// <summary>The provider's own statement of what it does by default, where it makes one. Shown rather
-        /// than acted on: we do not preselect it, because not sending the field already means exactly that.</summary>
-        public string? Hint { get; }
-
-        public bool HasHint => !string.IsNullOrWhiteSpace(Hint);
         public bool IsCurrent { get; }
 
         /// <summary>What the chip shows when this position is the current one.</summary>

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -293,21 +293,16 @@
                                                      model picker (#693). An Auto column would measure the
                                                      label at infinite width and push the tick off the row. -->
                                                 <Grid ColumnDefinitions="*,Auto">
-                                                    <StackPanel Grid.Column="0">
-                                                        <TextBlock Text="{Binding Label}" FontSize="12"
-                                                                   Classes.current="{Binding IsCurrent}">
-                                                            <TextBlock.Styles>
-                                                                <Style Selector="TextBlock.current">
-                                                                    <Setter Property="Foreground"
-                                                                            Value="{DynamicResource SystemAccentColor}"/>
-                                                                </Style>
-                                                            </TextBlock.Styles>
-                                                        </TextBlock>
-                                                        <TextBlock Text="{Binding Hint}"
-                                                                   IsVisible="{Binding HasHint}"
-                                                                   FontSize="10" TextWrapping="Wrap"
-                                                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                                                    </StackPanel>
+                                                    <TextBlock Grid.Column="0" Text="{Binding Label}"
+                                                               FontSize="12" VerticalAlignment="Center"
+                                                               Classes.current="{Binding IsCurrent}">
+                                                        <TextBlock.Styles>
+                                                            <Style Selector="TextBlock.current">
+                                                                <Setter Property="Foreground"
+                                                                        Value="{DynamicResource SystemAccentColor}"/>
+                                                            </Style>
+                                                        </TextBlock.Styles>
+                                                    </TextBlock>
                                                     <TextBlock Grid.Column="1" Text="✓" FontSize="11"
                                                                IsVisible="{Binding IsCurrent}"
                                                                VerticalAlignment="Center"
@@ -317,10 +312,6 @@
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
-
-                                <TextBlock Text="Only the levels this model publishes. Provider default sends nothing, so the provider applies its own."
-                                           FontSize="10" TextWrapping="Wrap" Margin="6,6,6,2"
-                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                             </StackPanel>
                         </Flyout>
                     </Button.Flyout>


### PR DESCRIPTION
Follow-up to #783, which merged before this commit was written. Part of #671.

Reported from use, looking at the effort flyout for a model publishing `high` and `medium` with a default of `high`:

> "If we know the provider's default, we should check it. In this case it should just be high (checked and showing by default) and medium. We do not need the explanatory text."

Right on both counts. The flyout was explaining its own mechanism instead of answering the question the reader had:

```
✓ Provider default
  the provider uses high
  high
  medium
  Only the levels this model publishes. Provider default sends nothing,
  so the provider applies its own.
```

A row saying "default" above a list that *contains* that default says the same thing twice and answers it once, and the paragraph underneath described a distinction — sent versus omitted — that is ours to keep straight, not theirs. Now:

```
✓ high
  medium
```

## What did not change

**Nothing is sent while the choice matches the provider's default.** The tick describes the outcome, not the payload: `high` shows ticked with `ReasoningEffort` still null, and the request goes out without the field exactly as before. Pinned by a test, because this is the part that would be easy to "simplify" into always sending the ticked value — which would start sending a parameter to every model with a published default, including on turns where the reader never opened the flyout.

**The extra row survives where the provider publishes no default.** There, nothing can say what happens when the field is omitted, so something has to be current and only the explicit row can be.

## What the tick follows

What *will* happen, not what is stored. A choice made on another model — `max` on DeepSeek, then a switch to a model offering `low/medium/high` — is dropped by the wire guard in `AiChatOrchestrator`, so it must not appear current here either. With a published default that falls back to the default being ticked; without one, to the Provider default row.

That was not free: the first cut of this change reintroduced the no-row-ticked state Fable found during #783's review, where a stale choice left the flyout showing an unmarked list for a setting that does have an effect. The test written for that finding caught it again immediately, which is the second time today a test earned its place by failing on a later change rather than on the one it was written for.

Full suite green (2388 passed, 0 failed), 0 build warnings.
