### PR TITLE
Read the vendor API keys the environment already holds (#714)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiEnvironmentKeysTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiEnvironmentKeysTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Reading the vendor API keys a reader's environment already holds. (#714)
+///
+/// <para><b>Discovery is automatic; use is not.</b> Nothing here adopts a key — that is a click, recorded on
+/// the connection. The separation is the point: OpenCode adopts silently, which produced a connected provider
+/// the maintainer had not configured, from a variable he had forgotten was set on his own machine, and then
+/// offered no way to disconnect it because an app cannot delete a credential it never stored.</para>
+///
+/// <para>Every test reads through an injected lookup, never the real environment — a suite that depended on
+/// which variables happen to be exported on the machine running it would pass or fail for reasons that have
+/// nothing to do with the code.</para>
+/// </summary>
+public sealed class AiEnvironmentKeysTests
+{
+    private static AiProviderPreset Preset(string id, params string[] envNames) =>
+        new(id, id.ToUpperInvariant(), ChatProviderKind.OpenAiCompatible, "https://example.invalid/v1",
+            new AiCredentialMethod[] { new AiCredentialMethod.Env(envNames) },
+            Array.Empty<AiInputPrompt>());
+
+    private static AiEnvironmentKeys Keys(params (string Name, string? Value)[] environment)
+    {
+        var map = environment.ToDictionary(e => e.Name, e => e.Value, StringComparer.Ordinal);
+        return new AiEnvironmentKeys(name => map.TryGetValue(name, out var v) ? v : null);
+    }
+
+    [Fact]
+    public void A_variable_that_is_set_is_found_by_name()
+    {
+        var keys = Keys(("OPENAI_API_KEY", "sk-test"));
+
+        Assert.Equal("OPENAI_API_KEY", keys.VariableFor(Preset("openai", "OPENAI_API_KEY")));
+    }
+
+    [Fact]
+    public void A_preset_with_no_variable_set_reports_nothing()
+    {
+        var keys = Keys(("SOMETHING_ELSE", "x"));
+
+        Assert.Null(keys.VariableFor(Preset("openai", "OPENAI_API_KEY")));
+        Assert.Null(keys.ValueFor(Preset("openai", "OPENAI_API_KEY")));
+    }
+
+    // The catalogue decides precedence, not us: Google alone answers to three names.
+    [Fact]
+    public void The_first_variable_the_preset_lists_wins()
+    {
+        var keys = Keys(
+            ("GOOGLE_GENERATIVE_AI_API_KEY", "second"),
+            ("GEMINI_API_KEY", "third"),
+            ("GOOGLE_API_KEY", "first"));
+
+        var google = Preset("google", "GOOGLE_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY");
+
+        Assert.Equal("GOOGLE_API_KEY", keys.VariableFor(google));
+        Assert.Equal("first", keys.ValueFor(google));
+    }
+
+    [Fact]
+    public void A_later_variable_is_used_when_the_earlier_ones_are_unset()
+    {
+        var keys = Keys(("GEMINI_API_KEY", "third"));
+        var google = Preset("google", "GOOGLE_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY");
+
+        Assert.Equal("GEMINI_API_KEY", keys.VariableFor(google));
+    }
+
+    // `export OPENAI_API_KEY=` in a shell profile, or a CI runner defining every name it knows. Offering to
+    // connect with one of these produces an authentication failure the reader cannot explain, from a variable
+    // they did not know they had.
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void A_variable_exported_empty_is_not_a_credential(string value)
+    {
+        var keys = Keys(("OPENAI_API_KEY", value));
+
+        Assert.Null(keys.VariableFor(Preset("openai", "OPENAI_API_KEY")));
+    }
+
+    [Fact]
+    public void Discovery_names_every_preset_whose_variable_is_present_and_no_others()
+    {
+        var keys = Keys(("OPENAI_API_KEY", "a"), ("GEMINI_API_KEY", "b"));
+
+        var found = keys.Discover(new[]
+        {
+            Preset("openai", "OPENAI_API_KEY"),
+            Preset("google", "GOOGLE_API_KEY", "GEMINI_API_KEY"),
+            Preset("anthropic", "ANTHROPIC_API_KEY"),      // not set
+            Preset("ollama"),                              // a local runner declares none
+        });
+
+        Assert.Equal(new[] { "google", "openai" }, found.Select(f => f.PresetId).OrderBy(id => id).ToArray());
+        Assert.Equal("GEMINI_API_KEY", found.Single(f => f.PresetId == "google").VariableName);
+    }
+
+    // The value is read at the moment of use, never captured — so a variable the reader changes or unsets
+    // takes effect on the next request rather than at the next launch. A copy in our keychain would outlive
+    // the variable, and the row it came from offers no remove action to undo that with (#691).
+    [Fact]
+    public void The_value_is_read_afresh_each_time_rather_than_captured()
+    {
+        string? current = "before";
+        var keys = new AiEnvironmentKeys(name => name == "OPENAI_API_KEY" ? current : null);
+        var preset = Preset("openai", "OPENAI_API_KEY");
+
+        Assert.Equal("before", keys.ValueFor(preset));
+        current = "after";
+        Assert.Equal("after", keys.ValueFor(preset));
+        current = null;
+        Assert.Null(keys.ValueFor(preset));
+    }
+
+    // A platform that refuses to read the environment is "no key", not a crash on the settings screen.
+    [Fact]
+    public void A_reader_that_throws_is_treated_as_no_key()
+    {
+        var keys = new AiEnvironmentKeys(_ => throw new InvalidOperationException("denied"));
+
+        Assert.Null(keys.VariableFor(Preset("openai", "OPENAI_API_KEY")));
+        Assert.Empty(keys.Discover(new[] { Preset("openai", "OPENAI_API_KEY") }));
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -771,4 +771,66 @@ public class AiModelCatalogTests
         Assert.Null(AiModelCatalog.LastEntryId("""{"data":[]}"""));
         Assert.Null(AiModelCatalog.LastEntryId("not json"));
     }
+
+    // #714: the listing authenticates exactly as chat does, INCLUDING from an adopted environment key.
+    //
+    // The first version of that work wired the environment into the chat resolver and left this path reading
+    // the credential store alone. An adopted connection would answer a question and then fail to list its
+    // models, reporting "the provider rejected the stored key" for a connection that has no stored key — the
+    // two-surfaces-disagreeing failure #673 exists to prevent, and which Authenticate's own summary forbids
+    // two lines above the code that had it. Untested is how it went missing. (fable)
+    [Fact]
+    public async Task An_adopted_environment_key_authenticates_the_listing_too()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"data":[{"id":"claude-opus-5"}]}"""),
+        });
+
+        var catalog = new AiModelCatalog(
+            new HttpClient(handler), credentials: null, NullLogger<AiModelCatalog>.Instance,
+            new CST.Avalonia.Services.Ai.Credentials.AiEnvironmentKeys(
+                n => n == "ANTHROPIC_API_KEY" ? "sk-from-env" : null));
+
+        await catalog.FetchAsync(new AiConnection(
+            Id: "claude",
+            DisplayName: "Claude",
+            Kind: ChatProviderKind.Anthropic,
+            BaseUrl: "https://api.anthropic.com",
+            Models: new List<AiModelEntry>(),
+            Headers: System.Array.Empty<AiHeader>(),
+            Inputs: new Dictionary<string, string>(),
+            UsesEnvironmentKey: true,
+            EnvironmentVariable: "ANTHROPIC_API_KEY"));
+
+        Assert.Equal("sk-from-env", string.Join(",", handler.LastRequest!.Headers.GetValues("x-api-key")));
+    }
+
+    // And a connection that never opted in does not borrow it here either.
+    [Fact]
+    public async Task A_listing_does_not_use_an_environment_key_without_the_opt_in()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"data":[{"id":"claude-opus-5"}]}"""),
+        });
+
+        var catalog = new AiModelCatalog(
+            new HttpClient(handler), credentials: null, NullLogger<AiModelCatalog>.Instance,
+            new CST.Avalonia.Services.Ai.Credentials.AiEnvironmentKeys(
+                n => n == "ANTHROPIC_API_KEY" ? "sk-from-env" : null));
+
+        await catalog.FetchAsync(new AiConnection(
+            Id: "claude",
+            DisplayName: "Claude",
+            Kind: ChatProviderKind.Anthropic,
+            BaseUrl: "https://api.anthropic.com",
+            Models: new List<AiModelEntry>(),
+            Headers: System.Array.Empty<AiHeader>(),
+            Inputs: new Dictionary<string, string>(),
+            UsesEnvironmentKey: false,
+            EnvironmentVariable: "ANTHROPIC_API_KEY"));
+
+        Assert.False(handler.LastRequest!.Headers.Contains("x-api-key"));
+    }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models.Ai;
 using System.Net.Http;
