### PR TITLE
Read a model listing to its end, and say what could not be read (#769)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -525,4 +525,250 @@ public class AiModelCatalogTests
         Assert.DoesNotContain("59.5", serialised, StringComparison.Ordinal);
         Assert.DoesNotContain("intelligence", serialised, StringComparison.OrdinalIgnoreCase);
     }
+
+    // ---- following the pages (#769) ---------------------------------------------------------------------
+
+    /// <summary>An Anthropic-shaped connection, for the paging tests.</summary>
+    private static AiConnection Paged() => new(
+        Id: "anthropic",
+        DisplayName: "Claude",
+        Kind: ChatProviderKind.Anthropic,
+        BaseUrl: "https://api.anthropic.com",
+        Models: new List<AiModelEntry>(),
+        Headers: System.Array.Empty<AiHeader>(),
+        Inputs: new Dictionary<string, string>());
+
+    private static AiModelCatalog CatalogOver(StubHttpMessageHandler handler) =>
+        new(new HttpClient(handler), credentials: null, NullLogger<AiModelCatalog>.Instance);
+
+    /// <summary>
+    /// The listing is read to the end, not one page deep. Before #769 an Anthropic-protocol connection with
+    /// more than twenty models showed the first twenty — and, because the flag said the listing was partial,
+    /// #728's retired-model marking never ran for it at all.
+    /// </summary>
+    [Fact]
+    public async Task A_paged_listing_is_followed_to_its_end()
+    {
+        var handler = new StubHttpMessageHandler(request =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    request.RequestUri!.Query.Contains("after_id=", StringComparison.Ordinal)
+                        ? """{"data":[{"id":"claude-sonnet"}],"has_more":false}"""
+                        : """{"data":[{"id":"claude-opus"}],"has_more":true,"last_id":"claude-opus"}"""),
+            });
+
+        var result = await CatalogOver(handler).FetchAsync(Paged());
+
+        Assert.True(result.Ok);
+        Assert.Equal(new[] { "claude-opus", "claude-sonnet" }, result.Models.Select(m => m.Id));
+
+        // Complete, so #728's marking may run from it — the point of following the pages at all.
+        Assert.True(result.Complete);
+        Assert.Equal(2, handler.RequestedUrls.Count);
+        Assert.Contains("after_id=claude-opus", handler.RequestedUrls[1].Query, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The cursor is the endpoint's LAST entry in document order, not the last of what Parse returns — Parse
+    /// sorts alphabetically, so paging from its tail would ask the provider to continue after a model in the
+    /// middle of the page and silently lose everything between.
+    /// </summary>
+    [Fact]
+    public async Task Paging_continues_from_the_endpoints_own_last_entry_not_the_alphabetical_one()
+    {
+        var handler = new StubHttpMessageHandler(request =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    request.RequestUri!.Query.Contains("after_id=", StringComparison.Ordinal)
+                        ? """{"data":[{"id":"m-last"}],"has_more":false}"""
+                        // Document order zebra, alpha — and no last_id, so the walk has to find it.
+                        : """{"data":[{"id":"zebra"},{"id":"alpha"}],"has_more":true}"""),
+            });
+
+        await CatalogOver(handler).FetchAsync(Paged());
+
+        Assert.Contains("after_id=alpha", handler.RequestedUrls[1].Query, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A gateway that invents <c>has_more</c> but ignores <c>after_id</c> hands back the same page for ever.
+    /// The walk stops the moment a page adds nothing, rather than looping until the timeout — and says the
+    /// listing is partial, because the endpoint is still claiming there is more.
+    /// </summary>
+    [Fact]
+    public async Task An_endpoint_that_promises_more_and_repeats_itself_is_not_followed_for_ever()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"data":[{"id":"only"}],"has_more":true,"last_id":"only"}"""),
+        });
+
+        var result = await CatalogOver(handler).FetchAsync(Paged());
+
+        Assert.True(result.Ok);
+        Assert.Equal("only", Assert.Single(result.Models).Id);
+        Assert.False(result.Complete);
+
+        // Two: the first page, and one attempt to advance that came back with nothing new.
+        Assert.Equal(2, handler.RequestedUrls.Count);
+    }
+
+    /// <summary>
+    /// A later page failing costs the rest of the listing, not the part already in hand. Throwing twenty real
+    /// models away because the twenty-first page answered 500 turns a partial answer into no answer.
+    /// </summary>
+    [Fact]
+    public async Task A_page_that_fails_after_the_first_keeps_what_was_already_read()
+    {
+        var handler = new StubHttpMessageHandler(request =>
+            request.RequestUri!.Query.Contains("after_id=", StringComparison.Ordinal)
+                ? new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"data":[{"id":"kept"}],"has_more":true,"last_id":"kept"}"""),
+                });
+
+        var result = await CatalogOver(handler).FetchAsync(Paged());
+
+        Assert.True(result.Ok);
+        Assert.Equal("kept", Assert.Single(result.Models).Id);
+        Assert.False(result.Complete);
+    }
+
+    /// <summary>The FIRST page failing still produces its own named sentence, rather than an empty success.</summary>
+    [Fact]
+    public async Task A_first_page_that_fails_still_reports_the_failure()
+    {
+        var handler = new StubHttpMessageHandler(
+            _ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var result = await CatalogOver(handler).FetchAsync(Paged());
+
+        Assert.False(result.Ok);
+        Assert.NotNull(result.Problem);
+        Assert.True(result.Reachable);
+    }
+
+    /// <summary>
+    /// Entries we cannot read are counted, not merely logged. The observed case was a listing whose nine
+    /// entries yielded two — and the reader saw "2 models" with no way to tell that from a provider that
+    /// offers two.
+    /// </summary>
+    [Fact]
+    public async Task Unreadable_entries_are_counted_for_the_reader()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """{"data":[{"id":"good"},{"name":"no id"},{"name":"nor here"}],"has_more":false}"""),
+        });
+
+        var result = await CatalogOver(handler).FetchAsync(Paged());
+
+        Assert.True(result.Ok);
+        Assert.Equal("good", Assert.Single(result.Models).Id);
+        Assert.Equal(2, result.Skipped);
+
+        // A hole in the listing still bars #728's marking: a skipped entry is precisely a model that is
+        // absent from what we parsed without having been retired.
+        Assert.False(result.Complete);
+    }
+
+    /// <summary>
+    /// A gateway repeating a page must not have its entries counted twice as unreadable. Deriving the skipped
+    /// count by subtracting at the end would do exactly that — the ids dedupe, the entry counts do not.
+    /// </summary>
+    [Fact]
+    public async Task A_repeated_page_does_not_invent_unreadable_entries()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"data":[{"id":"a"},{"id":"b"}],"has_more":true,"last_id":"b"}"""),
+        });
+
+        var result = await CatalogOver(handler).FetchAsync(Paged());
+
+        Assert.Equal(2, result.Models.Count);
+        Assert.Equal(0, result.Skipped);
+        Assert.False(result.Complete);
+    }
+
+    /// <summary>Models stay alphabetical across a page boundary, not merely within each page.</summary>
+    [Fact]
+    public async Task Models_from_several_pages_are_sorted_together()
+    {
+        var handler = new StubHttpMessageHandler(request =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    request.RequestUri!.Query.Contains("after_id=", StringComparison.Ordinal)
+                        ? """{"data":[{"id":"a-model"}],"has_more":false}"""
+                        : """{"data":[{"id":"z-model"}],"has_more":true,"last_id":"z-model"}"""),
+            });
+
+        var result = await CatalogOver(handler).FetchAsync(Paged());
+
+        Assert.Equal(new[] { "a-model", "z-model" }, result.Models.Select(m => m.Id));
+    }
+
+    /// <summary>
+    /// The cursor is added to a base URL that already carries a query without producing a second '?' — an
+    /// Azure-style endpoint pins api-version there, and the malformed URL would be rejected with a message
+    /// about the wrong thing entirely.
+    /// </summary>
+    [Fact]
+    public void The_cursor_is_added_to_a_url_that_already_has_a_query()
+    {
+        var next = AiModelCatalog.After(
+            new System.Uri("https://x.example/openai/v1/models?api-version=2026-01-01"), "m/1");
+
+        Assert.Equal("https", next.Scheme);
+        Assert.Equal("/openai/v1/models", next.AbsolutePath);
+        Assert.Contains("api-version=2026-01-01", next.Query, StringComparison.Ordinal);
+        Assert.Contains("after_id=m%2F1", next.Query, StringComparison.Ordinal);
+        Assert.Equal(1, next.Query.Count(c => c == '?'));
+    }
+
+    /// <summary>
+    /// An endpoint that always says there is more AND always advances is bounded by the page cap rather than
+    /// by the 20-second budget. Without the cap it would page until the timeout and then report nothing at
+    /// all — the worst of both, since every page it did read was real.
+    /// </summary>
+    [Fact]
+    public async Task An_endpoint_that_never_ends_is_stopped_by_the_page_cap()
+    {
+        var page = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            var id = $"m{page++}";
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    $$"""{"data":[{"id":"{{id}}"}],"has_more":true,"last_id":"{{id}}"}"""),
+            };
+        });
+
+        var result = await CatalogOver(handler).FetchAsync(Paged());
+
+        Assert.True(result.Ok);
+        Assert.Equal(25, handler.RequestedUrls.Count);
+        Assert.Equal(25, result.Models.Count);
+        Assert.False(result.Complete);
+        Assert.Equal(0, result.Skipped);
+    }
+
+    /// <summary>The published cursor wins over the walk, and the walk covers a gateway that publishes none.</summary>
+    [Fact]
+    public void The_last_entry_is_read_from_last_id_when_the_endpoint_publishes_one()
+    {
+        Assert.Equal("published", AiModelCatalog.LastEntryId(
+            """{"data":[{"id":"a"},{"id":"b"}],"last_id":"published"}"""));
+
+        Assert.Equal("b", AiModelCatalog.LastEntryId("""{"data":[{"id":"a"},{"id":"b"}]}"""));
+        Assert.Null(AiModelCatalog.LastEntryId("""{"data":[]}"""));
+        Assert.Null(AiModelCatalog.LastEntryId("not json"));
+    }
 }

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -96,10 +96,23 @@ namespace CST.Avalonia.Services.Ai
     /// Whether this listing is everything the endpoint has, so far as we can tell. (#728)
     ///
     /// <para>False when entries were skipped for want of a usable id — observed in the wild, a listing whose
-    /// nine entries yielded two we could read — or when the endpoint says there is another page. <b>A short
-    /// listing is still a listing</b>: it is shown, and every model in it is real. What it cannot support is
-    /// the inference in the other direction, that a model absent from it has been retired, which is why the
-    /// flag exists rather than a failure.</para>
+    /// nine entries yielded two we could read — or when the endpoint still says there is another page after
+    /// we stopped asking. <b>A short listing is still a listing</b>: it is shown, and every model in it is
+    /// real. What it cannot support is the inference in the other direction, that a model absent from it has
+    /// been retired, which is why the flag exists rather than a failure.</para>
+    ///
+    /// <para>Pages are now followed (#769), so the ordinary paged catalogue comes back complete. This stays
+    /// false for the cases where following them did not finish: an endpoint that claims another page but
+    /// gives no cursor to ask for it, one that ignores the cursor and repeats itself, a page that failed
+    /// after earlier pages had already been read, and the page cap.</para>
+    /// </param>
+    /// <param name="Skipped">
+    /// How many entries across every page carried no usable id, and so are not in <paramref name="Models"/>.
+    /// (#769)
+    ///
+    /// <para>Counted rather than only logged. A reader looking at a short list has no way to tell "this
+    /// provider offers three models" from "this provider listed nine and we understood three", and the log
+    /// line that knew the difference is not somewhere they will ever look.</para>
     /// </param>
     /// <param name="Reachable">
     /// Whether the endpoint answered at all — <b>not</b> whether the listing was useful.
@@ -110,10 +123,11 @@ namespace CST.Avalonia.Services.Ai
     /// </param>
     public sealed record AiCatalogResult(
         bool Ok, string? Problem, IReadOnlyList<AiCatalogModel> Models, bool? Reachable = null,
-        bool Complete = true)
+        bool Complete = true, int Skipped = 0)
     {
-        public static AiCatalogResult Success(IReadOnlyList<AiCatalogModel> models, bool complete = true) =>
-            new(true, null, models, true, complete);
+        public static AiCatalogResult Success(
+            IReadOnlyList<AiCatalogModel> models, bool complete = true, int skipped = 0) =>
+            new(true, null, models, true, complete, skipped);
 
         public static AiCatalogResult Fail(string problem, bool? reachable = null) =>
             new(false, problem, Array.Empty<AiCatalogModel>(), reachable, false);
@@ -146,6 +160,16 @@ namespace CST.Avalonia.Services.Ai
         /// This is a directory lookup, not a generation — none of the patience #673 grants a local runner
         /// applies.</summary>
         private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(20);
+
+        /// <summary>
+        /// How many pages to follow before stopping and saying the listing is partial. (#769)
+        ///
+        /// <para>Anthropic's listing defaults to twenty entries a page, so this reaches five hundred models —
+        /// comfortably past any real catalogue, and OpenRouter's four hundred and twenty arrive on one page
+        /// because that protocol does not page at all. It is a backstop against an endpoint that always says
+        /// there is more, not an opinion about how many models a provider may have.</para>
+        /// </summary>
+        private const int MaxPages = 25;
 
         private readonly HttpClient _http;
         private readonly IAiCredentialStore? _credentials;
@@ -201,72 +225,162 @@ namespace CST.Avalonia.Services.Ai
                 return AiCatalogResult.Fail(ex.Error.Message);
             }
 
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            Authenticate(request, connection);
-
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
             timeout.CancelAfter(Timeout);
 
+            var models = new List<AiCatalogModel>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var skipped = 0;
+            var complete = true;
+            string? cursor = null;
+
             try
             {
-                using var response = await _http.SendAsync(request, timeout.Token).ConfigureAwait(false);
-
-                // Answered, even if the answer was no. A rejected key and a missing listing both prove the
-                // endpoint is there, which is the fact this reports - it says nothing about whether the
-                // listing was any use.
-                if (!response.IsSuccessStatusCode)
-                    return AiCatalogResult.Fail(
-                        Explain(response.StatusCode, connection, url), reachable: true);
-
-                var body = await response.Content.ReadAsStringAsync(timeout.Token).ConfigureAwait(false);
-                var models = Parse(body);
-
-                // A 200 carrying no models is not an error, but it is not a success the UI should silently
-                // present as an empty list either - the reader would read it as "this provider has none".
-                if (models.Count == 0)
-                    return AiCatalogResult.Fail($"{url} answered, but listed no models.", reachable: true);
-
-                // Both numbers, because one of them cannot answer the question that gets asked of this line.
-                // "Fetched 2 models from cerebras" reads as a fact about the provider, and is equally
-                // consistent with the provider having sent two and with our having understood two of nine -
-                // and the reader who says "but I know they support more" has no way to tell which, nor did
-                // we, from the log.
-                var listed = CountEntries(body);
-                var complete = listed == models.Count && !HasMore(body);
-                if (listed == models.Count)
+                for (var page = 1; ; page++)
                 {
-                    _logger.LogInformation(
-                        "Fetched {Count} models from {Connection}", models.Count, connection.Id);
+                    var pageUrl = cursor is null ? url : After(url, cursor);
+                    using var request = new HttpRequestMessage(HttpMethod.Get, pageUrl);
+                    Authenticate(request, connection);
+
+                    using var response = await _http.SendAsync(request, timeout.Token).ConfigureAwait(false);
+
+                    // Answered, even if the answer was no. A rejected key and a missing listing both prove the
+                    // endpoint is there, which is the fact this reports - it says nothing about whether the
+                    // listing was any use.
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        if (page == 1)
+                            return AiCatalogResult.Fail(
+                                Explain(response.StatusCode, connection, url), reachable: true);
+
+                        // A later page failing costs the REST of the listing, not the part already in hand.
+                        // Throwing away twenty real models because the twenty-first page 500'd would turn a
+                        // partial answer into no answer, and the reader can use what arrived.
+                        _logger.LogWarning(
+                            "Listing {Connection}: page {Page} answered {Status}; keeping {Count} models "
+                            + "already read", connection.Id, page, (int)response.StatusCode, models.Count);
+                        complete = false;
+                        break;
+                    }
+
+                    var body = await response.Content.ReadAsStringAsync(timeout.Token).ConfigureAwait(false);
+                    var pageModels = Parse(body);
+
+                    // Both numbers, because one of them cannot answer the question that gets asked of this
+                    // line. "Fetched 2 models from cerebras" reads as a fact about the provider, and is
+                    // equally consistent with the provider having sent two and with our having understood two
+                    // of nine - and the reader who says "but I know they support more" has no way to tell
+                    // which, nor did we, from the log.
+                    //
+                    // Accumulated per page rather than derived at the end from a total, because a gateway that
+                    // ignores the cursor sends the same page twice: the ids dedupe, the entry counts do not,
+                    // and a subtraction would report entries as unreadable that we read perfectly well.
+                    var listed = CountEntries(body);
+                    skipped += Math.Max(0, listed - pageModels.Count);
+                    if (listed != pageModels.Count)
+                        _logger.LogDebug("{Connection} listing page {Page}: {Body}", connection.Id, page, body);
+
+                    var added = 0;
+                    foreach (var model in pageModels)
+                        if (seen.Add(model.Id))
+                        {
+                            models.Add(model);
+                            added++;
+                        }
+
+                    // The end of the listing, and the ordinary exit.
+                    if (!HasMore(body)) break;
+
+                    // It says there is more. Ask for it by the last entry the endpoint itself listed - in
+                    // DOCUMENT order, which is not the order Parse returns: Parse sorts alphabetically, so
+                    // the last model in `pageModels` is generally not the last entry on the page, and paging
+                    // from it would skip whatever lies between.
+                    var next = LastEntryId(body);
+
+                    if (next is null || string.Equals(next, cursor, StringComparison.Ordinal) || added == 0)
+                    {
+                        // Three ways an endpoint can promise another page and not deliver one: no cursor to
+                        // ask with, the same cursor it gave last time, or a page whose every id we already
+                        // hold - which is what an OpenAI-compatible gateway that invents `has_more` but
+                        // ignores `after_id` produces. Each would loop forever if followed. (#769)
+                        _logger.LogWarning(
+                            "Listing {Connection}: page {Page} says there is more but did not advance; "
+                            + "keeping {Count} models", connection.Id, page, models.Count);
+                        complete = false;
+                        break;
+                    }
+
+                    cursor = next;
+
+                    if (page >= MaxPages)
+                    {
+                        // A bound, not a judgment about how many models a provider may have. Without it a
+                        // misbehaving endpoint that always says `has_more` and always advances would page
+                        // until the 20-second budget ran out, and report nothing at all.
+                        _logger.LogWarning(
+                            "Listing {Connection}: stopped at the {Max}-page limit with {Count} models",
+                            connection.Id, MaxPages, models.Count);
+                        complete = false;
+                        break;
+                    }
                 }
-                else
-                {
-                    _logger.LogWarning(
-                        "Fetched {Count} models from {Connection}, but its listing had {Listed} entries - "
-                        + "{Skipped} had no usable id", models.Count, connection.Id, listed, listed - models.Count);
-                    _logger.LogDebug("{Connection} listing: {Body}", connection.Id, body);
-                }
-                return AiCatalogResult.Success(models, complete);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
                 throw;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (models.Count == 0)
             {
                 return AiCatalogResult.Fail(
                     $"No answer from {url} within {Timeout.TotalSeconds:0} seconds.", reachable: false);
             }
-            catch (HttpRequestException ex)
+            catch (HttpRequestException ex) when (models.Count == 0)
             {
                 // The endpoint is named on purpose. "Cannot connect to API" is the sentence OpenCode writes
                 // and the reason its users cannot diagnose a stopped local runner.
                 _logger.LogDebug(ex, "Model listing failed for {Connection}", connection.Id);
                 return AiCatalogResult.Fail($"No response from {url} — is the endpoint running?", reachable: false);
             }
-            catch (JsonException)
+            catch (JsonException) when (models.Count == 0)
             {
                 return AiCatalogResult.Fail($"{url} answered, but not with a model listing.", reachable: true);
             }
+            catch (Exception ex) when (
+                ex is OperationCanceledException or HttpRequestException or JsonException)
+            {
+                // Same three failures, but pages had already been read. The guards above carry `models.Count
+                // == 0` so that the FIRST page still produces its own named sentence; past that point the
+                // models in hand are worth more than the sentence, and the flag says they are not everything.
+                _logger.LogWarning(ex, "Listing {Connection}: stopped after {Count} models", connection.Id, models.Count);
+                complete = false;
+            }
+
+            // A 200 carrying no models is not an error, but it is not a success the UI should silently
+            // present as an empty list either - the reader would read it as "this provider has none".
+            if (models.Count == 0)
+                return AiCatalogResult.Fail($"{url} answered, but listed no models.", reachable: true);
+
+            // An entry we could not read is a HOLE in a listing, not a short listing, and the two want
+            // different sentences: "there may be more models" sends a reader to look for models that are not
+            // there, when the truth is that one of the entries is malformed. Both still clear Complete,
+            // because its one job is to gate the inference that a model absent from the listing has been
+            // retired - and a skipped entry is exactly a model that is absent without being retired.
+            // (egret, on #769)
+            if (skipped > 0) complete = false;
+
+            // Re-sorted across pages: Parse orders each page on its own, so concatenating two of them
+            // interleaves nothing and leaves the second page's A after the first page's Z.
+            models.Sort((a, b) => string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase));
+
+            if (skipped == 0)
+                _logger.LogInformation("Fetched {Count} models from {Connection}", models.Count, connection.Id);
+            else
+                _logger.LogWarning(
+                    "Fetched {Count} models from {Connection}, but its listing had {Listed} entries - "
+                    + "{Skipped} had no usable id",
+                    models.Count, connection.Id, models.Count + skipped, skipped);
+
+            return AiCatalogResult.Success(models, complete, skipped);
         }
 
         /// <summary>
@@ -329,18 +443,67 @@ namespace CST.Avalonia.Services.Ai
         };
 
         /// <summary>
-        /// Reads the fields we name, and only those.
+        /// The same listing URL, asking for what comes after <paramref name="cursor"/>. (#769)
         ///
-        /// <para><b>Never "whatever the source says".</b> A listing can gain a field that ranks or scores
-        /// models in a release nobody read, and rendering it wholesale would adopt that judgment silently. So
-        /// each field is pulled by name, and adding one is a deliberate act.</para>
+        /// <para>Built through <see cref="UriBuilder"/> and not by string concatenation, because the base URL
+        /// may already carry a query — an Azure-style endpoint pins <c>api-version</c> there — and appending
+        /// a second <c>?</c> produces a URL the endpoint rejects with a message about the wrong thing.</para>
         /// </summary>
+        internal static Uri After(Uri url, string cursor)
+        {
+            var builder = new UriBuilder(url);
+            var existing = builder.Query.TrimStart('?');
+            var pair = "after_id=" + Uri.EscapeDataString(cursor);
+            builder.Query = existing.Length == 0 ? pair : existing + "&" + pair;
+            return builder.Uri;
+        }
+
+        /// <summary>
+        /// The id of the last entry the listing carried, in the order the endpoint wrote them. (#769)
+        ///
+        /// <para><b>Document order, deliberately.</b> <see cref="Parse"/> sorts alphabetically for display, so
+        /// its last element is not the endpoint's last entry, and paging from that one would ask the endpoint
+        /// to continue after a model in the middle — silently losing everything between. Anthropic publishes
+        /// <c>last_id</c> for exactly this, and it is preferred where it exists; the walk is the fallback for
+        /// a gateway that pages without publishing one.</para>
+        /// </summary>
+        internal static string? LastEntryId(string json)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+
+                if (doc.RootElement.TryGetProperty("last_id", out var last) &&
+                    last.ValueKind == JsonValueKind.String &&
+                    last.GetString() is { Length: > 0 } published)
+                    return published;
+
+                if (!doc.RootElement.TryGetProperty("data", out var data) ||
+                    data.ValueKind != JsonValueKind.Array)
+                    return null;
+
+                string? id = null;
+                foreach (var item in data.EnumerateArray())
+                    if (item.ValueKind == JsonValueKind.Object &&
+                        item.TryGetProperty("id", out var value) &&
+                        value.ValueKind == JsonValueKind.String &&
+                        value.GetString() is { Length: > 0 } entry)
+                        id = entry;
+
+                return id;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         /// Whether the endpoint says it has another page. (#728)
         ///
-        /// <para>Anthropic's listing is paged and defaults to twenty per page. We do not follow the pages yet
-        /// — that is its own work — but reading the flag is what stops a first page being mistaken for the
-        /// whole catalogue, which would mark every model after the twentieth as retired.</para>
+        /// <para>Anthropic's listing is paged and defaults to twenty per page. Since #769 the pages ARE
+        /// followed, and this is what drives the walk; before that it existed only to stop a first page being
+        /// mistaken for the whole catalogue, which would mark every model after the twentieth as retired.</para>
         /// </summary>
         internal static bool HasMore(string json)
         {
@@ -358,6 +521,13 @@ namespace CST.Avalonia.Services.Ai
             }
         }
 
+        /// <summary>
+        /// Reads the fields we name, and only those.
+        ///
+        /// <para><b>Never "whatever the source says".</b> A listing can gain a field that ranks or scores
+        /// models in a release nobody read, and rendering it wholesale would adopt that judgment silently. So
+        /// each field is pulled by name, and adding one is a deliberate act.</para>
+        /// </summary>
         internal static IReadOnlyList<AiCatalogModel> Parse(string json)
         {
             using var doc = JsonDocument.Parse(json);

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -478,6 +478,25 @@ namespace CST.Avalonia.ViewModels
                             Id, _fetched.Select(m => m.Id).ToList()));
                         Refresh();
                     }
+
+                    // A fetch can succeed and still not be the whole listing, and the two ways that happens
+                    // are different facts that must not share a sentence. An entry we could not read is a
+                    // HOLE - the models around it are all here, one is malformed - while a walk that stopped
+                    // early means there are more models we never saw. Telling the first reader "there may be
+                    // more" sends them looking for models that do not exist; telling the second "one entry
+                    // was unreadable" understates it. (#769, egret)
+                    //
+                    // Said at all because until now it was said only to the log: the count read "3 models"
+                    // whether the provider offered three or offered nine and we understood three, and the
+                    // reader who knew better had no way to tell which. (#769)
+                    FetchProblem = result.Skipped switch
+                    {
+                        0 when result.Complete => null,
+                        0 => $"This is part of {DisplayName}'s listing — it did not send the rest.",
+                        1 => $"One entry in {DisplayName}'s listing could not be read, so it is not shown.",
+                        var n => $"{n} entries in {DisplayName}'s listing could not be read, "
+                                 + "so they are not shown.",
+                    };
                 }
                 else
                 {


### PR DESCRIPTION
Closes #769.

`AiModelCatalog.Parse` read `data[]` and stopped. Anthropic's `GET /v1/models` is paged — `has_more` and `last_id`, twenty per page — so a connection on that protocol with more than twenty models showed the first twenty. And because #728 correctly refused to infer anything from a partial listing, its retired-model marking **never ran for that connection at all**: a quiet degradation that silently disabled a feature.

## Following the pages

While the endpoint says there is more, ask again with `after_id`.

**The cursor is the endpoint's last entry in DOCUMENT order.** `Parse` sorts alphabetically for display, so its last element is generally *not* the last entry on the page — paging from it asks the provider to continue after a model in the middle, losing everything between with no error anywhere. `LastEntryId` prefers a published `last_id` and walks `data[]` only where a gateway publishes none.

**A gateway that invents `has_more` and ignores `after_id`** — issue #769's third question — is handled without deciding by provider kind. The walk stops whenever it fails to advance: no cursor, the same cursor twice, or a page whose every id we already hold. Plus a 25-page cap, so an endpoint that always claims more *and* always advances is bounded by pages rather than by the 20-second budget, which it would otherwise spend before reporting nothing at all — having read real models the whole time.

**A page failing after the first keeps what was already read.** Discarding twenty real models because page 21 answered 500 turns a partial answer into no answer.

## Two ways of being partial, two sentences, one flag

An unreadable entry is now counted rather than only logged. The observed case was a listing whose nine entries yielded two — the reader saw "2 models", which reads as a fact about the provider and is equally consistent with the provider offering two.

The count is accumulated **per page**, not derived by subtracting at the end: a repeated page dedupes on ids but not on entry counts, so a subtraction would report entries as unreadable that we read perfectly well. There is a test for that.

A reviewing agent made the distinction that shaped the rest: an entry we could not read is a **hole in a listing**, not a short listing, and telling that reader "there may be more models" sends them looking for models that are not there.

**But both still clear `Complete`, and that is not a conflation.** `Complete`'s only job is to gate the inference that a model absent from the listing has been *retired* — and a skipped entry is exactly a model that is absent without having been retired. Leaving `Complete` true for it would mark a live model as gone, which is the false alarm #728 exists to prevent. So:

| | answers |
|---|---|
| `Complete` | may we infer that what is absent was retired? |
| `Skipped` (new) | why is this partial, and what do we tell the reader? |

```
Skipped > 0  ->  "3 entries in Claude's listing could not be read, so they are not shown."
otherwise    ->  "This is part of Claude's listing — it did not send the rest."
```

Until now neither was said anywhere but the log.

## Also

Three `<summary>` blocks in this file had stacked onto a single member, leaving `Parse` and `HasMore` undocumented — and adding the paging helpers made it a **three**-stack before I noticed, which is the argument for fixing it here rather than filing it. The same defect in `AiConnectionService` came from my own #767 and is filed as #810.

## Verification

Nine new tests: the walk to the end, document-order cursor, the repeating gateway, the never-ending gateway against the cap, a later page failing, a first page failing, unreadable entries counted, a repeated page not inventing unreadable entries, cross-page sort order, and `After` against a base URL that already carries a query (an Azure-style endpoint pins `api-version` there, and a second `?` would be rejected with a message about the wrong thing).

Full suite green — 2465 passed, 0 failed, 17 skipped. 0 build warnings.
