### PR TITLE
Find the repo root from inside a git worktree too

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -762,7 +762,14 @@ public class AiConnectionsViewModelTests
     private static string RepoRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".git"))) dir = dir.Parent;
+        // File OR directory: in a git worktree, .git is a FILE holding a pointer to the real one, so testing
+        // only for a directory walks past every level and yields null. That made two tests fail for a reason
+        // having nothing to do with what they assert - and worktrees are how a review agent is given an
+        // isolated tree, so the false failures land exactly where they are least expected and most costly.
+        while (dir is not null
+               && !Directory.Exists(Path.Combine(dir.FullName, ".git"))
+               && !File.Exists(Path.Combine(dir.FullName, ".git")))
+            dir = dir.Parent;
         Assert.NotNull(dir);
         return dir!.FullName;
     }


### PR DESCRIPTION
`RepoRoot()` in `AiConnectionsViewModelTests` walks up from the test binary looking for a `.git` **directory**:

```csharp
while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".git"))) dir = dir.Parent;
Assert.NotNull(dir);
```

In a **git worktree**, `.git` is a *file* holding a pointer to the real one. So the walk passes every level, `dir` reaches null, and two tests fail on an assertion that has nothing to do with what they were written to check:

```
The_generic_icon_takes_its_colour_from_the_theme                     [FAIL]
The_bundled_generic_icon_is_the_mark_the_catalogue_serves_for_no_logo [FAIL]
  Assert.NotNull() Failure: Value is null
    at AiConnectionsViewModelTests.RepoRoot()
```

Now it accepts either.

## Why this is worth fixing rather than avoiding

A worktree is how a review agent is given an isolated tree — which is the arrangement that stops it reviewing a branch that moves underneath it while the author keeps working. That happened here earlier today and cost a review pass.

False failures in that setting are expensive twice over: they land in an unfamiliar environment, and they land on a reviewer with no particular reason to suspect the harness rather than the diff. A reviewer that opens by finding two unrelated red tests either wastes its budget on them or learns to discount red, and neither is what you want from an adversarial pass.

## How it was found

Diagnosing two failures on an unrelated branch (#788, the model count wording), which turned out not to be on that branch at all — the branch was fine and the folder was not.

Worth noting one thing about the fix itself: my first attempt matched the line without its indentation and wrote the replacement back with different indentation, so the edit silently did nothing while reporting success. The tests failing a second time is what caught it. A patch that "succeeds" and changes nothing is the same shape as a test that passes and checks nothing.

Test-only change. Full suite green.
