### PR TITLE
Keep a secret prompt answer out of settings.json (#777)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -638,4 +638,215 @@ public class AiConnectionServiceTests
         Assert.True(service.Add("mine", Draft()).Ok);
         Assert.True(service.Update("mine", Draft("Renamed")).Ok);
     }
+
+    // ---- a secret prompt answer (#777) ------------------------------------------------------------------
+
+    /// <summary>A preset source holding exactly the presets a test names.</summary>
+    private sealed class Presets : IAiPresetSource
+    {
+        public Presets(params AiProviderPreset[] presets) => Presets_ = presets;
+        private AiProviderPreset[] Presets_ { get; }
+        IReadOnlyList<AiProviderPreset> IAiPresetSource.Presets => Presets_;
+        public AiPresetState State => AiPresetState.Ready;
+        public string? Problem => null;
+        public event System.EventHandler? PresetsChanged;
+        public System.Threading.Tasks.Task EnsureLoadedAsync(System.Threading.CancellationToken ct = default)
+            => System.Threading.Tasks.Task.CompletedTask;
+        public System.Threading.Tasks.Task RefreshAsync(System.Threading.CancellationToken ct = default)
+        {
+            PresetsChanged?.Invoke(this, System.EventArgs.Empty);
+            return System.Threading.Tasks.Task.CompletedTask;
+        }
+    }
+
+    /// <summary>A gateway that wants a token in a HEADER — the legitimate destination for a secret.</summary>
+    private static AiProviderPreset GatewayPreset() => new(
+        Id: "gateway",
+        DisplayName: "Gateway",
+        Kind: ChatProviderKind.OpenAiCompatible,
+        BaseUrl: "https://gateway.example/v1",
+        Methods: new List<AiCredentialMethod> { new AiCredentialMethod.Key() },
+        Prompts: new List<AiInputPrompt>
+        {
+            new("accountId", "Account id"),
+            new("gatewayToken", "Gateway token", Secret: true),
+        },
+        Headers: new Dictionary<string, string> { ["cf-aig-authorization"] = "Bearer {gatewayToken}" });
+
+    private static (AiConnectionService Service, Settings Settings, Keys Keys) MakeWith(AiProviderPreset preset)
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var keys = new Keys();
+        return (new AiConnectionService(svc.Object, keys, new Presets(preset)), settings, keys);
+    }
+
+    /// <summary>
+    /// The defect #777 exists for. Every prompt answer used to go to <c>Inputs</c>, which is written to
+    /// settings.json in the clear — so the moment a preset asked for a secret, the easy route leaked it.
+    /// </summary>
+    [Fact]
+    public void A_secret_prompt_answer_goes_to_the_credential_store_and_not_the_settings_file()
+    {
+        var (service, settings, keys) = MakeWith(GatewayPreset());
+
+        var result = service.AddFromPreset("gateway", new Dictionary<string, string>
+        {
+            ["accountId"] = "acct-123",
+            ["gatewayToken"] = "sk-secret-value",
+        });
+
+        Assert.True(result.Ok);
+        var record = Assert.Single(settings.Ai.Chat.Connections);
+
+        // The identifier is in the file, as it should be.
+        Assert.Equal("acct-123", record.Inputs["accountId"]);
+
+        // The secret is NOT, under any key.
+        Assert.DoesNotContain("gatewayToken", record.Inputs.Keys);
+        Assert.DoesNotContain("sk-secret-value", record.Inputs.Values);
+
+        // It is in the store, and the record says which key to look under.
+        Assert.Equal("sk-secret-value", keys.Get("gateway", AiCredentialNames.Input("gatewayToken")));
+        Assert.Equal(new[] { "gatewayToken" }, record.SecretInputs);
+    }
+
+    /// <summary>
+    /// Removing a connection must take its input secret with it. An orphan in the keychain is invisible by
+    /// definition — nothing reads it, so nothing reports it — and would be silently re-adopted by a later
+    /// connection created under the same id. (#759)
+    /// </summary>
+    [Fact]
+    public void Removing_a_connection_deletes_its_input_secret_too()
+    {
+        var (service, _, keys) = MakeWith(GatewayPreset());
+        service.AddFromPreset("gateway", new Dictionary<string, string>
+        {
+            ["accountId"] = "acct-123",
+            ["gatewayToken"] = "sk-secret-value",
+        });
+
+        service.Remove("gateway");
+
+        Assert.Null(keys.Get("gateway", AiCredentialNames.Input("gatewayToken")));
+    }
+
+    /// <summary>
+    /// A secret must not be substituted into a base URL. A URL reaches the provider's access logs, every
+    /// proxy between, the Providers list, and the error sentences this code is careful to make name the
+    /// endpoint — so refusing at the seam makes it unreachable rather than discouraged.
+    /// </summary>
+    [Fact]
+    public void A_preset_that_would_put_a_secret_in_its_address_is_refused()
+    {
+        var leaky = new AiProviderPreset(
+            Id: "leaky",
+            DisplayName: "Leaky",
+            Kind: ChatProviderKind.OpenAiCompatible,
+            BaseUrl: "https://leaky.example/{gatewayToken}/v1",
+            Methods: new List<AiCredentialMethod> { new AiCredentialMethod.Key() },
+            Prompts: new List<AiInputPrompt> { new("gatewayToken", "Gateway token", Secret: true) });
+
+        var (service, settings, keys) = MakeWith(leaky);
+
+        var result = service.AddFromPreset("leaky", new Dictionary<string, string>
+        {
+            ["gatewayToken"] = "sk-secret-value",
+        });
+
+        Assert.False(result.Ok);
+        Assert.Contains("must not go in a URL", result.Problem);
+
+        // Refused means nothing was created and nothing was filed.
+        Assert.Empty(settings.Ai.Chat.Connections);
+        Assert.Null(keys.Get("leaky", AiCredentialNames.Input("gatewayToken")));
+    }
+
+    /// <summary>
+    /// Where there is nowhere to store a secret, say so. Writing it to the plaintext file "for now" is the
+    /// leak; doing that without telling the reader is the worse half. (#771's call, unchanged.)
+    /// </summary>
+    [Fact]
+    public void A_secret_prompt_is_refused_where_there_is_no_credential_store()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var service = new AiConnectionService(svc.Object, credentials: null, new Presets(GatewayPreset()));
+
+        var result = service.AddFromPreset("gateway", new Dictionary<string, string>
+        {
+            ["accountId"] = "acct-123",
+            ["gatewayToken"] = "sk-secret-value",
+        });
+
+        Assert.False(result.Ok);
+        Assert.Contains("no credential store", result.Problem);
+        Assert.Empty(settings.Ai.Chat.Connections);
+    }
+
+    /// <summary>A preset with no secret prompt is unaffected, credential store or not.</summary>
+    [Fact]
+    public void A_plain_prompt_answer_still_goes_to_the_settings_file()
+    {
+        var (service, settings, _) = MakeWith(new AiProviderPreset(
+            Id: "azure-like",
+            DisplayName: "Azure-like",
+            Kind: ChatProviderKind.OpenAiCompatible,
+            BaseUrl: "https://{resourceName}.example/v1",
+            Methods: new List<AiCredentialMethod> { new AiCredentialMethod.Key() },
+            Prompts: new List<AiInputPrompt> { new("resourceName", "Resource name") }));
+
+        var result = service.AddFromPreset(
+            "azure-like", new Dictionary<string, string> { ["resourceName"] = "mybox" });
+
+        Assert.True(result.Ok);
+        var record = Assert.Single(settings.Ai.Chat.Connections);
+        Assert.Equal("mybox", record.Inputs["resourceName"]);
+        Assert.Null(record.SecretInputs);
+    }
+
+    /// <summary>
+    /// No preset this build ships puts a secret prompt in its address. (#777)
+    ///
+    /// <para>The service refuses one at the point of save, which is what makes it unreachable for a reader.
+    /// This is the other half: it fails the BUILD, so the mistake is caught by whoever writes the preset
+    /// rather than by whoever tries to add it. The presets are hand-kept in one file and the fetched
+    /// catalogue constructs no prompts at all, so this is a foot-gun we would hand ourselves — the kind worth
+    /// nailing shut rather than remembering.</para>
+    /// </summary>
+    [Fact]
+    public void No_shipped_preset_would_put_a_secret_in_its_address()
+    {
+        foreach (var preset in AiProviderPresets.All)
+        {
+            var secrets = (preset.Prompts ?? Array.Empty<AiInputPrompt>())
+                .Where(prompt => prompt.Secret)
+                .Select(prompt => prompt.Key)
+                .ToHashSet(StringComparer.Ordinal);
+
+            if (secrets.Count == 0) continue;
+
+            foreach (var placeholder in AiTemplate.PlaceholdersIn(preset.BaseUrl))
+                Assert.False(
+                    secrets.Contains(placeholder),
+                    $"{preset.Id} substitutes the secret '{placeholder}' into its base URL. A URL reaches "
+                    + "access logs, the Providers list and every error that names the endpoint. Put it in a "
+                    + "header template instead.");
+        }
+    }
+
+    /// <summary>
+    /// An input secret and a header secret of the same name occupy different accounts. A provider wanting a
+    /// `token` input and an `X-Token` header on one connection is not exotic, and folding both to one name
+    /// would have the second silently overwrite the first — the #771 collision from a direction that check
+    /// does not cover.
+    /// </summary>
+    [Fact]
+    public void An_input_secret_and_a_header_secret_of_the_same_name_do_not_collide()
+    {
+        Assert.NotEqual(AiCredentialNames.Input("token"), AiCredentialNames.Header("token"));
+        Assert.NotEqual(AiCredentialNames.Input("token"), AiCredentialNames.Primary);
+    }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -387,4 +387,104 @@ public class ChatProviderResolverTests
         Assert.Null(resolver.Resolve(out var problem));
         Assert.Contains("x-api-key", problem);
     }
