### PR TITLE
Show the connection tabs only while the assistant is on, and put it first (#795)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
@@ -159,5 +159,93 @@ namespace CST.Avalonia.Tests.ViewModels
             vm.LocalApiEnabled = true;
             Assert.True(raised);   // the REST toggle must re-notify the remote-control gate, not just the MCP one
         }
+
+        // ---- the connection tabs follow the assistant (#795) -------------------------------------------
+
+        /// <summary>
+        /// Providers and Models configure connections and model lists, and the assistant is their only
+        /// consumer — nothing in the local API or MCP surfaces resolves a provider. With it off they are two
+        /// tabs of settings for a feature that is not running.
+        /// </summary>
+        [Fact]
+        public void The_connection_tabs_are_shown_only_while_the_assistant_is_on()
+        {
+            var (vm, _) = Make();
+
+            vm.AiEnabled = true;
+            vm.ChatEnabled = true;
+            Assert.True(vm.ShowConnectionTabs);
+
+            vm.ChatEnabled = false;
+            Assert.False(vm.ShowConnectionTabs);
+        }
+
+        /// <summary>The master switch takes them too — everything under it is off when it is.</summary>
+        [Fact]
+        public void The_master_switch_hides_the_connection_tabs_as_well()
+        {
+            var (vm, _) = Make();
+            vm.AiEnabled = true;
+            vm.ChatEnabled = true;
+
+            vm.AiEnabled = false;
+
+            Assert.False(vm.ShowConnectionTabs);
+        }
+
+        /// <summary>
+        /// The selection cannot be left pointing at a tab that is no longer there: a reader on Models who
+        /// unticks the assistant would otherwise be looking at a blank pane with no tab header selected.
+        /// </summary>
+        [Fact]
+        public void Hiding_the_tabs_moves_the_selection_off_them()
+        {
+            var (vm, _) = Make();
+            vm.AiEnabled = true;
+            vm.ChatEnabled = true;
+            vm.SelectedTab = 2;              // Models
+
+            vm.ChatEnabled = false;
+
+            Assert.Equal(0, vm.SelectedTab);
+        }
+
+        /// <summary>
+        /// HIDDEN, never cleared. Every connection, model list and stored key survives the assistant being
+        /// switched off and comes back untouched — tidying up on the way past is how a settings file loses
+        /// work that took a reader an evening to build. (#784 is the fresh reminder.)
+        /// </summary>
+        [Fact]
+        public void Turning_the_assistant_off_preserves_the_providers_and_models()
+        {
+            var (vm, settings, keys) = MakeWithAssistant();
+
+            // A configured provider with a hand-built model list, which is the work at stake.
+            settings.Ai.Chat.Connections.Add(new CST.Avalonia.Models.AiConnectionRecord
+            {
+                Id = "groq",
+                DisplayName = "Groq",
+                BaseUrl = "https://api.groq.com/openai/v1",
+                Models =
+                {
+                    new CST.Avalonia.Models.AiModelRecord { Id = "openai/gpt-oss-120b", Enabled = true },
+                    new CST.Avalonia.Models.AiModelRecord { Id = "qwen/qwen3.6-27b", Enabled = true },
+                },
+            });
+            keys.Set("groq", CST.Avalonia.Services.Ai.AiCredentialNames.Primary, "gsk-test");
+
+            vm.AiEnabled = true;
+            vm.ChatEnabled = true;
+
+            vm.ChatEnabled = false;
+
+            var after = settings.Ai.Chat.Connections.Single();
+            Assert.Equal("groq", after.Id);
+            Assert.Equal(
+                new[] { "openai/gpt-oss-120b", "qwen/qwen3.6-27b" },
+                after.Models.Select(m => m.Id));
+            Assert.All(after.Models, m => Assert.True(m.Enabled));
+            Assert.Equal("gsk-test", keys.Get("groq", CST.Avalonia.Services.Ai.AiCredentialNames.Primary));
+        }
     }
 }

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1433,6 +1433,9 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
                 _settingsService.RequestSave();
                 // The two enable-gates below both depend on the master.
                 this.RaisePropertyChanged(nameof(SubPermissionsEnabled));
+                this.RaisePropertyChanged(nameof(ShowConnectionTabs));
+                // The selection cannot be left pointing at a tab that is no longer there.
+                if (!ShowConnectionTabs) SelectedTab = 0;
                 this.RaisePropertyChanged(nameof(RemoteControlEnabled));
                 this.RaisePropertyChanged(nameof(AssistantFieldsEnabled));
                 // The assistant hangs off the master switch too, so turning AI off takes its panel with it.
@@ -1566,6 +1569,8 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
                 _settingsService.Settings.Ai.Chat.Enabled = value;
                 _settingsService.RequestSave();
                 this.RaisePropertyChanged(nameof(AssistantFieldsEnabled));
