### PR TITLE
Remember each connection's model listing between sessions (#790)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelListingCacheTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelListingCacheTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CST.Avalonia.Services.Ai;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Remembering each connection's listing between sessions. (#790)
+///
+/// <para>The reason this exists at all: the listing lived in memory for one window and was discarded, and it
+/// is fetched only when a group is first expanded — so every launch opened on the reader's own saved models
+/// where the provider offers many more. Three against thirteen, in the report that prompted it.</para>
+/// </summary>
+public class AiModelListingCacheTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "cst-listing-cache-" + Guid.NewGuid().ToString("N"));
+
+    private AiModelListingCache Cache() =>
+        new(Path.Combine(_dir, "ai-model-listings.json"));
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Nothing_cached_reads_as_empty_rather_than_null()
+    {
+        Assert.Empty(Cache().Get("groq"));
+    }
+
+    /// <summary>The whole point: a listing recorded in one session is there for the next one, before any
+    /// network call.</summary>
+    [Fact]
+    public void A_listing_survives_into_a_new_instance()
+    {
+        Cache().Put("groq", new[]
+        {
+            new AiCatalogModel("openai/gpt-oss-120b", "GPT-OSS 120B"),
+            new AiCatalogModel("qwen/qwen3.6-27b", "Qwen3.6 27B"),
+        });
+
+        var reopened = Cache().Get("groq");
+
+        Assert.Equal(
+            new[] { "openai/gpt-oss-120b", "qwen/qwen3.6-27b" },
+            reopened.Select(m => m.Id));
+    }
+
+    /// <summary>Connections do not share an entry — the bug class #678 was, one layer up.</summary>
+    [Fact]
+    public void Connections_keep_separate_listings()
+    {
+        var cache = Cache();
+        cache.Put("groq", new[] { new AiCatalogModel("a", "A") });
+        cache.Put("openrouter", new[] { new AiCatalogModel("b", "B") });
+
+        Assert.Equal("a", Cache().Get("groq").Single().Id);
+        Assert.Equal("b", Cache().Get("openrouter").Single().Id);
+    }
+
+    [Fact]
+    public void A_later_listing_replaces_the_earlier_one()
+    {
+        var cache = Cache();
+        cache.Put("groq", new[] { new AiCatalogModel("old", "Old") });
+        cache.Put("groq", new[] { new AiCatalogModel("new", "New") });
+
+        Assert.Equal("new", Cache().Get("groq").Single().Id);
+    }
+
+    /// <summary>
+    /// A connection removed and recreated under the same id must not inherit the old one's listing: it looks
+    /// like the app knowing something it cannot know, and is wrong the moment the new connection points
+    /// somewhere else.
+    /// </summary>
+    [Fact]
+    public void A_listing_is_dropped_when_its_connection_is_gone()
+    {
+        var cache = Cache();
+        cache.Put("groq", new[] { new AiCatalogModel("a", "A") });
+        cache.Put("openrouter", new[] { new AiCatalogModel("b", "B") });
+
+        cache.Forget("groq");
+
+        Assert.Empty(Cache().Get("groq"));
+        Assert.Single(Cache().Get("openrouter"));
+    }
+
+    /// <summary>The published facts travel with the ids, or the per-turn picker's hover card goes blank on a
+    /// cache-seeded model. (#726, #671)</summary>
+    [Fact]
+    public void Published_facts_survive_the_round_trip()
+    {
+        Cache().Put("groq", new[]
+        {
+            new AiCatalogModel(
+                "m", "M",
+                ContextLength: 131072,
+                SupportedParameters: new[] { "reasoning_effort" },
+                ReasoningEfforts: new[] { "low", "high" },
+                DefaultReasoningEffort: "high"),
+        });
+
+        var model = Cache().Get("groq").Single();
+
+        Assert.Equal(131072, model.ContextLength);
+        Assert.Equal(new[] { "low", "high" }, model.ReasoningEfforts);
+        Assert.Equal("high", model.DefaultReasoningEffort);
+        Assert.True(model.AcceptsReasoningEffort);
+    }
+
+    /// <summary>
+    /// An unreadable cache is an inconvenience, never a failure: the reader waits for a fetch. Throwing would
+    /// turn a faster copy of something we can ask for again into a reason the Models tab cannot render.
+    /// </summary>
+    [Fact]
+    public void An_unreadable_cache_reads_as_empty_and_is_replaced_on_the_next_write()
+    {
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path.Combine(_dir, "ai-model-listings.json"), "{ this is not json");
+
+        var cache = Cache();
+        Assert.Empty(cache.Get("groq"));
+
+        cache.Put("groq", new[] { new AiCatalogModel("a", "A") });
+        Assert.Single(Cache().Get("groq"));
+    }
+}

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -41,13 +41,40 @@ public class AiModelsViewModelTests
     }
 
     private static (AiModelsViewModel Vm, AiConnectionService Service) Make(
-        IAiModelCatalog? catalog = null, IAiProviderLogos? logos = null)
+        IAiModelCatalog? catalog = null, IAiProviderLogos? logos = null,
+        IAiModelListingCache? listings = null)
     {
         var settings = new Settings();
         var svc = new Mock<ISettingsService>();
         svc.SetupGet(s => s.Settings).Returns(settings);
         var service = new AiConnectionService(svc.Object);
-        return (new AiModelsViewModel(service, catalog, logos), service);
+        return (new AiModelsViewModel(service, catalog, logos, listings), service);
+    }
+
+    /// <summary>A catalog that cannot reach the endpoint, for the offline and provider-down cases.</summary>
+    private sealed class FailingCatalog : IAiModelCatalog
+    {
+        public Task<AiCatalogResult> FetchAsync(AiConnection connection, CancellationToken ct = default) =>
+            Task.FromResult(AiCatalogResult.Fail($"Cannot connect to {connection.DisplayName}.", reachable: false));
+    }
+
+    /// <summary>An in-memory listing cache, so a test can stand a connection up as if it had been fetched in
+    /// an earlier session.</summary>
+    private sealed class FakeListings : IAiModelListingCache
+    {
+        public Dictionary<string, IReadOnlyList<AiCatalogModel>> Entries { get; } = new(StringComparer.Ordinal);
+        public List<string> Written { get; } = new();
+
+        public IReadOnlyList<AiCatalogModel> Get(string connectionId) =>
+            Entries.TryGetValue(connectionId, out var models) ? models : Array.Empty<AiCatalogModel>();
+
+        public void Put(string connectionId, IReadOnlyList<AiCatalogModel> models)
+        {
+            Entries[connectionId] = models;
+            Written.Add(connectionId);
+        }
+
+        public void Forget(string connectionId) => Entries.Remove(connectionId);
     }
 
     private static AiConnectionDraft Draft(params AiModelEntry[] models) =>
