### PR TITLE
Put the routing ahead of the selection in the title (#827)

### DIFF
--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -284,8 +284,17 @@ public partial class BookDisplayView : UserControl
     /// </returns>
     public async Task<(string? Text, int? Paragraph)> GetWebViewSelectionWithParagraphAsync()
     {
+        // EVERY WAY THIS CAN FAIL NOW SAYS WHICH ONE IT WAS. Two of the three returned a bare null, so a
+        // reader who was told "the page was not ready, or the request timed out" could not learn which, and
+        // neither could anyone reading the log: the sentence names two causes because nothing distinguished
+        // them. Same shape of defect as #817 and #824 — a failure with nowhere to report itself.
         if (_webView == null || !_isBrowserInitialized)
+        {
+            _logger.Information(
+                "AI selection unavailable: webView={HasWebView} browserInitialized={Initialized} tab={Tab}",
+                _webView != null, _isBrowserInitialized, _tabId);
             return (null, null);
+        }
         try
         {
             var tcs = new TaskCompletionSource<(string? Text, int? Paragraph)>();
@@ -335,24 +344,56 @@ public partial class BookDisplayView : UserControl
                             para = t;
                         }
                     }
-                    document.title = 'CST_AI_SEL:' + encodeURIComponent(text) + '|PARA=' + para + '|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                    var b64 = '';
+                    try {
+                        var bytes = new TextEncoder().encode(text), raw = '';
+                        for (var bi = 0; bi < bytes.length; bi++) raw += String.fromCharCode(bytes[bi]);
+                        b64 = btoa(raw);
+                    } catch (be) { b64 = ''; }
+                    document.title = 'CST_AI_SEL:|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1) + '|PARA=' + para + '|LEN=' + b64.length + '|B64:' + b64;
                 } catch (e) {
-                    document.title = 'CST_AI_SEL:|PARA=|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                    document.title = 'CST_AI_SEL:|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1) + '|PARA=|LEN=0|B64:';
                 }
                 })();";
             script = script.Replace("__TAB_ID_PLACEHOLDER__", _tabId);
             _webView.ExecuteScript(script);
 
-            var done = await Task.WhenAny(tcs.Task, Task.Delay(700));
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            var done = await Task.WhenAny(tcs.Task, Task.Delay(AiSelectionTimeout));
             _aiSelectionTcs = null;
-            return done == tcs.Task ? await tcs.Task : (null, null);
+            watch.Stop();
+
+            if (done != tcs.Task)
+            {
+                // The title channel is shared — status updates and the dictionary lookup write it too — so a
+                // response that never arrives is worth recording rather than reporting as a generic timeout.
+                _logger.Information(
+                    "AI selection timed out after {Elapsed}ms waiting on the title channel, tab={Tab}",
+                    watch.ElapsedMilliseconds, _tabId);
+                return (null, null);
+            }
+
+            var answer = await tcs.Task;
+            _logger.Debug(
+                "AI selection read in {Elapsed}ms: {Length} char(s), paragraph {Paragraph}, tab={Tab}",
+                watch.ElapsedMilliseconds, answer.Text?.Length ?? 0, answer.Paragraph, _tabId);
+            return answer;
         }
         catch (Exception ex)
         {
-            _logger.Information(ex, "GetWebViewSelectionWithParagraph failed");
+            _logger.Information(ex, "GetWebViewSelectionWithParagraph failed, tab={Tab}", _tabId);
             return (null, null);
         }
     }
+
+    /// <summary>
+    /// How long to wait for the book WebView to answer with the current selection.
+    ///
+    /// <para>Named rather than inline so the number is arguable. It is a round trip through
+    /// <c>ExecuteScript</c> and back out through <c>document.title</c>, and the channel is shared with status
+    /// updates and the dictionary lookup, so the wait is not really "how long does the script take".</para>
+    /// </summary>
+    private static readonly TimeSpan AiSelectionTimeout = TimeSpan.FromMilliseconds(700);
 
     /// <summary>
     /// Returns the text the user has selected inside the book WebView (or null/empty if none). Used by
