### PR TITLE
Read the model count plainly, for real this time (#786)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -90,7 +90,7 @@ public class AiModelsViewModelTests
 
         Assert.False(Group(vm).IsExpanded);
         Assert.Empty(Rows(vm));
-        Assert.Equal("2 models saved", Group(vm).CountText);   // collapsed: nothing fetched yet
+        Assert.Equal("2 models", Group(vm).CountText);
     }
 
     /// <summary>Several models under one connection must be on at once — the whole point of a short list you
@@ -337,7 +337,7 @@ public class AiModelsViewModelTests
 
         Rows(vm).Single(r => r.ModelId == "a").Enabled = true;
 
-        Assert.Equal("1 of 3 models listed", Group(vm).CountText);
+        Assert.Equal("1 of 3 models", Group(vm).CountText);
     }
 
     /// <summary>Fetched once, on first expand — not on every expand, and not on every keystroke in the search
@@ -411,7 +411,7 @@ public class AiModelsViewModelTests
 
         Rows(vm).Single(r => r.ModelId == "a").Enabled = true;
 
-        Assert.Equal("1 of 2 models listed", Group(vm).CountText);
+        Assert.Equal("1 of 2 models", Group(vm).CountText);
     }
 
     /// <summary>
@@ -932,53 +932,31 @@ public class AiModelsViewModelTests
         Assert.Equal(new[] { "Apollo", "mercury", "Zephyr" }, Rows(vm).Select(r => r.DisplayName));
     }
 
-    // ---- what the count is counting (#785) --------------------------------------------------------------
+    // ---- the count reads plainly (#786) -----------------------------------------------------------------
 
-    /// <summary>
-    /// The listing is fetched only when the group is first expanded, so before that the rows are the reader's
-    /// OWN saved models. "2 of 3" then reads as "this provider has 3 models", which is a different claim from
-    /// the one the number supports — and it sent a reader looking for models that were never missing, three
-    /// times in one sitting.
-    /// </summary>
+    /// <summary>"2 of 13 models", not "2 of 13 models on": the shape already says which number is enabled.</summary>
     [Fact]
-    public void Before_a_fetch_the_count_says_the_models_are_the_readers_own()
+    public void The_count_names_no_state_and_carries_no_trailing_word()
     {
         var (vm, service) = Make(new FakeCatalog(
             new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B"), new AiCatalogModel("c", "C")));
         service.Add("mine", Draft(
             new AiModelEntry("a", "A"), new AiModelEntry("b", "B", Enabled: false)));
 
-        Assert.Equal("1 of 2 models saved", Group(vm).CountText);
-    }
-
-    /// <summary>And once the provider has answered, the same words would mean something else, so they change.</summary>
-    [Fact]
-    public void After_a_fetch_the_count_says_it_is_the_providers_listing()
-    {
-        var (vm, service) = Make(new FakeCatalog(
-            new AiCatalogModel("a", "A"), new AiCatalogModel("b", "B"), new AiCatalogModel("c", "C")));
-        service.Add("mine", Draft(
-            new AiModelEntry("a", "A"), new AiModelEntry("b", "B", Enabled: false)));
+        Assert.Equal("1 of 2 models", Group(vm).CountText);
 
         Group(vm).IsExpanded = true;
 
-        Assert.Equal("1 of 3 models listed", Group(vm).CountText);
+        Assert.Equal("1 of 3 models", Group(vm).CountText);
     }
 
-    /// <summary>A narrowed view is a third meaning again: neither what the reader has nor what the provider
-    /// offers, and indistinguishable from a short listing without saying so.</summary>
+    /// <summary>All of them on reads as the bare count rather than "3 of 3".</summary>
     [Fact]
-    public void While_searching_the_count_says_it_is_showing_matches()
+    public void With_everything_on_the_count_is_the_bare_number()
     {
-        var (vm, service) = Make(new FakeCatalog(
-            new AiCatalogModel("alpha", "Alpha"),
-            new AiCatalogModel("beta", "Beta"),
-            new AiCatalogModel("alpine", "Alpine")));
-        service.Add("mine", Draft());
-        Group(vm).IsExpanded = true;
+        var (vm, service) = Make();
+        service.Add("mine", Draft(new AiModelEntry("a", "A"), new AiModelEntry("b", "B")));
 
-        vm.Search = "alp";
-
-        Assert.Equal("0 of 2 models matching", Group(vm).CountText);
+        Assert.Equal("2 models", Group(vm).CountText);
     }
 }

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -283,21 +283,16 @@ namespace CST.Avalonia.ViewModels
                 var on = Visible.Count(r => r.Enabled);
                 if (total == 0) return _hasFetched ? "no models" : "no models yet";
 
-                // WHAT the number counts, not just the number. The same words meant three different things
-                // in one sitting: the reader's own saved models before the listing arrives, a subset while a
-                // search narrows the view, and the provider's full listing after a fetch. "2 of 3" read as
-                // "Groq has 3 models" every time, and sent them looking for models that were never missing.
+                // Plain: "2 models", or "2 of 13 models". The trailing "on" said which of the two numbers was
+                // the enabled one, which the shape "2 of 13" already says.
                 //
-                // The listing is only fetched when the group is first expanded, so the pre-fetch state is
-                // ordinary rather than a corner: it is what every reader sees for the first second, and what
-                // they keep seeing if they never expand.
-                var noun = !_hasFetched ? "saved"
-                    : _filtered ? "matching"
-                    : "listed";
-
-                return on == total
-                    ? $"{Plural(total)} {noun}"
-                    : $"{on} of {Plural(total)} {noun}";
+                // An earlier cut qualified the noun - saved / listed / matching - because the same words meant
+                // three different things depending on whether the provider's listing had been fetched yet.
+                // That was solving the wrong half. The reason a reader ever saw their own saved count is that
+                // the listing lived in memory for one window and was discarded; caching it (#790) makes the
+                // number the listing from the first paint, and a label explaining which set you are looking at
+                // then explains a distinction that no longer exists. (#786)
+                return on == total ? Plural(total) : $"{on} of {Plural(total)}";
             }
         }
 