@@ -958,5 +985,141 @@ public class AiModelsViewModelTests
         service.Add("mine", Draft(new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
 
         Assert.Equal("2 models", Group(vm).CountText);
+    }
+
+    // ---- the cached listing (#790) ----------------------------------------------------------------------
+
+    /// <summary>
+    /// The requirement, in one assertion: the provider's list is on screen before anything is expanded and
+    /// before any request. Without the cache the reader met their own saved models on every launch — three
+    /// against thirteen in the report that prompted this.
+    /// </summary>
+    [Fact]
+    public void A_group_opens_on_the_cached_listing_rather_than_the_saved_models()
+    {
+        var listings = new FakeListings();
+        listings.Entries["mine"] = new[]
+        {
+            new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B"), new AiCatalogModel("c", "C"),
+        };
+
+        var (vm, service) = Make(listings: listings);
+        service.Add("mine", Draft(new AiModelEntry("a", "A")));
+
+        // Row counts rather than CountText: the wording is #786's business and this test is about which set
+        // is on screen, not what it is called.
+        Assert.Equal(3, Group(vm).Visible.Count);
+        Assert.Equal(1, Group(vm).Visible.Count(r => r.Enabled));
+    }
+
+    /// <summary>
+    /// A cache is what the reader SEES, never what the app CONCLUDES. #728's "no longer listed" mark needs a
+    /// fetch that succeeded and was complete; seeding from a stored listing must mark nothing, or a model the
+    /// provider still offers gets reported as retired on the strength of a file.
+    /// </summary>
+    [Fact]
+    public void Seeding_from_the_cache_marks_no_model_as_missing()
+    {
+        var listings = new FakeListings();
+        listings.Entries["mine"] = new[] { new AiCatalogModel("a", "A") };
+
+        var (vm, service) = Make(listings: listings);
+        service.Add("mine", Draft(
+            new AiModelEntry("a", "A"),
+            new AiModelEntry("gone", "Gone")));   // absent from the cached listing
+
+        Assert.All(service.Connections.Single().Models, m => Assert.False(m.Missing));
+    }
+
+    [Fact]
+    public void A_successful_fetch_is_written_to_the_cache()
+    {
+        var listings = new FakeListings();
+        var (vm, service) = Make(
+            new FakeCatalog(new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B")),
+            listings: listings);
+        service.Add("mine", Draft());
+
+        Group(vm).IsExpanded = true;
+
+        Assert.Contains("mine", listings.Written);
+        Assert.Equal(2, listings.Entries["mine"].Count);
+    }
+
+    /// <summary>Removing a connection drops its listing, so a new one created under the same id starts
+    /// blank rather than inheriting an endpoint it never spoke to.</summary>
+    [Fact]
+    public void Removing_a_connection_drops_its_cached_listing()
+    {
+        var listings = new FakeListings();
+        listings.Entries["mine"] = new[] { new AiCatalogModel("a", "A") };
+        listings.Entries["other"] = new[] { new AiCatalogModel("b", "B") };
+
+        var (vm, service) = Make(listings: listings);
+        service.Add("mine", Draft());
+        service.Add("other", Draft());
+
+        service.Remove("mine");
+
+        Assert.Empty(listings.Get("mine"));
+        Assert.Single(listings.Get("other"));
+    }
+
+    /// <summary>
+    /// A failed refresh over a cached listing must say the list is the old one.
+    ///
+    /// <para>Otherwise the reader sees an error line above a full list of models and reasonably concludes the
+    /// failure did not matter — "this is what the provider lists" and "this is what it listed some time ago
+    /// and we could not reach it just now" render identically. That is #786's defect exactly, in a different
+    /// place: two states, one appearance. (raised in review)</para>
+    /// </summary>
+    [Fact]
+    public void A_failed_refresh_over_a_cached_listing_says_it_is_the_old_one()
+    {
+        var listings = new FakeListings();
+        listings.Entries["mine"] = new[] { new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B") };
+
+        var (vm, service) = Make(new FailingCatalog(), listings: listings);
+        service.Add("mine", Draft());
+
+        Group(vm).IsExpanded = true;
+
+        Assert.Contains("listed last time", Group(vm).FetchProblem);
+        Assert.Equal(2, Group(vm).Visible.Count);   // and the cached list is still shown
+    }
+
+    /// <summary>With nothing cached, the provider's own reason is what the reader needs — there is no older
+    /// list to explain.</summary>
+    [Fact]
+    public void A_failed_fetch_with_no_cache_reports_the_providers_reason()
+    {
+        var (vm, service) = Make(new FailingCatalog(), listings: new FakeListings());
+        service.Add("mine", Draft());
+
+        Group(vm).IsExpanded = true;
+
+        Assert.DoesNotContain("listed last time", Group(vm).FetchProblem ?? "");
+    }
+
+    /// <summary>
+    /// A connection that has not loaded yet keeps its listing.
+    ///
+    /// <para>The first cut of this deleted everything absent from the current connection list, which is wrong
+    /// on every rebind where the list is still filling: adding one connection wiped the entry of every
+    /// connection not yet added back, and the very first rebind — before anything loads — wiped all of them.
+    /// A snapshot of what exists right now is not a statement that everything else is gone, which is the same
+    /// reasoning behind #728's marking rules.</para>
+    /// </summary>
+    [Fact]
+    public void A_connection_that_has_not_loaded_yet_keeps_its_listing()
+    {
+        var listings = new FakeListings();
+        listings.Entries["mine"] = new[] { new AiCatalogModel("a", "A") };
+        listings.Entries["later"] = new[] { new AiCatalogModel("b", "B") };
+
+        var (vm, service) = Make(listings: listings);
+        service.Add("mine", Draft());   // "later" is not here yet
+
+        Assert.Single(listings.Get("later"));
     }
 }

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1439,6 +1439,12 @@ public partial class App : Application
             sp.GetService<Services.Ai.IAiCredentialStore>(),
             sp.GetRequiredService<ILoggerFactory>().CreateLogger<Services.Ai.AiModelCatalog>()));
 