@@ -378,20 +419,41 @@ public partial class BookDisplayView : UserControl
             var script = @"
                 try {
                     var sel = window.getSelection ? window.getSelection().toString() : '';
-                    document.title = 'CST_LOOKUP_SEL:' + encodeURIComponent(sel) + '|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                    var lb64 = '';
+                    try {
+                        var lbytes = new TextEncoder().encode(sel), lraw = '';
+                        for (var li = 0; li < lbytes.length; li++) lraw += String.fromCharCode(lbytes[li]);
+                        lb64 = btoa(lraw);
+                    } catch (lbe) { lb64 = ''; }
+                    document.title = 'CST_LOOKUP_SEL:|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1) + '|LEN=' + lb64.length + '|B64:' + lb64;
                 } catch (e) {
-                    document.title = 'CST_LOOKUP_SEL:|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1);
+                    document.title = 'CST_LOOKUP_SEL:|TAB:__TAB_ID_PLACEHOLDER__' + '|SEQ:' + (window.__cstTitleSeq = (window.__cstTitleSeq || 0) + 1) + '|LEN=0|B64:';
                 }";
             script = script.Replace("__TAB_ID_PLACEHOLDER__", _tabId);
             _webView.ExecuteScript(script);
 
-            var done = await Task.WhenAny(tcs.Task, Task.Delay(700));
+            var done = await Task.WhenAny(tcs.Task, Task.Delay(AiSelectionTimeout));
             _lookupSelectionTcs = null;
-            return done == tcs.Task ? await tcs.Task : null;
+
+            if (done != tcs.Task)
+            {
+                // WORTH SAYING BECAUSE NOTHING ELSE WILL. Both callers treat a null as "nothing selected":
+                // Cmd+D does nothing, and Cmd+Shift+F opens corpus search with no term prefilled, which is
+                // a supported state — you get exactly what you would get having selected nothing. So a
+                // selection lost to the title cap degrades into a case the design tolerates, and leaves no
+                // trace anywhere. That is why it could have been happening unnoticed. (#827)
+                _logger.Information(
+                    "Lookup selection timed out after {Elapsed}ms waiting on the title channel — the "
+                    + "caller will see this as no selection, tab={Tab}",
+                    AiSelectionTimeout.TotalMilliseconds, _tabId);
+                return null;
+            }
+
+            return await tcs.Task;
         }
         catch (Exception ex)
         {
-            _logger.Information(ex, "GetSelectionForLookup failed");
+            _logger.Information(ex, "GetSelectionForLookup failed, tab={Tab}", _tabId);
             return null;
         }
     }