+
+    // ---- a secret prompt answer reaching a header template (#777) ---------------------------------------
+
+    /// <summary>
+    /// The legitimate destination for a secret prompt: a header template. Cloudflare's gateway token is the
+    /// case in view — the value lives in the credential store, the key lives in <c>SecretInputs</c>, and it is
+    /// substituted at the last possible moment rather than being written back into <c>Inputs</c>, which is
+    /// what the save path persists.
+    /// </summary>
+    [Fact]
+    public void A_header_template_substitutes_a_secret_input_from_the_credential_store()
+    {
+        var resolver = Resolver(c =>
+        {
+            var conn = Conn(c);
+            conn.Kind = "openai-compatible";
+            conn.BaseUrl = "https://gateway.example/v1";
+            conn.Headers.Add(new AiHeaderRecord
+            {
+                Name = "cf-aig-authorization",
+                Value = "Bearer {gatewayToken}",
+            });
+            conn.Inputs["accountId"] = "acct-123";
+            conn.SecretInputs = new List<string> { "gatewayToken" };
+            c.ActiveModelId = "some-model";
+        },
+        apiKey: "sk-upstream",
+        secrets: new Dictionary<string, string>
+        {
+            [AiCredentialNames.Input("gatewayToken")] = "tok-live",
+        });
+
+        var resolution = resolver.Resolve(out var problem);
+
+        Assert.Null(problem);
+        var options = Assert.IsType<OpenAiCompatibleProvider>(resolution!.Provider).Options;
+        Assert.Equal("Bearer tok-live", options.ExtraHeaders!["cf-aig-authorization"]);
+    }
+
+    /// <summary>
+    /// A secret input with nothing stored leaves its placeholder in the header rather than filling it with an
+    /// empty string — and the refusal that already guards unfinished header templates then names the field.
+    ///
+    /// <para>That naming is the whole reason for leaving it unexpanded. Substituting an empty string would
+    /// send <c>Bearer </c> on the wire and come back a 401 that reads as a bad credential, which is the #711
+    /// complaint arriving from a new direction; the reader would be sent to re-paste a key that was never the
+    /// problem. This asserts the message, not just the header, because the message is the feature.</para>
+    /// </summary>
+    [Fact]
+    public void A_secret_input_with_nothing_stored_leaves_the_placeholder_rather_than_blanking_it()
+    {
+        var resolver = Resolver(c =>
+        {
+            var conn = Conn(c);
+            conn.Kind = "openai-compatible";
+            conn.BaseUrl = "https://gateway.example/v1";
+            conn.Headers.Add(new AiHeaderRecord
+            {
+                Name = "cf-aig-authorization",
+                Value = "Bearer {gatewayToken}",
+            });
+            conn.SecretInputs = new List<string> { "gatewayToken" };
+            c.ActiveModelId = "some-model";
+        },
+        apiKey: "sk-upstream",
+        secrets: new Dictionary<string, string>());
+
+        var resolution = resolver.Resolve(out var problem);
+
+        Assert.Null(resolution);
+        Assert.NotNull(problem);
+
+        // Named, so the reader knows WHICH field is unfilled rather than being told the provider said no.
+        Assert.Contains("gatewayToken", problem);
+    }
+
+    /// <summary>
+    /// A connection with no secret inputs behaves exactly as before — the substitution dictionary is the
+    /// plain <c>Inputs</c> object, not a copy, so nothing about the ordinary path changed.
+    /// </summary>
+    [Fact]
+    public void A_plain_input_still_substitutes_into_a_header_template()
+    {
+        var resolver = Resolver(c =>
+        {
+            var conn = Conn(c);
+            conn.Kind = "openai-compatible";
+            conn.BaseUrl = "https://gateway.example/v1";
+            conn.Headers.Add(new AiHeaderRecord { Name = "x-account", Value = "{accountId}" });
+            conn.Inputs["accountId"] = "acct-123";
+            c.ActiveModelId = "some-model";
+        },
+        apiKey: "sk-upstream");
+
+        var resolution = resolver.Resolve(out var problem);
+
+        Assert.Null(problem);
+        var options = Assert.IsType<OpenAiCompatibleProvider>(resolution!.Provider).Options;
+        Assert.Equal("acct-123", options.ExtraHeaders!["x-account"]);
+    }
 }

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -148,6 +148,7 @@ namespace CST.Avalonia.Models.Ai
         IReadOnlyList<AiHeader> Headers,
         IReadOnlyDictionary<string, string> Inputs,
         string? PresetId = null,