+        // Each connection's last model listing, so the Models tab opens on the provider's list rather than
+        // on whatever the reader had saved. Beside models-dev.json rather than in settings.json: provider
+        // data, hundreds of entries per connection, and nothing else should share that file's failure
+        // mode. (#790)
+        services.AddSingleton<Services.Ai.IAiModelListingCache>(_ => new Services.Ai.AiModelListingCache());
+
         // The fidelity advisory (#584). Data only — Settings (#585) and the panel (#586) surface it.
         services.AddSingleton<ILemmaReportService, LemmaReportService>();
 

--- a/src/CST.Avalonia/Services/Ai/AiModelListingCache.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelListingCache.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CST.Avalonia.Constants;
+using Serilog;
+
+namespace CST.Avalonia.Services.Ai
+{
+    /// <summary>The last listing we read from a connection's endpoint, and when. (#790)</summary>
+    public sealed class AiCachedListing
+    {
+        [JsonPropertyName("fetchedAt")]
+        public DateTimeOffset FetchedAt { get; set; }
+
+        [JsonPropertyName("models")]
+        public List<AiCatalogModel> Models { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Remembers each connection's model listing between sessions. (#790)
+    ///
+    /// <para><b>Why this exists.</b> The listing lived in memory for as long as the Models tab was open and
+    /// was then thrown away, and it is fetched only when a group is first expanded. So every launch began by
+    /// showing the reader their own saved models where the provider offers many more — three against thirteen,
+    /// in the report that prompted this. The number was correct and useless: someone who configured a provider
+    /// wants to see what it offers, and reading "3" immediately after an incident that really did lose models
+    /// sent them looking for a loss that had not happened.</para>
+    ///
+    /// <para><b>What it is for, and what it is not.</b> This is what the reader SEES before a live fetch
+    /// returns. It is never what the app CONCLUDES. In particular it must never drive #728's "no longer
+    /// listed" marking, which needs a fetch that succeeded and was complete: a cache records what was true
+    /// once, and marking from it would report a live model as retired — precisely the false alarm #728 exists
+    /// to prevent.</para>
+    ///
+    /// <para><b>Not in <c>settings.json</c>.</b> It is the provider's data rather than the reader's
+    /// configuration, it runs to hundreds of entries per connection (OpenRouter returns 422), and everything
+    /// sharing that file shares its failure mode — which #784 is a fresh reminder of. It sits beside
+    /// <c>models-dev.json</c>, which caches the provider catalogue for the same reasons.</para>
+    ///
+    /// <para><b>No freshness window.</b> <see cref="ModelsDevCatalog"/> has one because refetching it is a
+    /// 4.2 MB download; a single connection's listing is small, and the rule here is simpler and easier to
+    /// reason about: show the newest we have, and refresh whenever the reader looks. A stale entry is
+    /// corrected the moment they open the tab, and until then it is a far better answer than their own
+    /// saved list.</para>
+    /// </summary>
+    public interface IAiModelListingCache
+    {
+        /// <summary>The last listing read from this connection, or empty when there is none.</summary>
+        IReadOnlyList<AiCatalogModel> Get(string connectionId);
+
+        /// <summary>Record a listing. Only ever called with one a live fetch actually returned.</summary>
+        void Put(string connectionId, IReadOnlyList<AiCatalogModel> models);
+
+        /// <summary>
+        /// Drop one connection's listing, because that connection was removed.
+        ///
+        /// <para>Without this a connection removed and recreated under the same id inherits the old one's
+        /// listing — which looks like the app knowing something it cannot know, and is wrong the moment the
+        /// new connection points somewhere else.</para>
+        ///
+        /// <para><b>Told, never inferred.</b> The first cut of this took the live connection list and deleted
+        /// everything absent from it. That is wrong twice over, and both were caught by its own tests: it runs
+        /// on every rebind including the first, where the list is empty because nothing has loaded yet and it
+        /// deletes the entire cache; and mid-load it deletes the entry for every connection that has not been
+        /// added back yet. A snapshot of what exists right now is not a statement that everything else is
+        /// gone — the same reasoning behind #728's marking rules and <c>Reachability</c>'s third state.</para>
+        /// </summary>
+        void Forget(string connectionId);
+    }
+
+    /// <inheritdoc cref="IAiModelListingCache"/>
+    public sealed class AiModelListingCache : IAiModelListingCache
+    {
+        private readonly string _path;
+        private readonly object _gate = new();
+        private Dictionary<string, AiCachedListing>? _entries;
+
+        private static readonly JsonSerializerOptions Json = new()
+        {
+            WriteIndented = true,
+            PropertyNameCaseInsensitive = true,
+        };
+
+        public AiModelListingCache(string? path = null) =>
+            _path = path ?? Path.Combine(AppConstants.DataDirectory, "ai-model-listings.json");
+
+        public IReadOnlyList<AiCatalogModel> Get(string connectionId)
+        {
+            lock (_gate)
+            {
+                Load();
+                return _entries!.TryGetValue(connectionId, out var entry)
+                    ? entry.Models
+                    : Array.Empty<AiCatalogModel>();
+            }
+        }
+
+        public void Put(string connectionId, IReadOnlyList<AiCatalogModel> models)
+        {
+            lock (_gate)
+            {
+                Load();
+                _entries![connectionId] = new AiCachedListing
+                {
+                    FetchedAt = DateTimeOffset.Now,
+                    Models = models.ToList(),
+                };
+                Save();
+            }
+        }
+
+        public void Forget(string connectionId)
+        {
+            lock (_gate)
+            {
+                Load();
+                if (_entries!.Remove(connectionId)) Save();
+            }
+        }
+
+        /// <summary>
+        /// Reads the file once per session, and treats every failure as "nothing cached".
+        ///
+        /// <para>A cache that cannot be read is an inconvenience — the reader waits for a fetch. Throwing
+        /// would make it a failure to show the Models tab at all, which is a far worse trade for data whose
+        /// entire purpose is to be a faster copy of something we can ask for again.</para>
+        /// </summary>
+        private void Load()
+        {
+            if (_entries is not null) return;
+
+            try
+            {
+                if (File.Exists(_path))
+                {
+                    _entries = JsonSerializer
+                        .Deserialize<Dictionary<string, AiCachedListing>>(File.ReadAllText(_path), Json);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Could not read the model listing cache; treating it as empty (#790)");
+            }
+
+            _entries ??= new Dictionary<string, AiCachedListing>(StringComparer.Ordinal);
+        }
+
+        private void Save()
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+
+                // Temp then replace, like every other file this app writes: a torn cache would read as empty
+                // on the next start, which is recoverable, but there is no reason to accept even that.
+                var temp = _path + ".tmp";
+                File.WriteAllText(temp, JsonSerializer.Serialize(_entries, Json));
+
+                if (File.Exists(_path)) File.Replace(temp, _path, null);
+                else File.Move(temp, _path);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Could not write the model listing cache (#790)");
+            }
+        }
+    }
+}

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -479,7 +479,20 @@ namespace CST.Avalonia.ViewModels
                         Refresh();
                     }
                 }
-                else FetchProblem = result.Problem;
+                else
+                {
+                    // A cached listing is still on screen behind this. Say so, or the reader sees an error
+                    // line above a full list of models and reasonably concludes the failure did not matter -
+                    // they cannot tell "this is what the provider lists" from "this is what it listed some
+                    // time ago and we could not reach it just now". Absence of a fresh answer must not read
+                    // as confirmation of the old one.
+                    //
+                    // The wording is ModelsDevCatalog's, deliberately: it says exactly this about its own
+                    // cached copy, and a fifth phrasing for the same situation helps nobody. (#790)
+                    FetchProblem = _fetched.Count > 0
+                        ? $"Couldn't reach {DisplayName}. Showing the models it listed last time."
+                        : result.Problem;
+                }
 
                 // Asking a provider for its models IS contacting it, and the answer is the same fact a chat
                 // turn establishes. Without this a reader who had just fetched four hundred models from

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -34,6 +34,7 @@ namespace CST.Avalonia.ViewModels
         private readonly IAiConnectionService? _service;
         private readonly IAiModelCatalog? _catalog;
         private readonly IAiProviderLogos? _logos;
+        private readonly IAiModelListingCache? _listings;
         private string _search = "";
         private bool _freeOnly;
         private bool _suppressRebind;
@@ -41,17 +42,39 @@ namespace CST.Avalonia.ViewModels
         public AiModelsViewModel(
             IAiConnectionService? service,
             IAiModelCatalog? catalog = null,
-            IAiProviderLogos? logos = null)
+            IAiProviderLogos? logos = null,
+            IAiModelListingCache? listings = null)
         {
             _service = service;
             _catalog = catalog;
             _logos = logos;
+            _listings = listings;
 
             if (_service is not null)
             {
                 _service.ConnectionsChanged += OnConnectionsChanged;
                 Rebind();
+
+                // Every connection is asked again when this tab is built, which is the moment the reader has
+                // said "show me models". Not at application start: firing at every configured provider on
+                // launch, for a feature that ships disabled and a reader who may never open Settings, is the
+                // same thing AiCredentialStore refuses to do with the keychain and for the same reason.
+                //
+                // The cache is what makes the numbers right immediately; this is what keeps them current.
+                // Neither is redundant - without the cache the count is the reader's own list until the
+                // response lands, and offline it stays that way. (#790)
+                RefreshAll();
             }
+        }
+
+        internal IAiModelListingCache? Listings => _listings;
+
+        /// <summary>Asks every connection for its listing, without waiting and without reporting failures
+        /// here: each group already shows its own outcome, and a provider being down must not stop the tab
+        /// from rendering the others.</summary>
+        private void RefreshAll()
+        {
+            foreach (var group in Groups) group.BeginRefresh();
         }
 
         /// <summary>