@@ -2686,21 +2748,58 @@ public partial class BookDisplayView : UserControl
         {
             try
             {
+                // ROUTING BEFORE PAYLOAD, and the order is the whole of this. Chromium caps document.title
+                // at 4096 characters and truncates the tail; the selection used to come first, so a long one
+                // pushed |TAB: off the end, the tab check below rejected its own answer, and the request sat
+                // there until it timed out. Every observed failure had a title of exactly 4096 and no TAB.
+                // Myanmar percent-encodes to nine characters apiece, so ~455 characters were enough to do it
+                // — which is why it looked intermittent and script-dependent. (#827)
                 var data = title.Substring("CST_AI_SEL:".Length);
-                var parts = data.Split('|');
+
+                // Split only the routing half: base64 contains no '|', but taking the payload by index keeps
+                // that from being a thing anyone has to remember.
+                var payloadAt = data.IndexOf("|B64:", StringComparison.Ordinal);
+                var routing = (payloadAt >= 0 ? data.Substring(0, payloadAt) : data).Split('|');
+
                 string messageTabId = "";
-                foreach (var p in parts)
+                foreach (var p in routing)
                     if (p.StartsWith("TAB:")) { messageTabId = p.Substring(4); break; }
                 if (messageTabId != _tabId)
                     return;   // not for this tab
 
-                var encoded = parts.Length > 0 ? parts[0] : "";
-                string sel;
-                try { sel = Uri.UnescapeDataString(encoded); } catch { sel = encoded; }
-
                 int? para = null;
-                foreach (var p in parts)
+                foreach (var p in routing)
                     if (p.StartsWith("PARA=") && int.TryParse(p.Substring(5), out var n)) { para = n; break; }
+
+                var declaredLength = -1;
+                foreach (var p in routing)
+                    if (p.StartsWith("LEN=") && int.TryParse(p.Substring(4), out var l)) { declaredLength = l; break; }
+
+                var encoded = payloadAt >= 0 ? data.Substring(payloadAt + "|B64:".Length) : "";
+
+                // The payload can still be cut at the cap; base64 buys roughly 2.25x over percent-encoding
+                // for Myanmar but does not remove the ceiling. Say so rather than hand the model a half
+                // sentence — a silently shortened selection is a worse answer than an admitted failure,
+                // because nothing downstream can tell it apart from what the reader meant. Chunking is the
+                // real fix and is its own issue.
+                if (declaredLength >= 0 && encoded.Length != declaredLength)
+                {
+                    _logger.Warning(
+                        "CST_AI_SEL truncated by the title cap: {Got} of {Declared} base64 char(s), "
+                        + "title length {TitleLength}, tab={Tab}",
+                        encoded.Length, declaredLength, title.Length, _tabId);
+                    _aiSelectionTcs?.TrySetResult((null, null));
+                    return;
+                }
+
+                string sel;
+                try { sel = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encoded)); }
+                catch (Exception decodeEx)
+                {
+                    _logger.Warning(decodeEx, "CST_AI_SEL payload did not decode, tab={Tab}", _tabId);
+                    _aiSelectionTcs?.TrySetResult((null, null));
+                    return;
+                }
 
                 _logger.Information(
                     "CST_AI_SEL: {Length} char(s) selected, paragraph {Para}",
@@ -2720,16 +2819,46 @@ public partial class BookDisplayView : UserControl
         {
             try
             {
+                // Same layout as CST_AI_SEL and for the same reason — routing ahead of the payload, so the
+                // title cap costs selection characters rather than the ability to route the answer. Less
+                // likely to bite here, since a lookup is a word and a search is a phrase, but #827 wants
+                // searching a few sentences to be workable and that is the length where it starts to.
                 var data = title.Substring("CST_LOOKUP_SEL:".Length);
-                var parts = data.Split('|');
+
+                var payloadAt = data.IndexOf("|B64:", StringComparison.Ordinal);
+                var routing = (payloadAt >= 0 ? data.Substring(0, payloadAt) : data).Split('|');
+
                 string messageTabId = "";
-                foreach (var p in parts)
+                foreach (var p in routing)
                     if (p.StartsWith("TAB:")) { messageTabId = p.Substring(4); break; }
                 if (messageTabId != _tabId)
                     return;   // not for this tab
-                var encoded = parts.Length > 0 ? parts[0] : "";
+
+                var declaredLength = -1;
+                foreach (var p in routing)
+                    if (p.StartsWith("LEN=") && int.TryParse(p.Substring(4), out var l)) { declaredLength = l; break; }
+
+                var encoded = payloadAt >= 0 ? data.Substring(payloadAt + "|B64:".Length) : "";
+
+                if (declaredLength >= 0 && encoded.Length != declaredLength)
+                {
+                    _logger.Warning(
+                        "CST_LOOKUP_SEL truncated by the title cap: {Got} of {Declared} base64 char(s), "
+                        + "title length {TitleLength}, tab={Tab}",
+                        encoded.Length, declaredLength, title.Length, _tabId);
+                    _lookupSelectionTcs?.TrySetResult(null);
+                    return;
+                }
+
                 string sel;
-                try { sel = Uri.UnescapeDataString(encoded); } catch { sel = encoded; }
+                try { sel = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encoded)); }
+                catch (Exception decodeEx)
+                {
+                    _logger.Warning(decodeEx, "CST_LOOKUP_SEL payload did not decode, tab={Tab}", _tabId);
+                    _lookupSelectionTcs?.TrySetResult(null);
+                    return;
+                }
+
                 _lookupSelectionTcs?.TrySetResult(sel);
             }
             catch (Exception ex)


