### PR TITLE
Try again for a dictionary that failed to download (#773)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionaryRetryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryRetryTests.cs
@@ -31,11 +31,29 @@ public sealed class DictionaryRetryTests : IDisposable
 {
     private readonly string _root;
 
+    // The real install paths, sampled around EVERY test in this class.
+    //
+    // A per-test assertion would only have covered the test that wrote it, and the incident this guards
+    // against was a shared fixture helper — the one place a per-test check does not look. Sampling in the
+    // constructor and verifying in Dispose means any test here that reaches the real user data directory, by
+    // any route, fails the class. (#773, fable)
+    private static readonly string[] RealPaths =
+        { DpdUpdateService.DpdSubsetPath, DpdUpdateService.DppnLexiconPath };
+
+    private readonly string[] _realBefore;
+
     public DictionaryRetryTests()
     {
         _root = Path.Combine(Path.GetTempPath(), $"dict-retry-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_root);
+        _realBefore = RealPaths.Select(Snapshot).ToArray();
     }
+
+    // Existence, size and last-write time: enough to catch a file created, replaced or truncated.
+    private static string Snapshot(string path) =>
+        File.Exists(path)
+            ? $"{path}|{File.GetLastWriteTimeUtc(path):O}|{new FileInfo(path).Length}"
+            : $"{path}|absent";
 
     private DpdUpdateService Service(bool automaticUpdates = true, string? repositoryOwner = null)
     {
@@ -45,13 +63,20 @@ public sealed class DictionaryRetryTests : IDisposable
             DpdUpdateSettings = new DpdUpdateSettings
             {
                 EnableAutomaticUpdates = automaticUpdates,
-                // An address that cannot resolve, so a run that DOES reach the network fails fast and
-                // locally — no real request, and nothing that could install anything.
-                RepositoryOwner = repositoryOwner ?? "invalid.invalid",
+                RepositoryOwner = repositoryOwner ?? "no-such-owner",
                 RepositoryName = "no-such-repository",
             }
         });
-        return new DpdUpdateService(NullLogger<DpdUpdateService>.Instance, settings.Object, _root);
+        // Pointed at a closed local port, so no test here reaches the network.
+        //
+        // The previous version used a repository owner of "invalid.invalid" and a comment claiming that could
+        // not resolve. It is a PATH SEGMENT, not a host: Octokit still called api.github.com and took a 404,
+        // six times per suite run, against a shared unauthenticated rate limit. The tests were green and the
+        // isolation claim was false — which is worse than being obviously online, because nobody looks again.
+        // (fable)
+        return new DpdUpdateService(
+            NullLogger<DpdUpdateService>.Instance, settings.Object, _root,
+            gitHubBaseAddress: new Uri("http://127.0.0.1:1/"));
     }
 
     // ---- the retry ----
@@ -62,15 +87,17 @@ public sealed class DictionaryRetryTests : IDisposable
         BuildDpd();
         BuildDppn();
         var svc = Service();
+        var status = new System.Collections.Concurrent.ConcurrentBag<string>();
+        svc.StatusChanged += m => status.Add(m);
 
         await svc.RetryMissingAsync();
 
-        // A run would have reconciled and recorded nothing (both files exist), so the failure set cannot
-        // distinguish the two. IsBusy would; but the real evidence is that a run against an unresolvable host
-        // takes network time, and this returns synchronously fast. Assert the observable consequence instead:
-        // nothing was attempted, so nothing is reported as failed and no work is in flight.
-        Assert.False(svc.IsBusy);
-        Assert.Empty(svc.FailedAssetIds);
+        // StatusChanged is the discriminator, and it has to be: with both files present a run that DID happen
+        // would reconcile and record nothing, so the failure set cannot tell the two apart, and IsBusy is
+        // false after the await either way. The first thing a run does is announce "Checking for dictionary
+        // data updates..." — so silence is proof the early return fired. The previous version asserted those
+        // two proxies and passed under exactly the mutation it existed to catch. (fable)
+        Assert.Empty(status);
     }
 
     // The heart of #773: a missing asset means the retry DOES run — and a run that fails records the failure.
@@ -154,19 +181,6 @@ public sealed class DictionaryRetryTests : IDisposable
         Assert.True(File.Exists(Path.Combine(_root, "dpd-cst-subset", "dpd-cst-subset.db")));
     }
 
