### PR TITLE
Record which preset a connection came from, instead of guessing (#766)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -16,18 +16,36 @@ namespace CST.Avalonia.Tests.ViewModels;
 /// </summary>
 public class AiConnectionEditorViewModelTests
 {
+    /// <summary>A preset list a test can grow, which is what a models.dev refresh does. (#766)</summary>
+    private sealed class GrowablePresets : IAiPresetSource
+    {
+        public List<AiProviderPreset> Entries { get; } = AiPresetSource.SnapshotDefaults.ToList();
+        public IReadOnlyList<AiProviderPreset> Presets => Entries;
+        public AiPresetState State => AiPresetState.Ready;
+        public string? Problem => null;
+        public event EventHandler? PresetsChanged;
+        public Task EnsureLoadedAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void Grow(AiProviderPreset preset)
+        {
+            Entries.Add(preset);
+            PresetsChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
     private sealed class Harness
     {
         public AiConnectionService Service { get; }
         public FakeCredentialStore Keys { get; } = new();
+        public Settings Settings { get; } = new();
+        public GrowablePresets Presets { get; } = new();
         public bool? Closed { get; private set; }
 
         public Harness()
         {
-            var settings = new Settings();
             var svc = new Mock<ISettingsService>();
-            svc.SetupGet(s => s.Settings).Returns(settings);
-            Service = new AiConnectionService(svc.Object, Keys);
+            svc.SetupGet(s => s.Settings).Returns(Settings);
+            Service = new AiConnectionService(svc.Object, Keys, Presets);
         }
 
         public void Close(bool saved) => Closed = saved;
@@ -1229,6 +1247,78 @@ public class AiConnectionEditorViewModelTests
         row.IsSecret = true;
 
         Assert.NotEqual('\0', row.ValueMask);
+    }
+
+    // ---- the origin is recorded, not guessed (#766) -----------------------------------------------------
+
+    /// <summary>
+    /// The reported bug. A custom endpoint whose slug the models.dev catalogue later grows into was
+    /// reclassified as that provider: the sheet narrowed to the key box, hiding the reader's own address,
+    /// protocol, models and headers, and told them the address "comes from the provider list" — which was
+    /// false. Since #733 the preset list is fetched and grows, so this needed no action by the reader at all.
+    /// </summary>
+    [Fact]
+    public void A_custom_connection_is_not_reclassified_when_the_catalogue_grows_into_its_id()
+    {
+        var h = new Harness();
+
+        // Added as a custom endpoint, so no origin is recorded.
+        var add = h.Custom();
+        add.Id = "deepseek-mine";
+        add.BaseUrl = "https://my-proxy.example/v1";
+        Save(add);
+
+        // Simulate the catalogue growing an entry with that exact id.
+        h.Presets.Grow(new AiProviderPreset(
+            "deepseek-mine", "DeepSeek Mine", ChatProviderKind.OpenAiCompatible,
+            "https://api.deepseek.com/v1",
+            new AiCredentialMethod[] { new AiCredentialMethod.Key() }));
+
+        var connection = h.Service.Connections.Single();
+
+        // Still a custom endpoint: the full form, not the narrowed key sheet.
+        Assert.Equal("Edit", AiConnectionEditorViewModel.EditAction(h.Service, connection));
+
+        var edit = h.Existing("deepseek-mine");
+        Assert.True(edit.ShowHeaders);                      // the custom-only section is present
+        Assert.Equal("https://my-proxy.example/v1", edit.BaseUrl);
+    }
+
+    /// <summary>A connection genuinely added from the provider list still gets the narrowed sheet.</summary>
+    [Fact]
+    public void A_preset_connection_still_knows_its_origin()
+    {
+        var h = new Harness();
+        var vm = h.Preset("deepseek");
+        vm.ApiKeyEntry = "sk-test";
+        Save(vm);
+
+        var connection = h.Service.Connections.Single();
+
+        Assert.Equal("deepseek", connection.PresetId);
+        Assert.Equal("Replace key", AiConnectionEditorViewModel.EditAction(h.Service, connection));
+    }
+
+    /// <summary>
+    /// A settings file written before the origin was recorded falls back to the id match, which is the right
+    /// answer for every connection such a file can hold — a custom one was refused any preset's id at the
+    /// time, and the only presets that could have existed are the ones that did.
+    /// </summary>
+    [Fact]
+    public void An_older_connection_with_no_recorded_origin_falls_back_to_the_id()
+    {
+        var h = new Harness();
+        h.Settings.Ai.Chat.Connections.Add(new CST.Avalonia.Models.AiConnectionRecord
+        {
+            Id = "deepseek",
+            DisplayName = "DeepSeek",
+            BaseUrl = "https://api.deepseek.com/v1",
+            PresetId = null,                       // written before #766
+        });
+
+        var connection = h.Service.Connections.Single();
+
+        Assert.Equal("Replace key", AiConnectionEditorViewModel.EditAction(h.Service, connection));
     }
 }
 

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -225,7 +225,7 @@ public class AiConnectionsViewModelTests
         var connection = new AiConnection(
             "local", "Local Ollama", ChatProviderKind.OpenAiCompatible, baseUrl,
             new List<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>(),
-            source, state);
+            PresetId: null, KeySource: source, State: state);
         return new AiConnectionRowViewModel(new AiConnectionsViewModel(null, null), connection);
     }
 
@@ -959,7 +959,11 @@ public class AiConnectionRowLogoTests
             "Anthropic (work)", ChatProviderKind.OpenAiCompatible, "http://localhost:8000/v1",
             Array.Empty<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>()));
         var row = vm.Connections.Single();