@@ -161,7 +184,13 @@ namespace CST.Avalonia.ViewModels
 
             for (int i = Groups.Count - 1; i >= 0; i--)
                 if (!connections.Any(c => string.Equals(c.Id, Groups[i].Id, StringComparison.Ordinal)))
+                {
+                    // Forgetting here, where a connection is actually going away, rather than deleting
+                    // everything absent from the current list: a group only disappears because its connection
+                    // did. (#790)
+                    _listings?.Forget(Groups[i].Id);
                     Groups.RemoveAt(i);
+                }
 
             for (int i = 0; i < connections.Count; i++)
             {
@@ -207,9 +236,22 @@ namespace CST.Avalonia.ViewModels
 
             LoadLogo(owner.Logos);
 
+            // The provider's list, from the last time anyone asked - so the first paint is already the right
+            // set rather than the reader's own saved models. _hasFetched stays FALSE: this is what is shown,
+            // never what is concluded, and expanding still asks the endpoint. (#790)
+            _fetched = owner.Listings?.Get(connection.Id) ?? Array.Empty<AiCatalogModel>();
+
             ToggleCommand = ReactiveCommand.Create(() => { IsExpanded = !IsExpanded; });
             OpenDocCommand = ReactiveCommand.Create(() => AiConnectionsViewModel.OpenUrl(DocUrl));
             FetchCommand = ReactiveCommand.CreateFromTask(FetchAsync);
+        }
+
+        /// <summary>Start a listing fetch without waiting for it, unless one has already happened or is in
+        /// flight. Used when the tab is built, so a cached listing is brought up to date. (#790)</summary>
+        internal void BeginRefresh()
+        {
+            if (_hasFetched || _isFetching) return;
+            _ = FetchAsync();
         }
 
         public string Id => _connection.Id;
