### PR TITLE
A control for the shell lookup, and somewhere for it to report (#820 UI)

### DIFF
--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -177,6 +177,28 @@
 
             <!-- Add a provider -->
             <TextBlock Text="Add a provider" Classes="SettingLabel" FontWeight="SemiBold"/>
+            <!-- Where discovery is allowed to look, and what it found. (#820)
+
+                 A SIBLING of the found-keys block below, never nested inside it. That block hides when it is
+                 empty, and the sentence here is at its most useful in exactly that case — a shell skipped by
+                 name, a profile that timed out, an environment holding no provider key. Nested, the one
+                 state worth explaining could never be shown, which is #817's own complaint one layer up.
+
+                 Hidden on Windows rather than shown disabled: Windows inherits its environment normally, so
+                 the lookup is unnecessary there rather than unavailable. -->
+            <StackPanel IsVisible="{Binding ShowShellEnvironmentControl}" Margin="0,0,0,16">
+                <CheckBox IsChecked="{Binding ReadLoginShellEnvironment}"
+                          Content="Look for API keys in your login shell"/>
+                <!-- The consent is for the action, not the mechanism, so the description leads with what it
+                     does to the reader's machine. The last sentence answers the question the toggle raises
+                     and would otherwise answer later, as a connection failing for no visible reason. -->
+                <TextBlock Text="Apps opened from Finder don't inherit the environment your shell sets up, so keys exported from ~/.zshrc or ~/.bash_profile are invisible. Runs your shell profile once at startup. Connections using a key found this way stop working while this is off."
+                           Classes="SettingDescription" Margin="0,2,0,0"/>
+                <TextBlock Text="{Binding ShellEnvironmentStatusText}"
+                           IsVisible="{Binding ShellEnvironmentStatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                           Classes="SettingDescription" Margin="0,6,0,0"/>
+            </StackPanel>
+
             <!-- Keys this machine already holds. Above the search box on purpose: the reader this exists for
                  is the one who does NOT know the variable is set, and they will never search for it. Shown
                  only when something was found, so a reader with a clean environment sees nothing at all


### PR DESCRIPTION
The UI half of #820. The backend (#822) is **merged** — this is now rebased onto it and is a single commit touching one file.

## What it adds

One `StackPanel` on the Providers tab, above the "Found in your environment" block: the checkbox, its description, and the status line.

Everything binds straight to what #822 already exposes and unit-tests — `ReadLoginShellEnvironment`, `ShowShellEnvironmentControl`, `ShellEnvironmentStatusText`. No logic was added around them.

## Two decisions worth review

**It is a sibling of the found-keys block, not inside it.** That block is `IsVisible="{Binding HasFoundKeys}"`, so it disappears when empty — and the status sentence earns its place in exactly that case: a shell skipped by name, a profile that timed out, an environment with no provider key. Nested, the one state worth explaining could never be shown, which is #817's own complaint rebuilt one layer up. This is the property most likely to be undone by a later refactor, and the one nothing tests (see below).

**The consequence of turning it off is stated inline, not in a dialog.** #820 flagged this as undecided and asked for judgement. The description carries one sentence beyond the suggested copy:

> Connections using a key found this way stop working while this is off.

A confirmation dialog was the alternative and is the wrong weight: the act is one click to undo, re-ticking re-reads, and a modal on a settings checkbox teaches people to click through modals. Saying it inline answers the question at the moment it is raised, rather than later as a connection failing for no visible reason. Happy to be overruled — it is a UX call, and the dialog is a small change from here.

## Deliberately not done

The status line uses the ordinary `SettingDescription` style for all five states, including the three failure ones, rather than the caution colour `CatalogueProblem` gets. Distinguishing them needs a severity property on the view model, and the handoff was explicit that the UI should bind rather than add logic. Easy to add later if the failure states read as too quiet in use.

## Verification

- `dotnet build src/CST.Avalonia` — 0 warnings, 0 errors. Not incidental: `AvaloniaUseCompiledBindingsByDefault` is `true` and the view sets `x:DataType`, so all three binding paths are checked against `AiConnectionsViewModel` at compile time. A typo would be a build error, not a silently empty control.
- `dotnet test src/CST.Avalonia.Tests` — **2592 passed, 0 failed, 17 skipped**, run against the merged backend including the retired-generation fix (da2428d).

## No test, and what that leaves uncovered

The five status sentences are covered by `ShellEnvironmentControlTests` in #822. What is **not** covered is the sibling-not-nested structure above: asserting the status line is visible while `HasFoundKeys` is false needs an instantiated view, and this project has no headless Avalonia harness — the existing `Views/` tests exercise static helpers only, and `AnswerTableWidthTests` says the same of table wrapping (#655). Recording it rather than leaving it implied.

## Manual check

On macOS: the control appears; unticking makes the found-keys rows and the sentence go away; re-ticking runs a second shell and they return. On Windows: no control at all, and no shell spawned.
