### PR TITLE
Keep what parses when a settings file will not load whole (#803)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/SettingsBackupRecoveryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SettingsBackupRecoveryTests.cs
@@ -67,14 +67,41 @@ public sealed class SettingsBackupRecoveryTests : IDisposable
     {
         await WithOneGoodSave("/books");
 
-        // Exactly the shape of the real failure: valid JSON, one property this build cannot convert.
-        await File.WriteAllTextAsync(SettingsPath,
-            """{ "Version": "1.0", "XmlBooksDirectory": "/books", "FontSettings": 12345 }""");
+        // Unreadable as a DOCUMENT, so there is nothing to salvage and the backup is the only answer.
+        //
+        // This test used to write valid JSON with one unconvertible property, which is the incident's own
+        // shape — and #803 now keeps such a file rather than replacing it with a previous save, which is the
+        // better outcome and is asserted in TolerantSettingsLoadTests. The backup path is for what tolerance
+        // cannot reach, and the fixture has to be that.
+        await File.WriteAllTextAsync(SettingsPath, "{ torn write, not json");
 
         var reopened = await Loaded(_dir);
 
         Assert.Equal("/books", reopened.Settings.XmlBooksDirectory);
         Assert.Equal("/idx", reopened.Settings.IndexDirectory);
+    }
+
+    // The routing between the two, stated once: a file that can be partly read is partly read, and only what
+    // cannot be read at all falls back to an older copy. The order matters because a backup is a PREVIOUS
+    // save — recovering from one loses everything changed since, while keeping what parses loses only the
+    // part genuinely unreadable. (#803)
+    [Fact]
+    public async Task A_partly_readable_file_is_kept_rather_than_replaced_by_an_older_backup()
+    {
+        await WithOneGoodSave("/books");
+
+        // Everything the reader has now, plus one property this build cannot convert.
+        await File.WriteAllTextAsync(SettingsPath,
+            """
+            { "Version": "1.0", "XmlBooksDirectory": "/new-books", "IndexDirectory": "/new-idx",
+              "FontSettings": 12345 }
+            """);
+
+        var reopened = await Loaded(_dir);
+
+        // The CURRENT values, not the backup's — the reader's recent changes survive.
+        Assert.Equal("/new-books", reopened.Settings.XmlBooksDirectory);
+        Assert.Equal("/new-idx", reopened.Settings.IndexDirectory);
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/TolerantSettingsLoadTests.cs
+++ b/src/CST.Avalonia.Tests/Services/TolerantSettingsLoadTests.cs
@@ -178,17 +178,103 @@ public sealed class TolerantSettingsLoadTests : IDisposable
         Assert.Equal("/books", reread!.XmlBooksDirectory);
     }
 
-    // A salvage keeps the file, so the reader has not lost their configuration AND the cause is still
-    // diagnosable — unlike the original behaviour, which overwrote it with defaults.
+    // The bytes that could NOT be read are kept, because the salvage overwrites the only copy of them.
+    //
+    // An earlier version of this test asserted the opposite — that nothing was preserved, "because the file
+    // was READ, not discarded". That was wrong by the salvage's own arithmetic: this path is reached only
+    // when at least one node was dropped, so part of the file was not read, and saving destroyed it. Their
+    // paths are in the log; their content was nowhere. (fable)
     [Fact]
-    public async Task A_salvaged_file_is_not_destroyed()
+    public async Task The_part_that_could_not_be_read_is_kept_before_the_salvage_overwrites_it()
     {
         await Load("""
         { "XmlBooksDirectory": "/books", "FontSettings": 12345 }
         """);
 
-        // Nothing was preserved-aside, because nothing was lost: the file was READ, not discarded.
-        Assert.Empty(Directory.GetFiles(_dir, "settings.unreadable-*.json"));
+        var kept = Directory.GetFiles(_dir, "settings.unreadable-*.json");
+        Assert.Single(kept);
+        Assert.Contains("12345", await File.ReadAllTextAsync(kept[0]));
+
+        // A COPY: the primary file is still there, salvaged, and is what the next launch reads.
+        Assert.True(File.Exists(Path.Combine(_dir, "settings.json")));
+    }
+
+    // Azure's connections store AuthScheme as null — "a bare credential, no scheme" — and the initializer is
+    // "Bearer". Skipping an explicit null replaced the stored value with the initializer and wrote it back,
+    // so the connection would send `api-key: Bearer <key>` and fail with nothing on screen to explain it.
+    [Fact]
+    public async Task An_explicit_null_that_is_a_stored_value_survives_the_salvage()
+    {
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Chat": { "Connections": [
+            { "Id": "azure", "Kind": "openai-compatible", "BaseUrl": "https://x.invalid",
+              "AuthHeaderName": "api-key", "AuthScheme": null,
+              "Models": "this should be a list" }
+          ] } }
+        }
+        """);
+
+        var connection = settings.Ai.Chat.Connections.Single();
+        Assert.Null(connection.AuthScheme);
+        Assert.Equal("api-key", connection.AuthHeaderName);
+    }
+
+    // One unreadable entry should cost that entry, not the dictionary. Emptying it takes the reader's other
+    // inputs with it — and Azure's resourceName lives in one of these.
+    [Fact]
+    public async Task One_bad_dictionary_entry_does_not_empty_the_dictionary()
+    {
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Chat": { "Connections": [
+            { "Id": "azure", "Kind": "openai-compatible", "BaseUrl": "https://x.invalid",
+              "Inputs": { "resourceName": "my-resource", "region": 5 } }
+          ] } }
+        }
+        """);
+
+        var inputs = settings.Ai.Chat.Connections.Single().Inputs;
+        Assert.Equal("my-resource", inputs["resourceName"]);
+    }
+
+    // A collection written as the wrong JSON kind must be DROPPED and reported, never salvaged as an object.
+    // Dictionary and List both have parameterless constructors, so they were handed to the property-by-
+    // property salvage, which iterated Comparer/Count/Keys and returned them empty with nothing recorded.
+    [Fact]
+    public async Task A_connection_list_written_as_an_object_is_reported_not_silently_emptied()
+    {
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Chat": { "Connections": { "not": "a list" } } }
+        }
+        """);
+
+        // The books directory survives, the connections are empty — and the file that held them was kept,
+        // which is the difference between a reported loss and a silent one.
+        Assert.Equal("/books", settings.XmlBooksDirectory);
+        Assert.Empty(settings.Ai.Chat.Connections);
+        Assert.Single(Directory.GetFiles(_dir, "settings.unreadable-*.json"));
+    }
+
+    // Fable's sharpest: the zero-drop guard threw away a file the salvage had FULLY repaired.
+    //
+    // An explicit null on a non-nullable scalar — a plausible hand-edit, and hand-edited files are this
+    // code's stated common case — fails a strict read. The salvage handled it perfectly and recorded nothing,
+    // so the guard concluded "the strict read failed for a reason we cannot see" and fell through to the
+    // backups. With none, the reader lost a books directory from a file that was entirely recoverable: the
+    // exact disproportion this whole change argues against.
+    [Fact]
+    public async Task A_file_repaired_by_the_salvage_is_kept_even_though_nothing_was_lost()
+    {
+        var settings = await Load("""
+        { "XmlBooksDirectory": "/books", "UseHardwareAcceleration": null }
+        """);
+
+        Assert.Equal("/books", settings.XmlBooksDirectory);
     }
 
     public void Dispose()

--- a/src/CST.Avalonia.Tests/Services/TolerantSettingsLoadTests.cs
+++ b/src/CST.Avalonia.Tests/Services/TolerantSettingsLoadTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// One bad property should cost that property, not the file. (#803)
+///
+/// <para><b>The incident.</b> A persisted type changed (#771) and a settings file written the previous day
+/// threw on <c>$.Ai.Chat.Connections[0].Headers</c>. <c>Deserialize</c> is all-or-nothing, so that one
+/// property cost the books directory, the fonts, the layout, every connection and every hand-built model
+/// list. #785 made that survivable by restoring the previous save. This makes it proportionate.</para>
+///
+/// <para>The two answers are not interchangeable, which is why tolerance is tried FIRST: a backup is a
+/// previous save, so recovering from one loses everything changed since, while keeping what parses loses only
+/// the part genuinely unreadable.</para>
+/// </summary>
+public sealed class TolerantSettingsLoadTests : IDisposable
+{
+    private readonly string _dir;
+
+    public TolerantSettingsLoadTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"tolerant-settings-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    private async Task<Settings> Load(string json)
+    {
+        await File.WriteAllTextAsync(Path.Combine(_dir, "settings.json"), json);
+        var svc = new SettingsService(_dir);
+        await svc.LoadSettingsAsync();
+        return svc.Settings;
+    }
+
+    // The incident, replayed at the level it should have cost.
+    [Fact]
+    public async Task An_unreadable_property_costs_that_property_and_nothing_else()
+    {
+        var settings = await Load("""
+        {
+          "Version": "1.0",
+          "XmlBooksDirectory": "/books",
+          "IndexDirectory": "/idx",
+          "FontSettings": 12345,
+          "Ai": { "Enabled": true, "Chat": { "Enabled": true } }
+        }
+        """);
+
+        // Everything around it survives — this is the assertion that failed in the field.
+        Assert.Equal("/books", settings.XmlBooksDirectory);
+        Assert.Equal("/idx", settings.IndexDirectory);
+        Assert.True(settings.Ai.Enabled);
+        Assert.True(settings.Ai.Chat.Enabled);
+
+        // And the unreadable one is its default, not null.
+        Assert.NotNull(settings.FontSettings);
+    }
+
+    // A malformed ENTRY should cost that entry. Every real instance of this defect so far has been inside
+    // Ai.Chat.Connections — a header shape, a null collection, a null entry.
+    //
+    // The element here is a bare string where an object belongs, chosen because it is genuinely unreadable:
+    // an earlier version of this test used "Headers": 99, which the #784 converter absorbs into an empty
+    // list — so the whole file parsed strictly and the test never entered the tolerant path at all. It
+    // passed with per-element salvage deleted, which is the mutation it exists to catch.
+    [Fact]
+    public async Task One_unreadable_connection_does_not_take_the_others_with_it()
+    {
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Chat": { "Connections": [
+            { "Id": "good-one", "Kind": "openai-compatible", "BaseUrl": "https://a.invalid/v1" },
+            "this is not a connection",
+            { "Id": "good-two", "Kind": "anthropic", "BaseUrl": "https://b.invalid" }
+          ] } }
+        }
+        """);
+
+        Assert.Equal("/books", settings.XmlBooksDirectory);
+        Assert.Equal(
+            new[] { "good-one", "good-two" },
+            settings.Ai.Chat.Connections.Select(c => c.Id).OrderBy(id => id).ToArray());
+        Assert.Equal("https://a.invalid/v1", settings.Ai.Chat.Connections.Single(c => c.Id == "good-one").BaseUrl);
+    }
+
+    // And a connection with one unreadable PROPERTY keeps its readable ones, rather than vanishing: its id
+    // and base URL parsed perfectly well, and dropping the whole connection is the same error one level down.
+    [Fact]
+    public async Task A_connection_with_one_bad_property_keeps_the_rest_of_itself()
+    {
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "Ai": { "Chat": { "Connections": [
+            { "Id": "partly", "Kind": "openai-compatible", "BaseUrl": "https://a.invalid/v1",
+              "Models": "this should be a list" }
+          ] } }
+        }
+        """);
+
+        var connection = settings.Ai.Chat.Connections.Single();
+        Assert.Equal("partly", connection.Id);
+        Assert.Equal("https://a.invalid/v1", connection.BaseUrl);
+        Assert.NotNull(connection.Models);
+        Assert.Empty(connection.Models);
+    }
+
+    // A section this build cannot read at all must not cost an unrelated one.
+    [Fact]
+    public async Task A_bad_section_does_not_cost_the_books_directory()
+    {
+        var settings = await Load("""
+        {
+          "XmlBooksDirectory": "/books",
+          "FontSettings": { "DefaultFontSize": 14 },
+          "Ai": "this used to be an object"
+        }
+        """);
+
+        Assert.Equal("/books", settings.XmlBooksDirectory);
+        Assert.NotNull(settings.Ai);
+        Assert.False(settings.Ai.Enabled);       // defaulted, and off is the shipped default
+    }
+
+    // Tolerance runs only after a strict read has failed. An ordinary file must take the ordinary path —
+    // tolerance on every load is tolerance that hides a shape change from everyone until it has hidden it
+    // for a year.
+    [Fact]
+    public async Task An_ordinary_file_is_read_strictly_and_completely()
+    {
+        var settings = await Load("""
+        {
+          "Version": "1.0",
+          "XmlBooksDirectory": "/books",
+          "IndexDirectory": "/idx",
+          "Ai": { "Enabled": true, "Chat": { "Connections": [
+            { "Id": "c1", "Kind": "anthropic", "BaseUrl": "https://b.invalid" } ] } }
+        }
+        """);
+
+        Assert.Equal("/books", settings.XmlBooksDirectory);
+        Assert.Equal("/idx", settings.IndexDirectory);
+        Assert.Equal("c1", settings.Ai.Chat.Connections.Single().Id);
+    }
+
+    // Not JSON at all is not something to be tolerant OF. A torn write has no salvageable structure, and the
+    // honest answer is the backup path rather than a half-invented settings object.
+    [Fact]
+    public async Task A_file_that_is_not_json_falls_through_rather_than_being_salvaged()
+    {
+        var settings = await Load("{ this is not json");
+
+        Assert.False(string.IsNullOrEmpty(settings.XmlBooksDirectory));   // first-run defaulting ran
+        Assert.NotEmpty(Directory.GetFiles(_dir, "settings.unreadable-*.json"));
+    }
+
+    // The salvage is written back, so the next launch is an ordinary one rather than another salvage.
+    [Fact]
+    public async Task What_was_salvaged_is_written_back_as_the_primary_file()
+    {
+        await Load("""
+        { "XmlBooksDirectory": "/books", "FontSettings": 12345 }
+        """);
+
+        // The rewritten file must itself parse strictly.
+        var rewritten = await File.ReadAllTextAsync(Path.Combine(_dir, "settings.json"));
+        var reread = System.Text.Json.JsonSerializer.Deserialize<Settings>(
+            rewritten, new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(reread);
+        Assert.Equal("/books", reread!.XmlBooksDirectory);
+    }
+
+    // A salvage keeps the file, so the reader has not lost their configuration AND the cause is still
+    // diagnosable — unlike the original behaviour, which overwrote it with defaults.
+    [Fact]
+    public async Task A_salvaged_file_is_not_destroyed()
+    {
+        await Load("""
+        { "XmlBooksDirectory": "/books", "FontSettings": 12345 }
+        """);
+
+        // Nothing was preserved-aside, because nothing was lost: the file was READ, not discarded.
+        Assert.Empty(Directory.GetFiles(_dir, "settings.unreadable-*.json"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/src/CST.Avalonia/Services/SettingsService.cs
+++ b/src/CST.Avalonia/Services/SettingsService.cs
@@ -47,11 +47,15 @@ namespace CST.Avalonia.Services
 
         public async Task LoadSettingsAsync()
         {
+            // Held outside the try so the catch can attempt a tolerant read of the same bytes rather than
+            // going back to disk, where a file being rewritten underneath us would give a different answer
+            // than the one that failed. (#803)
+            string? json = null;
             try
             {
                 if (File.Exists(_settingsFilePath))
                 {
-                    var json = await File.ReadAllTextAsync(_settingsFilePath);
+                    json = await File.ReadAllTextAsync(_settingsFilePath);
                     var loadedSettings = JsonSerializer.Deserialize<Settings>(json, _jsonOptions);
                     
                     if (loadedSettings != null)
@@ -132,6 +136,19 @@ namespace CST.Avalonia.Services
                 // "Corrupt" is the rarer case anyway. The likelier one, and the observed one, is a file this
                 // build does not understand YET: written by a newer version, restored from a backup, or
                 // holding a shape we changed. None of those deserve deletion.
+                // Keep what parses, BEFORE falling back to an older copy. (#803)
+                //
+                // The two answers are not equivalent and the order matters: a backup is a previous save, so
+                // recovering from one loses everything the reader changed since, while this loses only the
+                // part we genuinely cannot read. The incident that produced all of this — one property whose
+                // type had changed — should have cost a header, not a session's work.
+                //
+                // Only reached once a strict read has already failed. An ordinary file never comes through
+                // here, which is deliberate: tolerance on every load would hide a shape change from everyone
+                // until it had hidden it for a year.
+                if (await TryLoadTolerantlyAsync(json).ConfigureAwait(false))
+                    return;
+
                 PreserveUnreadable();
 
                 // Then try to RECOVER, which is the half that means the reader never learns any of this
@@ -159,6 +176,50 @@ namespace CST.Avalonia.Services
         /// no backup could be read, which must not become the newest backup. (#785)
         /// </summary>
         private bool _backupNextSave = true;
+
+        /// <summary>
+        /// Rebuild the settings from a file a strict read refused, keeping every part that parses. (#803)
+        /// </summary>
+        private async Task<bool> TryLoadTolerantlyAsync(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return false;
+
+            try
+            {
+                var salvaged = TolerantSettingsReader.Read<Settings>(json!, _jsonOptions, out var dropped);
+                if (salvaged is null) return false;
+
+                // Nothing dropped means the strict read failed for a reason this cannot see. Do not claim a
+                // salvage that did not happen — fall through to the backups, which is the stronger answer.
+                if (dropped.Count == 0) return false;
+
+                foreach (var note in SettingsValidator.Migrate(salvaged))
+                    _logger.Information("Settings migration (partial read): {Note}", note);
+                foreach (var fix in SettingsValidator.Sanitize(salvaged))
+                    _logger.Warning("Settings sanitized (partial read): {Fix}", fix);
+
+                _settings = salvaged;
+                try { ApplyFirstRunDefaults(); } catch { /* see the load path */ }
+
+                // At Error, listing every path, because this is the one message that says what the reader
+                // lost. A partial load reported as a success is the defect one level down.
+                _logger.Error(
+                    "Settings could not be read in full. Kept everything that parsed; these were reset to "
+                    + "their defaults: {Dropped}", string.Join(", ", dropped));
+
+                // AWAITED, not fired and forgotten — the same defect #785's review caught in the backup
+                // restore, which I reproduced here in a new place. Until the primary file is readable again
+                // a crash or force-quit sends the next launch down a path that knows nothing about this
+                // salvage, and the reader loses it having been silently rescued in between.
+                await SaveSettingsAsync().ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "Could not read the settings file even partially");
+                return false;
+            }
+        }
 
         /// <summary>The directory holding timestamped copies of previously-saved settings. (#785)</summary>
         private string BackupDirectory => Path.Combine(_settingsDirectory, "settings-backups");

--- a/src/CST.Avalonia/Services/SettingsService.cs
+++ b/src/CST.Avalonia/Services/SettingsService.cs
@@ -207,6 +207,16 @@ namespace CST.Avalonia.Services
                     "Settings could not be read in full. Kept everything that parsed; these were reset to "
                     + "their defaults: {Dropped}", string.Join(", ", dropped));
 
+                // A COPY of the original kept beside it, before the salvage is written over it.
+                //
+                // The salvage path is only reached when at least one node was dropped — so part of the file
+                // was NOT read, and saving replaces its only copy. The dropped paths are named in the log;
+                // their CONTENT would survive only in a #785 backup, and only if the app itself had once
+                // saved it. A connection or model list the reader added since the last save would be
+                // destroyed outright, where the behaviour this replaces at least kept the whole file. A copy
+                // costs nothing and keeps that guarantee. (fable)
+                PreserveUnreadable(copy: true);
+
                 // AWAITED, not fired and forgotten — the same defect #785's review caught in the backup
                 // restore, which I reproduced here in a new place. Until the primary file is readable again
                 // a crash or force-quit sends the next launch down a path that knows nothing about this
@@ -337,7 +347,11 @@ namespace CST.Avalonia.Services
         /// <para>Never throws. It runs inside the load's catch, and a failure to preserve must not become a
         /// failure to start — the reader would then have neither their settings nor an application.</para>
         /// </summary>
-        private void PreserveUnreadable()
+        /// <param name="copy">
+        /// Keep the original in place as well. True on the salvage path, where the file is still the primary
+        /// and is about to be rewritten; false when the file is being abandoned entirely.
+        /// </param>
+        private void PreserveUnreadable(bool copy = false)
         {
             try
             {
@@ -350,13 +364,14 @@ namespace CST.Avalonia.Services
                     // reader's configuration would be left in place to be overwritten by the next save. (fable)
                     $"settings.unreadable-{DateTime.Now:yyyyMMdd-HHmmss-fff}.json");
 
-                File.Move(_settingsFilePath, kept, overwrite: false);
+                if (copy) File.Copy(_settingsFilePath, kept, overwrite: false);
+                else File.Move(_settingsFilePath, kept, overwrite: false);
 
                 // At Error, beside the failure itself: a reader who has just lost their configuration is
                 // reading this line, and it is the one that tells them it is recoverable.
                 _logger.Error(
-                    "The previous settings file could not be read and has been kept at {Path}. "
-                    + "Defaults are in use; nothing from it was deleted.", kept);
+                    "The previous settings file could not be read in full and has been kept at {Path}. "
+                    + "Nothing from it was deleted.", kept);
             }
             catch (Exception ex)
             {

--- a/src/CST.Avalonia/Services/TolerantSettingsReader.cs
+++ b/src/CST.Avalonia/Services/TolerantSettingsReader.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+
+namespace CST.Avalonia.Services;
+
+/// <summary>
+/// Reads a settings file that <see cref="JsonSerializer"/> refuses, keeping every part it can. (#803)
+///
+/// <para><b>Why this exists.</b> A persisted type changed (#771) and a file written the previous day threw on
+/// one property — <c>$.Ai.Chat.Connections[0].Headers</c>. `Deserialize` is all-or-nothing, so that one
+/// property cost the books directory, the fonts, the layout, every connection and every hand-built model
+/// list. #785 made that survivable by restoring the previous save; this makes it *proportionate*: the same
+/// incident should have cost a header.</para>
+///
+/// <para><b>It runs only after a strict read has failed.</b> An ordinary file takes the ordinary path and
+/// this code never executes, which is deliberate — tolerance that runs on every load is tolerance that hides
+/// a shape change from everyone until it has hidden it for a year.</para>
+///
+/// <para><b>What is dropped is reported, never silent.</b> A section quietly replaced by its defaults is the
+/// same defect one level down: the file loaded, nothing was said, and the reader's connections are gone. Every
+/// node this cannot read is named in <c>dropped</c>, by path.</para>
+/// </summary>
+internal static class TolerantSettingsReader
+{
+    /// <summary>
+    /// Rebuild <typeparamref name="T"/> from <paramref name="json"/>, keeping what parses.
+    /// Returns null only when the document is not a JSON object at all — nothing to salvage.
+    /// </summary>
+    internal static T? Read<T>(string json, JsonSerializerOptions options, out IReadOnlyList<string> dropped)
+        where T : class, new()
+    {
+        var lost = new List<string>();
+        dropped = lost;
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (document.RootElement.ValueKind != JsonValueKind.Object) return null;
+            return (T?)Node(document.RootElement, typeof(T), "$", options, lost);
+        }
+        catch (JsonException)
+        {
+            // Not even well-formed JSON — a torn write, or a file that is not settings at all. There is
+            // nothing here to be tolerant OF, and the caller falls through to its backups.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// One node: try it whole, and only on failure take it apart.
+    ///
+    /// <para>Trying whole first is what keeps this honest. A list of a hundred connections with one bad entry
+    /// deserializes ninety-nine of them through the ordinary path, with the converters, naming policy and
+    /// attributes the real load uses — this only steps in where that path has already refused.</para>
+    /// </summary>
+    private static object? Node(
+        JsonElement element, Type type, string path, JsonSerializerOptions options, List<string> dropped)
+    {
+        try
+        {
+            return element.Deserialize(type, options);
+        }
+        catch (JsonException)
+        {
+            // fall through and salvage
+        }
+        catch (NotSupportedException)
+        {
+            // A converter refusing the shape outright — same treatment.
+        }
+
+        if (element.ValueKind == JsonValueKind.Array && ListElementType(type) is { } itemType)
+            return SalvageList(element, type, itemType, path, options, dropped);
+
+        if (element.ValueKind == JsonValueKind.Object && HasParameterlessConstructor(type))
+            return SalvageObject(element, type, path, options, dropped);
+
+        // A leaf we cannot read — a number where a string belongs. The caller keeps its default and says so.
+        dropped.Add(path);
+        return null;
+    }
+
+    // Keep every element that reads; name the ones that do not. Dropping one connection is a loss the reader
+    // can see and repair; dropping the file is not.
+    private static object SalvageList(
+        JsonElement element, Type listType, Type itemType, string path,
+        JsonSerializerOptions options, List<string> dropped)
+    {
+        var list = (IList)Activator.CreateInstance(listType)!;
+        int index = 0;
+        foreach (var item in element.EnumerateArray())
+        {
+            var value = Node(item, itemType, $"{path}[{index}]", options, dropped);
+            if (value is not null) list.Add(value);
+            index++;
+        }
+        return list;
+    }
+
+    // Property by property, so a bad Ai section costs the AI settings and not the books directory.
+    private static object SalvageObject(
+        JsonElement element, Type type, string path, JsonSerializerOptions options, List<string> dropped)
+    {
+        var instance = Activator.CreateInstance(type)!;
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!property.CanWrite || property.GetIndexParameters().Length > 0) continue;
+            if (!TryGetProperty(element, property.Name, out var json)) continue;
+
+            // An explicit null is a value, and leaving the initializer in place is the RIGHT answer for it —
+            // the same reasoning as #787's null-coalescing, from the other side: the model's `= new()` is
+            // what the reader gets, rather than a null nothing downstream checks for.
+            if (json.ValueKind == JsonValueKind.Null) continue;
+
+            var value = Node(json, property.PropertyType, $"{path}.{property.Name}", options, dropped);
+            if (value is not null) property.SetValue(instance, value);
+        }
+        return instance;
+    }
+
+    private static bool TryGetProperty(JsonElement element, string name, out JsonElement value)
+    {
+        // Case-insensitive, matching the reader's own PropertyNameCaseInsensitive. Hand-edited files are the
+        // common case here and their casing is whatever the person typed.
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+        value = default;
+        return false;
+    }
+
+    private static Type? ListElementType(Type type) =>
+        type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>)
+            ? type.GetGenericArguments()[0]
+            : null;
+
+    private static bool HasParameterlessConstructor(Type type) =>
+        !type.IsAbstract && type.GetConstructor(Type.EmptyTypes) is not null;
+}

--- a/src/CST.Avalonia/Services/TolerantSettingsReader.cs
+++ b/src/CST.Avalonia/Services/TolerantSettingsReader.cs
@@ -74,6 +74,23 @@ internal static class TolerantSettingsReader
         if (element.ValueKind == JsonValueKind.Array && ListElementType(type) is { } itemType)
             return SalvageList(element, type, itemType, path, options, dropped);
 
+        if (element.ValueKind == JsonValueKind.Object && DictionaryValueType(type) is { } valueType)
+            return SalvageDictionary(element, type, valueType, path, options, dropped);
+
+        // A collection this cannot take apart entry-by-entry is DROPPED, never handed to SalvageObject.
+        //
+        // Dictionary and List both have parameterless constructors, so without this they were salvaged as
+        // ordinary objects — iterating their CLR properties (Comparer, Count, Keys), none of which is
+        // writable — and came back EMPTY with nothing recorded. A settings file whose Connections was written
+        // as an object lost every connection, silently, and the mutilated result was then saved over the only
+        // copy. That is the incident this whole feature exists to prevent, reproduced inside the mechanism
+        // meant to prevent it. (fable)
+        if (IsCollection(type))
+        {
+            dropped.Add(path);
+            return null;
+        }
+
         if (element.ValueKind == JsonValueKind.Object && HasParameterlessConstructor(type))
             return SalvageObject(element, type, path, options, dropped);
 
@@ -99,6 +116,22 @@ internal static class TolerantSettingsReader
         return list;
     }
 
+    // Entry by entry, for the same reason a list is salvaged element by element: one unreadable value should
+    // cost that value. Emptying the dictionary would take the reader's other inputs with it — and Azure's
+    // resourceName lives in one of these. (fable)
+    private static object SalvageDictionary(
+        JsonElement element, Type dictionaryType, Type valueType, string path,
+        JsonSerializerOptions options, List<string> dropped)
+    {
+        var dictionary = (IDictionary)Activator.CreateInstance(dictionaryType)!;
+        foreach (var entry in element.EnumerateObject())
+        {
+            var value = Node(entry.Value, valueType, $"{path}.{entry.Name}", options, dropped);
+            if (value is not null) dictionary[entry.Name] = value;
+        }
+        return dictionary;
+    }
+
     // Property by property, so a bad Ai section costs the AI settings and not the books directory.
     private static object SalvageObject(
         JsonElement element, Type type, string path, JsonSerializerOptions options, List<string> dropped)
@@ -109,10 +142,27 @@ internal static class TolerantSettingsReader
             if (!property.CanWrite || property.GetIndexParameters().Length > 0) continue;
             if (!TryGetProperty(element, property.Name, out var json)) continue;
 
-            // An explicit null is a value, and leaving the initializer in place is the RIGHT answer for it —
-            // the same reasoning as #787's null-coalescing, from the other side: the model's `= new()` is
-            // what the reader gets, rather than a null nothing downstream checks for.
-            if (json.ValueKind == JsonValueKind.Null) continue;
+            if (json.ValueKind == JsonValueKind.Null)
+            {
+                // An explicit null needs three answers, not one.
+                //
+                // For a COLLECTION, keeping the initializer is right — the same reasoning as #787's
+                // null-coalescing from the other side: the model's `= new()` is what the reader gets, rather
+                // than a null nothing downstream checks for.
+                //
+                // For anything else nullable, the null is a STORED VALUE and must be preserved. Skipping it
+                // silently replaced AiConnectionRecord.AuthScheme's null — which means "a bare credential,
+                // no scheme", and is exactly what a saved Azure connection holds — with its "Bearer"
+                // initializer, then wrote that back. The connection would send `api-key: Bearer <key>` and
+                // fail to authenticate with nothing on screen to explain it. (fable)
+                //
+                // For a non-nullable value type, a null is unreadable: record it rather than pretending the
+                // initializer was what the file said.
+                if (IsCollection(property.PropertyType)) continue;
+                if (IsNullable(property.PropertyType)) { property.SetValue(instance, null); continue; }
+                dropped.Add($"{path}.{property.Name}");
+                continue;
+            }
 
             var value = Node(json, property.PropertyType, $"{path}.{property.Name}", options, dropped);
             if (value is not null) property.SetValue(instance, value);
@@ -140,6 +190,19 @@ internal static class TolerantSettingsReader
         type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>)
             ? type.GetGenericArguments()[0]
             : null;
+
+    private static Type? DictionaryValueType(Type type) =>
+        type.IsGenericType
+        && type.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+        && type.GetGenericArguments()[0] == typeof(string)
+            ? type.GetGenericArguments()[1]
+            : null;
+
+    private static bool IsCollection(Type type) =>
+        type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(type);
+
+    private static bool IsNullable(Type type) =>
+        !type.IsValueType || Nullable.GetUnderlyingType(type) is not null;
 
     private static bool HasParameterlessConstructor(Type type) =>
         !type.IsAbstract && type.GetConstructor(Type.EmptyTypes) is not null;


### PR DESCRIPTION
Closes #803. The last item in the beta 6 milestone. **Two commits** — the second is Fable's review, applied.

## The incident this finishes

A persisted type changed (#771) and a file written the previous day threw on one property — `$.Ai.Chat.Connections[0].Headers`. `Deserialize` is all-or-nothing, so that one property cost the books directory, the fonts, the layout, every AI connection and every hand-built model list.

#785 made that **survivable** by restoring the previous save. This makes it **proportionate**: the same incident should have cost a header.

## Commit 1 — three properties, each deliberate

**Only after a strict read fails.** An ordinary file takes the ordinary path and none of this executes. Tolerance on every load is tolerance that hides a shape change from everyone until it has hidden it for a year.

**Before the backup walk**, which is the whole argument. A backup is a *previous save*, so recovering from one loses everything changed since; keeping what parses loses only the part genuinely unreadable.

**Every node is tried whole first.** A hundred connections with one bad entry deserialize ninety-nine through the real path, with the real converters. The salvage is recursive, so sections, lists and nested objects share one rule.

## Commit 2 — Fable's review

**It found the tolerance mechanism doing the exact thing tolerance exists to prevent.** Every finding confirmed by execution.

**Dictionaries were emptied, unreported.** `Dictionary<K,V>` has a parameterless constructor, so a failed dictionary went to the property-by-property salvage — which iterated `Comparer`, `Count`, `Keys`, none writable — and returned it **empty with nothing recorded**. A connection's `Inputs` with one bad entry lost the good ones too, including Azure's `resourceName`, and the mutilated result was saved over the file that held them. `List<>` has one as well, so `Connections` written as an object lost every connection the same way. Dictionaries are now salvaged entry by entry, and any collection this cannot take apart is dropped and **reported**.

**An explicit null was flipped to the initializer.** `AuthScheme: null` means "a bare credential, no scheme" — what a saved Azure connection holds — and its initializer is `"Bearer"`. The connection would send `api-key: Bearer <key>` and fail with nothing on screen to explain it. A null now has three answers: keep the initializer for a collection, preserve the null where it is a stored value, record a drop where the type cannot hold one.

**The zero-drop guard threw away files the salvage had fully repaired.** An explicit null on a non-nullable scalar — a plausible hand-edit, and hand-edited files are this code's stated common case — was handled perfectly and recorded nothing, so the guard fell through to the backups. With none, a books directory was lost from an entirely recoverable file.

**And the salvage destroyed the bytes it could not read.** This path is reached only when something was dropped, so part of the file was *not* read and saving replaced its only copy. The paths were in the log; the content was nowhere. The original is now copied aside first — a copy, not a move, since the file is still the primary.

## Mutation, measured rather than claimed

Commit 1's message gave figures that did not reproduce (claimed 4/2/6; Fable measured 7/2/7). Re-measured per mutation:

| mutation | tests failed |
|---|---|
| tolerance removed entirely | 11 |
| per-element salvage removed | 4 |
| per-entry (dictionary) salvage removed | 1 |
| explicit-null handling removed | 2 |
| copy-aside removed | 2 |

Full suite: **2495 passed, 0 failed, 17 skipped.**

## One existing test changed meaning, honestly

`An_unreadable_file_is_recovered_from_the_backup_rather_than_defaulted` used valid JSON with one unconvertible property — the incident's own shape. That file is now *kept* rather than replaced by a previous save. Its fixture is a torn write now, and a new test asserts the routing directly: a partly readable file keeps the reader's **current** values rather than reverting to the backup's older ones.

## Not addressed

Reporting the dropped paths to the **reader** rather than the log. The state exists — every dropped path is collected and logged at Error — but the wording of a settings screen that says "this part of your configuration could not be read" is not mine to invent.