### PR TITLE
Accept a probe whose output arrived but whose exit was never seen (#824)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/ShellProbeOutcomeTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ShellProbeOutcomeTests.cs
@@ -1,0 +1,74 @@
+using CST.Avalonia.Services.Ai.Credentials;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// #824: when a probe that produced output counts as having succeeded.
+///
+/// <para><b>The incident.</b> Inside the running app on macOS the login-shell probe reported a timeout every
+/// single time, and the Providers tab told the reader their shell profile was too slow to load. It was not:
+/// the shell finished in about forty milliseconds, wrote its entire environment, and stdout reached EOF —
+/// while <c>Process.HasExited</c> was still false when the five-second budget expired. The child's exit
+/// status is consumed before the runtime's own bookkeeping sees it, so the exit could never be observed
+/// however long anything waited.</para>
+///
+/// <para><b>Why these tests are shaped around a null exit code.</b> The old policy was
+/// <c>process.ExitCode == 0</c>, which cannot express "the work finished and there is no status to read".
+/// Reading <c>ExitCode</c> in that state throws, so the code took the only branch left and threw the payload
+/// away. The first test below is the one that fails against the old policy; the rest hold it to everything it
+/// was already right about, so restoring the strictness cannot be mistaken for a fix.</para>
+///
+/// <para>The spawn path itself has no test and cannot usefully have one: the failure needs CEF loaded in the
+/// same process, so a test that ran a real shell would pass either way. What is testable is the policy, and
+/// pinning it is what stops a later refactor quietly reinstating exit-or-nothing.</para>
+/// </summary>
+public class ShellProbeOutcomeTests
+{
+    /// <summary>
+    /// A complete payload with no observed exit is a success.
+    ///
+    /// <para>This is #824 itself. Against the old policy it fails, because there is no exit code to compare
+    /// against zero and asking for one throws.</para>
+    /// </summary>
+    [Fact]
+    public void Output_that_arrived_is_kept_even_when_the_exit_was_never_observed()
+    {
+        Assert.True(ProcessShellProbeRunner.Decide(payloadLength: 2553, exitCode: null));
+    }
+
+    /// <summary>The ordinary case, unchanged: the shell exited cleanly and wrote something.</summary>
+    [Fact]
+    public void A_clean_exit_with_output_is_a_success()
+    {
+        Assert.True(ProcessShellProbeRunner.Decide(payloadLength: 2553, exitCode: 0));
+    }
+
+    /// <summary>
+    /// A shell that exited non-zero is still refused.
+    ///
+    /// <para>Kept deliberately. Where the runtime DID observe the exit, its verdict is real evidence and the
+    /// loosening in #824 was only ever about the case where no verdict exists.</para>
+    /// </summary>
+    [Fact]
+    public void A_failing_exit_code_is_still_a_failure()
+    {
+        Assert.False(ProcessShellProbeRunner.Decide(payloadLength: 2553, exitCode: 1));
+    }
+
+    /// <summary>
+    /// Nothing written is a failure however the process ended.
+    ///
+    /// <para>Without this, "no exit code" plus "no output" would read as success and the parser would be
+    /// handed an empty buffer — reported to the reader as a shell that holds no provider keys, which is a
+    /// different and equally wrong sentence.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void An_empty_payload_is_never_a_success(int? exitCode)
+    {
+        Assert.False(ProcessShellProbeRunner.Decide(payloadLength: 0, exitCode));
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/ShellProbeOutcomeTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ShellProbeOutcomeTests.cs
@@ -34,14 +34,14 @@ public class ShellProbeOutcomeTests
     [Fact]
     public void Output_that_arrived_is_kept_even_when_the_exit_was_never_observed()
     {
-        Assert.True(ProcessShellProbeRunner.Decide(payloadLength: 2553, exitCode: null));
+        Assert.True(ProcessShellProbeRunner.Decide(payloadLength: 2553, wellFormed: true, exitCode: null));
     }
 
     /// <summary>The ordinary case, unchanged: the shell exited cleanly and wrote something.</summary>
     [Fact]
     public void A_clean_exit_with_output_is_a_success()
     {
-        Assert.True(ProcessShellProbeRunner.Decide(payloadLength: 2553, exitCode: 0));
+        Assert.True(ProcessShellProbeRunner.Decide(payloadLength: 2553, wellFormed: true, exitCode: 0));
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ public class ShellProbeOutcomeTests
     [Fact]
     public void A_failing_exit_code_is_still_a_failure()
     {
-        Assert.False(ProcessShellProbeRunner.Decide(payloadLength: 2553, exitCode: 1));
+        Assert.False(ProcessShellProbeRunner.Decide(payloadLength: 2553, wellFormed: true, exitCode: 1));
     }
 
     /// <summary>
@@ -69,6 +69,60 @@ public class ShellProbeOutcomeTests
     [InlineData(1)]
     public void An_empty_payload_is_never_a_success(int? exitCode)
     {
-        Assert.False(ProcessShellProbeRunner.Decide(payloadLength: 0, exitCode));
+        Assert.False(ProcessShellProbeRunner.Decide(payloadLength: 0, wellFormed: false, exitCode));
+    }
+
+    /// <summary>
+    /// A payload that does not end where <c>env -0</c> would end it is refused when there is no exit code to
+    /// consult. (#824, review)
+    ///
+    /// <para>The case: a profile that mangles PATH until <c>env</c> cannot be found leaves nothing behind but
+    /// the sentinel, and the first version of this fix accepted it because one byte is more than zero. It
+    /// reached the reader as "your login shell exports none of the variables we know about", and — being a
+    /// success — stopped the ladder retrying with <c>-l</c>, which is where the keys were.</para>
+    /// </summary>
+    [Fact]
+    public void A_payload_that_does_not_end_cleanly_is_refused_when_no_exit_code_is_available()
+    {
+        Assert.False(ProcessShellProbeRunner.Decide(payloadLength: 1, wellFormed: false, exitCode: null));
+    }
+
+    /// <summary>
+    /// An observed clean exit still carries a payload that ended mid-entry.
+    ///
+    /// <para>Deliberate: where the runtime saw the shell exit cleanly there is real evidence the write
+    /// finished, and this branch must not become a second, stricter gate on the ordinary path.</para>
+    /// </summary>
+    [Fact]
+    public void A_clean_observed_exit_does_not_need_the_payload_to_vouch_for_itself()
+    {
+        Assert.True(ProcessShellProbeRunner.Decide(payloadLength: 2553, wellFormed: false, exitCode: 0));
+    }
+
+    /// <summary>What <see cref="ProcessShellProbeRunner.WellFormed"/> accepts, and what it must not.</summary>
+    [Theory]
+    [InlineData(new byte[] { 0x41, 0x3d, 0x31, 0x00 }, true)]   // A=1\0 — a complete entry
+    [InlineData(new byte[] { 0x00, 0x41, 0x3d, 0x31 }, false)]  // truncated mid-entry
+    [InlineData(new byte[] { 0x00 }, false)]                    // sentinel alone: env never ran
+    [InlineData(new byte[0], false)]
+    public void Only_a_payload_that_ends_where_env_would_end_it_is_well_formed(byte[] payload, bool expected)
+    {
+        Assert.Equal(expected, ProcessShellProbeRunner.WellFormed(payload));
+    }
+
+    /// <summary>
+    /// Chatter before the sentinel is still well formed.
+    ///
+    /// <para>The review proposed requiring a LEADING NUL as well. That would have been wrong: a profile's
+    /// banners reach stdout before the probe command runs, so the first byte is usually theirs. The sentinel
+    /// exists to survive exactly that, and testing for it at position zero would reject every chatty
+    /// profile.</para>
+    /// </summary>
+    [Fact]
+    public void A_banner_before_the_sentinel_does_not_make_a_payload_malformed()
+    {
+        // "hi" NUL "A=1" NUL
+        var payload = new byte[] { 0x68, 0x69, 0x00, 0x41, 0x3d, 0x31, 0x00 };
+        Assert.True(ProcessShellProbeRunner.WellFormed(payload));
     }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/ShellProbeRunnerTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ShellProbeRunnerTests.cs
@@ -144,4 +144,55 @@ public sealed class ShellProbeRunnerTests
         Assert.True(result.Stdout.Length <= ProcessShellProbeRunner.MaxStdoutBytes);
         Assert.True(watch.Elapsed < TimeSpan.FromSeconds(10));
     }
+
+    /// <summary>
+    /// A shell that printed something and then failed is still a failure. (#824, review)
+    ///
+    /// <para>Found by adversarial review of the first version of the #824 fix, which snapshotted the exit at
+    /// the moment either signal arrived. End-of-stream wins that race almost always — including with nothing
+    /// interfering — so the exit code was discarded on nearly every probe and this returned success. The
+    /// ladder above then took the empty parse as an answer and never retried with <c>-l</c>, which is the
+    /// rung that finds keys in a profile the interactive shell bailed out of.</para>
+    /// </summary>
+    [UnixFact]
+    public void A_shell_that_printed_and_then_failed_is_not_a_success()
+    {
+        var result = Run("echo 'restricted account, contact IT'; exit 3");
+
+        Assert.False(result.Succeeded);
+    }
+
+    /// <summary>
+    /// The sentinel on its own is not an environment. (#824, review)
+    ///
+    /// <para>The shape of a profile that mangles PATH until <c>env</c> is no longer findable: the probe
+    /// writes its NUL and nothing follows. One byte passed the first version's length test, and reached the
+    /// reader as a shell that exports nothing we recognise rather than a shell we failed to read.</para>
+    /// </summary>
+    [UnixFact]
+    public void The_sentinel_alone_is_not_an_environment()
+    {
+        var result = Run("printf '\\0'; exit 127");
+
+        Assert.False(result.Succeeded);
+    }
+
+    /// <summary>
+    /// A shell that wrote a COMPLETE payload and then failed is still a failure. (#824, review)
+    ///
+    /// <para>This is the one that needs the exit-observation grace, and the reason the grace exists as
+    /// something separate from the well-formedness check. A banner-and-exit-3 shell is caught by the payload
+    /// not ending where <c>env -0</c> would end it; this one's payload is impeccable, so the only thing left
+    /// to object with is the exit code — and end-of-stream beats the runtime's notice of the exit almost
+    /// every time, so without a moment's grace there would be no exit code to object with.</para>
+    ///
+    /// <para>Confirmed by mutation: removing the grace makes this the only test that fails.</para>
+    /// </summary>
+    [UnixFact]
+    public void A_complete_payload_from_a_failing_shell_is_still_refused()
+    {
+        var result = Run("printf 'A=1\\0'; exit 3");
+
+        Assert.False(result.Succeeded);
+    }
 }

--- a/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
@@ -522,16 +522,45 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
                 try { process.StandardError.BaseStream.CopyTo(Stream.Null); } catch { /* closing is enough */ }
             });
 