@@ -350,13 +345,8 @@ namespace CST.Avalonia.ViewModels
         /// hiding one behind a price filter would look like it had been lost. Fetched models the reader has
         /// not touched are subject to both the search and the price filter.</para>
         /// </summary>
-        /// <summary>True while the rows are a narrowed view rather than everything this group has, so the
-        /// count can say which it is showing.</summary>
-        private bool _filtered;
-
         internal void ApplyFilter(string search, bool freeOnly, bool searching)
         {
-            _filtered = !string.IsNullOrWhiteSpace(search) || freeOnly;
 
             var stored = _connection.Models.ToDictionary(m => m.Id, StringComparer.Ordinal);
             var rows = new List<AiCatalogRowViewModel>();


### PR DESCRIPTION
Finishes #786. **#788 merged the wrong version of this change, and the fault is mine.**

## What happened

**[fsnow]** asked for the plain form — *"I'd prefer it say '2 models' or '2 of 13 models'"*. I made that change, ran the suite, and updated #788's description to describe it. But I made it in a second working tree, and never force-pushed the amended commit. So the branch on origin still carried the earlier `saved` / `listed` / `matching` wording, that is what merged, and main renders `2 of 3 models saved` today.

The description was accurate about the intent and wrong about the contents.

Worth stating precisely, because "I forgot to push" undersells it: every individual step was right. I amended in one tree, verified in that tree, and described the verified state. What was missing was the step connecting the tree I verified to the ref that gets merged — and no artefact anywhere in that flow would have shown the divergence. The reviewer merges on the description, and a description matching the *intended* diff is indistinguishable from one matching the *actual* diff without reading the diff.

That is the same defect as the code instances collected today: **a green suite on an unpushed tree is not a green suite on the ref.** An absence with no name and no rendering.

## The change

```
2 models
2 of 13 models
```

The trailing `on` goes too: it said which of the two numbers was the enabled one, which the shape `2 of 13` already says.

The `saved` / `listed` / `matching` nouns are removed along with the `_filtered` flag that existed only to choose between them. They were a truthful label over a state the reader should not be in — the reason anyone ever saw their own saved count is that the listing lived in memory for one window and was discarded, and #790 fixes that by caching it. Once the number is the provider's listing from the first paint, a label explaining which set you are looking at explains a distinction that no longer exists.

## Tests

The three that pinned the three state names go with the wording they pinned. Two remain: that no state name and no trailing word appear, and that an all-enabled group reads as the bare count. Pre-fetch coverage is unchanged — it simply no longer asserts a different label for that moment.

Full suite green (2401 passed, 0 failed), 0 build warnings.
