### PR TITLE
Let an adopted connection be edited, and show the consent it carries (#714)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -933,6 +933,82 @@ public class AiConnectionsViewModelTests
     }
 
     /// <summary>
+    /// The sheet path, end to end — the half that had no enforcement at all.
+    ///
+    /// <para>Three mutations survived the whole suite before this existed: dropping the variable name on the
+    /// way into the sheet, dropping it again on the way out, and deleting the required-key suppression. Each
+    /// silently turns adoption into an ordinary add that then demands a typed key. This test fails on all
+    /// three. (fable review of #814)</para>
+    /// </summary>
+    [Fact]
+    public void A_prompted_provider_adopted_through_the_sheet_records_the_variable_and_needs_no_key()
+    {
+        var (vm, service) = MakeWithEnv(
+            Env("AZURE_API_KEY"),
+            EnvPreset("azure", "Azure", new[] { "AZURE_API_KEY" },
+                new List<AiInputPrompt> { new("resourceName", "Resource name") }));
+
+        Assert.Single(vm.FoundKeys).UseCommand.Execute().Subscribe();
+
+        var editor = Assert.IsType<AiConnectionEditorViewModel>(vm.Editor);
+
+        // The sheet says which variable it is carrying. It was bound to nothing before this.
+        Assert.True(editor.HasEnvironmentKeyNote);
+        Assert.Contains("AZURE_API_KEY", editor.EnvironmentKeyNote!, StringComparison.Ordinal);
+
+        editor.Inputs.Single(i => i.Key == "resourceName").Value = "mybox";
+
+        // Saving with the key box EMPTY has to succeed: demanding a key here would refuse the very thing the
+        // button offered to do.
+        editor.SaveCommand.Execute().Subscribe();
+
+        var connection = Assert.Single(service.Connections);
+        Assert.Equal(CredentialSource.Environment, connection.KeySource);
+        Assert.Equal("AZURE_API_KEY", connection.EnvironmentVariable);
+    }
+
+    /// <summary>
+    /// Editing an adopted connection must not demand a key it was promised it would never need.
+    ///
+    /// <para>The sheet forgot the adoption on the edit path, so <c>MissingRequiredKey</c> fired and Save was
+    /// refused with "needs an API key" — on a connection whose credential works. The only ways out were
+    /// pasting the environment's key into the keychain, which is the copy adoption exists to avoid, or
+    /// delete-and-re-add, which destroys the model list the edit path exists to preserve. (fable review of
+    /// #814)</para>
+    /// </summary>
+    [Fact]
+    public void An_adopted_connection_can_be_edited_without_pasting_a_key()
+    {
+        var (vm, service) = MakeWithEnv(
+            Env("AZURE_API_KEY"),
+            EnvPreset("azure", "Azure", new[] { "AZURE_API_KEY" },
+                new List<AiInputPrompt> { new("resourceName", "Resource name") }));
+
+        Assert.Single(vm.FoundKeys).UseCommand.Execute().Subscribe();
+        var adding = Assert.IsType<AiConnectionEditorViewModel>(vm.Editor);
+        adding.Inputs.Single(i => i.Key == "resourceName").Value = "mybox";
+        adding.SaveCommand.Execute().Subscribe();
+
+        // Now reopen it, change the resource name, and save — with nothing in the key box.
+        var row = vm.Connections.Single(r => r.Id == "azure");
+        row.EditCommand.Execute().Subscribe();
+        var editing = Assert.IsType<AiConnectionEditorViewModel>(vm.Editor);
+
+        editing.Inputs.Single(i => i.Key == "resourceName").Value = "renamed";
+        editing.SaveCommand.Execute().Subscribe();
+
+        Assert.Null(vm.Problem);
+        Assert.Null(editing.Problem);
+
+        var connection = Assert.Single(service.Connections);
+        Assert.Equal("renamed", connection.Inputs["resourceName"]);
+
+        // And the adoption survived the edit rather than being silently dropped or conferred.
+        Assert.Equal("AZURE_API_KEY", connection.EnvironmentVariable);
+        Assert.Equal(CredentialSource.Environment, connection.KeySource);
+    }
+
+    /// <summary>
     /// A provider the reader has already configured is not offered, whatever their environment holds. That
     /// decision is made, and re-offering it would be the nagging this section is shaped to avoid.
     /// </summary>
