### PR TITLE
Offer the keys the environment already holds, and adopt none (#714)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -8,6 +8,7 @@ using CST.Avalonia.Models;
 using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services;
 using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
 using CST.Avalonia.ViewModels;
 using Moq;
 using Xunit;
@@ -801,6 +802,194 @@ public class AiConnectionsViewModelTests
             Assert.InRange(tone, 0, AiMonogram.ToneCount - 1);
             Assert.Equal(tone, AiMonogram.ToneFor(id));
         }
+    }
+
+    // ---- keys the environment already holds (#714) -------------------------------------------------------
+
+    /// <summary>An environment holding exactly the variables a test names.</summary>
+    private static IAiEnvironmentKeys Env(params string[] set)
+    {
+        var present = new HashSet<string>(set, StringComparer.Ordinal);
+        return new AiEnvironmentKeys(name => present.Contains(name) ? "sk-not-rendered-anywhere" : null);
+    }
+
+    private static AiProviderPreset EnvPreset(
+        string id, string display, string[] variables, IReadOnlyList<AiInputPrompt>? prompts = null) =>
+        new(id, display, ChatProviderKind.OpenAiCompatible, "https://" + id + ".example/v1",
+            new List<AiCredentialMethod> { new AiCredentialMethod.Env(variables) },
+            Prompts: prompts);
+
+    private static (AiConnectionsViewModel Vm, AiConnectionService Service) MakeWithEnv(
+        IAiEnvironmentKeys env, params AiProviderPreset[] presets)
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var keys = new FakeCredentialStore();
+        var source = new StubPresets(AiPresetState.Ready, null, presets);
+        var service = new AiConnectionService(svc.Object, keys, source, env);
+        return (new AiConnectionsViewModel(service, keys, null, env), service);
+    }
+
+    /// <summary>A provider whose variable is set is offered — by NAME, and with nothing adopted yet.</summary>
+    [Fact]
+    public void A_provider_whose_variable_is_set_is_offered_but_not_adopted()
+    {
+        var (vm, service) = MakeWithEnv(
+            Env("OPENAI_API_KEY"), EnvPreset("openai", "OpenAI", new[] { "OPENAI_API_KEY" }));
+
+        var row = Assert.Single(vm.FoundKeys);
+        Assert.True(vm.HasFoundKeys);
+        Assert.Equal("OpenAI", row.DisplayName);
+        Assert.Equal("Key in OPENAI_API_KEY", row.VariableText);
+
+        // Discovery alone creates nothing. This is the whole difference from the behaviour that prompted the
+        // issue: a provider connected without the reader ever choosing it.
+        Assert.Empty(service.Connections);
+    }
+
+    /// <summary>The value never reaches the row. The variable's name is the whole of what is carried.</summary>
+    [Fact]
+    public void The_key_itself_is_never_carried_into_the_row()
+    {
+        var (vm, _) = MakeWithEnv(
+            Env("OPENAI_API_KEY"), EnvPreset("openai", "OpenAI", new[] { "OPENAI_API_KEY" }));
+
+        var row = Assert.Single(vm.FoundKeys);
+        var rendered = string.Join("|", row.DisplayName, row.VariableName, row.VariableText, row.Monogram);
+        Assert.DoesNotContain("sk-not-rendered-anywhere", rendered, StringComparison.Ordinal);
+    }
+
+    /// <summary>Nothing set, nothing offered — and no empty section explaining an absence.</summary>
+    [Fact]
+    public void An_environment_holding_nothing_offers_nothing()
+    {
+        var (vm, _) = MakeWithEnv(Env(), EnvPreset("openai", "OpenAI", new[] { "OPENAI_API_KEY" }));
+
+        Assert.Empty(vm.FoundKeys);
+        Assert.False(vm.HasFoundKeys);
+    }
+
+    /// <summary>
+    /// Absence of a variable is never rendered as absence of a credential. Bedrock authenticates through the
+    /// whole AWS chain — ~/.aws/credentials, SSO, instance roles — so "no key found" would be confidently
+    /// wrong exactly where it is most likely to be in use (#702). The section can only ADD a row for
+    /// something present, so there is no shape in which it can say that.
+    /// </summary>
+    [Fact]
+    public void A_provider_with_no_variable_set_gets_no_row_at_all_rather_than_a_negative_one()
+    {
+        var (vm, _) = MakeWithEnv(
+            Env("OPENAI_API_KEY"),
+            EnvPreset("openai", "OpenAI", new[] { "OPENAI_API_KEY" }),
+            EnvPreset("amazon-bedrock", "Amazon Bedrock", new[] { "AWS_ACCESS_KEY_ID" }));
+
+        var row = Assert.Single(vm.FoundKeys);
+        Assert.Equal("openai", row.Id);
+    }
+
+    /// <summary>Pressing the button is what adopts it — and the opt-in is what gets recorded.</summary>
+    [Fact]
+    public void Using_a_found_key_adopts_it_and_records_the_opt_in()
+    {
+        var (vm, service) = MakeWithEnv(
+            Env("OPENAI_API_KEY"), EnvPreset("openai", "OpenAI", new[] { "OPENAI_API_KEY" }));
+
+        Assert.Single(vm.FoundKeys).UseCommand.Execute().Subscribe();
+
+        var connection = Assert.Single(service.Connections);
+        Assert.Equal("openai", connection.Id);
+        Assert.Equal(CredentialSource.Environment, connection.KeySource);
+
+        // The variable the reader was SHOWN is the one recorded. Re-deriving it from the preset on each
+        // request would let a models.dev reordering change which credential a recorded connection uses,
+        // months later and with no second consent — the very thing this feature exists to prevent, arriving
+        // late instead of at the start. (fable, on #813)
+        Assert.Equal("OPENAI_API_KEY", connection.EnvironmentVariable);
+
+        // And it leaves the offer list, because it is no longer an available preset.
+        Assert.Empty(vm.FoundKeys);
+    }
+
+    /// <summary>
+    /// A preset that needs an answer cannot be adopted in one click, so it opens the sheet rather than
+    /// failing. Azure wants a resource name and Cloudflare an account id, and both declare environment
+    /// variables — adopting either without asking would create a connection whose address still has a hole
+    /// in it.
+    /// </summary>
+    [Fact]
+    public void A_provider_that_needs_an_answer_opens_the_sheet_instead_of_adopting_blind()
+    {
+        var (vm, service) = MakeWithEnv(
+            Env("AZURE_API_KEY"),
+            EnvPreset("azure", "Azure", new[] { "AZURE_API_KEY" },
+                new List<AiInputPrompt> { new("resourceName", "Resource name") }));
+
+        Assert.Single(vm.FoundKeys).UseCommand.Execute().Subscribe();
+
+        Assert.NotNull(vm.Editor);
+        Assert.Empty(service.Connections);
+        Assert.Null(vm.Problem);
+    }
+
+    /// <summary>
+    /// A provider the reader has already configured is not offered, whatever their environment holds. That
+    /// decision is made, and re-offering it would be the nagging this section is shaped to avoid.
+    /// </summary>
+    [Fact]
+    public void An_already_configured_provider_is_not_offered()
+    {
+        var (vm, service) = MakeWithEnv(
+            Env("OPENAI_API_KEY"), EnvPreset("openai", "OpenAI", new[] { "OPENAI_API_KEY" }));
+
+        // No manual refresh: adding raises ConnectionsChanged, which is what the tab binds to.
+        service.AddFromPreset("openai", new Dictionary<string, string>());
+
+        Assert.Empty(vm.FoundKeys);
+    }
+
+    /// <summary>
+    /// The section is not filtered by the catalogue search. Typing to find a provider must not take away the
+    /// block that says a key for it is already on the machine.
+    /// </summary>
+    [Fact]
+    public void Searching_the_catalogue_does_not_hide_a_found_key()
+    {
+        var (vm, _) = MakeWithEnv(
+            Env("OPENAI_API_KEY"), EnvPreset("openai", "OpenAI", new[] { "OPENAI_API_KEY" }));
+
+        vm.PresetSearch = "something that matches no provider";
+
+        Assert.Single(vm.FoundKeys);
+        Assert.True(vm.HasFoundKeys);
+    }
+
+    /// <summary>
+    /// A variable unset between one look and the next stops being offered, rather than lingering from a
+    /// cached answer. Reading the environment fresh on every rebind is what makes that true.
+    /// </summary>
+    [Fact]
+    public void A_variable_that_disappears_stops_being_offered()
+    {
+        var present = new HashSet<string>(StringComparer.Ordinal) { "OPENAI_API_KEY" };
+        var env = new AiEnvironmentKeys(name => present.Contains(name) ? "sk-x" : null);
+
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var keys = new FakeCredentialStore();
+        var service = new AiConnectionService(
+            svc.Object, keys,
+            new StubPresets(AiPresetState.Ready, null, EnvPreset("openai", "OpenAI", new[] { "OPENAI_API_KEY" })),
+            env);
+        var vm = new AiConnectionsViewModel(service, keys, null, env);
+
+        Assert.Single(vm.FoundKeys);
+
+        present.Clear();
+        vm.PresetSearch = " ";   // any rebind will do; this is one a reader can cause
+
+        Assert.Empty(vm.FoundKeys);
     }
 }
 

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -76,7 +76,27 @@ namespace CST.Avalonia.Services.Ai
         /// <summary>Creates a connection from a preset, with its base URL, kind and headers pre-filled.</summary>
         /// <param name="inputs">Answers to the preset's <see cref="AiProviderPreset.Prompts"/> — resource
         /// name, account id and so on. Pass an empty dictionary when the preset asks for nothing.</param>
