### PR TITLE
See a key exported from a shell profile (#817)

### DIFF
--- a/docs/features/in-progress/AI_SURFACE_B.md
+++ b/docs/features/in-progress/AI_SURFACE_B.md
@@ -403,6 +403,22 @@ hold-back filter — the same hazard as the think-tag filter, and the same failu
   configured provider. State this in Settings in plain language. The **fully local option is real**: a local
   runner through the OpenAI-compatible adapter sends nothing off the machine.
 - **Prompt logging** — bundle contents and responses contain the user's question. Do not log them above Debug.
+- **Reading your shell's environment** — when an AI feature is enabled, or a connection has been set to use a
+  variable, CST Reader runs your login shell once per launch and asks it for its environment. This is what
+  makes a key exported from `~/.zshrc` or `~/.bash_profile` visible at all: an app launched from Finder, the
+  Dock or Spotlight is started by launchd and inherits launchd's environment, not your shell's (#817). Only
+  variables the provider catalogue or one of your connections actually names are kept; everything else is
+  discarded as it is read. Nothing is written to disk, and the log records a count, never a name and never a
+  value. An ordinary launch — no AI features, no adopted connection — runs no shell at all.
+
+  It is a session snapshot, like the process environment has always been: editing a shell profile takes effect
+  at the next launch. Where the probe cannot run — Windows, which does not need it; `nu`, `csh` and `tcsh`,
+  whose flags do not mean what this needs; or a profile slow enough to hit the five-second timeout — behaviour
+  falls back to reading this process's own environment, and the two workarounds are `launchctl setenv NAME
+  value` (which publishes the value to every process in the login session, worth knowing before using it) or
+  launching the binary from a shell that already has the variable:
+  `"/Applications/CST Reader.app/Contents/MacOS/CST Reader"`. Note that `open -a "CST Reader"` does **not**
+  work — `open` hands the request to launchd, which supplies its own environment.
 - **House terminology in generated output — do not post-filter.** String surgery on model prose produces worse
   artifacts than the term it removes, cannot handle inflected or compounded forms, and blurs the line the plan
   correctly draws: output is *labeled generated*, and the project's own scoping of the rule governs our prose

--- a/src/CST.Avalonia.Tests/Services/Ai/AiEnvironmentKeysMergeTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiEnvironmentKeysMergeTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Two sources for one variable: this process's environment, and the login shell's. (#817)
+///
+/// <para>The rule these tests hold in place is that the PROCESS always wins and the shell only fills gaps.
+/// Reversing it is a one-line change that no other test would notice, and it would let a forgotten
+/// <c>.zprofile</c> export shadow a <c>launchctl setenv</c> the reader made to correct it — an app
+/// authenticating with a key its owner believes they have replaced, which is the class of failure #714 exists
+/// to prevent.</para>
+/// </summary>
+public sealed class AiEnvironmentKeysMergeTests
+{
+    /// <summary>A settled snapshot, standing in for a probe that has already finished.</summary>
+    private sealed class FakeShell : IShellEnvironment
+    {
+        private readonly Dictionary<string, string> _values;
+        public FakeShell(params (string Name, string Value)[] values) =>
+            _values = values.ToDictionary(v => v.Name, v => v.Value, StringComparer.Ordinal);
+
+        public bool Primed { get; private set; }
+        public void Prime() => Primed = true;
+        public Task Completion => Task.CompletedTask;
+        public string? TryRead(string variableName) =>
+            _values.TryGetValue(variableName, out var v) ? v : null;
+        public event EventHandler? Probed;
+        public void RaiseProbed() => Probed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>A probe that has not answered yet, which is what every read sees for the first seconds.</summary>
+    private sealed class PendingShell : IShellEnvironment
+    {
+        private readonly TaskCompletionSource _tcs = new();
+        public void Prime() { }
+        public Task Completion => _tcs.Task;
+        public string? TryRead(string variableName) => null;
+        public event EventHandler? Probed;
+        public void Finish() { _tcs.SetResult(); Probed?.Invoke(this, EventArgs.Empty); }
+    }
+
+    private static AiProviderPreset Preset(string id, params string[] envNames) =>
+        new(id, id.ToUpperInvariant(), ChatProviderKind.OpenAiCompatible, "https://example.invalid/v1",
+            new AiCredentialMethod[] { new AiCredentialMethod.Env(envNames) },
+            Array.Empty<AiInputPrompt>());
+
+    private static AiEnvironmentKeys Keys(
+        IShellEnvironment? shell, params (string Name, string? Value)[] processEnvironment)
+    {
+        var map = processEnvironment.ToDictionary(e => e.Name, e => e.Value, StringComparer.Ordinal);
+        return new AiEnvironmentKeys(name => map.TryGetValue(name, out var v) ? v : null, shell);
+    }
+
+    [Fact]
+    public void The_process_environment_wins_over_the_shell_for_the_same_variable()
+    {
+        var keys = Keys(
+            new FakeShell(("OPENAI_API_KEY", "sk-from-profile")),
+            ("OPENAI_API_KEY", "sk-from-launchctl"));
+
+        Assert.Equal("sk-from-launchctl", keys.Read("OPENAI_API_KEY"));
+    }
+
+    [Fact]
+    public void The_shell_supplies_a_variable_the_process_does_not_have()
+    {
+        var keys = Keys(new FakeShell(("CEREBRAS_API_KEY", "csk-profile")));
+
+        // The bug in one line: launched from Finder, this is the only place the key exists.
+        Assert.Equal("csk-profile", keys.Read("CEREBRAS_API_KEY"));
+    }
+
+    [Fact]
+    public void An_empty_process_variable_does_not_mask_the_shell()
+    {
+        var keys = Keys(new FakeShell(("OPENAI_API_KEY", "sk-profile")), ("OPENAI_API_KEY", ""));
+
+        // Documented consequence rather than an oversight. Empty is "absent" everywhere in this file, so
+        // `OPENAI_API_KEY= app` does not withhold a profile key; declining to opt in is what does.
+        Assert.Equal("sk-profile", keys.Read("OPENAI_API_KEY"));
+    }
+
+    [Fact]
+    public void The_presets_declared_order_still_decides_which_variable_a_provider_uses()
+    {
+        // GOOGLE_API_KEY is declared first, and it is the shell that has it; GEMINI_API_KEY is later, and the
+        // process has it. Source precedence answers "which value for this name"; catalogue precedence answers
+        // "which name for this preset". Conflating them — merging per preset instead of per variable — makes
+        // the process's later-ranked variable win, which is the catalogue's decision quietly overruled.
+        var keys = Keys(
+            new FakeShell(("GOOGLE_API_KEY", "profile-google")),
+            ("GEMINI_API_KEY", "process-gemini"));
+
+        var preset = Preset("google", "GOOGLE_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY");
+
+        Assert.Equal("GOOGLE_API_KEY", keys.VariableFor(preset));
+        Assert.Equal("profile-google", keys.ValueFor(preset));
+    }
+
+    [Fact]
+    public void A_probe_still_running_reads_exactly_as_this_app_always_did()
+    {
+        var keys = Keys(new PendingShell(), ("OPENAI_API_KEY", "sk-process"));
+
+        Assert.Equal("sk-process", keys.Read("OPENAI_API_KEY"));
+        Assert.Null(keys.Read("CEREBRAS_API_KEY"));
+    }
+
+    [Fact]
+    public void Discovery_finds_a_preset_whose_key_only_the_shell_can_see()
+    {
+        var keys = Keys(new FakeShell(("GROQ_API_KEY", "gsk-profile")));
+
+        var found = keys.Discover(new[] { Preset("groq", "GROQ_API_KEY"), Preset("openai", "OPENAI_API_KEY") });
+
+        var one = Assert.Single(found);
+        Assert.Equal("groq", one.PresetId);
+        Assert.Equal("GROQ_API_KEY", one.VariableName);
+    }
+
+    [Fact]
+    public async Task Readiness_is_already_settled_when_there_is_no_shell_to_wait_for()
+    {
+        // Awaited on the chat send path and before a model listing. On Windows, and on every launch that did
+        // not prime a probe, that await must cost nothing at all.
+        var keys = Keys(shell: null, ("OPENAI_API_KEY", "sk"));
+        Assert.True(keys.Ready.IsCompleted);
+        await keys.Ready;
+    }
+
+    [Fact]
+    public void A_landing_probe_tells_the_panels_the_environment_now_reads_differently()
+    {
+        var shell = new FakeShell(("CEREBRAS_API_KEY", "csk"));
+        var keys = Keys(shell);
+        var told = 0;
+        keys.Changed += (_, _) => told++;
+
+        shell.RaiseProbed();
+
+        // Without this, a panel built before the probe landed keeps saying "not configured" for the rest of
+        // the session — to a reader whose key IS set, in the variable the app is about to use. Completion
+        // cannot serve here: read before anything primed, it reports "already settled". (fable)
+        Assert.Equal(1, told);
+    }
+
+    [Fact]
+    public void Readiness_is_pending_while_a_probe_is()
+    {
+        var pending = new PendingShell();
+        var keys = Keys(pending);
+
+        Assert.False(keys.Ready.IsCompleted);
+        pending.Finish();
+        Assert.True(keys.Ready.IsCompleted);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/ShellEnvironmentGateTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ShellEnvironmentGateTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using CST.Avalonia.Models;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Which launches run a login shell, and which do not. (#817)
+///
+/// <para>CST Reader opens Pāli texts. The AI master switch ships off, so the great majority of launches must
+/// not spawn a shell at all — both because it costs everyone for a feature few use, and because a reader
+/// looking at their process list should not find a <c>zsh -il</c> a text reader cannot account for.</para>
+/// </summary>
+public sealed class ShellEnvironmentGateTests
+{
+    private static Settings WithConnection(bool aiEnabled, bool usesEnvironmentKey, string? variable)
+    {
+        var settings = new Settings();
+        settings.Ai.Enabled = aiEnabled;
+        settings.Ai.Chat.Connections = new List<AiConnectionRecord>
+        {
+            new() { Id = "one", UsesEnvironmentKey = usesEnvironmentKey, EnvironmentVariable = variable },
+        };
+        return settings;
+    }
+
+    [Fact]
+    public void An_ordinary_launch_does_not_probe()
+    {
+        Assert.False(CST.Avalonia.App.ShouldPrimeShellEnvironment(new Settings()));
+    }
+
+    [Fact]
+    public void No_settings_at_all_does_not_probe()
+    {
+        Assert.False(CST.Avalonia.App.ShouldPrimeShellEnvironment(null));
+    }
+
+    [Fact]
+    public void The_ai_master_switch_being_on_is_enough()
+    {
+        var settings = new Settings();
+        settings.Ai.Enabled = true;
+        Assert.True(CST.Avalonia.App.ShouldPrimeShellEnvironment(settings));
+    }
+
+    [Fact]
+    public void A_stored_connection_that_uses_an_environment_key_probes_even_with_the_master_switch_off()
+    {
+        // The arm that is easy to leave out and expensive to omit. A reader can hold an adopted connection
+        // while the chat surface is off — Surface C answers under the same master switch — and without this
+        // their first request of the session races the probe and loses.
+        Assert.True(CST.Avalonia.App.ShouldPrimeShellEnvironment(
+            WithConnection(aiEnabled: false, usesEnvironmentKey: true, variable: "OPENAI_API_KEY")));
+    }
+
+    [Fact]
+    public void A_connection_that_stores_its_own_key_does_not_probe()
+    {
+        Assert.False(CST.Avalonia.App.ShouldPrimeShellEnvironment(
+            WithConnection(aiEnabled: false, usesEnvironmentKey: false, variable: null)));
+    }
+
+    [Fact]
+    public void An_adopted_connection_with_no_variable_recorded_does_not_probe()
+    {
+        // There is nothing to look up, so there is nothing a shell could tell us.
+        Assert.False(CST.Avalonia.App.ShouldPrimeShellEnvironment(
+            WithConnection(aiEnabled: false, usesEnvironmentKey: true, variable: "  ")));
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/ShellEnvironmentTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ShellEnvironmentTests.cs
@@ -1,0 +1,334 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Reading the variables a login shell exports, for the GUI launch that cannot see them. (#817)
+///
+/// <para>Nothing here spawns a shell. The probe runner is a seam precisely so that this suite does not depend
+/// on which shell the machine running it uses, what that shell's profile does, or how long it takes — a test
+/// that ran a real login shell would be measuring the developer's dotfiles.</para>
+/// </summary>
+public sealed class ShellEnvironmentTests
+{
+    /// <summary>A runner that answers from a script rather than a process, and counts what it was asked.</summary>
+    private sealed class FakeRunner : IShellProbeRunner
+    {
+        private readonly Queue<ShellProbeResult> _answers;
+        public List<ShellProbeAttempt> Attempts { get; } = new();
+
+        public FakeRunner(params ShellProbeResult[] answers) => _answers = new Queue<ShellProbeResult>(answers);
+
+        public ShellProbeResult Run(ShellProbeAttempt attempt)
+        {
+            Attempts.Add(attempt);
+            return _answers.Count > 0 ? _answers.Dequeue() : ShellProbeResult.Failed();
+        }
+    }
+
+    private static byte[] NulStream(params string[] assignments) =>
+        Encoding.UTF8.GetBytes(string.Join("\0", assignments) + "\0");
+
+    private static ShellEnvironment Probe(
+        FakeRunner runner, string shell = "/bin/zsh", bool supported = true, params string[] wanted)
+    {
+        var names = wanted.Length > 0 ? wanted : new[] { "OPENAI_API_KEY" };
+        return new ShellEnvironment(
+            _ => Task.FromResult<IReadOnlyCollection<string>>(names),
+            runner, logger: null, supported: supported, shellPath: shell);
+    }
+
+    // ---- the ladder, and what it does when a shell will not answer ------------------------------------
+
+    [Fact]
+    public async Task An_interactive_login_shell_is_asked_first()
+    {
+        var runner = new FakeRunner(ShellProbeResult.Ok(NulStream("OPENAI_API_KEY=sk-profile")));
+        var shell = Probe(runner);
+
+        shell.Prime();
+        await shell.Completion;
+
+        var attempt = Assert.Single(runner.Attempts);
+        // -il, not -l: for bash, -l sources .bash_profile and -i sources .bashrc, and a reader may have used
+        // either convention. Dropping -i silently loses every key exported from .bashrc or .zshrc.
+        Assert.Equal(new[] { "-il", "-c", ShellEnvironment.ProbeCommand }, attempt.Arguments);
+        Assert.Equal("sk-profile", shell.TryRead("OPENAI_API_KEY"));
+    }
+
+    [Fact]
+    public async Task A_shell_that_refuses_the_interactive_flag_is_retried_as_a_plain_login_shell()
+    {
+        var runner = new FakeRunner(
+            ShellProbeResult.Failed(),
+            ShellProbeResult.Ok(NulStream("OPENAI_API_KEY=sk-second-try")));
+        var shell = Probe(runner);
+
+        shell.Prime();
+        await shell.Completion;
+
+        Assert.Equal(2, runner.Attempts.Count);
+        Assert.Equal(new[] { "-l", "-c", ShellEnvironment.ProbeCommand }, runner.Attempts[1].Arguments);
+        Assert.Equal("sk-second-try", shell.TryRead("OPENAI_API_KEY"));
+    }
+
+    [Fact]
+    public async Task A_timeout_ends_the_probe_and_is_never_retried()
+    {
+        var runner = new FakeRunner(ShellProbeResult.Timeout(), ShellProbeResult.Ok(NulStream("OPENAI_API_KEY=sk")));
+        var shell = Probe(runner);
+
+        shell.Prime();
+        await shell.Completion;
+
+        // The retry exists for a shell that REJECTS the flags, not for one that hangs. A profile that hangs
+        // once hangs twice, and retrying it doubles the time the app spends waiting on something it has
+        // already decided to abandon.
+        Assert.Single(runner.Attempts);
+        Assert.Null(shell.TryRead("OPENAI_API_KEY"));
+    }
+
+    [Fact]
+    public async Task A_probe_that_finds_nothing_completes_rather_than_faulting()
+    {
+        var shell = Probe(new FakeRunner(ShellProbeResult.Failed(), ShellProbeResult.Failed()));
+
+        shell.Prime();
+        await shell.Completion;
+
+        // Completion is awaited on the chat send path. A faulted task there would throw inside the request
+        // and report a shell problem as a provider problem.
+        Assert.True(shell.Completion.IsCompletedSuccessfully);
+        Assert.Null(shell.TryRead("OPENAI_API_KEY"));
+    }
+
+    [Theory]
+    [InlineData("/usr/local/bin/nu")]
+    [InlineData("/opt/homebrew/bin/nushell")]
+    [InlineData("/bin/csh")]
+    [InlineData("/bin/tcsh")]
+    public async Task A_shell_whose_flags_mean_something_else_is_never_run(string shellPath)
+    {
+        var runner = new FakeRunner(ShellProbeResult.Ok(NulStream("OPENAI_API_KEY=sk")));
+        var shell = Probe(runner, shellPath);
+
+        shell.Prime();
+        await shell.Completion;
+
+        Assert.Empty(runner.Attempts);
+    }
+
+    [Fact]
+    public async Task Windows_runs_nothing_at_all()
+    {
+        var runner = new FakeRunner(ShellProbeResult.Ok(NulStream("OPENAI_API_KEY=sk")));
+        var shell = Probe(runner, supported: false);
+
+        shell.Prime();
+        await shell.Completion;
+
+        Assert.Empty(runner.Attempts);
+        Assert.True(shell.Completion.IsCompletedSuccessfully);
+    }
+
+    // ---- what reads do while it is running ------------------------------------------------------------
+
+    [Fact]
+    public void Reading_never_starts_a_probe()
+    {
+        var runner = new FakeRunner(ShellProbeResult.Ok(NulStream("OPENAI_API_KEY=sk")));
+        var shell = Probe(runner);
+
+        Assert.Null(shell.TryRead("OPENAI_API_KEY"));
+
+        // The gate that decides whether to run a login shell is Prime, and it is deliberate. If a read could
+        // trigger one, every consumer that merely LOOKS at the environment — the settings screen being built
+        // on the UI thread — would start a shell as a side effect.
+        Assert.Empty(runner.Attempts);
+        Assert.True(shell.Completion.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task Two_callers_priming_at_once_run_one_shell_between_them()
+    {
+        var gate = new ManualResetEventSlim(false);
+        var runs = 0;
+        var runner = new BlockingRunner(gate, () => Interlocked.Increment(ref runs));
+        var shell = new ShellEnvironment(
+            _ => Task.FromResult<IReadOnlyCollection<string>>(new[] { "OPENAI_API_KEY" }),
+            runner, logger: null, supported: true, shellPath: "/bin/zsh");
+
+        var primes = Enumerable.Range(0, 8).Select(_ => Task.Run(shell.Prime)).ToArray();
+        await Task.WhenAll(primes);
+        gate.Set();
+        await shell.Completion;
+
+        Assert.Equal(1, runs);
+    }
+
+    private sealed class BlockingRunner : IShellProbeRunner
+    {
+        private readonly ManualResetEventSlim _gate;
+        private readonly Action _onRun;
+        public BlockingRunner(ManualResetEventSlim gate, Action onRun) { _gate = gate; _onRun = onRun; }
+
+        public ShellProbeResult Run(ShellProbeAttempt attempt)
+        {
+            _onRun();
+            _gate.Wait(TimeSpan.FromSeconds(5));
+            return ShellProbeResult.Ok(Encoding.UTF8.GetBytes("OPENAI_API_KEY=sk\0"));
+        }
+    }
+
+    [Fact]
+    public async Task Nothing_is_kept_when_no_variable_is_of_interest()
+    {
+        var runner = new FakeRunner(ShellProbeResult.Ok(NulStream("OPENAI_API_KEY=sk")));
+        var shell = new ShellEnvironment(
+            _ => Task.FromResult<IReadOnlyCollection<string>>(Array.Empty<string>()),
+            runner, logger: null, supported: true, shellPath: "/bin/zsh");
+
+        shell.Prime();
+        await shell.Completion;
+
+        // No keep-set means no filter means the whole environment retained, so this must not run at all.
+        Assert.Empty(runner.Attempts);
+        Assert.Null(shell.TryRead("OPENAI_API_KEY"));
+    }
+
+    [Fact]
+    public async Task A_keep_set_that_cannot_be_resolved_leaves_the_probe_unrun()
+    {
+        var runner = new FakeRunner(ShellProbeResult.Ok(NulStream("OPENAI_API_KEY=sk")));
+        var shell = new ShellEnvironment(
+            _ => throw new InvalidOperationException("the catalogue is unavailable"),
+            runner, logger: null, supported: true, shellPath: "/bin/zsh");
+
+        shell.Prime();
+        await shell.Completion;
+
+        Assert.Empty(runner.Attempts);
+        Assert.True(shell.Completion.IsCompletedSuccessfully);
+    }
+}
+
+/// <summary>
+/// Turning <c>env -0</c> output into the few variables this feature may keep. (#817)
+///
+/// <para>The filter is the security boundary, not a tidiness measure: a login shell's environment holds
+/// session tokens, agent sockets and — on this project's own machines — an iCloud-wide app password, and
+/// retaining it for the session would put all of it in a long-lived dictionary.</para>
+/// </summary>
+public sealed class ShellEnvParserTests
+{
+    private static IReadOnlyDictionary<string, string> Parse(string stdout, params string[] keep) =>
+        ShellEnvParser.Parse(
+            Encoding.UTF8.GetBytes(stdout),
+            new HashSet<string>(keep, StringComparer.Ordinal));
+
+    [Fact]
+    public void A_name_outside_the_keep_set_does_not_survive_the_parse()
+    {
+        var parsed = Parse(
+            "OPENAI_API_KEY=sk-wanted\0APPLE_APP_PASSWORD=abcd-efgh-ijkl-mnop\0SSH_AUTH_SOCK=/tmp/agent\0",
+            "OPENAI_API_KEY");
+
+        // The regression test for the whole design. Remove the filter and this fails, which is the only
+        // automated warning anyone gets before an unrelated credential starts living in the app's heap for
+        // the session and turning up in crash dumps.
+        Assert.Equal(new[] { "OPENAI_API_KEY" }, parsed.Keys.ToArray());
+        Assert.DoesNotContain("APPLE_APP_PASSWORD", parsed.Keys);
+    }
+
+    [Fact]
+    public void Chatter_that_the_sentinel_separated_is_discarded()
+    {
+        // What the real stream looks like: chatter, the sentinel NUL, then env's own NUL-terminated output.
+        var parsed = Parse(
+            "Now using node v20.11.0 (npm v10.2.4)\nnvm: default=v20\0OPENAI_API_KEY=sk-real\0",
+            "OPENAI_API_KEY", "default");
+
+        // A banner containing '=' parses as an assignment to a naive splitter. "default=v20" is exactly the
+        // shape nvm prints, and it is in the keep-set here to prove the NAME SHAPE check is what rejects it.
+        Assert.Equal("sk-real", parsed["OPENAI_API_KEY"]);
+        Assert.Single(parsed);
+    }
+
+    [Fact]
+    public void Chatter_glued_to_the_first_variable_costs_exactly_that_variable()
+    {
+        // The stream WITHOUT the sentinel, which is what `env -0` alone produces: a profile's output has no
+        // NUL after it, so the chatter and the first assignment are one chunk. This test does not assert a
+        // fix — it pins the damage the sentinel exists to prevent, so that anyone who removes
+        // ShellEnvironment.ProbeCommand's `printf` can see what it costs. Which variable is first is
+        // environment-order dependent, so in the field this is one reader's key vanishing and nobody
+        // else's. (fable)
+        var glued = Parse(
+            "Now using node v20.11.0\nGROQ_API_KEY=gsk-first\0OPENAI_API_KEY=sk-second\0",
+            "GROQ_API_KEY", "OPENAI_API_KEY");
+
+        Assert.False(glued.ContainsKey("GROQ_API_KEY"));
+        Assert.Equal("sk-second", glued["OPENAI_API_KEY"]);
+    }
+
+    [Fact]
+    public void The_probe_command_puts_a_sentinel_before_the_environment()
+    {
+        // Cheap, and it is the only thing standing between the test above and production.
+        Assert.StartsWith("printf", ShellEnvironment.ProbeCommand);
+        Assert.Contains(@"\0", ShellEnvironment.ProbeCommand);
+        Assert.Contains("env -0", ShellEnvironment.ProbeCommand);
+    }
+
+    [Fact]
+    public void A_value_containing_a_newline_survives_intact()
+    {
+        var parsed = Parse("ANTHROPIC_API_KEY=line-one\nline-two\0", "ANTHROPIC_API_KEY");
+
+        // The entire reason for `env -0` rather than `env`. Split on newlines instead and this key is
+        // truncated at "line-one" — a corrupted credential, which fails as an unexplainable 401.
+        Assert.Equal("line-one\nline-two", parsed["ANTHROPIC_API_KEY"]);
+    }
+
+    [Fact]
+    public void A_value_containing_an_equals_sign_is_not_split_twice()
+    {
+        var parsed = Parse("GROQ_API_KEY=gsk_aaa=bbb=ccc\0", "GROQ_API_KEY");
+        Assert.Equal("gsk_aaa=bbb=ccc", parsed["GROQ_API_KEY"]);
+    }
+
+    [Fact]
+    public void A_chunk_that_is_not_an_assignment_is_dropped_without_throwing()
+    {
+        var parsed = Parse("no-equals-here\0=leading-equals\0 SPACED=value\0OPENAI_API_KEY=sk\0",
+            "OPENAI_API_KEY", "SPACED", " SPACED");
+
+        Assert.Equal(new[] { "OPENAI_API_KEY" }, parsed.Keys.ToArray());
+    }
+
+    [Fact]
+    public void An_empty_export_is_not_a_credential()
+    {
+        var parsed = Parse("OPENAI_API_KEY=\0OPENROUTER_API_KEY=   \0", "OPENAI_API_KEY", "OPENROUTER_API_KEY");
+
+        // Same rule the process-environment reader applies: `export OPENAI_API_KEY=` in a profile must not
+        // produce an offer to connect that then fails to authenticate.
+        Assert.Empty(parsed);
+    }
+
+    [Fact]
+    public void Nothing_is_kept_from_an_empty_stream()
+    {
+        Assert.Empty(ShellEnvParser.Parse(Array.Empty<byte>(), new HashSet<string> { "OPENAI_API_KEY" }));
+        Assert.Empty(ShellEnvParser.Parse(Encoding.UTF8.GetBytes("OPENAI_API_KEY=sk\0"), new HashSet<string>()));
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/ShellProbeRunnerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ShellProbeRunnerTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using CST.Avalonia.Services.Ai.Credentials;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// The one part of the probe that spawns a real process, tested against a real one. (#817)
+///
+/// <para>Everything else in this feature runs behind <see cref="IShellProbeRunner"/> precisely so it can be
+/// tested without a shell. That leaves the runner itself uncovered, and it is where the interesting failures
+/// live — pipes, exit codes, and children that outlive their parent. These use <c>/bin/sh</c> with a fixed
+/// script rather than the reader's login shell, so they test this code and not somebody's dotfiles.</para>
+/// </summary>
+public sealed class ShellProbeRunnerTests
+{
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(5);
+
+    private static ShellProbeResult Run(string script) =>
+        new ProcessShellProbeRunner().Run(
+            new ShellProbeAttempt("/bin/sh", new[] { "-c", script }, Budget));
+
+    private static IReadOnlyDictionary<string, string> Parse(ShellProbeResult result, params string[] keep) =>
+        ShellEnvParser.Parse(result.Stdout, new HashSet<string>(keep, StringComparer.Ordinal));
+
+    [UnixFact]
+    public void A_real_shell_answers_with_its_environment()
+    {
+        var result = Run(ShellEnvironment.ProbeCommand);
+
+        Assert.True(result.Succeeded);
+        Assert.NotEmpty(Parse(result, "PATH", "HOME"));
+    }
+
+    [UnixFact]
+    public void The_sentinel_saves_the_first_variable_from_a_chatty_profile()
+    {
+        // Both halves come from a REAL shell, so this compares what actually arrives rather than what a
+        // hand-written stream is imagined to look like — the mistake in the first version of these tests.
+        var withSentinel = Parse(Run("echo 'Now using node v20.11.0'; " + ShellEnvironment.ProbeCommand),
+            AllNames(Run(ShellEnvironment.ProbeCommand)));
+        var glued = Parse(Run("echo 'Now using node v20.11.0'; env -0"),
+            AllNames(Run(ShellEnvironment.ProbeCommand)));
+
+        // Without the sentinel the chatter is glued to the first assignment and that variable is lost; with
+        // it, nothing is. This is the regression test for a bug that would have shipped as "one user's key is
+        // invisible and nobody can reproduce it". (fable)
+        Assert.Equal(withSentinel.Count - 1, glued.Count);
+        Assert.True(withSentinel.Count > 0);
+    }
+
+    private static string[] AllNames(ShellProbeResult clean) =>
+        Encoding.UTF8.GetString(clean.Stdout)
+            .Split('\0')
+            .Select(chunk => chunk.Split('=')[0])
+            .Where(name => name.Length > 0 && (char.IsAsciiLetter(name[0]) || name[0] == '_'))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+    [UnixFact]
+    public void A_background_job_holding_the_pipe_does_not_turn_a_success_into_a_timeout()
+    {
+        var watch = Stopwatch.StartNew();
+
+        // The shell exits immediately; the `sleep` inherits stdout and holds the write end open for 30
+        // seconds. Waiting for end-of-stream here would block on a probe whose output is already in the
+        // buffer — reporting a SUCCESS as a timeout, which the ladder treats as "give up permanently", and
+        // parking a thread on the raw environment for the life of the app. (fable)
+        var result = Run(ShellEnvironment.ProbeCommand + "; sleep 30 &");
+        watch.Stop();
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.TimedOut);
+        Assert.NotEmpty(Parse(result, "PATH", "HOME"));
+        Assert.True(watch.Elapsed < Budget, $"took {watch.ElapsedMilliseconds}ms, so it waited for EOF");
+    }
+
+    [UnixFact]
+    public void A_shell_that_hangs_is_killed_and_reported_as_a_timeout()
+    {
+        var watch = Stopwatch.StartNew();
+        var result = new ProcessShellProbeRunner().Run(
+            new ShellProbeAttempt("/bin/sh", new[] { "-c", "sleep 60" }, TimeSpan.FromMilliseconds(400)));
+        watch.Stop();
+
+        Assert.True(result.TimedOut);
+        Assert.False(result.Succeeded);
+        Assert.True(watch.Elapsed < TimeSpan.FromSeconds(5));
+    }
+
+    [UnixFact]
+    public void A_nonzero_exit_is_a_failure_rather_than_an_empty_success()
+    {
+        // The difference matters to the ladder: a failure is retried as a plain login shell, and a success
+        // with no variables would end the probe having learned nothing.
+        var result = Run("exit 3");
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.TimedOut);
+    }
+
+    [UnixFact]
+    public void A_shell_that_does_not_exist_is_a_failure_rather_than_a_crash()
+    {
+        var result = new ProcessShellProbeRunner().Run(
+            new ShellProbeAttempt("/nonexistent/shell.invalid", new[] { "-c", "env -0" }, Budget));
+
+        Assert.False(result.Succeeded);
+    }
+
+    [UnixFact]
+    public void Output_below_the_cap_is_returned_whole()
+    {
+        // A megabyte is far more than any real environment and well under the cap, so this is the control
+        // for the test below: large output on its own is not what gets refused.
+        var result = Run("head -c 1000000 /dev/zero");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1000000, result.Stdout.Length);
+    }
+
+    [UnixFact]
+    public void A_runaway_profile_is_refused_rather_than_buffered()
+    {
+        var watch = Stopwatch.StartNew();
+
+        // Eight megabytes, twice the cap. The reader stops at the cap, the shell blocks on the write it
+        // cannot finish, and the attempt ends as a timeout — which the ladder treats as give up, and
+        // degrading to the process environment is the right answer for a profile behaving like this.
+        //
+        // The first version of this test asserted `Stdout.Length <= MaxStdoutBytes` and could not fail:
+        // removing the cap sends the run down the timeout path, where Stdout is empty and the assertion holds
+        // anyway. Asserting on the OUTCOME is what makes it a real test.
+        var result = new ProcessShellProbeRunner().Run(
+            new ShellProbeAttempt("/bin/sh", new[] { "-c", "head -c 8000000 /dev/zero" },
+                TimeSpan.FromSeconds(2)));
+        watch.Stop();
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.Stdout.Length <= ProcessShellProbeRunner.MaxStdoutBytes);
+        Assert.True(watch.Elapsed < TimeSpan.FromSeconds(10));
+    }
+}

--- a/src/CST.Avalonia.Tests/UnixFactAttribute.cs
+++ b/src/CST.Avalonia.Tests/UnixFactAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+using Xunit;
+
+namespace CST.Avalonia.Tests;
+
+/// <summary>
+/// A <see cref="FactAttribute"/> that reports SKIPPED on Windows instead of passing.
+///
+/// <para>The twin of <see cref="WindowsFactAttribute"/>, and for the reason given there: an early
+/// <c>return</c> leaves a green test that executed no assertions, which is how a platform stops being covered
+/// without anything turning red.</para>
+///
+/// <para>Used by the tests that spawn a real shell (#817). Those cannot run on Windows, where there is no
+/// probe to test — and should not be faked there, because what they exist to check is the behaviour of an
+/// actual process and an actual pipe.</para>
+/// </summary>
+public sealed class UnixFactAttribute : FactAttribute
+{
+    public UnixFactAttribute()
+    {
+        if (OperatingSystem.IsWindows())
+            Skip = "Unix only: there is no shell probe on Windows, which inherits its environment normally.";
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -439,6 +440,14 @@ public partial class App : Application
                 // silently absent for a reader who HAD enabled it, and ticking an already-ticked box changed
                 // nothing and so brought nothing back. Reconciled once, here, where the values are real. (#667)
                 ReconcileAssistantPanel(settingsService);
+
+                // Here for the reason the paragraph above gives, and it is the same bug one feature later.
+                // SettingsService starts with `new Settings()` — master switch off, no connections — so a
+                // gate consulted before this point reads the defaults, decides there is no AI on this
+                // machine, and never probes on any launch ever. Placed INSIDE this method rather than after
+                // the call to it, so the ordering is a property of the code rather than of where somebody
+                // happened to put a line. (#817, fable)
+                PrimeShellEnvironment();
             }
         }
         catch (Exception ex)
@@ -652,6 +661,85 @@ public partial class App : Application
     /// Bind the DPD lemma provider's reopen to the asset-install event. Called at startup, before the layout
     /// (and so before <c>DictionaryViewModel</c>) subscribes to the same event. (#536/#563)
     /// </summary>
+    /// <summary>
+    /// The only variables the shell probe is allowed to keep. (#817)
+    ///
+    /// <para>Resolved when the probe runs, not when the container is built. The provider catalogue loads
+    /// asynchronously, and a set captured at registration would be empty — which would filter out every name
+    /// the reader is about to ask about and make the whole feature silently inert. Awaiting the catalogue
+    /// costs nothing here because this already runs on the thread pool, behind everything the reader can
+    /// see.</para>
+    ///
+    /// <para>Two sources, and both are needed. The catalogue covers discovery — offering a key the reader has
+    /// not connected yet. The stored connections cover the moment of use: a reader who adopted a variable last
+    /// session must still authenticate with it after a relaunch, and that name is in settings whether or not
+    /// the catalogue ever loads.</para>
+    /// </summary>
+    private static async Task<IReadOnlyCollection<string>> ShellVariablesOfInterestAsync(
+        IServiceProvider services, CancellationToken ct)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+
+        var presets = services.GetService<Services.Ai.IAiPresetSource>();
+        if (presets is not null)
+        {
+            // Best effort, and time-boxed. EnsureLoadedAsync serialises behind the models.dev fetch, whose
+            // HttpClient allows 30 seconds — and Completion is awaited on the chat send path, so an
+            // unreachable network would stall a request for half a minute on behalf of a shell probe that
+            // takes milliseconds. Presets are already seeded from the bundled snapshot in the constructor;
+            // what the fetch adds is newly listed providers, which is not worth a send-path stall. (fable)
+            using var catalogue = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            catalogue.CancelAfter(TimeSpan.FromSeconds(3));
+            try { await presets.EnsureLoadedAsync(catalogue.Token); }
+            catch { /* the bundled snapshot, or the stored connections below, or nothing */ }
+
+            foreach (var preset in presets.Presets)
+                foreach (var name in preset.EnvironmentVariables)
+                    if (!string.IsNullOrWhiteSpace(name)) names.Add(name);
+        }
+
+        var settings = services.GetService<ISettingsService>()?.Settings;
+        foreach (var connection in settings?.Ai?.Chat?.Connections ?? new List<Models.AiConnectionRecord>())
+            if (connection is { UsesEnvironmentKey: true, EnvironmentVariable: { } variable }
+                && !string.IsNullOrWhiteSpace(variable))
+                names.Add(variable);
+
+        return names;
+    }
+
+    /// <summary>
+    /// Runs the shell probe, but only for readers an AI feature is actually live for. (#817)
+    ///
+    /// <para>CST Reader opens Pāli texts; the AI master switch ships off, and most launches never touch any of
+    /// this. Spawning a login shell on every launch to serve a feature most readers have not enabled fails the
+    /// proportionality test twice over — it costs everyone for the few, and it puts a <c>zsh -il</c> in the
+    /// process list of a text reader, which a reader auditing their machine would be right to ask about.</para>
+    /// </summary>
+    private void PrimeShellEnvironment()
+    {
+        var settings = ServiceProvider?.GetService<ISettingsService>()?.Settings;
+        if (!ShouldPrimeShellEnvironment(settings)) return;
+
+        ServiceProvider?.GetService<Services.Ai.Credentials.IShellEnvironment>()?.Prime();
+    }
+
+    /// <summary>
+    /// Whether a launch should probe. Split out to be testable without an app instance. (#817)
+    ///
+    /// <para>The second arm is the one that matters and the one easy to leave out. A reader can hold a
+    /// connection adopted from the environment while the chat surface itself is off, and turning chat back on
+    /// does not go through here. Priming on a stored environment-key connection is what stops that reader's
+    /// first request of the session losing a race with the probe.</para>
+    /// </summary>
+    internal static bool ShouldPrimeShellEnvironment(Models.Settings? settings)
+    {
+        if (settings?.Ai is not { } ai) return false;
+        if (ai.Enabled) return true;
+
+        return ai.Chat?.Connections?.Any(
+            c => c is { UsesEnvironmentKey: true } && !string.IsNullOrWhiteSpace(c.EnvironmentVariable)) == true;
+    }
+
     private void SubscribeLemmaReopen()
     {
         var updates = ServiceProvider?.GetService<IDpdUpdateService>();
@@ -1417,9 +1505,19 @@ public partial class App : Application
             sp.GetService<Services.Ai.IAiPresetSource>(),
             sp.GetService<Services.Ai.Credentials.IAiEnvironmentKeys>()));
 
+        // The reader's login-shell environment (#817). A GUI launch inherits launchd's environment, not the
+        // login shell's, so a key exported from a shell profile is invisible to the process; this runs the
+        // shell once to see it. Registered unconditionally, primed conditionally — see PrimeShellEnvironment.
+        services.AddSingleton<Services.Ai.Credentials.IShellEnvironment>(sp =>
+            new Services.Ai.Credentials.ShellEnvironment(
+                ct => ShellVariablesOfInterestAsync(sp, ct),
+                sp.GetService<ILoggerFactory>()?.CreateLogger<Services.Ai.Credentials.ShellEnvironment>()));
+
         // Vendor API keys the reader's environment already holds (#714). Discovery only — nothing here adopts
         // a key; that is the reader's click, recorded on the connection.
-        services.AddSingleton<Services.Ai.Credentials.IAiEnvironmentKeys, Services.Ai.Credentials.AiEnvironmentKeys>();
+        services.AddSingleton<Services.Ai.Credentials.IAiEnvironmentKeys>(sp =>
+            new Services.Ai.Credentials.AiEnvironmentKeys(
+                sp.GetService<Services.Ai.Credentials.IShellEnvironment>()));
 
         // The models.dev provider catalogue (#736). Singleton because it caches the document in memory and
         // holds the fetch gate; nothing user-visible depends on it yet (#737 turns it into presets).
@@ -1508,7 +1606,8 @@ public partial class App : Application
             sp.GetService<Services.Ai.IReaderStateService>(),
             sp.GetService<Services.Ai.IChatProviderResolver>(),
             sp.GetService<ISettingsService>(),
-            sp.GetService<Services.Ai.IAiConnectionService>()));
+            sp.GetService<Services.Ai.IAiConnectionService>(),
+            sp.GetService<Services.Ai.Credentials.IAiEnvironmentKeys>()));
         // services.AddTransient<MainWindowViewModel>();
     }
 

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -193,6 +193,14 @@ namespace CST.Avalonia.Services.Ai
                 return AiCatalogResult.Fail(
                     $"{connection.DisplayName} is not finished being set up, so it cannot be asked for a list.");
 
+            // Settled before authenticating, never before deciding what to show. Already-complete unless a
+            // shell probe is genuinely in flight (#817), so this is a no-op on Windows and on every launch
+            // that did not prime one. Without it, a connection adopted from a shell-profile variable reports
+            // "the provider rejected the key" for the first listing after a relaunch and works on the second
+            // — an intermittent authentication failure decided by a race, which is unreportable as a bug.
+            if (_environmentKeys is not null && connection.UsesEnvironmentKey)
+                await _environmentKeys.Ready.ConfigureAwait(false);
+
             // A header marked secret with nothing stored, refused here for the same reason the chat path
             // refuses it: sent blank it is dropped at the wire and comes back as a 401 naming nothing, which
             // is the #711 complaint arriving from a third direction. Refused in BOTH places or not at all -

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiEnvironmentKeys.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiEnvironmentKeys.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using CST.Avalonia.Models.Ai;
 
 namespace CST.Avalonia.Services.Ai.Credentials;
@@ -49,6 +50,15 @@ public interface IAiEnvironmentKeys
     IReadOnlyList<AiEnvironmentKey> Discover(IEnumerable<AiProviderPreset> presets);
 
     /// <summary>
+    /// Completes once every source this can read has been consulted. (#817)
+    ///
+    /// <para>Reads never block, so a caller that must not miss a key — one about to authenticate — awaits
+    /// this first. Already complete unless a shell probe is actually in flight, so awaiting it costs nothing
+    /// in the ordinary case and never starts a probe of its own.</para>
+    /// </summary>
+    Task Ready { get; }
+
+    /// <summary>
     /// The value of one named variable, or null when it is unset or empty. (#714)
     ///
     /// <para>This is what an adopted connection reads, and it takes the NAME the reader consented to rather
@@ -58,17 +68,42 @@ public interface IAiEnvironmentKeys
     /// which is the precise property this feature exists to prevent. (fable)</para>
     /// </summary>
     string? Read(string variableName);
+
+    /// <summary>
+    /// Raised when the set of readable variables has grown — today, when a shell probe lands. (#817)
+    ///
+    /// <para>Surfaces that render "no key is set" subscribe to this, because on a GUI launch that sentence can
+    /// be wrong for the first few seconds of a session and nothing else would ever correct it.</para>
+    /// </summary>
+    event EventHandler? Changed;
 }
 
 /// <inheritdoc />
 public sealed class AiEnvironmentKeys : IAiEnvironmentKeys
 {
     private readonly Func<string, string?> _read;
+    private readonly IShellEnvironment? _shell;
 
-    public AiEnvironmentKeys() : this(Environment.GetEnvironmentVariable) { }
+    public AiEnvironmentKeys(IShellEnvironment? shell = null)
+        : this(Environment.GetEnvironmentVariable, shell) { }
 
     /// <summary>Test seam. The real reader is <see cref="Environment.GetEnvironmentVariable(string)"/>.</summary>
-    internal AiEnvironmentKeys(Func<string, string?> read) => _read = read;
+    internal AiEnvironmentKeys(Func<string, string?> read, IShellEnvironment? shell = null)
+    {
+        _read = read;
+        _shell = shell;
+
+        // Forwarded rather than exposing IShellEnvironment to the panels: what they need to know is that the
+        // environment now reads differently, not that a shell was involved in making it so.
+        if (_shell is not null)
+            _shell.Probed += (_, _) => Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <inheritdoc />
+    public event EventHandler? Changed;
+
+    /// <inheritdoc />
+    public Task Ready => _shell?.Completion ?? Task.CompletedTask;
 
     /// <inheritdoc />
     public string? Read(string variableName) =>
@@ -110,17 +145,46 @@ public sealed class AiEnvironmentKeys : IAiEnvironmentKeys
     // or a CI runner that defines every name it knows — would otherwise read as a key that is present, and
     // offering to connect with it produces an authentication failure the reader cannot explain, from a
     // variable they did not know they had.
+    //
+    // TWO SOURCES, AND THE PROCESS ALWAYS WINS. (#817) The shell snapshot fills gaps; it never overrides. Per
+    // variable, not per preset — which source supplies a name and which name a preset prefers are separate
+    // questions, and keeping them separate leaves the catalogue's declared order (below) in charge of the
+    // second one.
+    //
+    // Process-first because everything in the process environment is the more deliberate signal. It arrived
+    // by launching from a terminal, by `launchctl setenv`, or inline for this one run — and that last case,
+    // `OPENAI_API_KEY=test "…/MacOS/CST Reader"`, is the canonical override that probe-first would silently
+    // defeat. A profile line is the stalest of the sources: letting a forgotten .zprofile export shadow a
+    // launchctl correction is the OpenCode failure #714 exists to prevent, in miniature.
+    //
+    // It is also what keeps the late arrival honest — for VALUES, which is the claim worth making. A value
+    // the reader already saw is never swapped underneath them by the probe.
+    //
+    // NAMES are a weaker guarantee, and the difference is worth stating rather than glossing. VariableFor
+    // below walks the preset's declared order and takes the first that is set, so a preset whose earlier-
+    // ranked variable exists only in the shell will change WHICH variable it offers when the probe lands —
+    // GEMINI_API_KEY becoming GOOGLE_API_KEY, say. That is the catalogue's own precedence applied to a fuller
+    // environment rather than a partial one, so the later answer is the more correct of the two; it is called
+    // out because the row the reader consents to names a variable. (fable)
+    //
+    // One consequence, accepted: because empty is absent, `OPENAI_API_KEY= "…/MacOS/CST Reader"` does not MASK
+    // a profile value — the gap-fill takes over. That follows from the whitespace rule above, and the real way
+    // to withhold a key is not to opt in.
     private string? ReadRaw(string name)
     {
         try
         {
             var value = _read(name);
-            return string.IsNullOrWhiteSpace(value) ? null : value;
+            if (!string.IsNullOrWhiteSpace(value)) return value;
         }
         catch
         {
             // A platform that refuses to read the environment is "no key", not a crash on the settings screen.
-            return null;
         }
+
+        // Null until a probe has been primed AND has finished. Deliberately not awaited: this is called on the
+        // UI thread while the Settings window is being built.
+        var probed = _shell?.TryRead(name);
+        return string.IsNullOrWhiteSpace(probed) ? null : probed;
     }
 }

--- a/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
@@ -1,0 +1,513 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Ai.Credentials;
+
+/// <summary>
+/// The variables a reader's login shell exports, for the case where the app cannot see them. (#817)
+///
+/// <para><b>The problem.</b> <see cref="Environment.GetEnvironmentVariable(string)"/> reads this process's own
+/// environment, fixed at <c>exec</c>. On macOS an app launched from Finder, the Dock or Spotlight is started by
+/// launchd and inherits launchd's environment — not the login shell's. A key exported from
+/// <c>~/.zshrc</c>, <c>~/.zprofile</c> or <c>~/.bash_profile</c> is therefore invisible, and "no variable is
+/// set" and "the variable is set somewhere this process cannot see" look identical. That is the ordinary case
+/// rather than an exotic one: a shell profile is where most people who have a vendor key have put it. Windows
+/// is unaffected, because a user or system variable is inherited normally.</para>
+///
+/// <para><b>The fix, and its shape.</b> Run the reader's shell once as a login+interactive shell, ask it for
+/// its environment, and keep the answer for the session. Everything about the design follows from the fact
+/// that this is expensive, fallible, and handling other people's secrets:</para>
+///
+/// <list type="bullet">
+/// <item><b>Nothing waits for it.</b> <see cref="TryRead"/> never blocks and answers null while a probe is in
+/// flight, so a slow profile delays nothing; callers that genuinely need the answer await
+/// <see cref="Completion"/>, and the UI redraws when it lands. A blocking read here would freeze the Settings
+/// window for as long as the reader's <c>nvm</c> initialisation takes.</item>
+/// <item><b>Only the variables this feature could be asked about are retained.</b> See
+/// <see cref="ShellEnvParser"/> — a login shell's environment holds far more than provider keys.</item>
+/// <item><b>Every failure degrades to the process environment</b>, which is exactly today's behaviour. There
+/// is one code path, not two: what Windows does, what a shell we decline to run does, and what a probe that
+/// times out does are all the same thing.</item>
+/// <item><b>It runs only when an AI feature is actually in play.</b> Most launches of a Pāli text reader never
+/// touch this; they should not pay for a login shell, and a reader reading their process list should not find
+/// one they cannot account for.</item>
+/// </list>
+///
+/// <para><b>Nothing here is written anywhere.</b> The snapshot lives in memory for the session and is never
+/// persisted — a probe result on disk is a credential on disk. The log line records a count, never a name and
+/// never a value.</para>
+/// </summary>
+public interface IShellEnvironment
+{
+    /// <summary>
+    /// Starts the probe if it has not started. Returns immediately, and is safe to call from anywhere as often
+    /// as you like — concurrent calls collapse onto the one probe.
+    /// </summary>
+    void Prime();
+
+    /// <summary>
+    /// Completes when the probe has finished — success, failure and timeout alike. Already complete when
+    /// nothing has primed it, so awaiting this never starts a probe: a caller asking "is the environment
+    /// settled?" must not be the thing that decides to run a shell.
+    ///
+    /// <para>Never faults. A probe that throws is a probe that found nothing.</para>
+    /// </summary>
+    Task Completion { get; }
+
+    /// <summary>
+    /// The probed value of one variable, or null when the probe has not finished, did not run, failed, or did
+    /// not retain that name. Never blocks, and never starts a probe.
+    /// </summary>
+    string? TryRead(string variableName);
+
+    /// <summary>
+    /// Raised once, when a probe has finished and its answers are readable. (#817)
+    ///
+    /// <para>An event rather than a continuation on <see cref="Completion"/>, because a consumer built before
+    /// anything primed would see <see cref="Completion"/> already complete and conclude, permanently, that
+    /// there is nothing to wait for. That consumer exists: the assistant panel is a DI singleton whose
+    /// construction is not ordered against startup, and it is the surface that says "not configured".</para>
+    /// </summary>
+    event EventHandler? Probed;
+}
+
+/// <inheritdoc />
+public sealed class ShellEnvironment : IShellEnvironment
+{
+    /// <summary>
+    /// Per attempt, matching OpenCode's. Long enough for a heavy profile, short enough that the retry and the
+    /// give-up both happen inside the time a reader spends getting to the Settings screen.
+    /// </summary>
+    internal static readonly TimeSpan AttemptTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Shells whose flags do not mean what this code needs them to mean, skipped by name rather than
+    /// attempted. <c>nu</c> is not POSIX and has no <c>-c "env -0"</c> equivalent to offer; <c>csh</c> and
+    /// <c>tcsh</c> honour <c>-l</c> only as the sole argument, so the combined form is at best ignored. There
+    /// is no per-shell capability matrix beyond this list — the give-up path is the compatibility story.
+    /// </summary>
+    private static readonly string[] SkippedShells = { "nu", "nushell", "csh", "tcsh" };
+
+    /// <summary>
+    /// What the shell is asked to run.
+    ///
+    /// <para><c>env -0</c> because NUL separation is what makes a value containing a newline parse back
+    /// correctly — the reason not to use plain <c>env</c>.</para>
+    ///
+    /// <para><b>The leading <c>printf '\0'</c> is not decoration.</b> A profile prints things — version
+    /// manager notices, banners, <c>fortune</c> — and that output goes to stdout with no NUL after it, so the
+    /// chatter and the FIRST assignment arrive glued together in one chunk: <c>"Now using node v20\nHOME=…"</c>.
+    /// Split on NUL and that chunk's name is <c>"Now using node v20\nHOME"</c>, which is not a variable name,
+    /// so the first variable of the environment is silently dropped. Which variable is first depends on the
+    /// machine, so the symptom is one reader's key going missing and nobody else's. The sentinel puts a NUL
+    /// between the chatter and the data, so the chatter is its own discardable chunk. (fable)</para>
+    /// </summary>
+    internal const string ProbeCommand = "printf '\\0'; env -0";
+
+    private readonly Func<CancellationToken, Task<IReadOnlyCollection<string>>> _namesOfInterest;
+    private readonly IShellProbeRunner _runner;
+    private readonly ILogger? _logger;
+    private readonly bool _supported;
+    private readonly string? _shellPath;
+    private readonly Lazy<Task<IReadOnlyDictionary<string, string>>> _probe;
+
+    private static readonly IReadOnlyDictionary<string, string> Empty =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <param name="namesOfInterest">
+    /// The variables worth keeping, resolved when the probe runs rather than when this is constructed. Late by
+    /// design: the provider catalogue is still loading at startup, and a set captured too early would filter
+    /// out the very names the reader is about to ask about.
+    /// </param>
+    public ShellEnvironment(
+        Func<CancellationToken, Task<IReadOnlyCollection<string>>> namesOfInterest,
+        ILogger? logger = null)
+        : this(namesOfInterest, new ProcessShellProbeRunner(), logger,
+               supported: !OperatingSystem.IsWindows(),
+               shellPath: Environment.GetEnvironmentVariable("SHELL"))
+    {
+    }
+
+    /// <summary>Test seam. The real runner spawns a process; the real platform check is <c>!IsWindows</c>.</summary>
+    internal ShellEnvironment(
+        Func<CancellationToken, Task<IReadOnlyCollection<string>>> namesOfInterest,
+        IShellProbeRunner runner,
+        ILogger? logger,
+        bool supported,
+        string? shellPath)
+    {
+        _namesOfInterest = namesOfInterest ?? throw new ArgumentNullException(nameof(namesOfInterest));
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        _logger = logger;
+        _supported = supported;
+        _shellPath = shellPath;
+
+        // ExecutionAndPublication so that two callers priming at once run one shell between them, not two.
+        _probe = new Lazy<Task<IReadOnlyDictionary<string, string>>>(
+            () => Task.Run(async () =>
+            {
+                var snapshot = await ProbeAsync().ConfigureAwait(false);
+                // Raised after the result is in hand, so a handler that reads immediately sees it.
+                try { Probed?.Invoke(this, EventArgs.Empty); } catch { /* a handler's problem, not ours */ }
+                return snapshot;
+            }),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <inheritdoc />
+    public event EventHandler? Probed;
+
+    /// <inheritdoc />
+    public void Prime()
+    {
+        if (!_supported) return;
+        _ = _probe.Value;
+    }
+
+    /// <inheritdoc />
+    public Task Completion => _probe.IsValueCreated ? _probe.Value : Task.CompletedTask;
+
+    /// <inheritdoc />
+    public string? TryRead(string variableName)
+    {
+        if (string.IsNullOrWhiteSpace(variableName)) return null;
+
+        // IsValueCreated first: reading must never be what starts a shell. A caller that wants the probe says
+        // so by calling Prime.
+        if (!_probe.IsValueCreated) return null;
+
+        var task = _probe.Value;
+        if (!task.IsCompletedSuccessfully) return null;
+
+        return task.Result.TryGetValue(variableName, out var value) ? value : null;
+    }
+
+    /// <summary>
+    /// The whole probe. Returns an empty snapshot for every failure rather than throwing: this task is
+    /// awaited by <see cref="Completion"/>, and letting an exception escape would turn every later await into
+    /// a throw — inside the chat send path, which would report a shell problem as a provider problem.
+    /// </summary>
+    private async Task<IReadOnlyDictionary<string, string>> ProbeAsync()
+    {
+        try
+        {
+            var shell = string.IsNullOrWhiteSpace(_shellPath) ? "/bin/sh" : _shellPath!;
+            var name = Path.GetFileName(shell);
+
+            if (SkippedShells.Contains(name, StringComparer.OrdinalIgnoreCase))
+            {
+                _logger?.LogDebug("Shell environment probe skipped: {Shell} is not supported", name);
+                return Empty;
+            }
+
+            IReadOnlyCollection<string> keep;
+            try
+            {
+                keep = await _namesOfInterest(CancellationToken.None).ConfigureAwait(false)
+                       ?? Array.Empty<string>();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug(ex, "Shell environment probe skipped: the variables of interest are unknown");
+                return Empty;
+            }
+
+            if (keep.Count == 0) return Empty;
+            var wanted = new HashSet<string>(keep, StringComparer.Ordinal);
+
+            var started = Stopwatch.StartNew();
+
+            // -il first, and the pair is load-bearing. For bash, -l sources .bash_profile and -i sources
+            // .bashrc; only both cover the two conventions a reader may have used.
+            var first = _runner.Run(new ShellProbeAttempt(shell, new[] { "-il", "-c", ProbeCommand }, AttemptTimeout));
+
+            ShellProbeResult result;
+            if (first.Succeeded)
+            {
+                result = first;
+            }
+            else if (first.TimedOut)
+            {
+                // Deliberately no retry. A profile that hangs once hangs twice, and the second attempt buys
+                // nothing but another five seconds of a shell this app has already decided to give up on.
+                _logger?.LogDebug("Shell environment probe timed out: {Shell}", name);
+                return Empty;
+            }
+            else
+            {
+                // A shell that rejects -i (no tty, or a profile that exits early under it) may still answer a
+                // plain login shell.
+                result = _runner.Run(new ShellProbeAttempt(shell, new[] { "-l", "-c", ProbeCommand }, AttemptTimeout));
+                if (!result.Succeeded)
+                {
+                    _logger?.LogDebug("Shell environment probe found nothing: {Shell}", name);
+                    return Empty;
+                }
+            }
+
+            var snapshot = ShellEnvParser.Parse(result.Stdout, wanted);
+            started.Stop();
+
+            // A count, never a name and never a value. The environment this walked contains the reader's
+            // whole working life; the only safe thing to say about it is how much of it we kept.
+            _logger?.LogInformation(
+                "Shell environment probe: {Shell}, {Elapsed}ms, {Retained} of {Wanted} variables retained",
+                name, started.ElapsedMilliseconds, snapshot.Count, wanted.Count);
+
+            return snapshot;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Shell environment probe failed");
+            return Empty;
+        }
+    }
+}
+
+/// <summary>One run of a shell: what to run, and how long to allow it.</summary>
+internal readonly record struct ShellProbeAttempt(string ShellPath, string[] Arguments, TimeSpan Timeout);
+
+/// <summary>
+/// What came back. <see cref="TimedOut"/> is distinct from a plain failure because the two get different
+/// treatment: a failure is retried once with a simpler shell, a timeout ends the probe.
+/// </summary>
+internal readonly record struct ShellProbeResult(bool Succeeded, bool TimedOut, byte[] Stdout)
+{
+    public static ShellProbeResult Failed() => new(false, false, Array.Empty<byte>());
+    public static ShellProbeResult Timeout() => new(false, true, Array.Empty<byte>());
+    public static ShellProbeResult Ok(byte[] stdout) => new(true, false, stdout);
+}
+
+/// <summary>The seam that spawns a real process, so everything above it is testable without one.</summary>
+internal interface IShellProbeRunner
+{
+    ShellProbeResult Run(ShellProbeAttempt attempt);
+}
+
+/// <inheritdoc />
+internal sealed class ProcessShellProbeRunner : IShellProbeRunner
+{
+    /// <summary>
+    /// Far above any real environment — a large one is tens of kilobytes — and low enough that a dotfile
+    /// stuck in a loop cannot exhaust memory. A pipe sustains gigabytes per second, so an unbounded read has
+    /// five seconds in which to take the whole machine down on behalf of somebody's broken profile.
+    /// </summary>
+    internal const int MaxStdoutBytes = 4 * 1024 * 1024;
+
+    /// <summary>
+    /// How long to keep reading after the shell has exited. Everything it wrote is already in the pipe by
+    /// then, so this is generous; what it must NOT do is wait for end-of-stream. See the comment at the wait.
+    /// </summary>
+    private static readonly TimeSpan DrainGrace = TimeSpan.FromMilliseconds(500);
+
+    /// <inheritdoc />
+    public ShellProbeResult Run(ShellProbeAttempt attempt)
+    {
+        var info = new ProcessStartInfo(attempt.ShellPath)
+        {
+            // stdin redirected and immediately closed. An interactive shell with an open stdin and no
+            // terminal is the likeliest hang of the lot: it reaches a prompt and waits forever for input
+            // nobody is going to type.
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var argument in attempt.Arguments) info.ArgumentList.Add(argument);
+
+        Process? process = null;
+        BoundedReader? reader = null;
+        try
+        {
+            process = Process.Start(info);
+            if (process is null) return ShellProbeResult.Failed();
+
+            process.StandardInput.Close();
+
+            // Read on a background task rather than after WaitForExit. A profile that writes more than the
+            // pipe buffer holds blocks on the write until someone drains it, and a shell blocked on write
+            // never exits — which would turn every chatty profile into a five-second timeout.
+            reader = new BoundedReader(process.StandardOutput.BaseStream, MaxStdoutBytes);
+            var reading = reader.Start();
+
+            // stderr drained and discarded for the same blocking reason, and never waited on. Its content is
+            // the reader's profile warnings, which are none of this app's business.
+            _ = Task.Run(() =>
+            {
+                try { process.StandardError.BaseStream.CopyTo(Stream.Null); } catch { /* closing is enough */ }
+            });
+
+            if (!process.WaitForExit((int)attempt.Timeout.TotalMilliseconds))
+            {
+                // entireProcessTree, because the thing that hangs is rarely the shell itself: a profile that
+                // execs a version manager, or blocks on a keychain prompt, leaves the subtree behind and the
+                // pipe open when only the parent is killed.
+                KillTree(process);
+                return ShellProbeResult.Timeout();
+            }
+
+            // A GRACE, NOT A WAIT FOR EOF, and the distinction is the whole of this method. If the profile
+            // started anything in the background — `some-updater &` — that grandchild inherited the stdout
+            // pipe and holds the write end open after the shell exits. Waiting for end-of-stream would then
+            // block forever on a probe that has ALREADY SUCCEEDED: its output is sitting in the buffer. The
+            // consequences of getting this wrong are all bad and all silent — a successful probe reported as
+            // a timeout, which per the ladder means give up permanently; a read thread parked for the life of
+            // the app; and that thread holding the raw, unfiltered environment, which is the one allocation
+            // this whole design exists to prevent. (fable)
+            reading.Wait(DrainGrace);
+
+            var bytes = reader.Bytes();
+
+            // Releases the buffer whether or not the read thread ever comes back, so nothing beyond the
+            // keep-set outlives this call even in the inherited-pipe case.
+            reader.Stop();
+
+            return process.ExitCode == 0
+                ? ShellProbeResult.Ok(bytes)
+                : ShellProbeResult.Failed();
+        }
+        catch
+        {
+            // No such shell, no permission to execute it, a platform that refuses to spawn: all "no snapshot".
+            if (process is not null) KillTree(process);
+            return ShellProbeResult.Failed();
+        }
+        finally
+        {
+            reader?.Stop();
+            process?.Dispose();
+        }
+    }
+
+    private static void KillTree(Process process)
+    {
+        try { process.Kill(entireProcessTree: true); }
+        catch { /* already gone, or never ours to kill */ }
+    }
+
+    /// <summary>
+    /// Reads a stream into a capped buffer, and can be told to let go of it without waiting for the reader to
+    /// notice. Disposing a pipe does not reliably unblock a read that is already parked in the kernel, so
+    /// "stop" here means "release the memory", which is the part that matters.
+    /// </summary>
+    private sealed class BoundedReader
+    {
+        private readonly Stream _stream;
+        private readonly int _cap;
+        private readonly MemoryStream _buffer = new();
+        private bool _stopped;
+
+        public BoundedReader(Stream stream, int cap) { _stream = stream; _cap = cap; }
+
+        public Task Start() => Task.Run(() =>
+        {
+            try
+            {
+                var chunk = new byte[8192];
+                int read;
+                while ((read = _stream.Read(chunk, 0, chunk.Length)) > 0)
+                {
+                    lock (_buffer)
+                    {
+                        if (_stopped) return;
+                        if (_buffer.Length + read > _cap) return;
+                        _buffer.Write(chunk, 0, read);
+                    }
+                }
+            }
+            catch
+            {
+                // A closed or broken pipe is the ordinary way this ends.
+            }
+        });
+
+        public byte[] Bytes()
+        {
+            lock (_buffer) return _buffer.ToArray();
+        }
+
+        public void Stop()
+        {
+            lock (_buffer)
+            {
+                _stopped = true;
+                _buffer.SetLength(0);
+                _buffer.Capacity = 0;
+            }
+            // DELIBERATELY NOT DISPOSING THE STREAM HERE. FileStream.Dispose blocks until an in-flight read
+            // completes, and the read we want to abandon is parked on a pipe an inherited process is holding
+            // open — so disposing would wait exactly as long as the wait this method exists to avoid. The
+            // thread ends on its own when that process finally exits; what matters is that the bytes are
+            // already gone. (fable)
+        }
+    }
+}
+
+/// <summary>
+/// Turns <c>env -0</c> output into the handful of variables this feature is allowed to keep. (#817)
+///
+/// <para><b>The keep-set is the security boundary, and it is applied here rather than by the caller.</b> A
+/// login shell's environment is not a list of API keys — it holds session tokens, agent sockets, and on this
+/// project's own machines an Apple app-specific password that is iCloud-wide rather than notarization-scoped.
+/// Retaining the whole thing for the session would put all of it in a long-lived managed dictionary, where it
+/// would survive into any heap dump. So the parse keeps only names the provider catalogue or a stored
+/// connection actually declares, and everything else stops existing when this method returns.</para>
+///
+/// <para><b>A profile is chatty.</b> Banners, version-manager warnings, <c>fortune</c> — all of it lands on
+/// stdout ahead of what <c>env</c> writes. Two things handle it, and BOTH are needed: the sentinel NUL in
+/// <see cref="ShellEnvironment.ProbeCommand"/> keeps the chatter from being glued to the first assignment,
+/// and the name-shape check below discards whatever chunk the chatter ends up as. Dropping either one loses
+/// a variable rather than raising an error — the sentinel loses the first one, the shape check lets
+/// <c>"nvm: default=v20"</c> through as a variable called <c>"nvm: default"</c>.</para>
+/// </summary>
+internal static class ShellEnvParser
+{
+    /// <param name="stdout">Raw bytes: the encoding of a value is the reader's business, not ours.</param>
+    /// <param name="keep">The only names that may survive this call.</param>
+    public static IReadOnlyDictionary<string, string> Parse(byte[] stdout, ISet<string> keep)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (stdout is null || stdout.Length == 0 || keep is null || keep.Count == 0) return result;
+
+        var text = Encoding.UTF8.GetString(stdout);
+        foreach (var chunk in text.Split('\0'))
+        {
+            var split = chunk.IndexOf('=');
+            if (split <= 0) continue;
+
+            var name = chunk.Substring(0, split);
+            if (!IsVariableName(name)) continue;
+            if (!keep.Contains(name)) continue;
+
+            var value = chunk.Substring(split + 1);
+            if (string.IsNullOrWhiteSpace(value)) continue;
+
+            result[name] = value;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// The shape of an environment variable name. This is what rejects the banner line that happens to
+    /// contain an <c>=</c> — "Loading nvm... default=v20" parses as an assignment otherwise.
+    /// </summary>
+    private static bool IsVariableName(string name)
+    {
+        if (name.Length == 0) return false;
+        if (!(char.IsAsciiLetter(name[0]) || name[0] == '_')) return false;
+
+        for (int i = 1; i < name.Length; i++)
+            if (!(char.IsAsciiLetterOrDigit(name[i]) || name[i] == '_')) return false;
+
+        return true;
+    }
+}

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -78,7 +78,8 @@ public class AiAssistantViewModel : ReactiveTool
         IReaderStateService? readerState,
         IChatProviderResolver? resolver,
         ISettingsService? settings,
-        IAiConnectionService? connections = null)
+        IAiConnectionService? connections = null,
+        Services.Ai.Credentials.IAiEnvironmentKeys? environmentKeys = null)
     {
         _orchestrator = orchestrator;
         _readerState = readerState;
@@ -118,7 +119,16 @@ public class AiAssistantViewModel : ReactiveTool
 
         // Asked once at construction so the panel can say it is not configured before anything is pressed.
         RefreshReadiness();
+
+        // A key exported from a shell profile arrives seconds after launch, not at it (#817). Without this
+        // the panel opens saying the assistant is not configured and keeps saying it until something else
+        // happens to re-ask — for a reader whose key IS set, in the variable the app is about to use.
+        _environmentKeys = environmentKeys;
+        if (_environmentKeys is not null)
+            _environmentKeys.Changed += (_, _) => Dispatcher.UIThread.Post(RefreshReadiness);
     }
+
+    private readonly Services.Ai.Credentials.IAiEnvironmentKeys? _environmentKeys;
 
     /// <summary>The per-turn model chip and its list. (#693)</summary>
     public AiModelPickerViewModel ModelPicker { get; }
@@ -296,6 +306,13 @@ public class AiAssistantViewModel : ReactiveTool
             Status = "The assistant is not available in this build.";
             return;
         }
+
+        // Settled before asking the resolver anything (#817). Already-complete unless a shell probe is in
+        // flight, so this changes nothing for anyone whose key is in the process environment; for the reader
+        // whose key is in a shell profile it is the difference between "not configured" on the first send of
+        // the session and an answer.
+        if (_environmentKeys is not null)
+            await _environmentKeys.Ready.ConfigureAwait(true);
 
         // Checked BEFORE touching the reader, so an unconfigured user is told what to set rather than being
         // asked to wait while the app assembles a bundle it cannot send.

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -37,7 +37,9 @@ namespace CST.Avalonia.ViewModels
         private readonly IAiCredentialStore? _credentials;
         private readonly IAiProviderLogos? _logos;
         private readonly IAiEnvironmentKeys? _environmentKeys;
+        private readonly IShellEnvironment? _shellEnvironment;
         private AiConnectionEditorViewModel? _editor;
+        private bool _disposed;
         private string? _problem;
         private string _presetSearch = "";
         private int _catalogueTotal;
@@ -46,12 +48,14 @@ namespace CST.Avalonia.ViewModels
             IAiConnectionService? service,
             IAiCredentialStore? credentials = null,
             IAiProviderLogos? logos = null,
-            IAiEnvironmentKeys? environmentKeys = null)
+            IAiEnvironmentKeys? environmentKeys = null,
+            IShellEnvironment? shellEnvironment = null)
         {
             _service = service;
             _credentials = credentials;
             _logos = logos;
             _environmentKeys = environmentKeys;
+            _shellEnvironment = shellEnvironment;
 
             AddCustomCommand = ReactiveCommand.Create(AddCustom);
             RetryCatalogueCommand = ReactiveCommand.CreateFromTask(RetryCatalogueAsync);
@@ -60,6 +64,21 @@ namespace CST.Avalonia.ViewModels
             {
                 _service.ConnectionsChanged += OnConnectionsChanged;
                 Rebind();
+            }
+
+            // This tab IS the discovery surface, so opening it is the strongest signal that the probe is
+            // wanted — a reader who has just enabled AI has never been through the startup gate. Prime is
+            // idempotent, so the common case where startup already primed costs a field read. (#817)
+            if (_shellEnvironment is not null)
+            {
+                _shellEnvironment.Prime();
+
+                // Progressive disclosure, the same shape the catalogue already uses: rows appear when the
+                // probe lands rather than the window waiting for it. Fire-and-forget by design — Completion
+                // never faults, and there is nothing to report if it finds nothing.
+                _shellEnvironment.Completion.ContinueWith(
+                    _ => Dispatcher.UIThread.Post(() => { if (!_disposed) Rebind(); }),
+                    TaskScheduler.Default);
             }
         }
 
@@ -421,6 +440,10 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public void Dispose()
         {
+            // Set before unsubscribing: the shell probe's continuation is scheduled on the pool and may
+            // already be on its way to the UI thread, and rebinding a disposed tab is how a closed Settings
+            // window comes back to life holding a dead service. (#817)
+            _disposed = true;
             if (_service is not null) _service.ConnectionsChanged -= OnConnectionsChanged;
         }
 
@@ -459,8 +482,14 @@ namespace CST.Avalonia.ViewModels
             // moment they type would take it away exactly when they are looking for the provider it is
             // about. (#714)
             //
-            // Re-read on every rebind rather than cached: the environment can change between one open of
-            // this tab and the next, and a variable the reader has just unset should stop being offered.
+            // Re-read on every rebind rather than cached — with one honest qualification. The process
+            // environment is genuinely re-read here, so a variable set or unset with `launchctl setenv`, or
+            // inherited from a terminal launch, behaves exactly as this always claimed.
+            //
+            // The shell snapshot (#817) is read once per launch, because reading it costs a login shell and
+            // Rebind runs on every keystroke in the search box. That is not a new staleness: the process
+            // environment is itself a snapshot taken at exec, so editing ~/.zshrc has never affected a
+            // running instance either. A profile edit takes effect at next launch, and the docs say so.
             var found = _environmentKeys is null
                 ? new List<AiEnvironmentKey>()
                 : _environmentKeys.Discover(_service.AvailablePresets).ToList();

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1348,6 +1348,18 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
             _credentials = credentials;
             _providerResolver = providerResolver;
 
+            // The third surface that can say "not configured" about a key that is simply not visible yet
+            // (#817). The assistant panel and the Providers tab both refresh when a shell probe lands; this
+            // one is computed from the resolver on demand, so without a nudge it keeps the old answer until
+            // some unrelated property changes.
+            var environmentKeys = App.TryGetService<Services.Ai.Credentials.IAiEnvironmentKeys>();
+            if (environmentKeys is not null)
+                environmentKeys.Changed += (_, _) => Dispatcher.UIThread.Post(() =>
+                {
+                    this.RaisePropertyChanged(nameof(ReadinessText));
+                    this.RaisePropertyChanged(nameof(IsReady));
+                });
+
             var ai = _settingsService.Settings.Ai;
             _aiEnabled = ai.Enabled;
             _localApiEnabled = ai.LocalApi.Enabled;
@@ -1371,7 +1383,8 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
             var connectionService = App.TryGetService<Services.Ai.IAiConnectionService>();
             Connections = new AiConnectionsViewModel(
                 connectionService, credentials, App.TryGetService<Services.Ai.IAiProviderLogos>(),
-                App.TryGetService<Services.Ai.Credentials.IAiEnvironmentKeys>());
+                App.TryGetService<Services.Ai.Credentials.IAiEnvironmentKeys>(),
+                App.TryGetService<Services.Ai.Credentials.IShellEnvironment>());
             Models = new AiModelsViewModel(
                 connectionService,
                 App.TryGetService<Services.Ai.IAiModelCatalog>(),


### PR DESCRIPTION
Closes #817.

A GUI launch inherits launchd's environment, not the login shell's, so a key exported from a shell profile was invisible to #714's discovery — and indistinguishable from no key at all.

**Confirmed on Egret, not just reasoned about.** `GEMINI_API_KEY` is exported from a shell profile there, which the Google preset declares. Run from a stripped environment — the launchd case — the process sees nothing and the probe recovers it in 59 ms. No value was printed at any point in establishing that.

## The design

`ShellEnvironment` runs `$SHELL -il -c "printf '\0'; env -0"` once per session and becomes a second source behind `AiEnvironmentKeys`.

| | |
|---|---|
| **Precedence** | Process wins, **per variable**; the shell only fills gaps |
| **Blocking** | `TryRead` never blocks and never *starts* a probe — only `Prime()` does |
| **Retention** | Keep-set applied **at parse time**; log records a count only |
| **Gate** | AI master switch, or a stored connection using an env key |
| **Failure** | Always degrades to the process environment — today's behaviour |

Process-first because everything in the process environment is the more deliberate signal: a terminal launch, a `launchctl setenv`, or an inline `OPENAI_API_KEY=x app`. A profile line is the stalest of the four, and letting a forgotten `.zprofile` shadow a `launchctl` correction is #714's failure in miniature.

The keep-set is the security boundary. A login shell's environment holds session tokens, agent sockets and — on this project's own machines — an iCloud-wide app password beside the provider keys. Retaining it whole would put all of it in a session-long dictionary and into any heap dump.

## Four defects found in review, all silent in the field

**The gate read settings that had not loaded yet.** `SettingsService` starts with `new Settings()`, so it always saw the master switch off and zero connections — no launch would ever have primed, and the only surviving trigger was opening the Providers tab, i.e. exactly the reader who did not need it. Now called *inside* `LoadSettingsAsync`, so the ordering is structural rather than positional. `ReconcileAssistantPanel` sits three lines above it recording the identical bug from #667.

**Profile chatter was eating the first variable.** Chatter has no NUL after it, so `"Now using node v20\nFIRSTVAR=value"` arrived as one chunk whose name failed validation. Which variable is first is machine-dependent — the symptom is one reader's key vanishing and nobody able to reproduce it. A sentinel NUL now separates chatter from data.

**A background job in a profile turned success into permanent failure.** `some-updater &` inherits stdout and holds the pipe open after the shell exits. Waiting for EOF blocked on a probe whose output was already in the buffer: success reported as a timeout, which the ladder treats as give-up-forever, plus a thread parked on the raw unfiltered environment for the life of the app. Now a 500 ms grace, not an EOF wait. Disposing the stream turned out to block on the very same read — 30 s in the test — so it is deliberately not disposed and the buffer is released instead.

**The read was unbounded.** A profile stuck in a loop had five seconds of pipe bandwidth in which to exhaust memory.

## Tests

45 new: 13 on the ladder, 9 on the parser, 9 on the merge rules, 6 on the gate, and **8 real-process tests** for the runner — the one part the seam cannot cover, and where the last two defects lived. They use `/bin/sh` with fixed scripts, not the developer's login shell.

Ten mutations run. Nine killed a test immediately. The tenth survived and exposed a test of mine that **could not fail**: it asserted a buffer length that held whether or not the cap existed, because removing the cap sends the run down the timeout path where the buffer is empty. Rewritten to assert the outcome.

Full suite green: 2567 passed, 0 failed.

## Not covered

No test pins *when* production primes — that is startup ordering, and the reason the first defect existed. Putting the call inside `LoadSettingsAsync` is the mitigation. The Finder-launch confirmation from the issue's testing section still wants a packaged build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