+using CST.Avalonia.Tests.TestSupport;
 using CST.Avalonia.Models;
 using CST.Avalonia.Services;
 using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System.Linq;
@@ -46,7 +52,9 @@ public class ChatProviderResolverTests
 
     private static ChatProviderResolver Resolver(
         Action<ChatSettings> configure, string? apiKey = null, bool aiEnabled = true,
-        string? storageUnavailable = null, IReadOnlyDictionary<string, string>? secrets = null)
+        string? storageUnavailable = null, IReadOnlyDictionary<string, string>? secrets = null,
+        IAiEnvironmentKeys? environmentKeys = null, IAiPresetSource? presets = null,
+        HttpMessageHandler? handler = null)
     {
         var settings = new Settings();
         settings.Ai.Enabled = aiEnabled;
@@ -62,7 +70,144 @@ public class ChatProviderResolverTests
                 ? null
                 : new FixedKey(apiKey, storageUnavailable, secrets),
             NullLoggerFactory.Instance,
-            new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan });
+            handler is null
+                ? new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan }
+                : new HttpClient(handler) { Timeout = System.Threading.Timeout.InfiniteTimeSpan },
+            environmentKeys,
+            presets);
+    }
+
+    // ---- environment keys (#714) ----
+
+    private sealed class FakePresets : IAiPresetSource
+    {
+        public IReadOnlyList<AiProviderPreset> Presets { get; }
+        public AiPresetState State => AiPresetState.Ready;
+        public string? Problem => null;
+        public event EventHandler? PresetsChanged { add { } remove { } }
+        public Task EnsureLoadedAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public FakePresets(params AiProviderPreset[] presets) => Presets = presets;
+    }
+
+    private static AiProviderPreset EnvPreset(string id, params string[] names) =>
+        new(id, id.ToUpperInvariant(), ChatProviderKind.OpenAiCompatible, "https://example.invalid/v1",
+            new AiCredentialMethod[] { new AiCredentialMethod.Env(names) }, Array.Empty<AiInputPrompt>());
+
+    private static IAiEnvironmentKeys Env(string name, string? value) =>
+        new AiEnvironmentKeys(n => n == name ? value : null);
+
+    [Fact]
+    public void A_connection_that_opted_in_authenticates_with_the_environment_key()
+    {
+        var resolver = Resolver(chat =>
+        {
+            var c = Conn(chat);
+            c.PresetId = "openai";
+            c.UsesEnvironmentKey = true;
+            c.Kind = "openai-compatible";
+            c.BaseUrl = "https://example.invalid/v1";
+            chat.ActiveModelId = "gpt-4";
+        }, environmentKeys: Env("OPENAI_API_KEY", "sk-from-env"),
+           presets: new FakePresets(EnvPreset("openai", "OPENAI_API_KEY")));
+
+        Assert.NotNull(resolver.Resolve(out var problem));
+        Assert.Null(problem);
+    }
+
+    // The opt-in is the whole feature. Discovery must never authenticate on its own — that is the difference
+    // between this and an app that adopts a forgotten variable and spends the reader's money.
+    [Fact]
+    public void A_connection_that_did_not_opt_in_does_not_use_the_environment_key()
+    {
+        var resolver = Resolver(chat =>
+        {
+            var c = Conn(chat);
+            c.PresetId = "anthropic";
+            c.UsesEnvironmentKey = false;          // discovered, not adopted
+            c.Kind = "anthropic";
+            chat.ActiveModelId = "claude-opus-5";
+        }, environmentKeys: Env("ANTHROPIC_API_KEY", "sk-from-env"),
+           presets: new FakePresets(EnvPreset("anthropic", "ANTHROPIC_API_KEY")));
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.NotNull(problem);
+    }
+
+    // Entering a key is a deliberate act; a variable is often forgotten. A reader who typed one must not find
+    // the app quietly authenticating with something else.
+    [Fact]
+    public async Task A_stored_key_wins_over_one_in_the_environment()
+    {
+        // Asserted on the CREDENTIAL THAT REACHES THE ENDPOINT, not on the resolution succeeding. Both keys
+        // resolve, so a non-null check cannot tell which was used — an earlier version of this test asserted
+        // exactly that and passed with the precedence reversed, which is the failure it exists to catch.
+        var handler = StubHttpMessageHandler.Sse(
+            "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n");
+
+        var resolver = Resolver(chat =>
+        {
+            var c = Conn(chat);
+            c.PresetId = "anthropic";
+            c.UsesEnvironmentKey = true;
+            c.Kind = "anthropic";
+            chat.ActiveModelId = "claude-opus-5";
+        }, apiKey: "sk-stored",
+           environmentKeys: Env("ANTHROPIC_API_KEY", "sk-from-env"),
+           presets: new FakePresets(EnvPreset("anthropic", "ANTHROPIC_API_KEY")),
+           handler: handler);
+
+        var resolution = resolver.Resolve(out var problem);
+        Assert.NotNull(resolution);
+        Assert.Null(problem);
+
+        await foreach (var _ in resolution!.Provider.StreamAsync(
+            new ChatRequest("claude-opus-5", 256, null,
+                new[] { new ChatMessage(ChatRole.User, "hello") }), CancellationToken.None)) { }
+
+        Assert.Equal("sk-stored", string.Join(",", handler.LastRequest!.Headers.GetValues("x-api-key")));
+    }
+
+    // The reader unset it, which they are allowed to do. That reads as "no key", not as an error.
+    [Fact]
+    public void A_variable_that_disappeared_reads_as_no_key_rather_than_a_fault()
+    {
+        var resolver = Resolver(chat =>
+        {
+            var c = Conn(chat);
+            c.PresetId = "anthropic";
+            c.UsesEnvironmentKey = true;
+            c.Kind = "anthropic";
+            chat.ActiveModelId = "claude-opus-5";
+        }, environmentKeys: Env("ANTHROPIC_API_KEY", null),
+           presets: new FakePresets(EnvPreset("anthropic", "ANTHROPIC_API_KEY")));
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.NotNull(problem);
+        Assert.Contains("key", problem!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // A custom endpoint records "" as its origin (#766). Matching that against a catalogue slug it happens to
+    // resemble is how a reader's own connection would come to authenticate with someone else's key.
+    [Fact]
+    public void A_custom_connection_never_borrows_a_presets_environment_key()
+    {
+        var resolver = Resolver(chat =>
+        {
+            var c = Conn(chat);
+            c.Id = "openai";               // an id that LOOKS like the preset
+            c.PresetId = "";               // recorded as custom
+            c.UsesEnvironmentKey = true;
+            c.Kind = "openai-compatible";
+            c.BaseUrl = "https://my-own-gateway.invalid/v1";
+            chat.ActiveConnectionId = "openai";
+            chat.ActiveModelId = "gpt-4";
+        }, environmentKeys: Env("OPENAI_API_KEY", "sk-from-env"),
+           presets: new FakePresets(EnvPreset("openai", "OPENAI_API_KEY")));
+
+        // Resolves (OpenAI-compatible needs no key) but must NOT have picked up the environment credential.
+        var resolution = resolver.Resolve(out _);
+        Assert.NotNull(resolution);
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -98,21 +98,36 @@ public class ChatProviderResolverTests
         new AiEnvironmentKeys(n => n == name ? value : null);
 
     [Fact]
-    public void A_connection_that_opted_in_authenticates_with_the_environment_key()
+    public async Task A_connection_that_opted_in_authenticates_with_the_environment_key()
     {
+        // Asserted on the wire, and on the ANTHROPIC kind, which requires a key. The first version used
+        // openai-compatible — for which a key is deliberately optional — and asserted only that resolution
+        // succeeded, so it passed with the whole environment fallback deleted. The feature's one positive
+        // path had no test at all. (fable)
+        var handler = StubHttpMessageHandler.Sse(
+            "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n");
+
         var resolver = Resolver(chat =>
         {
             var c = Conn(chat);
-            c.PresetId = "openai";
+            c.PresetId = "anthropic";
             c.UsesEnvironmentKey = true;
-            c.Kind = "openai-compatible";
-            c.BaseUrl = "https://example.invalid/v1";
-            chat.ActiveModelId = "gpt-4";
-        }, environmentKeys: Env("OPENAI_API_KEY", "sk-from-env"),
-           presets: new FakePresets(EnvPreset("openai", "OPENAI_API_KEY")));
+            c.EnvironmentVariable = "ANTHROPIC_API_KEY";
+            c.Kind = "anthropic";
+            chat.ActiveModelId = "claude-opus-5";
+        }, environmentKeys: Env("ANTHROPIC_API_KEY", "sk-from-env"),
+           presets: new FakePresets(EnvPreset("anthropic", "ANTHROPIC_API_KEY")),
+           handler: handler);
 
-        Assert.NotNull(resolver.Resolve(out var problem));
+        var resolution = resolver.Resolve(out var problem);
+        Assert.NotNull(resolution);
         Assert.Null(problem);
+
+        await foreach (var _ in resolution!.Provider.StreamAsync(
+            new ChatRequest("claude-opus-5", 256, null,
+                new[] { new ChatMessage(ChatRole.User, "hello") }), CancellationToken.None)) { }
+
+        Assert.Equal("sk-from-env", string.Join(",", handler.LastRequest!.Headers.GetValues("x-api-key")));
     }
 
     // The opt-in is the whole feature. Discovery must never authenticate on its own — that is the difference
@@ -190,24 +205,36 @@ public class ChatProviderResolverTests
     // A custom endpoint records "" as its origin (#766). Matching that against a catalogue slug it happens to
     // resemble is how a reader's own connection would come to authenticate with someone else's key.
     [Fact]
-    public void A_custom_connection_never_borrows_a_presets_environment_key()
+    public async Task A_custom_connection_never_borrows_a_presets_environment_key()
     {
+        var handler = StubHttpMessageHandler.Sse("data: [DONE]\n\n");
         var resolver = Resolver(chat =>
         {
             var c = Conn(chat);
             c.Id = "openai";               // an id that LOOKS like the preset
             c.PresetId = "";               // recorded as custom
             c.UsesEnvironmentKey = true;
+            c.EnvironmentVariable = null;  // nothing was ever consented to
             c.Kind = "openai-compatible";
             c.BaseUrl = "https://my-own-gateway.invalid/v1";
             chat.ActiveConnectionId = "openai";
             chat.ActiveModelId = "gpt-4";
         }, environmentKeys: Env("OPENAI_API_KEY", "sk-from-env"),
-           presets: new FakePresets(EnvPreset("openai", "OPENAI_API_KEY")));
+           presets: new FakePresets(EnvPreset("openai", "OPENAI_API_KEY")),
+           handler: handler);
 
-        // Resolves (OpenAI-compatible needs no key) but must NOT have picked up the environment credential.
+        // Asserted on the ABSENCE of a credential on the wire. Non-null resolution proves nothing here:
+        // OpenAI-compatible resolves with or without a key, so a version that borrowed the preset's key
+        // would have passed this test while sending someone else's credential to the reader's own gateway.
+        // (fable)
         var resolution = resolver.Resolve(out _);
         Assert.NotNull(resolution);
+
+        await foreach (var _ in resolution!.Provider.StreamAsync(
+            new ChatRequest("gpt-4", 256, null,
+                new[] { new ChatMessage(ChatRole.User, "hello") }), CancellationToken.None)) { }
+
+        Assert.False(handler.LastRequest!.Headers.Contains("Authorization"));
     }
 
     /// <summary>

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1399,7 +1399,9 @@ public partial class App : Application
         services.AddSingleton<Services.Ai.IChatProviderResolver>(sp => new Services.Ai.ChatProviderResolver(
             sp.GetRequiredService<ISettingsService>(),
             sp.GetService<Services.Ai.IAiCredentialStore>(),
-            sp.GetRequiredService<ILoggerFactory>()));
+            sp.GetRequiredService<ILoggerFactory>(),
+            sp.GetService<Services.Ai.Credentials.IAiEnvironmentKeys>(),
+            sp.GetService<Services.Ai.IAiPresetSource>()));
         services.AddSingleton<Services.Ai.IAiChatOrchestrator, Services.Ai.AiChatOrchestrator>();
 
         // Key storage (#579). Registered unconditionally: the store itself reports whether the platform has