@@ -413,6 +455,12 @@ namespace CST.Avalonia.ViewModels
                 if (result.Ok)
                 {
                     _fetched = result.Models;
+
+                    // Recorded from any successful fetch, complete or not: an incomplete listing is a fine
+                    // thing to SHOW - every model in it is real - and showing it beats showing the reader's
+                    // own saved list. The completeness gate below is about what we INFER, which is a
+                    // different question and stays where it is. (#790, #728)
+                    _owner.Listings?.Put(Id, result.Models);
 
                     // The listing is in memory only while this tab is open, so what it says about the
                     // reader's stored models has to be written down now or the per-turn picker will go on

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1374,7 +1374,8 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
             Models = new AiModelsViewModel(
                 connectionService,
                 App.TryGetService<Services.Ai.IAiModelCatalog>(),
-                App.TryGetService<Services.Ai.IAiProviderLogos>());
+                App.TryGetService<Services.Ai.IAiProviderLogos>(),
+                App.TryGetService<Services.Ai.IAiModelListingCache>());
 
         }
 


### PR DESCRIPTION
Closes #790.

> **[fsnow]** *"I don't like this 3 vs 13 behaviour. If /v1/models returns the 13, should we cache that? I never ever want to see 3."*

The listing lived in memory for as long as the Models tab was open and was then discarded, and it is fetched only when a group is *first expanded*. So every launch opened on the reader's own saved models where the provider offers many more. The number was correct and useless: someone who configures a provider wants to see what it offers — and reading `3` immediately after an incident that really had lost models (#784) sent them looking for a loss that had not happened.