### PR DESCRIPTION
Fixes the reported case in #827. **The ceiling is raised, not removed** — the native bridge stays on #827 for after beta 6, by maintainer's decision.

## What went wrong

Selecting one medium paragraph and asking the assistant returned *"the reader could not read the selection (the page was not ready, or the request timed out)"*. Neither cause was true: the selection was read correctly, arrived within 2 ms, and was then dropped.

Chromium caps `document.title` at 4096 characters and truncates the tail. The message put the payload first and the routing last, so a long selection pushed `|TAB:` off the end and the handler's tab check rejected the view's own answer. The `TaskCompletionSource` was never completed and the request sat until its 700 ms timeout.

| title length | `TAB` present | outcome |
|---|---|---|
| **4096** | no | **failed** (×4) |
| 2730 | yes | worked |
| 3831 | yes | worked |

`encodeURIComponent` costs **nine characters per Myanmar character**, so the real ceiling was ~500 characters. The reported paragraph is **557** — 11% over. Hence the apparent randomness: it tracked length and script, not timing.

## Changes

Applied to both messages carrying reader-selected text (`CST_AI_SEL`, `CST_LOOKUP_SEL`):

1. **Routing before payload** — `|TAB:`, `|SEQ:`, `|PARA=`, `|LEN=` now precede `|B64:`, so truncation costs selection characters rather than the ability to route.
2. **Base64 instead of percent-encoding** — four characters per Myanmar character instead of nine. Measured on the actual paragraph: 4489 → **1996**. Ceiling ~500 → **~1126**.
3. **Truncation detected, not silently shortened** — `|LEN=` declares the payload length; a short arrival is refused with both counts logged.
4. **Both paths log their own timeouts** — the lookup path had none, and both its callers read failure as "nothing selected".

## Deliberately not the whole channel

Measured across every log in the data directory:

| message | count | max length |
|---|---|---|
| `CST_AI_SEL` | 51 | **4096** |
| `CST_LOOKUP_SEL` | 44 | 791 |
| `CST_STATUS_UPDATE` | 3600 | **223** |
| everything else (14 kinds) | ~610 | ≤ 101 |

Page numbers, anchors and scroll offsets are bounded by their own shape. A 4096-character ceiling is a fine way to move a page number; it stopped being fine when the same channel was asked to carry whatever a reader highlighted. Replacing the channel wholesale would touch 17 message types and 3,600 messages a session in the subsystem where a mistake costs a SIGSEGV, to fix something two of them have.

## Verification

- Build clean; suite **2592 passed, 0 failed, 17 skipped**.
- Root cause established from instrumented logs, not inference — the exact-4096 correlation above, with the missing `TAB` visible in each failing title.
- Encoding ratios measured against the real paragraph from `s0203m.mul.xml`, not estimated.

No test covers the round trip: it needs a live CEF browser, and this project has no headless Avalonia or WebView harness. What could be tested — that a truncated payload is refused rather than decoded — is a decision inside the title handler, which is not reachable without one either. Recording that rather than leaving it implied.

## Release note wanted

Beta 6 ships with a selection ceiling of roughly 1100 characters in a non-Latin script (about two average paragraphs), or ~3000 in Latin. Beyond that the assistant reports the selection as unavailable rather than answering on a truncated one.