@@ -941,6 +1017,10 @@ public class AiConnectionsViewModelTests
     {
         var (vm, service) = MakeWithEnv(
             Env("OPENAI_API_KEY"), EnvPreset("openai", "OpenAI", new[] { "OPENAI_API_KEY" }));
+
+        // Asserted BEFORE, or this passes with discovery deleted entirely — it would be checking that an
+        // empty list is still empty. (fable review of #814)
+        Assert.Single(vm.FoundKeys);
 
         // No manual refresh: adding raises ConnectionsChanged, which is what the tab binds to.
         service.AddFromPreset("openai", new Dictionary<string, string>());

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -220,6 +220,17 @@ namespace CST.Avalonia.ViewModels
                 // (fable review)
                 _authHeaderName = connection.AuthHeaderName,
                 _authScheme = connection.AuthScheme,
+
+                // The adoption has to survive an edit too, and for the same reason the auth shape does.
+                // Without it the sheet forgets this connection authenticates from the environment, decides a
+                // required key is missing, and REFUSES TO SAVE — telling a reader whose credential works
+                // perfectly that the provider needs an API key. Their only ways out were pasting the
+                // environment's key into the keychain, which is the copy the adoption promises never to make,
+                // or deleting and re-adding, which destroys the model list this edit path exists to preserve.
+                // (#714, fable review)
+                _adoptEnvironmentVariable = connection.UsesEnvironmentKey
+                    ? connection.EnvironmentVariable
+                    : null,
             };
 
             foreach (var model in connection.Models)
@@ -391,7 +402,12 @@ namespace CST.Avalonia.ViewModels
             ? "Stored in the operating system's credential store, never in settings."
             : HasStoredKey
                 ? $"A key is stored for {_displayName}. Paste a new one to replace it."
-                : $"No key is stored for {_displayName}.";
+                // "No key is stored" is true and reads as "you have no key", which on an adopted connection is
+                // false — it authenticates from the environment, and saying otherwise sends the reader to
+                // paste one they do not need. (#714, fable review)
+                : _adoptEnvironmentVariable is { } variable
+                    ? $"{_displayName} uses the key in {variable}. Paste one here only to use a different key."
+                    : $"No key is stored for {_displayName}.";
 
         /// <summary>
         /// Whether the "optional" line under the key box applies.
@@ -437,8 +453,8 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public string? EnvironmentKeyNote => _adoptEnvironmentVariable is null
             ? null
-            : $"This connection will use the key in {_adoptEnvironmentVariable}. "
-              + "It stays in your environment — nothing is copied here.";
+            : $"This connection uses the key in {_adoptEnvironmentVariable}. It stays in your environment — "
+              + "nothing is copied here, and you do not need to paste a key below.";
 
         public bool HasEnvironmentKeyNote => EnvironmentKeyNote is not null;
 

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -267,7 +267,10 @@ namespace CST.Avalonia.ViewModels
         /// discovers the gap later and has to find Edit. OpenCode opens a sheet on every Connect.</para>
         /// </summary>
         private AiProviderPreset? PresetFor(string presetId) =>
-            _service?.Presets.FirstOrDefault(p => string.Equals(p.Id, presetId, StringComparison.Ordinal));
+            // OrdinalIgnoreCase, matching the service's one rule for connection ids. Harmless here today,
+            // since these ids round-trip from the same objects — but a second rule in this file is exactly
+            // what #805 is about. (fable review)
+            _service?.Presets.FirstOrDefault(p => string.Equals(p.Id, presetId, StringComparison.OrdinalIgnoreCase));
 
         /// <summary>
         /// Adopts the key the environment holds for this provider. (#714)

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -425,6 +425,17 @@
                              shared key box elsewhere in Settings cannot say which connection it belongs to,
                              so a reader pasting an OpenRouter key while some other endpoint happens to be
                              active files it under that one — #678's collision with a new cause. -->