@@ -1409,7 +1411,15 @@ public partial class App : Application
 
         // Endpoints the reader has configured (#689). Singleton because the UI binds to its ConnectionsChanged
         // event and every consumer must see the same list.
-        services.AddSingleton<Services.Ai.IAiConnectionService, Services.Ai.AiConnectionService>();
+        services.AddSingleton<Services.Ai.IAiConnectionService>(sp => new Services.Ai.AiConnectionService(
+            sp.GetRequiredService<ISettingsService>(),
+            sp.GetService<Services.Ai.IAiCredentialStore>(),
+            sp.GetService<Services.Ai.IAiPresetSource>(),
+            sp.GetService<Services.Ai.Credentials.IAiEnvironmentKeys>()));
+
+        // Vendor API keys the reader's environment already holds (#714). Discovery only — nothing here adopts
+        // a key; that is the reader's click, recorded on the connection.
+        services.AddSingleton<Services.Ai.Credentials.IAiEnvironmentKeys, Services.Ai.Credentials.AiEnvironmentKeys>();
 
         // The models.dev provider catalogue (#736). Singleton because it caches the document in memory and
         // holds the fetch gate; nothing user-visible depends on it yet (#737 turns it into presets).

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1447,7 +1447,8 @@ public partial class App : Application
         services.AddSingleton<Services.Ai.IAiModelCatalog>(sp => new Services.Ai.AiModelCatalog(
             new System.Net.Http.HttpClient(),
             sp.GetService<Services.Ai.IAiCredentialStore>(),
-            sp.GetRequiredService<ILoggerFactory>().CreateLogger<Services.Ai.AiModelCatalog>()));
+            sp.GetRequiredService<ILoggerFactory>().CreateLogger<Services.Ai.AiModelCatalog>(),
+            sp.GetService<Services.Ai.Credentials.IAiEnvironmentKeys>()));
 
         // Each connection's last model listing, so the Models tab opens on the provider's list rather than
         // on whatever the reader had saved. Beside models-dev.json rather than in settings.json: provider

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -152,7 +152,9 @@ namespace CST.Avalonia.Models.Ai
         CredentialSource KeySource = CredentialSource.None,
         Reachability State = Reachability.Configured,
         string AuthHeaderName = "Authorization",
