### PR TITLE
Refuse an unfilled input on every save path, not just the preset one (#767)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -559,4 +559,83 @@ public class AiConnectionServiceTests
 
         Assert.True(result.Ok);
     }
+
+    // ---- an unfilled input is refused on every path (#767) ----------------------------------------------
+
+    private static AiConnectionDraft Templated(string? resourceName) =>
+        new("Azure OpenAI", ChatProviderKind.OpenAiCompatible,
+            "https://{resourceName}.openai.azure.com/openai/v1",
+            new List<AiModelEntry>(),
+            Array.Empty<AiHeader>(),
+            resourceName is null
+                ? new Dictionary<string, string>()
+                : new Dictionary<string, string> { ["resourceName"] = resourceName });
+
+    /// <summary>
+    /// The reported bug: clearing the resource name on the edit sheet saved cleanly, the sheet closed as
+    /// though it had worked, and what was stored was a base URL still reading
+    /// https://{resourceName}.openai.azure.com/openai/v1. The reader found out when a request went nowhere.
+    /// </summary>
+    [Fact]
+    public void An_edit_that_empties_a_templated_input_is_refused()
+    {
+        var (service, _, _) = MakeWithKeys();
+        service.Add("my-azure", Templated("my-resource"));
+
+        var result = service.Update("my-azure", Templated(""));
+
+        Assert.False(result.Ok);
+        Assert.Contains("resource", result.Problem, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(
+            "https://my-resource.openai.azure.com/openai/v1",
+            service.Connections.Single().ResolvedBaseUrl);   // the good one is still there
+    }
+
+    /// <summary>Removing the answer entirely is the same state as blanking it.</summary>
+    [Fact]
+    public void An_edit_that_drops_a_templated_input_is_refused()
+    {
+        var (service, _, _) = MakeWithKeys();
+        service.Add("my-azure", Templated("my-resource"));
+
+        Assert.False(service.Update("my-azure", Templated(null)).Ok);
+    }
+
+    /// <summary>
+    /// Add was missing the check too, which the issue did not report — found by reading the three paths side
+    /// by side rather than by fixing only the one that was named. A custom endpoint typed with a brace in it
+    /// saved just as quietly.
+    /// </summary>
+    [Fact]
+    public void An_add_with_an_unfilled_placeholder_is_refused()
+    {
+        var (service, _, _) = MakeWithKeys();
+
+        var result = service.Add("my-azure", Templated(null));
+
+        Assert.False(result.Ok);
+        Assert.Empty(service.Connections);
+    }
+
+    [Fact]
+    public void A_filled_input_saves_on_both_paths()
+    {
+        var (service, _, _) = MakeWithKeys();
+
+        Assert.True(service.Add("my-azure", Templated("first")).Ok);
+        Assert.True(service.Update("my-azure", Templated("second")).Ok);
+        Assert.Equal(
+            "https://second.openai.azure.com/openai/v1",
+            service.Connections.Single().ResolvedBaseUrl);
+    }
+
+    /// <summary>A base URL with no placeholders is unaffected — most connections are this.</summary>
+    [Fact]
+    public void A_plain_base_url_is_untouched_by_the_check()
+    {
+        var (service, _, _) = MakeWithKeys();
+
+        Assert.True(service.Add("mine", Draft()).Ok);
+        Assert.True(service.Update("mine", Draft("Renamed")).Ok);
+    }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -431,17 +431,34 @@ public class AiModelPickerViewModelTests
         Assert.True(AllModels(picker).Single().IsUsable);
     }
 
