### PR TITLE
Register the logo renderer once, not twice (#818)

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1437,10 +1437,6 @@ public partial class App : Application
         // once per row.
         services.AddSingleton<Services.Ai.IAiLogoImages, Services.Ai.AiLogoImages>();
 
-        // Rendering those logos (#748). Singleton so a mark is rasterised once per theme colour rather than
-        // once per row.
-        services.AddSingleton<Services.Ai.IAiLogoImages, Services.Ai.AiLogoImages>();
-
         // Asking a connection what models it offers (#674). Additive to the hand-typed list, never a
         // prerequisite: an endpoint that publishes no listing stays fully usable, so a failure here is
         // reported and nothing more.


### PR DESCRIPTION
Closes #818.

Deletes the second `services.AddSingleton<IAiLogoImages, AiLogoImages>()` and its duplicated comment block in `ConfigureServices`. Both lines arrived together in 58e08bb (#748 / PR #749) — a copy-paste inside that PR, not a merge artifact.

## Why fix something harmless

`AddSingleton` twice leaves two `ServiceDescriptor`s for one service type. `GetService<T>` returns the last and instantiates only that one, and the only consumer resolves it singly — `ProviderLogoConverter.cs:30`, via `App.TryGetService<IAiLogoImages>()`. So today: one instance, one cache, behaviour exactly as the comment describes.

The harmlessness is a property of how it is *resolved*, though, not of the registration:

- Resolving `IEnumerable<IAiLogoImages>` constructs **both**. `AiLogoImages` caches rasterised marks per theme colour, so that is two caches, twice the rasterisation, twice the retained bitmaps — the exact cost the singleton exists to avoid.
- `ValidateOnBuild` / `ValidateScopes`, if ever enabled, constructs every descriptor.

Neither is reachable now. Both were one line away.

## No test, and not for the reason it first appears

`ConfigureServices` is `private`, but it is reflection-reachable and `App` has no constructor to satisfy — so counting descriptors needs no `BuildServiceProvider` and no graph. Reach is not the obstacle, and an earlier draft of this message said it was; that was wrong.

The real obstacle is that the method does its logging bootstrap inline, before registering anything (`App.axaml.cs:1307-1338`): it reads the saved log level, creates a logs directory under the real `ApplicationData`, and replaces the global `Log.Logger`. A test asserting that no service type appears twice would carry all three side effects, plus brittleness to a rename, in order to establish something reading the file already shows.

The seam that would make such a test cheap is separating the registrations from that bootstrap — a larger change than this one, and not this issue's.

## Verification

- `dotnet build src/CST.Avalonia` — 0 warnings, 0 errors
- `dotnet test src/CST.Avalonia.Tests` — **2522 passed, 0 failed, 17 skipped**

Four deleted lines, no behaviour change.

---

Reviewed adversarially before merge. The reviewer tried to refute the no-op claim on seven fronts and confirmed: the two deleted lines were byte-identical to the survivor (same md5), nothing in the repo resolves `IEnumerable<IAiLogoImages>` or observes descriptor order, the provider is built bare with no `ValidateOnBuild`, the sole runtime consumer is `ProviderLogoConverter.cs:30` through single-service resolution, the surviving comment and both neighbouring registrations are intact, and a sweep of all 50 `services.Add*` calls in `ConfigureServices` found **no other duplicate service type**. It also corrected the "no test" reasoning above.
