### PR TITLE
Collect release notes by label, instead of remembering them (#827)

### DIFF
--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -419,6 +419,20 @@ git log v5.0.0-beta.2..v5.0.0-beta.3 --format="%h %s%n%b"
 
 This ensures accurate release notes based on actual changes, not assumptions.
 
+**Then collect the notes that cannot be derived from commits.** A shipped limitation is invisible in a
+commit log — the commit says what was fixed, not what still is not. Anything that needs a sentence in the
+release is labelled `release-note` as the work lands, so it is queried rather than remembered:
+
+```bash
+# Everything flagged for this release's notes, open or closed
+gh issue list --repo fsnow/cst --label release-note --milestone "5.0.0-beta.X" --state all \
+  --json number,title,url --jq '.[] | "#\(.number) \(.title)\n  \(.url)"'
+```
+
+Each such issue carries the wording to use in a comment. **An open issue in the milestone is normal here**:
+a limitation that ships is a known issue precisely because it is not fixed, and it needs re-stating in every
+release until it is. Clear the label once the note has been written and the limitation is gone.
+
 ```markdown
 # CST Reader 5.0.0-beta.X
 


### PR DESCRIPTION
The release-notes template has a **Known Issues** section and nothing that fills it.

Its instruction is to derive the notes from commits since the last tag. That works for what changed, and cannot work for what did not: a shipped limitation leaves no commit behind, because the commit describes the fix and the limitation is precisely what the fix stopped short of.

#827 is the case in hand. #829 raised the assistant's selection ceiling from ~500 characters to ~1126 but did not remove it, and Beta 6 ships with that. Nothing in `git log` will say so at release time, and the wording currently exists only in a PR body.

So: anything needing a sentence in the release gets the **`release-note`** label as the work lands, with the wording in a comment, and Step 3 now queries for it:

```bash
gh issue list --repo fsnow/cst --label release-note --milestone "5.0.0-beta.X" --state all \
  --json number,title,url --jq '.[] | "#\(.number) \(.title)\n  \(.url)"'
```

Already applied to #827, and the query returns it.

One thing stated explicitly in the doc because it looks like an oversight otherwise: **an open issue in the milestone is the normal state for these.** A limitation that ships is a known issue *because* it is not fixed, and it wants re-stating in every release until it is.

Docs only — no code, no tests affected.
