### PR TITLE
One notice for one fact, and no guess about the cause (#831)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/PromptBuilderTests.cs
@@ -228,6 +228,48 @@ public class PromptBuilderTests : IDisposable
         Assert.DoesNotContain(prompt.Notices, n => n.Contains("not found in the passage window"));
     }
 
+    [Fact]
+    public void An_unreadable_selection_produces_exactly_one_notice()
+    {
+        // #831: the reader saw "2 notes about this request" for a single fact — a generic one from the
+        // parts loop and the specific one from the switch below it. Two notices read as two things having
+        // gone wrong, and the generic one was the worse of the pair: it said "could not be gathered", which
+        // is the bundler's vocabulary, and named a cause ("the page was not ready, or the request timed
+        // out") that #824 and #827 both showed was not what had happened.
+        //
+        // Asserted as a COUNT plus the surviving wording. Asserting only that the good one is present would
+        // pass with both, which is the state being fixed.
+        var prompt = _builder.Build(Bundle(
+            selection: new SelectionContext(null, SelectionState.Unavailable),
+            parts: new[]
+            {
+                new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window"),
+                new BundlePart(BundlePartNames.Selection, BundlePartState.Unavailable,
+                    "the reader could not read the selection"),
+            }));
+
+        Assert.Single(prompt.Notices);
+        Assert.Contains("the answer covers the whole passage", prompt.Notices[0]);
+        Assert.DoesNotContain("could not be gathered", prompt.Notices[0]);
+    }
+
+    [Fact]
+    public void Another_unavailable_part_still_gets_the_generic_notice()
+    {
+        // The exclusion in #831 is for the selection alone. Word analysis and the rest have no sentence of
+        // their own, so silencing the generic notice for everything would trade two notices for none — and
+        // a missing part nobody is told about is where this whole family of defects started.
+        var prompt = _builder.Build(Bundle(
+            task: AiTask.WordByWord,
+            parts: new[]
+            {
+                new BundlePart(BundlePartNames.Passage, BundlePartState.Included, "a window"),
+                new BundlePart(BundlePartNames.Lemmas, BundlePartState.Unavailable, "the dictionary is still downloading"),
+            }));
+
+        Assert.Contains(prompt.Notices, n => n.Contains("could not be gathered"));
+    }
+
     // ---- The selection is the subject of the request -----------------------------------------------
 
     [Fact]

--- a/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
+++ b/src/CST.Avalonia/Services/Ai/AiContextBundler.cs
@@ -209,7 +209,10 @@ public sealed class AiContextBundler : IAiContextBundler
             parts.Add(new BundlePart(
                 BundlePartNames.Selection,
                 BundlePartState.Unavailable,
-                "the reader could not read the selection (the page was not ready, or the request timed out)"));
+                // No speculative cause. This reaches the model, and the two causes it used to name were
+                // guesses that #824 and #827 both found to be wrong in the case at hand; a third (the title
+                // cap) was not among them. What the model needs is that the selection is absent. (#827)
+                "the reader could not read the selection"));
             return new SelectionContext(null, SelectionState.Unavailable);
         }
 

--- a/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
+++ b/src/CST.Avalonia/Services/Ai/PromptBuilder.cs
@@ -448,6 +448,15 @@ public sealed class PromptBuilder : IPromptBuilder
         // Explain answer, which never asks for one, is a nag about something that did not affect the answer.
         foreach (var part in bundle.Budget.Parts.Where(p => IsShown(p, shown)))
         {
+            // THE SELECTION IS EXCLUDED BECAUSE IT HAS ITS OWN SENTENCE BELOW, and without this it got both.
+            // The reader saw "2 notes about this request": the generic one naming a cause, then the specific
+            // one saying what actually happened to their answer. Two notices for one fact reads as two
+            // things having gone wrong, and the generic one was the worse of the pair — it named a cause
+            // ("the page was not ready, or the request timed out") that #824 and #827 showed was not what
+            // happened, and said "could not be gathered", which is the bundler's vocabulary, not a reader's.
+            if (string.Equals(part.Name, BundlePartNames.Selection, System.StringComparison.Ordinal))
+                continue;
+
             if (part.State == BundlePartState.Unavailable)
                 notices.Add($"The {PartLabel(part.Name)} could not be gathered: {part.Detail ?? "not available"}.");
             else if (part.State == BundlePartState.TrimmedForBudget)


### PR DESCRIPTION
Closes #831.

An unreadable selection produced **two** notices for one fact:

> **2 notes about this request**
> The selection could not be gathered: the reader could not read the selection (the page was not ready, or the request timed out).
> Your selection could not be read, so the answer covers the whole passage.

`PromptBuilder.BuildNotices` reports it twice: a generic loop over `bundle.Budget.Parts` fires for anything `Unavailable`, and the `switch` below adds the specific sentence. Both are right about their own job; nothing noticed the selection satisfies both.

## Why the generic one is the one to drop

- **Its cause was not true.** #824 and #827 established that the page had been ready and nothing had timed out — the selection was read correctly in 2 ms and discarded because the 4096-character title cap had truncated the routing off the end. The real cause was never in the list. A wrong explanation is worse than none: it sends the reader to look at their own machine.
- **"could not be gathered" is the bundler's vocabulary**, not a reader's.
- **It does not say what happened to the answer.** The specific notice does, and that is the part a reader can act on.

The speculative causes also come out of the bundle detail in `AiContextBundler`. That string still reaches the model, and what the model needs is that the selection is absent — not two guesses about why.

**Other parts keep the generic notice.** Silencing it for everything would trade two notices for none, and a part quietly missing is where this whole family of defects began.

## Tests

Two added, and they assert the **count** rather than the presence of the good sentence — asserting presence alone passes with both notices, which is exactly the state being fixed.

Mutation-verified:

| mutant | killed by |
|---|---|
| exclusion removed | `An_unreadable_selection_produces_exactly_one_notice` |
| generic notice silenced for everything | `Another_unavailable_part_still_gets_the_generic_notice` + an existing lemma test |

Suite **2610 passed, 0 failed, 17 skipped**.

## Note on severity, for the record

The reader-facing behaviour here was never a failure: the turn still answers, over the surrounding passage, and says so. With the ceiling raised in #829 to ~1,100 characters in non-Latin scripts and ~3,000 in Latin — most of a screenful — this is reached rarely, and when it is, the passage-level answer is usually close to what was wanted anyway. This PR is about the wording being right when it happens.