-        string? AuthScheme = "Bearer")
+        string? AuthScheme = "Bearer",
+        bool UsesEnvironmentKey = false,
+        string? EnvironmentVariable = null)
     {
         /// <summary>The base URL with <see cref="Inputs"/> substituted in — what a request actually goes to.</summary>
         public string ResolvedBaseUrl => AiTemplate.Expand(BaseUrl, Inputs);

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -180,6 +180,16 @@ namespace CST.Avalonia.Models
         /// </summary>
         public bool UsesEnvironmentKey { get; set; }
 
+        /// <summary>
+        /// The environment variable the reader adopted, recorded at the moment they adopted it. (#714)
+        ///
+        /// <para>Pinned rather than re-derived. The preset's variable list comes from models.dev and is
+        /// refreshed: a reordering, or an alias added upstream that the reader happens to have set for
+        /// something else, would change which credential goes to this endpoint with no second consent — the
+        /// exact silent adoption this feature exists to prevent, arriving later instead of at the start.</para>
+        /// </summary>
+        public string? EnvironmentVariable { get; set; }
+
         public string DisplayName { get; set; } = "";
 
         /// <summary><c>anthropic</c> or <c>openai-compatible</c>. A string rather than the enum so a rename

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -161,6 +161,25 @@ namespace CST.Avalonia.Models
         /// </summary>
         public string? PresetId { get; set; }
 
+        /// <summary>
+        /// The reader opted in to the API key their environment already holds. (#714)
+        ///
+        /// <para><b>This flag is the opt-in itself.</b> Discovery is automatic and use is not: finding
+        /// <c>OPENAI_API_KEY</c> set makes a provider AVAILABLE, and only a reader's click makes it
+        /// authenticate. Recording that click is what separates this from OpenCode, which adopts an
+        /// environment key silently — producing a connected provider the maintainer had not configured, from
+        /// a variable he had forgotten was set on his own machine, with no way to disconnect it.</para>
+        ///
+        /// <para>The key itself is NEVER stored. It is read from the environment at the moment of use, so a
+        /// variable the reader changes or unsets takes effect immediately; a copy in the keychain would go on
+        /// authenticating with a credential they believe they have revoked, and a row sourced from the
+        /// environment offers no remove action to undo it with (#691).</para>
+        ///
+        /// <para>A connection with this set whose variable is no longer present reads as "no key", not as an
+        /// error — the reader unset it, which is a thing they are allowed to do.</para>
+        /// </summary>
+        public bool UsesEnvironmentKey { get; set; }
+
         public string DisplayName { get; set; } = "";
 
         /// <summary><c>anthropic</c> or <c>openai-compatible</c>. A string rather than the enum so a rename

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -217,30 +217,14 @@ namespace CST.Avalonia.Services.Ai
             // OrdinalIgnoreCase sends a model to the wrong connection. (kestrel-cst-2)
             var record = Chat.Connections.FirstOrDefault(
                 r => r is not null && IdMatches(r.Id, connectionId));
-            if (record is { UsesEnvironmentKey: true } && EnvironmentKeyFor(record) is not null)
+            if (record is not null
+                && AiEnvironmentCredential.For(
+                    record.UsesEnvironmentKey, record.EnvironmentVariable, _environmentKeys) is not null)
                 return CredentialSource.Environment;
 
             return CredentialSource.None;
         }
 