+        IReadOnlyList<string>? SecretInputs = null,
         CredentialSource KeySource = CredentialSource.None,
         Reachability State = Reachability.Configured,
         string AuthHeaderName = "Authorization",
@@ -159,6 +160,16 @@ namespace CST.Avalonia.Models.Ai
         /// <summary>True when an input the URL needs has not been supplied, so this connection cannot be used
         /// yet. Checked before sending rather than discovered as a DNS failure naming nothing.</summary>
         public bool IsIncomplete => AiTemplate.HasUnresolvedPlaceholders(ResolvedBaseUrl);
+
+        /// <summary>
+        /// Whether <paramref name="key"/> names a prompt answer kept in the credential store. (#777)
+        ///
+        /// <para>Ordinal, because an input key is a template token matched character for character by
+        /// <see cref="AiTemplate"/> — folding case here would claim to hold a secret for a placeholder the
+        /// expander will never fill.</para>
+        /// </summary>
+        public bool IsSecretInput(string key) =>
+            SecretInputs is { } keys && keys.Contains(key, System.StringComparer.Ordinal);
     }
 
     /// <summary>

--- a/src/CST.Avalonia/Models/Ai/AiCredentialMethod.cs
+++ b/src/CST.Avalonia/Models/Ai/AiCredentialMethod.cs
@@ -49,12 +49,32 @@ namespace CST.Avalonia.Models.Ai
     /// substitutes.</param>
     /// <param name="When">Ask only when another input has (or has not) a given value. Azure needs this: it
     /// wants a resource name <i>or</i> an explicit base URL, and asking for both is wrong.</param>
