### PR TITLE
Try again for a dictionary that failed to download (#773)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading.Tasks;
+using CST.Avalonia.Services;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -278,6 +280,53 @@ public sealed class DpdUpdateServiceTests : IDisposable
         Assert.False(staged);
         Assert.True(File.Exists(final));
         Assert.False(File.Exists(final + ".pending"));
+    }
+
+    // ---- a failed download is a STATE, not a log line (#773) ----
+
+    [Fact]
+    public async Task RetryMissing_does_not_touch_the_network_when_nothing_is_missing()
+    {
+        // The common case, and it runs every time the dictionary panel opens — so it has to be free. A service
+        // pointed at a repository that does not exist would throw or hang if this reached the network; it must
+        // return before it gets there.
+        var svc = new DpdUpdateService(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<DpdUpdateService>.Instance,
+            SettingsWithBothAssetsPresent());
+
+        await svc.RetryMissingAsync();     // must not throw, must not hang
+
+        Assert.Empty(svc.FailedAssetIds);
+    }
+
+    [Fact]
+    public void A_service_that_has_run_nothing_reports_no_failures()
+    {
+        var svc = new DpdUpdateService(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<DpdUpdateService>.Instance,
+            SettingsWithBothAssetsPresent());
+
+        // Not "no failures because we have not looked" dressed as "no failures" — an empty set here is the
+        // honest starting state, and the tests above are what make it mean something.
+        Assert.Empty(svc.FailedAssetIds);
+    }
+
+    // A settings service whose asset paths both exist, so RetryMissing has nothing to fetch.
+    private ISettingsService SettingsWithBothAssetsPresent()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(DpdUpdateService.DpdSubsetPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(DpdUpdateService.DppnLexiconPath)!);
+        if (!File.Exists(DpdUpdateService.DpdSubsetPath))
+            BuildMetaFixture(DpdUpdateService.DpdSubsetPath, dpd: "v0", conv: "1");
+        if (!File.Exists(DpdUpdateService.DppnLexiconPath))
+            BuildLexiconDb(DpdUpdateService.DppnLexiconPath, src: "2025-06", conv: "1");
+
+        var mock = new Moq.Mock<ISettingsService>();
+        mock.SetupGet(s => s.Settings).Returns(new CST.Avalonia.Models.Settings
+        {
+            DpdUpdateSettings = new CST.Avalonia.Models.DpdUpdateSettings { EnableAutomaticUpdates = true }
+        });
+        return mock.Object;
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
+++ b/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
@@ -195,14 +195,17 @@ public sealed class FirstRunDictionaryVisibilityTests : IDisposable
         public event Action<string>? StatusChanged;
         public event Action<string>? AssetInstalled;
         public event Action<long, long>? DownloadProgressChanged;
+        public event Action<string>? AssetFailed;
         public bool IsBusy => false;
+        public IReadOnlyCollection<string> FailedAssetIds => System.Array.Empty<string>();
         public Task CheckAndUpdateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task RetryMissingAsync(CancellationToken ct = default) => Task.CompletedTask;
 
         public int SubscriberCount => AssetInstalled?.GetInvocationList().Length ?? 0;
         public void RaiseAssetInstalled(string id) => AssetInstalled?.Invoke(id);
 
         // Silences the unused-event warnings without changing behaviour.
-        internal void Unused() { StatusChanged?.Invoke(""); DownloadProgressChanged?.Invoke(0, 0); }
+        internal void Unused() { StatusChanged?.Invoke(""); DownloadProgressChanged?.Invoke(0, 0); AssetFailed?.Invoke(""); }
     }
 
     // ---- the app's own wiring, assembled ----

--- a/src/CST.Avalonia/Services/DpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/DpdUpdateService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -54,7 +55,26 @@ public sealed class DpdUpdateService : IDpdUpdateService
     /// <inheritdoc />
     public event Action<string>? AssetInstalled;
     public event Action<long, long>? DownloadProgressChanged;
+    /// <inheritdoc />
+    public event Action<string>? AssetFailed;
     public bool IsBusy => Volatile.Read(ref _busy) == 1;
+
+    // Failure as a STATE, not just a log line. A reader whose download failed sees exactly what a reader of a
+    // build without DPD sees — nothing in the picker — and nothing distinguishes the two. (#773)
+    private readonly ConcurrentDictionary<string, byte> _failed = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<string> FailedAssetIds => _failed.Keys.ToArray();
+
+    /// <inheritdoc />
+    public async Task RetryMissingAsync(CancellationToken ct = default)
+    {
+        // Nothing missing, nothing to do — and no network touched. This runs whenever the dictionary panel
+        // opens, so the common case has to cost nothing.
+        if (!Descriptors.Any(d => !File.Exists(d.InstallPath)))
+            return;
+        await CheckAndUpdateAsync(ct).ConfigureAwait(false);
+    }
 
     public DpdUpdateService(ILogger<DpdUpdateService> logger, ISettingsService settings)
     {
@@ -150,6 +170,15 @@ public sealed class DpdUpdateService : IDpdUpdateService
             {
                 anyFailed = true;
                 _logger.LogWarning(ex, "Update of dictionary '{Id}' failed (non-fatal; others continue).", desc.Id);
+
+                // Only when the reader has NOTHING: a failed UPDATE leaves a working older asset in place, and
+                // reporting that as a missing dictionary would be false. A failed FIRST download leaves the
+                // picker silent, which is the case worth naming. (#773)
+                if (!File.Exists(desc.InstallPath))
+                {
+                    _failed[desc.Id] = 1;
+                    AssetFailed?.Invoke(desc.Id);
+                }
             }
         }
 