+                        <!-- The consent this sheet was opened to carry. Without it the reader who pressed a
+                             button naming their environment variable lands on a screen that says "Enter your
+                             API key" and mentions the variable nowhere — so they paste the very key the
+                             adoption exists to avoid copying, or they conclude the button did nothing.
+                             The property existed and was bound to nothing. (#714, fable review) -->
+                        <TextBlock Text="{Binding EnvironmentKeyNote}"
+                                   IsVisible="{Binding HasEnvironmentKeyNote}"
+                                   Classes="SettingDescription"
+                                   TextWrapping="Wrap"
+                                   Margin="0,0,0,12"/>
+
                         <StackPanel IsVisible="{Binding ShowKeyField}">
                             <TextBlock Text="API key" Classes="SettingLabel"/>
                             <StackPanel Orientation="Horizontal" Spacing="6">


### PR DESCRIPTION
Follow-up to #814, which I merged **without a Fable review**. It got one afterwards and found two reader-visible bugs, both in the sheet path — the half I added beyond the handoff, and the half no test touched.

## 1. An adopted connection could not be edited at all

`ForExisting` never carried the connection's adoption into the sheet, although `ToRuntime` hands it both fields. So `MissingRequiredKey` evaluated with no adoption, no stored key and an empty box, and **Save was refused**:

> Azure OpenAI needs an API key. Paste one to continue.

On a connection whose credential works. Reached by adopting Azure, having the resource renamed, and correcting it a month later. The only ways forward were pasting the environment's key into the keychain — *the copy adoption exists to avoid* — or delete-and-re-add, which destroys the enabled-model list that `EditAction`'s own comment says the edit path exists to preserve.

`KeyStatus` said *"No key is stored for Azure OpenAI"* on the same screen: true of the keychain, false of the reader, and it sends them to paste a key they do not need. It now names the variable instead.

## 2. The consent note was bound to nothing

`EnvironmentKeyNote` existed as a property and appeared in **no `.axaml` file**. The reader who pressed a button naming their environment variable landed on a sheet reading *"Enter your Azure OpenAI API key to use Azure OpenAI models"*, with a key box beneath it and the environment mentioned nowhere. Either they paste the key the adoption promised not to copy, or they conclude the button did nothing.

#814 said "the sheet carries the choice already made". True of the view model, false of the screen — consent machinery that shipped invisible.

## Why neither was caught

Three mutations survived all 2507 tests:

| mutation | previously |
|---|---|
| drop the variable name going into the sheet | survived |
| drop it coming out of the sheet | survived |
| delete the required-key suppression | survived |

Each silently turns adoption into an ordinary add that then demands a typed key.

I verified three mutations on the one-click path and **none on the sheet path** — so the enforcement sat exactly where the code was already simple. That is the failure I had described in someone else's code an hour earlier: a passing test is evidence only if it could have failed, and the tests I did not write could not.

Two tests now cover it end to end: adopt a prompted preset through the sheet and save with the key box empty; then reopen it, change the answer, and save again. Each of the three mutations above now fails one or both, and the edit test fails against the pre-fix code.

## Also here

- `An_already_configured_provider_is_not_offered` asserted only an empty list at the end, so it passed with discovery deleted entirely. It now asserts the row exists first.
- `PresetFor` compared ids `Ordinal` where this service's one rule is `OrdinalIgnoreCase`. Harmless where it stood — the ids round-trip from the same objects — and exactly the second-rule-in-one-file that #805 is about.

## What the review confirmed still holds

Worth recording, since the rest of #814 was checked and passed: the key value genuinely never reaches a rendered or logged path (traced through the row, XAML, tooltips, `ToString()`, and every logger in the touched files — there are none); "opted in with nothing recorded" is unrepresentable at the service seam, and `Apply` touches neither field so `Update` can neither drop nor confer an adoption; the one-click path has no route to an unclicked adoption; and Bedrock holds twice over.

One correction to #814's wording: the "value never carried into the row" test **could not have failed** — `AiEnvironmentKey` has no value field, so the proof is the record shape and the test is a tripwire for a future refactor. Worth stating accurately rather than counting it as evidence.

Full suite green — 2509 passed, 0 failed, 17 skipped. 0 build warnings.