-        /// <summary>
-        /// The environment key a connection adopted, read at the moment of use, or null. (#714)
-        ///
-        /// <para>Never copied into the credential store. It belongs to the environment; a duplicate in our
-        /// keychain would survive the reader changing or unsetting the variable, so the app would go on
-        /// authenticating with a credential they believe they have revoked — and would offer no way to remove
-        /// it, since a row sourced from the environment shows no remove action (#691).</para>
-        /// </summary>
-        internal string? EnvironmentKeyFor(AiConnectionRecord record)
-        {
-            if (_environmentKeys is null || !record.UsesEnvironmentKey) return null;
-            // The recorded origin, never a guess from the id — #766's whole point. A custom endpoint records
-            // "" and must not be matched against a catalogue slug it happens to resemble, which is exactly how
-            // a reader's own connection would come to authenticate with someone else's environment key.
-            if (string.IsNullOrEmpty(record.PresetId)) return null;
-            var preset = Presets.FirstOrDefault(p => IdMatches(p.Id, record.PresetId));
-            return preset is null ? null : _environmentKeys.ValueFor(preset);
-        }
 
         public IReadOnlyList<AiProviderPreset> Presets =>
             _presets?.Presets ?? AiPresetSource.SnapshotDefaults;
@@ -709,7 +693,9 @@ namespace CST.Avalonia.Services.Ai
             SourceFor(r.Id),
             ReachabilityOf(r.Id),
             r.AuthHeaderName,
-            r.AuthScheme);
+            r.AuthScheme,
+            r.UsesEnvironmentKey,
+            r.EnvironmentVariable);
 
         /// <summary>
         /// Every credential name this connection could have filed a secret under. (#759)

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -212,8 +212,11 @@ namespace CST.Avalonia.Services.Ai
             // Adopted from the environment, and the variable still holds something. When it does not — unset
             // between sessions, or renamed — this falls through to None, which reads as "no key" rather than
             // as an error, because that is what it is.
+            // IdMatches, not Ordinal — one rule for id comparison in this file. The split it avoids is the
+            // mechanism behind #805, where the resolver comparing Ordinal against this service's
+            // OrdinalIgnoreCase sends a model to the wrong connection. (kestrel-cst-2)
             var record = Chat.Connections.FirstOrDefault(
-                r => r is not null && string.Equals(r.Id, connectionId, StringComparison.Ordinal));
+                r => r is not null && IdMatches(r.Id, connectionId));
             if (record is { UsesEnvironmentKey: true } && EnvironmentKeyFor(record) is not null)
                 return CredentialSource.Environment;
 

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CST.Avalonia.Models;
+using CST.Avalonia.Services.Ai.Credentials;
 using CST.Avalonia.Models.Ai;
 
 namespace CST.Avalonia.Services.Ai
@@ -133,6 +134,7 @@ namespace CST.Avalonia.Services.Ai
         private readonly ISettingsService _settings;
         private readonly IAiCredentialStore? _credentials;
         private readonly IAiPresetSource? _presets;
+        private readonly IAiEnvironmentKeys? _environmentKeys;
 
         /// <summary>
         /// Last-known reachability, in memory only.
@@ -153,11 +155,13 @@ namespace CST.Avalonia.Services.Ai
         public AiConnectionService(
             ISettingsService settings,
             IAiCredentialStore? credentials = null,
-            IAiPresetSource? presets = null)
+            IAiPresetSource? presets = null,
+            IAiEnvironmentKeys? environmentKeys = null)
         {
             _settings = settings;
             _credentials = credentials;
             _presets = presets;
+            _environmentKeys = environmentKeys;
 
             // The preset list changing is a change to what this service reports, so it reaches the UI on the
             // one event it already binds to rather than through a second channel.
@@ -187,10 +191,53 @@ namespace CST.Avalonia.Services.Ai
                 return _reachability.TryGetValue(connectionId, out var state) ? state : Reachability.Configured;
         }
 
-        private CredentialSource SourceFor(string connectionId) =>
-            _credentials?.Get(connectionId, AiCredentialNames.Primary) is not null
-                ? CredentialSource.Keychain
-                : CredentialSource.None;
+        /// <summary>
+        /// Where this connection's credential comes from. (#689, #714)
+        ///
+        /// <para><b>Stored wins.</b> Entering a key is a deliberate act and a variable in the environment is
+        /// often forgotten — the maintainer was surprised by one on his own machine — so a reader who typed a
+        /// key must not find the app quietly using something else instead. The reverse order would also make
+        /// the stored key unreachable without unsetting a variable, which is not something the app can offer
+        /// to do.</para>
+        ///
+        /// <para>A discovered credential counts only for a connection that was ADOPTED from the environment.
+        /// Discovery alone never makes a connection authenticated: that is the opt-in step, and this method
+        /// reports state rather than creating it.</para>
+        /// </summary>
+        private CredentialSource SourceFor(string connectionId)
+        {
+            if (_credentials?.Get(connectionId, AiCredentialNames.Primary) is not null)
+                return CredentialSource.Keychain;
+
+            // Adopted from the environment, and the variable still holds something. When it does not — unset
+            // between sessions, or renamed — this falls through to None, which reads as "no key" rather than
+            // as an error, because that is what it is.
+            var record = Chat.Connections.FirstOrDefault(
+                r => r is not null && string.Equals(r.Id, connectionId, StringComparison.Ordinal));
+            if (record is { UsesEnvironmentKey: true } && EnvironmentKeyFor(record) is not null)
+                return CredentialSource.Environment;
+
+            return CredentialSource.None;
+        }
+
+        /// <summary>
+        /// The environment key a connection adopted, read at the moment of use, or null. (#714)
+        ///
+        /// <para>Never copied into the credential store. It belongs to the environment; a duplicate in our
+        /// keychain would survive the reader changing or unsetting the variable, so the app would go on
+        /// authenticating with a credential they believe they have revoked — and would offer no way to remove
+        /// it, since a row sourced from the environment shows no remove action (#691).</para>
+        /// </summary>
+        internal string? EnvironmentKeyFor(AiConnectionRecord record)
+        {
+            if (_environmentKeys is null || !record.UsesEnvironmentKey) return null;
+            // The recorded origin, never a guess from the id — #766's whole point. A custom endpoint records
+            // "" and must not be matched against a catalogue slug it happens to resemble, which is exactly how
+            // a reader's own connection would come to authenticate with someone else's environment key.
+            if (string.IsNullOrEmpty(record.PresetId)) return null;
+            var preset = Presets.FirstOrDefault(p => IdMatches(p.Id, record.PresetId));
+            return preset is null ? null : _environmentKeys.ValueFor(preset);
+        }
 
         public IReadOnlyList<AiProviderPreset> Presets =>
             _presets?.Presets ?? AiPresetSource.SnapshotDefaults;

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
 using Microsoft.Extensions.Logging;
 
 namespace CST.Avalonia.Services.Ai