-    /// <summary>A connection whose URL still has an unanswered placeholder cannot send anything, which is a
-    /// fact rather than a guess.</summary>
+    /// <summary>
+    /// A connection whose URL still has an unanswered placeholder cannot send anything, which is a fact
+    /// rather than a guess.
+    ///
+    /// <para><b>Built directly in settings rather than through the service</b>, because #767 taught the
+    /// service to refuse this state on every save path — which is why the picker's guard now looks
+    /// unreachable and is not. A hand-edited <c>settings.json</c> is a supported way in (the resolver's own
+    /// comments say so, and #784 is the reminder of what happens when we assume otherwise), and a file
+    /// written before #767 can hold exactly this. The service refusing to CREATE it does not mean nothing
+    /// can be READING it.</para>
+    /// </summary>
     [Fact]
     public void An_unfinished_connection_is_disabled_with_the_reason()
     {
-        var (picker, service, keys) = Make();
-        service.Add("azure-ish", new AiConnectionDraft(
-            "Half-built", ChatProviderKind.OpenAiCompatible,
-            "https://{resourceName}.openai.azure.com/openai/v1",
-            new[] { new AiModelEntry("a", "A") },
-            Array.Empty<AiHeader>(), new Dictionary<string, string>()));
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        settings.Ai.Chat.Connections.Add(new CST.Avalonia.Models.AiConnectionRecord
+        {
+            Id = "azure-ish",
+            DisplayName = "Half-built",
+            BaseUrl = "https://{resourceName}.openai.azure.com/openai/v1",
+            Models = { new CST.Avalonia.Models.AiModelRecord { Id = "a", DisplayName = "A", Enabled = true } },
+        });
+        settings.Ai.Chat.ActiveConnectionId = "azure-ish";
+
+        var picker = new AiModelPickerViewModel(
+            new AiConnectionService(svc.Object, new FakeCredentialStore()));
 
         var model = AllModels(picker).Single();
         Assert.False(model.IsUsable);

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -219,6 +219,7 @@ namespace CST.Avalonia.Services.Ai
 
             if (DuplicateHeader(draft) is { } duplicate) return AiConnectionResult.Fail(duplicate);
             if (CollidingSecretHeader(draft) is { } collision) return AiConnectionResult.Fail(collision);
+            if (UnfilledInput(id, draft) is { } unfilled) return AiConnectionResult.Fail(unfilled);
 
             var record = new AiConnectionRecord { Id = id };
             Apply(record, draft);
@@ -270,6 +271,7 @@ namespace CST.Avalonia.Services.Ai
 
             if (DuplicateHeader(draft) is { } duplicate) return AiConnectionResult.Fail(duplicate);
             if (CollidingSecretHeader(draft) is { } collision) return AiConnectionResult.Fail(collision);
+            if (UnfilledInput(id, draft) is { } unfilled) return AiConnectionResult.Fail(unfilled);
 
             Apply(record, draft);
             return Saved(record);
@@ -305,6 +307,35 @@ namespace CST.Avalonia.Services.Ai
         /// too, nothing in the app can express what a repeat would mean, and a refusal naming the header beats
         /// an exception naming nothing.</para>
         /// </summary>
+        /// <summary>
+        /// A base URL still carrying a {placeholder} nothing fills, or null when it is complete. (#767)
+        ///
+        /// <para><b>The add-from-preset path has always refused this and the two draft paths never did.</b>
+        /// So an Azure connection whose resource name is cleared on the edit sheet saved cleanly, the sheet
+        /// closed as though it had worked, and what was stored was a base URL still reading
+        /// <c>https://{resourceName}.openai.azure.com/openai/v1</c>. The reader found out when a request went
+        /// nowhere. Reachable in one action: open Azure from the Providers tab, clear the box, press Save.</para>
+        ///
+        /// <para><b>Add was missing it too</b>, which the issue did not report — found by reading the three
+        /// paths side by side rather than by fixing the one that was named. A custom endpoint typed with a
+        /// brace in it saved just as quietly.</para>
+        ///
+        /// <para>Blank counts as unfilled, exactly as it does on the preset path: expanding an empty answer
+        /// leaves no placeholder behind, so a check that only looked for surviving braces would pass a URL
+        /// with a hole in it.</para>
+        /// </summary>
+        private string? UnfilledInput(string id, AiConnectionDraft draft)
+        {
+            var preset = Presets.FirstOrDefault(p => IdMatches(p.Id, id));
+
+            foreach (var key in AiTemplate.PlaceholdersIn(draft.BaseUrl))
+                if (!draft.Inputs.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+                    return $"{draft.DisplayName} needs "
+                           + $"{(preset is null ? key : PromptLabel(preset, key))} before it can be saved.";
+
+            return null;
+        }
+
         private static string? DuplicateHeader(AiConnectionDraft draft)
         {
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
Closes #767.

`AddFromPreset` has always refused a base URL still carrying a `{placeholder}` nothing fills. `Update` never did — so an Azure connection whose resource name is cleared on the edit sheet saved cleanly, the sheet closed as though it had worked, and what was stored read `https://{resourceName}.openai.azure.com/openai/v1`. The reader found out when a request went nowhere. Reachable in one action: open Azure from the Providers tab, clear the box, press Save.

## Add was missing it too

The issue suggested checking whether any *other* add-time validation was absent from `Update`. Reading the three paths side by side turned up the reverse as well: **`Add` had no placeholder check either**, so a custom endpoint typed with a brace in it saved just as quietly. Fixing only the path that was named would have left half the bug.

The check now sits on both draft paths, so all three refuse for the same reason.

**Blank counts as unfilled**, exactly as on the preset path. Expanding an empty answer leaves no placeholder behind, so a check that only looked for surviving braces would pass `https://.openai.azure.com/openai/v1` — a URL with a hole in it and no brace to show for it.

The refusal already has somewhere to go: the sheet surfaces `result.Problem` on the same line that shows *"There is already a connection called 'x'"*.

## The test this broke, and why the guard stayed

Making the state uncreatable broke `An_unfinished_connection_is_disabled_with_the_reason`, which built one through `service.Add` to check that the per-turn picker disables it with a reason.

The tempting move was to delete that guard as unreachable. **The service refusing to create a state does not mean nothing will be reading it.** A hand-edited `settings.json` is a supported way in — the resolver's own comments say so — and any file written before this change can hold exactly that base URL. So the guard stays and the test builds the record directly, which is how the state is now actually reached.

That is the same assumption that cost a reader their model lists this morning in #784: that a file only ever contains what this build would write.

## Verification

Mutating the `Update` check away fails the two edit tests and nothing else. Full suite green (2441 passed, 0 failed), 0 build warnings.