-        AiConnectionResult AddFromPreset(string presetId, IReadOnlyDictionary<string, string> inputs);
+        /// <param name="environmentVariable">
+        /// The environment variable the reader chose to authenticate with, or null for the ordinary path.
+        /// (#714)
+        ///
+        /// <para><b>The NAME is the opt-in, not a flag beside it.</b> Discovery is automatic and adoption is
+        /// not: finding a variable set makes a provider available, and only this — passed from a click — makes
+        /// anything authenticate with it. Carrying the name rather than a boolean means a consent with nothing
+        /// recorded cannot be expressed at all, where a flag-plus-name pair can be half-set and has to be
+        /// defended against downstream.</para>
+        ///
+        /// <para>It is the name the reader was SHOWN, passed down from the row they pressed — not one
+        /// re-derived from the preset here. The preset's variable list is refreshed from models.dev, so
+        /// re-deriving it would let a reordering upstream change which credential a recorded connection uses,
+        /// months later and with no second consent. That is the property this feature exists to prevent,
+        /// arriving late instead of at the start. (fable, on #813)</para>
+        ///
+        /// <para>Defaulted null so every existing caller keeps the behaviour it had, and so adopting is
+        /// something a caller has to say rather than something it can fall into.</para>
+        /// </param>
+        AiConnectionResult AddFromPreset(
+            string presetId, IReadOnlyDictionary<string, string> inputs, string? environmentVariable = null);
 
         /// <summary>Edits everything except the id, which is immutable because the credential is filed under it.</summary>
         AiConnectionResult Update(string id, AiConnectionDraft draft);