@@ -173,13 +174,17 @@ namespace CST.Avalonia.Services.Ai
 
         private readonly HttpClient _http;
         private readonly IAiCredentialStore? _credentials;
+        private readonly IAiEnvironmentKeys? _environmentKeys;
         private readonly ILogger<AiModelCatalog> _logger;
 
-        public AiModelCatalog(HttpClient http, IAiCredentialStore? credentials, ILogger<AiModelCatalog> logger)
+        public AiModelCatalog(
+            HttpClient http, IAiCredentialStore? credentials, ILogger<AiModelCatalog> logger,
+            IAiEnvironmentKeys? environmentKeys = null)
         {
             _http = http;
             _credentials = credentials;
             _logger = logger;
+            _environmentKeys = environmentKeys;
         }
 
         public async Task<AiCatalogResult> FetchAsync(AiConnection connection, CancellationToken ct = default)
@@ -396,7 +401,13 @@ namespace CST.Avalonia.Services.Ai
         /// </summary>
         private void Authenticate(HttpRequestMessage request, AiConnection connection)
         {
-            var key = _credentials?.Get(connection.Id, AiCredentialNames.Primary);
+            // Stored, then the environment — the SAME rule the chat path applies, through the same helper.
+            // Reading only the store here is the contradiction the summary above forbids: an adopted
+            // connection would answer a question and then fail to list its models, reporting "the provider
+            // rejected the stored key" for a connection that has no stored key. (#714, fable)
+            var key = _credentials?.Get(connection.Id, AiCredentialNames.Primary)
+                      ?? AiEnvironmentCredential.For(
+                          connection.UsesEnvironmentKey, connection.EnvironmentVariable, _environmentKeys);
             // Same rule as the chat path, for the same reason the summary above gives: the two surfaces send
             // the same credentials, so a secret header must resolve identically here or a provider's model
             // list would load while its answers 401. A secret is a literal, never a template. (#771)

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -307,7 +307,8 @@ public sealed class ChatProviderResolver : IChatProviderResolver
         // effect on the next request. Nothing is copied into the credential store — a duplicate there would
         // outlive the variable, and the row it came from offers no remove action to undo that with (#691).
         var apiKey = _credentials?.Get(connection.Id, AiCredentialNames.Primary)
-                     ?? EnvironmentKeyFor(connection);
+                     ?? AiEnvironmentCredential.For(
+                         connection.UsesEnvironmentKey, connection.EnvironmentVariable, _environmentKeys);
 
         switch (kind)
         {
@@ -377,24 +378,6 @@ public sealed class ChatProviderResolver : IChatProviderResolver
                 kind = default;
                 return false;
         }
-    }
-
-    /// <summary>
-    /// The key an environment-adopted connection authenticates with, or null. (#714)
-    ///
-    /// <para>Requires BOTH the reader's recorded opt-in and a preset origin that was recorded rather than
-    /// guessed: a custom endpoint records an empty origin and must never be matched against a catalogue slug
-    /// it happens to resemble, which is how a reader's own connection would come to authenticate with someone
-    /// else's key (#766).</para>
-    /// </summary>
-    private string? EnvironmentKeyFor(AiConnectionRecord connection)
-    {
-        if (_environmentKeys is null || !connection.UsesEnvironmentKey) return null;
-        if (string.IsNullOrEmpty(connection.PresetId)) return null;
-
-        var preset = _presets?.Presets.FirstOrDefault(
-            p => string.Equals(p.Id, connection.PresetId, StringComparison.OrdinalIgnoreCase));
-        return preset is null ? null : NullIfBlank(_environmentKeys.ValueFor(preset));
     }
 
     private static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using CST.Avalonia.Models;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
 using Microsoft.Extensions.Logging;
 
 namespace CST.Avalonia.Services.Ai;
@@ -144,12 +146,16 @@ public sealed class ChatProviderResolver : IChatProviderResolver
     private readonly IAiCredentialStore? _credentials;
     private readonly ILoggerFactory _loggerFactory;
     private readonly HttpClient _http;
+    private readonly IAiEnvironmentKeys? _environmentKeys;
+    private readonly IAiPresetSource? _presets;
 
     public ChatProviderResolver(
         ISettingsService settings,
         IAiCredentialStore? credentials,
-        ILoggerFactory loggerFactory)
-        : this(settings, credentials, loggerFactory, CreateHttpClient())
+        ILoggerFactory loggerFactory,
+        IAiEnvironmentKeys? environmentKeys = null,
+        IAiPresetSource? presets = null)
+        : this(settings, credentials, loggerFactory, CreateHttpClient(), environmentKeys, presets)
     {
     }
 
@@ -158,12 +164,16 @@ public sealed class ChatProviderResolver : IChatProviderResolver
         ISettingsService settings,
         IAiCredentialStore? credentials,
         ILoggerFactory loggerFactory,
-        HttpClient http)
+        HttpClient http,
+        IAiEnvironmentKeys? environmentKeys = null,
+        IAiPresetSource? presets = null)
     {
         _settings = settings;
         _credentials = credentials;
         _loggerFactory = loggerFactory;
         _http = http;
+        _environmentKeys = environmentKeys;
+        _presets = presets;
     }
 
     /// <summary>
@@ -289,7 +299,15 @@ public sealed class ChatProviderResolver : IChatProviderResolver
             return null;
         }
 
-        var apiKey = _credentials?.Get(connection.Id, AiCredentialNames.Primary);
+        // Stored first, then the environment. Order matters and is not arbitrary: entering a key is a
+        // deliberate act, a variable is often forgotten, and a reader who typed one must not find the app
+        // quietly authenticating with something else. (#714)
+        //
+        // Read at the moment of use rather than cached, so a variable the reader changes or unsets takes
+        // effect on the next request. Nothing is copied into the credential store — a duplicate there would
+        // outlive the variable, and the row it came from offers no remove action to undo that with (#691).
+        var apiKey = _credentials?.Get(connection.Id, AiCredentialNames.Primary)
+                     ?? EnvironmentKeyFor(connection);
 
         switch (kind)
         {
@@ -359,6 +377,24 @@ public sealed class ChatProviderResolver : IChatProviderResolver
                 kind = default;
                 return false;
         }