+    /// <param name="Secret">
+    /// Whether the answer is a credential, and so must never reach <c>settings.json</c>. (#777)
+    ///
+    /// <para><b>Nothing in the catalogue sets this today</b> — the two prompts that exist are Azure's resource
+    /// name and Cloudflare's account id, both identifiers rather than secrets, and both correctly stored in
+    /// the clear. The flag exists because the hazard is structural: the moment a provider needs a second
+    /// secret, the prompt mechanism is the path of least resistance and it writes to a plaintext file. An AWS
+    /// secret access key reaching <c>settings.json</c> that way would be a real leak taken by the easy route,
+    /// and without this flag nothing in the types would object.</para>
+    ///
+    /// <para>A secret answer is filed in the OS credential store under
+    /// <c>AiCredentialNames.Input(key)</c> and its key recorded in <c>AiConnectionRecord.SecretInputs</c> —
+    /// the same name-here/value-there routing a secret header uses (#771), reused rather than reinvented.</para>
+    ///
+    /// <para><b>A secret may not be substituted into a base URL.</b> A URL reaches server logs, the Providers
+    /// list, and every error message that names the endpoint. Refused at the point of save rather than
+    /// discouraged in a comment — see <c>AiConnectionService.SecretInUrl</c>. A header template is the
+    /// legitimate destination.</para>
+    /// </param>
     public sealed record AiInputPrompt(
         string Key,
         string Message,
         string? Placeholder = null,
         IReadOnlyList<AiPromptOption>? Options = null,
-        AiPromptCondition? When = null);
+        AiPromptCondition? When = null,
+        bool Secret = false);
 
     /// <summary>One choice in a select-style prompt.</summary>
     public sealed record AiPromptOption(string Label, string Value, string? Hint = null);

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -185,6 +185,21 @@ namespace CST.Avalonia.Models
         public Dictionary<string, string> Inputs { get; set; } = new();
 
         /// <summary>
+        /// Which prompt answers are credentials, and so live in the OS credential store rather than here.
+        /// (#777)
+        ///
+        /// <para>The key is recorded and the value is not, exactly as a secret header records its name and not
+        /// its value (#771). A key listed here is absent from <see cref="Inputs"/>; it is fetched under
+        /// <c>AiCredentialNames.Input(key)</c> when a header template needs it.</para>
+        ///
+        /// <para><b>Nullable rather than <c>= new()</c>.</b> A property initializer is overwritten by an
+        /// explicit <c>null</c> in the JSON, so the initializer is not the guarantee it looks like — and
+        /// every read here treats absent and empty alike, which is the honest reading for a file written
+        /// before this field existed.</para>
+        /// </summary>
+        public List<string>? SecretInputs { get; set; }
+
+        /// <summary>
         /// Which header carries the credential. Azure uses <c>api-key</c> and expects <c>Authorization</c> to
         /// be ABSENT rather than also present, so this REPLACES the auth header rather than adding one.
         /// </summary>

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -246,6 +246,22 @@ namespace CST.Avalonia.Services.Ai
                     return AiConnectionResult.Fail(
                         $"{preset.DisplayName} needs {PromptLabel(preset, key)} before it can be added.");
 
