### PR TITLE
Drop the explanation under the shell-lookup checkbox (#820)

### DIFF
--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -189,14 +189,9 @@
             <StackPanel IsVisible="{Binding ShowShellEnvironmentControl}" Margin="0,0,0,16">
                 <CheckBox IsChecked="{Binding ReadLoginShellEnvironment}"
                           Content="Look for API keys in your login shell"/>
-                <!-- The consent is for the action, not the mechanism, so the description leads with what it
-                     does to the reader's machine. The last sentence answers the question the toggle raises
-                     and would otherwise answer later, as a connection failing for no visible reason. -->
-                <TextBlock Text="Apps opened from Finder don't inherit the environment your shell sets up, so keys exported from ~/.zshrc or ~/.bash_profile are invisible. Runs your shell profile once at startup. Connections using a key found this way stop working while this is off."
-                           Classes="SettingDescription" Margin="0,2,0,0"/>
                 <TextBlock Text="{Binding ShellEnvironmentStatusText}"
                            IsVisible="{Binding ShellEnvironmentStatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                           Classes="SettingDescription" Margin="0,6,0,0"/>
+                           Classes="SettingDescription" Margin="0,4,0,0"/>
             </StackPanel>
 
             <!-- Keys this machine already holds. Above the search box on purpose: the reader this exists for


### PR DESCRIPTION
Removes the three-sentence description under **Look for API keys in your login shell**, added in #823. Maintainer's call.

The label says what the control does, and the status line under it reports what actually happened — *"Looked in your login shell (bash) — found 2 keys"*. That line earns its place because it is a state the reader can act on. The paragraph above it was background, and background belongs in the issue or in a comment in the file.

Worth naming the reasoning that produced it, because it is the reasoning that produces every such paragraph: *the consent is for the action rather than the mechanism, so the description should explain what the app does to your machine.* Explaining a mechanism in order to justify a checkbox is how a checkbox acquires a paragraph. Where a control seems to need a sentence answering the question it raises, the label is usually what wants fixing.

One incidental: the status line's top margin closes from 6 to 4, since it now follows the checkbox directly rather than a block of text.

Build clean. No test touches this markup; bindings are compiled, so the remaining two paths are still checked against `AiConnectionsViewModel` at build time.

Not swept beyond the one block asked for — there are other long descriptions on this tab and elsewhere in Settings, and trimming them is a separate pass with its own judgement calls.