+    }
+
+    /// <summary>
+    /// The key an environment-adopted connection authenticates with, or null. (#714)
+    ///
+    /// <para>Requires BOTH the reader's recorded opt-in and a preset origin that was recorded rather than
+    /// guessed: a custom endpoint records an empty origin and must never be matched against a catalogue slug
+    /// it happens to resemble, which is how a reader's own connection would come to authenticate with someone
+    /// else's key (#766).</para>
+    /// </summary>
+    private string? EnvironmentKeyFor(AiConnectionRecord connection)
+    {
+        if (_environmentKeys is null || !connection.UsesEnvironmentKey) return null;
+        if (string.IsNullOrEmpty(connection.PresetId)) return null;
+
+        var preset = _presets?.Presets.FirstOrDefault(
+            p => string.Equals(p.Id, connection.PresetId, StringComparison.OrdinalIgnoreCase));
+        return preset is null ? null : NullIfBlank(_environmentKeys.ValueFor(preset));
     }
 
     private static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiEnvironmentCredential.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiEnvironmentCredential.cs
@@ -1,0 +1,29 @@
+namespace CST.Avalonia.Services.Ai.Credentials;
+
+/// <summary>
+/// The one place that decides whether a connection authenticates from the environment. (#714)
+///
+/// <para><b>Shared because two copies disagreed.</b> The first version of this work implemented the rule in
+/// the chat resolver and in the connection service, and left the model-listing path reading the credential
+/// store alone — so an adopted connection could answer a question and fail to list its models, reporting
+/// <i>"the provider rejected the stored key"</i> for a connection that has no stored key. That contradiction
+/// between two surfaces is what #673 exists to prevent, and <c>AiModelCatalog.Authenticate</c>'s own comment
+/// says as much, two lines above the code that had it. (fable)</para>
+/// </summary>
+internal static class AiEnvironmentCredential
+{
+    /// <summary>
+    /// The adopted key, or null.
+    ///
+    /// <para>Requires the reader's recorded opt-in AND the variable they consented to. Reading the recorded
+    /// name rather than re-deriving it from the preset is what keeps a catalogue refresh from silently
+    /// changing which credential goes to this endpoint.</para>
+    /// </summary>
+    internal static string? For(bool usesEnvironmentKey, string? variableName, IAiEnvironmentKeys? keys)
+    {
+        if (!usesEnvironmentKey || keys is null) return null;
+        if (string.IsNullOrWhiteSpace(variableName)) return null;
+        var value = keys.Read(variableName!);
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+}

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiEnvironmentKeys.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiEnvironmentKeys.cs
@@ -47,6 +47,17 @@ public interface IAiEnvironmentKeys
 
     /// <summary>Every preset whose declared variables are satisfied right now.</summary>
     IReadOnlyList<AiEnvironmentKey> Discover(IEnumerable<AiProviderPreset> presets);
+
+    /// <summary>
+    /// The value of one named variable, or null when it is unset or empty. (#714)
+    ///
+    /// <para>This is what an adopted connection reads, and it takes the NAME the reader consented to rather
+    /// than re-deriving it from the preset. The catalogue's <c>env</c> lists are refreshed from models.dev:
+    /// a reordering, or a newly added alias the reader happens to have set for something else entirely, would
+    /// otherwise change which credential goes to the recorded endpoint — silently, with no second consent,
+    /// which is the precise property this feature exists to prevent. (fable)</para>
+    /// </summary>
+    string? Read(string variableName);
 }
 
 /// <inheritdoc />
@@ -60,6 +71,10 @@ public sealed class AiEnvironmentKeys : IAiEnvironmentKeys
     internal AiEnvironmentKeys(Func<string, string?> read) => _read = read;
 
     /// <inheritdoc />
+    public string? Read(string variableName) =>
+        string.IsNullOrWhiteSpace(variableName) ? null : ReadRaw(variableName);
+
+    /// <inheritdoc />
     public string? VariableFor(AiProviderPreset preset)
     {
         if (preset is null) return null;
@@ -70,7 +85,7 @@ public sealed class AiEnvironmentKeys : IAiEnvironmentKeys
         foreach (var name in preset.EnvironmentVariables)
         {
             if (string.IsNullOrWhiteSpace(name)) continue;
-            if (!string.IsNullOrWhiteSpace(Read(name))) return name;
+            if (!string.IsNullOrWhiteSpace(ReadRaw(name))) return name;
         }
         return null;
     }
@@ -79,7 +94,7 @@ public sealed class AiEnvironmentKeys : IAiEnvironmentKeys
     public string? ValueFor(AiProviderPreset preset)
     {
         var name = VariableFor(preset);
-        return name is null ? null : Read(name);
+        return name is null ? null : ReadRaw(name);
     }
 
     /// <inheritdoc />
@@ -95,7 +110,7 @@ public sealed class AiEnvironmentKeys : IAiEnvironmentKeys
     // or a CI runner that defines every name it knows — would otherwise read as a key that is present, and
     // offering to connect with it produces an authentication failure the reader cannot explain, from a
     // variable they did not know they had.