+            if (SecretInUrl(preset) is { } inUrl) return AiConnectionResult.Fail(inUrl);
+
+            var secretKeys = (preset.Prompts ?? Array.Empty<AiInputPrompt>())
+                .Where(p => p.Secret)
+                .Select(p => p.Key)
+                .Where(k => inputs.ContainsKey(k) && !string.IsNullOrWhiteSpace(inputs[k]))
+                .ToList();
+
+            // Nowhere to put a secret is a refusal, not a silent downgrade to the plaintext file. #771 made
+            // that call for headers and the reasoning is unchanged: writing the credential to settings.json
+            // "for now" is the leak, and doing it without telling the reader is the worse half.
+            if (secretKeys.Count > 0 && _credentials?.IsAvailable != true)
+                return AiConnectionResult.Fail(
+                    $"{preset.DisplayName} needs {PromptLabel(preset, secretKeys[0])} stored securely, and "
+                    + "this machine has no credential store available.");
+
             var record = new AiConnectionRecord
             {
                 Id = preset.Id,
@@ -259,10 +275,23 @@ namespace CST.Avalonia.Services.Ai
                 Headers = (preset.Headers ?? new Dictionary<string, string>())
                     .Select(h => new AiHeaderRecord { Name = h.Key, Value = h.Value })
                     .ToList(),
-                Inputs = new Dictionary<string, string>(inputs),
+                // Every answer EXCEPT the secret ones. This is the line that keeps a credential out of the
+                // settings file, so it is written as a filter rather than as a later removal: a copy-then-
+                // delete would put the secret in the object that the save path reads, and correctness would
+                // depend on the order of two statements. (#777)
+                Inputs = inputs
+                    .Where(pair => !secretKeys.Contains(pair.Key, StringComparer.Ordinal))
+                    .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal),
+                SecretInputs = secretKeys.Count > 0 ? secretKeys : null,
                 AuthHeaderName = preset.AuthHeaderName,
                 AuthScheme = preset.AuthScheme,
             };
+
+            // Filed BEFORE the record is added, so a store that refuses cannot leave a connection behind that
+            // claims to hold a secret nothing can fetch.
+            foreach (var key in secretKeys)
+                _credentials?.Set(record.Id, AiCredentialNames.Input(key), inputs[key]);
+
             Chat.Connections.Add(record);
             Chat.ActiveConnectionId ??= record.Id;
 
@@ -626,6 +655,7 @@ namespace CST.Avalonia.Services.Ai
             r.Headers.Select(h => new AiHeader(h.Name, h.Secret ? null : h.Value, h.Secret)).ToList(),
             new Dictionary<string, string>(r.Inputs),
             r.PresetId,
+            r.SecretInputs?.ToList(),
             SourceFor(r.Id),
             ReachabilityOf(r.Id),
             r.AuthHeaderName,
@@ -638,12 +668,50 @@ namespace CST.Avalonia.Services.Ai
         /// a list in the settings file would be one more thing to keep true, and the failure mode of it being
         /// stale is an orphaned credential nobody can see.</para>
         /// </summary>
+        /// <summary>
+        /// A preset whose base URL substitutes a secret prompt, or null when none does. (#777)
+        ///
+        /// <para><b>Refused rather than discouraged.</b> A base URL is not a private place: it is written to
+        /// the provider's own access logs and to any proxy between, it is shown in the Providers list and in
+        /// the editor, and it is named in most of the error sentences this code is careful to produce — the
+        /// #678 lesson about naming the endpoint works directly against keeping anything in it quiet. A
+        /// header template is the legitimate destination for a secret, which is where Cloudflare's gateway
+        /// token goes.</para>
+        ///
+        /// <para>Checked at the point of save rather than only where presets are authored, because the preset
+        /// list is generated from a fetched catalogue (#733/#737) and this is the seam every connection goes
+        /// through. Nothing in the catalogue can set <c>Secret</c> today — <c>ModelsDevCatalog</c> constructs
+        /// no prompts at all — so this guards a foot-gun we would hand ourselves, which is exactly the kind
+        /// worth making unreachable rather than remembering.</para>
+        /// </summary>
+        private static string? SecretInUrl(AiProviderPreset preset)
+        {
+            var secrets = (preset.Prompts ?? Array.Empty<AiInputPrompt>())
+                .Where(p => p.Secret)
+                .Select(p => p.Key)
+                .ToHashSet(StringComparer.Ordinal);
+
+            if (secrets.Count == 0) return null;
+
+            foreach (var key in AiTemplate.PlaceholdersIn(preset.BaseUrl))
+                if (secrets.Contains(key))
+                    return $"{preset.DisplayName} cannot be added: its address would contain the "
+                        + $"{PromptLabel(preset, key)}, and a secret must not go in a URL.";
+
+            return null;
+        }
+
         private static IEnumerable<string> CredentialNamesOf(AiConnectionRecord record)
         {
             yield return AiCredentialNames.Primary;
 
             foreach (var header in record.Headers.Where(h => h.Secret))
                 yield return AiCredentialNames.Header(header.Name);
+
+            // A secret prompt answer is filed here too, and an orphan is invisible precisely because nothing
+            // reads it - the reason this method exists at all. (#777)
+            foreach (var key in record.SecretInputs ?? Enumerable.Empty<string>())
+                yield return AiCredentialNames.Input(key);
         }
 
         /// <summary>

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -78,6 +78,16 @@ public static class AiCredentialNames
     public static string Header(string headerName) => "header-" + Slug(headerName);
 
     /// <summary>