@@ -265,7 +285,8 @@ namespace CST.Avalonia.Services.Ai
             return Saved(record);
         }
 
-        public AiConnectionResult AddFromPreset(string presetId, IReadOnlyDictionary<string, string> inputs)
+        public AiConnectionResult AddFromPreset(
+            string presetId, IReadOnlyDictionary<string, string> inputs, string? environmentVariable = null)
         {
             var preset = Presets.FirstOrDefault(p => IdMatches(p.Id, presetId));
             if (preset is null) return AiConnectionResult.Fail($"'{presetId}' is not a known provider.");
@@ -317,6 +338,11 @@ namespace CST.Avalonia.Services.Ai
                     .Where(pair => !secretKeys.Contains(pair.Key, StringComparer.Ordinal))
                     .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal),
                 SecretInputs = secretKeys.Count > 0 ? secretKeys : null,
+                // Recorded only where the caller asked for it, and the two fields are set from ONE value so
+                // they cannot disagree. Nothing here consults the environment: this stores the reader's
+                // decision, and the decision is the feature. (#714)
+                UsesEnvironmentKey = environmentVariable is not null,
+                EnvironmentVariable = environmentVariable,
                 AuthHeaderName = preset.AuthHeaderName,
                 AuthScheme = preset.AuthScheme,
             };

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -43,6 +43,10 @@ namespace CST.Avalonia.ViewModels
         private readonly IAiCredentialStore? _credentials;
         private readonly Action<bool> _close;
         private readonly AiProviderPreset? _preset;