-        await row.LogoLoad!;
+
+        // May be null now: a connection recorded as custom does not attempt a lookup at all, because there is
+        // no provider behind it to look up. Before #766 it tried the id and got nothing; now it does not ask.
+        // The assertion is the intent either way — a custom endpoint shows no provider mark.
+        if (row.LogoLoad is not null) await row.LogoLoad;
 
         Assert.Equal("anthropic-work", row.Id);
         Assert.Null(row.LogoPath);

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -147,6 +147,7 @@ namespace CST.Avalonia.Models.Ai
         IReadOnlyList<AiModelEntry> Models,
         IReadOnlyList<AiHeader> Headers,
         IReadOnlyDictionary<string, string> Inputs,
+        string? PresetId = null,
         CredentialSource KeySource = CredentialSource.None,
         Reachability State = Reachability.Configured,
         string AuthHeaderName = "Authorization",

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -132,6 +132,35 @@ namespace CST.Avalonia.Models
         /// <summary>Stable slug, immutable once created, and the account the credential is filed under.</summary>
         public string Id { get; set; } = "";
 
+        /// <summary>
+        /// The provider-list entry this connection was added from, or null for a custom endpoint. (#766)
+        ///
+        /// <para><b>Recorded at the moment it is known, because it cannot be recovered later.</b> It used to
+        /// be inferred by matching the id against the preset list, on the reasoning that a custom connection
+        /// is refused any preset's id — true when the connection is created, and only against the presets
+        /// known then. Since #733 that list is generated from a models.dev catalogue that grows, so a custom
+        /// endpoint whose slug later appears in it was silently reclassified: its sheet narrowed to the key
+        /// box, hiding its own address and models, and told the reader the address "comes from the provider
+        /// list", which was false.</para>
+        ///
+        /// <para><b>Three states, and the difference between two of them is the whole point.</b></para>
+        /// <list type="bullet">
+        /// <item>a preset id — added from the provider list, and this is which entry;</item>
+        /// <item><b>empty</b> — recorded as a custom endpoint. Known, not merely unstated;</item>
+        /// <item><b>null</b> — nothing was recorded, because the file predates this field.</item>
+        /// </list>
+        ///
+        /// <para>Collapsing the last two is what the first cut of this did, and it did not fix the bug: a
+        /// custom connection created after the change looked exactly like one from an older file, so it still
+        /// fell through to the id match and was still reclassified when the catalogue grew into its slug. An
+        /// absence has to be recorded as an absence to be worth anything — the same shape as #728's marking
+        /// rules and <c>Reachability</c>'s third state.</para>
+        ///
+        /// <para>Only null falls back to matching the id, which is the right answer for every connection a
+        /// pre-#766 file can hold.</para>
+        /// </summary>
+        public string? PresetId { get; set; }
+
         public string DisplayName { get; set; } = "";
 
         /// <summary><c>anthropic</c> or <c>openai-compatible</c>. A string rather than the enum so a rename

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -221,7 +221,9 @@ namespace CST.Avalonia.Services.Ai
             if (CollidingSecretHeader(draft) is { } collision) return AiConnectionResult.Fail(collision);
             if (UnfilledInput(id, draft) is { } unfilled) return AiConnectionResult.Fail(unfilled);
 