+    /// The name a secret prompt answer is filed under. (#777)
+    ///
+    /// <para>Prefixed distinctly from <see cref="Header"/> because the two namespaces are independent: a
+    /// provider may well want a <c>token</c> input and an <c>X-Token</c> header on the same connection, and
+    /// folding both to one account name would have the second silently overwrite the first — the collision
+    /// #771 documents, arriving from a direction that check does not cover.</para>
+    /// </summary>
+    public static string Input(string inputKey) => "input-" + Slug(inputKey);
+
+    /// <summary>
     /// The character folding every part of an account name goes through, defined here so that the code which
     /// checks two names for collision and the code which stores under them cannot disagree.
     ///
@@ -376,12 +386,42 @@ public sealed class ChatProviderResolver : IChatProviderResolver
         // Indexer assignment rather than ToDictionary: a duplicate name is refused before this runs, so this
         // cannot be reached with one - and if a later edit moves the guard, the reader should get a wrong
         // header rather than an exception surfacing as "Something went wrong running that request".
+        var substitutions = Substitutions(connection);
+
         var headers = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var header in connection.Headers)
             headers[header.Name] = header.Secret
                 ? _credentials?.Get(connection.Id, AiCredentialNames.Header(header.Name)) ?? string.Empty
-                : CST.Avalonia.Models.Ai.AiTemplate.Expand(header.Value ?? string.Empty, connection.Inputs);
+                : CST.Avalonia.Models.Ai.AiTemplate.Expand(header.Value ?? string.Empty, substitutions);
 
         return headers;
+    }
+
+    /// <summary>
+    /// The inputs a header template may substitute: the plaintext answers, plus any secret answer fetched
+    /// from the credential store at this moment. (#777)
+    ///
+    /// <para>A header template is the one legitimate destination for a secret prompt — Cloudflare's gateway
+    /// token is the case in view — so the value has to arrive somewhere, and here is the latest possible
+    /// moment. It is not written back to <see cref="AiConnectionRecord.Inputs"/>: that object is what the
+    /// save path persists, and putting the secret in it even briefly is the leak this routing exists to
+    /// prevent.</para>
+    ///
+    /// <para><b>A secret with nothing stored is left unexpanded rather than filled with an empty string.</b>
+    /// The placeholder then survives into the header value, where <c>IsSendableHeader</c> already refuses it
+    /// — so the reader gets the refusal that names the unfinished field, instead of a header sent with a hole
+    /// in it and a 401 that names nothing. (#711)</para>
+    /// </summary>
+    private IReadOnlyDictionary<string, string> Substitutions(AiConnectionRecord connection)
+    {
+        if (connection.SecretInputs is not { Count: > 0 } secretKeys)
+            return connection.Inputs;
+
+        var substitutions = new Dictionary<string, string>(connection.Inputs, StringComparer.Ordinal);
+        foreach (var key in secretKeys)
+            if (_credentials?.Get(connection.Id, AiCredentialNames.Input(key)) is { Length: > 0 } value)
+                substitutions[key] = value;
+
+        return substitutions;
     }
 }

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -243,6 +243,17 @@ namespace CST.Avalonia.ViewModels
                         ?? new AiInputPrompt(input.Key, input.Key),
                     vm.OnInputChanged) { Value = input.Value });
 
+            // A secret answer is not in Inputs — that is the point of it — so without this it would have no
+            // row at all, and a reader whose gateway token was rotated would have no way to enter the new one
+            // short of deleting the connection. The row opens EMPTY and says so, exactly as a secret header's
+            // does: a stored credential is never read back into a screen. (#777)
+            foreach (var key in connection.SecretInputs ?? Array.Empty<string>())
+                vm.Inputs.Add(new AiInputRowViewModel(
+                    preset?.Prompts?.FirstOrDefault(p => p.Key == key)
+                        ?? new AiInputPrompt(key, key, Secret: true),
+                    vm.OnInputChanged,
+                    hasStoredSecret: true));
+
             if (vm.Models.Count == 0) vm.Models.Add(new AiModelRowViewModel(vm.Models));
             vm.RefreshInputVisibility();
             return vm;
@@ -510,16 +521,25 @@ namespace CST.Avalonia.ViewModels
                 return;
             }
 
-            var inputs = Inputs
+            var typed = Inputs
                 .Where(i => i.IsVisible && !string.IsNullOrWhiteSpace(i.Value))
                 .ToDictionary(i => i.Key, i => i.Value.Trim(), StringComparer.Ordinal);