+
+        /// <summary>The environment variable this connection was opened to adopt, or null. Name only — the
+        /// value is never read here, never rendered and never stored. (#714)</summary>
+        private string? _adoptEnvironmentVariable;
         private readonly string? _existingId;
         private readonly bool _keyRequired;
 
@@ -152,12 +156,22 @@ namespace CST.Avalonia.ViewModels
         /// is one form driven by data rather than a hand-written dialog per provider. A provider arriving in a
         /// later upstream sync needing a field we have never heard of gets a working dialog for free.</para>
         /// </summary>
+        /// <param name="adoptEnvironmentKey">
+        /// Opened from the "Found in your environment" section, so this connection will authenticate with the
+        /// variable the reader's machine already holds. (#714)
+        ///
+        /// <para>Azure and Cloudflare are why this path exists at all: both declare environment variables AND
+        /// need a prompt answered, so neither can be adopted in one click. The sheet asks for what is missing
+        /// and carries the reader's choice through to the save — it does not re-ask it, because they made it
+        /// by pressing a button that named the variable.</para>
+        /// </param>
         public static AiConnectionEditorViewModel ForPreset(
             IAiConnectionService service, IAiCredentialStore? credentials, AiProviderPreset preset,
-            Action<bool> close)
+            Action<bool> close, string? adoptEnvironmentKey = null)
         {
             var vm = new AiConnectionEditorViewModel(service, credentials, close, preset, null)
             {
+                _adoptEnvironmentVariable = adoptEnvironmentKey,
                 _id = preset.Id,
                 _displayName = preset.DisplayName,
                 _baseUrl = preset.BaseUrl,
@@ -407,8 +421,26 @@ namespace CST.Avalonia.ViewModels
         /// and no key can be filed by any route on that machine, so a refusal on top of the explanation would
         /// leave the reader nowhere to go — a row that cannot answer is the lesser evil there.</para>
         /// </summary>
+        /// <para><b>Nor where the reader is adopting the key their environment already holds.</b> They have a
+        /// key; it simply is not one we store. Demanding a typed one here would refuse the very thing the
+        /// button they pressed offered to do. (#714)</para>
         private bool MissingRequiredKey =>
-            _keyRequired && CanStoreKeys && string.IsNullOrWhiteSpace(ApiKeyEntry) && !HasStoredKey;
+            _keyRequired && CanStoreKeys && _adoptEnvironmentVariable is null
+            && string.IsNullOrWhiteSpace(ApiKeyEntry) && !HasStoredKey;
+
+        /// <summary>
+        /// The variable this sheet was opened to adopt, named for the reader. (#714)
+        ///
+        /// <para>The NAME, never the value. A settings screen that prints a credential is the last thing this
+        /// app should grow, and the name is the whole of what the reader needs in order to recognise — or
+        /// disown — the key that is about to be used.</para>
+        /// </summary>
+        public string? EnvironmentKeyNote => _adoptEnvironmentVariable is null
+            ? null
+            : $"This connection will use the key in {_adoptEnvironmentVariable}. "
+              + "It stays in your environment — nothing is copied here.";
+
+        public bool HasEnvironmentKeyNote => EnvironmentKeyNote is not null;
 
         /// <summary>
         /// A header marked secret with nothing to store and nothing already stored. (#771)
@@ -565,7 +597,9 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         private AiConnectionResult AddPreset(IReadOnlyDictionary<string, string> inputs)
         {
-            var added = _service.AddFromPreset(_preset!.Id, inputs);
+            // The name the reader was shown on the row they pressed, carried through the sheet unchanged.
+            var added = _service.AddFromPreset(
+                _preset!.Id, inputs, environmentVariable: _adoptEnvironmentVariable);
             if (!added.Ok || added.Connection is not { } created) return added;
 
             var models = TypedModels();

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Avalonia.Threading;
 using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
 using ReactiveUI;
 
 namespace CST.Avalonia.ViewModels
@@ -35,6 +36,7 @@ namespace CST.Avalonia.ViewModels
         private readonly IAiConnectionService? _service;
         private readonly IAiCredentialStore? _credentials;
         private readonly IAiProviderLogos? _logos;
+        private readonly IAiEnvironmentKeys? _environmentKeys;
         private AiConnectionEditorViewModel? _editor;
         private string? _problem;
         private string _presetSearch = "";
@@ -43,11 +45,13 @@ namespace CST.Avalonia.ViewModels
         public AiConnectionsViewModel(
             IAiConnectionService? service,
             IAiCredentialStore? credentials = null,
-            IAiProviderLogos? logos = null)
+            IAiProviderLogos? logos = null,
+            IAiEnvironmentKeys? environmentKeys = null)
         {
             _service = service;
             _credentials = credentials;
             _logos = logos;
+            _environmentKeys = environmentKeys;
 
             AddCustomCommand = ReactiveCommand.Create(AddCustom);
             RetryCatalogueCommand = ReactiveCommand.CreateFromTask(RetryCatalogueAsync);
@@ -81,6 +85,29 @@ namespace CST.Avalonia.ViewModels
         /// provider.</para>
         /// </summary>
         public ObservableCollection<AiPresetRowViewModel> AvailablePresets { get; } = new();
+
+        /// <summary>
+        /// Providers this machine already holds a key for, and has not been told to use. (#714)
+        ///
+        /// <para><b>Its own section rather than a note on a catalogue row.</b> The catalogue is a search box
+        /// over more than a hundred and sixty providers, so a line on a row is only ever read by someone who
+        /// already went looking — which is precisely not the reader this exists for: the one who does not
+        /// know the variable is set. That reader was the case in view. Above the search box, it is seen
+        /// without being asked for.</para>
+        ///
+        /// <para><b>And nothing more than a list with a button.</b> No banner, no badge, no dismissal. There
+        /// is nothing to decline because nothing is being pressed on the reader: it states what is on their
+        /// machine and offers to use it, on a settings tab they opened deliberately. A "not now" would need
+        /// somewhere to be stored, a way back, and an answer to what happens when the variable changes — all
+        /// to suppress a two-line block nobody has to act on.</para>
+        ///
+        /// <para>Drawn from <see cref="IAiConnectionService.AvailablePresets"/>, so a provider the reader has
+        /// already configured never appears here — whatever their environment holds, that decision is made.
+        /// </para>
+        /// </summary>
+        public ObservableCollection<AiEnvironmentRowViewModel> FoundKeys { get; } = new();
+
+        public bool HasFoundKeys => FoundKeys.Count > 0;
 
         /// <summary>True while nothing is configured, so the empty state can say so rather than showing a
         /// blank area above a catalogue and leaving the reader to infer it.</summary>
@@ -239,6 +266,39 @@ namespace CST.Avalonia.ViewModels
         /// and a provider added with neither a key nor a model id cannot answer a question, so the reader
         /// discovers the gap later and has to find Edit. OpenCode opens a sheet on every Connect.</para>
         /// </summary>
+        private AiProviderPreset? PresetFor(string presetId) =>
+            _service?.Presets.FirstOrDefault(p => string.Equals(p.Id, presetId, StringComparison.Ordinal));
+
+        /// <summary>
+        /// Adopts the key the environment holds for this provider. (#714)
+        ///
+        /// <para><b>One click where one click is honest, a sheet where it is not.</b> A catalogue preset needs
+        /// nothing beyond the reader's consent, so pressing the button that names the variable is the whole
+        /// act. Azure and Cloudflare declare environment variables AND need a prompt answered — a resource
+        /// name, an account id — so adopting them in one click is not possible; those open the ordinary sheet
+        /// carrying the choice already made, rather than asking for it twice.</para>
+        /// </summary>
+        internal void UseEnvironmentKey(string presetId, string variableName)
+        {
+            if (_service is null) return;
+            Problem = null;
+
+            if (PresetFor(presetId) is not { } preset) return;
+
+            if (preset.Prompts is { Count: > 0 })
+            {
+                Editor = AiConnectionEditorViewModel.ForPreset(
+                    _service, _credentials, preset, CloseEditor, adoptEnvironmentKey: variableName);
+                return;
+            }
+
+            // The variable NAME the row displayed, not one re-derived from the preset: it is the one the
+            // reader consented to, and it is what the connection records. (#714, fable on #813)
+            var result = _service.AddFromPreset(
+                presetId, new Dictionary<string, string>(), environmentVariable: variableName);
+            Problem = result.Ok ? null : result.Problem;
+        }
+
         internal void AddPreset(string presetId)
         {
             if (_service is null) return;
@@ -391,6 +451,24 @@ namespace CST.Avalonia.ViewModels
                 p => new AiPresetRowViewModel(this, p),
                 (row, p) => row.Update(p));
 
+            // Deliberately NOT filtered by the search box. The search is for finding a provider in the
+            // catalogue; this section answers a question the reader has not asked yet, and hiding it the
+            // moment they type would take it away exactly when they are looking for the provider it is
+            // about. (#714)
+            //
+            // Re-read on every rebind rather than cached: the environment can change between one open of
+            // this tab and the next, and a variable the reader has just unset should stop being offered.
+            var found = _environmentKeys is null
+                ? new List<AiEnvironmentKey>()
+                : _environmentKeys.Discover(_service.AvailablePresets).ToList();
+
+            Sync(FoundKeys, found,
+                k => k.PresetId,
+                r => r.Id,
+                k => new AiEnvironmentRowViewModel(this, k, PresetFor(k.PresetId)),
+                (row, k) => row.Update(k, PresetFor(k.PresetId)));
+
+            this.RaisePropertyChanged(nameof(HasFoundKeys));
             this.RaisePropertyChanged(nameof(HasNoConnections));
             this.RaisePropertyChanged(nameof(HasAvailablePresets));
             this.RaisePropertyChanged(nameof(CatalogueCount));
@@ -784,6 +862,68 @@ namespace CST.Avalonia.ViewModels
             this.RaisePropertyChanged(nameof(Monogram));
             this.RaisePropertyChanged(nameof(MonogramTone));
             this.RaisePropertyChanged(nameof(RequirementText));
+        }
+    }
+
+    /// <summary>
+    /// One provider whose API key is already sitting in this machine's environment. (#714)
+    ///
+    /// <para><b>The variable's NAME, never its value.</b> The value is not carried into this object, not
+    /// rendered, and not logged: the name is the whole of what a reader needs in order to recognise the key
+    /// — or to realise they had forgotten it was set, which is the case this feature exists for.</para>
+    /// </summary>
+    public class AiEnvironmentRowViewModel : AiLogoRowViewModel
+    {
+        private readonly AiConnectionsViewModel _owner;
+        private AiEnvironmentKey _key;
+        private AiProviderPreset? _preset;
+
+        public AiEnvironmentRowViewModel(
+            AiConnectionsViewModel owner, AiEnvironmentKey key, AiProviderPreset? preset)
+        {
+            _owner = owner;
+            _key = key;
+            _preset = preset;
+
+            UseCommand = ReactiveCommand.Create(() => _owner.UseEnvironmentKey(Id, VariableName));
+
+            LoadLogo(owner.Logos);
+        }
+
+        public string Id => _key.PresetId;
+
+        protected override string? ProviderId => _key.PresetId;
+
+        public string VariableName => _key.VariableName;
+
+        /// <summary>The provider's own name where the catalogue is loaded, and the id otherwise — a row that
+        /// says "openai" is still a row the reader can act on, where no row at all is not.</summary>
+        public string DisplayName => _preset?.DisplayName ?? _key.PresetId;
+
+        public override string Monogram => AiMonogram.For(DisplayName);
+
+        public override int MonogramTone => AiMonogram.ToneFor(Id);
+
+        /// <summary>
+        /// What the row says beneath the provider's name.
+        ///
+        /// <para>A statement of fact rather than a recommendation. It does not say the key is valid — nothing
+        /// here has tried it — only that the variable is set, which is the one thing that has been
+        /// established.</para>
+        /// </summary>
+        public string VariableText => $"Key in {VariableName}";
+
+        public ReactiveCommand<Unit, Unit> UseCommand { get; }
+
+        internal void Update(AiEnvironmentKey key, AiProviderPreset? preset)
+        {
+            _key = key;
+            _preset = preset;
+            this.RaisePropertyChanged(nameof(VariableName));
+            this.RaisePropertyChanged(nameof(VariableText));
+            this.RaisePropertyChanged(nameof(DisplayName));
+            this.RaisePropertyChanged(nameof(Monogram));
+            this.RaisePropertyChanged(nameof(MonogramTone));
         }
     }
 

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1370,7 +1370,8 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
             // parameterless constructor used by the designer needs.
             var connectionService = App.TryGetService<Services.Ai.IAiConnectionService>();
             Connections = new AiConnectionsViewModel(
-                connectionService, credentials, App.TryGetService<Services.Ai.IAiProviderLogos>());
+                connectionService, credentials, App.TryGetService<Services.Ai.IAiProviderLogos>(),
+                App.TryGetService<Services.Ai.Credentials.IAiEnvironmentKeys>());
             Models = new AiModelsViewModel(
                 connectionService,
                 App.TryGetService<Services.Ai.IAiModelCatalog>(),

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -177,6 +177,53 @@
 
             <!-- Add a provider -->
             <TextBlock Text="Add a provider" Classes="SettingLabel" FontWeight="SemiBold"/>
+            <!-- Keys this machine already holds. Above the search box on purpose: the reader this exists for
+                 is the one who does NOT know the variable is set, and they will never search for it. Shown
+                 only when something was found, so a reader with a clean environment sees nothing at all
+                 rather than an empty section explaining an absence. (#714) -->
+            <StackPanel IsVisible="{Binding HasFoundKeys}" Margin="0,0,0,16">
+                <TextBlock Text="Found in your environment" Classes="SettingLabel"/>
+                <TextBlock Text="These providers can use a key your machine already has. Nothing uses one until you say so, and the key stays where it is — it is never copied into this app."
+                           Classes="SettingDescription" Margin="0,2,0,8"/>
+
+                <Border Classes="SettingGroup" Padding="0">
+                    <ItemsControl ItemsSource="{Binding FoundKeys}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:AiEnvironmentRowViewModel">
+                                <Border Classes="Row">
+                                    <Grid ColumnDefinitions="Auto,*,Auto">
+
+                                        <Panel Grid.Column="0" Width="28" Height="28" Margin="0,1,12,0"
+                                               VerticalAlignment="Top">
+                                            <Border Classes="Tile" Margin="0"
+                                                    IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}, ConverterParameter=invert}"
+                                                    Background="{Binding MonogramTone,
+                                                        Converter={x:Static conv:MonogramToneConverter.Instance}}">
+                                                <TextBlock Text="{Binding Monogram}"/>
+                                            </Border>
+                                            <Image IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}}"
+                                                   Source="{Binding LogoPath,
+                                                       Converter={x:Static conv:ProviderLogoConverter.Instance}}"
+                                                   Stretch="Uniform" Margin="2"/>
+                                        </Panel>
+
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                            <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
+                                            <!-- The variable's NAME. Never its value. -->
+                                            <TextBlock Text="{Binding VariableText}" Classes="Secondary"/>
+                                        </StackPanel>
+
+                                        <Button Grid.Column="2" Content="Use it"
+                                                Command="{Binding UseCommand}"
+                                                VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Border>
+            </StackPanel>
+
             <!-- The hosted catalogue. Named when it is missing rather than rendered as an empty section: an
                  empty list reads as a broken feature, a sentence with a Retry reads as weather. -->
             <StackPanel IsVisible="{Binding HasCatalogueProblem}" Margin="0,0,0,16">


