### PR TITLE
Let the reader turn the shell lookup off, and see what it found (#820 backend)

### DIFF
--- a/docs/features/in-progress/AI_SURFACE_B.md
+++ b/docs/features/in-progress/AI_SURFACE_B.md
@@ -411,8 +411,14 @@ hold-back filter — the same hazard as the think-tag filter, and the same failu
   discarded as it is read. Nothing is written to disk, and the log records a count, never a name and never a
   value. An ordinary launch — no AI features, no adopted connection — runs no shell at all.
 
+  A checkbox on the Providers tab controls this, on by default and absent on Windows (#820). Unticking it
+  releases the snapshot rather than merely ceasing to consult it, so re-ticking reads the shell again — which
+  also gives a reader who has just edited their profile a way to pick it up without relaunching. Beside it, a
+  line saying what the last look found: how many keys, or that the shell is one we cannot read, or that the
+  profile took too long. Those used to be indistinguishable from having no keys at all.
+
   It is a session snapshot, like the process environment has always been: editing a shell profile takes effect
-  at the next launch. Where the probe cannot run — Windows, which does not need it; `nu`, `csh` and `tcsh`,
+  at the next launch, or at the next tick of that box. Where the probe cannot run — Windows, which does not need it; `nu`, `csh` and `tcsh`,
   whose flags do not mean what this needs; or a profile slow enough to hit the five-second timeout — behaviour
   falls back to reading this process's own environment, and the two workarounds are `launchctl setenv NAME
   value` (which publishes the value to every process in the login session, worth knowing before using it) or

--- a/docs/features/in-progress/AI_SURFACE_B.md
+++ b/docs/features/in-progress/AI_SURFACE_B.md
@@ -418,7 +418,8 @@ hold-back filter — the same hazard as the think-tag filter, and the same failu
   profile took too long. Those used to be indistinguishable from having no keys at all.
 
   It is a session snapshot, like the process environment has always been: editing a shell profile takes effect
-  at the next launch, or at the next tick of that box. Where the probe cannot run — Windows, which does not need it; `nu`, `csh` and `tcsh`,
+  at the next launch, or at the next tick of that box. Where the probe cannot run — Windows, which does not
+  need it; `nu`, `csh` and `tcsh`,
   whose flags do not mean what this needs; or a profile slow enough to hit the five-second timeout — behaviour
   falls back to reading this process's own environment, and the two workarounds are `launchctl setenv NAME
   value` (which publishes the value to every process in the login session, worth knowing before using it) or

--- a/src/CST.Avalonia.Tests/Services/Ai/AiEnvironmentKeysMergeTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiEnvironmentKeysMergeTests.cs
@@ -34,6 +34,9 @@ public sealed class AiEnvironmentKeysMergeTests
             _values.TryGetValue(variableName, out var v) ? v : null;
         public event EventHandler? Probed;
         public void RaiseProbed() => Probed?.Invoke(this, EventArgs.Empty);
+        public void Forget() { _values.Clear(); RaiseProbed(); }
+        public ShellEnvironmentStatus Status { get; } =
+            new(ShellEnvironmentState.Completed, "zsh", 1);
     }
 
     /// <summary>A probe that has not answered yet, which is what every read sees for the first seconds.</summary>
@@ -45,6 +48,8 @@ public sealed class AiEnvironmentKeysMergeTests
         public string? TryRead(string variableName) => null;
         public event EventHandler? Probed;
         public void Finish() { _tcs.SetResult(); Probed?.Invoke(this, EventArgs.Empty); }
+        public void Forget() { }
+        public ShellEnvironmentStatus Status { get; } = ShellEnvironmentStatus.Running;
     }
 
     private static AiProviderPreset Preset(string id, params string[] envNames) =>

--- a/src/CST.Avalonia.Tests/Services/Ai/ShellEnvironmentToggleTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ShellEnvironmentToggleTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services.Ai.Credentials;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// Turning the login-shell lookup off and on again, and having somewhere to say what happened. (#820)
+///
+/// <para>The rule underneath every test here: turning it OFF releases the values rather than merely ceasing
+/// to consult them. An app that kept a reader's keys in memory after being told to stop reading them would
+/// obey the instruction and miss its point — and that is what forces re-enabling to run a second shell, since
+/// there is deliberately nothing left to restore.</para>
+/// </summary>
+public sealed class ShellEnvironmentToggleTests
+{
+    private sealed class CountingRunner : IShellProbeRunner
+    {
+        private readonly Func<int, ShellProbeResult> _answer;
+        public int Runs { get; private set; }
+
+        public CountingRunner(Func<int, ShellProbeResult>? answer = null) =>
+            _answer = answer ?? (_ => ShellProbeResult.Ok(
+                Encoding.UTF8.GetBytes("\0OPENAI_API_KEY=sk-profile\0")));
+
+        public ShellProbeResult Run(ShellProbeAttempt attempt) => _answer(++Runs);
+    }
+
+    private static ShellEnvironment Probe(
+        IShellProbeRunner runner, bool supported = true, string shell = "/bin/zsh",
+        params string[] wanted)
+    {
+        var names = wanted.Length > 0 ? wanted : new[] { "OPENAI_API_KEY" };
+        return new ShellEnvironment(
+            _ => Task.FromResult<IReadOnlyCollection<string>>(names),
+            runner, logger: null, supported: supported, shellPath: shell);
+    }
+
+    [Fact]
+    public async Task Forgetting_releases_what_the_probe_found()
+    {
+        var shell = Probe(new CountingRunner());
+        shell.Prime();
+        await shell.Completion;
+        Assert.Equal("sk-profile", shell.TryRead("OPENAI_API_KEY"));
+
+        shell.Forget();
+
+        // Not "stops being offered while staying in memory". The reader said stop reading my environment.
+        Assert.Null(shell.TryRead("OPENAI_API_KEY"));
+        Assert.Equal(ShellEnvironmentState.NotRun, shell.Status.State);
+    }
+
+    [Fact]
+    public async Task Re_enabling_reads_the_shell_again_rather_than_restoring_a_cache()
+    {
+        var runner = new CountingRunner();
+        var shell = Probe(runner);
+
+        shell.Prime();
+        await shell.Completion;
+        Assert.Equal(1, runner.Runs);
+
+        shell.Forget();
+        shell.Prime();
+        await shell.Completion;
+
+        // Two shells, because Forget kept nothing to restore. That is the cost of the guarantee above, and
+        // it also means a reader who has just edited ~/.zshrc can pick it up without relaunching.
+        Assert.Equal(2, runner.Runs);
+        Assert.Equal("sk-profile", shell.TryRead("OPENAI_API_KEY"));
+    }
+
+    [Fact]
+    public async Task A_second_generation_can_find_something_the_first_did_not()
+    {
+        // The re-read has to be a real one: a generation that returned the previous answer would make the
+        // toggle useless to the reader who fixed their profile and toggled to pick it up.
+        var runner = new CountingRunner(run => run == 1
+            ? ShellProbeResult.Ok(Encoding.UTF8.GetBytes("\0IRRELEVANT=x\0"))
+            : ShellProbeResult.Ok(Encoding.UTF8.GetBytes("\0OPENAI_API_KEY=sk-added\0")));
+        var shell = Probe(runner);
+
+        shell.Prime();
+        await shell.Completion;
+        Assert.Null(shell.TryRead("OPENAI_API_KEY"));
+
+        shell.Forget();
+        shell.Prime();
+        await shell.Completion;
+
+        Assert.Equal("sk-added", shell.TryRead("OPENAI_API_KEY"));
+    }
+
+    [Fact]
+    public async Task Priming_twice_without_forgetting_still_runs_one_shell()
+    {
+        // The collapse guarantee has to survive becoming a generation — it is what stops the startup gate and
+        // the Providers tab from running two shells between them.
+        var runner = new CountingRunner();
+        var shell = Probe(runner);
+
+        shell.Prime();
+        shell.Prime();
+        await shell.Completion;
+        shell.Prime();
+
+        Assert.Equal(1, runner.Runs);
+    }
+
+    [Fact]
+    public void Forgetting_tells_the_surfaces_that_showed_the_rows()
+    {
+        var shell = Probe(new CountingRunner());
+        var told = 0;
+        shell.Probed += (_, _) => told++;
+
+        shell.Forget();
+
+        // Same signal that told them to start showing rows. Without it a tab keeps offering keys from a
+        // snapshot that no longer exists, and adopting one would fail with no explanation.
+        Assert.Equal(1, told);
+    }
+
+    // ---- the states that had nowhere to be reported --------------------------------------------------
+
+    [Fact]
+    public void Nothing_asked_for_yet_is_its_own_state()
+    {
+        Assert.Equal(ShellEnvironmentState.NotRun, Probe(new CountingRunner()).Status.State);
+    }
+
+    [Fact]
+    public void Windows_reports_unsupported_rather_than_not_run()
+    {
+        var shell = Probe(new CountingRunner(), supported: false);
+        shell.Prime();
+        Assert.Equal(ShellEnvironmentState.Unsupported, shell.Status.State);
+    }
+
+    [Fact]
+    public async Task A_shell_skipped_by_name_says_so_and_names_it()
+    {
+        var shell = Probe(new CountingRunner(), shell: "/usr/local/bin/nu");
+        shell.Prime();
+        await shell.Completion;
+
+        // The one failure a reader can act on, so it must be distinguishable from "you have no keys".
+        Assert.Equal(ShellEnvironmentState.ShellNotSupported, shell.Status.State);
+        Assert.Equal("nu", shell.Status.ShellName);
+    }
+
+    [Fact]
+    public async Task A_timeout_and_an_empty_environment_are_different_states()
+    {
+        var timedOut = Probe(new CountingRunner(_ => ShellProbeResult.Timeout()));
+        timedOut.Prime();
+        await timedOut.Completion;
+
+        var empty = Probe(new CountingRunner(_ => ShellProbeResult.Ok(
+            Encoding.UTF8.GetBytes("\0IRRELEVANT=x\0"))));
+        empty.Prime();
+        await empty.Completion;
+
+        // Both leave the found-keys section empty, and before this they were indistinguishable on screen —
+        // which is #817's own complaint one layer up. One means "fix your profile", the other means
+        // "there is nothing here to find".
+        Assert.Equal(ShellEnvironmentState.TimedOut, timedOut.Status.State);
+        Assert.Equal(ShellEnvironmentState.Completed, empty.Status.State);
+        Assert.Equal(0, empty.Status.RetainedCount);
+    }
+
+    [Fact]
+    public async Task A_successful_probe_reports_how_many_it_kept_and_never_which()
+    {
+        var shell = Probe(
+            new CountingRunner(_ => ShellProbeResult.Ok(
+                Encoding.UTF8.GetBytes("\0OPENAI_API_KEY=sk\0GROQ_API_KEY=gsk\0APPLE_APP_PASSWORD=abcd\0"))),
+            wanted: new[] { "OPENAI_API_KEY", "GROQ_API_KEY" });
+
+        shell.Prime();
+        await shell.Completion;
+
+        Assert.Equal(ShellEnvironmentState.Completed, shell.Status.State);
+        Assert.Equal(2, shell.Status.RetainedCount);
+
+        // The status is rendered on screen and written to a log. A variable name in it would be the first
+        // place this feature leaked one.
+        var rendered = shell.Status.ToString();
+        Assert.DoesNotContain("OPENAI_API_KEY", rendered);
+        Assert.DoesNotContain("APPLE_APP_PASSWORD", rendered);
+    }
+
+    // ---- the gate ------------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_readers_switch_turns_the_startup_probe_off()
+    {
+        var settings = new Settings();
+        settings.Ai.Enabled = true;
+        Assert.True(CST.Avalonia.App.ShouldPrimeShellEnvironment(settings));
+
+        settings.Ai.ReadLoginShellEnvironment = false;
+        Assert.False(CST.Avalonia.App.ShouldPrimeShellEnvironment(settings));
+    }
+
+    [Fact]
+    public void The_switch_defaults_on_because_defaulting_off_would_rebuild_the_bug()
+    {
+        // The reader this serves does not know their key is invisible — that IS #817. Requiring them to find
+        // a checkbox in order to discover a problem they cannot see puts the bug back with an extra step.
+        Assert.True(new Settings().Ai.ReadLoginShellEnvironment);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/ShellEnvironmentToggleTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ShellEnvironmentToggleTests.cs
@@ -196,6 +196,110 @@ public sealed class ShellEnvironmentToggleTests
         Assert.DoesNotContain("APPLE_APP_PASSWORD", rendered);
     }
 
+    // ---- generations, which is where a probe can lie about a world that no longer exists --------------
+
+    /// <summary>A runner held open until a test releases it, so a probe can be in flight across a toggle.</summary>
+    private sealed class HeldRunner : IShellProbeRunner
+    {
+        private readonly System.Threading.ManualResetEventSlim _held = new(false);
+        private readonly Func<int, ShellProbeResult> _answer;
+        private int _runs;
+
+        /// <summary>
+        /// Set once the FIRST probe is inside the runner and blocked.
+        ///
+        /// <para>The test must wait on this before retiring that probe. Without it both generations race for
+        /// the runner and either may take the "first call" slot — which fails by describing generation 2 as
+        /// the timed-out one, an artefact of the fake rather than anything the product did.</para>
+        /// </summary>
+        public System.Threading.ManualResetEventSlim Entered { get; } = new(false);
+
+        public HeldRunner(Func<int, ShellProbeResult> answer) => _answer = answer;
+
+        public ShellProbeResult Run(ShellProbeAttempt attempt)
+        {
+            var run = System.Threading.Interlocked.Increment(ref _runs);
+            if (run == 1)
+            {
+                Entered.Set();
+                _held.Wait(TimeSpan.FromSeconds(10));
+            }
+            return _answer(run);
+        }
+
+        public void Release() => _held.Set();
+    }
+
+    [Fact]
+    public async Task A_retired_probe_cannot_overwrite_what_the_live_one_found()
+    {
+        // The first shell is slow and heads for a timeout; the reader toggles off and on while it runs; the
+        // second answers quickly. Nothing stops a shell already running, so the first arrives afterwards with
+        // a verdict about a world that has been thrown away.
+        var runner = new HeldRunner(run => run == 1
+            ? ShellProbeResult.Timeout()
+            : ShellProbeResult.Ok(Encoding.UTF8.GetBytes("\0OPENAI_API_KEY=sk-live\0")));
+        var shell = Probe(runner);
+
+        shell.Prime();                       // generation 1
+        runner.Entered.Wait(TimeSpan.FromSeconds(5));   // ...confirmed inside the runner and blocked
+        shell.Forget();                      // retires it
+        shell.Prime();                       // generation 2
+        await shell.Completion;              // which finishes at once
+
+        Assert.Equal(ShellEnvironmentState.Completed, shell.Status.State);
+        Assert.Equal(1, shell.Status.RetainedCount);
+
+        runner.Release();                    // generation 1 finally lands, with TimedOut
+        await Task.Delay(200);
+
+        // Without the generation check the screen ends up saying "your shell profile took too long to load"
+        // beside the very keys the live probe found — and saying it permanently, because generation 2 has
+        // already written and will not write again. That is this feature's own failure mode turned against
+        // it: a sentence that is confidently wrong is worse than the empty section it replaced. (fable)
+        Assert.Equal(ShellEnvironmentState.Completed, shell.Status.State);
+        Assert.Equal("sk-live", shell.TryRead("OPENAI_API_KEY"));
+    }
+
+    [Fact]
+    public async Task A_retired_probe_does_not_announce_that_it_landed()
+    {
+        var runner = new HeldRunner(_ => ShellProbeResult.Ok(
+            Encoding.UTF8.GetBytes("\0OPENAI_API_KEY=sk\0")));
+        var shell = Probe(runner);
+
+        shell.Prime();
+        runner.Entered.Wait(TimeSpan.FromSeconds(5));
+        shell.Forget();
+
+        var toldAfterForget = 0;
+        shell.Probed += (_, _) => toldAfterForget++;
+
+        runner.Release();
+        await Task.Delay(200);
+
+        // Surfaces treat Probed as "go and look again". A retired generation raising it sends them to a
+        // snapshot that no longer exists.
+        Assert.Equal(0, toldAfterForget);
+    }
+
+    [Fact]
+    public async Task A_forget_while_a_probe_runs_leaves_nothing_readable()
+    {
+        var runner = new HeldRunner(_ => ShellProbeResult.Ok(
+            Encoding.UTF8.GetBytes("\0OPENAI_API_KEY=sk-inflight\0")));
+        var shell = Probe(runner);
+
+        shell.Prime();
+        runner.Entered.Wait(TimeSpan.FromSeconds(5));
+        shell.Forget();
+        runner.Release();
+        await Task.Delay(200);
+
+        Assert.Null(shell.TryRead("OPENAI_API_KEY"));
+        Assert.Equal(ShellEnvironmentState.NotRun, shell.Status.State);
+    }
+
     // ---- the gate ------------------------------------------------------------------------------------
 
     [Fact]

--- a/src/CST.Avalonia.Tests/ViewModels/ShellEnvironmentControlTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/ShellEnvironmentControlTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai.Credentials;
+using CST.Avalonia.ViewModels;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// The Providers-tab control for reading keys from the login shell. (#820)
+///
+/// <para>Two things are being pinned. That the toggle actually reaches the service — a checkbox that changes
+/// a setting and nothing else would look right and do nothing until the next launch. And that every outcome
+/// of a probe produces a DIFFERENT sentence, because the whole reason for the control is that a skipped
+/// shell, a timed-out profile and an environment with no keys in it were previously indistinguishable on
+/// screen.</para>
+/// </summary>
+public sealed class ShellEnvironmentControlTests
+{
+    private sealed class FakeShell : IShellEnvironment
+    {
+        public int Primes { get; private set; }
+        public int Forgets { get; private set; }
+        public ShellEnvironmentStatus Status { get; set; } = ShellEnvironmentStatus.NotRun;
+
+        public void Prime() => Primes++;
+        public void Forget() { Forgets++; Probed?.Invoke(this, EventArgs.Empty); }
+        public Task Completion => Task.CompletedTask;
+        public string? TryRead(string variableName) => null;
+        public event EventHandler? Probed;
+    }
+
+    private static (AiConnectionsViewModel Vm, FakeShell Shell, Settings Settings, Mock<ISettingsService> Service)
+        Make(bool enabled = true)
+    {
+        var settings = new Settings();
+        settings.Ai.ReadLoginShellEnvironment = enabled;
+        var service = new Mock<ISettingsService>();
+        service.SetupGet(s => s.Settings).Returns(settings);
+
+        var shell = new FakeShell();
+        var vm = new AiConnectionsViewModel(null, null, null, null, shell, service.Object);
+        return (vm, shell, settings, service);
+    }
+
+    [Fact]
+    public void Opening_the_tab_with_the_control_on_reads_the_shell()
+    {
+        var (_, shell, _, _) = Make(enabled: true);
+        Assert.Equal(1, shell.Primes);
+    }
+
+    [Fact]
+    public void Opening_the_tab_with_the_control_off_reads_nothing()
+    {
+        // The setting has to be honoured here as well as at startup, or the tab becomes a second way to
+        // start a shell the reader has said they do not want.
+        var (_, shell, _, _) = Make(enabled: false);
+        Assert.Equal(0, shell.Primes);
+    }
+
+    [Fact]
+    public void Unticking_releases_the_snapshot_and_is_written_down()
+    {
+        var (vm, shell, settings, service) = Make(enabled: true);
+
+        vm.ReadLoginShellEnvironment = false;
+
+        Assert.Equal(1, shell.Forgets);
+        Assert.False(settings.Ai.ReadLoginShellEnvironment);
+        service.Verify(s => s.RequestSave(), Times.Once);
+    }
+
+    [Fact]
+    public void Re_ticking_reads_the_shell_again()
+    {
+        var (vm, shell, settings, _) = Make(enabled: false);
+
+        vm.ReadLoginShellEnvironment = true;
+
+        // Not "restores what it had" — Forget kept nothing. This is the second shell, and it is the point.
+        Assert.Equal(1, shell.Primes);
+        Assert.True(settings.Ai.ReadLoginShellEnvironment);
+    }
+
+    [Fact]
+    public void Setting_it_to_what_it_already_is_does_nothing()
+    {
+        var (vm, shell, _, service) = Make(enabled: true);
+        var primesAfterConstruction = shell.Primes;
+
+        vm.ReadLoginShellEnvironment = true;
+
+        Assert.Equal(primesAfterConstruction, shell.Primes);
+        service.Verify(s => s.RequestSave(), Times.Never);
+    }
+
+    // ---- the sentences ---------------------------------------------------------------------------------
+
+    private static string TextFor(ShellEnvironmentState state, string? shellName = "zsh", int retained = 0)
+    {
+        var (vm, shell, _, _) = Make(enabled: true);
+        shell.Status = new ShellEnvironmentStatus(state, shellName, retained);
+        return vm.ShellEnvironmentStatusText;
+    }
+
+    [Fact]
+    public void Every_outcome_says_something_different()
+    {
+        var skipped = TextFor(ShellEnvironmentState.ShellNotSupported, "nu");
+        var timedOut = TextFor(ShellEnvironmentState.TimedOut);
+        var failed = TextFor(ShellEnvironmentState.Failed);
+        var empty = TextFor(ShellEnvironmentState.Completed, retained: 0);
+        var found = TextFor(ShellEnvironmentState.Completed, retained: 2);
+
+        // This is the whole feature in one assertion. Before #820 all five of these produced an empty
+        // section and no explanation, so a reader whose key was genuinely unreachable and a reader who
+        // simply had no keys saw exactly the same screen.
+        var all = new[] { skipped, timedOut, failed, empty, found };
+        Assert.Equal(all.Length, new System.Collections.Generic.HashSet<string>(all).Count);
+        Assert.All(all, sentence => Assert.False(string.IsNullOrWhiteSpace(sentence)));
+    }
+
+    [Fact]
+    public void The_unsupported_shell_is_named_so_the_reader_can_act_on_it()
+    {
+        Assert.Contains("nu", TextFor(ShellEnvironmentState.ShellNotSupported, "nu"));
+    }
+
+    [Fact]
+    public void One_key_is_not_reported_as_one_keys()
+    {
+        Assert.Contains("found 1 key.", TextFor(ShellEnvironmentState.Completed, retained: 1));
+        Assert.Contains("found 3 keys.", TextFor(ShellEnvironmentState.Completed, retained: 3));
+    }
+
+    [Fact]
+    public void Turning_it_off_stops_the_sentence_rather_than_leaving_a_stale_one()
+    {
+        var (vm, shell, _, _) = Make(enabled: true);
+        shell.Status = new ShellEnvironmentStatus(ShellEnvironmentState.Completed, "zsh", 2);
+        Assert.NotEqual("", vm.ShellEnvironmentStatusText);
+
+        vm.ReadLoginShellEnvironment = false;
+
+        // A sentence saying "found 2 keys" beside an unticked box would describe a snapshot that no longer
+        // exists.
+        Assert.Equal("", vm.ShellEnvironmentStatusText);
+    }
+
+    [Fact]
+    public void With_no_shell_environment_at_all_the_control_is_not_offered()
+    {
+        var service = new Mock<ISettingsService>();
+        service.SetupGet(s => s.Settings).Returns(new Settings());
+        var vm = new AiConnectionsViewModel(null, null, null, null, null, service.Object);
+
+        Assert.False(vm.ShowShellEnvironmentControl);
+        Assert.Equal("", vm.ShellEnvironmentStatusText);
+    }
+}

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -734,6 +734,12 @@ public partial class App : Application
     internal static bool ShouldPrimeShellEnvironment(Models.Settings? settings)
     {
         if (settings?.Ai is not { } ai) return false;
+
+        // The reader's own switch, and it ANDs rather than replaces (#820). Proportionality still applies:
+        // leaving this on — which is the default — must not make an ordinary launch of a text reader spawn a
+        // login shell for a feature nobody on this machine uses.
+        if (!ai.ReadLoginShellEnvironment) return false;
+
         if (ai.Enabled) return true;
 
         return ai.Chat?.Connections?.Any(

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -40,6 +40,20 @@ namespace CST.Avalonia.Models
         /// <summary>Master switch — "Enable AI Features". Default OFF (opt-in); nothing AI-related runs while false.</summary>
         public bool Enabled { get; set; } = false;
 
+        /// <summary>
+        /// Whether to read API keys from the login shell's environment. Default ON, and non-Windows only in
+        /// effect. (#820)
+        ///
+        /// <para><b>On rather than off, deliberately.</b> The reader this serves does not know their key is
+        /// invisible — that is the bug (#817) — so a default of off would require them to find a checkbox in
+        /// order to discover a problem they cannot see, which rebuilds the bug with an extra step.</para>
+        ///
+        /// <para>It governs the LOGIN SHELL lookup only. This process's own environment is read regardless,
+        /// so a reader who used <c>launchctl setenv</c>, or launched from a terminal, still has their keys
+        /// found with this off.</para>
+        /// </summary>
+        public bool ReadLoginShellEnvironment { get; set; } = true;
+
         public LocalApiSettings LocalApi { get; set; } = new();
 
         /// <summary>Surface B — the assistant inside the reader. Off until configured.</summary>

--- a/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
@@ -192,6 +192,20 @@ public sealed class ShellEnvironment : IShellEnvironment
     private readonly object _gate = new();
     private ShellEnvironmentStatus _status = ShellEnvironmentStatus.NotRun;
 
+    /// <summary>
+    /// Which generation is current. A probe carries the number it was started under and may only write what
+    /// it learned if that is still the answer. (#820, fable)
+    ///
+    /// <para><b>Nothing can stop a shell that is already running</b> — there is no cancellation through a
+    /// spawned process — so a probe retired by <see cref="Forget"/> keeps going for up to its whole budget and
+    /// then arrives with a verdict about a world that no longer exists. Without this check it stamps that
+    /// verdict over the live one, and the failure is the exact thing this feature was built to stop: the
+    /// screen saying "your shell profile took too long to load" beside a list of the keys a later probe
+    /// found, and saying it permanently, because the newer generation has already written and will not write
+    /// again.</para>
+    /// </summary>
+    private long _generation;
+
     private static readonly IReadOnlyDictionary<string, string> Empty =
         new Dictionary<string, string>(StringComparer.Ordinal);
 
@@ -236,33 +250,47 @@ public sealed class ShellEnvironment : IShellEnvironment
     }
 
     // ExecutionAndPublication so that two callers priming at once run one shell between them, not two.
-    private Lazy<Task<IReadOnlyDictionary<string, string>>> NewProbe() =>
+    private Lazy<Task<IReadOnlyDictionary<string, string>>> NewProbe(long generation) =>
         new(() => Task.Run(async () =>
             {
-                var snapshot = await ProbeAsync().ConfigureAwait(false);
-                // Raised after the result is in hand, so a handler that reads immediately sees it.
-                try { Probed?.Invoke(this, EventArgs.Empty); } catch { /* a handler's problem, not ours */ }
+                var snapshot = await ProbeAsync(generation).ConfigureAwait(false);
+
+                // Raised after the result is in hand, so a handler that reads immediately sees it — and only
+                // by the generation still in service. A retired probe announcing that it landed tells every
+                // surface to go and look at a snapshot that was thrown away.
+                if (IsCurrent(generation))
+                {
+                    try { Probed?.Invoke(this, EventArgs.Empty); } catch { /* a handler's problem, not ours */ }
+                }
                 return snapshot;
             }),
             LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private bool IsCurrent(long generation)
+    {
+        lock (_gate) return generation == _generation;
+    }
 
     /// <inheritdoc />
     public void Prime()
     {
         if (!_supported) return;
 
-        Lazy<Task<IReadOnlyDictionary<string, string>>> probe;
         lock (_gate)
         {
-            _probe ??= NewProbe();
-            probe = _probe;
-            if (_status.State == ShellEnvironmentState.NotRun)
-                _status = ShellEnvironmentStatus.Running;
-        }
+            if (_probe is null)
+            {
+                _probe = NewProbe(++_generation);
+                if (_status.State == ShellEnvironmentState.NotRun)
+                    _status = ShellEnvironmentStatus.Running;
+            }
 
-        // Outside the lock: the factory hands off to the thread pool, but nothing about this needs the gate
-        // held while it does.
-        _ = probe.Value;
+            // Materialised INSIDE the gate. The factory only hands off to the thread pool, so it cannot
+            // block on anything, and doing it outside leaves a window in which a Forget retires the
+            // generation between the read and the start — launching a shell the reader has just said they
+            // do not want. (fable)
+            _ = _probe.Value;
+        }
     }
 
     /// <inheritdoc />
@@ -274,6 +302,10 @@ public sealed class ShellEnvironment : IShellEnvironment
             // "off" true rather than merely obeyed. Keeping it to restore later would leave the reader's keys
             // in the heap of an app they have just told to stop reading them.
             _probe = null;
+
+            // Retires whatever is in flight as well as what has landed. The running shell cannot be stopped,
+            // but its verdict can be refused when it finally arrives.
+            _generation++;
             _status = _supported ? ShellEnvironmentStatus.NotRun : ShellEnvironmentStatus.Unsupported;
         }
 
@@ -311,9 +343,13 @@ public sealed class ShellEnvironment : IShellEnvironment
         return task.Result.TryGetValue(variableName, out var value) ? value : null;
     }
 
-    private void SetStatus(ShellEnvironmentStatus status)
+    private void SetStatus(long generation, ShellEnvironmentStatus status)
     {
-        lock (_gate) _status = status;
+        lock (_gate)
+        {
+            if (generation != _generation) return;
+            _status = status;
+        }
     }
 
     /// <summary>
@@ -321,7 +357,7 @@ public sealed class ShellEnvironment : IShellEnvironment
     /// awaited by <see cref="Completion"/>, and letting an exception escape would turn every later await into
     /// a throw — inside the chat send path, which would report a shell problem as a provider problem.
     /// </summary>
-    private async Task<IReadOnlyDictionary<string, string>> ProbeAsync()
+    private async Task<IReadOnlyDictionary<string, string>> ProbeAsync(long generation)
     {
         try
         {
@@ -331,7 +367,7 @@ public sealed class ShellEnvironment : IShellEnvironment
             if (SkippedShells.Contains(name, StringComparer.OrdinalIgnoreCase))
             {
                 _logger?.LogDebug("Shell environment probe skipped: {Shell} is not supported", name);
-                SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.ShellNotSupported, name));
+                SetStatus(generation, new ShellEnvironmentStatus(ShellEnvironmentState.ShellNotSupported, name));
                 return Empty;
             }
 
@@ -344,7 +380,7 @@ public sealed class ShellEnvironment : IShellEnvironment
             catch (Exception ex)
             {
                 _logger?.LogDebug(ex, "Shell environment probe skipped: the variables of interest are unknown");
-                SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.Failed, name));
+                SetStatus(generation, new ShellEnvironmentStatus(ShellEnvironmentState.Failed, name));
                 return Empty;
             }
 
@@ -352,7 +388,7 @@ public sealed class ShellEnvironment : IShellEnvironment
             {
                 // Nothing to look for is not a failure of the shell, and reporting it as one would send a
                 // reader off to debug a profile that is fine.
-                SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.Completed, name));
+                SetStatus(generation, new ShellEnvironmentStatus(ShellEnvironmentState.Completed, name));
                 return Empty;
             }
             var wanted = new HashSet<string>(keep, StringComparer.Ordinal);
@@ -373,7 +409,7 @@ public sealed class ShellEnvironment : IShellEnvironment
                 // Deliberately no retry. A profile that hangs once hangs twice, and the second attempt buys
                 // nothing but another five seconds of a shell this app has already decided to give up on.
                 _logger?.LogDebug("Shell environment probe timed out: {Shell}", name);
-                SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.TimedOut, name));
+                SetStatus(generation, new ShellEnvironmentStatus(ShellEnvironmentState.TimedOut, name));
                 return Empty;
             }
             else
@@ -384,7 +420,7 @@ public sealed class ShellEnvironment : IShellEnvironment
                 if (!result.Succeeded)
                 {
                     _logger?.LogDebug("Shell environment probe found nothing: {Shell}", name);
-                    SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.Failed, name));
+                    SetStatus(generation, new ShellEnvironmentStatus(ShellEnvironmentState.Failed, name));
                     return Empty;
                 }
             }
@@ -398,7 +434,7 @@ public sealed class ShellEnvironment : IShellEnvironment
                 "Shell environment probe: {Shell}, {Elapsed}ms, {Retained} of {Wanted} variables retained",
                 name, started.ElapsedMilliseconds, snapshot.Count, wanted.Count);
 
-            SetStatus(new ShellEnvironmentStatus(
+            SetStatus(generation, new ShellEnvironmentStatus(
                 ShellEnvironmentState.Completed, name, snapshot.Count));
 
             return snapshot;
@@ -406,7 +442,7 @@ public sealed class ShellEnvironment : IShellEnvironment
         catch (Exception ex)
         {
             _logger?.LogDebug(ex, "Shell environment probe failed");
-            SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.Failed));
+            SetStatus(generation, new ShellEnvironmentStatus(ShellEnvironmentState.Failed));
             return Empty;
         }
     }

--- a/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
@@ -44,6 +44,52 @@ namespace CST.Avalonia.Services.Ai.Credentials;
 /// persisted — a probe result on disk is a credential on disk. The log line records a count, never a name and
 /// never a value.</para>
 /// </summary>
+/// <summary>
+/// What happened the last time the login shell was consulted. (#820)
+///
+/// <para>Exists because until now the probe had nowhere to report itself. A shell skipped by name, a profile
+/// that timed out, and an environment that genuinely holds no provider key all produced the same thing on
+/// screen — an empty "found in your environment" section — which is #817's own complaint (absence rendered as
+/// absence) one layer up. Every one of these states is something a reader can act on, and none of them was
+/// distinguishable before.</para>
+/// </summary>
+public enum ShellEnvironmentState
+{
+    /// <summary>Nothing has asked for a probe, or the reader has turned the feature off.</summary>
+    NotRun,
+
+    /// <summary>Windows, where the environment is inherited normally and there is nothing to look for.</summary>
+    Unsupported,
+
+    /// <summary>A probe is in flight. Reads answer null until it lands.</summary>
+    Running,
+
+    /// <summary>The reader's shell is one whose flags do not mean what this needs — <c>nu</c>, <c>csh</c>,
+    /// <c>tcsh</c>. Worth saying out loud, because it is the one failure the reader can do something about.</summary>
+    ShellNotSupported,
+
+    /// <summary>The shell did not finish inside the budget, so the probe gave up rather than retry.</summary>
+    TimedOut,
+
+    /// <summary>The shell would not answer: no such shell, refused to run, or a nonzero exit both times.</summary>
+    Failed,
+
+    /// <summary>The shell answered. <see cref="ShellEnvironmentStatus.RetainedCount"/> may still be zero,
+    /// which is the honest and useful answer "your shell exports none of the variables we know about".</summary>
+    Completed,
+}
+
+/// <summary>The reportable outcome of the last probe, and enough detail to say something specific.</summary>
+/// <param name="ShellName">The shell's basename — <c>zsh</c>, never the full path.</param>
+/// <param name="RetainedCount">How many variables of interest were found. Never which ones.</param>
+public sealed record ShellEnvironmentStatus(
+    ShellEnvironmentState State, string? ShellName = null, int RetainedCount = 0)
+{
+    public static readonly ShellEnvironmentStatus NotRun = new(ShellEnvironmentState.NotRun);
+    public static readonly ShellEnvironmentStatus Unsupported = new(ShellEnvironmentState.Unsupported);
+    public static readonly ShellEnvironmentStatus Running = new(ShellEnvironmentState.Running);
+}
+
 public interface IShellEnvironment
 {
     /// <summary>
@@ -76,6 +122,19 @@ public interface IShellEnvironment
     /// construction is not ordered against startup, and it is the surface that says "not configured".</para>
     /// </summary>
     event EventHandler? Probed;
+
+    /// <summary>
+    /// Drops the snapshot and resets, so a later <see cref="Prime"/> reads the shell again. (#820)
+    ///
+    /// <para>What the reader unticking the control calls. It genuinely releases the values rather than merely
+    /// ceasing to consult them — an app that kept a reader's keys in memory after being told to stop reading
+    /// them would be obeying the letter of the instruction and not the point of it. The cost is that
+    /// re-enabling runs a second shell, since there is deliberately nothing left to restore.</para>
+    /// </summary>
+    void Forget();
+
+    /// <summary>What happened last time, so a surface can say so. Never names a variable. (#820)</summary>
+    ShellEnvironmentStatus Status { get; }
 }
 
 /// <inheritdoc />
@@ -116,7 +175,22 @@ public sealed class ShellEnvironment : IShellEnvironment
     private readonly ILogger? _logger;
     private readonly bool _supported;
     private readonly string? _shellPath;
-    private readonly Lazy<Task<IReadOnlyDictionary<string, string>>> _probe;
+
+    /// <summary>
+    /// The current probe, or null when none has been asked for — replaced wholesale by
+    /// <see cref="Forget"/>. (#820)
+    ///
+    /// <para><b>A generation, not the single <c>Lazy</c> this started as.</b> A <c>Lazy</c> created once in
+    /// the constructor is single-shot by construction, which was exactly the property that made eight
+    /// concurrent <see cref="Prime"/> calls collapse onto one shell. Turning the feature off and on again has
+    /// to run a second shell — because turning it off RELEASES the values, and a release that kept them
+    /// around to restore would make "off" a lie — so the field became a generation. The collapse guarantee
+    /// still holds within one.</para>
+    /// </summary>
+    private Lazy<Task<IReadOnlyDictionary<string, string>>>? _probe;
+
+    private readonly object _gate = new();
+    private ShellEnvironmentStatus _status = ShellEnvironmentStatus.NotRun;
 
     private static readonly IReadOnlyDictionary<string, string> Empty =
         new Dictionary<string, string>(StringComparer.Ordinal);
@@ -149,9 +223,21 @@ public sealed class ShellEnvironment : IShellEnvironment
         _supported = supported;
         _shellPath = shellPath;
 
-        // ExecutionAndPublication so that two callers priming at once run one shell between them, not two.
-        _probe = new Lazy<Task<IReadOnlyDictionary<string, string>>>(
-            () => Task.Run(async () =>
+        if (!_supported) _status = ShellEnvironmentStatus.Unsupported;
+    }
+
+    /// <inheritdoc />
+    public event EventHandler? Probed;
+
+    /// <inheritdoc />
+    public ShellEnvironmentStatus Status
+    {
+        get { lock (_gate) return _status; }
+    }
+
+    // ExecutionAndPublication so that two callers priming at once run one shell between them, not two.
+    private Lazy<Task<IReadOnlyDictionary<string, string>>> NewProbe() =>
+        new(() => Task.Run(async () =>
             {
                 var snapshot = await ProbeAsync().ConfigureAwait(false);
                 // Raised after the result is in hand, so a handler that reads immediately sees it.
@@ -159,34 +245,75 @@ public sealed class ShellEnvironment : IShellEnvironment
                 return snapshot;
             }),
             LazyThreadSafetyMode.ExecutionAndPublication);
-    }
-
-    /// <inheritdoc />
-    public event EventHandler? Probed;
 
     /// <inheritdoc />
     public void Prime()
     {
         if (!_supported) return;
-        _ = _probe.Value;
+
+        Lazy<Task<IReadOnlyDictionary<string, string>>> probe;
+        lock (_gate)
+        {
+            _probe ??= NewProbe();
+            probe = _probe;
+            if (_status.State == ShellEnvironmentState.NotRun)
+                _status = ShellEnvironmentStatus.Running;
+        }
+
+        // Outside the lock: the factory hands off to the thread pool, but nothing about this needs the gate
+        // held while it does.
+        _ = probe.Value;
     }
 
     /// <inheritdoc />
-    public Task Completion => _probe.IsValueCreated ? _probe.Value : Task.CompletedTask;
+    public void Forget()
+    {
+        lock (_gate)
+        {
+            // Dropping the generation drops this object's only reference to the snapshot, which is what makes
+            // "off" true rather than merely obeyed. Keeping it to restore later would leave the reader's keys
+            // in the heap of an app they have just told to stop reading them.
+            _probe = null;
+            _status = _supported ? ShellEnvironmentStatus.NotRun : ShellEnvironmentStatus.Unsupported;
+        }
+
+        // Surfaces that showed rows from the snapshot need to stop showing them, and this is the same signal
+        // that told them to start.
+        try { Probed?.Invoke(this, EventArgs.Empty); } catch { /* a handler's problem, not ours */ }
+    }
+
+    /// <inheritdoc />
+    public Task Completion
+    {
+        get
+        {
+            Lazy<Task<IReadOnlyDictionary<string, string>>>? probe;
+            lock (_gate) probe = _probe;
+            return probe is { IsValueCreated: true } ? probe.Value : Task.CompletedTask;
+        }
+    }
 
     /// <inheritdoc />
     public string? TryRead(string variableName)
     {
         if (string.IsNullOrWhiteSpace(variableName)) return null;
 
-        // IsValueCreated first: reading must never be what starts a shell. A caller that wants the probe says
-        // so by calling Prime.
-        if (!_probe.IsValueCreated) return null;
+        Lazy<Task<IReadOnlyDictionary<string, string>>>? probe;
+        lock (_gate) probe = _probe;
 
-        var task = _probe.Value;
+        // IsValueCreated first: reading must never be what starts a shell. A caller that wants the probe says
+        // so by calling Prime. A null generation is a probe that has been forgotten, or never asked for.
+        if (probe is not { IsValueCreated: true }) return null;
+
+        var task = probe.Value;
         if (!task.IsCompletedSuccessfully) return null;
 
         return task.Result.TryGetValue(variableName, out var value) ? value : null;
+    }
+
+    private void SetStatus(ShellEnvironmentStatus status)
+    {
+        lock (_gate) _status = status;
     }
 
     /// <summary>
@@ -204,6 +331,7 @@ public sealed class ShellEnvironment : IShellEnvironment
             if (SkippedShells.Contains(name, StringComparer.OrdinalIgnoreCase))
             {
                 _logger?.LogDebug("Shell environment probe skipped: {Shell} is not supported", name);
+                SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.ShellNotSupported, name));
                 return Empty;
             }
 
@@ -216,10 +344,17 @@ public sealed class ShellEnvironment : IShellEnvironment
             catch (Exception ex)
             {
                 _logger?.LogDebug(ex, "Shell environment probe skipped: the variables of interest are unknown");
+                SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.Failed, name));
                 return Empty;
             }
 
-            if (keep.Count == 0) return Empty;
+            if (keep.Count == 0)
+            {
+                // Nothing to look for is not a failure of the shell, and reporting it as one would send a
+                // reader off to debug a profile that is fine.
+                SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.Completed, name));
+                return Empty;
+            }
             var wanted = new HashSet<string>(keep, StringComparer.Ordinal);
 
             var started = Stopwatch.StartNew();
@@ -238,6 +373,7 @@ public sealed class ShellEnvironment : IShellEnvironment
                 // Deliberately no retry. A profile that hangs once hangs twice, and the second attempt buys
                 // nothing but another five seconds of a shell this app has already decided to give up on.
                 _logger?.LogDebug("Shell environment probe timed out: {Shell}", name);
+                SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.TimedOut, name));
                 return Empty;
             }
             else
@@ -248,6 +384,7 @@ public sealed class ShellEnvironment : IShellEnvironment
                 if (!result.Succeeded)
                 {
                     _logger?.LogDebug("Shell environment probe found nothing: {Shell}", name);
+                    SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.Failed, name));
                     return Empty;
                 }
             }
@@ -261,11 +398,15 @@ public sealed class ShellEnvironment : IShellEnvironment
                 "Shell environment probe: {Shell}, {Elapsed}ms, {Retained} of {Wanted} variables retained",
                 name, started.ElapsedMilliseconds, snapshot.Count, wanted.Count);
 
+            SetStatus(new ShellEnvironmentStatus(
+                ShellEnvironmentState.Completed, name, snapshot.Count));
+
             return snapshot;
         }
         catch (Exception ex)
         {
             _logger?.LogDebug(ex, "Shell environment probe failed");
+            SetStatus(new ShellEnvironmentStatus(ShellEnvironmentState.Failed));
             return Empty;
         }
     }

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -7,6 +7,7 @@ using System.Reactive;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services;
 using CST.Avalonia.Services.Ai;
 using CST.Avalonia.Services.Ai.Credentials;
 using ReactiveUI;
@@ -38,6 +39,8 @@ namespace CST.Avalonia.ViewModels
         private readonly IAiProviderLogos? _logos;
         private readonly IAiEnvironmentKeys? _environmentKeys;
         private readonly IShellEnvironment? _shellEnvironment;
+        private readonly ISettingsService? _settings;
+        private bool _readLoginShellEnvironment = true;
         private AiConnectionEditorViewModel? _editor;
         private bool _disposed;
         private string? _problem;
@@ -49,13 +52,16 @@ namespace CST.Avalonia.ViewModels
             IAiCredentialStore? credentials = null,
             IAiProviderLogos? logos = null,
             IAiEnvironmentKeys? environmentKeys = null,
-            IShellEnvironment? shellEnvironment = null)
+            IShellEnvironment? shellEnvironment = null,
+            ISettingsService? settings = null)
         {
             _service = service;
             _credentials = credentials;
             _logos = logos;
             _environmentKeys = environmentKeys;
             _shellEnvironment = shellEnvironment;
+            _settings = settings;
+            _readLoginShellEnvironment = settings?.Settings?.Ai?.ReadLoginShellEnvironment ?? true;
 
             AddCustomCommand = ReactiveCommand.Create(AddCustom);
             RetryCatalogueCommand = ReactiveCommand.CreateFromTask(RetryCatalogueAsync);
@@ -71,14 +77,97 @@ namespace CST.Avalonia.ViewModels
             // idempotent, so the common case where startup already primed costs a field read. (#817)
             if (_shellEnvironment is not null)
             {
-                _shellEnvironment.Prime();
-
                 // Progressive disclosure, the same shape the catalogue already uses: rows appear when the
-                // probe lands rather than the window waiting for it. Fire-and-forget by design — Completion
-                // never faults, and there is nothing to report if it finds nothing.
-                _shellEnvironment.Completion.ContinueWith(
-                    _ => Dispatcher.UIThread.Post(() => { if (!_disposed) Rebind(); }),
-                    TaskScheduler.Default);
+                // probe lands rather than the window waiting for it.
+                //
+                // The event rather than a continuation on Completion (#820): a continuation is bound to one
+                // probe, and the reader can now retire that probe and start another by toggling the control.
+                _shellEnvironment.Probed += OnShellProbed;
+
+                if (_readLoginShellEnvironment) _shellEnvironment.Prime();
+            }
+        }
+
+        private void OnShellProbed(object? sender, EventArgs e) =>
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (_disposed) return;
+                Rebind();
+                this.RaisePropertyChanged(nameof(ShellEnvironmentStatusText));
+            });
+
+        /// <summary>
+        /// Whether to read API keys from the login shell. (#820)
+        ///
+        /// <para><b>Turning it off releases the snapshot; turning it back on reads the shell again.</b> There
+        /// is deliberately nothing kept to restore — keeping a reader's keys in memory after being told to
+        /// stop reading them would obey the instruction and miss its point — so the cost of a toggle is one
+        /// login shell, which is the right price for a deliberate act.</para>
+        /// </summary>
+        public bool ReadLoginShellEnvironment
+        {
+            get => _readLoginShellEnvironment;
+            set
+            {
+                if (_readLoginShellEnvironment == value) return;
+                this.RaiseAndSetIfChanged(ref _readLoginShellEnvironment, value);
+
+                if (_settings?.Settings?.Ai is { } ai)
+                {
+                    ai.ReadLoginShellEnvironment = value;
+                    _settings.RequestSave();
+                }
+
+                if (value) _shellEnvironment?.Prime();
+                else _shellEnvironment?.Forget();
+
+                // Forget raises Probed too, so the rows and the sentence both follow from the same signal.
+                this.RaisePropertyChanged(nameof(ShellEnvironmentStatusText));
+            }
+        }
+
+        /// <summary>
+        /// Hidden on Windows rather than shown disabled: Windows inherits its environment normally, so the
+        /// lookup is unnecessary there rather than unavailable, and a greyed control invites the reader to
+        /// ask why they cannot turn it on. (#820)
+        /// </summary>
+        public bool ShowShellEnvironmentControl =>
+            _shellEnvironment is not null && !OperatingSystem.IsWindows();
+
+        /// <summary>
+        /// What happened when the login shell was consulted, in a sentence. (#820)
+        ///
+        /// <para>This exists because until now the probe had nowhere to report itself: a shell skipped by
+        /// name, a profile that timed out and an environment holding no provider key all showed the reader
+        /// the same empty section. Each of these is something they can act on.</para>
+        /// </summary>
+        public string ShellEnvironmentStatusText
+        {
+            get
+            {
+                if (_shellEnvironment is null || !_readLoginShellEnvironment) return "";
+
+                var status = _shellEnvironment.Status;
+                var shell = string.IsNullOrWhiteSpace(status.ShellName) ? "your login shell" : status.ShellName;
+
+                return status.State switch
+                {
+                    ShellEnvironmentState.Running => "Looking in your login shell…",
+                    ShellEnvironmentState.ShellNotSupported =>
+                        $"Your shell ({shell}) isn't supported here, so keys exported from your profile "
+                        + "can't be seen.",
+                    ShellEnvironmentState.TimedOut =>
+                        "Your shell profile took too long to load, so it was skipped.",
+                    ShellEnvironmentState.Failed =>
+                        "Your login shell couldn't be read, so keys exported from your profile can't be seen.",
+                    ShellEnvironmentState.Completed when status.RetainedCount == 1 =>
+                        $"Looked in your login shell ({shell}) — found 1 key.",
+                    ShellEnvironmentState.Completed when status.RetainedCount > 1 =>
+                        $"Looked in your login shell ({shell}) — found {status.RetainedCount} keys.",
+                    ShellEnvironmentState.Completed =>
+                        $"Looked in your login shell ({shell}) — no provider keys there.",
+                    _ => "",
+                };
             }
         }
 
@@ -445,6 +534,7 @@ namespace CST.Avalonia.ViewModels
             // window comes back to life holding a dead service. (#817)
             _disposed = true;
             if (_service is not null) _service.ConnectionsChanged -= OnConnectionsChanged;
+            if (_shellEnvironment is not null) _shellEnvironment.Probed -= OnShellProbed;
         }
 
         /// <summary>

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -104,22 +104,33 @@ namespace CST.Avalonia.ViewModels
         /// stop reading them would obey the instruction and miss its point — so the cost of a toggle is one
         /// login shell, which is the right price for a deliberate act.</para>
         /// </summary>
+        /// <remarks>
+        /// This property is the ONLY place the stored setting and the running service are kept in step. That
+        /// is fine while the settings window is the only thing that writes it, and it is the reason to move
+        /// this to a service method the moment anything else can — an import, or an API surface, would change
+        /// the setting and leave the probe running, or not running, until the next launch. (fable)
+        /// </remarks>
         public bool ReadLoginShellEnvironment
         {
             get => _readLoginShellEnvironment;
             set
             {
-                if (_readLoginShellEnvironment == value) return;
+                if (_disposed || _readLoginShellEnvironment == value) return;
                 this.RaiseAndSetIfChanged(ref _readLoginShellEnvironment, value);
+
+                // THE SERVICE FIRST, THEN THE SETTING. If persistence throws, the box reads unticked and the
+                // setting saves as off while the snapshot is still held — the "off is a lie" state this
+                // property exists to prevent, arrived at by the failure of something unrelated to it.
+                // RequestSave only arms a timer and is effectively non-throwing today, which is exactly the
+                // kind of "today" that stops being true without anyone revisiting this line. (fable)
+                if (value) _shellEnvironment?.Prime();
+                else _shellEnvironment?.Forget();
 
                 if (_settings?.Settings?.Ai is { } ai)
                 {
                     ai.ReadLoginShellEnvironment = value;
                     _settings.RequestSave();
                 }
-
-                if (value) _shellEnvironment?.Prime();
-                else _shellEnvironment?.Forget();
 
                 // Forget raises Probed too, so the rows and the sentence both follow from the same signal.
                 this.RaisePropertyChanged(nameof(ShellEnvironmentStatusText));

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1384,7 +1384,8 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
             Connections = new AiConnectionsViewModel(
                 connectionService, credentials, App.TryGetService<Services.Ai.IAiProviderLogos>(),
                 App.TryGetService<Services.Ai.Credentials.IAiEnvironmentKeys>(),
-                App.TryGetService<Services.Ai.Credentials.IShellEnvironment>());
+                App.TryGetService<Services.Ai.Credentials.IShellEnvironment>(),
+                App.TryGetService<ISettingsService>());
             Models = new AiModelsViewModel(
                 connectionService,
                 App.TryGetService<Services.Ai.IAiModelCatalog>(),


### PR DESCRIPTION
The backend half of #820, on top of #817. **The XAML is deliberately not here** — see the handoff at the bottom.

## Why it isn't only a preference

The probe from #817 worked but had nowhere to report itself. A shell skipped by name (`nu`, `csh`, `tcsh`), a profile that timed out, and an environment that genuinely holds no provider key all produced the same thing on screen: an empty "Found in your environment" section, with no explanation. That is #817's own complaint — absence rendered as absence — one layer up. Each of those is something a reader can act on, and none was distinguishable.

## The setting

`AiSettings.ReadLoginShellEnvironment`, **default on**. Off would be actively harmful: the reader this serves does not know their key is invisible — that *is* the bug — so requiring them to find a checkbox in order to discover a problem they cannot see rebuilds #817 with an extra step.

It **ANDs** with the existing gate rather than replacing it, so an ordinary launch of a text reader still spawns nothing. And it governs the **login-shell lookup only**: this process's own environment is read regardless, so a reader using `launchctl setenv` still has their keys found with it off. The label must not promise more than that.

## Forget() drops, it does not merely stop consulting

Ceasing to consult values we keep in memory would obey the instruction and miss its point — the reader's keys would still be in the heap of an app they have just told to stop reading them. So there is deliberately nothing left to restore, and re-enabling runs a second shell. One login shell per deliberate toggle is the right price, and it hands a reader who has just edited `~/.zshrc` a way to pick it up without relaunching.

**That forced the probe to become a generation.** The `Lazy<Task<...>>` created in the constructor was single-shot by construction — which was exactly the property that made eight concurrent `Prime()` calls collapse onto one shell. It is now a replaceable field under a lock, with the collapse guarantee preserved *within* a generation, and `Completion`/`TryRead` made generation-aware.

## Reporting

`ShellEnvironmentStatus`: `NotRun`, `Unsupported`, `Running`, `ShellNotSupported` (naming the shell — the one failure a reader can fix), `TimedOut`, `Failed`, `Completed` with a count.

A **count, never a name and never a value.** This string is rendered on screen and written to a log, so it is the first place this feature could leak one; a test asserts it doesn't.

## Tests

22 new. Four mutations, each killing at least one test: a `Forget` that keeps the snapshot, a gate that ignores the switch, a toggle that writes the setting but never tells the service, and a default of off.

The assertion I'd point at first is `Every_outcome_says_something_different` — five states, five distinct non-empty sentences. That is the feature in one line.

Full suite: 2589 passed, 0 failed.

## Handoff — the UI half

Everything below the XAML is done and testable. What's left, for the Providers tab:

- A checkbox bound to `AiConnectionsViewModel.ReadLoginShellEnvironment`
- Visibility bound to `ShowShellEnvironmentControl` (false on Windows — **hidden, not disabled**: the lookup is unnecessary there rather than unavailable, and a greyed control invites "why can't I turn this on?")
- A status line bound to `ShellEnvironmentStatusText`, which is `""` when there's nothing to say

Suggested copy, since the thing needing consent is the action rather than the mechanism:

> **Look for API keys in your login shell**
> Apps opened from Finder don't inherit the environment your shell sets up, so keys exported from `~/.zshrc` or `~/.bash_profile` are invisible. Runs your shell profile once at startup.

One open question I flagged in #820 and did not decide: turning this off breaks any connection whose key was only ever visible through the shell — correctly, but silently. The UI could say so first: *"2 connections use keys found this way and will stop working."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