+
+            // The draft's dictionary becomes `record.Inputs` verbatim, and `record.Inputs` is written to
+            // settings.json - so a secret answer must not be in it. `typed` keeps them for AddFromPreset,
+            // which is the one caller allowed to see them, and files them in the credential store itself.
+            // (#777)
+            var inputs = typed
+                .Where(pair => !Inputs.Any(i =>
+                    i.IsSecret && string.Equals(i.Key, pair.Key, StringComparison.Ordinal)))
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal);
 
             // Order matters: an edit updates even when it carries a preset, or saving one would try to add a
             // second connection under an id that is already taken.
             var result = _existingId is not null
                 ? _service.Update(_existingId, BuildDraft(inputs))
                 : _preset is not null
-                    ? AddPreset(inputs)
+                    ? AddPreset(typed)
                     : _service.Add(Id.Trim(), BuildDraft(inputs));
 
             if (!result.Ok)
@@ -531,6 +551,7 @@ namespace CST.Avalonia.ViewModels
             var savedId = result.Connection?.Id ?? _existingId ?? Id.Trim();
             StoreKey(savedId);
             StoreHeaderSecrets(savedId);
+            StoreInputSecrets(savedId, typed);
             _close(true);
         }
 
@@ -561,6 +582,29 @@ namespace CST.Avalonia.ViewModels
 
         /// <summary>Hands the key over once the connection it belongs to exists, so it is filed under an id
         /// that is already real.</summary>