### PR DESCRIPTION
Closes #714. The UI half; discovery landed in #813.

## A section above the catalogue

"Found in your environment", shown only when something was found: the provider, the variable's **name**, and a button.

Above the search box rather than as a line on a catalogue row, and that is the design decision the rest follows from. The catalogue is a search box over 160+ providers, so a line on a row is read only by someone who already went looking — **which is precisely not the reader this exists for**, the one who does not know the variable is set. That reader was the case in view: the maintainer watched another tool adopt a Google key he had forgotten was on his own machine, on a connection he never configured, with no way to disconnect it. A note only the already-curious would find is the same failure as a log line nobody reads standing in for a message.

## Nothing to decline

No dismissal, no "not now", no suppression flag. Nothing is pressed on the reader: the section states what is on their machine and offers to use it, on a settings tab they opened deliberately. A "not now" would need somewhere to be stored, a way back, and an answer for what happens when the variable changes — a third state (offered / adopted / declined-for-now) existing only to suppress a two-line block nobody has to act on.

## One click where one click is honest

A catalogue preset needs nothing beyond consent, so pressing the button that names the variable is the whole act.

**Azure and Cloudflare cannot work that way, and this was not in the handoff.** Both hand-kept presets that declare environment variables *also* carry prompts, so adopting either blind produces a connection whose base URL still reads `{resourceName}`. Those open the ordinary sheet carrying the choice already made rather than asking for it twice — and the sheet suppresses its required-key refusal while adopting, or it would refuse the very thing the button offered to do.