-            if (!process.WaitForExit((int)attempt.Timeout.TotalMilliseconds))
+            // TWO INDEPENDENT SIGNALS THAT THE SHELL IS DONE, and waiting for whichever arrives first is
+            // the whole of #824. Exit alone is not trustworthy: inside this app the child's exit status is
+            // consumed before the runtime's own SIGCHLD bookkeeping sees it — CEF/Chromium installs POSIX
+            // signal handlers and reaps children — so WaitForExit could never return true however long it
+            // waited. Measured: the shell wrote its entire environment and stdout reached EOF, while
+            // HasExited was still false at the five-second budget. Every macOS probe reported a timeout,
+            // and the reader was told their shell profile was slow.
+            //
+            // EOF is the stronger signal for the same reason it is the more dangerous one to wait for
+            // ALONE (see the grace below): the write end closing requires the shell and everything holding
+            // that descriptor to be gone.
+            using var budget = new CancellationTokenSource(attempt.Timeout);
+            var exited = process.WaitForExitAsync(budget.Token);
+
+            // Never throws, and cancellation at the budget is what releases it if neither signal arrives.
+            Task.WhenAny(reading, exited).Wait();
+
+            // Cancellation does not raise UnobservedTaskException, but a fault would; this keeps either from
+            // depending on which one won the race.
+            _ = exited.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+
+            // Completed is not enough: the reader also finishes early at the cap and when stopped, and
+            // neither says anything about the shell. Only its RESULT distinguishes end-of-stream.
+            var reachedEof = reading.IsCompletedSuccessfully && reading.Result;
+            var exitObserved = exited.IsCompletedSuccessfully;
+
+            if (!reachedEof && !exitObserved)
             {
                 // entireProcessTree, because the thing that hangs is rarely the shell itself: a profile that
                 // execs a version manager, or blocks on a keychain prompt, leaves the subtree behind and the
                 // pipe open when only the parent is killed.
+                //
+                // Only on a REAL timeout. Killing after EOF would be aiming at a pid the runtime believes is
+                // live and the kernel has already freed — which, once reaped, may name somebody else.
                 KillTree(process);
                 return ShellProbeResult.Timeout();
             }
 