@@ -197,7 +226,10 @@ public sealed class DpdUpdateService : IDpdUpdateService
         // its availability at construction and must be reopened, and the dictionary picker has to re-query
         // the registry. A staged install is deliberately NOT announced — it is not live yet. (#536)
         if (!staged)
+        {
+            _failed.TryRemove(desc.Id, out _);
             AssetInstalled?.Invoke(desc.Id);
+        }
         return true;
     }
 

--- a/src/CST.Avalonia/Services/IDpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/IDpdUpdateService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,6 +25,33 @@ public interface IDpdUpdateService
 
     /// <summary>Download progress: (bytesSoFar, totalBytes). totalBytes may be 0 if the length is unknown.</summary>
     event Action<long, long>? DownloadProgressChanged;
+
+    /// <summary>
+    /// Raised with the asset id when a dictionary could not be installed this session — a bad checksum, a
+    /// failed usability probe, a dropped connection, an unreachable release. (#773)
+    ///
+    /// <para>A counterpart to <see cref="AssetInstalled"/>, and it exists for the same reason: without it, a
+    /// failed download is indistinguishable from a build that never offered the dictionary at all. The picker
+    /// simply does not list it, which reads as "this app has no DPD" rather than "we could not fetch it".</para>
+    /// </summary>
+    event Action<string>? AssetFailed;
+
+    /// <summary>
+    /// Asset ids that failed this session and are still not installed. A STATE rather than a log line, so a
+    /// caller can say which dictionary is missing and why, and can offer to try again. (#773)
+    /// </summary>
+    IReadOnlyCollection<string> FailedAssetIds { get; }
+
+    /// <summary>
+    /// Re-run the check for dictionaries that are absent or failed, ignoring the ones already installed and
+    /// current. Cheap when nothing is missing — it returns without touching the network. (#773)
+    ///
+    /// <para>Demand-driven rather than timed: <see cref="CheckAndUpdateAsync"/> runs once per launch, so a
+    /// first run that fails leaves the reader without dictionaries until they restart. The moment a reader
+    /// opens the dictionary panel is the moment they have said they want one, and it is a better trigger than
+    /// any interval we could pick.</para>
+    /// </summary>
+    Task RetryMissingAsync(CancellationToken ct = default);
 
     bool IsBusy { get; }
 

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -170,6 +170,17 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         // preferFirstEnabled is deliberately false: an asset arriving must not move the user's selection.
         _assetInstalledHandler = _ => Dispatcher.UIThread.Post(() => RebuildSources());
         _dpdUpdates.AssetInstalled += _assetInstalledHandler;
+
+        // A dictionary that failed to download stays missing for the whole session, because the update check
+        // runs once per launch. So the reader's only route back to DPD or DPPN was to restart — which is the
+        // #563 symptom again, reached by a different mechanism entirely, and just as invisible.
+        //
+        // Retried HERE because opening the dictionary panel is the reader saying they want a dictionary, and
+        // that is a better trigger than any interval we could pick: it costs nothing when everything is
+        // installed (RetryMissingAsync returns without touching the network), and it fires exactly when the
+        // absence matters. Fire-and-forget — the panel must open at once whatever the network is doing, and
+        // AssetInstalled already brings the picker up to date if the retry succeeds. (#773)
+        _ = _dpdUpdates.RetryMissingAsync();
     }
 
     /// <summary>Recompute <see cref="Sources"/> (and the picker-width measurer) from the enable/order


### PR DESCRIPTION
Closes #773.

## The defect

`CheckAndUpdateAsync` runs **once per launch** and catches each asset's failure as non-fatal so the others still run. That is right as far as it goes — one bad asset should not take down the rest. But there is no retry and nothing re-runs the check later, so a first run whose download fails leaves the reader with **no DPD and no DPPN until they restart**.

Which is #563's symptom, reached by a completely different mechanism. #536 fixed the case where the asset lands and the app fails to notice; this is the case where the asset never lands and the app never tries again. Indistinguishable from the reader's chair, and the tests added for #563 cover only the first — a regression here would look like #563 returning and send whoever picks it up back through the reopen machinery, which is sound.

## A failed download is now a state

`AssetFailed` fires and `FailedAssetIds` records it, as a counterpart to `AssetInstalled`.

Without that, a failure is indistinguishable from a build that never offered the dictionary: the picker simply does not list it, which reads as *"this app has no DPD"* rather than *"we could not fetch it"*. Absence of the dictionary was standing in for two entirely different facts.

Recorded **only when the reader has nothing**. A failed *update* leaves a working older asset in place, and reporting that as a missing dictionary would be false — the distinction is `File.Exists(desc.InstallPath)` at the moment of failure. Cleared when a later attempt succeeds.

## The retry is demand-driven, not timed

`RetryMissingAsync`, called when the dictionary panel opens.

Opening the panel is the reader saying they want a dictionary, and that is a better trigger than any interval we could pick: it fires exactly when the absence matters, and it costs nothing otherwise — with both assets present it returns before touching the network, which matters because it runs on every panel open. Fire-and-forget, so the panel opens at once whatever the network is doing, and `AssetInstalled` already brings the picker up to date if the retry succeeds.

An immediate or interval retry would have been the obvious move and a worse one: the failure modes here (offline, unreachable release, dropped connection) are not fixed by trying again a second later, and a timer would spend the reader's bandwidth on a schedule nobody asked for.

## What is deliberately not here

**A visible message.** The state exists so one can be built on it, and the wording belongs to whoever designs the panel. Shipping a half-designed sentence would be worse than shipping the state and saying so.

## Tests

Two new, plus the existing `FirstRunDictionaryVisibilityTests` fake updated for the interface. The interesting one asserts that `RetryMissingAsync` returns **without touching the network** when both assets are present — the property that makes calling it on every panel open acceptable.

Full suite: **2443 passed, 0 failed, 17 skipped.**