## The name, not a flag

Rebasing onto #813 as merged changed the shape this depends on. Recording the opt-in as a bare `bool` and re-deriving the variable from the preset per request was itself a silent-adoption risk: the preset's variable list is refreshed from models.dev, so a reordering upstream — or an alias added that the reader happens to have set for something else — would change which credential reaches a recorded endpoint, months later, with no second consent. The property this feature exists to prevent, arriving late instead of at the start.

So `AddFromPreset` takes `string? environmentVariable`, not `bool useEnvironmentKey`, and it is **the name the row displayed**, carried down from the button the reader pressed — not one re-derived from the preset a moment later. Two consequences:

- the recorded name is provably the one they consented to;
- **"opted in, nothing recorded" is unrepresentable** rather than merely handled — both record fields are set from one value, so they cannot disagree.

Defaulted null, so every existing caller keeps its behaviour and adopting is something a caller has to *say* rather than fall into — the same property the flag itself has.

## The three constraints, and where each is met

**The value is never carried, rendered or logged.** Rows hold the preset id and the variable name. A test joins everything a row exposes and asserts the key is not in it.

**A variable that disappears reads as "no key".** Discovery is re-read on every rebind rather than cached, so an unset variable stops being offered. The reader unset it; that is a thing they are allowed to do.

**Bedrock is met by construction rather than by a rule.** Its credentials come from the whole AWS chain — `~/.aws/credentials`, SSO, instance roles — so "no credential found" would be confidently wrong exactly where it is most likely to be in use (#702). A section that can only *add* a row for something present has no shape in which it can say that. The test states it that way: Bedrock with no variable beside OpenAI with one, asserting a single row.

The section is also not filtered by the catalogue search — typing to find a provider must not take away the block saying a key for it is already here.

## Verified by mutation, not by green

Three tests were checked by breaking the thing they name, after Fable found an entire environment fallback could be deleted from #813 with the suite still green:

| mutation | fails |
|---|---|
| drop the recorded opt-in | the adoption test, alone |
| adopt directly for a prompted preset | the sheet test, alone |
| record the flag but not the variable name | the adoption test, alone |

Sources restored, no markers left.

## Verification

Nine new tests: offered-but-not-adopted, the value never reaching the row, an empty environment offering nothing, Bedrock getting no negative row, adoption recording the opt-in *and* the consented variable, a prompted preset opening the sheet, an already-configured provider not being re-offered, search not hiding the section, and a disappeared variable ceasing to be offered.

Full suite green — 2507 passed, 0 failed, 17 skipped. 0 build warnings.
