### PR TITLE
Test that this build loads what earlier builds wrote (#787)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/OlderApplicationStateFilesLoadTests.cs
+++ b/src/CST.Avalonia.Tests/Services/OlderApplicationStateFilesLoadTests.cs
@@ -1,0 +1,119 @@
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CST.Avalonia.Models;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// The same question as <see cref="OlderSettingsFilesLoadTests"/>, for the other persisted store: can this
+/// build load an <c>app-state.json</c> an earlier build wrote? (#787)
+///
+/// <para><b>Why this one needs saying twice.</b> <c>ApplicationStateService</c> looks protected, because a
+/// failed load falls back through timestamped backups until one deserializes. But the backups are written in
+/// the SAME shape as the primary file — so a persisted-type change breaks every one of them at once, and the
+/// recovery walks a whole directory of files it also cannot read before defaulting. Backup recovery and this
+/// test are complements, not alternatives.</para>
+///
+/// <para>These exercise deserialize + migrate + sanitize, which is what the service's load path does with the
+/// file's bytes; the file IO around it is covered elsewhere.</para>
+/// </summary>
+public sealed class OlderApplicationStateFilesLoadTests
+{
+    // Must mirror ApplicationStateService's options exactly — camelCase in particular, since a mismatch here
+    // would make every fixture "load" as an empty object and quietly pass.
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private static ApplicationState Load(string json)
+    {
+        var state = JsonSerializer.Deserialize<ApplicationState>(json, Options);
+        Assert.NotNull(state);
+        ApplicationStateValidator.Migrate(state!);
+        ApplicationStateValidator.Sanitize(state!);
+        return state!;
+    }
+
+    // The guard against the whole class silently passing: if the options above drifted from the service's, a
+    // camelCase fixture would deserialize to defaults and every assertion below would still hold.
+    [Fact]
+    public void The_fixtures_really_deserialize_rather_than_yielding_defaults()
+    {
+        var state = Load("""{ "version": "1.0", "mainWindow": { "width": 1234 } }""");
+        Assert.Equal(1234, state.MainWindow.Width);
+    }
+
+    [Fact]
+    public void A_state_file_with_no_dictionary_or_ai_sections_loads()
+    {
+        // Sections are added over time; an older file simply lacks the newer ones.
+        var state = Load("""
+        {
+          "version": "1.0",
+          "mainWindow": { "width": 1400, "height": 900 }
+        }
+        """);
+
+        Assert.Equal(1400, state.MainWindow.Width);
+        Assert.NotNull(state.SettingsWindow);
+        Assert.NotNull(state.DictionaryDialog);
+    }
+
+    [Fact]
+    public void Properties_this_build_does_not_know_are_ignored_not_fatal()
+    {
+        // The likelier failure than corruption: a file written by a NEWER build, or restored from one.
+        var state = Load("""
+        {
+          "version": "9.9",
+          "mainWindow": { "width": 1400, "somethingNewer": { "a": [1, 2] } },
+          "aFutureSection": { "b": "c" }
+        }
+        """);
+
+        Assert.Equal(1400, state.MainWindow.Width);
+    }
+
+    [Fact]
+    public void A_null_collection_does_not_come_back_null_for_the_next_thing_to_enumerate()
+    {
+        // #319's shape: a null section reaching code that enumerates it. Sanitize is what must absorb this,
+        // and an explicit null is the case that skips converters and defaults alike.
+        var state = Load("""
+        {
+          "version": "1.0",
+          "dictionaryDialog": { "sourceOrder": null },
+          "openBookDialog": { "expandedNodeKeys": null },
+          "searchDialog": { "selectedTerms": null },
+          "appliedDataMigrations": null,
+          "bookWindows": [ { "bookIndex": 1, "searchTerms": null, "searchPositions": null } ],
+          "mainWindow": { "width": 1400 }
+        }
+        """);
+
+        // A property initializer runs when the object is constructed and is then OVERWRITTEN by an explicit
+        // JSON null, so "= new()" on the model is no defence at all. Sanitize is what must absorb it.
+        Assert.NotNull(state.DictionaryDialog.SourceOrder);
+        Assert.Empty(state.DictionaryDialog.SourceOrder);
+        Assert.NotNull(state.OpenBookDialog.ExpandedNodeKeys);
+        Assert.NotNull(state.SearchDialog.SelectedTerms);
+        Assert.NotNull(state.AppliedDataMigrations);
+        Assert.NotNull(Assert.Single(state.BookWindows).SearchTerms);
+        Assert.NotNull(Assert.Single(state.BookWindows).SearchPositions);
+    }
+
+    [Fact]
+    public void An_empty_object_loads_as_a_usable_default_state()
+    {
+        var state = Load("{}");
+
+        Assert.NotNull(state.MainWindow);
+        Assert.NotNull(state.DictionaryDialog.SourceOrder);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/OlderApplicationStateFilesLoadTests.cs
+++ b/src/CST.Avalonia.Tests/Services/OlderApplicationStateFilesLoadTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CST.Avalonia.Models;
+using CST.Avalonia.Services;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services;
@@ -21,15 +22,11 @@ namespace CST.Avalonia.Tests.Services;
 /// </summary>
 public sealed class OlderApplicationStateFilesLoadTests
 {
-    // Must mirror ApplicationStateService's options exactly — camelCase in particular, since a mismatch here
-    // would make every fixture "load" as an empty object and quietly pass.
-    private static readonly JsonSerializerOptions Options = new()
-    {
-        WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-        Converters = { new JsonStringEnumConverter() }
-    };
+    // THE SERVICE'S OWN OPTIONS, not a copy of them. A mirrored copy cannot detect drift from the original —
+    // change the naming policy or drop the enum converter and every real file on disk stops loading while this
+    // suite stays green, because fixture and copy moved together. That is precisely the class of regression
+    // these tests exist to catch, so mirroring would have made them decorative. (#787, fable)
+    private static readonly JsonSerializerOptions Options = ApplicationStateService.JsonOptions;
 
     private static ApplicationState Load(string json)
     {
@@ -47,6 +44,34 @@ public sealed class OlderApplicationStateFilesLoadTests
     {
         var state = Load("""{ "version": "1.0", "mainWindow": { "width": 1234 } }""");
         Assert.Equal(1234, state.MainWindow.Width);
+    }
+
+    // The riskiest thing in a REAL old state file, and nothing covered it: enum strings.
+    //
+    // BookScript, CurrentScript and SearchMode carry their own converter attributes, but
+    // MainWindowState.WindowState and BookWindowState.WindowState depend on the GLOBAL
+    // JsonStringEnumConverter in the service's options alone — and every real file whose window was maximized
+    // carries one. Drop or reconfigure that converter and every such file throws on load, which destroys the
+    // primary file AND invalidates every backup at once, since the backups share its shape. That is the exact
+    // scenario this class exists to prevent, and hand-written minimal fixtures were blind to it. (#787, fable)
+    [Fact]
+    public void Enum_values_written_as_strings_still_load()
+    {
+        var state = Load("""
+        {
+          "version": "1.0",
+          "mainWindow": { "width": 1400, "height": 900, "windowState": "Maximized" },
+          "searchDialog": { "searchMode": "Regex" },
+          "bookWindows": [ {
+            "bookIndex": 3, "bookScript": "Thai", "windowState": "Maximized" } ]
+        }
+        """);
+
+        Assert.Equal(CST.Avalonia.Models.WindowState.Maximized, state.MainWindow.WindowState);
+        Assert.Equal(CST.Avalonia.Models.SearchMode.Regex, state.SearchDialog.SearchMode);
+        var book = Assert.Single(state.BookWindows);
+        Assert.Equal(CST.Conversion.Script.Thai, book.BookScript);
+        Assert.Equal(CST.Avalonia.Models.WindowState.Maximized, book.WindowState);
     }
 
     [Fact]
@@ -106,6 +131,28 @@ public sealed class OlderApplicationStateFilesLoadTests
         Assert.NotNull(state.AppliedDataMigrations);
         Assert.NotNull(Assert.Single(state.BookWindows).SearchTerms);
         Assert.NotNull(Assert.Single(state.BookWindows).SearchPositions);
+    }
+
+    // A null ENTRY is the same mechanism one level in, and coalescing the list does nothing for it. The
+    // dictionary picker dereferences pref.Id directly. (#787, fable)
+    [Fact]
+    public void Null_entries_inside_those_collections_are_dropped()
+    {
+        var state = Load("""
+        {
+          "version": "1.0",
+          "dictionaryDialog": { "sourceOrder": [ null, { "id": null }, { "id": "dpd", "enabled": true } ] },
+          "searchDialog": { "selectedTerms": [ null, "dhamma" ] },
+          "openBookDialog": { "expandedNodeKeys": [ null, "n1" ] },
+          "bookWindows": [ { "bookIndex": 1, "searchTerms": [ null, "x" ] } ]
+        }
+        """);
+
+        var pref = Assert.Single(state.DictionaryDialog.SourceOrder);
+        Assert.Equal("dpd", pref.Id);
+        Assert.DoesNotContain(null, state.SearchDialog.SelectedTerms);
+        Assert.DoesNotContain(null, state.OpenBookDialog.ExpandedNodeKeys);
+        Assert.DoesNotContain(null, Assert.Single(state.BookWindows).SearchTerms);
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/OlderSettingsFilesLoadTests.cs
+++ b/src/CST.Avalonia.Tests/Services/OlderSettingsFilesLoadTests.cs
@@ -153,6 +153,27 @@ public sealed class OlderSettingsFilesLoadTests : IDisposable
         Assert.Equal("c1", connection.Id);
     }
 
+    [Fact]
+    public async Task Null_entries_and_id_less_records_are_dropped_rather_than_projected()
+    {
+        // ToRuntime projects every connection and every model unconditionally, and hands each id to a
+        // dictionary lookup — so one null entry, or one record with no id, breaks the whole AI settings page
+        // rather than itself. (#787, fable)
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Chat": { "Connections": [
+            { "Id": null, "Kind": "openai-compatible", "BaseUrl": "https://example.invalid/v1" },
+            { "Id": "c1", "Kind": "openai-compatible", "BaseUrl": "https://example.invalid/v1",
+              "Models": [ null, { "Id": null }, { "Id": "llama-3.1-8b" } ] } ] } }
+        }
+        """);
+
+        var connection = Assert.Single(settings.Ai.Chat.Connections);
+        Assert.Equal("c1", connection.Id);
+        Assert.Equal("llama-3.1-8b", Assert.Single(connection.Models).Id);
+    }
+
     // ---- files older than the AI work entirely ----
 
     // Beta 5 shipped before any of the AI configuration existed, so its file has no Ai section at all. A
@@ -178,8 +199,13 @@ public sealed class OlderSettingsFilesLoadTests : IDisposable
     [Fact]
     public async Task A_nearly_empty_file_loads_rather_than_being_discarded()
     {
-        var settings = await Load("""{ "Version": "1.0" }""");
+        var settings = await Load("""{ "Version": "1.0", "IndexDirectory": "/idx" }""");
 
+        // A distinctive value, because every other assertion here is also true of a DISCARDED file: defaults
+        // plus first-run defaulting produce a non-null FontSettings, a non-null Ai and a filled
+        // XmlBooksDirectory too. Without this the test could not fail through the path its name denounces.
+        // (fable)
+        Assert.Equal("/idx", settings.IndexDirectory);
         Assert.NotNull(settings.FontSettings);
         Assert.NotNull(settings.Ai);
         // ApplyFirstRunDefaults must still have run: an empty XmlBooksDirectory changes update and indexing

--- a/src/CST.Avalonia.Tests/Services/OlderSettingsFilesLoadTests.cs
+++ b/src/CST.Avalonia.Tests/Services/OlderSettingsFilesLoadTests.cs
@@ -50,6 +50,12 @@ public sealed class OlderSettingsFilesLoadTests : IDisposable
     }
 
     // ---- the shape that actually broke ----
+    //
+    // The converter's own fixtures live in AiHeaderRecordListConverterTests (#784) and go deeper into the
+    // shape itself. What is here is deliberately the OTHER question: not "does the converter read both
+    // shapes" but "does a whole settings file written by the previous build still load, and does the rest of
+    // it survive" — which is the assertion that failed in the field, and it failed for XmlBooksDirectory as
+    // much as for the connection. Extend the converter tests for shape questions; extend these for file ones.
 
     // Headers as a JSON OBJECT, which is what every build before #771 wrote.
     [Fact]
@@ -94,6 +100,57 @@ public sealed class OlderSettingsFilesLoadTests : IDisposable
         var connection = Assert.Single(settings.Ai.Chat.Connections);
         Assert.NotNull(connection.Headers);          // the next thing to enumerate it must not throw
         Assert.Empty(connection.Headers);
+    }
+
+    // Four collections declared "= new()" on the model and enumerated with no null check. The initializer
+    // runs at construction and an explicit JSON null overwrites it, so it guarantees nothing. #319 identified
+    // this mechanism exactly and applied it to the SECTIONS only — a section null bricks the Settings window,
+    // which is what it was chasing, but a collection null is what AiConnectionService actually enumerates.
+    // Found by kestrel-cst-2 while reading this work. (#787)
+    [Fact]
+    public async Task Null_collections_anywhere_in_the_AI_section_load_as_empty()
+    {
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Enabled": true, "Chat": { "Connections": [ {
+            "Id": "c1", "Kind": "openai-compatible", "BaseUrl": "https://example.invalid/v1",
+            "Models": null, "Inputs": null, "Headers": null } ] } }
+        }
+        """);
+
+        var connection = Assert.Single(settings.Ai.Chat.Connections);
+        Assert.NotNull(connection.Models);
+        Assert.NotNull(connection.Inputs);
+        Assert.NotNull(connection.Headers);
+    }
+
+    [Fact]
+    public async Task A_null_connections_list_loads_as_empty_rather_than_null()
+    {
+        var settings = await Load("""
+        { "XmlBooksDirectory": "/books", "Ai": { "Chat": { "Connections": null } } }
+        """);
+
+        Assert.NotNull(settings.Ai.Chat.Connections);
+        Assert.Empty(settings.Ai.Chat.Connections);
+    }
+
+    [Fact]
+    public async Task A_null_entry_in_the_connections_list_is_dropped()
+    {
+        // Same hazard as a null list, one level in: ToRuntime dereferences each entry.
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Chat": { "Connections": [
+            null,
+            { "Id": "c1", "Kind": "openai-compatible", "BaseUrl": "https://example.invalid/v1" } ] } }
+        }
+        """);
+
+        var connection = Assert.Single(settings.Ai.Chat.Connections);
+        Assert.Equal("c1", connection.Id);
     }
 
     // ---- files older than the AI work entirely ----

--- a/src/CST.Avalonia.Tests/Services/OlderSettingsFilesLoadTests.cs
+++ b/src/CST.Avalonia.Tests/Services/OlderSettingsFilesLoadTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// Can this build load what an EARLIER build wrote? (#787)
+///
+/// <para>Every persisted model here is round-tripped in some test — serialize the current shape, deserialize
+/// it, assert it survives. Those tests pass the whole time a type change is breaking real installations,
+/// because both halves speak the new shape. The test that fails is this one, and nobody writes it because
+/// after a type change the old shape no longer exists in the code to write it against. So it has to be
+/// captured as a literal, which is what the fixtures below are.</para>
+///
+/// <para><b>What went wrong without it.</b> <c>AiConnectionRecord.Headers</c> changed from
+/// <c>Dictionary&lt;string, string&gt;</c> to <c>List&lt;AiHeaderRecord&gt;</c> (#771). A settings file
+/// written the previous day threw <c>JsonException</c> on load — and <c>SettingsService</c> answers a failed
+/// load by replacing the settings with defaults and SAVING them, so the file was not merely unreadable, it was
+/// overwritten. One property cost a whole configuration: books directory, fonts, layout, every connection and
+/// every hand-built model list. (#784 fixed the reading; #785 covers the blast radius.)</para>
+///
+/// <para><b>These assert the load path copes, not that it round-trips.</b> An old file legitimately lacks
+/// fields that exist now, and a file from a NEWER build carries fields that do not exist yet. Neither is an
+/// error; both must leave the rest of the file intact.</para>
+///
+/// <para>Adding a fixture here is the cheap half. The discipline worth keeping is capturing one BEFORE
+/// changing a persisted type, while the old shape still exists to copy.</para>
+/// </summary>
+public sealed class OlderSettingsFilesLoadTests : IDisposable
+{
+    private readonly string _dir;
+
+    public OlderSettingsFilesLoadTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"old-settings-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    private async Task<Settings> Load(string json)
+    {
+        await File.WriteAllTextAsync(Path.Combine(_dir, "settings.json"), json);
+        var svc = new SettingsService(_dir);
+        await svc.LoadSettingsAsync();
+        return svc.Settings;
+    }
+
+    // ---- the shape that actually broke ----
+
+    // Headers as a JSON OBJECT, which is what every build before #771 wrote.
+    [Fact]
+    public async Task A_pre_771_file_with_object_headers_still_loads_and_keeps_them()
+    {
+        var settings = await Load("""
+        {
+          "Version": "1.0",
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Enabled": true, "Chat": { "Enabled": true, "ActiveConnectionId": "c1",
+            "Connections": [ {
+              "Id": "c1", "DisplayName": "A gateway", "Kind": "openai-compatible",
+              "BaseUrl": "https://example.invalid/v1",
+              "Headers": { "X-Gateway": "token", "X-Title": "CST Reader" }
+            } ] } }
+        }
+        """);
+
+        // The whole file survives — this is the assertion that failed in the field, and it failed for
+        // XmlBooksDirectory as much as for the connection.
+        Assert.Equal("/books", settings.XmlBooksDirectory);
+        var connection = Assert.Single(settings.Ai.Chat.Connections);
+        Assert.Equal("A gateway", connection.DisplayName);
+        Assert.Equal(2, connection.Headers.Count);
+        Assert.Contains(connection.Headers, h => h.Name == "X-Gateway" && h.Value == "token");
+    }
+
+    // The second hole, found only by writing this kind of test: System.Text.Json does not consult a converter
+    // for null unless it opts in via HandleNull, so an explicit null bypassed the shape handling entirely.
+    [Fact]
+    public async Task Null_headers_load_as_an_empty_list_not_as_null()
+    {
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Chat": { "Connections": [ {
+            "Id": "c1", "Kind": "openai-compatible", "BaseUrl": "https://example.invalid/v1",
+            "Headers": null } ] } }
+        }
+        """);
+
+        var connection = Assert.Single(settings.Ai.Chat.Connections);
+        Assert.NotNull(connection.Headers);          // the next thing to enumerate it must not throw
+        Assert.Empty(connection.Headers);
+    }
+
+    // ---- files older than the AI work entirely ----
+
+    // Beta 5 shipped before any of the AI configuration existed, so its file has no Ai section at all. A
+    // missing section is an ordinary state, not a defect.
+    [Fact]
+    public async Task A_file_with_no_Ai_section_loads_and_defaults_it()
+    {
+        var settings = await Load("""
+        {
+          "Version": "1.0",
+          "XmlBooksDirectory": "/books",
+          "FontSettings": { },
+          "XmlUpdateSettings": { }
+        }
+        """);
+
+        Assert.Equal("/books", settings.XmlBooksDirectory);
+        Assert.NotNull(settings.Ai);
+        Assert.False(settings.Ai.Enabled);           // off is the shipped default
+        Assert.Empty(settings.Ai.Chat.Connections);
+    }
+
+    [Fact]
+    public async Task A_nearly_empty_file_loads_rather_than_being_discarded()
+    {
+        var settings = await Load("""{ "Version": "1.0" }""");
+
+        Assert.NotNull(settings.FontSettings);
+        Assert.NotNull(settings.Ai);
+        // ApplyFirstRunDefaults must still have run: an empty XmlBooksDirectory changes update and indexing
+        // behaviour, which is the whole point of STATE-3.
+        Assert.False(string.IsNullOrEmpty(settings.XmlBooksDirectory));
+    }
+
+    // ---- files from a build NEWER than this one ----
+
+    // A reader who runs a newer build, then goes back — or restores a backup from one. Unknown properties are
+    // not an error, and treating them as one would discard a working configuration for containing something we
+    // do not need. This is the likelier case in practice than genuine corruption.
+    [Fact]
+    public async Task Properties_this_build_does_not_know_are_ignored_not_fatal()
+    {
+        var settings = await Load("""
+        {
+          "Version": "9.9",
+          "XmlBooksDirectory": "/books",
+          "SomeFutureSetting": { "nested": [1, 2, 3] },
+          "Ai": { "Enabled": true, "FutureAiKnob": "on",
+            "Chat": { "Connections": [ {
+              "Id": "c1", "Kind": "openai-compatible", "BaseUrl": "https://example.invalid/v1",
+              "Headers": [ { "Name": "X-A", "Value": "1" } ],
+              "FutureConnectionField": 42 } ] } }
+        }
+        """);
+
+        Assert.Equal("/books", settings.XmlBooksDirectory);
+        Assert.True(settings.Ai.Enabled);
+        var connection = Assert.Single(settings.Ai.Chat.Connections);
+        Assert.Equal("X-A", Assert.Single(connection.Headers).Name);
+    }
+
+    // ---- the current shape, so the fixtures above cannot silently stop being "old" ----
+
+    [Fact]
+    public async Task The_current_header_shape_still_loads()
+    {
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Chat": { "Connections": [ {
+            "Id": "c1", "Kind": "openai-compatible", "BaseUrl": "https://example.invalid/v1",
+            "Headers": [ { "Name": "X-A", "Value": "1", "Secret": false } ] } ] } }
+        }
+        """);
+
+        var header = Assert.Single(Assert.Single(settings.Ai.Chat.Connections).Headers);
+        Assert.Equal("X-A", header.Name);
+        Assert.Equal("1", header.Value);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/src/CST.Avalonia/Models/ApplicationStateValidator.cs
+++ b/src/CST.Avalonia/Models/ApplicationStateValidator.cs
@@ -111,6 +111,15 @@ public static class ApplicationStateValidator
         sd.SelectedTerms ??= new List<string>();
         dd.SourceOrder ??= new List<DictionarySourcePreference>();
 
+        // And the ENTRIES, which coalescing the list does nothing for. `[null]` and `[{"id": null}]` both
+        // reach DictionarySourcePreferenceService.GetRows, which dereferences pref.Id and then hands it to a
+        // dictionary lookup — an NRE and an ArgumentNullException respectively, in the dictionary picker.
+        // Same mechanism as the list itself, one level in. (#787, fable)
+        ob.ExpandedNodeKeys.RemoveAll(string.IsNullOrEmpty);
+        sd.SelectedTerms.RemoveAll(string.IsNullOrEmpty);
+        int badPrefs = dd.SourceOrder.RemoveAll(p => p == null || string.IsNullOrWhiteSpace(p.Id));
+        if (badPrefs > 0) fixes.Add($"removed {badPrefs} dictionary source preference(s) with no id");
+
         // Book windows
         state.BookWindows ??= new List<BookWindowState>();
         int removed = state.BookWindows.RemoveAll(w => w == null || w.BookIndex < 0);
@@ -121,6 +130,8 @@ public static class ApplicationStateValidator
             if (IsBadSize(w.Height)) { w.Height = BookH; fixes.Add($"book window '{w.BookFileName}' height -> {BookH}"); }
             w.SearchTerms ??= new List<string>();
             w.SearchPositions ??= new List<TermPosition>();
+            w.SearchTerms.RemoveAll(string.IsNullOrEmpty);
+            w.SearchPositions.RemoveAll(p => p == null);
             if (IsBadCoord(w.X)) w.X = null;
             if (IsBadCoord(w.Y)) w.Y = null;
             if (string.IsNullOrEmpty(w.WindowId)) { w.WindowId = Guid.NewGuid().ToString(); fixes.Add("book window assigned a new id"); }

--- a/src/CST.Avalonia/Models/ApplicationStateValidator.cs
+++ b/src/CST.Avalonia/Models/ApplicationStateValidator.cs
@@ -98,6 +98,19 @@ public static class ApplicationStateValidator
         var sd = state.SearchDialog ??= new SearchDialogState();
         if (sd.ProximityDistance < 0) { sd.ProximityDistance = 10; fixes.Add("search proximity distance -> 10"); }
 
+        // Every collection, null-coalesced.
+        //
+        // Sanitize already ??=-ed the SECTIONS, but not the lists inside them — so an explicit
+        // "sourceOrder": null survived to the first thing that enumerated it. Deserialization is where this
+        // arrives: a property initializer runs when the object is constructed and is then OVERWRITTEN by an
+        // explicit JSON null, which is exactly the shape #319 records (a null section bricking the Settings
+        // window). A state file can carry a null for any of these — hand-edited, written by a build where the
+        // field was nullable, or produced by a serializer configured differently. (#787)
+        state.AppliedDataMigrations ??= new List<string>();
+        ob.ExpandedNodeKeys ??= new List<string>();
+        sd.SelectedTerms ??= new List<string>();
+        dd.SourceOrder ??= new List<DictionarySourcePreference>();
+
         // Book windows
         state.BookWindows ??= new List<BookWindowState>();
         int removed = state.BookWindows.RemoveAll(w => w == null || w.BookIndex < 0);
@@ -106,6 +119,8 @@ public static class ApplicationStateValidator
         {
             if (IsBadSize(w.Width)) { w.Width = BookW; fixes.Add($"book window '{w.BookFileName}' width -> {BookW}"); }
             if (IsBadSize(w.Height)) { w.Height = BookH; fixes.Add($"book window '{w.BookFileName}' height -> {BookH}"); }
+            w.SearchTerms ??= new List<string>();
+            w.SearchPositions ??= new List<TermPosition>();
             if (IsBadCoord(w.X)) w.X = null;
             if (IsBadCoord(w.Y)) w.Y = null;
             if (string.IsNullOrEmpty(w.WindowId)) { w.WindowId = Guid.NewGuid().ToString(); fixes.Add("book window assigned a new id"); }

--- a/src/CST.Avalonia/Models/SettingsValidator.cs
+++ b/src/CST.Avalonia/Models/SettingsValidator.cs
@@ -117,6 +117,11 @@ public static class SettingsValidator
                 connection.Models = new List<AiModelRecord>();
                 fixes.Add($"models list for connection '{connection.Id}' was null; reset to empty");
             }
+            // A null ENTRY is the same mechanism one level in: AiConnectionService.ToRuntime projects every
+            // model unconditionally, so one null in the list breaks the whole connection. (#787, fable)
+            int badModels = connection.Models.RemoveAll(m => m == null || string.IsNullOrWhiteSpace(m.Id));
+            if (badModels > 0)
+                fixes.Add($"removed {badModels} model(s) with no id from connection '{connection.Id}'");
             if (connection.Inputs == null)
             {
                 connection.Inputs = new Dictionary<string, string>();
@@ -128,10 +133,14 @@ public static class SettingsValidator
                 fixes.Add($"headers for connection '{connection.Id}' were null; reset to empty");
             }
         }
-        // A null ENTRY in the list is the same hazard as a null list — ToRuntime would dereference it.
-        int removedConnections = settings.Ai.Chat.Connections.RemoveAll(c => c == null);
+        // A null ENTRY in the list is the same hazard as a null list — ToRuntime would dereference it. So is a
+        // connection with no Id: ToRuntime passes it straight to a dictionary lookup, which throws
+        // ArgumentNullException rather than returning nothing, and an id-less connection cannot be selected,
+        // credentialed or reached in any case. (#787, fable)
+        int removedConnections = settings.Ai.Chat.Connections.RemoveAll(
+            c => c == null || string.IsNullOrWhiteSpace(c.Id));
         if (removedConnections > 0)
-            fixes.Add($"removed {removedConnections} null connection entr(ies)");
+            fixes.Add($"removed {removedConnections} connection(s) with no id");
 
         // (The historical local-API Port/Token scrub is gone with those fields, removed in #280: the port is
         // ephemeral and the token per-session, both held only in local-api.json. A stale value left in an old

--- a/src/CST.Avalonia/Models/SettingsValidator.cs
+++ b/src/CST.Avalonia/Models/SettingsValidator.cs
@@ -93,6 +93,46 @@ public static class SettingsValidator
         if (settings.Ai.LocalApi == null) { settings.Ai.LocalApi = new LocalApiSettings(); fixes.Add("ai.localApi settings were null; reset to default"); }
         if (settings.Ai.Chat == null) { settings.Ai.Chat = new ChatSettings(); fixes.Add("ai.chat settings were null; reset to default"); }
 
+        // The same mechanism as #319 above, one level further down — where it was left unfinished twice, here
+        // and in ApplicationStateValidator. The comment above states the rule correctly: an explicit JSON null
+        // overwrites the `= new()` initializer. It was then applied to the SECTIONS and not to the collections
+        // inside them, and a collection is the thing that actually gets enumerated.
+        //
+        // These four are each declared `= new()` and each enumerated with no null check —
+        // AiConnectionService projects Connections, Models and Inputs on nearly every operation. The failure
+        // lands differently from a section null: it is outside SettingsService's try, so nothing is destroyed,
+        // but there is also no catch to make it survivable and the AI settings simply stop working. Headers is
+        // already covered by its converter's HandleNull (#784); coalesced here too so the guarantee is stated
+        // in one place rather than depending on a converter that only exists because the shape changed. (#787)
+        if (settings.Ai.Chat.Connections == null)
+        {
+            settings.Ai.Chat.Connections = new List<AiConnectionRecord>();
+            fixes.Add("ai.chat.connections was null; reset to empty");
+        }
+        foreach (var connection in settings.Ai.Chat.Connections)
+        {
+            if (connection == null) continue;
+            if (connection.Models == null)
+            {
+                connection.Models = new List<AiModelRecord>();
+                fixes.Add($"models list for connection '{connection.Id}' was null; reset to empty");
+            }
+            if (connection.Inputs == null)
+            {
+                connection.Inputs = new Dictionary<string, string>();
+                fixes.Add($"inputs for connection '{connection.Id}' were null; reset to empty");
+            }
+            if (connection.Headers == null)
+            {
+                connection.Headers = new List<AiHeaderRecord>();
+                fixes.Add($"headers for connection '{connection.Id}' were null; reset to empty");
+            }
+        }
+        // A null ENTRY in the list is the same hazard as a null list — ToRuntime would dereference it.
+        int removedConnections = settings.Ai.Chat.Connections.RemoveAll(c => c == null);
+        if (removedConnections > 0)
+            fixes.Add($"removed {removedConnections} null connection entr(ies)");
+
         // (The historical local-API Port/Token scrub is gone with those fields, removed in #280: the port is
         // ephemeral and the token per-session, both held only in local-api.json. A stale value left in an old
         // settings.json is now an unknown property the deserializer ignores.)

--- a/src/CST.Avalonia/Services/ApplicationStateService.cs
+++ b/src/CST.Avalonia/Services/ApplicationStateService.cs
@@ -22,6 +22,24 @@ public class ApplicationStateService : IApplicationStateService, IDisposable
     private readonly string _stateFilePath;
     private readonly string _backupDirectory;
     private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// How application state is read and written. <b>Shared rather than mirrored</b> — a test that re-declares
+    /// these cannot detect drift FROM them, which is the one thing it most needs to detect: change the naming
+    /// policy or drop the enum converter and every real file on disk stops loading while a mirroring test suite
+    /// stays green, because the fixture and the copy moved together. (#787)
+    ///
+    /// <para>The global <see cref="JsonStringEnumConverter"/> is load-bearing beyond the properties that carry
+    /// their own converter attribute: <c>MainWindowState.WindowState</c> and <c>BookWindowState.WindowState</c>
+    /// depend on it alone, and every real state file with a maximized window carries one.</para>
+    /// </summary>
+    internal static JsonSerializerOptions JsonOptions { get; } = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
     private readonly Timer _saveTimer;
     // Serializes concurrent saves (timer tick vs. shutdown ForceSave): they shared one .tmp path, so a
     // half-written tmp could be promoted over good state by File.Replace, and collided on backups. (STATE-2)
@@ -68,14 +86,7 @@ public class ApplicationStateService : IApplicationStateService, IDisposable
         _stateFilePath = Path.Combine(appDataPath, "application-state.json");
         _backupDirectory = Path.Combine(appDataPath, "app-state-backups");
 
-        // Configure JSON serialization for readability
-        _jsonOptions = new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
-            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
-        };
+        _jsonOptions = JsonOptions;
 
         Current = new ApplicationState();
         

--- a/src/CST.Avalonia/Services/SettingsService.cs
+++ b/src/CST.Avalonia/Services/SettingsService.cs
@@ -66,6 +66,14 @@ namespace CST.Avalonia.Services
                         _settings = loadedSettings;
                         _logger.Information("Settings loaded successfully from {Path}", _settingsFilePath);
 
+                        // A file that PARSES can still be missing the field. STATE-3 covered the no-file and
+                        // unreadable paths, so a settings.json written before XmlBooksDirectory existed — or
+                        // hand-edited, or produced by a build that did not set it — loaded cleanly and left
+                        // the app running with a blank books directory, which is the exact state STATE-3
+                        // exists to prevent. The call is idempotent: it returns immediately when the
+                        // directory is already set, so an ordinary file costs nothing. (#787)
+                        ApplyFirstRunDefaults();
+
                         // Persist the upgraded/repaired settings so the on-disk file is brought up to date.
                         if (notes.Count > 0 || fixes.Count > 0)
                             RequestSave();
@@ -97,9 +105,10 @@ namespace CST.Avalonia.Services
             }
         }
 
-        // Set the default XML books directory (creating it) when it isn't already set. Runs on a true
-        // first run (no file) and whenever the file is empty/corrupt, so the app never operates with a
-        // blank XmlBooksDirectory. (STATE-3)
+        // Set the default XML books directory (creating it) when it isn't already set. Runs on a true first
+        // run (no file), whenever the file is unreadable, and after ANY successful load — a file can parse
+        // perfectly and still not carry the field. The app must never operate with a blank
+        // XmlBooksDirectory. (STATE-3, #787)
         private void ApplyFirstRunDefaults()
         {
             if (!string.IsNullOrEmpty(_settings.XmlBooksDirectory))

--- a/src/CST.Avalonia/Services/SettingsService.cs
+++ b/src/CST.Avalonia/Services/SettingsService.cs
@@ -72,7 +72,18 @@ namespace CST.Avalonia.Services
                         // the app running with a blank books directory, which is the exact state STATE-3
                         // exists to prevent. The call is idempotent: it returns immediately when the
                         // directory is already set, so an ordinary file costs nothing. (#787)
-                        ApplyFirstRunDefaults();
+                        //
+                        // Guarded, because it CREATES a directory. On a read-only or missing parent that
+                        // throws, and inside the try it would carry a perfectly good parsed file into the
+                        // catch below — which discards it. A valid file must never be lost to a failure to
+                        // create somewhere to put books; the app can run with a blank directory and complain,
+                        // and the load path had never thrown for a parseable file before. (fable)
+                        try { ApplyFirstRunDefaults(); }
+                        catch (Exception ex)
+                        {
+                            _logger.Warning(ex,
+                                "Could not create the default XML books directory; settings were still loaded.");
+                        }
 
                         // Persist the upgraded/repaired settings so the on-disk file is brought up to date.
                         if (notes.Count > 0 || fixes.Count > 0)


### PR DESCRIPTION
Closes #787. **Three commits** — the third is Fable's review, applied.

## The gap

Every persisted model here is round-tripped somewhere: serialize the current shape, deserialize it, assert it survives. **Those tests passed the whole time #771's header type change was destroying real settings files**, because both halves speak the new shape.

The test that fails is *"does this version load what the **previous** version wrote"* — and nobody writes it for a structural reason: after a type change the old shape no longer exists in the code to write a test against. It has to be captured as a literal.

## Commit 1 — the fixtures, and two live defects

Two classes, one per persisted store. `ApplicationState` needs its own despite recovering from timestamped backups, because **those backups share the primary file's shape** — a type change breaks every one at once.

1. **A settings file that parses can still lack `XmlBooksDirectory`.** The successful-load path never called `ApplyFirstRunDefaults`; STATE-3 covered the no-file and unreadable paths and stopped there.
2. **`ApplicationStateValidator.Sanitize` coalesced the sections but not the collections inside them.** `"sourceOrder": null` survived to `DictionarySourcePreferenceService`, which enumerates it directly.

## Commit 2 — four more, on the AI side

Found by kestrel-cst-2 reading commit 1. **#319 named this mechanism exactly** — its comment states that an explicit JSON null overwrites the `= new()` initializer — then fixed the **sections** only, which is where `ApplicationStateValidator` also stopped. A section null bricks the Settings window, which is what #319 was chasing; a collection null is what the code enumerates.

`Connections`, and each connection's `Models`, `Inputs`, `Headers`.

## Commit 3 — Fable's review

**Its lead finding was that the ApplicationState half proved the validators handle the fixtures, not that the app loads old files.** The test class re-declared `JsonSerializerOptions` to mirror the service's — and a mirror cannot detect drift *from* what it mirrors, which is the one regression these tests most need to catch. Change the naming policy or drop the enum converter and every real file stops loading while the suite stays green, because fixture and copy moved together. The service's options are `internal static` now and the tests use them.

**That converter is load-bearing in a way no fixture exercised.** `BookScript`, `CurrentScript` and `SearchMode` carry their own converter attributes, but **both `WindowState` properties depend on the global `JsonStringEnumConverter` alone** — and every real state file with a maximized window carries one. Losing it throws on load, destroying the primary file *and* invalidating every backup at once. There is a fixture with enum strings now.

**Null entries, which coalescing a list does nothing for.** `"sourceOrder": [null]` and `[{"id": null}]` reach the dictionary picker as an NRE and an `ArgumentNullException`. A model or connection with no id reaches `ToRuntime`, which projects every one unconditionally — one bad entry breaks the whole AI settings page rather than itself.

**`ApplyFirstRunDefaults` on the load path is guarded.** It *creates* a directory; inside the try, a read-only parent would carry a perfectly good parsed file into the catch that discards it.

**And one of my own tests could not fail through the path its name denounced** — every assertion in "a nearly empty file is not discarded" was also true of a discarded file. It asserts a distinctive value now.

## What this does not do

Neither #785 half — backup-and-restore, nor per-section tolerance. Both still open, both mine.

## Suite

**2419 passed, 0 failed, 17 skipped.**

## The part worth keeping

Adding a fixture is the cheap half. The discipline is capturing one **before** changing a persisted type, while the old shape still exists to copy.