+                this.RaisePropertyChanged(nameof(ShowConnectionTabs));
+                if (!ShowConnectionTabs) SelectedTab = 0;
                 RefreshReadiness();
                 // Ticking the box IS the gesture: the panel appears now rather than at the next launch, and
                 // unticking takes it away rather than leaving four buttons that decline every request. (#667)
@@ -1604,6 +1609,20 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
         /// "Enable the assistant" unticked, and readiness still reporting on a feature that was off.
         /// </summary>
         public bool AssistantFieldsEnabled => AiEnabled && ChatEnabled;
+
+        /// <summary>
+        /// Whether the Providers and Models tabs are shown at all. (#795)
+        ///
+        /// <para>They configure connections and model lists, and the assistant is their only consumer —
+        /// nothing in the local API or MCP surfaces resolves a provider. So with the assistant off they are
+        /// two tabs of settings for a feature that is not running, and the reader has to work out that the
+        /// checkbox on the first tab is what makes them meaningful.</para>
+        ///
+        /// <para><b>Hidden, never cleared.</b> Every connection, model list and stored key stays exactly as it
+        /// was and comes back untouched when the assistant is switched on again. Tidying up on the way past is
+        /// how a settings file loses work that took a reader an evening to build.</para>
+        /// </summary>
+        public bool ShowConnectionTabs => AiEnabled && ChatEnabled;
 
         public string ReadinessText
         {

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -518,6 +518,33 @@
                                     </StackPanel>
                                 </Border>
 
+                                <!-- The in-app assistant — surface B (#585).
+                                     FIRST after the master switch, and above the agent surfaces: it is the
+                                     one most readers will use, and the two tabs beside it are its
+                                     configuration. Deliberately NO temperature control — current Claude
+                                     models reject sampling parameters with a 400. -->
+                                <Border Classes="SettingGroup">
+                                    <StackPanel>
+                                        <TextBlock Text="Assistant" Classes="SettingLabel"/>
+
+                                        <CheckBox IsChecked="{Binding ChatEnabled}"
+                                                 IsEnabled="{Binding SubPermissionsEnabled}"
+                                                 Content="Enable the assistant"
+                                                 Margin="0,10,0,0"/>
+
+                                        <!-- The protocol, the address, the model list and the key all moved to
+                                             the Providers and Models tabs, where they belong to a connection
+                                             rather than to the app (#691/#692/#693). What is left here is what
+                                             is genuinely one-per-app. -->
+                                        <TextBlock Text="Answer language" Classes="SettingLabel" Margin="0,14,0,0"/>
+                                        <AutoCompleteBox Text="{Binding AnswerLanguage}"
+                                                        ItemsSource="{Binding AnswerLanguageSuggestions}"
+                                                        IsEnabled="{Binding AssistantFieldsEnabled}"
+                                                        FilterMode="StartsWith"
+                                                        Width="320" HorizontalAlignment="Left"/>
+                                    </StackPanel>
+                                </Border>
+
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
                                         <TextBlock Text="Access for AI Clients" Classes="SettingLabel"/>
@@ -568,61 +595,15 @@
                                     </StackPanel>
                                 </Border>
 
-                                <!-- The in-app assistant — surface B (#585).
-                                     Sits under the same master switch as the agent surfaces above: this is a
-                                     third way in, not a separate feature area. Deliberately NO temperature
-                                     control — current Claude models reject sampling parameters with a 400. -->
-                                <Border Classes="SettingGroup">
-                                    <StackPanel>
-                                        <TextBlock Text="Assistant" Classes="SettingLabel"/>
-                                        <TextBlock Text="Ask about the passage you are reading — an explanation, a translation, a grammatical breakdown — answered by a model you choose. Answers are generated text, shown separately from the canonical text, and can be wrong."
-                                                  Classes="SettingDescription"/>
-
-                                        <CheckBox IsChecked="{Binding ChatEnabled}"
-                                                 IsEnabled="{Binding SubPermissionsEnabled}"
-                                                 Content="Enable the assistant"
-                                                 Margin="0,10,0,0"/>
-
-                                        <!-- The protocol and the address moved to the Providers tab, where
-                                             they belong to a connection rather than to the app (#691). What
-                                             is left here is what is still genuinely one-per-app. -->
-                                        <!-- The Model box, the shared API-key box and the per-model Pāli note
-                                             lived here while the assistant had exactly one provider. The
-                                             Providers tab replaced all three (#691/#692/#693), and leaving
-                                             them meant two screens editing the same records by different
-                                             routes: this one wrote settings directly, bypassing validation
-                                             and the change event, and filed keys under whichever connection
-                                             happened to be active - the very mis-filing #678 fixed. Removed
-                                             rather than hidden. (fable review) -->
-
-                                        <TextBlock Text="Answer language" Classes="SettingLabel" Margin="0,14,0,0"/>
-                                        <AutoCompleteBox Text="{Binding AnswerLanguage}"
-                                                        ItemsSource="{Binding AnswerLanguageSuggestions}"
-                                                        IsEnabled="{Binding AssistantFieldsEnabled}"
-                                                        FilterMode="StartsWith"
-                                                        Width="320" HorizontalAlignment="Left"/>
-                                        <TextBlock Text="{Binding PaliScriptNote}" Classes="SettingDescription"/>
-
-                                        <!-- §10: state plainly what leaves the machine, on the screen where
-                                             the user decides — not only in the documentation. -->
-                                        <TextBlock Text="What is sent" Classes="SettingLabel" Margin="0,14,0,0"/>
-                                        <TextBlock Text="{Binding PrivacyNote}" Classes="SettingDescription"/>
-
-                                        <TextBlock Text="{Binding ReadinessText}"
-                                                  Classes="SettingDescription"
-                                                  FontWeight="SemiBold"
-                                                  Margin="0,12,0,0"/>
-                                    </StackPanel>
-                                </Border>
                                 </StackPanel>
                               </TabItem>
 
-                              <TabItem Header="Providers">
+                              <TabItem Header="Providers" IsVisible="{Binding ShowConnectionTabs}">
                                 <views:AiProvidersView DataContext="{Binding Connections}"
                                                        Margin="0,12,0,0"/>
                               </TabItem>
 
-                              <TabItem Header="Models">
+                              <TabItem Header="Models" IsVisible="{Binding ShowConnectionTabs}">
                                 <views:AiModelsView DataContext="{Binding Models}"
                                                     Margin="0,12,0,0"/>
                               </TabItem>


### PR DESCRIPTION
Closes #795.

Three changes to Settings → AI, all reported from use.

> **[fsnow]** *"If AI assistant is off, we should not show the Providers and Models tabs. Also, since AI Assistant will be more popular than the API / MCP surfaces, we should put that first in settings after the main AI enable switch."*
>
> **[fsnow]** *"but we **should** preserve any provider or models settings until it is enabled again"*
>
> **[fsnow]** *"Please simplify the AI Assistant settings. Just a checkbox and the language text box. Less explanatory text"*

## 1. Providers and Models follow the assistant

Both tabs are hidden unless the assistant is on. They configure connections and model lists, and with the assistant off they are two tabs of settings for a feature that is not running — leaving the reader to work out that a checkbox on the first tab is what makes them mean anything.

**The premise was checked rather than assumed.** Gating them on the assistant is only right if nothing else consumes a connection: nothing under `Services/LocalApi/` references `IAiConnectionService` or `IChatProviderResolver`. The API and MCP surfaces expose the corpus to external agents and never resolve a provider, so the assistant is genuinely their only consumer.

**Hidden, never cleared.** Every connection, model list and stored key survives being switched off and comes back untouched. There is a test that stands up a Groq connection with two enabled models and a stored key, toggles the assistant off, and asserts all three are identical afterwards — including the key still being in the store. That is pinned rather than left to a comment because tidying up on the way past is precisely how #784 cost a reader an evening's work this morning.

**The selection moves with them.** A reader sitting on Models who unticks the assistant would otherwise be left looking at a blank pane with no tab header selected, so `SelectedTab` returns to General.

## 2. Assistant first, above the agent surfaces

The order is now **Enable AI → Assistant → Access for AI Clients**. The assistant is what most readers will use; the API and MCP surfaces are for people who already know they want them.

## 3. The Assistant group is a checkbox and the language box

Removed: the introductory paragraph, the Pāli-script note, and the readiness line.

**One removal worth flagging rather than burying: the "What is sent" privacy note.** It was there to satisfy AI_SURFACE_B.md §10 — state plainly what leaves the machine, on the screen where the reader decides, not only in the documentation. It is gone here as asked, and the options are to leave it gone, restore it behind an expander, or move it into the assistant panel where the decision to send actually happens. That is a call for **[fsnow]** rather than one to make silently while trimming text.

`PrivacyNote`, `PaliScriptNote` and `ReadinessText` are all unbound and untested after this change. They are left in the view model deliberately, pending that decision — deleting them now would mean rewriting one of them if the answer is "put it back". They come out in one sweep once it is settled.

Rebased on current main. Full suite green (2419 passed, 0 failed), 0 build warnings.

One caveat recorded rather than hidden: the first run after rebasing showed a single failure whose name I lost (my command redirected stdout past the capture). Two further full runs are green with the same total, so nothing is being skipped differently. Filed as #798 with what is known — one failure in roughly thirteen full runs today. Merging on two green runs and a filed flake, not on "it passed the second time".
