### PR TITLE
Rewrite the welcome page for Beta 6, and put it first on the checklist

### DIFF
--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -146,13 +146,26 @@ pre-1.0 follow-up (#28).
 
 ## Pre-Release Checklist (Kestrel)
 
-Before starting the release process, verify on Kestrel:
+Before starting the release process, verify on Kestrel.
+
+**The first two items are the ones that get missed**, because nothing downstream fails when they are wrong —
+the build succeeds, the tests pass, and the mistake ships. Both were missed in Beta 6 and caught by hand.
+
+- [ ] **In-app welcome page rewritten for this release** — `src/CST.Avalonia/Resources/welcome-content.html`.
+      This is BUNDLED INTO THE BUILD, so it must be correct before anything is packaged; it is not the same
+      file as `welcome-updates.json`, which is live-fetched and updated post-publish in Step 5. Three parts go
+      stale every cycle and none of them fail a test:
+      - the **upgrade notice** — whether a clean start is required, and from which version. Beta 5's said
+        "delete your data directory", which would have been wrong advice for every Beta 5 upgrader;
+      - the **focus areas** — they should name what is new *in this release*, not the last one;
+      - the **known limitations** — delete the ones that were fixed. Beta 6 still listed book fonts as
+        not customizable, which #42 had shipped.
+- [ ] **Version strings updated and consistent** (bucket A) — see **Version strings: two timing buckets**
+      below. Bumped at the *start* of the cycle, so verify rather than discover. These all drifted before
+      Beta 4.
 
 - [ ] .NET 10 SDK present (`dotnet --list-sdks` shows 10.0.x) — see Toolchain Requirements
 
-- [ ] All version strings updated and consistent — see **Version strings: two timing buckets** below.
-      By release time, bucket A should already be done (it is bumped at the *start* of the cycle);
-      verify it rather than discovering it here. These all drifted before Beta 4.
 - [ ] Provider catalogue snapshot refreshed: `./src/CST.Avalonia/refresh-models-snapshot.sh`, then
       **read the diff** before committing — it shows which providers appeared or disappeared since the last
       release, and that review is the point of committing the file rather than fetching it at build time.

--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -343,8 +343,9 @@
     </div>
 
     <div class="beta-notice">
-        <strong>⚠️ Please start clean</strong>
-        <p>If you tested any earlier version, delete your CST Reader data directory before running Beta 5 &mdash; several on-disk layouts changed and the beta line carries no migration.</p>
+        <strong>Upgrading from Beta 5? Nothing to do.</strong>
+        <p>Install over the top. Your settings, layout, open books and downloaded dictionaries carry across.</p>
+        <p style="margin-top: 8px;"><strong>Coming from Beta 4 or earlier:</strong> delete your CST Reader data directory first &mdash; the search index changed in Beta 5 and an older one will not be read correctly.</p>
         <p style="margin-top: 8px;"><strong>macOS:</strong> <code>~/Library/Application Support/CSTReader/</code> &nbsp;&bull;&nbsp; <strong>Windows:</strong> <code>%APPDATA%\CSTReader\</code></p>
     </div>
 
@@ -353,46 +354,47 @@
         <p>Thank you for testing CST Reader! Your feedback will help shape the final release.</p>
 
         <h3 style="margin-top: 24px; margin-bottom: 16px;">Focus Areas</h3>
-        <p>Beta 5 is the first release at feature parity with CST4. These areas are new or changed, so feedback on them is especially valuable:</p>
+        <p>Beta 5 reached feature parity with CST4. Beta 6 adds a great deal on top of it, and these areas are the newest &mdash; feedback on them is especially valuable:</p>
 
         <div class="focus-item">
-            <strong>Windows &mdash; brand new in this release</strong>
+            <strong>The Assistant &mdash; brand new</strong>
             <ul>
+                <li>Select a passage and ask for a translation, a word-by-word breakdown, or an explanation</li>
+                <li>Turn it on under Settings &rsaquo; Assistant, and add a provider you have an account with under Providers</li>
+                <li>Your API key goes to the macOS Keychain or Windows Credential store &mdash; never into the app's settings file</li>
+                <li>If a key is already in your environment, the Providers tab offers it; nothing connects until you say so</li>
+                <li>Every answer shows what was actually sent to the model &mdash; is it the passage you meant?</li>
+            </ul>
+            <p style="margin-top: 12px; font-size: 14px; color: #4c566a;">This is the least-tested part of the release. Anything that looks wrong is worth reporting.</p>
+        </div>
+
+        <div class="focus-item">
+            <strong>Windows on ARM &mdash; brand new</strong>
+            <ul>
+                <li>A native arm64 build, alongside the existing x64 one</li>
                 <li>Install and first launch: does the text download and index build complete?</li>
-                <li>Everyday reading, searching and dictionary lookups</li>
-                <li>Keyboard shortcuts: Ctrl+O, Ctrl+G, Ctrl+D, Ctrl+F, Ctrl+P, Ctrl+, for Settings</li>
                 <li>If book text appears blank, turn off hardware acceleration in Settings and restart</li>
             </ul>
-            <p style="margin-top: 12px; font-size: 14px; color: #4c566a;">This is the least-tested part of the release. Anything at all that looks wrong is worth reporting.</p>
         </div>
 
         <div class="focus-item">
-            <strong>Dictionaries</strong>
+            <strong>Reading</strong>
             <ul>
-                <li>Switch between sources with the picker: the VRI dictionaries, the Digital Pāḷi Dictionary, and the Dictionary of Pāḷi Proper Names</li>
-                <li>Choose which dictionaries appear, and in what order, under Settings &rsaquo; Dictionary</li>
-                <li>The extra dictionaries download on first run &mdash; did that complete without trouble?</li>
-            </ul>
-        </div>
-
-        <div class="focus-item">
-            <strong>Printing</strong>
-            <ul>
-                <li>Print a whole book, and print a selection (&#8984;P / Ctrl+P, &#8679;&#8984;P / Ctrl+Shift+P)</li>
-                <li>Check that search highlights remain legible on paper</li>
+                <li><strong>Find in Page</strong> &mdash; &#8984;F / Ctrl+F searches within the book you are reading</li>
+                <li><strong>Text zoom</strong> &mdash; &#8984;/Ctrl with +, &minus; and 0, or the percentage control in the book toolbar</li>
+                <li><strong>Book fonts</strong> &mdash; choose a face for each script under Settings &rsaquo; Fonts</li>
+                <li>Does your reading position survive zooming, switching tabs and restarting?</li>
             </ul>
         </div>
 
         <div class="focus-item">
             <strong>Windows and tabs</strong>
             <ul>
-                <li><strong>Float a book by dragging its tab out</strong> of the main window, and drag it back to re-dock (the old Float and Dock buttons are gone)</li>
-                <li>Drag the book tree and search panel out and back &mdash; watch for the drop-target indicators</li>
-                <li>Reorder book tabs, and split the reading area</li>
+                <li>Float a book by dragging its tab out of the main window, and drag it back to re-dock</li>
+                <li>Split the reading area, and move a book between splits</li>
+                <li>Books that were floated or moved should all reopen when you restart</li>
             </ul>
-            <p style="margin-top: 12px; font-size: 14px; color: #4c566a;">Does your reading position survive floating, re-docking and restarting?</p>
         </div>
-    </div>
 
     <div class="quick-start">
         <h3>🚀 Quick Start</h3>
@@ -437,8 +439,8 @@
         <ul>
             <li>The texts are presented in Pāli only &mdash; CST Reader does not include translations. The built-in dictionaries give the meaning of individual words.</li>
             <li>Menus and dialogs are English only. CST4 offers 24 interface languages; that work is still ahead.</li>
-            <li>Book content fonts not yet customizable (UI fonts for each script are customizable in Settings)</li>
-            <li>macOS: Elevated CPU usage (~30% idle) is an Avalonia framework limitation, not specific to CST Reader</li>
+            <li>macOS: idle CPU is higher than it should be, from a framework-level timer amplified by the text view. Beta 6 reduces how often that timer fires; the underlying issue is not ours to fix and is not yet closed</li>
+            <li>The Assistant can read a selection of roughly 1,100 characters in Devanāgarī, Myanmar and other non-Latin scripts, or about 2,900 in Latin. Beyond that the answer covers the surrounding passage instead, and says so</li>
         </ul>
     </div>
 


### PR DESCRIPTION
The bundled welcome page still described Beta 5, and one line of it was actively wrong.

## The line that mattered

> ⚠️ **Please start clean** — If you tested any earlier version, delete your CST Reader data directory before running Beta 5 — several on-disk layouts changed and the beta line carries no migration.

Every Beta 5 upgrader would have been told to wipe a directory that Beta 6 migrates perfectly well. The version number directly above it already read `5.0.0-beta.6` — which is exactly what lets this kind of miss survive review: the part anyone thinks to check was right.

It now says upgrade in place from Beta 5, clean start from Beta 4 or earlier, and why.

## Also stale

- **Focus areas** were Beta 5's — Windows as brand new, dictionaries, printing. Now the Assistant, Windows on ARM, the new reading controls (Find in Page, zoom, book fonts), and the dock.
- **Known limitations** listed two things that are no longer true: book fonts as not customizable, which #42 shipped this cycle, and an idle-CPU figure predating the message-pump change. Both removed; the #827 selection ceiling added, so the page states the limitation the release actually has.

## Checklist change

None of the above fails a build or a test. That is the whole argument: the mistake ships silently, and the only thing standing between it and users is someone remembering.

So `Pre-Release Checklist` now opens with the welcome page and the version strings, marked as **the two that get missed**, with the three parts of the page that go stale each cycle named individually rather than left to "update the welcome page".

It also records that `welcome-content.html` is **bundled into the build** and must be right before packaging — which is what separates it from `welcome-updates.json`, the live-fetched file updated *after* publishing in Step 5. Two files sharing most of a name and having opposite timing is most of the reason one of them gets forgotten.

Build clean. No code changed; no tests affected.