-            var record = new AiConnectionRecord { Id = id };
+            // Empty rather than null: this connection is recorded as having NO preset, which is a different
+            // fact from "nothing was recorded". See AiConnectionRecord.PresetId. (#766)
+            var record = new AiConnectionRecord { Id = id, PresetId = "" };
             Apply(record, draft);
             Chat.Connections.Add(record);
             Chat.ActiveConnectionId ??= record.Id;
@@ -247,6 +249,8 @@ namespace CST.Avalonia.Services.Ai
             var record = new AiConnectionRecord
             {
                 Id = preset.Id,
+                // The one moment the origin is a fact rather than an inference. (#766)
+                PresetId = preset.Id,
                 DisplayName = preset.DisplayName,
                 Kind = preset.Kind == ChatProviderKind.Anthropic ? "anthropic" : "openai-compatible",
                 BaseUrl = preset.BaseUrl,
@@ -621,6 +625,7 @@ namespace CST.Avalonia.Services.Ai
                 .ToList(),
             r.Headers.Select(h => new AiHeader(h.Name, h.Secret ? null : h.Value, h.Secret)).ToList(),
             new Dictionary<string, string>(r.Inputs),
+            r.PresetId,
             SourceFor(r.Id),
             ReachabilityOf(r.Id),
             r.AuthHeaderName,

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -86,11 +86,25 @@ namespace CST.Avalonia.ViewModels
         /// it. Not stored as <see cref="_preset"/> — that field decides which <i>fields</i> the sheet shows,
         /// and an edit must keep showing all of them.</para>
         /// </summary>
-        private static AiProviderPreset? OriginPreset(IAiConnectionService service, string? existingId) =>
-            existingId is null
-                ? null
-                : service.Presets.FirstOrDefault(
-                    p => string.Equals(p.Id, existingId, StringComparison.OrdinalIgnoreCase));
+        private static AiProviderPreset? OriginPreset(IAiConnectionService service, AiConnection? connection)
+        {
+            if (connection is null) return null;
+
+            // Recorded at creation since #766, and an EMPTY string is a recorded answer: this connection is
+            // a custom endpoint. Only null means nothing was recorded.
+            if (connection.PresetId is { } recorded)
+                return recorded.Length == 0
+                    ? null
+                    : service.Presets.FirstOrDefault(
+                        p => string.Equals(p.Id, recorded, StringComparison.OrdinalIgnoreCase));
+
+            // Null on a settings file written before that, where matching the id is still right: a custom
+            // connection was refused any preset's id, and the only presets that could have existed are the
+            // ones that did. What it is NOT right for is a custom endpoint whose slug the catalogue grew into
+            // afterwards - which is the bug, and which cannot happen to a connection created from here on.
+            return service.Presets.FirstOrDefault(
+                p => string.Equals(p.Id, connection.Id, StringComparison.OrdinalIgnoreCase));
+        }
 
         /// <summary>
         /// What the row's edit button should say, or null where it should not be there at all. (#691)
@@ -115,7 +129,7 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public static string? EditAction(IAiConnectionService service, AiConnection connection)
         {
-            var preset = OriginPreset(service, connection.Id);
+            var preset = OriginPreset(service, connection);
             if (preset is null || preset.Prompts?.Count > 0) return "Edit";
             return preset.RequiresKey ? "Replace key" : null;
         }
@@ -177,7 +191,7 @@ namespace CST.Avalonia.ViewModels
             IAiConnectionService service, IAiCredentialStore? credentials, AiConnection connection,
             Action<bool> close)
         {
-            var preset = OriginPreset(service, connection.Id);
+            var preset = OriginPreset(service, connection);
             var vm = new AiConnectionEditorViewModel(service, credentials, close, preset, connection.Id)
             {
                 _id = connection.Id,

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -537,14 +537,32 @@ namespace CST.Avalonia.ViewModels
         }
 
         /// <summary>
-        /// The connection id, which is the provider id for a connection added from the catalogue — the editor
-        /// seeds it from the preset.
+        /// The provider this connection was added from, recorded at creation since #766.
         ///
-        /// <para>A reader who renames it, or adds a second connection to the same provider, gets the monogram
-        /// instead. The connection does not record which preset it came from, and guessing from a renamed id
-        /// would show one provider's mark on another's row — a wrong logo is worse than a letter.</para>
+        /// <para>This was the second guess of the same shape the id match was: the comment here used to
+        /// concede that "the connection does not record which preset it came from, and guessing from a renamed
+        /// id would show one provider's mark on another's row". It records it now, so the mark follows the
+        /// provider rather than the slug — a connection renamed by its reader keeps the right logo, and a
+        /// custom endpoint whose slug the catalogue later grew into does not acquire one.</para>
+        ///
+        /// <para>Falls back to the id for a settings file written before that, where it is the same answer for
+        /// every connection such a file can hold. A custom endpoint still gets its monogram.</para>
         /// </summary>
-        protected override string? ProviderId => _connection.Id;
+        protected override string? ProviderId => _connection.PresetId switch
+        {
+            // Added from the provider list, and we know which entry. The mark follows the provider, so a
+            // connection the reader renamed keeps it.
+            { Length: > 0 } preset => preset,
+
+            // Recorded as a custom endpoint. No provider mark, and no lookup attempted: we KNOW there is no
+            // provider behind it, so trying the id would be the guess this issue removes. The monogram is the
+            // right answer and it is the answer we can give without asking anything. (#766)
+            { } => null,
+
+            // Nothing recorded — a file older than the field. The id is the same answer it always was, and
+            // right for every connection such a file can hold.
+            null => _connection.Id,
+        };
 
         public string Id => _connection.Id;
 


### PR DESCRIPTION
Closes #766.

A connection did not record which preset it came from. `OriginPreset` recovered it by matching the connection's id against the preset list, justified — in my own comment — by `ValidateId` refusing a custom connection any preset's id. True **at the moment of creation**, and only against the presets known then.

Since #733 the preset list is generated from a fetched models.dev catalogue **that grows**. So a custom endpoint whose slug later appeared in it was reclassified with no action by the reader at all:

- the sheet narrowed to the key box, hiding their own address, protocol, model list and headers;
- the button read **Replace key**;
- the blurb stated, falsely, that the address "comes from the provider list".

Their data was never lost — `BuildDraft` carried the connection's own values through a save — but the screen described someone else's provider.

## The fix

Record the origin at the one moment it is a fact: `AddFromPreset` has the preset in hand.

It also retires a second guess of the same shape. `AiConnectionRowViewModel` keyed the provider logo on the connection id, its comment conceding that "the connection does not record which preset it came from, and guessing from a renamed id would show one provider's mark on another's row". It records it now, so the mark follows the provider rather than the slug: a renamed connection keeps its logo, and a custom endpoint the catalogue grew into does not acquire one.

## Three states, because two were not enough

The first cut added a nullable `PresetId`, set it in `AddFromPreset`, and fell back to the id match when null. **The test still failed**, and the reason is the point of this PR:

A custom connection created *after* the change also had null. So it was indistinguishable from a connection in an older file, fell through to the same id match, and was still reclassified. `null` was carrying two meanings — *"this is a custom endpoint"* and *"nothing was recorded"* — and only one of them should fall back.

So:

| value | meaning |
|---|---|
| a preset id | added from the provider list, and which entry |
| **empty** | recorded as a custom endpoint — known, not merely unstated |
| **null** | nothing recorded; the file predates the field |

Only `null` falls back to matching the id, which remains the right answer for every connection a pre-#766 file can hold: a custom one was refused any preset's id at the time, and the only presets that could have existed are the ones that did.

This is the fifth instance today of *an absence needing to be a state rather than a default* — after an empty collection read as "nothing exists", `= new()` read as a guarantee, a snapshot read as an inventory, and a cached answer shown as a current one. It is also the first where I wrote that rule into a commit message and then implemented the bug anyway on the next attempt, which is the argument for the third state having a **name** rather than for being careful.

## Verification

Collapsing empty back to null fails `A_custom_connection_is_not_reclassified_when_the_catalogue_grows_into_its_id` and nothing else. Three tests cover the three states: a custom endpoint the catalogue grows into, a genuine preset connection, and an older record with nothing recorded.

The test that grows the catalogue does it through a preset source that fires `PresetsChanged`, which is what a models.dev refresh actually does — rather than asserting against a hand-built list the app would never see.

Full suite green (2444 passed, 0 failed), 0 build warnings.