+        /// <summary>
+        /// Files a secret prompt answer the reader typed on this sheet. (#777)
+        ///
+        /// <para>Runs on the EDIT path. The add path does not need it — <c>AddFromPreset</c> is handed the
+        /// secrets and files them itself, because it is also the code that decides which keys are secret and
+        /// records them on the connection, and splitting that decision across two objects is how the two come
+        /// to disagree.</para>
+        ///
+        /// <para>An empty box keeps what is stored rather than clearing it: the box is empty on every edit by
+        /// design, since a stored secret is never read back into a screen. There is no sweep to match
+        /// <c>StoreHeaderSecrets</c>' because an input key comes from the preset's own prompt list and cannot
+        /// be renamed or removed on this sheet — if that ever changes, the orphan it would leave is the same
+        /// invisible one, and this is where the sweep belongs.</para>
+        /// </summary>
+        private void StoreInputSecrets(string connectionId, IReadOnlyDictionary<string, string> typed)
+        {
+            if (_credentials is null) return;
+
+            foreach (var row in Inputs.Where(i => i.IsSecret))
+                if (typed.TryGetValue(row.Key, out var value) && !string.IsNullOrWhiteSpace(value))
+                    _credentials.Set(connectionId, AiCredentialNames.Input(row.Key), value);
+        }
+
         private void StoreKey(string connectionId)
         {
             if (_credentials is null || string.IsNullOrWhiteSpace(ApiKeyEntry)) return;
@@ -884,15 +928,38 @@ namespace CST.Avalonia.ViewModels
         private string _value = "";
         private bool _isVisible = true;
 
-        public AiInputRowViewModel(AiInputPrompt prompt, Action changed)
+        public AiInputRowViewModel(AiInputPrompt prompt, Action changed, bool hasStoredSecret = false)
         {
             _prompt = prompt;
             _changed = changed;
+            HasStoredSecret = hasStoredSecret;
         }
 
         public string Key => _prompt.Key;
 
         public string Message => _prompt.Message;
+
+        /// <summary>Whether this answer is a credential, and so is never persisted to the settings file or
+        /// read back into this screen. (#777)</summary>
+        public bool IsSecret => _prompt.Secret;
+
+        /// <summary>Whether the credential store already holds an answer for this prompt.</summary>
+        public bool HasStoredSecret { get; }
+
+        /// <summary>
+        /// The masking character, or <c>'\0'</c> for none — Avalonia reads NUL as "show the text", so this
+        /// is the whole of the mask rather than a separate flag. (#777)
+        /// </summary>
+        public char ValueMask => IsSecret ? '\u2022' : '\0';
+
+        /// <summary>
+        /// What the empty box says. A stored secret is never read back, so on an edit the box is empty for a
+        /// prompt that HAS an answer — and an empty box with the ordinary placeholder under it reads as "this
+        /// was never filled in", which invites a reader to retype a credential they did not need to.
+        /// </summary>
+        public string? ValueWatermark => IsSecret && HasStoredSecret
+            ? "Stored — type to replace"
+            : _prompt.Placeholder;
 
         public string? Placeholder => _prompt.Placeholder;
 

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -435,9 +435,16 @@
                                 <DataTemplate x:DataType="vm:AiInputRowViewModel">
                                     <StackPanel IsVisible="{Binding IsVisible}">
                                         <TextBlock Text="{Binding Message}" Classes="SettingLabel"/>
+                                        <!-- PasswordChar is the whole of the mask: Avalonia reads NUL as
+                                             "show the text", so a non-secret row binds '\0' and looks
+                                             exactly as it did. The watermark says "Stored — type to
+                                             replace" where a credential is already filed, because the box
+                                             is empty on every edit and would otherwise read as never
+                                             filled in. (#777) -->
                                         <TextBox Text="{Binding Value}"
                                                  IsVisible="{Binding IsFreeText}"
-                                                 Watermark="{Binding Placeholder}"
+                                                 PasswordChar="{Binding ValueMask}"
+                                                 Watermark="{Binding ValueWatermark}"
                                                  Width="320" HorizontalAlignment="Left"
                                                  Margin="0,0,0,15"/>
                                         <ComboBox ItemsSource="{Binding Options}"


### PR DESCRIPTION
Closes #777. The last part of #759's recommendation, and the third caller of the routing #771 landed.

`AiInputPrompt` had no way to say an answer was a credential, so every answer went to `AiConnectionRecord.Inputs` — written to `settings.json` in the clear. Correct for the two prompts that exist (Azure's resource name, Cloudflare's account id: identifiers, not secrets), and the hazard was structural rather than present: **the moment a provider needs a second secret, the prompt mechanism is the path of least resistance and it writes to a plaintext file.** Nothing in the types would have objected.

## The routing

`Secret: true` sends the answer to the credential store under `AiCredentialNames.Input(key)` and records the **key** — never the value — in the new `AiConnectionRecord.SecretInputs`. A header template referencing it is expanded from the store at the last possible moment, and never written back into `Inputs`, because `Inputs` is what the save path persists.

`Input()` is prefixed distinctly from `Header()`. A provider wanting a `token` input and an `X-Token` header on one connection is not exotic, and folding both to one account name would have the second silently overwrite the first — the #771 collision from a direction that check does not cover.

## A secret may not go in a URL

Refused at the seam, not discouraged in a comment. A base URL reaches the provider's access logs and every proxy between; it is shown in the Providers list and the editor; and it is named in most of the error sentences this code deliberately produces — **the #678 lesson about naming the endpoint works directly against keeping anything in a URL quiet.** A header template is the legitimate destination, which is where Cloudflare's gateway token goes.

Guarded twice: `AddFromPreset` refuses at save, and a test over the shipped presets fails the **build** — so the mistake is caught by whoever writes the preset, not by whoever tries to add it.

## Smaller decisions

- **`Inputs` is built as a filter, not copied then cleaned.** A copy-then-delete puts the secret into the object the save path reads, and correctness then depends on the order of two statements.
- **The secret is filed before the connection is added**, so a store that refuses cannot leave a connection claiming to hold a credential nothing can fetch.
- **`CredentialNamesOf` gained the input names**, so `Remove` takes them with it. An orphan in the keychain is invisible precisely because nothing reads it.
- **No credential store → refused, and it says so.** #771 made that call for headers: writing the credential to the plaintext file "for now" is the leak, and doing it silently is the worse half.
- **`SecretInputs` is nullable rather than `= new()`.** A property initializer is overwritten by an explicit JSON null, so it is not the guarantee it looks like — and absent and empty mean the same thing here.

## The edit sheet — a gap the issue did not name

A secret answer is not in `Inputs`, so it had no row at all. A reader whose gateway token was rotated would have had no way to enter the new one short of deleting the connection.

Secret inputs now get a masked row that opens **empty** and reads "Stored — type to replace" — the same contract a secret header's row has, since a stored credential is never read back into a screen. An empty box keeps what is stored rather than clearing it. `PasswordChar` carries the mask on its own: Avalonia reads NUL as "show the text", so a non-secret row binds `'\0'` and is unchanged.

## One correction from a test

I expected an unfilled secret placeholder to pass silently into the header. It does not — the resolver already refuses an unfinished header template and **names the field**: *"This provider still needs: gatewayToken."*

That is the better behaviour, and it is the reason for leaving the placeholder unexpanded rather than substituting an empty string: a blank would send `Bearer ` on the wire and come back a 401 reading as a bad credential, sending the reader to re-paste a key that was never the problem — #711 from a new direction. The test now asserts the message rather than the header value, because the message is the feature.

## Verification

Nine new tests: the secret stays out of the file and lands in the store, the key is recorded, `Remove` deletes it, a secret-in-URL preset is refused with nothing created and nothing filed, no-credential-store is refused, a plain prompt is unaffected, input and header names of the same spelling do not collide, no shipped preset would put a secret in its address, and the three header-template paths (secret substituted, secret missing → named refusal, plain input unchanged).

Nothing in the catalogue sets `Secret` today, and `ModelsDevCatalog` constructs no prompts at all, so a catalogue refresh cannot introduce one behind our backs. This is the mechanism being in place before the first provider needs it.

Full suite green — 2475 passed, 0 failed, 17 skipped. 0 build warnings.