## Two halves, neither redundant

**The cache** makes the count right at the **first paint**, before any request — including offline, and including a provider that has since gone down.

**Refreshing every connection when the tab is built** keeps it current.

Fetching earlier on its own does not meet the requirement: it shortens the window rather than closing it, and offline it never closes at all — which is the state a reader is least equipped to recognise, because nothing on screen looks wrong.

The refresh is on **tab open**, not at application start. Opening the Models tab is a deliberate "show me models"; launching the app is not, and firing at every configured provider on launch — for a feature that ships disabled, on behalf of a reader who may never open Settings — is the thing `AiCredentialStore` already refuses to do with the keychain, for the same reason.

## Where it lives, and why not `settings.json`

Beside `models-dev.json`, which caches the provider catalogue for the same reasons. Not in `settings.json`: it is the **provider's** data rather than the reader's configuration, it runs to hundreds of entries per connection (OpenRouter returns 422), and after #784 nothing else should share that file's failure mode.

No freshness window. `ModelsDevCatalog` has one because refetching it is a 4.2 MB download; a single connection's listing is small, and the rule here is simpler to reason about — show the newest we have, refresh whenever the reader looks.

## What the cache is not

**It is what the reader sees, never what the app concludes.** #728's "no longer listed" marking still requires a fetch that succeeded *and* was complete. A cache records what was true once; marking from it would report a live model as retired, which is exactly the false alarm #728 exists to prevent. Pinned by a test that seeds a cache missing a stored model and asserts nothing is marked.

