### PR TITLE
Recover settings from a backup instead of defaulting (#785)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/SettingsBackupRecoveryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SettingsBackupRecoveryTests.cs
@@ -131,6 +131,63 @@ public sealed class SettingsBackupRecoveryTests : IDisposable
         Assert.Empty(Directory.GetFiles(_dir, "settings.unreadable-*.json"));
     }
 
+    // Fable's lead finding: RequestSave only ARMS a 750ms timer, so after a restore there was a window with
+    // no primary file at all. A crash or force-quit inside it sent the next launch down the no-file branch,
+    // which called it a first run — the recovery evaporating silently, and the reader losing everything a
+    // second time. (#785)
+    [Fact]
+    public async Task A_restore_is_written_back_immediately_not_on_the_debounce_timer()
+    {
+        await WithOneGoodSave("/books");
+        await File.WriteAllTextAsync(SettingsPath, "{ broken");
+
+        await Loaded(_dir);
+
+        // No waiting, no flush: by the time the load returns, the primary file is on disk again.
+        Assert.True(File.Exists(SettingsPath));
+        Assert.Contains("\"/books\"", await File.ReadAllTextAsync(SettingsPath));
+    }
+
+    // And the belt to that braces: even if the write-back never happened, backups are consulted rather than
+    // the launch being treated as a first run.
+    [Fact]
+    public async Task A_missing_primary_file_with_backups_present_is_recovered_not_treated_as_a_first_run()
+    {
+        await WithOneGoodSave("/books");
+        File.Delete(SettingsPath);
+
+        var reopened = await Loaded(_dir);
+
+        Assert.Equal("/books", reopened.Settings.XmlBooksDirectory);
+        Assert.Equal("/idx", reopened.Settings.IndexDirectory);
+    }
+
+    // A genuine first run must still be a first run — the check above must not turn an empty backup directory
+    // into a recovery attempt that reports something it did not do.
+    [Fact]
+    public async Task A_genuine_first_run_is_still_a_first_run()
+    {
+        var svc = await Loaded(_dir);
+
+        Assert.Empty(svc.GetBackupFilePaths());
+        Assert.False(string.IsNullOrEmpty(svc.Settings.XmlBooksDirectory));
+        Assert.Equal("", svc.Settings.IndexDirectory);
+    }
+
+    // Fable's second finding: when the walk finds nothing, the defaults that follow must not become the
+    // NEWEST backup. A persisted-type change breaks every backup at once — the expected case — so defaults
+    // would bury a genuinely configured older backup that the walk stops before ever reaching.
+    [Fact]
+    public async Task Defaults_written_because_nothing_could_be_recovered_do_not_become_a_backup()
+    {
+        await File.WriteAllTextAsync(SettingsPath, "{ broken");
+
+        var svc = await Loaded(_dir);
+        await svc.SaveSettingsAsync();      // the debounced save, brought forward
+
+        Assert.Empty(svc.GetBackupFilePaths());
+    }
+
     public void Dispose()
     {
         try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }

--- a/src/CST.Avalonia.Tests/Services/SettingsBackupRecoveryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SettingsBackupRecoveryTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// Settings survive a file this build cannot read. (#785)
+///
+/// <para><b>The incident.</b> A persisted type changed (#771) and a settings file written the previous day
+/// stopped parsing. <c>SettingsService</c> answered that by replacing the settings with defaults and SAVING
+/// them — so a configuration was not merely unavailable, it was destroyed, and a hand-built model list had to
+/// be reconstructed by hand.</para>
+///
+/// <para><b>Why moving the file aside is not the fix.</b> It is necessary and it is not sufficient: a file
+/// called <c>settings.unreadable-….json</c> in the application support directory is a rescue only someone who
+/// wrote this code would ever find, and by the time a reader thought to look they would already have rebuilt
+/// what they lost. Recovery has to be automatic, which is what <c>ApplicationStateService</c> has always done
+/// and settings never did.</para>
+/// </summary>
+public sealed class SettingsBackupRecoveryTests : IDisposable
+{
+    private readonly string _dir;
+
+    public SettingsBackupRecoveryTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"settings-backup-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    private string SettingsPath => Path.Combine(_dir, "settings.json");
+
+    private static async Task<SettingsService> Loaded(string dir)
+    {
+        var svc = new SettingsService(dir);
+        await svc.LoadSettingsAsync();
+        return svc;
+    }
+
+    // Establish a real backup the way the app does: save once.
+    private async Task<SettingsService> WithOneGoodSave(string booksDirectory)
+    {
+        var svc = await Loaded(_dir);
+        svc.Settings.XmlBooksDirectory = booksDirectory;
+        svc.Settings.IndexDirectory = "/idx";
+        await svc.SaveSettingsAsync();
+        return svc;
+    }
+
+    [Fact]
+    public async Task A_successful_save_leaves_a_backup_behind()
+    {
+        var svc = await WithOneGoodSave("/books");
+
+        var backups = svc.GetBackupFilePaths();
+        Assert.NotEmpty(backups);
+        Assert.Contains("\"/books\"", await File.ReadAllTextAsync(backups[0]));
+    }
+
+    // The incident, replayed: the file becomes unreadable between sessions.
+    [Fact]
+    public async Task An_unreadable_file_is_recovered_from_the_backup_rather_than_defaulted()
+    {
+        await WithOneGoodSave("/books");
+
+        // Exactly the shape of the real failure: valid JSON, one property this build cannot convert.
+        await File.WriteAllTextAsync(SettingsPath,
+            """{ "Version": "1.0", "XmlBooksDirectory": "/books", "FontSettings": 12345 }""");
+
+        var reopened = await Loaded(_dir);
+
+        Assert.Equal("/books", reopened.Settings.XmlBooksDirectory);
+        Assert.Equal("/idx", reopened.Settings.IndexDirectory);
+    }
+
+    [Fact]
+    public async Task The_unreadable_file_is_kept_as_well_as_recovered_from()
+    {
+        await WithOneGoodSave("/books");
+        await File.WriteAllTextAsync(SettingsPath, "{ not json at all");
+
+        await Loaded(_dir);
+
+        // Both halves: the reader gets their settings back AND the file that failed is still on disk, so the
+        // cause remains diagnosable rather than being destroyed by the recovery.
+        Assert.NotEmpty(Directory.GetFiles(_dir, "settings.unreadable-*.json"));
+    }
+
+    [Fact]
+    public async Task A_backup_that_is_also_unreadable_is_skipped_for_an_older_one()
+    {
+        await WithOneGoodSave("/books");
+        var good = (await Loaded(_dir)).GetBackupFilePaths().Single();
+
+        // A newer backup that is itself broken — which is what a persisted-type change produces, since every
+        // backup shares the primary file's shape.
+        var newer = Path.Combine(Path.GetDirectoryName(good)!, "settings-99999999-235959-999.json");
+        await File.WriteAllTextAsync(newer, "{ broken");
+        await File.WriteAllTextAsync(SettingsPath, "{ broken too");
+
+        var reopened = await Loaded(_dir);
+
+        Assert.Equal("/books", reopened.Settings.XmlBooksDirectory);
+    }
+
+    // With nothing to recover from, the floor still has to hold.
+    [Fact]
+    public async Task With_no_backup_at_all_the_unreadable_file_is_still_kept_and_defaults_are_used()
+    {
+        await File.WriteAllTextAsync(SettingsPath, "{ broken");
+
+        var svc = await Loaded(_dir);
+
+        Assert.NotEmpty(Directory.GetFiles(_dir, "settings.unreadable-*.json"));
+        Assert.False(string.IsNullOrEmpty(svc.Settings.XmlBooksDirectory));   // first-run defaulting ran
+    }
+
+    [Fact]
+    public async Task An_ordinary_load_does_not_touch_the_backups()
+    {
+        await WithOneGoodSave("/books");
+        var before = (await Loaded(_dir)).GetBackupFilePaths().Length;
+
+        await Loaded(_dir);
+
+        Assert.Equal(before, (await Loaded(_dir)).GetBackupFilePaths().Length);
+        Assert.Empty(Directory.GetFiles(_dir, "settings.unreadable-*.json"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/src/CST.Avalonia/Services/SettingsService.cs
+++ b/src/CST.Avalonia/Services/SettingsService.cs
@@ -100,6 +100,14 @@ namespace CST.Avalonia.Services
                 }
                 else
                 {
+                    // No primary file is USUALLY a true first run — but not always, and the exception is the
+                    // recovery path's own worst moment. PreserveUnreadable moves the file aside, and if the
+                    // app is force-quit or crashes before the restore is written back, the next launch arrives
+                    // here with backups sitting right there and would have called it a first run: the restore
+                    // evaporates silently and the reader loses everything a second time. (#785, fable)
+                    if (GetBackupFilePaths().Length > 0 && await TryLoadFromBackupAsync().ConfigureAwait(false))
+                        return;
+
                     _logger.Information("No settings file found, using defaults");
                     ApplyFirstRunDefaults();
                 }
@@ -129,14 +137,28 @@ namespace CST.Avalonia.Services
                 // Then try to RECOVER, which is the half that means the reader never learns any of this
                 // happened. ApplicationStateService has done this since it was written; settings never did,
                 // and settings is the file that holds everything a reader configured by hand. (#785)
-                if (TryLoadFromBackup())
+                if (await TryLoadFromBackupAsync().ConfigureAwait(false))
                     return;
 
+                // Nothing to recover from. Defaults, and the unreadable file is already kept beside them.
+                //
+                // This save deliberately does NOT leave a backup. A persisted-type change breaks every backup
+                // at once — the expected case — so defaults would become the NEWEST backup, and the walk stops
+                // at the first readable one. A later recovery would then restore defaults and report that
+                // nothing was lost, with a genuinely configured backup sitting one file below, never reached.
+                // (#785, fable)
                 _settings = new Settings();
                 ApplyFirstRunDefaults();
+                _backupNextSave = false;
                 RequestSave();
             }
         }
+
+        /// <summary>
+        /// Whether the NEXT save should leave a backup. False for exactly one save: the defaults written when
+        /// no backup could be read, which must not become the newest backup. (#785)
+        /// </summary>
+        private bool _backupNextSave = true;
 
         /// <summary>The directory holding timestamped copies of previously-saved settings. (#785)</summary>
         private string BackupDirectory => Path.Combine(_settingsDirectory, "settings-backups");
@@ -146,8 +168,10 @@ namespace CST.Avalonia.Services
         {
             try
             {
+                // UTC: a local clock moved backwards, or a DST fall-back, would otherwise make a newer backup
+                // sort as older — and the walk restores the first one it can read. (fable)
                 return Directory.GetFiles(BackupDirectory, "settings-*.json")
-                    .OrderByDescending(File.GetLastWriteTime)
+                    .OrderByDescending(File.GetLastWriteTimeUtc)
                     .ToArray();
             }
             catch
@@ -198,26 +222,40 @@ namespace CST.Avalonia.Services
         /// the load-what-the-previous-version-wrote fixtures (#787) are its complement rather than its
         /// alternative.</para>
         /// </summary>
-        private bool TryLoadFromBackup()
+        private async Task<bool> TryLoadFromBackupAsync()
         {
             foreach (var path in GetBackupFilePaths())
             {
                 try
                 {
-                    var loaded = JsonSerializer.Deserialize<Settings>(File.ReadAllText(path), _jsonOptions);
+                    var loaded = JsonSerializer.Deserialize<Settings>(
+                        await File.ReadAllTextAsync(path).ConfigureAwait(false), _jsonOptions);
                     if (loaded == null) continue;
 
-                    SettingsValidator.Migrate(loaded);
-                    SettingsValidator.Sanitize(loaded);
+                    // The same repairs the primary file gets, and reported the same way. A restore that
+                    // silently dropped connections or models — Sanitize does remove id-less ones — would look
+                    // identical to one that lost nothing. (fable)
+                    foreach (var note in SettingsValidator.Migrate(loaded))
+                        _logger.Information("Settings migration (from backup): {Note}", note);
+                    foreach (var fix in SettingsValidator.Sanitize(loaded))
+                        _logger.Warning("Settings sanitized (from backup): {Fix}", fix);
+
                     _settings = loaded;
                     try { ApplyFirstRunDefaults(); } catch { /* see the load path */ }
 
+                    // The timestamp, and no claim beyond it. The newest READABLE backup can be older than the
+                    // file that failed — a shape change breaks the recent ones first — so "nothing was lost"
+                    // would be a guess stated as a fact. (fable)
                     _logger.Information(
-                        "Settings were restored from the backup taken at {Taken}; nothing was lost.",
+                        "Settings were restored from the backup taken at {Taken}.",
                         File.GetLastWriteTime(path));
 
-                    // Put it back as the primary file, so the next launch is an ordinary one.
-                    RequestSave();
+                    // Written back NOW, not on the debounce timer. Until the primary file exists again the
+                    // recovery is only in memory, and a crash or force-quit in that window sends the next
+                    // launch down the no-file path — which is why that path now checks the backups too, but
+                    // the fix belongs here first: a restore that has to survive a race to count is not a
+                    // restore. (fable)
+                    await SaveSettingsAsync().ConfigureAwait(false);
                     return true;
                 }
                 catch (Exception ex)
@@ -246,7 +284,10 @@ namespace CST.Avalonia.Services
 
                 var kept = Path.Combine(
                     _settingsDirectory,
-                    $"settings.unreadable-{DateTime.Now:yyyyMMdd-HHmmss}.json");
+                    // Milliseconds, matching the backup filenames: two failed loads in the same second would
+                    // otherwise collide, File.Move(overwrite: false) would throw, and the copy holding the
+                    // reader's configuration would be left in place to be overwritten by the next save. (fable)
+                    $"settings.unreadable-{DateTime.Now:yyyyMMdd-HHmmss-fff}.json");
 
                 File.Move(_settingsFilePath, kept, overwrite: false);
 
@@ -313,7 +354,8 @@ namespace CST.Avalonia.Services
 
                 // A copy of what we just wrote, so a later build that cannot read it has something to fall
                 // back to. Best-effort: a failure to keep a backup must never fail the save itself. (#785)
-                await WriteBackupAsync(json).ConfigureAwait(false);
+                if (_backupNextSave) await WriteBackupAsync(json).ConfigureAwait(false);
+                _backupNextSave = true;
             }
             catch (Exception ex)
             {

--- a/src/CST.Avalonia/Services/SettingsService.cs
+++ b/src/CST.Avalonia/Services/SettingsService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CST.Avalonia.Constants;
@@ -108,11 +109,156 @@ namespace CST.Avalonia.Services
                 // A corrupt/torn settings.json lands here. Previously we only logged and returned, so the
                 // app ran with an EMPTY XmlBooksDirectory (the default was set only in the no-file branch)
                 // — changing update/indexing behavior. Fall through to first-run defaulting instead, and
-                // persist it (the atomic save replaces the corrupt file). (STATE-3)
+                // persist it. (STATE-3)
                 _logger.Error(ex, "Failed to load settings from {Path} - reverting to defaults", _settingsFilePath);
+
+                // Keep the file we could not read, BEFORE the save below writes defaults over it. (#785)
+                //
+                // That save used to replace it, deliberately — "the atomic save replaces the corrupt file".
+                // The defaulting is right; the replacing is not, and the difference is everything: it turns
+                // "your configuration is unavailable this session" into "your configuration is gone", where
+                // even diagnosing the cause afterwards cannot bring it back. It has already cost a reader a
+                // hand-built model list — the file was readable JSON that one property of ours had outgrown,
+                // and it was destroyed rather than set aside.
+                //
+                // "Corrupt" is the rarer case anyway. The likelier one, and the observed one, is a file this
+                // build does not understand YET: written by a newer version, restored from a backup, or
+                // holding a shape we changed. None of those deserve deletion.
+                PreserveUnreadable();
+
+                // Then try to RECOVER, which is the half that means the reader never learns any of this
+                // happened. ApplicationStateService has done this since it was written; settings never did,
+                // and settings is the file that holds everything a reader configured by hand. (#785)
+                if (TryLoadFromBackup())
+                    return;
+
                 _settings = new Settings();
                 ApplyFirstRunDefaults();
                 RequestSave();
+            }
+        }
+
+        /// <summary>The directory holding timestamped copies of previously-saved settings. (#785)</summary>
+        private string BackupDirectory => Path.Combine(_settingsDirectory, "settings-backups");
+
+        /// <summary>Backups, newest first. Empty when there are none or the directory cannot be read.</summary>
+        internal string[] GetBackupFilePaths()
+        {
+            try
+            {
+                return Directory.GetFiles(BackupDirectory, "settings-*.json")
+                    .OrderByDescending(File.GetLastWriteTime)
+                    .ToArray();
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        /// <summary>
+        /// Keep a timestamped copy of a successful save, and prune old ones. Best-effort throughout: losing a
+        /// backup is a smaller failure than losing the save it was taken from. (#785)
+        /// </summary>
+        private async Task WriteBackupAsync(string json)
+        {
+            try
+            {
+                Directory.CreateDirectory(BackupDirectory);
+                var path = Path.Combine(
+                    BackupDirectory, $"settings-{DateTime.Now:yyyyMMdd-HHmmss-fff}.json");
+                await File.WriteAllTextAsync(path, json).ConfigureAwait(false);
+
+                var kept = GetBackupFilePaths()
+                    .Select(p => (path: p, when: File.GetLastWriteTime(p)))
+                    .ToList();
+                foreach (var stale in ApplicationStateService.SelectBackupsToDelete(kept))
+                {
+                    try { File.Delete(stale); } catch { /* best effort */ }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "Could not write a settings backup");
+            }
+        }
+
+        /// <summary>
+        /// Walk the backups newest-first and load the first one that reads, migrating and sanitizing it
+        /// exactly as the primary file would be. (#785)
+        ///
+        /// <para><b>This is the half that actually fixes #785.</b> Moving the unreadable file aside stops the
+        /// destruction, but a file named <c>settings.unreadable-...json</c> in the application support
+        /// directory is a rescue only someone who wrote this code would ever find — by the time a reader
+        /// thought to look they would have rebuilt their configuration by hand, which is exactly what
+        /// happened. Recovering automatically means they never learn the word.</para>
+        ///
+        /// <para>A backup is written in the same shape as the primary file, so a persisted-TYPE change breaks
+        /// every one of them at once and this walk finds nothing. That is not a reason to skip it — it is why
+        /// the load-what-the-previous-version-wrote fixtures (#787) are its complement rather than its
+        /// alternative.</para>
+        /// </summary>
+        private bool TryLoadFromBackup()
+        {
+            foreach (var path in GetBackupFilePaths())
+            {
+                try
+                {
+                    var loaded = JsonSerializer.Deserialize<Settings>(File.ReadAllText(path), _jsonOptions);
+                    if (loaded == null) continue;
+
+                    SettingsValidator.Migrate(loaded);
+                    SettingsValidator.Sanitize(loaded);
+                    _settings = loaded;
+                    try { ApplyFirstRunDefaults(); } catch { /* see the load path */ }
+
+                    _logger.Information(
+                        "Settings were restored from the backup taken at {Taken}; nothing was lost.",
+                        File.GetLastWriteTime(path));
+
+                    // Put it back as the primary file, so the next launch is an ordinary one.
+                    RequestSave();
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warning(ex, "Settings backup at {Path} could not be read either; trying the next", path);
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Moves an unreadable settings file aside so the defaults written next cannot destroy it. (#785)
+        ///
+        /// <para>Timestamped rather than a single <c>.bak</c>: a second failed start would otherwise overwrite
+        /// the copy holding the reader's real configuration with a copy of the defaults that replaced it,
+        /// which is the same loss one step removed.</para>
+        ///
+        /// <para>Never throws. It runs inside the load's catch, and a failure to preserve must not become a
+        /// failure to start — the reader would then have neither their settings nor an application.</para>
+        /// </summary>
+        private void PreserveUnreadable()
+        {
+            try
+            {
+                if (!File.Exists(_settingsFilePath)) return;
+
+                var kept = Path.Combine(
+                    _settingsDirectory,
+                    $"settings.unreadable-{DateTime.Now:yyyyMMdd-HHmmss}.json");
+
+                File.Move(_settingsFilePath, kept, overwrite: false);
+
+                // At Error, beside the failure itself: a reader who has just lost their configuration is
+                // reading this line, and it is the one that tells them it is recoverable.
+                _logger.Error(
+                    "The previous settings file could not be read and has been kept at {Path}. "
+                    + "Defaults are in use; nothing from it was deleted.", kept);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "Could not preserve the unreadable settings file");
             }
         }
 
@@ -164,6 +310,10 @@ namespace CST.Avalonia.Services
                 }
 
                 _logger.Information("Settings saved successfully to {Path}", _settingsFilePath);
+
+                // A copy of what we just wrote, so a later build that cannot read it has something to fall
+                // back to. Best-effort: a failure to keep a backup must never fail the save itself. (#785)
+                await WriteBackupAsync(json).ConfigureAwait(false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The first half of #785. **Two commits** — the second is Fable's review, applied. Includes kestrel-cst-2's `handoff/785-preserve-unreadable` work, cherry-picked and folded into commit 1; their `PreserveUnreadable` and its comment are theirs verbatim.

## The incident

A persisted type changed (#771) and a settings file written the previous day stopped parsing. `SettingsService` answered that by replacing the settings with defaults **and saving them** — so the configuration was not merely unavailable, it was destroyed. A hand-built model list had to be reconstructed by hand.

## Why moving the file aside is not the fix

> *"You can move the file aside, but no one except you (and maybe me?) would ever find it."*

Right. A reader who has just lost their configuration rebuilds it by hand rather than going looking in the application support directory — which is what happened.

## The fix already existed, on the other store

**`ApplicationStateService` has survived this since it was written** — timestamped backup on save, walk backups newest-first on failure, migrate and sanitize the first that reads. Retention 8 recent + 14 daily. `SettingsService` had none of it. The two persisted stores got opposite treatment and the unhardened one is the one that lost a reader's configuration.

Settings now do the same, reusing the retention policy rather than reimplementing it. Recovery writes the restored settings back as the primary file, so the next launch is ordinary and the reader never learns the word "unreadable".

## Commit 2 — Fable's review

**Its lead finding was that the recovery could evaporate silently**, which is the one failure a recovery must not have. `RequestSave` only *arms* a 750 ms timer, so after a successful restore there was a window with **no primary file at all** — `PreserveUnreadable` had moved it aside and nothing had written it back. A crash or force-quit inside that window sent the next launch down the no-file branch, which called it a first run: no walk, no log, and the reader lost everything a second time having been silently rescued in between. Startup is exactly when force-quits happen.

Fixed in two places, because either alone leaves a hole: the restore is written back with an **awaited save**, and the **no-file branch now checks the backups** before concluding first run.

**Defaults no longer leave a backup.** When the walk finds nothing — the expected case for a persisted-type change, since every backup shares the primary shape — those defaults would have become the *newest* backup, and the walk stops at the first readable one. A later recovery would restore defaults and report success with a genuinely configured backup one file below, never reached.

Also: the restore logs its migration notes and sanitize fixes like the primary path (Sanitize *can* remove id-less connections, and a restore that quietly dropped them looked identical to one that lost nothing); the log no longer claims "nothing was lost", which was a guess stated as fact since the newest *readable* backup can be older than the file that failed; backups are ordered by **UTC** so a clock change or DST fall-back cannot make a stale one sort newest; and the preserved filename carries milliseconds so two failed loads in the same second cannot collide.

## What stays underneath

Part 1 remains the floor for when recovery has nothing to recover from — including the first failure after this ships, since **no existing install has a backup until this build has saved once**.

Its reframing of the load comment is worth keeping: **"corrupt" is the rarer case.** The likelier one — and the observed one — is a file this build does not understand *yet*. Calling it corrupt is a large part of why deleting it looked like tidying up.

## Honest limitations

- A backup shares the primary file's shape, so a persisted-**type** change breaks every one at once. That is why #787's fixtures are the complement, not the alternative.
- Fable also recorded a pre-existing race not introduced here: anything calling `RequestSave` before the load completes could write defaults over the unreadable file before `PreserveUnreadable` runs. It found no startup writer inside the window, but the preservation guarantee holds against the load path's own save, not against a concurrent debounced one.

## Verified by mutation

Commit 1: removing the backup walk fails two of six, including the incident replay. Commit 2: reverting each of the three behavioural fixes fails exactly the test written for it.

## Suite

**2446 passed, 0 failed, 17 skipped.**

## Still open on #785

**Per-section tolerance** — keep what parses, default only what does not. Separate change, still mine.