-    [Fact]
-    public void Nothing_is_written_outside_the_root_it_was_given()
-    {
-        // The failure this replaces was a fixture planting fake dictionaries in a real user's data directory,
-        // where an empty-but-openable database becomes a source the picker lists and which answers nothing.
-        BuildDpd();
-        BuildDppn();
-
-        var written = Directory.GetFiles(_root, "*.db", SearchOption.AllDirectories);
-        Assert.Equal(2, written.Length);
-        Assert.All(written, f => Assert.StartsWith(_root, f, StringComparison.Ordinal));
-    }
-
     // ---- fixtures, all under _root ----
 
     private void BuildDpd()
@@ -210,5 +224,9 @@ public sealed class DictionaryRetryTests : IDisposable
     {
         SqliteConnection.ClearAllPools();
         try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+
+        // Fails the test that just ran if anything here touched a real dictionary — created, replaced or
+        // truncated. After the temp cleanup, so a failure does not leak the temp dir too.
+        Assert.Equal(_realBefore, RealPaths.Select(Snapshot).ToArray());
     }
 }

--- a/src/CST.Avalonia.Tests/Services/DictionaryRetryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryRetryTests.cs
@@ -1,0 +1,214 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// A dictionary that failed to download must not stay missing for the whole session. (#773)
+///
+/// <para><b>The defect.</b> <c>CheckAndUpdateAsync</c> runs once per launch and catches each asset's failure
+/// as non-fatal so the others still run. There is no retry and nothing re-runs the check, so a first run whose
+/// download fails leaves the reader with no DPD and no DPPN until they restart — #563's symptom reached by a
+/// different mechanism, and just as silent, because the picker simply does not list them.</para>
+///
+/// <para><b>Every test here installs into a temp directory.</b> The first attempt at this work did not: the
+/// install paths were static absolutes, so its fixtures wrote into the real
+/// <c>&lt;app-support&gt;/CSTReader/dictionaries</c>. On a machine with no dictionaries that plants an openable
+/// but EMPTY database — a source the picker lists and which answers nothing — and a lexicon stamped closely
+/// enough to the shipped one that the updater could treat the fake as current indefinitely. A test suite must
+/// not be able to do that, which is why <see cref="DpdUpdateService"/> now takes a root.</para>
+/// </summary>
+public sealed class DictionaryRetryTests : IDisposable
+{
+    private readonly string _root;
+
+    public DictionaryRetryTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"dict-retry-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+    }
+
+    private DpdUpdateService Service(bool automaticUpdates = true, string? repositoryOwner = null)
+    {
+        var settings = new Mock<ISettingsService>();
+        settings.SetupGet(s => s.Settings).Returns(new Settings
+        {
+            DpdUpdateSettings = new DpdUpdateSettings
+            {
+                EnableAutomaticUpdates = automaticUpdates,
+                // An address that cannot resolve, so a run that DOES reach the network fails fast and
+                // locally — no real request, and nothing that could install anything.
+                RepositoryOwner = repositoryOwner ?? "invalid.invalid",
+                RepositoryName = "no-such-repository",
+            }
+        });
+        return new DpdUpdateService(NullLogger<DpdUpdateService>.Instance, settings.Object, _root);
+    }
+
+    // ---- the retry ----
+
+    [Fact]
+    public async Task With_both_assets_present_the_retry_returns_without_running_a_check()
+    {
+        BuildDpd();
+        BuildDppn();
+        var svc = Service();
+
+        await svc.RetryMissingAsync();
+
+        // A run would have reconciled and recorded nothing (both files exist), so the failure set cannot
+        // distinguish the two. IsBusy would; but the real evidence is that a run against an unresolvable host
+        // takes network time, and this returns synchronously fast. Assert the observable consequence instead:
+        // nothing was attempted, so nothing is reported as failed and no work is in flight.
+        Assert.False(svc.IsBusy);
+        Assert.Empty(svc.FailedAssetIds);
+    }
+
+    // The heart of #773: a missing asset means the retry DOES run — and a run that fails records the failure.
+    [Fact]
+    public async Task With_an_asset_missing_the_retry_runs_and_a_failed_run_is_recorded()
+    {
+        BuildDpd();          // dppn deliberately absent
+
+        var svc = Service();
+        await svc.RetryMissingAsync();
+
+        Assert.Equal(new[] { "dppn" }, svc.FailedAssetIds.ToArray());
+    }
+
+    // Fable's finding, and the case that matters most: offline at launch never reaches an asset at all — the
+    // run dies at the release lookup. Recording failures only in the per-asset handler left the set empty at
+    // exactly the moment a reader most needs to be told something.
+    [Fact]
+    public async Task A_run_that_never_reaches_an_asset_still_records_every_missing_one()
+    {
+        // Neither asset present, and the release lookup cannot succeed.
+        var svc = Service();
+
+        await svc.CheckAndUpdateAsync();
+
+        Assert.Equal(new[] { "dpd", "dppn" }, svc.FailedAssetIds.OrderBy(id => id).ToArray());
+    }
+
+    [Fact]
+    public async Task The_failed_event_names_each_missing_asset_once()
+    {
+        var seen = new System.Collections.Concurrent.ConcurrentBag<string>();
+        var svc = Service();
+        svc.AssetFailed += id => seen.Add(id);
+
+        await svc.CheckAndUpdateAsync();
+        await svc.CheckAndUpdateAsync();      // a second failing run must not re-announce
+
+        Assert.Equal(new[] { "dpd", "dppn" }, seen.OrderBy(id => id).ToArray());
+    }
+
+    // An asset absent because the reader switched updates off is a choice, not a failure. Reporting it as one
+    // would hand the reader their own setting back as a fault.
+    [Fact]
+    public async Task Nothing_is_reported_as_failed_when_automatic_updates_are_off()
+    {
+        var svc = Service(automaticUpdates: false);
+
+        await svc.CheckAndUpdateAsync();
+
+        Assert.Empty(svc.FailedAssetIds);
+    }
+
+    // The state is filtered by presence at read time, so it cannot go stale.
+    [Fact]
+    public async Task An_asset_that_appears_later_stops_being_reported_as_failed()
+    {
+        var svc = Service();
+        await svc.CheckAndUpdateAsync();
+        Assert.Contains("dpd", svc.FailedAssetIds);
+
+        BuildDpd();          // dropped in by hand, or a staged install applied at the next launch
+
+        Assert.DoesNotContain("dpd", svc.FailedAssetIds);
+    }
+
+    // ---- the seam itself ----
+
+    [Fact]
+    public async Task The_service_reads_the_root_it_was_given_and_not_the_real_data_directory()
+    {
+        BuildDpd();          // under _root only
+        var svc = Service();
+
+        await svc.CheckAndUpdateAsync();
+
+        // The discriminator: dpd exists under OUR root and dppn does not, so exactly one is reported. A
+        // service still reading the real data directory would answer from whatever that machine happens to
+        // have installed — on a developer's box, both, and this would report nothing at all.
+        Assert.Equal(new[] { "dppn" }, svc.FailedAssetIds.ToArray());
+        Assert.True(File.Exists(Path.Combine(_root, "dpd-cst-subset", "dpd-cst-subset.db")));
+    }
+
+    [Fact]
+    public void Nothing_is_written_outside_the_root_it_was_given()
+    {
+        // The failure this replaces was a fixture planting fake dictionaries in a real user's data directory,
+        // where an empty-but-openable database becomes a source the picker lists and which answers nothing.
+        BuildDpd();
+        BuildDppn();
+
+        var written = Directory.GetFiles(_root, "*.db", SearchOption.AllDirectories);
+        Assert.Equal(2, written.Length);
+        Assert.All(written, f => Assert.StartsWith(_root, f, StringComparison.Ordinal));
+    }
+
+    // ---- fixtures, all under _root ----
+
+    private void BuildDpd()
+    {
+        var path = Path.Combine(_root, "dpd-cst-subset", "dpd-cst-subset.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using (var c = new SqliteConnection($"Data Source={path}"))
+        {
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = @"
+                CREATE TABLE lemma (id INTEGER PRIMARY KEY, lemma TEXT NOT NULL, pos TEXT, gloss TEXT, derived_from TEXT);
+                CREATE TABLE form_lemma (form TEXT NOT NULL, lemma_id INTEGER NOT NULL);
+                CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+                INSERT INTO meta VALUES ('dpd_version','v0.4.20260531'),('converter_version','3');";
+            cmd.ExecuteNonQuery();
+        }
+        SqliteConnection.ClearAllPools();
+    }
+
+    private void BuildDppn()
+    {
+        var path = Path.Combine(_root, "dppn", "dppn.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using (var c = new SqliteConnection($"Data Source={path}"))
+        {
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = @"
+                CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+                CREATE TABLE entry (id INTEGER PRIMARY KEY, headword TEXT NOT NULL, body_html TEXT);
+                INSERT INTO meta VALUES ('schema_version','1'),('source_id','dppn'),('display_name','DPPN'),
+                    ('definition_language','en'),('source_version','2025-06'),('converter_version','1');
+                INSERT INTO entry (headword, body_html) VALUES ('Nāgita','<p>a monk</p>');";
+            cmd.ExecuteNonQuery();
+        }
+        SqliteConnection.ClearAllPools();
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
+++ b/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
@@ -195,14 +195,17 @@ public sealed class FirstRunDictionaryVisibilityTests : IDisposable
         public event Action<string>? StatusChanged;
         public event Action<string>? AssetInstalled;
         public event Action<long, long>? DownloadProgressChanged;
+        public event Action<string>? AssetFailed;
         public bool IsBusy => false;
+        public IReadOnlyCollection<string> FailedAssetIds => System.Array.Empty<string>();
         public Task CheckAndUpdateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task RetryMissingAsync(CancellationToken ct = default) => Task.CompletedTask;
 
         public int SubscriberCount => AssetInstalled?.GetInvocationList().Length ?? 0;
         public void RaiseAssetInstalled(string id) => AssetInstalled?.Invoke(id);
 
         // Silences the unused-event warnings without changing behaviour.
-        internal void Unused() { StatusChanged?.Invoke(""); DownloadProgressChanged?.Invoke(0, 0); }
+        internal void Unused() { StatusChanged?.Invoke(""); DownloadProgressChanged?.Invoke(0, 0); AssetFailed?.Invoke(""); }
     }
 
     // ---- the app's own wiring, assembled ----

--- a/src/CST.Avalonia/Services/DpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/DpdUpdateService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -44,6 +45,9 @@ public sealed class DpdUpdateService : IDpdUpdateService
     /// <summary>The single root every dictionary lives under, shared with <see cref="DictionaryService"/>.</summary>
     internal const string DictionariesDirectoryName = "dictionaries";
 
+    // Null means the real user data directory. Only tests pass anything else. (#773)
+    private readonly string? _dictionariesRoot;
+
     private readonly ILogger<DpdUpdateService> _logger;
     private readonly ISettingsService _settings;
     private readonly GitHubClient _github;
@@ -54,10 +58,81 @@ public sealed class DpdUpdateService : IDpdUpdateService
     /// <inheritdoc />
     public event Action<string>? AssetInstalled;
     public event Action<long, long>? DownloadProgressChanged;
+    /// <inheritdoc />
+    public event Action<string>? AssetFailed;
     public bool IsBusy => Volatile.Read(ref _busy) == 1;
 
-    public DpdUpdateService(ILogger<DpdUpdateService> logger, ISettingsService settings)
+    // Failure as a STATE, not just a log line: a reader whose download failed sees exactly what a reader of a
+    // build without DPD sees — nothing in the picker — and nothing distinguishes the two. (#773)
+    private readonly ConcurrentDictionary<string, byte> _failed = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Filtered by presence at read time, so it cannot go stale. An asset dropped in by hand, or applied from
+    /// a staged install at the next launch, stops being a failure without anything having to notice.
+    /// </remarks>
+    public IReadOnlyCollection<string> FailedAssetIds =>
+        Descriptors.Where(d => _failed.ContainsKey(d.Id) && !File.Exists(d.InstallPath))
+                   .Select(d => d.Id)
+                   .ToArray();
+
+    /// <inheritdoc />
+    public async Task RetryMissingAsync(CancellationToken ct = default)
     {
+        // Nothing missing, nothing to do — and no network touched. This runs every time the reader opens the
+        // dictionary panel, so the ordinary case has to cost two File.Exists calls and nothing else.
+        if (Descriptors.All(d => File.Exists(d.InstallPath)))
+            return;
+        await CheckAndUpdateAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// After an attempted run, every asset still absent is a failure — however the run failed.
+    ///
+    /// <para>Recording this only in the per-asset catch was wrong in the case that matters most: offline at
+    /// launch never reaches an asset at all. It dies at the release lookup, so the per-asset handler never
+    /// runs, and the failure set stayed empty at precisely the moment a reader most needs to be told
+    /// something. Reconciling here covers the release lookup, the manifest download, the parse, the timeout
+    /// and the per-asset failures with one rule. (#773, fable)</para>
+    ///
+    /// <para>Only called when a run was actually ATTEMPTED. An asset absent because automatic updates are
+    /// switched off is a choice, not a failure, and reporting it as one would be a lie about the reader's own
+    /// setting.</para>
+    /// </summary>
+    private void ReconcileFailures()
+    {
+        foreach (var desc in Descriptors)
+        {
+            if (File.Exists(desc.InstallPath))
+            {
+                _failed.TryRemove(desc.Id, out _);
+            }
+            else if (_failed.TryAdd(desc.Id, 1))
+            {
+                AssetFailed?.Invoke(desc.Id);
+            }
+        }
+    }
+
+    public DpdUpdateService(ILogger<DpdUpdateService> logger, ISettingsService settings)
+        : this(logger, settings, dictionariesRoot: null)
+    {
+    }
+
+    /// <summary>
+    /// Test seam: install into <paramref name="dictionariesRoot"/> instead of the real user data directory.
+    ///
+    /// <para>Added because there was no way to test this class without writing into
+    /// <c>&lt;app-support&gt;/CSTReader/dictionaries</c> — the install paths were static absolutes. A test that
+    /// did so on a machine with no dictionaries installed would plant an openable but EMPTY database: a source
+    /// the picker lists and which answers nothing, and, for the lexicon, one stamped closely enough to the
+    /// shipped version that the updater could treat the fake as current indefinitely. A test suite must not be
+    /// able to do that. (#773)</para>
+    /// </summary>
+    internal DpdUpdateService(
+        ILogger<DpdUpdateService> logger, ISettingsService settings, string? dictionariesRoot)
+    {
+        _dictionariesRoot = dictionariesRoot;
         _logger = logger;
         _settings = settings;
         _github = new GitHubClient(new ProductHeaderValue(AppConstants.UserAgent));
@@ -68,15 +143,21 @@ public sealed class DpdUpdateService : IDpdUpdateService
     // The dictionaries this build knows how to install: id (matches a manifest entry), install path, how to read
     // the installed version stamps, and how to probe that a decompressed file is a usable asset (not just valid
     // gzip). Reading the version differs per asset (DPD's lemma db vs a lexicon), which is why it's a descriptor.
-    private static IReadOnlyList<AssetDescriptor> Descriptors => new[]
+    private IReadOnlyList<AssetDescriptor> Descriptors => new[]
     {
-        new AssetDescriptor("dpd", DpdSubsetPath, ReadDpdVersion, ProbeDpdUsable),
-        new AssetDescriptor("dppn", DppnLexiconPath, ReadLexiconVersion, ProbeLexiconUsable),
+        new AssetDescriptor("dpd", PathFor("dpd-cst-subset", "dpd-cst-subset.db"), ReadDpdVersion, ProbeDpdUsable),
+        new AssetDescriptor("dppn", PathFor("dppn", "dppn.db"), ReadLexiconVersion, ProbeLexiconUsable),
     };
+
+    private string PathFor(string folder, string file) =>
+        _dictionariesRoot is null
+            ? Path.Combine(AppConstants.DataDirectory, DictionariesDirectoryName, folder, file)
+            : Path.Combine(_dictionariesRoot, folder, file);
 
     public async Task CheckAndUpdateAsync(CancellationToken ct = default)
     {
         if (Interlocked.CompareExchange(ref _busy, 1, 0) != 0) return; // already running
+        bool attempted = false;
         try
         {
             var cfg = _settings.Settings.DpdUpdateSettings ?? new DpdUpdateSettings();
@@ -85,6 +166,8 @@ public sealed class DpdUpdateService : IDpdUpdateService
                 _logger.LogInformation("dictionary-asset automatic updates disabled; skipping update check (present files still work).");
                 return;
             }
+            // Past the opt-out: from here an absent asset is a failure rather than a choice.
+            attempted = true;
             // Hard bound on the WHOLE check+download (HttpClient.Timeout doesn't cover a streamed body). (fable)
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromMinutes(10));
@@ -101,7 +184,16 @@ public sealed class DpdUpdateService : IDpdUpdateService
             _logger.LogWarning(ex, "dictionary-asset update check failed (non-fatal; features degrade to asset-absent).");
             StatusChanged?.Invoke("Could not check for dictionary data updates.");
         }
-        finally { Volatile.Write(ref _busy, 0); }
+        finally
+        {
+            // After the run, whatever became of it. Inside the finally so a timeout or an unexpected throw
+            // records the same thing a clean failure does.
+            // Only when a run was actually attempted — the finally runs on the opt-out path too, and marking
+            // assets failed there would report the reader's own setting back to them as a fault.
+            if (attempted)
+                try { ReconcileFailures(); } catch { /* reporting must never fail the run */ }
+            Volatile.Write(ref _busy, 0);
+        }
     }
 
     private async Task RunAsync(DpdUpdateSettings cfg, CancellationToken ct)
@@ -426,9 +518,11 @@ public sealed class DpdUpdateService : IDpdUpdateService
     /// </summary>
     public static bool ApplyPendingInstall()
     {
+        // The REAL install paths, not a service instance's: this runs at startup before anything is resolved,
+        // and it must act on the files the app will actually open. (#773 seam)
         bool any = false;
-        foreach (var desc in Descriptors)
-            any |= ApplyPendingInstall(desc.InstallPath);
+        foreach (var path in new[] { DpdSubsetPath, DppnLexiconPath })
+            any |= ApplyPendingInstall(path);
         return any;
     }
 }

--- a/src/CST.Avalonia/Services/DpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/DpdUpdateService.cs
@@ -37,10 +37,17 @@ public sealed class DpdUpdateService : IDpdUpdateService
     // The installed asset paths (must match the DI wiring in App.axaml.cs). Every dictionary — the bundled
     // flat-file ones and these downloaded derived assets alike — lives under <data>/dictionaries/, so the
     // user data directory has one place to look for dictionary content rather than three.
-    public static string DpdSubsetPath =>
-        Path.Combine(AppConstants.DataDirectory, DictionariesDirectoryName, "dpd-cst-subset", "dpd-cst-subset.db");
-    public static string DppnLexiconPath =>
-        Path.Combine(AppConstants.DataDirectory, DictionariesDirectoryName, "dppn", "dppn.db");
+    public static string DpdSubsetPath => RealPath(DpdFolder, DpdFile);
+    public static string DppnLexiconPath => RealPath(DppnFolder, DppnFile);
+
+    // Spelled once. The static paths above and the instance Descriptors below both need them, and if the two
+    // drifted the service would install to one place while the app opened another — a split no compiler can
+    // catch and no test would notice, because each half would be self-consistent. (#773, fable)
+    private const string DpdFolder = "dpd-cst-subset", DpdFile = "dpd-cst-subset.db";
+    private const string DppnFolder = "dppn", DppnFile = "dppn.db";
+
+    private static string RealPath(string folder, string file) =>
+        Path.Combine(AppConstants.DataDirectory, DictionariesDirectoryName, folder, file);
 
     /// <summary>The single root every dictionary lives under, shared with <see cref="DictionaryService"/>.</summary>
     internal const string DictionariesDirectoryName = "dictionaries";
@@ -130,12 +137,19 @@ public sealed class DpdUpdateService : IDpdUpdateService
     /// able to do that. (#773)</para>
     /// </summary>
     internal DpdUpdateService(
-        ILogger<DpdUpdateService> logger, ISettingsService settings, string? dictionariesRoot)
+        ILogger<DpdUpdateService> logger, ISettingsService settings, string? dictionariesRoot,
+        Uri? gitHubBaseAddress = null)
     {
         _dictionariesRoot = dictionariesRoot;
         _logger = logger;
         _settings = settings;
-        _github = new GitHubClient(new ProductHeaderValue(AppConstants.UserAgent));
+        // A test that wants no network needs somewhere unreachable to point at, and a bad REPOSITORY name is
+        // not that: the owner and name are path segments, so Octokit still resolves api.github.com and issues
+        // a real request that happens to 404. The tests looked isolated and were spending a shared rate limit.
+        // (#773, fable)
+        _github = gitHubBaseAddress is null
+            ? new GitHubClient(new ProductHeaderValue(AppConstants.UserAgent))
+            : new GitHubClient(new ProductHeaderValue(AppConstants.UserAgent), gitHubBaseAddress);
         _http = new HttpClient();
         _http.DefaultRequestHeaders.Add("User-Agent", AppConstants.UserAgent);
     }
@@ -145,14 +159,12 @@ public sealed class DpdUpdateService : IDpdUpdateService
     // gzip). Reading the version differs per asset (DPD's lemma db vs a lexicon), which is why it's a descriptor.
     private IReadOnlyList<AssetDescriptor> Descriptors => new[]
     {
-        new AssetDescriptor("dpd", PathFor("dpd-cst-subset", "dpd-cst-subset.db"), ReadDpdVersion, ProbeDpdUsable),
-        new AssetDescriptor("dppn", PathFor("dppn", "dppn.db"), ReadLexiconVersion, ProbeLexiconUsable),
+        new AssetDescriptor("dpd", PathFor(DpdFolder, DpdFile), ReadDpdVersion, ProbeDpdUsable),
+        new AssetDescriptor("dppn", PathFor(DppnFolder, DppnFile), ReadLexiconVersion, ProbeLexiconUsable),
     };
 
     private string PathFor(string folder, string file) =>
-        _dictionariesRoot is null
-            ? Path.Combine(AppConstants.DataDirectory, DictionariesDirectoryName, folder, file)
-            : Path.Combine(_dictionariesRoot, folder, file);
+        _dictionariesRoot is null ? RealPath(folder, file) : Path.Combine(_dictionariesRoot, folder, file);
 
     public async Task CheckAndUpdateAsync(CancellationToken ct = default)
     {

--- a/src/CST.Avalonia/Services/IDpdUpdateService.cs
+++ b/src/CST.Avalonia/Services/IDpdUpdateService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,6 +25,38 @@ public interface IDpdUpdateService
 
     /// <summary>Download progress: (bytesSoFar, totalBytes). totalBytes may be 0 if the length is unknown.</summary>
     event Action<long, long>? DownloadProgressChanged;
+
+    /// <summary>
+    /// Raised with the asset id when a dictionary is still absent after an attempted update run — whatever
+    /// went wrong: an unreachable release, a manifest that would not parse, a bad checksum, a failed usability
+    /// probe, a dropped connection, a timeout. (#773)
+    ///
+    /// <para>A counterpart to <see cref="AssetInstalled"/>, and it exists for the same reason: without it a
+    /// failed download is indistinguishable from a build that never offered the dictionary at all. The picker
+    /// simply does not list it, which reads as "this app has no DPD" rather than "we could not fetch it".</para>
+    ///
+    /// <para>Raised on a background thread. A UI subscriber must marshal.</para>
+    ///
+    /// <para>Not raised when automatic updates are switched off — an absent asset is then the reader's choice,
+    /// not a failure.</para>
+    /// </summary>
+    event Action<string>? AssetFailed;
+
+    /// <summary>
+    /// Asset ids that were attempted and are still absent. A STATE rather than a log line, so a caller can say
+    /// which dictionary is missing and offer to try again. Filtered by presence at read time, so an asset that
+    /// later appears — dropped in by hand, or applied from a staged install — stops being a failure without
+    /// anything having to notice. (#773)
+    /// </summary>
+    IReadOnlyCollection<string> FailedAssetIds { get; }
+
+    /// <summary>
+    /// Re-run the check when a dictionary is absent; return immediately when none is. Cheap enough to call
+    /// whenever the reader opens the dictionary panel, which is the point — <see cref="CheckAndUpdateAsync"/>
+    /// runs once per launch, so a first run that fails leaves the reader without dictionaries until they
+    /// restart, and opening the panel is the reader saying they want one. (#773)
+    /// </summary>
+    Task RetryMissingAsync(CancellationToken ct = default);
 
     bool IsBusy { get; }
 

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -315,6 +315,16 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
 
     private async Task LookupAsync(string query)
     {
+        // The other place a reader says they want a dictionary. Opening the panel is the obvious signal and it
+        // is not the only one: a reader whose saved layout keeps this panel docked — the default — never
+        // generates a show request at all, and clicking its tab does not either. They are the readers most
+        // attached to the dictionary and the least likely to trigger the retry, which is a poor thing for a
+        // fix to be true of. Typing a word is unambiguous. (#773, fable)
+        //
+        // Free when nothing is missing: two File.Exists calls, and _busy collapses repeated keystrokes during
+        // a slow failing check into the one run already in flight.
+        _ = _dpdUpdates.RetryMissingAsync();
+
         var source = SelectedSource;   // capture: results are only valid if these still hold on completion
         try
         {

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -294,9 +294,26 @@ namespace CST.Avalonia.ViewModels
 
         // Recreate-on-demand so the View menu toggle and Cmd+D (Look Up in Dictionary) can reopen a closed
         // pane — LookUpInDictionaryAsync calls this then immediately proceeds, so it must stay synchronous. (#466)
-        public void ShowDictionaryPanel() =>
+        public void ShowDictionaryPanel()
+        {
+            // A dictionary that failed to download stays missing for the whole session: the update check runs
+            // once per launch, so the reader's only route back to DPD or DPPN was to restart. That is #563's
+            // symptom reached by a different mechanism, and just as invisible.
+            //
+            // Here, and NOT in DictionaryViewModel's constructor, which is where this was first put. The view
+            // model is a DI singleton — its constructor runs once during the startup layout build, and every
+            // reopen resolves that same instance — so the retry fired once at startup beside the check that
+            // already runs there and never again. It looked like a per-open trigger and was not. This method
+            // is called on every show request, after settings are loaded, which is also what keeps it from
+            // ignoring the reader's automatic-update setting. (#773)
+            //
+            // Fire-and-forget: the panel must open at once whatever the network is doing, and AssetInstalled
+            // already rebuilds the picker if the retry succeeds. Free when nothing is missing.
+            _ = App.ServiceProvider?.GetService<IDpdUpdateService>()?.RetryMissingAsync();
+
             ShowToolPanel("DictionaryTool", () => App.ServiceProvider?.GetRequiredService<DictionaryViewModel>(),
                 () => IsDictionaryPanelVisible = true, "Dictionary");
+        }
 
         public void HideDictionaryPanel() =>
             HideToolPanel("DictionaryTool", () => IsDictionaryPanelVisible = false, "Dictionary");


### PR DESCRIPTION
Closes #773. Replaces #801, whose two load-bearing decisions were both wrong. **Two commits** — the second is Fable's review of the first, applied.

## The defect

`CheckAndUpdateAsync` runs **once per launch** and catches each asset's failure as non-fatal so the others still run. There is no retry and nothing re-runs the check, so a first run whose download fails leaves the reader with **no DPD and no DPPN until they restart**.

That is #563's symptom reached by a different mechanism — #536 fixed *asset lands, app fails to notice*; this is *asset never lands, app never retries* — and it is just as silent, because the picker simply does not list them.

## Commit 1 — what #801 got wrong

**The retry was on a singleton's constructor.** `DictionaryViewModel` is `AddSingleton`, so its constructor runs once during the startup layout build and every reopen resolves that same instance. The retry fired once at startup beside the check already running there, and never again — a per-open trigger that was nothing of the kind, described confidently by a comment I wrote. It now hangs off `LayoutViewModel.ShowDictionaryPanel`, a method called on every show request. That also fixes a second problem for free: the constructor ran **before settings loaded**, so it ignored the reader's `EnableAutomaticUpdates` choice and could race the first-run corpus download.

**Failure was recorded only in the per-asset catch.** Offline at launch — the headline case — never reaches an asset: it dies at the release lookup, so that handler never ran and the failure set stayed empty at exactly the moment a reader most needs telling. Failure is now reconciled after any *attempted* run, one rule covering the release lookup, the manifest download, the parse, the timeout and the per-asset failures. Skipped when automatic updates are off, where an absent asset is the reader's choice rather than a fault.

**`DpdUpdateService` had no install-path seam.** The paths were static absolutes, so #801's tests wrote into the real `<app-support>/CSTReader/dictionaries` — planting, on a machine without dictionaries, an openable but **empty** database (a source the picker lists which answers nothing) and a lexicon stamped closely enough to the shipped one that the updater could treat the fake as current indefinitely. A testability defect in this class that the tests papered over rather than caused. It now takes a root.

## Commit 2 — Fable's review

No code defects; all four prior findings confirmed fixed. The tests were the problem, and one claim in my commit message was false.

**The tests made real HTTPS requests to api.github.com while a comment claimed they made none.** `RepositoryOwner = "invalid.invalid"` is a *path segment*, not a host: Octokit resolved api.github.com and took a 404, six times per suite run, against a shared unauthenticated rate limit. Green, isolated-looking, and untrue — worse than being obviously online, because nobody looks again. The service now takes a GitHub base address and the tests point at a closed local port. Dictionary tests went from ~1s to ~100ms, which is the network leaving.

**"One of them asserts that nothing is written outside it" was false.** That test enumerated files *from* the temp root and asserted their paths began with it — true by construction, and it would have passed against a service writing into the real user data directory, which is precisely what it claimed to rule out. Replaced by a **fixture-level guard**: the real install paths are sampled in the constructor and verified in `Dispose`, so any test in the class that reaches them, by any route, fails. A per-test check would not have covered the shared fixture helper, which is where the original incident actually lived.

**The "returns without running a check" test passed under its own mutation.** With both files present, a run that *did* happen reconciles and records nothing, and `IsBusy` is false after the await either way. It now watches `StatusChanged` — a run announces itself first, so silence is proof.

**A second trigger, for the reader the first one missed.** The panel-open retry never fires for someone whose saved layout keeps the dictionary docked — the default — and clicking its tab does not fire it either. They are the readers most attached to the dictionary and the least likely to generate a show request. `LookupAsync` retries too; typing a word is as unambiguous as opening the panel.

**Path fragments are spelled once.** The static real paths and the instance descriptors had separate copies; a drift would have installed to one place while the app opened another — each half self-consistent, so no compiler and no test would notice.

## Verified by mutation

Commit 1: removing run-level reconciliation fails 5 of 8; removing the opt-out guard fails 1; making descriptors ignore the root fails 5. Commit 2: removing the early return fails the status test; pointing one fixture at a real dictionary path fails the class guard.

Full suite: **2461 passed, 0 failed, 17 skipped.**

## Known and deliberate

- **No visible message.** The state exists so one can be built on it; the wording belongs to whoever designs the panel.
- `AssetFailed` announces once per session per asset. Correct for the state-based UI intended (`FailedAssetIds` stays accurate); worth knowing before building an event-driven banner on it.
- A retry arriving while a slow failing startup check still holds `_busy` is dropped and not re-armed. Self-healing on the next open or lookup.