Recording a listing is gated only on the fetch succeeding, deliberately — an incomplete listing is a fine thing to *show*, since every model in it is real, and showing it beats showing the reader's saved list. Completeness governs inference, not display.

## The bug this found in itself

Forgetting an entry is **told, never inferred**. The first cut took the live connection list and deleted everything absent from it. That is wrong twice, and its own tests caught both:

1. It runs on the **first rebind**, before any connection has loaded — so an empty list read as authoritative deleted the entire cache, on the very run that was meant to benefit from it.
2. It runs on **every rebind**, so adding one connection deleted the cached listing of every connection not yet added back.

Now a single `Forget(id)`, called at the one place a connection is actually going away.

That is the third time today a collection whose emptiness meant *"nothing to say"* was read as *"nothing exists"* — after a test helper that always supplied a value so the absent-value branch could not be reached, and `= new()` on a persisted collection being overwritten by an explicit JSON `null`. Same family, three different layers.

## Saying which list you are looking at

Raised in review, and it would have shipped without it. A failed refresh over a cached listing showed an error line above a full list of models — and the reader reasonably concludes the failure did not matter, because *"this is what the provider lists"* and *"this is what it listed some time ago and we could not reach it just now"* rendered identically.

That is #786's defect in a different place: two states, one appearance. It now says which:

> Couldn't reach Groq. Showing the models it listed last time.

The wording is `ModelsDevCatalog`'s, deliberately — it already says exactly this about its own cached copy, and a fifth phrasing for the same situation helps nobody. Where there is no cache the provider's own reason stands, since there is no older list to explain.

## Interaction with #788

Independent. #788 makes the count read plainly; this makes it the right number. The tests here assert row counts rather than `CountText`, so the two do not collide.

Rebased on current main. Full suite green (2416 passed, 0 failed), 0 build warnings.