-            // A GRACE, NOT A WAIT FOR EOF, and the distinction is the whole of this method. If the profile
+            // A GRACE, NOT A WAIT FOR EOF, and the distinction is the whole of this branch. If the profile
             // started anything in the background — `some-updater &` — that grandchild inherited the stdout
             // pipe and holds the write end open after the shell exits. Waiting for end-of-stream would then
             // block forever on a probe that has ALREADY SUCCEEDED: its output is sitting in the buffer. The
@@ -539,7 +568,10 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
             // a timeout, which per the ladder means give up permanently; a read thread parked for the life of
             // the app; and that thread holding the raw, unfiltered environment, which is the one allocation
             // this whole design exists to prevent. (fable)
-            reading.Wait(DrainGrace);
+            //
+            // Reached only when the exit was observed but the stream is still open; EOF needs no grace,
+            // because EOF is the end.
+            if (!reachedEof) reading.Wait(DrainGrace);
 
             var bytes = reader.Bytes();
 
@@ -547,9 +579,10 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
             // keep-set outlives this call even in the inherited-pipe case.
             reader.Stop();
 
-            return process.ExitCode == 0
-                ? ShellProbeResult.Ok(bytes)
-                : ShellProbeResult.Failed();
+            // ExitCode is only readable where the runtime observed the exit. Where it did not, the complete
+            // payload IS the evidence, and demanding a status we cannot obtain is what broke this.
+            int? exitCode = exitObserved ? SafeExitCode(process) : null;
+            return Decide(bytes.Length, exitCode) ? ShellProbeResult.Ok(bytes) : ShellProbeResult.Failed();
         }
         catch
         {
@@ -562,6 +595,26 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
             reader?.Stop();
             process?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Whether a probe that produced <paramref name="payloadLength"/> bytes counts as a success. (#824)
+    ///
+    /// <para>Split out so the policy can be tested. The defect it exists to prevent is a later refactor
+    /// quietly reinstating "exit code zero or nothing", which is what made every macOS probe report a
+    /// timeout: where the runtime never observed the exit there IS no exit code, and insisting on one
+    /// discards a payload that arrived in full.</para>
+    /// </summary>
+    /// <param name="exitCode">Null when the exit was never observed — not an error, and not a zero.</param>
+    internal static bool Decide(int payloadLength, int? exitCode)
+    {
+        if (payloadLength <= 0) return false;
+        return exitCode is null or 0;
+    }
+
+    private static int? SafeExitCode(Process process)
+    {
+        try { return process.ExitCode; } catch { return null; }
     }
 
     private static void KillTree(Process process)
@@ -584,7 +637,19 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
 
         public BoundedReader(Stream stream, int cap) { _stream = stream; _cap = cap; }
 
-        public Task Start() => Task.Run(() =>
+        /// <summary>
+        /// Reads until the stream ends. <b>The result says whether it ended, not whether reading stopped</b>,
+        /// and the two are different in three of the four ways this loop exits. (#824)
+        ///
+        /// <para>End-of-stream is the only one that means the writer is gone, and #824 turns on being able
+        /// to tell it apart: an earlier version of that fix treated the task merely COMPLETING as
+        /// end-of-stream, which made a runaway profile — the reader bailing at the cap while the shell sat
+        /// blocked on a write it could never finish — look exactly like a shell that had finished tidily,
+        /// and accepted four megabytes of <c>/dev/zero</c> as an environment.</para>
+        /// </summary>
+        /// <returns>True only on end-of-stream; false when the cap was hit, when stopped, or on a read
+        /// error.</returns>
+        public Task<bool> Start() => Task.Run(() =>
         {
             try
             {
@@ -594,15 +659,19 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
                 {
                     lock (_buffer)
                     {
-                        if (_stopped) return;
-                        if (_buffer.Length + read > _cap) return;
+                        if (_stopped) return false;
+                        if (_buffer.Length + read > _cap) return false;
                         _buffer.Write(chunk, 0, read);
                     }
                 }
+
+                // Read returned zero: the write end is closed and everything holding it is gone.
+                return true;
             }
             catch
             {
                 // A closed or broken pipe is the ordinary way this ends.
+                return false;
             }
         });
 

--- a/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
@@ -484,6 +484,15 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
     /// </summary>
     private static readonly TimeSpan DrainGrace = TimeSpan.FromMilliseconds(500);
 
+    /// <summary>
+    /// How long to let the runtime notice an exit that has already happened, once stdout has ended. (#824)
+    ///
+    /// <para>Short because it is pure margin: the shell is provably finished by the time this is reached.
+    /// Where the exit notification is being consumed elsewhere this elapses on every probe and the result is
+    /// the same either way, which is why it must stay small enough not to matter.</para>
+    /// </summary>
+    private static readonly TimeSpan ExitObservationGrace = TimeSpan.FromMilliseconds(50);
+
     /// <inheritdoc />
     public ShellProbeResult Run(ShellProbeAttempt attempt)
     {
@@ -502,6 +511,7 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
 
         Process? process = null;
         BoundedReader? reader = null;
+        CancellationTokenSource? budget = null;
         try
         {
             process = Process.Start(info);
@@ -533,7 +543,7 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
             // EOF is the stronger signal for the same reason it is the more dangerous one to wait for
             // ALONE (see the grace below): the write end closing requires the shell and everything holding
             // that descriptor to be gone.
-            using var budget = new CancellationTokenSource(attempt.Timeout);
+            budget = new CancellationTokenSource(attempt.Timeout);
             var exited = process.WaitForExitAsync(budget.Token);
 
             // Never throws, and cancellation at the budget is what releases it if neither signal arrives.
@@ -546,16 +556,44 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
             // Completed is not enough: the reader also finishes early at the cap and when stopped, and
             // neither says anything about the shell. Only its RESULT distinguishes end-of-stream.
             var reachedEof = reading.IsCompletedSuccessfully && reading.Result;
+
+            // EOF WINS THIS RACE ALMOST ALWAYS, INCLUDING WHERE NOTHING IS INTERFERING, so snapshotting the
+            // exit at the moment WhenAny returns would throw the exit code away on nearly every probe on
+            // every platform — not merely under CEF. That is not a smaller version of the old bug, it is a
+            // new one: a shell that printed a banner and exited non-zero would be accepted, and the ladder
+            // above would take its empty parse as an answer instead of retrying with -l. So give the exit a
+            // moment to be observed before concluding that it never will be. Where something is eating the
+            // notification this costs one grace per probe and changes nothing; everywhere else it keeps the
+            // exit code meaning what it says. (fable)
+            if (reachedEof && !exited.IsCompleted)
+            {
+                try { exited.Wait(ExitObservationGrace); } catch { /* cancelled at the budget */ }
+            }
+
             var exitObserved = exited.IsCompletedSuccessfully;
 
             if (!reachedEof && !exitObserved)
             {
+                // NEITHER SIGNAL ARRIVED, WHICH IS NOT THE SAME AS NOTHING HAVING HAPPENED. A profile that
+                // starts `some-updater &` leaves a grandchild holding the stdout write end, so EOF never
+                // comes; if the exit is being eaten as well, a probe whose whole payload is already in the
+                // buffer would be discarded and reported as a slow profile — #824 again by the other route.
+                // A complete payload is complete whatever the pipe is still doing.
+                //
+                // reading still PENDING is the load-bearing half of this test. When it has finished without
+                // reaching end-of-stream it bailed at the cap, and a runaway profile's four megabytes of
+                // /dev/zero both begins and ends with NUL — it would sail through a well-formedness check
+                // that only inspected the bytes. (fable)
+                var salvage = reader.Bytes();
+                if (!reading.IsCompleted && WellFormed(salvage))
+                {
+                    reader.Stop();
+                    return ShellProbeResult.Ok(salvage);
+                }
+
                 // entireProcessTree, because the thing that hangs is rarely the shell itself: a profile that
                 // execs a version manager, or blocks on a keychain prompt, leaves the subtree behind and the
                 // pipe open when only the parent is killed.
-                //
-                // Only on a REAL timeout. Killing after EOF would be aiming at a pid the runtime believes is
-                // live and the kernel has already freed — which, once reaped, may name somebody else.
                 KillTree(process);
                 return ShellProbeResult.Timeout();
             }
@@ -582,7 +620,9 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
             // ExitCode is only readable where the runtime observed the exit. Where it did not, the complete
             // payload IS the evidence, and demanding a status we cannot obtain is what broke this.
             int? exitCode = exitObserved ? SafeExitCode(process) : null;
-            return Decide(bytes.Length, exitCode) ? ShellProbeResult.Ok(bytes) : ShellProbeResult.Failed();
+            return Decide(bytes.Length, WellFormed(bytes), exitCode)
+                ? ShellProbeResult.Ok(bytes)
+                : ShellProbeResult.Failed();
         }
         catch
         {
@@ -592,6 +632,11 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
         }
         finally
         {
+            // Cancelling before disposing is what releases WaitForExitAsync's registration. Disposing alone
+            // disarms the timer without cancelling, so where the exit is never observed the wait — and the
+            // disposed Process it holds — would stay pending for the life of the app. (fable)
+            try { budget?.Cancel(); } catch { /* already disposed */ }
+            budget?.Dispose();
             reader?.Stop();
             process?.Dispose();
         }
@@ -606,11 +651,35 @@ internal sealed class ProcessShellProbeRunner : IShellProbeRunner
     /// discards a payload that arrived in full.</para>
     /// </summary>
     /// <param name="exitCode">Null when the exit was never observed — not an error, and not a zero.</param>
-    internal static bool Decide(int payloadLength, int? exitCode)
+    internal static bool Decide(int payloadLength, bool wellFormed, int? exitCode)
     {
         if (payloadLength <= 0) return false;
-        return exitCode is null or 0;
+
+        // An observed exit is real evidence and keeps its veto: a shell that failed, failed, whatever it
+        // managed to print on the way out.
+        if (exitCode is not null) return exitCode == 0;
+
+        // No verdict to consult, so the payload has to vouch for itself. Length alone will not do it: a
+        // profile that mangles PATH until `env` is missing leaves just the sentinel behind, and one byte
+        // was enough to pass the first version of this. (fable)
+        return wellFormed;
     }
+
+    /// <summary>
+    /// Whether the payload looks like a complete answer rather than a fragment of one. (#824)
+    ///
+    /// <para><c>env -0</c> terminates every entry it writes, the last one included, so a trailing NUL is
+    /// what says the shell finished writing. Without it a shell killed mid-write closes the pipe, EOF
+    /// arrives, and a truncated final entry — <c>ANTHROPIC_API_KEY=sk-ant-parti</c> — parses as a perfectly
+    /// well-shaped key that the app then sends, turning our truncation into the provider's 401.</para>
+    ///
+    /// <para><b>Deliberately not requiring a LEADING NUL.</b> The sentinel exists precisely because a
+    /// profile's banners and version-manager chatter reach stdout BEFORE the probe command runs, so the
+    /// first byte is usually theirs, not ours. Testing for it would reject every chatty profile — the exact
+    /// case the sentinel was added to survive.</para>
+    /// </summary>
+    internal static bool WellFormed(byte[] payload) =>
+        payload is { Length: > 1 } && payload[^1] == 0;
 
     private static int? SafeExitCode(Process process)
     {


### PR DESCRIPTION
Closes #824. **Confirmed working in the running app** by the maintainer; a second commit then fixes four findings from adversarial review.

## The defect

The login-shell probe could not succeed inside the app on macOS. Every attempt reported a timeout, and the Providers tab told the reader their shell profile was too slow to load. It was not — the shell finished in ~40 ms. Instrumented, reproduced twice, identical both times:

```
spawned /bin/bash -il -c printf '\0'; env -0 pid=88244
TIMEOUT after 5001ms budget=5000ms stdoutBytes=2553 readerCompleted=true hasExited=False
```

The shell wrote its entire environment and stdout reached end-of-stream — which requires the write end closed, so the shell is gone — while `HasExited` was still false at the budget. The child's exit status is consumed before the runtime's own `SIGCHLD` bookkeeping sees it (CEF/Chromium installs POSIX signal handlers and reaps children), so `WaitForExit` could never have returned true. The probe had already succeeded and the result was thrown away.

## The fix

Wait for whichever signal arrives first — exit or end-of-stream — and accept a payload that arrived either way. Timeout only when **neither** happened. Success no longer depends on `ExitCode`, which throws while `HasExited` is false; that dependency was the whole defect.

## What review caught (second commit)

**The exit code had stopped meaning anything, on every platform.** `exitObserved` was snapshotted the instant either signal arrived, and EOF wins that race almost always — including with nothing interfering. So a fix for a CEF-only defect silently disabled exit codes everywhere: a shell printing a banner and exiting 3 was accepted, and since the ladder treats success as an answer, the `-l` retry that would have found the keys never ran. Stdout ending now starts a 50 ms grace for the runtime to notice an exit that has already happened.

**A byte count was not evidence.** A profile that mangles PATH until `env` is missing leaves only the sentinel, and one byte passed. Worse, a shell killed mid-write closes the pipe, so a truncated final entry — `ANTHROPIC_API_KEY=sk-ant-parti` — parses as a well-shaped key we would then send, turning our truncation into the provider's 401. `env -0` terminates every entry including the last, so a trailing NUL now stands as the payload vouching for itself where no exit code exists.

**#824 survived by another route.** A profile starting something in the background leaves a grandchild holding the write end, so EOF never comes; with the exit eaten too, a complete payload sat in the buffer and was discarded as a slow profile. The budget now salvages a well-formed payload — but only while the reader is still *pending*, because a reader that finished without EOF bailed at the cap, and a runaway profile's four megabytes of `/dev/zero` both begins and ends with NUL.

**The budget is now cancelled before disposal.** Disposing disarms the timer without cancelling, so where the exit is never observed the wait and the `Process` it held stayed pending for the life of the app.

## One review suggestion not taken

Requiring a **leading** NUL as well. Profile chatter reaches stdout before the probe command runs, so the first byte is usually the profile's — which is why the sentinel exists at all. Testing position zero would reject every chatty profile. Trailing only, with `A_banner_before_the_sentinel_does_not_make_a_payload_malformed` pinning it.

## Verification

- Build clean; suite **2608 passed, 0 failed, 17 skipped**.
- **Mutation, over the whole shell suite** rather than one class — narrowing the filter is how the first commit came to claim a mutant killed one test when it killed four. Four mutants, all killed: no grace, accept-anything, no trailing-NUL, salvage without the pending guard.
- The grace mutant **survived** until a test was added for the case that actually needs it: a *complete* payload from a failing shell, where well-formedness cannot object and only the exit code can.
- In-app confirmation on macOS arm64 — the status line reads the found-keys sentence instead of the timeout.

The spawn path's original failure still cannot be unit-tested: it needs CEF in the same process, so a test spawning a real shell passes either way. The policy can be and is.