-    private string? Read(string name)
+    private string? ReadRaw(string name)
     {
         try
         {

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiEnvironmentKeys.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiEnvironmentKeys.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CST.Avalonia.Models.Ai;
+
+namespace CST.Avalonia.Services.Ai.Credentials;
+
+/// <summary>
+/// A vendor API key found in the environment, and the variable it came from. (#714)
+/// </summary>
+/// <param name="PresetId">The preset whose declared variables matched.</param>
+/// <param name="VariableName">
+/// The variable holding it — the NAME only. The value is never carried in this record, never logged, and never
+/// written anywhere: it is read at the moment of use and discarded. A discovered credential belongs to the
+/// environment, and a copy in our keychain would go stale the moment the reader changed or unset the variable,
+/// leaving the app authenticating with something the reader believes they have revoked.
+/// </param>
+public sealed record AiEnvironmentKey(string PresetId, string VariableName);
+
+/// <summary>
+/// Finds vendor API keys the reader's environment already holds — <c>OPENAI_API_KEY</c>,
+/// <c>ANTHROPIC_API_KEY</c>, and the rest. (#714)
+///
+/// <para><b>Discovery is automatic; use is not.</b> This service only reports what is there. Nothing here
+/// creates a connection or authenticates anything, and that separation is the whole point: OpenCode adopts an
+/// environment key silently, which produced a connected provider the maintainer had not configured, from a
+/// variable he had forgotten was set on his own machine — and then offered no way to disconnect it, because an
+/// app cannot delete a credential it never stored. The opt-in step exists so that spending a reader's money is
+/// something they chose.</para>
+/// </summary>
+public interface IAiEnvironmentKeys
+{
+    /// <summary>
+    /// The variable currently holding a key for this preset, in the preset's declared precedence order, or
+    /// null when none is set. Name only.
+    /// </summary>
+    string? VariableFor(AiProviderPreset preset);
+
+    /// <summary>
+    /// The key itself, read from the environment at the moment of use.
+    ///
+    /// <para>Deliberately not cached. A variable can change or be unset between one request and the next, and
+    /// a cached copy would keep authenticating with a credential the reader thinks is gone. Reading twice
+    /// costs a dictionary lookup.</para>
+    /// </summary>
+    string? ValueFor(AiProviderPreset preset);
+
+    /// <summary>Every preset whose declared variables are satisfied right now.</summary>
+    IReadOnlyList<AiEnvironmentKey> Discover(IEnumerable<AiProviderPreset> presets);
+}
+
+/// <inheritdoc />
+public sealed class AiEnvironmentKeys : IAiEnvironmentKeys
+{
+    private readonly Func<string, string?> _read;
+
+    public AiEnvironmentKeys() : this(Environment.GetEnvironmentVariable) { }
+
+    /// <summary>Test seam. The real reader is <see cref="Environment.GetEnvironmentVariable(string)"/>.</summary>
+    internal AiEnvironmentKeys(Func<string, string?> read) => _read = read;
+
+    /// <inheritdoc />
+    public string? VariableFor(AiProviderPreset preset)
+    {
+        if (preset is null) return null;
+
+        // Precedence order is the preset's own: Google alone answers to GOOGLE_API_KEY,
+        // GOOGLE_GENERATIVE_AI_API_KEY and GEMINI_API_KEY, and which one wins is the catalogue's decision,
+        // not ours. First one set, wins.
+        foreach (var name in preset.EnvironmentVariables)
+        {
+            if (string.IsNullOrWhiteSpace(name)) continue;
+            if (!string.IsNullOrWhiteSpace(Read(name))) return name;
+        }
+        return null;
+    }
+
+    /// <inheritdoc />
+    public string? ValueFor(AiProviderPreset preset)
+    {
+        var name = VariableFor(preset);
+        return name is null ? null : Read(name);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<AiEnvironmentKey> Discover(IEnumerable<AiProviderPreset> presets) =>
+        (presets ?? Array.Empty<AiProviderPreset>())
+            .Where(p => p is not null)
+            .Select(p => (preset: p, variable: VariableFor(p)))
+            .Where(t => t.variable is not null)
+            .Select(t => new AiEnvironmentKey(t.preset.Id, t.variable!))
+            .ToList();
+
+    // Whitespace is not a credential. A variable exported empty — `export OPENAI_API_KEY=` in a shell profile,
+    // or a CI runner that defines every name it knows — would otherwise read as a key that is present, and
+    // offering to connect with it produces an authentication failure the reader cannot explain, from a
+    // variable they did not know they had.
+    private string? Read(string name)
+    {
+        try
+        {
+            var value = _read(name);
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+        catch
+        {
+            // A platform that refuses to read the environment is "no key", not a crash on the settings screen.
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
The backend half of #714. **The discovery UI and the opt-in click are not here** — see the handoff note at the end.

## Discovery is automatic; use is not

That separation is the feature, not an implementation detail. The maintainer watched OpenCode pick up a Google API key he had **forgotten was set on his own machine**, producing a connected provider he had not configured — and then found no way to disconnect it, because an app cannot delete a credential it never stored. Our readers mostly did not set these variables, and the consequence of adopting one silently is spending their money.

So `AiEnvironmentKeys` only **reports**. It reads each preset's declared variables in the preset's own precedence order — Google alone answers to `GOOGLE_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY` and `GEMINI_API_KEY` — and says which one holds a value. Nothing in this PR creates a connection or authenticates anything.

## The opt-in is a persisted flag

`AiConnectionRecord.UsesEnvironmentKey`, set when the reader chooses to adopt a discovered key. Only a connection carrying it authenticates from the environment.

It must **also** carry a recorded preset origin. A custom endpoint records `""` (#766) and must never be matched against a catalogue slug it happens to resemble — that is how a reader's own gateway would come to authenticate with someone else's key.

## Three rules, decided here and open to argument

All three were listed as open questions on the issue. Marked as my decisions, not the maintainer's:

**Stored wins over the environment.** Entering a key is a deliberate act; a variable is often forgotten. A reader who typed one must not find the app quietly using something else. The reverse order would also make the stored key unreachable without unsetting a variable, which the app cannot offer to do.

**The value is read at the moment of use and never copied into the keychain.** A duplicate there would outlive the variable, so the app would go on authenticating with a credential the reader believes they revoked — and the row it came from offers no remove action to undo that with (#691).

**A variable that disappears reads as "no key", not an error.** The reader unset it, which they are allowed to do.

Plus one that was not asked but bites in practice: **an empty export is not a credential.** `export OPENAI_API_KEY=` in a shell profile, or a CI runner defining every name it knows, would otherwise read as a key that is present — and offering to connect with it produces an authentication failure the reader cannot explain, from a variable they did not know they had.

## Verified by mutation

- Ignoring the opt-in → `A_connection_that_did_not_opt_in_does_not_use_the_environment_key` fails.
- Reversing the precedence → `A_stored_key_wins_over_one_in_the_environment` fails — **after I rewrote it.** Its first version asserted only that resolution succeeded, and both keys resolve, so it passed with the precedence reversed. It now asserts the credential that reaches the endpoint.

Full suite: **2496 passed, 0 failed, 17 skipped.**

## Not addressed, and deliberately

- **Permanent decline.** Without it a declined key reappears in the available list every launch. It needs persisted state and a UI affordance, and the issue lists it as undecided.
- **Bedrock does not fit the pattern.** Its credentials come from the whole AWS chain — `~/.aws/credentials`, SSO, instance roles — so *absence of environment variables does not mean absence of credentials* (#702). Any "is a credential available?" check that only reads env vars is wrong precisely where Bedrock is most likely to be in use. Nothing here claims otherwise, but a UI that renders "no credential found" per provider must not say it about Bedrock.
- No `CST_AI_*` variables of our own — struck from #689 and out of scope.

## Handoff

The UI half goes to kestrel-cst-2. The surface it needs:

- `IAiEnvironmentKeys.Discover(presets)` → `AiEnvironmentKey(PresetId, VariableName)` for every preset whose variable is set.
- Set `AiConnectionRecord.UsesEnvironmentKey` when the reader adopts one; that click **is** the opt-in.
- `AiConnection.KeySource` already reports `CredentialSource.Environment` for an adopted connection whose variable is still present, which is what #691's no-remove-action row keys off.
- **Never display the value.** The record carries the variable NAME only, and nothing should log or render the secret.