### PR TITLE
Give the book tab the script's font, like every other control (#836)

### DIFF
--- a/src/CST.Avalonia/Styles/DockStyles.axaml
+++ b/src/CST.Avalonia/Styles/DockStyles.axaml
@@ -106,6 +106,11 @@
          FontFamily alone, and they keep the theme font, which is what they want anyway. -->
     <Style Selector="dock|DocumentTabStripItem" x:DataType="vm:BookDisplayViewModel">
         <Setter Property="FontFamily" Value="{Binding CurrentScriptFontFamily}"/>
+        <!-- Size travels with the family, because everywhere else it does: every control binding
+             DynamicFontFamily binds DynamicFontSize beside it, and SearchPanel.axaml:17 writes that down
+             as the rule for new chrome. Applying one without the other would make the tab the sole place
+             where the reader's Pāli font is half-honoured — a title in their face at the theme's size. -->
+        <Setter Property="FontSize" Value="{Binding CurrentScriptFontSize}"/>
     </Style>
 
     <!-- Hover (unselected tool tab): stock theme already sets the accent-med background; add the

--- a/src/CST.Avalonia/Styles/DockStyles.axaml
+++ b/src/CST.Avalonia/Styles/DockStyles.axaml
@@ -1,6 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:dock="using:Dock.Avalonia.Controls">
+        xmlns:dock="using:Dock.Avalonia.Controls"
+        xmlns:vm="using:CST.Avalonia.ViewModels">
 
     <!-- Position scrollbar below tabs using transform -->
     <Style Selector="dock|DockControl ScrollBar:horizontal">
@@ -85,6 +86,26 @@
         <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
         <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
+    </Style>
+
+    <!-- The book tab's title is Pāli, so it needs the script's font like every other control that
+         shows Pāli. (#836)
+
+         It was the only one without it. BookDisplayView binds FontHelper.DynamicFontFamily on the
+         chapter dropdown and the status line, and OpenBookPanel, SearchPanel and DictionaryPanel do
+         the same; the tab strip styled colours and never a font, so titles rendered in the theme's UI
+         font. That font has no Gurmukhi, and Avalonia does not fall back to a family that does the way
+         native text rendering would — so a Gurmukhi title came out as a row of tofu while the dropdown
+         beside it, holding the same string, was fine.
+
+         Bound to the document's own CurrentScriptFontFamily rather than the global script setting: a tab
+         shows the script ITS book is displayed in, which is not necessarily the one the toolbar names.
+         The property already raises change notifications when a book is re-scripted, so the tab follows.
+
+         Non-book tabs — Welcome — have no such property. The binding finds nothing, the setter leaves
+         FontFamily alone, and they keep the theme font, which is what they want anyway. -->
+    <Style Selector="dock|DocumentTabStripItem" x:DataType="vm:BookDisplayViewModel">
+        <Setter Property="FontFamily" Value="{Binding CurrentScriptFontFamily}"/>
     </Style>
 
     <!-- Hover (unselected tool tab): stock theme already sets the accent-med background; add the


### PR DESCRIPTION
Closes #836.

A Gurmukhi book title rendered as tofu in its tab on **both** Caracara and Kestrel, while the same string in the chapter dropdown beside it rendered correctly.

## Cause

The tab was the only control showing Pāli **without a script font**.

| control | script font |
|---|---|
| chapter dropdown, status line (`BookDisplayView.axaml:94, 225, 297`) | ✅ `FontHelper.DynamicFontFamily` |
| book tree (`OpenBookPanel.axaml:134`) | ✅ |
| search, dictionary (`SearchPanel.axaml:293/340/350`, `DictionaryPanel.axaml:71`) | ✅ |
| **document tab** (`DockStyles.axaml:84`) | ❌ Background, Foreground, BorderBrush — no font |

So titles rendered in the theme's UI font, which has no Gurmukhi. Avalonia does not fall back to a family that does, the way native text rendering would, so the glyphs came out as boxes.

**The symptom looks script-specific and isn't.** The theme font happens to cover the other scripts this app displays; any script it did not cover would do exactly the same thing. The maintainer confirmed Gurmukhi renders correctly everywhere else — tree, dropdown, content — which is what isolates it to this one control rather than to the script.

## Fix

```xml
<Style Selector="dock|DocumentTabStripItem" x:DataType="vm:BookDisplayViewModel">
    <Setter Property="FontFamily" Value="{Binding CurrentScriptFontFamily}"/>
</Style>
```

Bound to the **document's own** `CurrentScriptFontFamily`, not the global script setting — a tab shows the script *its* book is displayed in, and per-tab script is deliberate: the toolbar's script is the default for newly opened books, not a statement about the ones already open. The property already raises change notifications on re-scripting, so the tab follows without new plumbing.

`x:DataType` on the `Style` because compiled bindings are on by default and a Style has no other way to know its starting type. `SearchPanel.axaml:340` already binds this same string straight to `FontFamily`, so the string→`FontFamily` conversion is a proven path here.

## Verification

Build clean; suite **2610 passed, 0 failed, 17 skipped**.

**This needs eyes, not tests.** It is a rendered-glyph fact and the project has no headless Avalonia harness. Two things to look at:

1. A Gurmukhi book tab shows its title, and switching that book's script changes the tab with it.
2. **The Welcome tab still looks normal.** It carries a different view model, so the binding finds nothing and the setter should leave `FontFamily` alone — but that is the failure mode worth confirming rather than assuming.
