### PR TITLE
Refresh the models.dev snapshot for Beta 6 (#736)

### DIFF
--- a/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.json
+++ b/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.json
@@ -17730,7 +17730,7 @@
     "interleaved": {
      "field": "reasoning_content"
     },
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 384000
@@ -17744,7 +17744,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -18760,7 +18760,7 @@
     "interleaved": {
      "field": "reasoning_content"
     },
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 384000
@@ -18774,7 +18774,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -24348,6 +24348,55 @@
     "temperature": true,
     "tool_call": true
    },
+   "xai.grok-4.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.55,
+     "input": 2.2,
+     "output": 6.6
+    },
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "xai.grok-4.6",
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-18",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6",
+    "open_weights": false,
+    "provider": {
+     "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+     "npm": "@ai-sdk/amazon-bedrock/mantle",
+     "shape": "responses"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "zai.glm-4.7": {
     "attachment": false,
     "cost": {
@@ -24550,10 +24599,10 @@
    "deepseek/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.028,
+     "cache_read": 0.016,
      "cache_write": 0,
-     "input": 0.14,
-     "output": 0.28
+     "input": 0.08,
+     "output": 0.18
     },
     "description": "Fast DeepSeek model for efficient chat, coding help, and agent loops",
     "family": "deepseek-flash",
@@ -26795,7 +26844,7 @@
     "interleaved": {
      "field": "reasoning_content"
     },
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 384000
@@ -26809,7 +26858,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -34498,7 +34547,7 @@
       "text"
      ]
     },
-    "name": "Deepseek V4 Flash 0731",
+    "name": "DeepSeek V4 Flash 0731",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -34547,7 +34596,7 @@
       "text"
      ]
     },
-    "name": "Deepseek V4 Pro",
+    "name": "DeepSeek V4 Pro",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -34581,7 +34630,7 @@
     "interleaved": {
      "field": "reasoning_content"
     },
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 262144
@@ -34594,8 +34643,8 @@
       "text"
      ]
     },
-    "name": "Deepseek V4 Pro 0813",
-    "open_weights": false,
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -40440,7 +40489,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "@cf/deepseek-ai/deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 1048576
@@ -40454,7 +40503,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -41898,7 +41947,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -41946,7 +41996,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -41994,7 +42045,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42042,7 +42094,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42090,7 +42143,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42138,7 +42192,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42186,7 +42241,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42234,7 +42290,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42282,7 +42339,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42330,7 +42388,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42645,7 +42704,8 @@
      "input": [
       "text",
       "image",
-      "audio"
+      "audio",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42717,7 +42777,8 @@
      "input": [
       "text",
       "image",
-      "audio"
+      "audio",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42797,7 +42858,8 @@
      "input": [
       "text",
       "image",
-      "audio"
+      "audio",
+      "pdf"
      ],
      "output": [
       "text"
@@ -42888,7 +42950,8 @@
      "input": [
       "text",
       "image",
-      "audio"
+      "audio",
+      "pdf"
      ],
      "output": [
       "text"
@@ -43276,7 +43339,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -43309,7 +43373,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -43342,7 +43407,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -43375,7 +43441,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -43408,7 +43475,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -43574,7 +43642,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -43617,7 +43686,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -43644,10 +43714,10 @@
    "gpt-5.6-luna": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.11,
-     "cache_write": 1.38,
-     "input": 1.1,
-     "output": 6.599
+     "cache_read": 0.022,
+     "cache_write": 0.275,
+     "input": 0.219,
+     "output": 1.32
     },
     "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
     "family": "gpt-luna",
@@ -43662,7 +43732,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -43707,7 +43778,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -43734,10 +43806,10 @@
    "gpt-5.6-terra": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.275,
-     "cache_write": 3.437,
-     "input": 2.749,
-     "output": 16.498
+     "cache_read": 0.219,
+     "cache_write": 2.749,
+     "input": 2.2,
+     "output": 13.199
     },
     "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
     "family": "gpt-terra",
@@ -43752,7 +43824,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -44019,7 +44092,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -44060,7 +44134,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -44335,9 +44410,9 @@
    "minimax-m2.5": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.03,
+     "cache_read": 0.075,
      "input": 0.296,
-     "output": 1.087
+     "output": 1.186
     },
     "description": "MiniMax model for chat, coding, office work, and agentic tasks",
     "family": "minimax",
@@ -44525,7 +44600,7 @@
     "tool_call": true
    },
    "mistral-7b-instruct-v0.2": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "input": 0.159,
      "output": 0.219
@@ -44539,7 +44614,8 @@
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "pdf"
      ],
      "output": [
       "text"
@@ -44583,7 +44659,7 @@
     "tool_call": true
    },
    "mistral-large-2402": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "input": 4.284,
      "output": 12.952
@@ -44597,7 +44673,8 @@
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "pdf"
      ],
      "output": [
       "text"
@@ -44833,7 +44910,7 @@
     "tool_call": true
    },
    "mixtral-8x7B-instruct-v0.1": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "input": 0.488,
      "output": 0.758
@@ -44848,7 +44925,8 @@
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "pdf"
      ],
      "output": [
       "text"
@@ -44910,7 +44988,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -44941,7 +45020,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -45005,7 +45085,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -45127,7 +45208,8 @@
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -46006,119 +46088,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "glm-4.7": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.05,
-     "cache_write": 0,
-     "input": 0.25,
-     "output": 1.1
-    },
-    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
-    "family": "glm",
-    "id": "glm-4.7",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-04",
-    "last_updated": "2025-12-22",
-    "limit": {
-     "context": 202752,
-     "output": 202752
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-4.7",
-    "open_weights": true,
-    "provider": {
-     "npm": "@ai-sdk/openai-compatible"
-    },
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-12-22",
-    "temperature": true,
-    "tool_call": true
-   },
-   "glm-4.7-flash": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.008,
-     "cache_write": 0,
-     "input": 0.04,
-     "output": 0.3
-    },
-    "description": "Budget GLM lane for fast coding help, routing, and everyday automation",
-    "family": "glm-flash",
-    "id": "glm-4.7-flash",
-    "knowledge": "2025-04",
-    "last_updated": "2026-01-19",
-    "limit": {
-     "context": 202752,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-4.7-Flash",
-    "open_weights": true,
-    "provider": {
-     "npm": "@ai-sdk/openai-compatible"
-    },
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-01-19",
-    "temperature": true,
-    "tool_call": true
-   },
-   "glm-5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1,
-     "cache_write": 0,
-     "input": 0.48,
-     "output": 1.9
-    },
-    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
-    "family": "glm",
-    "id": "glm-5",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-02-12",
-    "limit": {
-     "context": 202752,
-     "output": 202752
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-5",
-    "open_weights": true,
-    "provider": {
-     "npm": "@ai-sdk/openai-compatible"
-    },
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-02-12",
-    "temperature": true,
-    "tool_call": true
-   },
    "glm-5.1": {
     "attachment": false,
     "cost": {
@@ -46332,104 +46301,6 @@
     "release_date": "2026-01-27",
     "temperature": true,
     "tool_call": false
-   },
-   "kimi-k2.5": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.07,
-     "input": 0.35,
-     "output": 1.7
-    },
-    "description": "Earlier Kimi frontier model for long-context agents, coding, and multimodal work",
-    "family": "kimi-k2",
-    "id": "kimi-k2.5",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-01",
-    "last_updated": "2026-01",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.5",
-    "open_weights": true,
-    "provider": {
-     "npm": "@ai-sdk/openai-compatible"
-    },
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-01",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "kimi-k2.5-lightning": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 1,
-     "output": 3
-    },
-    "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
-    "family": "kimi-k2",
-    "id": "kimi-k2.5-lightning",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-02-06",
-    "limit": {
-     "context": 131072,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.5 (Lightning)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-02-06",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
    },
    "kimi-k2.6": {
     "attachment": true,
@@ -46697,41 +46568,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "minimax-m2.5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.02,
-     "cache_write": 0.375,
-     "input": 0.11,
-     "output": 0.95
-    },
-    "description": "Prior MiniMax coding model for agent workflows, office edits, and automation",
-    "family": "minimax",
-    "id": "minimax-m2.5",
-    "last_updated": "2026-02-12",
-    "limit": {
-     "context": 204800,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "MiniMax-M2.5",
-    "open_weights": true,
-    "provider": {
-     "npm": "@ai-sdk/openai-compatible"
-    },
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-02-12",
-    "temperature": true,
-    "tool_call": true
-   },
    "qwen3.5-397b-a17b": {
     "attachment": true,
     "cost": {
@@ -46872,6 +46708,53 @@
      }
     ],
     "release_date": "2026-04-22",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-27b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.25,
+     "output": 2.1
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen3.8-27b",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "provider": {
+     "npm": "@ai-sdk/openai-compatible"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -47269,6 +47152,54 @@
      }
     ],
     "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.0135,
+     "cache_write": 0.405,
+     "input": 0.405,
+     "output": 1.215
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-vision-exp",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -49495,6 +49426,48 @@
      }
     ],
     "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 1.2,
+     "input": 1.2,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "z-ai/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -53035,7 +53008,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "deepseek-ai/DeepSeek-V4-Pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 384000
@@ -53049,7 +53022,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -54121,6 +54094,56 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.0028,
+     "input": 0.14,
+     "output": 0.28,
+     "reasoning": 0.28
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash-vision-exp",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "status": "beta",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepseek-v4-pro": {
     "attachment": false,
     "cost": {
@@ -54135,7 +54158,7 @@
     "interleaved": {
      "field": "reasoning_content"
     },
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 384000
@@ -54149,7 +54172,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -55418,7 +55441,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 1048576
@@ -55432,7 +55455,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -55615,8 +55638,8 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.2,
-     "input": 0.75,
-     "output": 2.4
+     "input": 1,
+     "output": 3.2
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
@@ -55660,7 +55683,7 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.26,
-     "input": 0.975,
+     "input": 1.3,
      "output": 4.3
     },
     "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
@@ -55777,8 +55800,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.203,
-     "input": 0.375,
-     "output": 2.025
+     "input": 0.5,
+     "output": 2.7
     },
     "description": "Kimi model for long-context chat, coding, and agentic reasoning",
     "family": "kimi-k2",
@@ -55824,8 +55847,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.19,
-     "input": 0.76,
-     "output": 3.2
+     "input": 0.95,
+     "output": 4
     },
     "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
     "family": "kimi-k2",
@@ -56051,8 +56074,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.06,
-     "input": 0.225,
-     "output": 0.9
+     "input": 0.3,
+     "output": 1.2
     },
     "description": "MiniMax model for chat, coding, office work, and agentic tasks",
     "family": "minimax-m2.5",
@@ -56386,8 +56409,8 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.06,
-     "input": 0.165,
-     "output": 0.3575
+     "input": 0.3,
+     "output": 0.65
     },
     "description": "Nemotron middle tier for collaborative agents and high-volume reasoning workloads",
     "family": "nemotron",
@@ -57722,8 +57745,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.111,
-     "input": 0.3025,
-     "output": 1.925
+     "input": 0.55,
+     "output": 3.5
     },
     "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
     "family": "qwen3.5",
@@ -57763,7 +57786,7 @@
     "tool_call": true
    },
    "qwen3.8-max": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.2,
      "input": 2,
@@ -57774,18 +57797,20 @@
     "id": "qwen3.8-max",
     "last_updated": "2026-08-03",
     "limit": {
-     "context": 262144,
+     "context": 1000000,
      "output": 262144
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image",
+      "video"
      ],
      "output": [
       "text"
      ]
     },
-    "name": "Qwen3.8-2.4T-A95B",
+    "name": "Qwen3.8-Max",
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
@@ -59445,7 +59470,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "cloudflare/@cf/deepseek-ai/deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 384000
@@ -59459,7 +59484,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -60087,7 +60112,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "deepinfra/deepseek-ai/DeepSeek-V4-Pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 384000
@@ -60101,7 +60126,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -60557,47 +60582,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "deepinfra/tencent/Hy3": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.035,
-     "input": 0.14,
-     "output": 0.58
-    },
-    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
-    "family": "Hy",
-    "id": "deepinfra/tencent/Hy3",
-    "last_updated": "2026-07-06",
-    "limit": {
-     "context": 262144,
-     "output": 64000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Hy3",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-07-06",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "deepinfra/thinkingmachines/Inkling": {
     "attachment": true,
     "cost": {
@@ -60801,7 +60785,7 @@
     "knowledge": "2025-05",
     "last_updated": "2026-04-24",
     "limit": {
-     "context": 1048576,
+     "context": 1000000,
      "output": 384000
     },
     "modalities": {
@@ -60831,6 +60815,49 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek/deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-vision-exp",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1048576,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepseek/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
@@ -60844,7 +60871,7 @@
     "knowledge": "2025-05",
     "last_updated": "2026-04-24",
     "limit": {
-     "context": 1048576,
+     "context": 1000000,
      "output": 384000
     },
     "modalities": {
@@ -60876,9 +60903,9 @@
    "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.028,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -60926,7 +60953,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 384000
@@ -60940,7 +60967,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -62373,8 +62400,8 @@
    "ionos/meta-llama/Llama-3.3-70B-Instruct": {
     "attachment": false,
     "cost": {
-     "input": 0.754325,
-     "output": 0.754325
+     "input": 0.760435,
+     "output": 0.760435
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
     "family": "llama",
@@ -62404,8 +62431,8 @@
    "ionos/openai/gpt-oss-120b": {
     "attachment": false,
     "cost": {
-     "input": 0.174075,
-     "output": 0.754325
+     "input": 0.175485,
+     "output": 0.760435
     },
     "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
     "family": "gpt-oss",
@@ -62605,8 +62632,8 @@
    "mistral/codestral-latest": {
     "attachment": false,
     "cost": {
-     "input": 1,
-     "output": 3
+     "input": 0.3,
+     "output": 0.9
     },
     "description": "Mistral code model for completions, refactors, and developer IDE workflows",
     "family": "codestral",
@@ -62954,8 +62981,8 @@
    "mistral/mistral-small-latest": {
     "attachment": true,
     "cost": {
-     "input": 0.06,
-     "output": 0.18
+     "input": 0.15,
+     "output": 0.6
     },
     "description": "Efficient Mistral model for fast chat, extraction, and production assistants",
     "family": "mistral-small",
@@ -63104,6 +63131,49 @@
     "temperature": false,
     "tool_call": true
    },
+   "nebius/deepseek-ai/DeepSeek-V4-Flash-0731": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.14,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "nebius/deepseek-ai/DeepSeek-V4-Flash-0731",
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1048576,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "nebius/meta-llama/Llama-3.3-70B-Instruct": {
     "attachment": false,
     "cost": {
@@ -63189,7 +63259,7 @@
     "id": "nebius/nvidia/nemotron-3-super-120b-a12b",
     "last_updated": "2026-03-11",
     "limit": {
-     "context": 8000,
+     "context": 262144,
      "output": 262144
     },
     "modalities": {
@@ -64368,22 +64438,22 @@
    "openai/gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
+     "cache_read": 0.4,
+     "cache_write": 5,
      "context_over_200k": {
-      "cache_read": 1,
-      "cache_write": 12.5,
-      "input": 10,
-      "output": 45
+      "cache_read": 0.8,
+      "cache_write": 10,
+      "input": 8,
+      "output": 30
      },
-     "input": 5,
-     "output": 30,
+     "input": 4,
+     "output": 20,
      "tiers": [
       {
-       "cache_read": 1,
-       "cache_write": 12.5,
-       "input": 10,
-       "output": 45,
+       "cache_read": 0.8,
+       "cache_write": 10,
+       "input": 8,
+       "output": 30,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -64502,22 +64572,22 @@
    "openai/gpt-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
+     "cache_read": 0.4,
+     "cache_write": 5,
      "context_over_200k": {
-      "cache_read": 1,
-      "cache_write": 12.5,
-      "input": 10,
-      "output": 45
+      "cache_read": 0.8,
+      "cache_write": 10,
+      "input": 8,
+      "output": 30
      },
-     "input": 5,
-     "output": 30,
+     "input": 4,
+     "output": 20,
      "tiers": [
       {
-       "cache_read": 1,
-       "cache_write": 12.5,
-       "input": 10,
-       "output": 45,
+       "cache_read": 0.8,
+       "cache_write": 10,
+       "input": 8,
+       "output": 30,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -65168,9 +65238,8 @@
    "qwen/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.04,
-     "input": 0.2,
-     "output": 0.4
+     "input": 0.176,
+     "output": 0.528
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -65204,20 +65273,20 @@
      }
     ],
     "release_date": "2026-07-31",
-    "structured_output": false,
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
    "qwen/deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
-     "input": 0.726,
-     "output": 2.178
+     "input": 0.627,
+     "output": 1.881
     },
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "qwen/deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 384000
@@ -65231,7 +65300,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -65868,8 +65937,8 @@
    "scaleway/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "input": 0.4642,
-     "output": 0.9284
+     "input": 0.46796,
+     "output": 0.93592
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -65910,8 +65979,8 @@
    "scaleway/gpt-oss-120b": {
     "attachment": false,
     "cost": {
-     "input": 0.174075,
-     "output": 0.6963
+     "input": 0.175485,
+     "output": 0.70194
     },
     "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
     "family": "gpt-oss",
@@ -65950,8 +66019,8 @@
    "scaleway/llama-3.3-70b-instruct": {
     "attachment": false,
     "cost": {
-     "input": 1.044449,
-     "output": 1.044449
+     "input": 1.05291,
+     "output": 1.05291
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
     "family": "llama",
@@ -66108,7 +66177,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "together_ai/deepseek-ai/DeepSeek-V4-Pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 384000
@@ -66122,7 +66191,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -68191,16 +68260,6 @@
       "type": "toggle"
      },
      {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "max"
-      ]
-     },
-     {
       "max": 393216,
       "min": 1,
       "type": "budget_tokens"
@@ -68214,9 +68273,9 @@
    "deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.14,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.424,
+     "input": 0.424,
+     "output": 1.272
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -68241,21 +68300,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "max"
-      ]
-     },
-     {
-      "max": 393216,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-07-31",
@@ -68295,16 +68339,6 @@
       "type": "toggle"
      },
      {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "max"
-      ]
-     },
-     {
       "max": 393216,
       "min": 1,
       "type": "budget_tokens"
@@ -68325,7 +68359,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 393216
@@ -68339,7 +68373,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -68512,6 +68546,9 @@
     "reasoning": true,
     "reasoning_options": [
      {
+      "type": "toggle"
+     },
+     {
       "type": "effort",
       "values": [
        "none",
@@ -68520,6 +68557,11 @@
        "high",
        "max"
       ]
+     },
+     {
+      "max": 32768,
+      "min": 128,
+      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-04-02",
@@ -68559,6 +68601,44 @@
      }
     ],
     "release_date": "2025-07-28",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-4-6v-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Lightweight GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "glm-4-6v-flash",
+    "last_updated": "2025-12-08",
+    "limit": {
+     "context": 128000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.6V Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-08",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -68639,16 +68719,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "max"
-      ]
      },
      {
       "max": 38912,
@@ -68782,21 +68852,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "max"
-      ]
-     },
-     {
-      "max": 81920,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-04-21",
@@ -73138,7 +73193,7 @@
     "interleaved": {
      "field": "reasoning_content"
     },
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 384000
@@ -73152,7 +73207,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -76921,22 +76976,22 @@
    "gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
+     "cache_read": 0.25,
+     "cache_write": 3.125,
      "context_over_200k": {
-      "cache_read": 1,
-      "cache_write": 12.5,
-      "input": 10,
-      "output": 45
+      "cache_read": 0.5,
+      "cache_write": 6.25,
+      "input": 5,
+      "output": 22.5
      },
-     "input": 5,
-     "output": 30,
+     "input": 2.5,
+     "output": 15,
      "tiers": [
       {
-       "cache_read": 1,
-       "cache_write": 12.5,
-       "input": 10,
-       "output": 45,
+       "cache_read": 0.5,
+       "cache_write": 6.25,
+       "input": 5,
+       "output": 22.5,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -79807,10 +79862,10 @@
    "gemini-3.6-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "input": 1.5,
-     "input_audio": 1.5,
-     "output": 7.5
+     "cache_read": 0.075,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -79967,16 +80022,16 @@
    "gemini-flash-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "input": 1.5,
-     "input_audio": 1.5,
-     "output": 9
+     "cache_read": 0.075,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75
     },
-    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
     "id": "gemini-flash-latest",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-19",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
     "limit": {
      "context": 1048576,
      "output": 65536
@@ -80000,14 +80055,13 @@
      {
       "type": "effort",
       "values": [
-       "minimal",
        "low",
        "medium",
        "high"
       ]
      }
     ],
-    "release_date": "2026-05-19",
+    "release_date": "2026-08-13",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -80015,16 +80069,15 @@
    "gemini-flash-lite-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.025,
-     "input": 0.25,
-     "input_audio": 0.5,
-     "output": 1.5
+     "cache_read": 0.03,
+     "input": 0.3,
+     "output": 2.5
     },
-    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash-lite",
     "id": "gemini-flash-lite-latest",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-07",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
     "limit": {
      "context": 1048576,
      "output": 65536
@@ -80055,7 +80108,7 @@
       ]
      }
     ],
-    "release_date": "2026-05-07",
+    "release_date": "2026-07-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -80357,6 +80410,55 @@
   ],
   "id": "google-vertex",
   "models": {
+   "claude-fable-5@default": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 1,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "id": "claude-fable-5@default",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-09",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/google-vertex/anthropic"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-09",
+    "temperature": false,
+    "tool_call": true
+   },
    "claude-haiku-4-5@20251001": {
     "attachment": true,
     "cost": {
@@ -81004,6 +81106,7 @@
    "deepseek-ai/deepseek-v3.1-maas": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.06,
      "input": 0.6,
      "output": 1.7
     },
@@ -81079,9 +81182,9 @@
    "gemini-2.5-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.075,
-     "cache_write": 0.383,
+     "cache_read": 0.03,
      "input": 0.3,
+     "input_audio": 1,
      "output": 2.5
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
@@ -81369,6 +81472,7 @@
    "gemini-3-pro-image": {
     "attachment": true,
     "cost": {
+     "cache_read": 0.2,
      "input": 2,
      "output": 120
     },
@@ -81402,6 +81506,7 @@
    "gemini-3.1-flash-image": {
     "attachment": true,
     "cost": {
+     "cache_read": 0.05,
      "input": 0.5,
      "output": 60
     },
@@ -81761,10 +81866,10 @@
    "gemini-3.6-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "input": 1.5,
-     "input_audio": 1.5,
-     "output": 7.5
+     "cache_read": 0.075,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -81891,11 +81996,11 @@
      "input_audio": 1.5,
      "output": 9
     },
-    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
     "id": "gemini-flash-latest",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-19",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
     "limit": {
      "context": 1048576,
      "output": 65536
@@ -81926,7 +82031,7 @@
       ]
      }
     ],
-    "release_date": "2026-05-19",
+    "release_date": "2026-08-13",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -81939,11 +82044,11 @@
      "input_audio": 0.5,
      "output": 1.5
     },
-    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash-lite",
     "id": "gemini-flash-lite-latest",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-07",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
     "limit": {
      "context": 1048576,
      "output": 65536
@@ -81974,7 +82079,7 @@
       ]
      }
     ],
-    "release_date": "2026-05-07",
+    "release_date": "2026-07-21",
     "temperature": true,
     "tool_call": true
    },
@@ -82053,6 +82158,7 @@
    "moonshotai/kimi-k2-thinking-maas": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.06,
      "input": 0.6,
      "output": 2.5
     },
@@ -82132,6 +82238,7 @@
    "openai/gpt-oss-20b-maas": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.007,
      "input": 0.07,
      "output": 0.25
     },
@@ -82208,6 +82315,7 @@
    "zai-org/glm-4.7-maas": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.06,
      "input": 0.6,
      "output": 2.2
     },
@@ -82306,6 +82414,52 @@
   ],
   "id": "google-vertex-anthropic",
   "models": {
+   "claude-fable-5@default": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 1,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "id": "claude-fable-5@default",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-09",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-09",
+    "temperature": false,
+    "tool_call": true
+   },
    "claude-haiku-4-5@20251001": {
     "attachment": true,
     "cost": {
@@ -89642,7 +89796,7 @@
     "description": "Flagship DeepSeek model for coding, reasoning, and agentic work",
     "family": "deepseek-thinking",
     "id": "deepseek-ai/DeepSeek-V4-Pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 384000
@@ -90430,6 +90584,41 @@
     "temperature": true,
     "tool_call": true
    },
+   "zai-org/GLM-4.6V-Flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0.3,
+     "output": 0.9
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "zai-org/GLM-4.6V-Flash",
+    "last_updated": "2025-12-08",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.6V-Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-08",
+    "temperature": true,
+    "tool_call": true
+   },
    "zai-org/GLM-4.7": {
     "attachment": false,
     "cost": {
@@ -90654,9 +90843,9 @@
    "deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.044,
-     "input": 0.44,
-     "output": 1.32
+     "cache_read": 0.015243,
+     "input": 0.479072,
+     "output": 1.437216
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -90664,7 +90853,7 @@
     "knowledge": "2025-05",
     "last_updated": "2026-08-02",
     "limit": {
-     "context": 1000000,
+     "context": 1048576,
      "output": 384000
     },
     "modalities": {
@@ -90682,9 +90871,13 @@
      {
       "type": "effort",
       "values": [
+       "none",
+       "minimal",
        "low",
+       "medium",
        "high",
-       "xhigh"
+       "xhigh",
+       "max"
       ]
      }
     ],
@@ -90758,7 +90951,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -90778,9 +90971,9 @@
    "gemma-4-26b-a4b-it": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.06,
-     "input": 0.12,
-     "output": 0.42
+     "cache_write": 0.055,
+     "input": 0.11,
+     "output": 0.408
     },
     "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
     "family": "gemma",
@@ -90810,9 +91003,9 @@
    "glm-5": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.43,
-     "input": 0.86,
-     "output": 2.806
+     "cache_write": 0.455,
+     "input": 0.91,
+     "output": 2.934
     },
     "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
     "family": "glm",
@@ -90841,9 +91034,9 @@
    "glm-5.1": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.666,
-     "input": 1.332,
-     "output": 4.312
+     "cache_write": 0.68,
+     "input": 1.36,
+     "output": 4.4
     },
     "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
     "family": "glm",
@@ -90871,23 +91064,24 @@
     "tool_call": true
    },
    "glm-5.2": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
-     "cache_read": 0.275,
-     "input": 1.1,
-     "output": 3.851
+     "cache_read": 0.152432,
+     "input": 1.52432,
+     "output": 4.79072
     },
     "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
     "family": "glm",
     "id": "glm-5.2",
     "last_updated": "2026-07-22",
     "limit": {
-     "context": 1000000,
+     "context": 1048576,
      "output": 32768
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
@@ -90900,8 +91094,9 @@
      {
       "type": "effort",
       "values": [
+       "none",
        "high",
-       "xhigh"
+       "max"
       ]
      }
     ],
@@ -90913,9 +91108,9 @@
    "gpt-oss-120b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.015243,
-     "input": 0.16332,
-     "output": 0.65328
+     "cache_write": 0.094,
+     "input": 0.188,
+     "output": 0.7
     },
     "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
     "family": "gpt-oss",
@@ -90954,9 +91149,9 @@
    "kimi-k2.5": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.2602,
-     "input": 0.5204,
-     "output": 2.735
+     "cache_write": 0.2722,
+     "input": 0.5444,
+     "output": 2.855
     },
     "description": "Earlier Kimi frontier model for long-context agents, coding, and multimodal work",
     "family": "kimi-k2",
@@ -91021,9 +91216,9 @@
    "kimi-k2.7-code": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.19,
-     "input": 0.95,
-     "output": 4
+     "cache_read": 0.206872,
+     "input": 1.03436,
+     "output": 4.3552
     },
     "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
     "family": "kimi-k2",
@@ -91065,7 +91260,7 @@
     "last_updated": "2026-07-30",
     "limit": {
      "context": 1048576,
-     "output": 131072
+     "output": 16000
     },
     "modalities": {
      "input": [
@@ -91097,9 +91292,9 @@
    "llama-3.3-70b-instruct": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.299,
-     "input": 0.598,
-     "output": 0.738
+     "cache_write": 0.319,
+     "input": 0.638,
+     "output": 0.768
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
     "family": "llama",
@@ -91159,9 +91354,9 @@
    "minimax-m2.7": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.205,
-     "input": 0.41,
-     "output": 1.52
+     "cache_write": 0.204,
+     "input": 0.408,
+     "output": 1.512
     },
     "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
     "family": "minimax",
@@ -103067,45 +103262,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "deepcogito/cogito-v2.1-671b": {
-    "attachment": false,
-    "cost": {
-     "input": 1.25,
-     "output": 1.25
-    },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "cogito",
-    "id": "deepcogito/cogito-v2.1-671b",
-    "last_updated": "2025-11-13",
-    "limit": {
-     "context": 128000,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Deep Cogito: Cogito v2.1 671B",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-11-13",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
    "deepseek/deepseek-chat": {
     "attachment": false,
     "cost": {
@@ -103180,8 +103336,8 @@
     "id": "deepseek/deepseek-chat-v3.1",
     "last_updated": "2025-08-21",
     "limit": {
-     "context": 163840,
-     "output": 32768
+     "context": 161000,
+     "output": 161000
     },
     "modalities": {
      "input": [
@@ -103337,8 +103493,8 @@
     "id": "deepseek/deepseek-v3.1-terminus",
     "last_updated": "2025-09-22",
     "limit": {
-     "context": 163840,
-     "output": 163840
+     "context": 131072,
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -103379,7 +103535,7 @@
     "last_updated": "2025-12-01",
     "limit": {
      "context": 163840,
-     "output": 65536
+     "output": 163840
     },
     "modalities": {
      "input": [
@@ -103491,8 +103647,8 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.028,
-     "input": 0.14,
-     "output": 0.28
+     "input": 0.44,
+     "output": 1.32
     },
     "description": "DeepSeek V4 Flash 0731 is a sparse mixture-of-experts model from DeepSeek, with 13B active parameters out of 284B total. This re-post-trained revision is suited for coding, reasoning, and agent workflows.",
     "family": "deepseek-flash",
@@ -103501,7 +103657,7 @@
     "last_updated": "2026-07-31",
     "limit": {
      "context": 1048576,
-     "output": 393216
+     "output": 384000
     },
     "modalities": {
      "input": [
@@ -103530,31 +103686,31 @@
     "temperature": true,
     "tool_call": true
    },
-   "deepseek/deepseek-v4-flash:discounted": {
-    "attachment": false,
+   "deepseek/deepseek-v4-flash-vision-exp": {
+    "attachment": true,
     "cost": {
-     "cache_read": 0.0028,
-     "input": 0.14,
-     "output": 0.28,
-     "reasoning": 0
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
     },
-    "description": "This DeepSeek V4 Flash endpoint provides the lowest cost for multi-turn conversations for this model. This is accomplished with an exceptionally low cache read price. By using this endpoint you agree prompts and completions may be retained by DeepSeek and used to train future models.",
-    "family": "deepseek",
-    "id": "deepseek/deepseek-v4-flash:discounted",
-    "last_updated": "2025-08-26",
+    "description": "DeepSeek V4 Flash Vision Exp is an experimental vision-enabled version of [DeepSeek V4 Flash 0731](https://openrouter.ai/deepseek/deepseek-v4-flash-0731) from DeepSeek, adding image understanding while matching the base model on text capabilities including agents,...",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-vision-exp",
+    "last_updated": "2026-08-21",
     "limit": {
      "context": 1048576,
      "output": 384000
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
      ]
     },
-    "name": "DeepSeek: DeepSeek V4 Flash 0731 (lowest price)",
+    "name": "DeepSeek V4 Flash Vision Exp",
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
@@ -103562,12 +103718,13 @@
       "type": "effort",
       "values": [
        "none",
+       "low",
        "high",
-       "xhigh"
+       "max"
       ]
      }
     ],
-    "release_date": "2025-08-26",
+    "release_date": "2026-08-21",
     "structured_output": false,
     "temperature": true,
     "tool_call": true
@@ -103585,8 +103742,8 @@
     "knowledge": "2025-05",
     "last_updated": "2026-04-24",
     "limit": {
-     "context": 1048576,
-     "output": 393216
+     "context": 1024000,
+     "output": 384000
     },
     "modalities": {
      "input": [
@@ -103624,9 +103781,9 @@
     "description": "DeepSeek V4 Pro 0813 is a large-scale mixture-of-experts model from DeepSeek. This is the GA release of DeepSeek V4 Pro.",
     "family": "deepseek-thinking",
     "id": "deepseek/deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
-     "context": 1048576,
+     "context": 1048575,
      "output": 384000
     },
     "modalities": {
@@ -103638,7 +103795,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -103653,48 +103810,6 @@
     ],
     "release_date": "2026-08-12",
     "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "deepseek/deepseek-v4-pro:discounted": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.003625,
-     "input": 0.435,
-     "output": 0.87,
-     "reasoning": 0
-    },
-    "description": "This DeepSeek V4 Pro endpoint provides the lowest cost for multi-turn conversations for this model. This is accomplished with an exceptionally low cache read price. By using this endpoint you agree prompts and completions may be retained by DeepSeek and used to train future models.",
-    "family": "deepseek",
-    "id": "deepseek/deepseek-v4-pro:discounted",
-    "last_updated": "2025-08-26",
-    "limit": {
-     "context": 1048576,
-     "output": 384000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek: DeepSeek V4 Pro 0813 (lowest price)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "high",
-       "xhigh"
-      ]
-     }
-    ],
-    "release_date": "2025-08-26",
-    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -104293,7 +104408,7 @@
     "last_updated": "2026-06-30",
     "limit": {
      "context": 65536,
-     "output": 66000
+     "output": 65536
     },
     "modalities": {
      "input": [
@@ -104821,8 +104936,8 @@
    "google/gemma-4-26b-a4b-it": {
     "attachment": true,
     "cost": {
-     "input": 0.07,
-     "output": 0.34
+     "input": 0.05,
+     "output": 0.25
     },
     "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
     "family": "gemma",
@@ -104872,7 +104987,7 @@
     "last_updated": "2026-04-02",
     "limit": {
      "context": 262144,
-     "output": 16384
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -105506,13 +105621,51 @@
     "temperature": true,
     "tool_call": true
    },
+   "liquid/lfm-2.5-2.6b:free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "LFM2.5-2.6B is a compact reasoning model from Liquid AI. It is suited for agent workflows, data extraction, RAG, and long-context processing. Liquid advises against using it for agentic coding or...",
+    "family": "liquid",
+    "id": "liquid/lfm-2.5-2.6b:free",
+    "last_updated": "2026-08-11",
+    "limit": {
+     "context": 65536,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "LiquidAI: LFM2.5-2.6B (free)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-11",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "mancer/weaver": {
     "attachment": false,
     "cost": {
      "input": 0.5,
      "output": 0.75
     },
-    "description": "General-purpose chat model for instruction following, writing, and analysis",
+    "description": "An attempt to recreate Claude-style verbosity, but don't expect the same level of coherence or memory. Meant for use in roleplay/narrative situations.",
     "family": "alpha",
     "id": "mancer/weaver",
     "last_updated": "2023-08-02",
@@ -105532,7 +105685,7 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2023-08-02",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": false
    },
@@ -105572,6 +105725,47 @@
      }
     ],
     "release_date": "2026-07-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "meituan/longcat-2.0-free": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0,
+     "reasoning": 0
+    },
+    "description": "LongCat 2.0 is a sparse mixture-of-experts language model from Meituan, with 48B active parameters out of 1.6T total. It is suited for coding, repository-level changes, long-horizon problem solving, and agentic workflows. Available free in Kilo for a limited time.",
+    "family": "longcat",
+    "id": "meituan/longcat-2.0-free",
+    "last_updated": "2025-08-26",
+    "limit": {
+     "context": 1048756,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Meituan: LongCat 2.0 (free)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-26",
     "structured_output": false,
     "temperature": true,
     "tool_call": true
@@ -105824,6 +106018,7 @@
    "meta/muse-glimmer-30b": {
     "attachment": true,
     "cost": {
+     "cache_read": 0.04,
      "input": 0.3,
      "output": 1.1
     },
@@ -105955,6 +106150,53 @@
      }
     ],
     "release_date": "2026-08-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.2-contributor": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.002,
+     "input": 0.1,
+     "output": 0.2
+    },
+    "description": "Muse Spark 1.2 contributor tier is a reasoning model from Meta designed for developers who want to start building at an even lower cost. It’s meaningfully cheaper than Muse Spark...",
+    "family": "muse",
+    "id": "meta/muse-spark-1.2-contributor",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Meta: Muse Spark 1.2 Contributor",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -106208,8 +106450,8 @@
     "id": "minimax/minimax-m2.5",
     "last_updated": "2026-02-12",
     "limit": {
-     "context": 65536,
-     "output": 196608
+     "context": 200000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -106411,6 +106653,36 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
+   },
+   "mistralai/ministral-8b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.11,
+     "output": 0.11
+    },
+    "description": "Ministral 8B is an 8B parameter model featuring a unique interleaved sliding-window attention pattern for faster, memory-efficient inference. Designed for edge use cases, it supports up to 128k context length...",
+    "family": "ministral",
+    "id": "mistralai/ministral-8b",
+    "last_updated": "2024-10-17",
+    "limit": {
+     "context": 128000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Mistral: Ministral 8B",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-10-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": false
    },
    "mistralai/ministral-8b-2512": {
     "attachment": true,
@@ -106818,15 +107090,15 @@
    "mistralai/mistral-small-3.2-24b-instruct": {
     "attachment": true,
     "cost": {
-     "input": 0.09375,
-     "output": 0.25
+     "input": 0.075,
+     "output": 0.2
     },
     "description": "Efficient Mistral model for fast chat, extraction, and production assistants",
     "family": "mistral-small",
     "id": "mistralai/mistral-small-3.2-24b-instruct",
     "last_updated": "2025-06-20",
     "limit": {
-     "context": 256000,
+     "context": 128000,
      "output": 16384
     },
     "modalities": {
@@ -107462,7 +107734,7 @@
    "nvidia/nemotron-3-nano-30b-a3b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.03,
+     "cache_read": 0.025,
      "input": 0.05,
      "output": 0.2
     },
@@ -109433,10 +109705,10 @@
    "openai/gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
-     "input": 5,
-     "output": 30
+     "cache_read": 0.4,
+     "cache_write": 5,
+     "input": 4,
+     "output": 20
     },
     "description": "GPT-5.6 Sol is the flagship model in OpenAI's GPT-5.6 series. It is suited for complex reasoning, coding, and agentic workflows, and is particularly strong at command-line and multi-step coding tasks...",
     "family": "gpt-sol",
@@ -109530,10 +109802,10 @@
    "openai/gpt-5.6-sol-pro": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
-     "input": 5,
-     "output": 30
+     "cache_read": 0.4,
+     "cache_write": 5,
+     "input": 4,
+     "output": 20
     },
     "description": "GPT-5.6 Sol Pro is the same underlying model as [GPT-5.6 Sol](https://openrouter.ai/openai/gpt-5.6-sol), served with `reasoning.mode` set to `pro` for higher-quality responses on complex tasks. Learn more in OpenAI's docs: https://developers.openai.com/api/docs/guides/reasoning#reasoning-mode",
     "family": "gpt-sol",
@@ -111112,8 +111384,8 @@
     "id": "qwen/qwen3-30b-a3b",
     "last_updated": "2025-04-28",
     "limit": {
-     "context": 131072,
-     "output": 8192
+     "context": 40960,
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -111530,7 +111802,7 @@
     "last_updated": "2025-09",
     "limit": {
      "context": 262144,
-     "output": 16384
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -112171,7 +112443,7 @@
     "last_updated": "2026-04-22",
     "limit": {
      "context": 262144,
-     "output": 65536
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -112509,8 +112781,8 @@
     "id": "qwen/qwen3.8-2.4t-a95b",
     "last_updated": "2026-08-12",
     "limit": {
-     "context": 1000000,
-     "output": 262144
+     "context": 1048576,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -112541,9 +112813,10 @@
    "qwen/qwen3.8-27b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.05,
-     "input": 0.45,
-     "output": 3.2
+     "cache_read": 0.1,
+     "cache_write": 0.625,
+     "input": 0.5,
+     "output": 3
     },
     "description": "Qwen3.8 27B is an open-weight dense vision-language model from Qwen. It is suited for coding, professional workflows, research, multimodal interaction, and long-running agent tasks, with flexible thinking that can be...",
     "family": "qwen",
@@ -113122,6 +113395,48 @@
     "temperature": true,
     "tool_call": true
    },
+   "stealth/ox-alpha": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Ox Alpha is a reasoning model designed for coding, sustained agentic work, and production workloads. It is suited for long-horizon software engineering, complex reasoning, and workflows that combine text with...",
+    "family": "alpha",
+    "id": "stealth/ox-alpha",
+    "last_updated": "2026-08-20",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ox Alpha",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "stealth/qwen3.6-plus": {
     "attachment": true,
     "cost": {
@@ -113332,12 +113647,102 @@
     "temperature": true,
     "tool_call": false
    },
+   "tencent/hy-mt2-1.8b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.044,
+     "output": 0.177
+    },
+    "description": "Hy-MT2-1.8B is a compact 1.8B-parameter translation model from Tencent. It supports 33 language pairs and five Chinese dialect and minority-language pairs, with workflows for structured, delimiter-based, contextual, glossary-based, and style-guided...",
+    "family": "Hy",
+    "id": "tencent/hy-mt2-1.8b",
+    "last_updated": "2026-08-20",
+    "limit": {
+     "context": 8192,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Tencent: Hy-MT2-1.8B",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "tencent/hy-mt2-30b-a3b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.074,
+     "output": 0.295
+    },
+    "description": "Hy-MT2-30B-A3B is Tencent's flagship translation model in the Hy-MT2 family. It supports 33 language pairs and five Chinese dialect and minority-language pairs, with workflows for structured, delimiter-based, contextual, glossary-based, and...",
+    "family": "Hy",
+    "id": "tencent/hy-mt2-30b-a3b",
+    "last_updated": "2026-08-20",
+    "limit": {
+     "context": 8192,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Tencent: Hy-MT2-30B-A3B",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-20",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": false
+   },
+   "tencent/hy-mt2-7b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.074,
+     "output": 0.295
+    },
+    "description": "Hy-MT2-7B is a 7B-parameter translation model from Tencent. It supports 33 language pairs and five Chinese dialect and minority-language pairs, with workflows for structured, delimiter-based, contextual, glossary-based, and style-guided translation.",
+    "family": "Hy",
+    "id": "tencent/hy-mt2-7b",
+    "last_updated": "2026-08-19",
+    "limit": {
+     "context": 8192,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Tencent: Hy-MT2-7B",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": false
+   },
    "tencent/hy3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.035,
-     "input": 0.14,
-     "output": 0.58
+     "cache_read": 0.033,
+     "input": 0.132,
+     "output": 0.528
     },
     "description": "Hy3 is a 295B-parameter Mixture-of-Experts model from Tencent (21B active, 192 experts with top-8 routing) built for reasoning, agentic workflows, and real-world production use. It supports a configurable reasoning effort:...",
     "family": "Hy",
@@ -113663,6 +114068,96 @@
     ],
     "release_date": "2026-07-30",
     "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "thinkingmachines/inkling-small:free": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Inkling Small is an open-weight multimodal mixture-of-experts model from Thinking Machines Lab, with 12B active parameters out of 276B total. It is positioned as the smaller, more efficient member of...",
+    "family": "ling",
+    "id": "thinkingmachines/inkling-small:free",
+    "last_updated": "2026-07-30",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Thinking Machines: Inkling Small (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-30",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "thinkingmachines/inkling:free": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Inkling is an open-weight multimodal mixture-of-experts model from Thinking Machines Lab, with 41B active parameters out of 975B total. It is designed for general-purpose reasoning, coding, agentic and tool-use systems,...",
+    "family": "ling",
+    "id": "thinkingmachines/inkling:free",
+    "last_updated": "2026-07-15",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Thinking Machines: Inkling (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-15",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -114908,9 +115403,9 @@
    "~deepseek/deepseek-v4-flash-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0153,
-     "input": 0.0765,
-     "output": 0.153
+     "cache_read": 0.01278,
+     "input": 0.0639,
+     "output": 0.1278
     },
     "description": "This model always redirects to the latest model in the DeepSeek V4 Flash family.",
     "family": "deepseek",
@@ -115088,10 +115583,10 @@
    "~openai/gpt-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
-     "input": 2.5,
-     "output": 15
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
     },
     "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
     "family": "gpt",
@@ -115991,39 +116486,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "claude-3-opus": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1.5,
-     "cache_write": 18.75,
-     "input": 15,
-     "output": 75
-    },
-    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-    "family": "claude",
-    "id": "claude-3-opus",
-    "last_updated": "2024-03-04",
-    "limit": {
-     "context": 200000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude 3 Opus",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-03-04",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
    "claude-fable-5": {
     "attachment": true,
     "cost": {
@@ -116783,9 +117245,9 @@
    "deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0027,
-     "input": 0.05,
-     "output": 0.09
+     "cache_read": 0.014,
+     "input": 0.076,
+     "output": 0.153
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -118212,6 +118674,38 @@
     "temperature": true,
     "tool_call": true
    },
+   "glm-5.2-fast": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.4,
+     "input": 1.99,
+     "output": 6.16
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "glm-5.2-fast",
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "glm-5.3": {
     "attachment": false,
     "cost": {
@@ -118517,37 +119011,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "gpt-4o-mini-search-preview": {
-    "attachment": true,
-    "cost": {
-     "input": 0.15,
-     "output": 0.6
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "gpt",
-    "id": "gpt-4o-mini-search-preview",
-    "last_updated": "2024-10-01",
-    "limit": {
-     "context": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-4o Mini Search Preview",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-10-01",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
    "gpt-4o-mini-transcribe": {
     "attachment": true,
     "cost": {
@@ -118578,37 +119041,6 @@
     "structured_output": false,
     "temperature": true,
     "tool_call": true
-   },
-   "gpt-4o-search-preview": {
-    "attachment": true,
-    "cost": {
-     "input": 2.5,
-     "output": 10
-    },
-    "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
-    "family": "gpt",
-    "id": "gpt-4o-search-preview",
-    "last_updated": "2024-10-01",
-    "limit": {
-     "context": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-4o Search Preview",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-10-01",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
    },
    "gpt-4o-transcribe": {
     "attachment": true,
@@ -119627,8 +120059,8 @@
    "gpt-oss-20b": {
     "attachment": false,
     "cost": {
-     "input": 0.04,
-     "output": 0.15
+     "input": 0.05,
+     "output": 0.2
     },
     "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
     "family": "gpt-oss",
@@ -120120,6 +120552,7 @@
      {
       "type": "effort",
       "values": [
+       "minimal",
        "low",
        "medium",
        "high",
@@ -120974,7 +121407,7 @@
     "knowledge": "2024-12",
     "last_updated": "2026-04-22",
     "limit": {
-     "context": 1000000,
+     "context": 1048576,
      "output": 131072
     },
     "modalities": {
@@ -120996,9 +121429,12 @@
       "type": "effort",
       "values": [
        "none",
+       "minimal",
        "low",
        "medium",
-       "high"
+       "high",
+       "xhigh",
+       "max"
       ]
      }
     ],
@@ -121038,7 +121474,7 @@
     "knowledge": "2024-12",
     "last_updated": "2026-04-22",
     "limit": {
-     "context": 1000000,
+     "context": 1048576,
      "output": 131072
     },
     "modalities": {
@@ -121057,9 +121493,12 @@
       "type": "effort",
       "values": [
        "none",
+       "minimal",
        "low",
        "medium",
-       "high"
+       "high",
+       "xhigh",
+       "max"
       ]
      }
     ],
@@ -123486,50 +123925,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "seed-2-1-turbo": {
-    "attachment": false,
-    "cost": {
-     "input": 0.5,
-     "output": 2.5
-    },
-    "description": "Efficient model for low-latency assistance, extraction, and routine automation",
-    "family": "seed",
-    "id": "seed-2-1-turbo",
-    "last_updated": "2026-08-10",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Seed 2.1 Turbo",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "minimal",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-08-10",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
    "sonar": {
     "attachment": false,
     "cost": {
@@ -123631,6 +124026,15767 @@
     "release_date": "2024-01-01",
     "temperature": true,
     "tool_call": false
+   }
+  },
+  "name": "DevPass (LLM Gateway)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "llmgateway-providers": {
+  "api": "https://api.llmgateway.io/v1",
+  "doc": "https://llmgateway.io/docs",
+  "env": [
+   "LLMGATEWAY_API_KEY"
+  ],
+  "id": "llmgateway-providers",
+  "models": {
+   "alibaba/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.04,
+     "input": 0.2,
+     "output": 0.4
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "alibaba/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (Alibaba Cloud)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 2.4,
+     "output": 4.8
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "alibaba/deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro (Alibaba Cloud)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/glm-5": {
+    "attachment": false,
+    "cost": {
+     "input": 0.573,
+     "output": 2.58
+    },
+    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
+    "family": "glm",
+    "id": "alibaba/glm-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 202752,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5 (Alibaba Cloud)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-02-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.28,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "alibaba/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 (Alibaba Cloud)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/kimi-k2.5": {
+    "attachment": true,
+    "cost": {
+     "input": 0.574,
+     "output": 3.011
+    },
+    "description": "Earlier Kimi frontier model for long-context agents, coding, and multimodal work",
+    "family": "kimi-k2",
+    "id": "alibaba/kimi-k2.5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-01",
+    "limit": {
+     "context": 262144,
+     "output": 98304
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.5 (Alibaba Cloud)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-01",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "alibaba/qwen-coder-plus": {
+    "attachment": false,
+    "cost": {
+     "input": 0.502,
+     "output": 1.004
+    },
+    "description": "Qwen coding model for software agents, repository edits, and code reasoning",
+    "family": "qwen",
+    "id": "alibaba/qwen-coder-plus",
+    "last_updated": "2024-09-18",
+    "limit": {
+     "context": 131072,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen Coder Plus (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-09-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.01,
+     "cache_write": 0.0625,
+     "input": 0.05,
+     "output": 0.4
+    },
+    "description": "Efficient Qwen model for fast chat, extraction, and high-volume workloads",
+    "family": "qwen",
+    "id": "alibaba/qwen-flash",
+    "knowledge": "2024-04",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 1000000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen Flash (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-07-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen-max": {
+    "attachment": true,
+    "cost": {
+     "input": 1.6,
+     "output": 6.4
+    },
+    "description": "Flagship Qwen model for complex reasoning, coding, and agentic workflows",
+    "family": "qwen",
+    "id": "alibaba/qwen-max",
+    "knowledge": "2024-04",
+    "last_updated": "2025-01-25",
+    "limit": {
+     "context": 32768,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen Max (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-04-03",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen-omni-turbo": {
+    "attachment": true,
+    "cost": {
+     "input": 0.2,
+     "output": 0.8
+    },
+    "description": "Qwen omni model for text, vision, audio, and multimodal agent tasks",
+    "family": "qwen",
+    "id": "alibaba/qwen-omni-turbo",
+    "knowledge": "2024-04",
+    "last_updated": "2025-03-26",
+    "limit": {
+     "context": 32768,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+     ],
+     "output": [
+      "text",
+      "audio"
+     ]
+    },
+    "name": "Qwen Omni Turbo (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-01-19",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "alibaba/qwen-plus": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.08,
+     "cache_write": 0.5,
+     "input": 0.4,
+     "output": 1.2
+    },
+    "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+    "family": "qwen",
+    "id": "alibaba/qwen-plus",
+    "knowledge": "2024-04",
+    "last_updated": "2025-09-11",
+    "limit": {
+     "context": 131072,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen Plus (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-01-25",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen-plus-latest": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.08,
+     "cache_write": 0.5,
+     "input": 0.4,
+     "output": 1.2
+    },
+    "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+    "family": "qwen",
+    "id": "alibaba/qwen-plus-latest",
+    "last_updated": "2024-09-09",
+    "limit": {
+     "context": 1000000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen Plus Latest (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-09-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3-coder-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "cache_write": 0.375,
+     "input": 0.3,
+     "output": 1.5
+    },
+    "description": "Qwen coding model for software agents, repository edits, and code reasoning",
+    "family": "qwen",
+    "id": "alibaba/qwen3-coder-flash",
+    "knowledge": "2025-04",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Coder Flash (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-07-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3-coder-plus": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 1.2,
+     "cache_write": 7.5,
+     "input": 6,
+     "output": 60
+    },
+    "description": "Hosted Qwen coder for software agents, repo edits, and long-context code",
+    "family": "qwen",
+    "id": "alibaba/qwen3-coder-plus",
+    "knowledge": "2025-04",
+    "last_updated": "2025-07-23",
+    "limit": {
+     "context": 1000000,
+     "output": 66000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Coder Plus (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-07-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3-max": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.6,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Flagship Qwen3 model for coding agents, complex reasoning, and tool use",
+    "family": "qwen",
+    "id": "alibaba/qwen3-max",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09-23",
+    "limit": {
+     "context": 256000,
+     "output": 32800
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Max (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-09-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3-vl-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.05,
+     "output": 0.4
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "id": "alibaba/qwen3-vl-flash",
+    "last_updated": "2025-10-15",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 VL Flash (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-10-15",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3-vl-plus": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.04,
+     "cache_write": 0.25,
+     "input": 0.2,
+     "output": 1.6
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "alibaba/qwen3-vl-plus",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09-23",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 VL Plus (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-09-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "alibaba/qwen3.6-35b-a3b": {
+    "attachment": true,
+    "cost": {
+     "input": 0.248,
+     "output": 1.485
+    },
+    "description": "Open multimodal Qwen MoE for local agents that need vision, audio, and code",
+    "family": "qwen",
+    "id": "alibaba/qwen3.6-35b-a3b",
+    "last_updated": "2026-04-17",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.6 35B A3B (Alibaba Cloud)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-17",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.6-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "cache_write": 0.3125,
+     "input": 0.25,
+     "output": 1.5
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen3.6",
+    "id": "alibaba/qwen3.6-flash",
+    "last_updated": "2026-04-27",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.6 Flash (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-27",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.6-max-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.13,
+     "input": 1.3,
+     "output": 7.8
+    },
+    "description": "Flagship Qwen model for complex reasoning, coding, and agentic workflows",
+    "family": "qwen",
+    "id": "alibaba/qwen3.6-max-preview",
+    "knowledge": "2025-04",
+    "last_updated": "2026-04-20",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.6 Max Preview (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-04-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.6-plus": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "context_over_200k": {
+      "cache_read": 0.2,
+      "cache_write": 2.5,
+      "input": 2,
+      "output": 6
+     },
+     "input": 0.5,
+     "output": 3,
+     "tiers": [
+      {
+       "cache_read": 0.2,
+       "cache_write": 2.5,
+       "input": 2,
+       "output": 6,
+       "tier": {
+        "size": 256000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Earlier Qwen multimodal workhorse for million-token agent and document tasks",
+    "family": "qwen",
+    "id": "alibaba/qwen3.6-plus",
+    "knowledge": "2025-04",
+    "last_updated": "2026-04-02",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.6 Plus (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.7-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.006,
+     "cache_write": 0.0375,
+     "input": 0.03,
+     "output": 0.13
+    },
+    "description": "Lightweight multimodal Qwen model for high-throughput text, image, and video tasks",
+    "family": "qwen",
+    "id": "alibaba/qwen3.7-flash",
+    "last_updated": "2026-07-15",
+    "limit": {
+     "context": 1000000,
+     "input": 991000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.7 Flash (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-15",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.7-max": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 3.125,
+     "input": 2.5,
+     "output": 7.5
+    },
+    "description": "Qwen frontier model tuned for agent frameworks, coding assistants, and long tasks",
+    "family": "qwen",
+    "id": "alibaba/qwen3.7-max",
+    "last_updated": "2026-05-21",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.7 Max (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-05-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.7-plus": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.08,
+     "cache_write": 0.5,
+     "input": 0.4,
+     "output": 1.6
+    },
+    "description": "Multimodal Qwen workhorse for long-context agents, visual inputs, and coding",
+    "family": "qwen",
+    "id": "alibaba/qwen3.7-plus",
+    "knowledge": "2025-04",
+    "last_updated": "2026-06-02",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.7 Plus (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.8-max": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "alibaba/qwen3.8-max",
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-03",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen35-397b-a17b": {
+    "attachment": true,
+    "cost": {
+     "input": 0.6,
+     "output": 3.6
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen3.5",
+    "id": "alibaba/qwen35-397b-a17b",
+    "last_updated": "2026-02-16",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.5 397B A17B (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-16",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-fable-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 1,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-5",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-09",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-haiku-4-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "cache_write": 1.25,
+     "input": 1,
+     "output": 5
+    },
+    "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
+    "family": "claude-haiku",
+    "id": "anthropic/claude-haiku-4-5",
+    "knowledge": "2025-02-28",
+    "last_updated": "2025-10-15",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Haiku 4.5 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-10-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-haiku-4-5-20251001": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "cache_write": 1.25,
+     "input": 1,
+     "output": 5
+    },
+    "description": "Fast Claude model for responsive assistance, classification, and lightweight agents",
+    "family": "claude-haiku",
+    "id": "anthropic/claude-haiku-4-5-20251001",
+    "knowledge": "2025-02-28",
+    "last_updated": "2025-10-15",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Haiku 4.5 (2025-10-01) (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-10-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-4-5-20251101": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-4-5-20251101",
+    "knowledge": "2025-05",
+    "last_updated": "2025-11-01",
+    "limit": {
+     "context": 200000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.5 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 31999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-11-01",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-4-6",
+    "knowledge": "2025-05-31",
+    "last_updated": "2026-03-13",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.6 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-4-7": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-4-7",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-04-16",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.7 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-4-8": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-4-8",
+    "knowledge": "2026-01",
+    "last_updated": "2026-05-28",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.8 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-05-28",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Strongest Claude Opus model for coding, agents, and professional work",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-5",
+    "knowledge": "2026-05",
+    "last_updated": "2026-07-24",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 5 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-24",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-sonnet-4-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
+    "family": "claude-sonnet",
+    "id": "anthropic/claude-sonnet-4-5",
+    "knowledge": "2025-07-31",
+    "last_updated": "2025-09-29",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.5 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 63999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-09-29",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-sonnet-4-5-20250929": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
+    "family": "claude-sonnet",
+    "id": "anthropic/claude-sonnet-4-5-20250929",
+    "knowledge": "2025-07-31",
+    "last_updated": "2025-09-29",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.5 (2025-09-29) (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 63999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-09-29",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-sonnet-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
+    "family": "claude-sonnet",
+    "id": "anthropic/claude-sonnet-4-6",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-13",
+    "limit": {
+     "context": 1000000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.6 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 63999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-sonnet-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
+    },
+    "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+    "family": "claude-sonnet",
+    "id": "anthropic/claude-sonnet-5",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-30",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 5 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-30",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-fable-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 1,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "id": "aws-bedrock/claude-fable-5",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-09",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-09",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-haiku-4-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "cache_write": 1.25,
+     "input": 1,
+     "output": 5
+    },
+    "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
+    "family": "claude-haiku",
+    "id": "aws-bedrock/claude-haiku-4-5",
+    "knowledge": "2025-02-28",
+    "last_updated": "2025-10-15",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Haiku 4.5 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-10-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-haiku-4-5-20251001": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "cache_write": 1.25,
+     "input": 1,
+     "output": 5
+    },
+    "description": "Fast Claude model for responsive assistance, classification, and lightweight agents",
+    "family": "claude-haiku",
+    "id": "aws-bedrock/claude-haiku-4-5-20251001",
+    "knowledge": "2025-02-28",
+    "last_updated": "2025-10-15",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Haiku 4.5 (2025-10-01) (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-10-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-opus-4-1-20250805": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 1.5,
+     "cache_write": 18.75,
+     "input": 15,
+     "output": 75
+    },
+    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "aws-bedrock/claude-opus-4-1-20250805",
+    "knowledge": "2025-03-31",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 200000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.1 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 31999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-opus-4-5-20251101": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "aws-bedrock/claude-opus-4-5-20251101",
+    "knowledge": "2025-05",
+    "last_updated": "2025-11-01",
+    "limit": {
+     "context": 200000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.5 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 31999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-11-01",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-opus-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
+    "family": "claude-opus",
+    "id": "aws-bedrock/claude-opus-4-6",
+    "knowledge": "2025-05-31",
+    "last_updated": "2026-03-13",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.6 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-opus-4-7": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
+    "family": "claude-opus",
+    "id": "aws-bedrock/claude-opus-4-7",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-04-16",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.7 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-16",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-opus-4-8": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "aws-bedrock/claude-opus-4-8",
+    "knowledge": "2026-01",
+    "last_updated": "2026-05-28",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.8 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-05-28",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-opus-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Strongest Claude Opus model for coding, agents, and professional work",
+    "family": "claude-opus",
+    "id": "aws-bedrock/claude-opus-5",
+    "knowledge": "2026-05",
+    "last_updated": "2026-07-24",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 5 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-24",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-sonnet-4-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
+    "family": "claude-sonnet",
+    "id": "aws-bedrock/claude-sonnet-4-5",
+    "knowledge": "2025-07-31",
+    "last_updated": "2025-09-29",
+    "limit": {
+     "context": 200000,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.5 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 63999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-09-29",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-sonnet-4-5-20250929": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
+    "family": "claude-sonnet",
+    "id": "aws-bedrock/claude-sonnet-4-5-20250929",
+    "knowledge": "2025-07-31",
+    "last_updated": "2025-09-29",
+    "limit": {
+     "context": 200000,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.5 (2025-09-29) (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 63999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-09-29",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-sonnet-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
+    "family": "claude-sonnet",
+    "id": "aws-bedrock/claude-sonnet-4-6",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-13",
+    "limit": {
+     "context": 1000000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.6 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 63999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "aws-bedrock/claude-sonnet-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
+    },
+    "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+    "family": "claude-sonnet",
+    "id": "aws-bedrock/claude-sonnet-5",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-30",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 5 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-30",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "aws-bedrock/grok-4-3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2.5,
+      "output": 5
+     },
+     "input": 1.25,
+     "output": 2.5,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2.5,
+       "output": 5,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "aws-bedrock/grok-4-3",
+    "last_updated": "2026-04-30",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.3 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-30",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "aws-bedrock/grok-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "aws-bedrock/grok-4-6",
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6 (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "aws-bedrock/llama-3.1-70b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.72,
+     "output": 0.72
+    },
+    "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+    "family": "llama",
+    "id": "aws-bedrock/llama-3.1-70b-instruct",
+    "last_updated": "2024-07-23",
+    "limit": {
+     "context": 128000,
+     "output": 2048
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 3.1 70B Instruct (AWS Bedrock)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-07-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "aws-bedrock/llama-4-maverick-17b-instruct": {
+    "attachment": true,
+    "cost": {
+     "input": 0.24,
+     "output": 0.97
+    },
+    "description": "Open multimodal Llama for strong reasoning with efficient everyday serving",
+    "family": "llama",
+    "id": "aws-bedrock/llama-4-maverick-17b-instruct",
+    "knowledge": "2024-08",
+    "last_updated": "2025-04-05",
+    "limit": {
+     "context": 8192,
+     "output": 2048
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 4 Maverick 17B Instruct (AWS Bedrock)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-04-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "aws-bedrock/llama-4-scout-17b-instruct": {
+    "attachment": true,
+    "cost": {
+     "input": 0.17,
+     "output": 0.66
+    },
+    "description": "Open Llama with long-context vision for efficient multimodal agents",
+    "family": "llama",
+    "id": "aws-bedrock/llama-4-scout-17b-instruct",
+    "knowledge": "2024-08",
+    "last_updated": "2025-04-05",
+    "limit": {
+     "context": 8192,
+     "output": 2048
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 4 Scout 17B Instruct (AWS Bedrock)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-04-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "aws-mantle/gpt-5.6-luna": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.022,
+     "cache_write": 0.275,
+     "input": 0.22,
+     "output": 1.32
+    },
+    "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+    "family": "gpt-luna",
+    "id": "aws-mantle/gpt-5.6-luna",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 278528,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Luna (AWS Mantle)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "aws-mantle/gpt-5.6-sol": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.55,
+     "cache_write": 6.875,
+     "input": 5.5,
+     "output": 33
+    },
+    "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+    "family": "gpt-sol",
+    "id": "aws-mantle/gpt-5.6-sol",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 278528,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Sol (AWS Mantle)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "aws-mantle/gpt-5.6-terra": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.22,
+     "cache_write": 2.75,
+     "input": 2.2,
+     "output": 13.2
+    },
+    "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+    "family": "gpt-terra",
+    "id": "aws-mantle/gpt-5.6-terra",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 278528,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Terra (AWS Mantle)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure-ai-foundry/grok-4-1-fast-non-reasoning": {
+    "attachment": true,
+    "cost": {
+     "input": 0.2,
+     "output": 0.5
+    },
+    "description": "Fast Grok model for responsive chat, reasoning, and tool-assisted work",
+    "family": "grok",
+    "id": "azure-ai-foundry/grok-4-1-fast-non-reasoning",
+    "last_updated": "2025-11-19",
+    "limit": {
+     "context": 2000000,
+     "output": 30000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.1 Fast Non-Reasoning (Azure AI Foundry)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-11-19",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure-ai-foundry/grok-4-1-fast-reasoning": {
+    "attachment": true,
+    "cost": {
+     "input": 0.2,
+     "output": 0.5
+    },
+    "description": "Fast Grok model for responsive chat, reasoning, and tool-assisted work",
+    "family": "grok",
+    "id": "azure-ai-foundry/grok-4-1-fast-reasoning",
+    "last_updated": "2025-11-19",
+    "limit": {
+     "context": 2000000,
+     "output": 30000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.1 Fast Reasoning (Azure AI Foundry)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-11-19",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure-ai-foundry/grok-4-3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2.5,
+      "output": 5
+     },
+     "input": 1.25,
+     "output": 2.5,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2.5,
+       "output": 5,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "azure-ai-foundry/grok-4-3",
+    "last_updated": "2026-04-30",
+    "limit": {
+     "context": 20000,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.3 (Azure AI Foundry)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-30",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure/gpt-3.5-turbo": {
+    "attachment": false,
+    "cost": {
+     "input": 0.5,
+     "output": 1.5
+    },
+    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
+    "family": "gpt",
+    "id": "azure/gpt-3.5-turbo",
+    "knowledge": "2021-09-01",
+    "last_updated": "2023-11-06",
+    "limit": {
+     "context": 16385,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-3.5 Turbo (Azure)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2023-03-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure/gpt-4": {
+    "attachment": false,
+    "cost": {
+     "input": 30,
+     "output": 60
+    },
+    "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+    "family": "gpt",
+    "id": "azure/gpt-4",
+    "knowledge": "2023-11",
+    "last_updated": "2024-04-09",
+    "limit": {
+     "context": 8192,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4 (Azure)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2023-11-06",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure/gpt-4-turbo": {
+    "attachment": true,
+    "cost": {
+     "input": 10,
+     "output": 30
+    },
+    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
+    "family": "gpt",
+    "id": "azure/gpt-4-turbo",
+    "knowledge": "2023-12",
+    "last_updated": "2024-04-09",
+    "limit": {
+     "context": 128000,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4 Turbo (Azure)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2023-11-06",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure/gpt-4.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 8
+    },
+    "description": "Long-lived GPT workhorse for coding, instruction following, and production apps",
+    "family": "gpt",
+    "id": "azure/gpt-4.1",
+    "knowledge": "2024-04",
+    "last_updated": "2025-04-14",
+    "limit": {
+     "context": 1000000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4.1 (Azure)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure/gpt-4.1-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.4,
+     "output": 1.6
+    },
+    "description": "Affordable GPT-4.1 lane for fast coding help and structured extraction",
+    "family": "gpt-mini",
+    "id": "azure/gpt-4.1-mini",
+    "knowledge": "2024-04",
+    "last_updated": "2025-04-14",
+    "limit": {
+     "context": 1000000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4.1 Mini (Azure)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure/gpt-4.1-nano": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Tiny GPT-4.1 option for classification, routing, and very high-volume tasks",
+    "family": "gpt-nano",
+    "id": "azure/gpt-4.1-nano",
+    "knowledge": "2024-04",
+    "last_updated": "2025-04-14",
+    "limit": {
+     "context": 1000000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4.1 Nano (Azure)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure/gpt-4o": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 1.25,
+     "input": 2.5,
+     "output": 10
+    },
+    "description": "Omni-era GPT for multimodal chat, practical coding, and general assistants",
+    "family": "gpt",
+    "id": "azure/gpt-4o",
+    "knowledge": "2023-09",
+    "last_updated": "2024-08-06",
+    "limit": {
+     "context": 128000,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4o (Azure)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-05-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure/gpt-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.125,
+     "input": 1.25,
+     "output": 10
+    },
+    "description": "Original GPT-5 workhorse for reasoning, coding, writing, and tool workflows",
+    "family": "gpt",
+    "id": "azure/gpt-5",
+    "knowledge": "2024-09-30",
+    "last_updated": "2025-08-07",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5 (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-07",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "input": 0.25,
+     "output": 2
+    },
+    "description": "Small GPT-5 for responsive agents, coding help, and everyday automation",
+    "family": "gpt-mini",
+    "id": "azure/gpt-5-mini",
+    "knowledge": "2024-05-30",
+    "last_updated": "2025-08-07",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5 Mini (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-07",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5-nano": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.005,
+     "input": 0.05,
+     "output": 0.4
+    },
+    "description": "Tiny GPT-5 lane for routing, extraction, classification, and bulk jobs",
+    "family": "gpt-nano",
+    "id": "azure/gpt-5-nano",
+    "knowledge": "2024-05-30",
+    "last_updated": "2025-08-07",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5 Nano (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-07",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.125,
+     "input": 1.25,
+     "output": 10
+    },
+    "description": "Sharper GPT-5 generation for coding, product work, and tool-assisted tasks",
+    "family": "gpt",
+    "id": "azure/gpt-5.1",
+    "knowledge": "2024-09-30",
+    "last_updated": "2025-11-13",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.1 (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2025-11-13",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.1-codex": {
+    "attachment": true,
+    "cost": {
+     "input": 1.25,
+     "output": 10
+    },
+    "description": "Codex GPT for repository edits, code review, and practical software agents",
+    "family": "gpt-codex",
+    "id": "azure/gpt-5.1-codex",
+    "knowledge": "2024-09-30",
+    "last_updated": "2025-11-13",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 272000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.1 Codex (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-11-13",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.1-codex-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "input": 0.25,
+     "output": 2
+    },
+    "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
+    "family": "gpt-codex",
+    "id": "azure/gpt-5.1-codex-mini",
+    "knowledge": "2024-09-30",
+    "last_updated": "2025-11-13",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.1 Codex mini (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-11-13",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.2": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.175,
+     "input": 1.75,
+     "output": 14
+    },
+    "description": "Reliable GPT generation for broad coding, writing, and tool-assisted product work",
+    "family": "gpt",
+    "id": "azure/gpt-5.2",
+    "knowledge": "2025-08-31",
+    "last_updated": "2025-12-11",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.2 (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2025-12-11",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.2-codex": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.175,
+     "input": 1.75,
+     "output": 14
+    },
+    "description": "Code-specialist GPT for repository edits, reviews, and long-running software agents",
+    "family": "gpt-codex",
+    "id": "azure/gpt-5.2-codex",
+    "knowledge": "2025-08-31",
+    "last_updated": "2025-12-11",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.2 Codex (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2025-12-11",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.2-pro": {
+    "attachment": true,
+    "cost": {
+     "input": 21,
+     "output": 168
+    },
+    "description": "Higher-accuracy GPT-5.2 variant for tougher reasoning and review workflows",
+    "family": "gpt-pro",
+    "id": "azure/gpt-5.2-pro",
+    "knowledge": "2025-08-31",
+    "last_updated": "2025-12-11",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 272000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.2 Pro (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2025-12-11",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.3-codex": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.175,
+     "input": 1.75,
+     "output": 14
+    },
+    "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
+    "family": "gpt-codex",
+    "id": "azure/gpt-5.3-codex",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-02-05",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.3 Codex (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-02-05",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.4": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "input": 2.5,
+     "output": 15
+    },
+    "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
+    "family": "gpt",
+    "id": "azure/gpt-5.4",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-05",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-05",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.4-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 4.5
+    },
+    "description": "Strong small GPT for coding subagents, quick tool use, and high-volume work",
+    "family": "gpt-mini",
+    "id": "azure/gpt-5.4-mini",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-17",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 Mini (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-17",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.4-nano": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02,
+     "input": 0.2,
+     "output": 1.25
+    },
+    "description": "Cheapest GPT-5.4 lane for simple routing, extraction, and bulk automation",
+    "family": "gpt-nano",
+    "id": "azure/gpt-5.4-nano",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-17",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 Nano (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-17",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.4-pro": {
+    "attachment": true,
+    "cost": {
+     "input": 30,
+     "output": 180
+    },
+    "description": "More exact GPT-5.4 tier for demanding professional reasoning and agent tasks",
+    "family": "gpt-pro",
+    "id": "azure/gpt-5.4-pro",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-05",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 Pro (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-05",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "context_over_200k": {
+      "cache_read": 1,
+      "input": 10,
+      "output": 45
+     },
+     "input": 5,
+     "output": 30,
+     "tiers": [
+      {
+       "cache_read": 1,
+       "input": 10,
+       "output": 45,
+       "tier": {
+        "size": 272000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Default frontier GPT for coding, computer use, research, and knowledge work",
+    "family": "gpt",
+    "id": "azure/gpt-5.5",
+    "knowledge": "2025-12-01",
+    "last_updated": "2026-04-23",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.5 (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-04-23",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.6-luna": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02,
+     "cache_write": 0.25,
+     "input": 0.2,
+     "output": 1.2
+    },
+    "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+    "family": "gpt-luna",
+    "id": "azure/gpt-5.6-luna",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Luna (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.6-sol": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 30
+    },
+    "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+    "family": "gpt-sol",
+    "id": "azure/gpt-5.6-sol",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Sol (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-5.6-terra": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 12
+    },
+    "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+    "family": "gpt-terra",
+    "id": "azure/gpt-5.6-terra",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Terra (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure/gpt-oss-120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.15,
+     "output": 0.6
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "azure/gpt-oss-120b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B (Azure)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure/o1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 7.5,
+     "input": 15,
+     "output": 60
+    },
+    "description": "O-series reasoning model for hard analysis, math, coding, and planning",
+    "family": "o",
+    "id": "azure/o1",
+    "knowledge": "2023-09",
+    "last_updated": "2024-12-05",
+    "limit": {
+     "context": 200000,
+     "output": 100000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "o1 (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2024-12-05",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": false
+   },
+   "azure/o3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 8
+    },
+    "description": "Deliberate o-series reasoner for hard math, coding, and multi-step analysis",
+    "family": "o",
+    "id": "azure/o3",
+    "knowledge": "2024-05",
+    "last_updated": "2025-04-16",
+    "limit": {
+     "context": 200000,
+     "output": 100000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "o3 (Azure)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": false
+   },
+   "azure/o3-mini": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.55,
+     "input": 1.1,
+     "output": 4.4
+    },
+    "description": "Smaller o-series reasoner for economical coding, math, and planning tasks",
+    "family": "o-mini",
+    "id": "azure/o3-mini",
+    "knowledge": "2024-05",
+    "last_updated": "2025-01-29",
+    "limit": {
+     "context": 200000,
+     "output": 100000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "o3 Mini (Azure)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-12-20",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": false
+   },
+   "azure/o4-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.275,
+     "input": 1.1,
+     "output": 4.4
+    },
+    "description": "Fast o-series model for compact reasoning, coding, and tool use",
+    "family": "o-mini",
+    "id": "azure/o4-mini",
+    "knowledge": "2024-05",
+    "last_updated": "2025-04-16",
+    "limit": {
+     "context": 200000,
+     "output": 100000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "o4 Mini (Azure)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-04-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "baidu/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.028,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "baidu/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (Baidu)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "baidu/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.14,
+     "input": 1.69,
+     "output": 3.38
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "baidu/deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro (Baidu)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "baidu/glm-5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
+    },
+    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
+    "family": "glm",
+    "id": "baidu/glm-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 202752,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5 (Baidu)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "baidu/glm-5.1": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
+    "family": "glm",
+    "id": "baidu/glm-5.1",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-04-07",
+    "limit": {
+     "context": 202752,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.1 (Baidu)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-07",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "baidu/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "baidu/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 (Baidu)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "baidu/kimi-k2.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.16,
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
+    "family": "kimi-k2",
+    "id": "baidu/kimi-k2.6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-21",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.6 (Baidu)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "bytedance/deepseek-v3.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.056,
+     "input": 0.28,
+     "output": 0.42
+    },
+    "description": "Hybrid-reasoning DeepSeek model with thinking and non-thinking modes, sparse attention, and tool-use",
+    "family": "deepseek",
+    "id": "bytedance/deepseek-v3.2",
+    "knowledge": "2024-07",
+    "last_updated": "2025-12-01",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V3.2 (ByteDance)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "bytedance/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.014,
+     "input": 0.44,
+     "output": 1.32
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "bytedance/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (ByteDance)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "bytedance/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.044,
+     "input": 1.32,
+     "output": 3.96
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "bytedance/deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro (ByteDance)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "bytedance/glm-4.7": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.6,
+     "output": 2.2
+    },
+    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
+    "family": "glm",
+    "id": "bytedance/glm-4.7",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.7 (ByteDance)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "bytedance/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "bytedance/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1024000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 (ByteDance)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "bytedance/gpt-oss-120b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.02,
+     "input": 0.1,
+     "output": 0.5
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "bytedance/gpt-oss-120b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 128000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B (ByteDance)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "bytedance/seed-1-6-250615": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.25,
+     "output": 2
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "seed",
+    "id": "bytedance/seed-1-6-250615",
+    "last_updated": "2025-06-25",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 1.6 (250615) (ByteDance)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-06-25",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "bytedance/seed-1-6-250915": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.25,
+     "output": 2
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "seed",
+    "id": "bytedance/seed-1-6-250915",
+    "last_updated": "2025-09-15",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 1.6 (250915) (ByteDance)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-09-15",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "bytedance/seed-1-6-flash-250715": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "input": 0.07,
+     "output": 0.3
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "seed",
+    "id": "bytedance/seed-1-6-flash-250715",
+    "last_updated": "2025-07-26",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 1.6 Flash (250715) (ByteDance)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-07-26",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "bytedance/seed-1-8-251228": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.25,
+     "output": 2
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "seed",
+    "id": "bytedance/seed-1-8-251228",
+    "last_updated": "2025-12-18",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 1.8 (251228) (ByteDance)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-12-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "canopywave/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "canopywave/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (CanopyWave)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "canopywave/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 1.74,
+     "output": 3.48
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "canopywave/deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro (CanopyWave)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "canopywave/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "canopywave/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 200000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 (CanopyWave)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "canopywave/kimi-k2.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.16,
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
+    "family": "kimi-k2",
+    "id": "canopywave/kimi-k2.6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-21",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.6 (CanopyWave)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "canopywave/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "canopywave/kimi-k3",
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3 (CanopyWave)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "cerebras/gemma-4-31b-it": {
+    "attachment": true,
+    "cost": {
+     "input": 0.99,
+     "output": 1.49
+    },
+    "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
+    "family": "gemma",
+    "id": "cerebras/gemma-4-31b-it",
+    "last_updated": "2026-04-02",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 31B IT (Cerebras)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "cerebras/glm-4.7": {
+    "attachment": false,
+    "cost": {
+     "input": 2.25,
+     "output": 2.75
+    },
+    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
+    "family": "glm",
+    "id": "cerebras/glm-4.7",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.7 (Cerebras)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "cerebras/gpt-oss-120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.35,
+     "output": 0.75
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "cerebras/gpt-oss-120b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B (Cerebras)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "cerebras/llama-3.3-70b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.85,
+     "output": 1.2
+    },
+    "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
+    "family": "llama",
+    "id": "cerebras/llama-3.3-70b-instruct",
+    "knowledge": "2023-12",
+    "last_updated": "2024-12-06",
+    "limit": {
+     "context": 128000,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 3.3 70B Instruct (Cerebras)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2024-12-06",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "cerebras/qwen3-235b-a22b-instruct-2507": {
+    "attachment": false,
+    "cost": {
+     "input": 0.6,
+     "output": 1.2
+    },
+    "description": "Updated large open Qwen3 MoE instruct model for multilingual chat, coding, and tool use",
+    "family": "qwen",
+    "id": "cerebras/qwen3-235b-a22b-instruct-2507",
+    "last_updated": "2025-07-21",
+    "limit": {
+     "context": 262000,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 235B A22B Instruct 2507 (Cerebras)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-07-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/deepseek-v3.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.13,
+     "input": 0.26,
+     "output": 0.38
+    },
+    "description": "Hybrid-reasoning DeepSeek model with thinking and non-thinking modes, sparse attention, and tool-use",
+    "family": "deepseek",
+    "id": "deepinfra/deepseek-v3.2",
+    "knowledge": "2024-07",
+    "last_updated": "2025-12-01",
+    "limit": {
+     "context": 160000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V3.2 (DeepInfra)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-12-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.016,
+     "input": 0.08,
+     "output": 0.18
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "deepinfra/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (DeepInfra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 1.3,
+     "output": 2.6
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "deepinfra/deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro (DeepInfra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/gemma-4-26b-a4b-it": {
+    "attachment": false,
+    "cost": {
+     "input": 0.07,
+     "output": 0.34
+    },
+    "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+    "family": "gemma",
+    "id": "deepinfra/gemma-4-26b-a4b-it",
+    "last_updated": "2026-04-02",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 26B A4B IT (DeepInfra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-04-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/gemma-4-31b-it": {
+    "attachment": false,
+    "cost": {
+     "input": 0.13,
+     "output": 0.38
+    },
+    "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
+    "family": "gemma",
+    "id": "deepinfra/gemma-4-31b-it",
+    "last_updated": "2026-04-02",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 31B IT (DeepInfra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/glm-5.1": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.205,
+     "input": 1.05,
+     "output": 3.5
+    },
+    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
+    "family": "glm",
+    "id": "deepinfra/glm-5.1",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-04-07",
+    "limit": {
+     "context": 198000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.1 (DeepInfra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-07",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/hy3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.035,
+     "input": 0.14,
+     "output": 0.58
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "deepinfra/hy3",
+    "last_updated": "2026-07-06",
+    "limit": {
+     "context": 262144,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy3 (DeepInfra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-06",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/kimi-k2.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.07,
+     "input": 0.45,
+     "output": 2.25
+    },
+    "description": "Earlier Kimi frontier model for long-context agents, coding, and multimodal work",
+    "family": "kimi-k2",
+    "id": "deepinfra/kimi-k2.5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-01",
+    "limit": {
+     "context": 256000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.5 (DeepInfra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-01",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "deepinfra/ling-3.0-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.012,
+     "input": 0.06,
+     "output": 0.18
+    },
+    "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+    "family": "ling",
+    "id": "deepinfra/ling-3.0-flash",
+    "last_updated": "2026-08-02",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "InclusionAI Ling 3.0 Flash (DeepInfra)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/mimo-v2.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.08,
+     "context_over_200k": {
+      "cache_read": 0.16,
+      "input": 0.8,
+      "output": 4
+     },
+     "input": 0.4,
+     "output": 2,
+     "tiers": [
+      {
+       "cache_read": 0.16,
+       "input": 0.8,
+       "output": 4,
+       "tier": {
+        "size": 256000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Open MiMo model for multimodal coding agents and long-context automation",
+    "family": "mimo",
+    "id": "deepinfra/mimo-v2.5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2024-12",
+    "last_updated": "2026-04-22",
+    "limit": {
+     "context": 262144,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiMo V2.5 (DeepInfra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-22",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/mimo-v2.5-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2,
+      "output": 6
+     },
+     "input": 1,
+     "output": 3,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2,
+       "output": 6,
+       "tier": {
+        "size": 256000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
+    "family": "mimo",
+    "id": "deepinfra/mimo-v2.5-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2024-12",
+    "last_updated": "2026-04-22",
+    "limit": {
+     "context": 1048576,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiMo V2.5 Pro (DeepInfra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "deepinfra/nemotron-3-ultra-550b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.5,
+     "output": 2.2
+    },
+    "description": "Nemotron multimodal model for visual reasoning and agentic AI workflows",
+    "family": "nemotron",
+    "id": "deepinfra/nemotron-3-ultra-550b",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Nemotron 3 Ultra 550B (DeepInfra)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-06-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/qwen3-vl-235b-a22b-instruct": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.2,
+     "output": 0.88
+    },
+    "description": "Qwen vision-language instruct model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "deepinfra/qwen3-vl-235b-a22b-instruct",
+    "knowledge": "2025-03-31",
+    "last_updated": "2025-09-23",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 VL 235B A22B Instruct (DeepInfra)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-09-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/qwen3-vl-30b-a3b-instruct": {
+    "attachment": true,
+    "cost": {
+     "input": 0.15,
+     "output": 0.6
+    },
+    "description": "Multimodal model for analyzing text, images, documents, and rich media",
+    "id": "deepinfra/qwen3-vl-30b-a3b-instruct",
+    "last_updated": "2025-10-05",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 VL 30B A3B Instruct (DeepInfra)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-10-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepinfra/qwen3.5-9b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.1,
+     "output": 0.15
+    },
+    "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+    "family": "qwen",
+    "id": "deepinfra/qwen3.5-9b",
+    "last_updated": "2026-02-23",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.5 9B (DeepInfra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-02-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0028,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1050000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (DeepSeek)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.003625,
+     "input": 0.435,
+     "output": 0.87
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "deepseek/deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1050000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro (DeepSeek)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "embercloud/glm-4.5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.6,
+     "output": 2.2
+    },
+    "description": "Hybrid-reasoning GLM release that made the 4.5 line broadly useful",
+    "family": "glm",
+    "id": "embercloud/glm-4.5",
+    "knowledge": "2025-04",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 131000,
+     "output": 96000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.5 (EmberCloud)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-07-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "embercloud/glm-4.5-air": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.025,
+     "input": 0.13,
+     "output": 0.85
+    },
+    "description": "Lighter GLM-4.5 variant for fast coding assistance and cheaper agents",
+    "family": "glm-air",
+    "id": "embercloud/glm-4.5-air",
+    "knowledge": "2025-04",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 131000,
+     "output": 96000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.5 Air (EmberCloud)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-07-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "embercloud/glm-4.7": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.19,
+     "input": 0.38,
+     "output": 1.98
+    },
+    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
+    "family": "glm",
+    "id": "embercloud/glm-4.7",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 200000,
+     "output": 131000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.7 (EmberCloud)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "embercloud/glm-4.7-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.06,
+     "output": 0.4
+    },
+    "description": "Budget GLM lane for fast coding help, routing, and everyday automation",
+    "family": "glm-flash",
+    "id": "embercloud/glm-4.7-flash",
+    "knowledge": "2025-04",
+    "last_updated": "2026-01-19",
+    "limit": {
+     "context": 200000,
+     "output": 131000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.7 Flash (EmberCloud)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-01-19",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "embercloud/glm-5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.144,
+     "input": 0.72,
+     "output": 2.3
+    },
+    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
+    "family": "glm",
+    "id": "embercloud/glm-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 203000,
+     "output": 131000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5 (EmberCloud)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "embercloud/glm-5.1": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.173,
+     "input": 0.931,
+     "output": 2.93
+    },
+    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
+    "family": "glm",
+    "id": "embercloud/glm-5.1",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-04-07",
+    "limit": {
+     "context": 203000,
+     "output": 131000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.1 (EmberCloud)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-04-07",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "embercloud/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.234,
+     "input": 1.26,
+     "output": 3.96
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "embercloud/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 203000,
+     "output": 131000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 (EmberCloud)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "embercloud/kimi-k2.5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.225,
+     "input": 0.405,
+     "output": 1.98
+    },
+    "description": "Earlier Kimi frontier model for long-context agents, coding, and multimodal work",
+    "family": "kimi-k2",
+    "id": "embercloud/kimi-k2.5",
+    "knowledge": "2025-01",
+    "last_updated": "2026-01",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.5 (EmberCloud)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-01",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "embercloud/qwen3-coder-next": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.108,
+     "output": 0.675
+    },
+    "description": "Open-weight Qwen coding model for agents, repository edits, and multi-turn tool use",
+    "family": "qwen",
+    "id": "embercloud/qwen3-coder-next",
+    "knowledge": "2025-09",
+    "last_updated": "2026-02-03",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Coder Next (EmberCloud)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-02-03",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "fireworks/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.028,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "fireworks/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (Fireworks AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "fireworks/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.044,
+     "input": 1.32,
+     "output": 3.96
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "fireworks/deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro (Fireworks AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "fireworks/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "fireworks/kimi-k3",
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1040384,
+     "output": 1040384
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3 (Fireworks AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "fireworks/kimi-k3-fast": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.45,
+     "input": 4.5,
+     "output": 22.5
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "fireworks/kimi-k3-fast",
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1040384,
+     "output": 1040384
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3 Fast (Fireworks AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "gonka24/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0155,
+     "input": 0.075,
+     "output": 0.175
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "gonka24/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 390000,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (Gonka24)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gonka24/kimi-k2.6": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.048,
+     "input": 0.22,
+     "output": 1.137
+    },
+    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
+    "family": "kimi-k2",
+    "id": "gonka24/kimi-k2.6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-21",
+    "limit": {
+     "context": 262144,
+     "output": 98304
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.6 (Gonka24)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gonka24/minimax-m2.7": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.017,
+     "input": 0.08,
+     "output": 0.32
+    },
+    "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+    "family": "minimax",
+    "id": "gonka24/minimax-m2.7",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 204800,
+     "output": 131100
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.7 (Gonka24)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-03-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-2.5-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.3,
+     "output": 2.5
+    },
+    "description": "Fast Gemini workhorse for multimodal apps where latency and price matter",
+    "family": "gemini-flash",
+    "id": "google-ai-studio/gemini-2.5-flash",
+    "knowledge": "2025-01",
+    "last_updated": "2025-06-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 2.5 Flash (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 24576,
+      "min": 1,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-06-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-2.5-flash-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Lean Gemini 2.5 lane for cheap multimodal traffic and quick agents",
+    "family": "gemini-flash-lite",
+    "id": "google-ai-studio/gemini-2.5-flash-lite",
+    "knowledge": "2025-01",
+    "last_updated": "2025-06-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 2.5 Flash Lite (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-06-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-2.5-pro": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.125,
+     "context_over_200k": {
+      "cache_read": 0.25,
+      "input": 2.5,
+      "output": 15
+     },
+     "input": 1.25,
+     "output": 10,
+     "tiers": [
+      {
+       "cache_read": 0.25,
+       "input": 2.5,
+       "output": 15,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Google's proven reasoning model for coding, math, and multimodal analysis",
+    "family": "gemini-pro",
+    "id": "google-ai-studio/gemini-2.5-pro",
+    "knowledge": "2025-01",
+    "last_updated": "2025-06-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 2.5 Pro (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     },
+     {
+      "max": 32768,
+      "min": 128,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2025-06-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-3-flash-preview": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.5,
+     "output": 3
+    },
+    "description": "New Gemini flash lane bringing frontier-style multimodal reasoning to cheaper runs",
+    "family": "gemini-flash",
+    "id": "google-ai-studio/gemini-3-flash-preview",
+    "knowledge": "2025-01",
+    "last_updated": "2025-12-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3 Flash (Preview) (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-12-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-3.1-flash-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "cache_write": 0.08333,
+     "input": 0.25,
+     "output": 1.5
+    },
+    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "family": "gemini-flash-lite",
+    "id": "google-ai-studio/gemini-3.1-flash-lite",
+    "knowledge": "2025-01",
+    "last_updated": "2026-05-07",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Flash Lite (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-07",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-3.1-pro-preview": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 4,
+      "output": 18
+     },
+     "input": 2,
+     "output": 12,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 4,
+       "output": 18,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
+    "family": "gemini-pro",
+    "id": "google-ai-studio/gemini-3.1-pro-preview",
+    "knowledge": "2025-01",
+    "last_updated": "2026-02-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Pro (Preview) (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-02-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-3.5-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "cache_write": 0.08333,
+     "input": 1.5,
+     "output": 9
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "google-ai-studio/gemini-3.5-flash",
+    "knowledge": "2025-01",
+    "last_updated": "2026-05-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Flash (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-3.5-flash-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "cache_write": 0.08333,
+     "input": 0.3,
+     "output": 2.5
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash-lite",
+    "id": "google-ai-studio/gemini-3.5-flash-lite",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Flash Lite (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-3.6-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "cache_write": 0.08333,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "google-ai-studio/gemini-3.6-flash",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.6 Flash (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-3.7-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "cache_write": 0.08333,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
+    "family": "gemini-flash",
+    "id": "google-ai-studio/gemini-3.7-flash",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.7 Flash (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-ai-studio/gemini-pro-latest": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 2,
+     "output": 12
+    },
+    "description": "Advanced Gemini model for complex reasoning, coding, and multimodal analysis",
+    "family": "gemini-pro",
+    "id": "google-ai-studio/gemini-pro-latest",
+    "last_updated": "2026-02-27",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini Pro Latest (Google AI Studio)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-02-27",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-vertex/gemini-2.5-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.3,
+     "output": 2.5
+    },
+    "description": "Fast Gemini workhorse for multimodal apps where latency and price matter",
+    "family": "gemini-flash",
+    "id": "google-vertex/gemini-2.5-flash",
+    "knowledge": "2025-01",
+    "last_updated": "2025-06-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 2.5 Flash (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 24576,
+      "min": 1,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-06-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-vertex/gemini-2.5-flash-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Lean Gemini 2.5 lane for cheap multimodal traffic and quick agents",
+    "family": "gemini-flash-lite",
+    "id": "google-vertex/gemini-2.5-flash-lite",
+    "knowledge": "2025-01",
+    "last_updated": "2025-06-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 2.5 Flash Lite (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-06-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-vertex/gemini-2.5-pro": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.125,
+     "context_over_200k": {
+      "cache_read": 0.25,
+      "input": 2.5,
+      "output": 15
+     },
+     "input": 1.25,
+     "output": 10,
+     "tiers": [
+      {
+       "cache_read": 0.25,
+       "input": 2.5,
+       "output": 15,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Google's proven reasoning model for coding, math, and multimodal analysis",
+    "family": "gemini-pro",
+    "id": "google-vertex/gemini-2.5-pro",
+    "knowledge": "2025-01",
+    "last_updated": "2025-06-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 2.5 Pro (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     },
+     {
+      "max": 32768,
+      "min": 128,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2025-06-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-vertex/gemini-3-flash-preview": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.5,
+     "output": 3
+    },
+    "description": "New Gemini flash lane bringing frontier-style multimodal reasoning to cheaper runs",
+    "family": "gemini-flash",
+    "id": "google-vertex/gemini-3-flash-preview",
+    "knowledge": "2025-01",
+    "last_updated": "2025-12-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3 Flash (Preview) (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-12-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-vertex/gemini-3.1-flash-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "cache_write": 0.08333,
+     "input": 0.25,
+     "output": 1.5
+    },
+    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "family": "gemini-flash-lite",
+    "id": "google-vertex/gemini-3.1-flash-lite",
+    "knowledge": "2025-01",
+    "last_updated": "2026-05-07",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Flash Lite (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-07",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-vertex/gemini-3.1-pro-preview": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 4,
+      "output": 18
+     },
+     "input": 2,
+     "output": 12,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 4,
+       "output": 18,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
+    "family": "gemini-pro",
+    "id": "google-vertex/gemini-3.1-pro-preview",
+    "knowledge": "2025-01",
+    "last_updated": "2026-02-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Pro (Preview) (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-02-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-vertex/gemini-3.5-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "cache_write": 0.08333,
+     "input": 1.5,
+     "output": 9
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "google-vertex/gemini-3.5-flash",
+    "knowledge": "2025-01",
+    "last_updated": "2026-05-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Flash (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-vertex/gemini-3.5-flash-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "cache_write": 0.08333,
+     "input": 0.3,
+     "output": 2.5
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash-lite",
+    "id": "google-vertex/gemini-3.5-flash-lite",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Flash Lite (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-vertex/gemini-3.6-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "cache_write": 0.08333,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "google-vertex/gemini-3.6-flash",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.6 Flash (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google-vertex/gemini-3.7-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "cache_write": 0.08333,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
+    "family": "gemini-flash",
+    "id": "google-vertex/gemini-3.7-flash",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.7 Flash (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "groq/gpt-oss-120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.15,
+     "output": 0.75
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "groq/gpt-oss-120b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32766
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B (Groq)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "groq/gpt-oss-20b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.1,
+     "output": 0.5
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "groq/gpt-oss-20b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32766
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 20B (Groq)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "iceberg/gemini-3-flash-preview": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.5,
+     "output": 3
+    },
+    "description": "New Gemini flash lane bringing frontier-style multimodal reasoning to cheaper runs",
+    "family": "gemini-flash",
+    "id": "iceberg/gemini-3-flash-preview",
+    "knowledge": "2025-01",
+    "last_updated": "2025-12-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3 Flash (Preview) (Iceberg)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-12-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "iceberg/gemini-3.1-pro-preview": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 4,
+      "output": 18
+     },
+     "input": 2,
+     "output": 12,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 4,
+       "output": 18,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
+    "family": "gemini-pro",
+    "id": "iceberg/gemini-3.1-pro-preview",
+    "knowledge": "2025-01",
+    "last_updated": "2026-02-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Pro (Preview) (Iceberg)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-02-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "iceberg/gemini-3.6-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "cache_write": 0.08333,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "iceberg/gemini-3.6-flash",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.6 Flash (Iceberg)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "inference.net/llama-3.2-11b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.07,
+     "output": 0.33
+    },
+    "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+    "family": "llama",
+    "id": "inference.net/llama-3.2-11b-instruct",
+    "last_updated": "2024-09-25",
+    "limit": {
+     "context": 128000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 3.2 11B Instruct (Inference.net)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-09-25",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "meta/muse-spark-1.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.25,
+     "output": 4.25
+    },
+    "description": "Muse Spark is a natively multimodal reasoning model with support for tool-use, visual chain of thought, and multi-agent orchestration.",
+    "family": "muse",
+    "id": "meta/muse-spark-1.1",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.1 (Meta)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-04-08",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.2": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.25,
+     "output": 4.25
+    },
+    "description": "Muse Spark 1.2 is a coding-focused update to Muse Spark 1.1 with improvements in code generation, complex debugging, codebase understanding, and end-to-end developer workflows.",
+    "family": "muse",
+    "id": "meta/muse-spark-1.2",
+    "last_updated": "2026-08-05",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.2 (Meta)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.2,
+     "output": 1
+    },
+    "description": "Efficient open MiniMax model built for coding agents and tool-heavy workflows",
+    "family": "minimax",
+    "id": "minimax/minimax-m2",
+    "last_updated": "2025-10-27",
+    "limit": {
+     "context": 196608,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2 (MiniMax)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-10-27",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m2.1": {
+    "attachment": false,
+    "cost": {
+     "input": 0.27,
+     "output": 1.1
+    },
+    "description": "Earlier MiniMax agent model for practical coding and productivity tasks",
+    "family": "minimax",
+    "id": "minimax/minimax-m2.1",
+    "last_updated": "2025-12-23",
+    "limit": {
+     "context": 196608,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.1 (MiniMax)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-12-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m2.1-lightning": {
+    "attachment": false,
+    "cost": {
+     "input": 0.12,
+     "output": 0.48
+    },
+    "description": "High-speed MiniMax model for low-latency coding and agent workflows",
+    "family": "minimax",
+    "id": "minimax/minimax-m2.1-lightning",
+    "last_updated": "2025-12-23",
+    "limit": {
+     "context": 196608,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.1 Lightning (MiniMax)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-12-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m2.5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "Prior MiniMax coding model for agent workflows, office edits, and automation",
+    "family": "minimax",
+    "id": "minimax/minimax-m2.5",
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 204800,
+     "output": 131100
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.5 (MiniMax)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m2.5-highspeed": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.6,
+     "output": 2.4
+    },
+    "description": "High-speed MiniMax model for low-latency coding and agent workflows",
+    "family": "minimax",
+    "id": "minimax/minimax-m2.5-highspeed",
+    "last_updated": "2026-02-13",
+    "limit": {
+     "context": 204800,
+     "output": 131100
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.5 Highspeed (MiniMax)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m2.7": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+    "family": "minimax",
+    "id": "minimax/minimax-m2.7",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 204800,
+     "output": 131100
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.7 (MiniMax)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-03-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m2.7-highspeed": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.6,
+     "output": 2.4
+    },
+    "description": "Low-latency M2.7 variant for interactive coding plans and agent loops",
+    "family": "minimax",
+    "id": "minimax/minimax-m2.7-highspeed",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 204800,
+     "output": 131100
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.7 Highspeed (MiniMax)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-03-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.12,
+     "input": 0.6,
+     "output": 2.4
+    },
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "family": "minimax",
+    "id": "minimax/minimax-m3",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 512000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M3 (MiniMax)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-text-01": {
+    "attachment": false,
+    "cost": {
+     "input": 0.2,
+     "output": 1.1
+    },
+    "description": "MiniMax model for chat, coding, office work, and agentic tasks",
+    "family": "minimax",
+    "id": "minimax/minimax-text-01",
+    "last_updated": "2025-01-15",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax Text 01 (MiniMax)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-01-15",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "mistral/codestral-2508": {
+    "attachment": false,
+    "cost": {
+     "input": 0.3,
+     "output": 0.9
+    },
+    "description": "Mistral coding model for code completion, generation, and developer workflows",
+    "family": "codestral",
+    "id": "mistral/codestral-2508",
+    "last_updated": "2025-07-30",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Codestral (Mistral AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-07-30",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "mistral/devstral-2512": {
+    "attachment": false,
+    "cost": {
+     "input": 0.4,
+     "output": 2
+    },
+    "description": "Mistral's coding-agent model for repository work, terminal tasks, and software fixes",
+    "family": "devstral",
+    "id": "mistral/devstral-2512",
+    "knowledge": "2025-12",
+    "last_updated": "2025-12-09",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Devstral 2 (Mistral AI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-12-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "mistral/ministral-14b-2512": {
+    "attachment": true,
+    "cost": {
+     "input": 0.2,
+     "output": 0.2
+    },
+    "description": "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads",
+    "family": "ministral",
+    "id": "mistral/ministral-14b-2512",
+    "last_updated": "2025-12-02",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ministral 14B (Mistral AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-12-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "mistral/ministral-3b-2512": {
+    "attachment": true,
+    "cost": {
+     "input": 0.1,
+     "output": 0.1
+    },
+    "description": "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads",
+    "family": "ministral",
+    "id": "mistral/ministral-3b-2512",
+    "last_updated": "2025-12-02",
+    "limit": {
+     "context": 131072,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ministral 3B (Mistral AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-12-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "mistral/ministral-8b-2512": {
+    "attachment": true,
+    "cost": {
+     "input": 0.15,
+     "output": 0.15
+    },
+    "description": "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads",
+    "family": "ministral",
+    "id": "mistral/ministral-8b-2512",
+    "last_updated": "2025-12-02",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ministral 8B (Mistral AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-12-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "mistral/mistral-large-2512": {
+    "attachment": true,
+    "cost": {
+     "input": 0.5,
+     "output": 1.5
+    },
+    "description": "Mistral's largest general model for enterprise agents, coding, and multilingual reasoning",
+    "family": "mistral-large",
+    "id": "mistral/mistral-large-2512",
+    "knowledge": "2024-11",
+    "last_updated": "2025-12-02",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Mistral Large 3 (Mistral AI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2024-11-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "mistral/mistral-large-latest": {
+    "attachment": false,
+    "cost": {
+     "input": 4,
+     "output": 12
+    },
+    "description": "Flagship Mistral model for advanced reasoning, coding, and multilingual work",
+    "family": "mistral-large",
+    "id": "mistral/mistral-large-latest",
+    "knowledge": "2024-11",
+    "last_updated": "2025-12-02",
+    "limit": {
+     "context": 128000,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Mistral Large Latest (Mistral AI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2024-11-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "mistral/mistral-small-2506": {
+    "attachment": true,
+    "cost": {
+     "input": 0.1,
+     "output": 0.3
+    },
+    "description": "Efficient Mistral model for fast chat, extraction, and production assistants",
+    "family": "mistral-small",
+    "id": "mistral/mistral-small-2506",
+    "knowledge": "2025-03",
+    "last_updated": "2025-06-20",
+    "limit": {
+     "context": 128000,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Mistral Small 3.2 (Mistral AI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-06-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "moonshot/kimi-k2.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.6,
+     "output": 3
+    },
+    "description": "Earlier Kimi frontier model for long-context agents, coding, and multimodal work",
+    "family": "kimi-k2",
+    "id": "moonshot/kimi-k2.5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-01",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.5 (Moonshot AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-01",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "moonshot/kimi-k2.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.16,
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
+    "family": "kimi-k2",
+    "id": "moonshot/kimi-k2.6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-21",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.6 (Moonshot AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "moonshot/kimi-k2.7-code": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.19,
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+    "family": "kimi-k2",
+    "id": "moonshot/kimi-k2.7-code",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code (Moonshot AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-12",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "moonshot/kimi-k2.7-code-highspeed": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.38,
+     "input": 1.9,
+     "output": 8
+    },
+    "description": "Lower-latency Kimi Code variant for interactive edits and coding-agent loops",
+    "family": "kimi-k2",
+    "id": "moonshot/kimi-k2.7-code-highspeed",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code Highspeed (Moonshot AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-12",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "moonshot/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "moonshot/kimi-k3",
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3 (Moonshot AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "nebius/cosmos3-super-reasoner": {
+    "attachment": true,
+    "cost": {
+     "input": 0.1,
+     "output": 0.3
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "id": "nebius/cosmos3-super-reasoner",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Cosmos 3 Super Reasoner (Nebius AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "input": 1.75,
+     "output": 3.5
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "nebius/deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro (Nebius AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/gemma-3-27b": {
+    "attachment": true,
+    "cost": {
+     "input": 0.1,
+     "output": 0.3
+    },
+    "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+    "family": "gemma",
+    "id": "nebius/gemma-3-27b",
+    "last_updated": "2025-03-12",
+    "limit": {
+     "context": 110000,
+     "output": 110000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 3 27B (Nebius AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-03-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "nebius/glm-5.1": {
+    "attachment": false,
+    "cost": {
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
+    "family": "glm",
+    "id": "nebius/glm-5.1",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-04-07",
+    "limit": {
+     "context": 202752,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.1 (Nebius AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-07",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "nebius/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 (Nebius AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/gpt-oss-120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.15,
+     "output": 0.6
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "nebius/gpt-oss-120b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B (Nebius AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/hermes-4-405b": {
+    "attachment": false,
+    "cost": {
+     "input": 1,
+     "output": 3
+    },
+    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
+    "family": "hermes",
+    "id": "nebius/hermes-4-405b",
+    "last_updated": "2025-08-26",
+    "limit": {
+     "context": 131072,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hermes 4 405B (Nebius AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-08-26",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/hermes-4-70b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.13,
+     "output": 0.4
+    },
+    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
+    "family": "hermes",
+    "id": "nebius/hermes-4-70b",
+    "last_updated": "2025-08-26",
+    "limit": {
+     "context": 131072,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hermes 4 70B (Nebius AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-08-26",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/kimi-k2.6": {
+    "attachment": true,
+    "cost": {
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
+    "family": "kimi-k2",
+    "id": "nebius/kimi-k2.6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-21",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.6 (Nebius AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/kimi-k2.7-code": {
+    "attachment": false,
+    "cost": {
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+    "family": "kimi-k2",
+    "id": "nebius/kimi-k2.7-code",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code (Nebius AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-12",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "nebius/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "input": 3,
+     "output": 15
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "nebius/kimi-k3",
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3 (Nebius AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "nebius/llama-3.1-nemotron-ultra-253b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.6,
+     "output": 1.8
+    },
+    "description": "Flagship Nemotron model for high-throughput reasoning and complex agents",
+    "family": "nemotron",
+    "id": "nebius/llama-3.1-nemotron-ultra-253b",
+    "last_updated": "2025-04-07",
+    "limit": {
+     "context": 128000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 3.1 Nemotron Ultra 253B (Nebius AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-07",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "nebius/llama-3.3-70b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.13,
+     "output": 0.4
+    },
+    "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
+    "family": "llama",
+    "id": "nebius/llama-3.3-70b-instruct",
+    "knowledge": "2023-12",
+    "last_updated": "2024-12-06",
+    "limit": {
+     "context": 128000,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 3.3 70B Instruct (Nebius AI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2024-12-06",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/minicpm-v-4.5": {
+    "attachment": true,
+    "cost": {
+     "input": 0.658,
+     "output": 1.11
+    },
+    "description": "Multimodal model for analyzing text, images, documents, and rich media",
+    "id": "nebius/minicpm-v-4.5",
+    "last_updated": "2025-08-26",
+    "limit": {
+     "context": 32000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniCPM-V 4.5 (Nebius AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-08-26",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "nebius/minimax-m2.5": {
+    "attachment": false,
+    "cost": {
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "Prior MiniMax coding model for agent workflows, office edits, and automation",
+    "family": "minimax",
+    "id": "nebius/minimax-m2.5",
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 196608,
+     "output": 131100
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.5 (Nebius AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/minimax-m3": {
+    "attachment": false,
+    "cost": {
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "family": "minimax",
+    "id": "nebius/minimax-m3",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 1048576,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M3 (Nebius AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/nemotron-3-nano-30b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.06,
+     "output": 0.24
+    },
+    "description": "Compact Nemotron model for efficient reasoning and deployable AI agents",
+    "family": "nemotron",
+    "id": "nebius/nemotron-3-nano-30b",
+    "last_updated": "2025-12-15",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Nemotron 3 Nano 30B (Nebius AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-15",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/nemotron-3-nano-omni": {
+    "attachment": true,
+    "cost": {
+     "input": 0.06,
+     "output": 0.24
+    },
+    "description": "Omni-modal model for text, vision, audio, and multimodal agent tasks",
+    "family": "nemotron",
+    "id": "nebius/nemotron-3-nano-omni",
+    "last_updated": "2026-04-28",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Nemotron 3 Nano Omni (Nebius AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-04-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/nemotron-3-super-120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.3,
+     "output": 0.9
+    },
+    "description": "Nemotron model for efficient reasoning, coding, and specialized AI agents",
+    "family": "nemotron",
+    "id": "nebius/nemotron-3-super-120b",
+    "last_updated": "2026-03-11",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Nemotron 3 Super 120B (Nebius AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-03-11",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/nemotron-3-ultra-550b": {
+    "attachment": false,
+    "cost": {
+     "input": 1,
+     "output": 3
+    },
+    "description": "Flagship Nemotron model for high-throughput reasoning and complex agents",
+    "family": "nemotron",
+    "id": "nebius/nemotron-3-ultra-550b",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Nemotron 3 Ultra 550B (Nebius AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/qwen2-5-vl-72b-instruct": {
+    "attachment": true,
+    "cost": {
+     "input": 0.25,
+     "output": 0.75
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "nebius/qwen2-5-vl-72b-instruct",
+    "knowledge": "2024-04",
+    "last_updated": "2024-09",
+    "limit": {
+     "context": 32000,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen2.5 VL 72B Instruct (Nebius AI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2024-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "nebius/qwen3-235b-a22b-instruct-2507": {
+    "attachment": false,
+    "cost": {
+     "input": 0.2,
+     "output": 0.6
+    },
+    "description": "Updated large open Qwen3 MoE instruct model for multilingual chat, coding, and tool use",
+    "family": "qwen",
+    "id": "nebius/qwen3-235b-a22b-instruct-2507",
+    "last_updated": "2025-07-21",
+    "limit": {
+     "context": 262000,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 235B A22B Instruct 2507 (Nebius AI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-07-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/qwen3-30b-a3b-instruct-2507": {
+    "attachment": false,
+    "cost": {
+     "input": 0.1,
+     "output": 0.3
+    },
+    "description": "Tool-capable chat model for instruction following and agentic application workflows",
+    "id": "nebius/qwen3-30b-a3b-instruct-2507",
+    "last_updated": "2025-07-30",
+    "limit": {
+     "context": 262000,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 30B A3B Instruct 2507 (Nebius AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-07-30",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/qwen3-32b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.1,
+     "output": 0.3
+    },
+    "description": "Dense open Qwen model for self-hosted chat, reasoning, and coding",
+    "family": "qwen",
+    "id": "nebius/qwen3-32b",
+    "knowledge": "2025-04",
+    "last_updated": "2025-04",
+    "limit": {
+     "context": 40960,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 32B (Nebius AI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-04",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nebius/qwen3-next-80b-a3b-thinking": {
+    "attachment": false,
+    "cost": {
+     "input": 0.15,
+     "output": 1.2
+    },
+    "description": "Efficient Qwen thinking model for local reasoning, math, and coding agents",
+    "family": "qwen",
+    "id": "nebius/qwen3-next-80b-a3b-thinking",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Next 80B A3B Thinking (Nebius AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/deepseek-v3.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.1345,
+     "input": 0.269,
+     "output": 0.4
+    },
+    "description": "Hybrid-reasoning DeepSeek model with thinking and non-thinking modes, sparse attention, and tool-use",
+    "family": "deepseek",
+    "id": "novita/deepseek-v3.2",
+    "knowledge": "2024-07",
+    "last_updated": "2025-12-01",
+    "limit": {
+     "context": 163840,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V3.2 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.028,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "novita/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1050000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/ernie-4.5-vl-424b-a47b": {
+    "attachment": true,
+    "cost": {
+     "input": 0.42,
+     "output": 1.25
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "ernie",
+    "id": "novita/ernie-4.5-vl-424b-a47b",
+    "last_updated": "2025-06-30",
+    "limit": {
+     "context": 123000,
+     "output": 16000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "ERNIE 4.5 VL 424B A47B (NovitaAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-06-30",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "novita/gemma-4-26b-a4b-it": {
+    "attachment": false,
+    "cost": {
+     "input": 0.13,
+     "output": 0.4
+    },
+    "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+    "family": "gemma",
+    "id": "novita/gemma-4-26b-a4b-it",
+    "last_updated": "2026-04-02",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 26B A4B IT (NovitaAI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-04-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/gemma-4-31b-it": {
+    "attachment": false,
+    "cost": {
+     "input": 0.14,
+     "output": 0.4
+    },
+    "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
+    "family": "gemma",
+    "id": "novita/gemma-4-31b-it",
+    "last_updated": "2026-04-02",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 31B IT (NovitaAI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-04-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/glm-4.5v": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.6,
+     "output": 1.8
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "novita/glm-4.5v",
+    "knowledge": "2025-04",
+    "last_updated": "2025-08-11",
+    "limit": {
+     "context": 65536,
+     "output": 16000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.5V (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-08-11",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/glm-4.6": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.55,
+     "output": 2.2
+    },
+    "description": "Late GLM-4 workhorse for coding agents, reasoning, and structured tasks",
+    "family": "glm",
+    "id": "novita/glm-4.6",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09-30",
+    "limit": {
+     "context": 204800,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.6 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-09-30",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/glm-4.6v": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.055,
+     "input": 0.3,
+     "output": 0.9
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "novita/glm-4.6v",
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-08",
+    "limit": {
+     "context": 131072,
+     "output": 16000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.6V (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-08",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/glm-4.7": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.6,
+     "output": 2.2
+    },
+    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
+    "family": "glm",
+    "id": "novita/glm-4.7",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 204800,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.7 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/glm-5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
+    },
+    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
+    "family": "glm",
+    "id": "novita/glm-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 202800,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/glm-5.1": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.38,
+     "output": 4.4
+    },
+    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
+    "family": "glm",
+    "id": "novita/glm-5.1",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-04-07",
+    "limit": {
+     "context": 204800,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.1 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-07",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "novita/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/hy3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.035,
+     "input": 0.14,
+     "output": 0.58
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "novita/hy3",
+    "last_updated": "2026-07-06",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy3 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-06",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/kimi-k2": {
+    "attachment": false,
+    "cost": {
+     "input": 0.57,
+     "output": 2.3
+    },
+    "description": "Kimi model for long-context chat, coding, and agentic reasoning",
+    "family": "kimi-k2",
+    "id": "novita/kimi-k2",
+    "last_updated": "2025-07-11",
+    "limit": {
+     "context": 131072,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2 (NovitaAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-07-11",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/kimi-k2.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.16,
+     "input": 0.8,
+     "output": 3.4
+    },
+    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
+    "family": "kimi-k2",
+    "id": "novita/kimi-k2.6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-21",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.6 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/kimi-k2.7-code": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.19,
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+    "family": "kimi-k2",
+    "id": "novita/kimi-k2.7-code",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-12",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "novita/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "novita/kimi-k3",
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "novita/ling-3.0-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.012,
+     "input": 0.06,
+     "output": 0.18
+    },
+    "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+    "family": "ling",
+    "id": "novita/ling-3.0-flash",
+    "last_updated": "2026-08-02",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "InclusionAI Ling 3.0 Flash (NovitaAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none"
+      ]
+     }
+    ],
+    "release_date": "2026-08-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/llama-3-70b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.51,
+     "output": 0.74
+    },
+    "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+    "family": "llama",
+    "id": "novita/llama-3-70b-instruct",
+    "last_updated": "2024-04-18",
+    "limit": {
+     "context": 8192,
+     "output": 8000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 3 70B Instruct (NovitaAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-04-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "novita/llama-3.2-3b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.03,
+     "output": 0.05
+    },
+    "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+    "family": "llama",
+    "id": "novita/llama-3.2-3b-instruct",
+    "last_updated": "2024-09-18",
+    "limit": {
+     "context": 32768,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 3.2 3B Instruct (NovitaAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-09-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "novita/llama-3.3-70b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.135,
+     "output": 0.4
+    },
+    "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
+    "family": "llama",
+    "id": "novita/llama-3.3-70b-instruct",
+    "knowledge": "2023-12",
+    "last_updated": "2024-12-06",
+    "limit": {
+     "context": 131072,
+     "output": 120000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 3.3 70B Instruct (NovitaAI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2024-12-06",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/llama-4-maverick-17b-instruct": {
+    "attachment": true,
+    "cost": {
+     "input": 0.27,
+     "output": 0.85
+    },
+    "description": "Open multimodal Llama for strong reasoning with efficient everyday serving",
+    "family": "llama",
+    "id": "novita/llama-4-maverick-17b-instruct",
+    "knowledge": "2024-08",
+    "last_updated": "2025-04-05",
+    "limit": {
+     "context": 1048576,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 4 Maverick 17B Instruct (NovitaAI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-04-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "novita/llama-4-scout-17b-instruct": {
+    "attachment": true,
+    "cost": {
+     "input": 0.18,
+     "output": 0.59
+    },
+    "description": "Open Llama with long-context vision for efficient multimodal agents",
+    "family": "llama",
+    "id": "novita/llama-4-scout-17b-instruct",
+    "knowledge": "2024-08",
+    "last_updated": "2025-04-05",
+    "limit": {
+     "context": 131072,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 4 Scout 17B Instruct (NovitaAI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-04-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "novita/mimo-v2.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.0034,
+     "context_over_200k": {
+      "cache_read": 0.16,
+      "input": 0.8,
+      "output": 4
+     },
+     "input": 0.168,
+     "output": 0.336,
+     "tiers": [
+      {
+       "cache_read": 0.16,
+       "input": 0.8,
+       "output": 4,
+       "tier": {
+        "size": 256000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Open MiMo model for multimodal coding agents and long-context automation",
+    "family": "mimo",
+    "id": "novita/mimo-v2.5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2024-12",
+    "last_updated": "2026-04-22",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiMo V2.5 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/mimo-v2.5-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0043,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2,
+      "output": 6
+     },
+     "input": 0.522,
+     "output": 1.044,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2,
+       "output": 6,
+       "tier": {
+        "size": 256000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
+    "family": "mimo",
+    "id": "novita/mimo-v2.5-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2024-12",
+    "last_updated": "2026-04-22",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiMo V2.5 Pro (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/minimax-m2.1": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "Earlier MiniMax agent model for practical coding and productivity tasks",
+    "family": "minimax",
+    "id": "novita/minimax-m2.1",
+    "last_updated": "2025-12-23",
+    "limit": {
+     "context": 204800,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.1 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-12-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/minimax-m2.5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "Prior MiniMax coding model for agent workflows, office edits, and automation",
+    "family": "minimax",
+    "id": "novita/minimax-m2.5",
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 204800,
+     "output": 131100
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.5 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/minimax-m2.7": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+    "family": "minimax",
+    "id": "novita/minimax-m2.7",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 204800,
+     "output": 131100
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.7 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-03-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3-235b-a22b-fp8": {
+    "attachment": false,
+    "cost": {
+     "input": 0.2,
+     "output": 0.8
+    },
+    "description": "General-purpose chat model for instruction following, writing, and analysis",
+    "id": "novita/qwen3-235b-a22b-fp8",
+    "last_updated": "2025-04-28",
+    "limit": {
+     "context": 40960,
+     "output": 20000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 235B A22B FP8 (NovitaAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "novita/qwen3-235b-a22b-instruct-2507": {
+    "attachment": false,
+    "cost": {
+     "input": 0.09,
+     "output": 0.58
+    },
+    "description": "Updated large open Qwen3 MoE instruct model for multilingual chat, coding, and tool use",
+    "family": "qwen",
+    "id": "novita/qwen3-235b-a22b-instruct-2507",
+    "last_updated": "2025-07-21",
+    "limit": {
+     "context": 131072,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 235B A22B Instruct 2507 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-07-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3-235b-a22b-thinking-2507": {
+    "attachment": false,
+    "cost": {
+     "input": 0.3,
+     "output": 3
+    },
+    "description": "Tool-capable chat model for instruction following and agentic application workflows",
+    "id": "novita/qwen3-235b-a22b-thinking-2507",
+    "last_updated": "2025-07-25",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 235B A22B Thinking 2507 (NovitaAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-07-25",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3-coder-30b-a3b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.07,
+     "output": 0.27
+    },
+    "description": "Smaller Qwen coder for efficient local agents and repo-level fixes",
+    "family": "qwen",
+    "id": "novita/qwen3-coder-30b-a3b-instruct",
+    "knowledge": "2025-04",
+    "last_updated": "2025-04",
+    "limit": {
+     "context": 160000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Coder 30B A3B Instruct (NovitaAI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-04",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3-coder-480b-a35b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.38,
+     "output": 1.55
+    },
+    "description": "Open Qwen coding heavyweight for repository reasoning and agentic engineering",
+    "family": "qwen",
+    "id": "novita/qwen3-coder-480b-a35b-instruct",
+    "knowledge": "2025-04",
+    "last_updated": "2025-04",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Coder 480B A35B Instruct (NovitaAI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-04",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3-max": {
+    "attachment": false,
+    "cost": {
+     "input": 0.845,
+     "output": 3.38
+    },
+    "description": "Flagship Qwen3 model for coding agents, complex reasoning, and tool use",
+    "family": "qwen",
+    "id": "novita/qwen3-max",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09-23",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Max (NovitaAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-09-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3-next-80b-a3b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.15,
+     "output": 1.5
+    },
+    "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+    "family": "qwen",
+    "id": "novita/qwen3-next-80b-a3b-instruct",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Next 80B A3B Instruct (NovitaAI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3-vl-235b-a22b-instruct": {
+    "attachment": true,
+    "cost": {
+     "input": 0.3,
+     "output": 1.5
+    },
+    "description": "Qwen vision-language instruct model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "novita/qwen3-vl-235b-a22b-instruct",
+    "knowledge": "2025-03-31",
+    "last_updated": "2025-09-23",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 VL 235B A22B Instruct (NovitaAI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-09-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3-vl-235b-a22b-thinking": {
+    "attachment": true,
+    "cost": {
+     "input": 0.98,
+     "output": 3.95
+    },
+    "description": "Qwen vision-language thinking model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "novita/qwen3-vl-235b-a22b-thinking",
+    "knowledge": "2025-03-31",
+    "last_updated": "2025-09-23",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 VL 235B A22B Thinking (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-09-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "novita/qwen3-vl-30b-a3b-instruct": {
+    "attachment": true,
+    "cost": {
+     "input": 0.2,
+     "output": 0.7
+    },
+    "description": "Multimodal model for analyzing text, images, documents, and rich media",
+    "id": "novita/qwen3-vl-30b-a3b-instruct",
+    "last_updated": "2025-10-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 VL 30B A3B Instruct (NovitaAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-10-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3.6-35b-a3b": {
+    "attachment": true,
+    "cost": {
+     "input": 0.248,
+     "output": 1.485
+    },
+    "description": "Open multimodal Qwen MoE for local agents that need vision, audio, and code",
+    "family": "qwen",
+    "id": "novita/qwen3.6-35b-a3b",
+    "last_updated": "2026-04-17",
+    "limit": {
+     "context": 262144,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.6 35B A3B (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-17",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3.7-max": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.25,
+     "input": 1.25,
+     "output": 3.75
+    },
+    "description": "Qwen frontier model tuned for agent frameworks, coding assistants, and long tasks",
+    "family": "qwen",
+    "id": "novita/qwen3.7-max",
+    "last_updated": "2026-05-21",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.7 Max (NovitaAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-05-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3.8-max": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "input": 2,
+     "output": 6
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "novita/qwen3.8-max",
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max (NovitaAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-03",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen35-397b-a17b": {
+    "attachment": true,
+    "cost": {
+     "input": 0.6,
+     "output": 3.6
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "qwen3.5",
+    "id": "novita/qwen35-397b-a17b",
+    "last_updated": "2026-02-16",
+    "limit": {
+     "context": 262144,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.5 397B A17B (NovitaAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-16",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-3.5-turbo": {
+    "attachment": false,
+    "cost": {
+     "input": 0.5,
+     "output": 1.5
+    },
+    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
+    "family": "gpt",
+    "id": "openai/gpt-3.5-turbo",
+    "knowledge": "2021-09-01",
+    "last_updated": "2023-11-06",
+    "limit": {
+     "context": 16385,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-3.5 Turbo (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2023-03-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-4": {
+    "attachment": false,
+    "cost": {
+     "input": 30,
+     "output": 60
+    },
+    "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+    "family": "gpt",
+    "id": "openai/gpt-4",
+    "knowledge": "2023-11",
+    "last_updated": "2024-04-09",
+    "limit": {
+     "context": 8192,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4 (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2023-11-06",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-4-turbo": {
+    "attachment": true,
+    "cost": {
+     "input": 10,
+     "output": 30
+    },
+    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
+    "family": "gpt",
+    "id": "openai/gpt-4-turbo",
+    "knowledge": "2023-12",
+    "last_updated": "2024-04-09",
+    "limit": {
+     "context": 128000,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4 Turbo (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2023-11-06",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-4.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 8
+    },
+    "description": "Long-lived GPT workhorse for coding, instruction following, and production apps",
+    "family": "gpt",
+    "id": "openai/gpt-4.1",
+    "knowledge": "2024-04",
+    "last_updated": "2025-04-14",
+    "limit": {
+     "context": 1000000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4.1 (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-4.1-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.4,
+     "output": 1.6
+    },
+    "description": "Affordable GPT-4.1 lane for fast coding help and structured extraction",
+    "family": "gpt-mini",
+    "id": "openai/gpt-4.1-mini",
+    "knowledge": "2024-04",
+    "last_updated": "2025-04-14",
+    "limit": {
+     "context": 1000000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4.1 Mini (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-4.1-nano": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Tiny GPT-4.1 option for classification, routing, and very high-volume tasks",
+    "family": "gpt-nano",
+    "id": "openai/gpt-4.1-nano",
+    "knowledge": "2024-04",
+    "last_updated": "2025-04-14",
+    "limit": {
+     "context": 1000000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4.1 Nano (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-4o": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 1.25,
+     "input": 2.5,
+     "output": 10
+    },
+    "description": "Omni-era GPT for multimodal chat, practical coding, and general assistants",
+    "family": "gpt",
+    "id": "openai/gpt-4o",
+    "knowledge": "2023-09",
+    "last_updated": "2024-08-06",
+    "limit": {
+     "context": 128000,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4o (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-05-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-4o-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.15,
+     "output": 0.6
+    },
+    "description": "Small omni GPT for cheap multimodal assistance and production-scale traffic",
+    "family": "gpt-mini",
+    "id": "openai/gpt-4o-mini",
+    "knowledge": "2023-09",
+    "last_updated": "2024-07-18",
+    "limit": {
+     "context": 128000,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4o Mini (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-07-18",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-4o-mini-transcribe": {
+    "attachment": false,
+    "cost": {
+     "input": 1.25,
+     "output": 5
+    },
+    "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
+    "family": "gpt",
+    "id": "openai/gpt-4o-mini-transcribe",
+    "last_updated": "2025-03-20",
+    "limit": {
+     "context": 16000,
+     "output": 2000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4o Mini Transcribe (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-03-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "openai/gpt-4o-transcribe": {
+    "attachment": false,
+    "cost": {
+     "input": 2.5,
+     "output": 10
+    },
+    "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
+    "family": "gpt",
+    "id": "openai/gpt-4o-transcribe",
+    "last_updated": "2025-03-20",
+    "limit": {
+     "context": 16000,
+     "output": 2000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4o Transcribe (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-03-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "openai/gpt-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.125,
+     "input": 1.25,
+     "output": 10
+    },
+    "description": "Original GPT-5 workhorse for reasoning, coding, writing, and tool workflows",
+    "family": "gpt",
+    "id": "openai/gpt-5",
+    "knowledge": "2024-09-30",
+    "last_updated": "2025-08-07",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5 (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-07",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "input": 0.25,
+     "output": 2
+    },
+    "description": "Small GPT-5 for responsive agents, coding help, and everyday automation",
+    "family": "gpt-mini",
+    "id": "openai/gpt-5-mini",
+    "knowledge": "2024-05-30",
+    "last_updated": "2025-08-07",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5 Mini (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-07",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5-nano": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.005,
+     "input": 0.05,
+     "output": 0.4
+    },
+    "description": "Tiny GPT-5 lane for routing, extraction, classification, and bulk jobs",
+    "family": "gpt-nano",
+    "id": "openai/gpt-5-nano",
+    "knowledge": "2024-05-30",
+    "last_updated": "2025-08-07",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5 Nano (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-07",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5-pro": {
+    "attachment": true,
+    "cost": {
+     "input": 15,
+     "output": 120
+    },
+    "description": "Higher-accuracy GPT-5 tier for tough analysis, coding reviews, and planning",
+    "family": "gpt-pro",
+    "id": "openai/gpt-5-pro",
+    "knowledge": "2024-09-30",
+    "last_updated": "2025-10-06",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 272000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5 Pro (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-10-06",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.125,
+     "input": 1.25,
+     "output": 10
+    },
+    "description": "Sharper GPT-5 generation for coding, product work, and tool-assisted tasks",
+    "family": "gpt",
+    "id": "openai/gpt-5.1",
+    "knowledge": "2024-09-30",
+    "last_updated": "2025-11-13",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.1 (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2025-11-13",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.2": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.175,
+     "input": 1.75,
+     "output": 14
+    },
+    "description": "Reliable GPT generation for broad coding, writing, and tool-assisted product work",
+    "family": "gpt",
+    "id": "openai/gpt-5.2",
+    "knowledge": "2025-08-31",
+    "last_updated": "2025-12-11",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.2 (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2025-12-11",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.2-pro": {
+    "attachment": true,
+    "cost": {
+     "input": 21,
+     "output": 168
+    },
+    "description": "Higher-accuracy GPT-5.2 variant for tougher reasoning and review workflows",
+    "family": "gpt-pro",
+    "id": "openai/gpt-5.2-pro",
+    "knowledge": "2025-08-31",
+    "last_updated": "2025-12-11",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 272000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.2 Pro (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2025-12-11",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.3-codex": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.175,
+     "input": 1.75,
+     "output": 14
+    },
+    "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
+    "family": "gpt-codex",
+    "id": "openai/gpt-5.3-codex",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-02-05",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.3 Codex (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-02-05",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.4": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "input": 2.5,
+     "output": 15
+    },
+    "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
+    "family": "gpt",
+    "id": "openai/gpt-5.4",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-05",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-05",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.4-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 4.5
+    },
+    "description": "Strong small GPT for coding subagents, quick tool use, and high-volume work",
+    "family": "gpt-mini",
+    "id": "openai/gpt-5.4-mini",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-17",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 Mini (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-17",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.4-nano": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02,
+     "input": 0.2,
+     "output": 1.25
+    },
+    "description": "Cheapest GPT-5.4 lane for simple routing, extraction, and bulk automation",
+    "family": "gpt-nano",
+    "id": "openai/gpt-5.4-nano",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-17",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 Nano (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-17",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.4-pro": {
+    "attachment": true,
+    "cost": {
+     "input": 30,
+     "output": 180
+    },
+    "description": "More exact GPT-5.4 tier for demanding professional reasoning and agent tasks",
+    "family": "gpt-pro",
+    "id": "openai/gpt-5.4-pro",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-05",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 Pro (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-05",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "context_over_200k": {
+      "cache_read": 1,
+      "input": 10,
+      "output": 45
+     },
+     "input": 5,
+     "output": 30,
+     "tiers": [
+      {
+       "cache_read": 1,
+       "input": 10,
+       "output": 45,
+       "tier": {
+        "size": 272000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Default frontier GPT for coding, computer use, research, and knowledge work",
+    "family": "gpt",
+    "id": "openai/gpt-5.5",
+    "knowledge": "2025-12-01",
+    "last_updated": "2026-04-23",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.5 (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-04-23",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.5-pro": {
+    "attachment": true,
+    "cost": {
+     "context_over_200k": {
+      "input": 60,
+      "output": 270
+     },
+     "input": 30,
+     "output": 180,
+     "tiers": [
+      {
+       "input": 60,
+       "output": 270,
+       "tier": {
+        "size": 272000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Highest-accuracy GPT-5.5 tier for slower, precision-heavy reasoning and coding",
+    "family": "gpt-pro",
+    "id": "openai/gpt-5.5-pro",
+    "knowledge": "2025-12-01",
+    "last_updated": "2026-04-23",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.5 Pro (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-04-23",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.6-luna": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02,
+     "cache_write": 0.25,
+     "input": 0.2,
+     "output": 1.2
+    },
+    "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+    "family": "gpt-luna",
+    "id": "openai/gpt-5.6-luna",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Luna (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.6-sol": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 30
+    },
+    "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+    "family": "gpt-sol",
+    "id": "openai/gpt-5.6-sol",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Sol (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.6-terra": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 12
+    },
+    "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+    "family": "gpt-terra",
+    "id": "openai/gpt-5.6-terra",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Terra (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/o1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 7.5,
+     "input": 15,
+     "output": 60
+    },
+    "description": "O-series reasoning model for hard analysis, math, coding, and planning",
+    "family": "o",
+    "id": "openai/o1",
+    "knowledge": "2023-09",
+    "last_updated": "2024-12-05",
+    "limit": {
+     "context": 200000,
+     "output": 100000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "o1 (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2024-12-05",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": false
+   },
+   "openai/o3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 8
+    },
+    "description": "Deliberate o-series reasoner for hard math, coding, and multi-step analysis",
+    "family": "o",
+    "id": "openai/o3",
+    "knowledge": "2024-05",
+    "last_updated": "2025-04-16",
+    "limit": {
+     "context": 200000,
+     "output": 100000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "o3 (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": false
+   },
+   "openai/o3-mini": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.55,
+     "input": 1.1,
+     "output": 4.4
+    },
+    "description": "Smaller o-series reasoner for economical coding, math, and planning tasks",
+    "family": "o-mini",
+    "id": "openai/o3-mini",
+    "knowledge": "2024-05",
+    "last_updated": "2025-01-29",
+    "limit": {
+     "context": 200000,
+     "output": 100000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "o3 Mini (OpenAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-12-20",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": false
+   },
+   "openai/o4-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.275,
+     "input": 1.1,
+     "output": 4.4
+    },
+    "description": "Fast o-series model for compact reasoning, coding, and tool use",
+    "family": "o-mini",
+    "id": "openai/o4-mini",
+    "knowledge": "2024-05",
+    "last_updated": "2025-04-16",
+    "limit": {
+     "context": 200000,
+     "output": 100000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "o4 Mini (OpenAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-04-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "permafrost/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.6,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "permafrost/kimi-k3",
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3 (Permafrost)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "perplexity/sonar": {
+    "attachment": false,
+    "cost": {
+     "input": 1,
+     "output": 1
+    },
+    "description": "Fast web-grounded Sonar for current answers, citations, and lightweight retrieval",
+    "family": "sonar",
+    "id": "perplexity/sonar",
+    "knowledge": "2025-09-01",
+    "last_updated": "2025-09-01",
+    "limit": {
+     "context": 130000,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Sonar (Perplexity)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-01-01",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": false
+   },
+   "perplexity/sonar-pro": {
+    "attachment": false,
+    "cost": {
+     "input": 3,
+     "output": 15
+    },
+    "description": "Deeper Sonar search model with broader retrieval and stronger synthesis",
+    "family": "sonar-pro",
+    "id": "perplexity/sonar-pro",
+    "knowledge": "2025-09-01",
+    "last_updated": "2025-09-01",
+    "limit": {
+     "context": 200000,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Sonar Pro (Perplexity)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-01-01",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": false
+   },
+   "perplexity/sonar-reasoning-pro": {
+    "attachment": false,
+    "cost": {
+     "input": 2,
+     "output": 8
+    },
+    "description": "Web-grounded Sonar for multi-step research questions that need cited reasoning",
+    "family": "sonar-reasoning",
+    "id": "perplexity/sonar-reasoning-pro",
+    "knowledge": "2025-09-01",
+    "last_updated": "2025-09-01",
+    "limit": {
+     "context": 128000,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Sonar Reasoning Pro (Perplexity)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-01-01",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": false
+   },
+   "quartz/gemini-3.1-pro-preview": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 4,
+      "output": 18
+     },
+     "input": 2,
+     "output": 12,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 4,
+       "output": 18,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
+    "family": "gemini-pro",
+    "id": "quartz/gemini-3.1-pro-preview",
+    "knowledge": "2025-01",
+    "last_updated": "2026-02-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Pro (Preview) (Quartz)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-02-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "ranoai/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.028,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "ranoai/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (RanoAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "runware/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.014,
+     "input": 0.076,
+     "output": 0.153
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "runware/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (Runware)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "runware/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.079,
+     "input": 0.961,
+     "output": 1.922
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "runware/deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro (Runware)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "runware/gemma-4-31b-it": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.012,
+     "input": 0.102,
+     "output": 0.297
+    },
+    "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
+    "family": "gemma",
+    "id": "runware/gemma-4-31b-it",
+    "last_updated": "2026-04-02",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 31B IT (Runware)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "runware/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.16,
+     "input": 0.8,
+     "output": 2.55
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "runware/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1024000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 (Runware)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "runware/gpt-oss-120b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.032,
+     "input": 0.032,
+     "output": 0.14
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "runware/gpt-oss-120b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B (Runware)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "runware/kimi-k2.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.13,
+     "input": 0.6,
+     "output": 3.05
+    },
+    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
+    "family": "kimi-k2",
+    "id": "runware/kimi-k2.6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-21",
+    "limit": {
+     "context": 262144,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.6 (Runware)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "sakana/fugu-ultra": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 5,
+     "output": 30
+    },
+    "description": "Quality-first multi-agent model for hard research, analysis, and competitions",
+    "family": "fugu",
+    "id": "sakana/fugu-ultra",
+    "last_updated": "2026-06-15",
+    "limit": {
+     "context": 1000000,
+     "output": 1000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Fugu Ultra (Sakana AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-15",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "scx-ai-gp/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.111,
+     "input": 0.55,
+     "output": 1.784
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "scx-ai-gp/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 (SCX.ai)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "scx-ai-gp/glm-5.2-fast": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.4,
+     "input": 1.99,
+     "output": 6.16
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "scx-ai-gp/glm-5.2-fast",
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 Turbo (SCX.ai)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "scx-ai-gp/qwen3.8-max": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.21,
+     "cache_write": 2.5,
+     "input": 1.815,
+     "output": 5.4461
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "scx-ai-gp/qwen3.8-max",
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max (SCX.ai)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-03",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "scx-ai/gemma-4-31b-it": {
+    "attachment": false,
+    "cost": {
+     "input": 0.3,
+     "output": 0.91
+    },
+    "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
+    "family": "gemma",
+    "id": "scx-ai/gemma-4-31b-it",
+    "last_updated": "2026-04-02",
+    "limit": {
+     "context": 131072,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 31B IT (SCX.ai (Turbo))",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-04-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "scx-ai/gpt-oss-120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.17,
+     "output": 0.55
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "scx-ai/gpt-oss-120b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B (SCX.ai (Turbo))",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "scx-ai/llama-4-maverick-17b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.53,
+     "output": 1.62
+    },
+    "description": "Open multimodal Llama for strong reasoning with efficient everyday serving",
+    "family": "llama",
+    "id": "scx-ai/llama-4-maverick-17b-instruct",
+    "knowledge": "2024-08",
+    "last_updated": "2025-04-05",
+    "limit": {
+     "context": 131072,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama 4 Maverick 17B Instruct (SCX.ai (Turbo))",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-04-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "scx-ai/minimax-m2.7": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.48,
+     "output": 1.79
+    },
+    "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+    "family": "minimax",
+    "id": "scx-ai/minimax-m2.7",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 196608,
+     "output": 196608
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.7 (SCX.ai (Turbo))",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-03-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "scx-ai/qwen3-32b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.36,
+     "output": 0.87
+    },
+    "description": "Dense open Qwen model for self-hosted chat, reasoning, and coding",
+    "family": "qwen",
+    "id": "scx-ai/qwen3-32b",
+    "knowledge": "2025-04",
+    "last_updated": "2025-04",
+    "limit": {
+     "context": 32768,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 32B (SCX.ai (Turbo))",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-04",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "together-ai/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "together-ai/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 163840,
+     "output": 163840
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (Together AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "together-ai/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.13,
+     "input": 1.32,
+     "output": 3.96
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "together-ai/deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048576,
+     "output": 163840
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro (Together AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "together-ai/gemma-4-31b-it": {
+    "attachment": false,
+    "cost": {
+     "input": 0.39,
+     "output": 0.97
+    },
+    "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
+    "family": "gemma",
+    "id": "together-ai/gemma-4-31b-it",
+    "last_updated": "2026-04-02",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 31B IT (Together AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-02",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "together-ai/glm-4.7": {
+    "attachment": false,
+    "cost": {
+     "input": 0.45,
+     "output": 2
+    },
+    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
+    "family": "glm",
+    "id": "together-ai/glm-4.7",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 202752,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.7 (Together AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "together-ai/gpt-oss-120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.15,
+     "output": 0.6
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "together-ai/gpt-oss-120b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B (Together AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "together-ai/gpt-oss-20b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.05,
+     "output": 0.2
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "together-ai/gpt-oss-20b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 20B (Together AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "together-ai/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "together-ai/kimi-k3",
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1000000,
+     "output": 1000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3 (Together AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "together-ai/minimax-m3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "family": "minimax",
+    "id": "together-ai/minimax-m3",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 524288,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M3 (Together AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-01",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": false
+   },
+   "tundra/kimi-k2.6": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.08,
+     "input": 0.4,
+     "output": 2.2
+    },
+    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
+    "family": "kimi-k2",
+    "id": "tundra/kimi-k2.6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-21",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.6 (Tundra)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-anthropic/claude-haiku-4-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 1,
+     "output": 5
+    },
+    "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
+    "family": "claude-haiku",
+    "id": "vertex-anthropic/claude-haiku-4-5",
+    "knowledge": "2025-02-28",
+    "last_updated": "2025-10-15",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Haiku 4.5 (Vertex AI (Anthropic))",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-10-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-anthropic/claude-opus-4-5-20251101": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "vertex-anthropic/claude-opus-4-5-20251101",
+    "knowledge": "2025-05",
+    "last_updated": "2025-11-01",
+    "limit": {
+     "context": 200000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.5 (Vertex AI (Anthropic))",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 31999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-11-01",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-anthropic/claude-opus-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 5,
+     "output": 25
+    },
+    "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
+    "family": "claude-opus",
+    "id": "vertex-anthropic/claude-opus-4-6",
+    "knowledge": "2025-05-31",
+    "last_updated": "2026-03-13",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.6 (Vertex AI (Anthropic))",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-anthropic/claude-opus-4-7": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
+    "family": "claude-opus",
+    "id": "vertex-anthropic/claude-opus-4-7",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-04-16",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.7 (Vertex AI (Anthropic))",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "vertex-anthropic/claude-sonnet-4-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
+    "family": "claude-sonnet",
+    "id": "vertex-anthropic/claude-sonnet-4-5",
+    "knowledge": "2025-07-31",
+    "last_updated": "2025-09-29",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.5 (Vertex AI (Anthropic))",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 63999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-09-29",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-anthropic/claude-sonnet-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
+    "family": "claude-sonnet",
+    "id": "vertex-anthropic/claude-sonnet-4-6",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-13",
+    "limit": {
+     "context": 1000000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.6 (Vertex AI (Anthropic))",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 63999,
+      "min": 1024,
+      "type": "budget_tokens"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-anthropic/claude-sonnet-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
+    },
+    "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+    "family": "claude-sonnet",
+    "id": "vertex-anthropic/claude-sonnet-5",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-30",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 5 (Vertex AI (Anthropic))",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-30",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "vertex-openai/deepseek-v3.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.056,
+     "input": 0.56,
+     "output": 1.68
+    },
+    "description": "Hybrid-reasoning DeepSeek model with thinking and non-thinking modes, sparse attention, and tool-use",
+    "family": "deepseek",
+    "id": "vertex-openai/deepseek-v3.2",
+    "knowledge": "2024-07",
+    "last_updated": "2025-12-01",
+    "limit": {
+     "context": 163840,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V3.2 (Vertex AI (OpenAI-compatible))",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-12-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-openai/glm-4.7": {
+    "attachment": false,
+    "cost": {
+     "input": 0.6,
+     "output": 2.2
+    },
+    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
+    "family": "glm",
+    "id": "vertex-openai/glm-4.7",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 202752,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.7 (Vertex AI (OpenAI-compatible))",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-openai/glm-5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 1,
+     "output": 3.2
+    },
+    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
+    "family": "glm",
+    "id": "vertex-openai/glm-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 202752,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5 (Vertex AI (OpenAI-compatible))",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-openai/grok-4-20-non-reasoning": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2.5,
+      "output": 5
+     },
+     "input": 1.25,
+     "output": 2.5,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2.5,
+       "output": 5,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "O-series reasoning model for hard analysis, math, coding, and planning",
+    "family": "grok",
+    "id": "vertex-openai/grok-4-20-non-reasoning",
+    "last_updated": "2026-03-09",
+    "limit": {
+     "context": 2000000,
+     "output": 30000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.20 Non-Reasoning (Vertex AI (OpenAI-compatible))",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-03-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-openai/grok-4-20-reasoning": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2.5,
+      "output": 5
+     },
+     "input": 1.25,
+     "output": 2.5,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2.5,
+       "output": 5,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "O-series reasoning model for hard analysis, math, coding, and planning",
+    "family": "grok",
+    "id": "vertex-openai/grok-4-20-reasoning",
+    "last_updated": "2026-03-09",
+    "limit": {
+     "context": 2000000,
+     "output": 30000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.20 Reasoning (Vertex AI (OpenAI-compatible))",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-03-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-openai/grok-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "vertex-openai/grok-4-6",
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6 (Vertex AI (OpenAI-compatible))",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-openai/kimi-k2-thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.6,
+     "output": 2.5
+    },
+    "description": "Thinking Kimi model for slower research passes, planning, and hard technical questions",
+    "family": "kimi-thinking",
+    "id": "vertex-openai/kimi-k2-thinking",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2024-08",
+    "last_updated": "2025-11-06",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2 Thinking (Vertex AI (OpenAI-compatible))",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-11-06",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-openai/qwen3-235b-a22b-instruct-2507": {
+    "attachment": false,
+    "cost": {
+     "input": 0.22,
+     "output": 0.88
+    },
+    "description": "Updated large open Qwen3 MoE instruct model for multilingual chat, coding, and tool use",
+    "family": "qwen",
+    "id": "vertex-openai/qwen3-235b-a22b-instruct-2507",
+    "last_updated": "2025-07-21",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 235B A22B Instruct 2507 (Vertex AI (OpenAI-compatible))",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-07-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-openai/qwen3-coder-480b-a35b-instruct": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.022,
+     "input": 0.22,
+     "output": 1.8
+    },
+    "description": "Open Qwen coding heavyweight for repository reasoning and agentic engineering",
+    "family": "qwen",
+    "id": "vertex-openai/qwen3-coder-480b-a35b-instruct",
+    "knowledge": "2025-04",
+    "last_updated": "2025-04",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Coder 480B A35B Instruct (Vertex AI (OpenAI-compatible))",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-04",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-openai/qwen3-next-80b-a3b-instruct": {
+    "attachment": false,
+    "cost": {
+     "input": 0.15,
+     "output": 1.2
+    },
+    "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+    "family": "qwen",
+    "id": "vertex-openai/qwen3-next-80b-a3b-instruct",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Next 80B A3B Instruct (Vertex AI (OpenAI-compatible))",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex-openai/qwen3-next-80b-a3b-thinking": {
+    "attachment": false,
+    "cost": {
+     "input": 0.15,
+     "output": 1.2
+    },
+    "description": "Efficient Qwen thinking model for local reasoning, math, and coding agents",
+    "family": "qwen",
+    "id": "vertex-openai/qwen3-next-80b-a3b-thinking",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Next 80B A3B Thinking (Vertex AI (OpenAI-compatible))",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-4": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.75,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "xai/grok-4",
+    "last_updated": "2025-07-09",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4 (xAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-07-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-4-20-beta-0309-non-reasoning": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2.5,
+      "output": 5
+     },
+     "input": 2,
+     "output": 6,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2.5,
+       "output": 5,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "xai/grok-4-20-beta-0309-non-reasoning",
+    "last_updated": "2026-03-09",
+    "limit": {
+     "context": 2000000,
+     "output": 30000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.20 Beta Non-Reasoning (0309) (xAI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-03-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-4-20-beta-0309-reasoning": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2.5,
+      "output": 5
+     },
+     "input": 2,
+     "output": 6,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2.5,
+       "output": 5,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "xai/grok-4-20-beta-0309-reasoning",
+    "last_updated": "2026-03-09",
+    "limit": {
+     "context": 2000000,
+     "output": 30000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.20 Beta Reasoning (0309) (xAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-03-09",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-4-3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2.5,
+      "output": 5
+     },
+     "input": 1.25,
+     "output": 2.5,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2.5,
+       "output": 5,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "xai/grok-4-3",
+    "last_updated": "2026-04-30",
+    "limit": {
+     "context": 1000000,
+     "output": 1000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.3 (xAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-30",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-4-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 2,
+     "output": 6
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "xai/grok-4-5",
+    "last_updated": "2026-07-08",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.5 (xAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-08",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "xai/grok-4-6",
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6 (xAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-build-0-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2,
+      "output": 4
+     },
+     "input": 1,
+     "output": 2,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2,
+       "output": 4,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Grok coding model for agentic engineering, edits, and codebase workflows",
+    "family": "grok-build",
+    "id": "xai/grok-build-0-1",
+    "last_updated": "2026-05-20",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok Build 0.1 (xAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xiaomi/mimo-v2.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.0028,
+     "context_over_200k": {
+      "cache_read": 0.16,
+      "input": 0.8,
+      "output": 4
+     },
+     "input": 0.14,
+     "output": 0.28,
+     "tiers": [
+      {
+       "cache_read": 0.16,
+       "input": 0.8,
+       "output": 4,
+       "tier": {
+        "size": 256000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Open MiMo model for multimodal coding agents and long-context automation",
+    "family": "mimo",
+    "id": "xiaomi/mimo-v2.5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2024-12",
+    "last_updated": "2026-04-22",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiMo V2.5 (Xiaomi)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xiaomi/mimo-v2.5-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0036,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2,
+      "output": 6
+     },
+     "input": 0.435,
+     "output": 0.87,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2,
+       "output": 6,
+       "tier": {
+        "size": 256000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
+    "family": "mimo",
+    "id": "xiaomi/mimo-v2.5-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2024-12",
+    "last_updated": "2026-04-22",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiMo V2.5 Pro (Xiaomi)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4-32b-0414-128k": {
+    "attachment": false,
+    "cost": {
+     "input": 0.1,
+     "output": 0.1
+    },
+    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+    "family": "glm",
+    "id": "zai/glm-4-32b-0414-128k",
+    "last_updated": "2025-04-14",
+    "limit": {
+     "context": 128000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4 32B (0414-128k) (Z AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-14",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4.5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.6,
+     "output": 2.2
+    },
+    "description": "Hybrid-reasoning GLM release that made the 4.5 line broadly useful",
+    "family": "glm",
+    "id": "zai/glm-4.5",
+    "knowledge": "2025-04",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 128000,
+     "output": 98304
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.5 (Z AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-07-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4.5-air": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.2,
+     "output": 1.1
+    },
+    "description": "Lighter GLM-4.5 variant for fast coding assistance and cheaper agents",
+    "family": "glm-air",
+    "id": "zai/glm-4.5-air",
+    "knowledge": "2025-04",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 128000,
+     "output": 98304
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.5 Air (Z AI)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-07-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4.5-airx": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.22,
+     "input": 1.1,
+     "output": 4.5
+    },
+    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+    "family": "glm",
+    "id": "zai/glm-4.5-airx",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 128000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.5 AirX (Z AI)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-07-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4.5-x": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.45,
+     "input": 2.2,
+     "output": 8.9
+    },
+    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+    "family": "glm",
+    "id": "zai/glm-4.5-x",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 128000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.5 X (Z AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-07-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4.5v": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.6,
+     "output": 1.8
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "zai/glm-4.5v",
+    "knowledge": "2025-04",
+    "last_updated": "2025-08-11",
+    "limit": {
+     "context": 128000,
+     "output": 16000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.5V (Z AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-08-11",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4.6": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.6,
+     "output": 2.2
+    },
+    "description": "Late GLM-4 workhorse for coding agents, reasoning, and structured tasks",
+    "family": "glm",
+    "id": "zai/glm-4.6",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09-30",
+    "limit": {
+     "context": 200000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.6 (Z AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-09-30",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4.6v": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.3,
+     "output": 0.9
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "zai/glm-4.6v",
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-08",
+    "limit": {
+     "context": 128000,
+     "output": 16000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.6V (Z AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-08",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4.6v-flashx": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.004,
+     "input": 0.04,
+     "output": 0.4
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "zai/glm-4.6v-flashx",
+    "last_updated": "2025-12-08",
+    "limit": {
+     "context": 128000,
+     "output": 16000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.6V FlashX (Z AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-08",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4.7": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.6,
+     "output": 2.2
+    },
+    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
+    "family": "glm",
+    "id": "zai/glm-4.7",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.7 (Z AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-22",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-4.7-flashx": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.07,
+     "output": 0.4
+    },
+    "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
+    "family": "glm-flash",
+    "id": "zai/glm-4.7-flashx",
+    "knowledge": "2025-04",
+    "last_updated": "2026-01-19",
+    "limit": {
+     "context": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.7 FlashX (Z AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-01-19",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
+    },
+    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
+    "family": "glm",
+    "id": "zai/glm-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 202800,
+     "output": 131100
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5 (Z AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-5.1": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
+    "family": "glm",
+    "id": "zai/glm-5.1",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-04-07",
+    "limit": {
+     "context": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.1 (Z AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-07",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "zai/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2 (Z AI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "zai/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 (Z AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "LLM Gateway",
@@ -127016,6 +143172,38 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek/deepseek-v4-pro-0423": {
+    "attachment": false,
+    "cost": {
+     "input": 1.65,
+     "output": 3.3
+    },
+    "description": "DeepSeek V4 Pro initial snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "deepseek/deepseek-v4-pro-0423",
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-23",
+    "limit": {
+     "context": 1000000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0423",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-04-23",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepseek/deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
@@ -127026,7 +143214,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "deepseek/deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 384000
@@ -127040,7 +143228,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -127878,11 +144066,11 @@
      "input_audio": 1.5,
      "output": 9
     },
-    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
     "id": "google/gemini-flash-latest",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-19",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
     "limit": {
      "context": 1048576,
      "output": 65536
@@ -127913,7 +144101,7 @@
       ]
      }
     ],
-    "release_date": "2026-05-19",
+    "release_date": "2026-08-13",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -127926,11 +144114,11 @@
      "input_audio": 0.5,
      "output": 1.5
     },
-    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash-lite",
     "id": "google/gemini-flash-lite-latest",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-07",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
     "limit": {
      "context": 1048576,
      "output": 65536
@@ -127961,7 +144149,7 @@
       ]
      }
     ],
-    "release_date": "2026-05-07",
+    "release_date": "2026-07-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -130202,8 +146390,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.5,
-     "input": 5,
-     "output": 30
+     "input": 4,
+     "output": 24
     },
     "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
     "family": "gpt-sol",
@@ -131092,7 +147280,7 @@
     "tool_call": true
    },
    "qwen/qwen3.5-122b-a10b": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
      "cache_read": 0.023,
      "input": 0.115,
@@ -131103,13 +147291,12 @@
     "id": "qwen/qwen3.5-122b-a10b",
     "last_updated": "2026-02-23",
     "limit": {
-     "context": 256000,
-     "output": 64000
+     "context": 131072,
+     "output": 32768
     },
     "modalities": {
      "input": [
-      "text",
-      "image"
+      "text"
      ],
      "output": [
       "text"
@@ -131203,7 +147390,7 @@
     "tool_call": true
    },
    "qwen/qwen3.5-397b-a17b": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.0344,
      "input": 0.172,
@@ -131214,12 +147401,13 @@
     "id": "qwen/qwen3.5-397b-a17b",
     "last_updated": "2026-02-15",
     "limit": {
-     "context": 131072,
-     "output": 32768
+     "context": 256000,
+     "output": 64000
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
@@ -132495,9 +148683,9 @@
    "zai/glm-5.3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
+     "cache_read": 0.13,
+     "input": 0.7,
+     "output": 2.2
     },
     "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
     "family": "glm",
@@ -144040,6 +160228,50 @@
     "structured_output": true,
     "tool_call": true
    },
+   "deepseek/deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.014,
+     "input": 0.44,
+     "output": 1.32
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-vision-exp",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepseek/deepseek-v4-flash:thinking": {
     "attachment": false,
     "cost": {
@@ -144136,7 +160368,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "deepseek/deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "input": 1048576,
@@ -144151,7 +160383,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -144179,7 +160411,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "deepseek/deepseek-v4-pro-0813:thinking",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "input": 1048576,
@@ -144194,7 +160426,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813 Thinking",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -146765,26 +162997,28 @@
    "google/gemini-flash-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.075,
-     "cache_write": 0.041667,
-     "input": 0.75,
-     "output": 3.75
+     "cache_read": 0.0375,
+     "cache_write": 0.020833,
+     "input": 0.375,
+     "output": 1.875
     },
-    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
     "id": "google/gemini-flash-latest",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-19",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
     "limit": {
-     "context": 1048756,
-     "input": 1048756,
+     "context": 1048576,
+     "input": 1048576,
      "output": 65536
     },
     "modalities": {
      "input": [
       "text",
       "image",
-      "audio"
+      "video",
+      "audio",
+      "pdf"
      ],
      "output": [
       "text"
@@ -146804,10 +163038,10 @@
       ]
      }
     ],
-    "release_date": "2026-05-19",
-    "structured_output": false,
+    "release_date": "2026-08-13",
+    "structured_output": true,
     "temperature": true,
-    "tool_call": false
+    "tool_call": true
    },
    "google/gemini-flash-lite-latest": {
     "attachment": true,
@@ -146817,11 +163051,11 @@
      "input": 0.3,
      "output": 2.5
     },
-    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash-lite",
     "id": "google/gemini-flash-lite-latest",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-07",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
     "limit": {
      "context": 1048576,
      "input": 1048576,
@@ -146853,7 +163087,7 @@
       ]
      }
     ],
-    "release_date": "2026-05-07",
+    "release_date": "2026-07-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -146905,9 +163139,9 @@
    "google/gemma-4-26b-a4b-it": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.065,
-     "input": 0.13,
-     "output": 0.4
+     "cache_read": 0.04,
+     "input": 0.08,
+     "output": 0.33
     },
     "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
     "family": "gemma",
@@ -146974,12 +163208,44 @@
     "temperature": true,
     "tool_call": true
    },
+   "google/gemma-4-26b-a4b-uncensored": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.04,
+     "input": 0.08,
+     "output": 0.33
+    },
+    "description": "Gemma 4 26B A4B Uncensored is an NVFP4 open-weight multimodal mixture-of-experts model tuned for fewer refusals across chat, coding, tool use, and long-context work.",
+    "family": "gemma",
+    "id": "google/gemma-4-26b-a4b-uncensored",
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 131072,
+     "input": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 26B A4B Uncensored",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-08-22",
+    "structured_output": true,
+    "tool_call": true
+   },
    "google/gemma-4-31b-it": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.05,
-     "input": 0.1,
-     "output": 0.35
+     "cache_read": 0.04,
+     "input": 0.08,
+     "output": 0.33
     },
     "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
     "family": "gemma",
@@ -152914,6 +169180,72 @@
     "structured_output": true,
     "tool_call": true
    },
+   "ornith-ai/ornith-1.5-35b-a3b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Ornith 1.5 35B A3B is an open-weight mixture-of-experts model for agentic coding, tool use, image understanding, and long-context work. This variant disables thinking for faster direct responses.",
+    "family": "ornith",
+    "id": "ornith-ai/ornith-1.5-35b-a3b",
+    "last_updated": "2026-08-20",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ornith 1.5 35B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-20",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "ornith-ai/ornith-1.5-35b-a3b:thinking": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Ornith 1.5 35B A3B is an open-weight mixture-of-experts model for agentic coding, reasoning, tool use, image understanding, and long-context work. This variant enables thinking by default.",
+    "family": "ornith",
+    "id": "ornith-ai/ornith-1.5-35b-a3b:thinking",
+    "last_updated": "2026-08-20",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ornith 1.5 35B Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-20",
+    "structured_output": true,
+    "tool_call": true
+   },
    "pamanseau/OpenReasoning-Nemotron-32B": {
     "attachment": false,
     "cost": {
@@ -154222,6 +170554,70 @@
     "structured_output": false,
     "temperature": true,
     "tool_call": false
+   },
+   "qwen/qwen3.6-35b-a3b-uncensored": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Qwen 3.6 35B A3B Uncensored is an FP8 open-weight mixture-of-experts model tuned for fewer refusals across chat, coding, tool use, and multimodal tasks.",
+    "family": "qwen3.6",
+    "id": "qwen/qwen3.6-35b-a3b-uncensored",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 65536,
+     "input": 65536,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen 3.6 35B A3B Uncensored",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-08-21",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-27b-uncensored": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.18,
+     "output": 0.5
+    },
+    "description": "Qwen 3.8 27B Uncensored is an FP8 open-weight multimodal model tuned for fewer refusals across chat, coding, tool use, and long-context work.",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-27b-uncensored",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 131072,
+     "input": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen 3.8 27B Uncensored",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-08-21",
+    "structured_output": true,
+    "tool_call": true
    },
    "qwen25-vl-72b-instruct": {
     "attachment": true,
@@ -155783,6 +172179,48 @@
     "structured_output": false,
     "tool_call": false
    },
+   "stealth/ox-alpha": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "input": 0.05,
+     "output": 0.05
+    },
+    "description": "Ox Alpha is an experimental stealth model with long-context reasoning, vision, tool calling, and structured output support. Prompts and responses are logged and retained by the provider.",
+    "family": "alpha",
+    "id": "stealth/ox-alpha",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "input": 1000000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ox Alpha",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "structured_output": true,
+    "tool_call": true
+   },
    "step-r1-v-mini": {
     "attachment": false,
     "cost": {
@@ -156442,9 +172880,9 @@
    "venice-uncensored": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.2,
+     "cache_read": 0.4,
      "input": 0.4,
-     "output": 0.4
+     "output": 1.8
     },
     "description": "Compact GPT model for low-latency assistance and high-volume workloads",
     "family": "venice",
@@ -156453,7 +172891,7 @@
     "limit": {
      "context": 128000,
      "input": 128000,
-     "output": 16384
+     "output": 8192
     },
     "modalities": {
      "input": [
@@ -168056,6 +184494,50 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek-ai/deepseek-v4-flash-0731": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "deepseek-ai/deepseek-v4-flash-0731",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepseek-ai/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
@@ -169213,6 +185695,54 @@
     "status": "deprecated",
     "structured_output": true,
     "temperature": true,
+    "tool_call": true
+   },
+   "moonshotai/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "moonshotai/kimi-k3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": true,
+    "temperature": false,
     "tool_call": true
    },
    "nvidia/active-speaker-detection": {
@@ -172122,9 +188652,9 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.2,
-     "cache_write": 2,
-     "input": 2,
-     "output": 12
+     "cache_write": 1.17,
+     "input": 2.15,
+     "output": 12.86
     },
     "description": "Flagship Qwen model for complex reasoning, coding, and agentic workflows",
     "family": "qwen",
@@ -172281,6 +188811,48 @@
     "temperature": true,
     "tool_call": true
    },
+   "bailian/qwen3.8-27b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "cache_write": 0.5625,
+     "input": 0.45,
+     "output": 3.2
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "bailian/qwen3.8-27b",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1131072,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "bailian/qwen3.8-max": {
     "attachment": true,
     "cost": {
@@ -172415,6 +188987,97 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek/deepseek-v4-flash-0731": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.014,
+     "input": 0.44,
+     "output": 1.32
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-0731",
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.014,
+     "input": 0.44,
+     "output": 1.32
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-vision-exp",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "status": "beta",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepseek/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
@@ -172459,6 +189122,50 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek/deepseek-v4-pro-0423": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.044,
+     "input": 1.32,
+     "output": 3.96
+    },
+    "description": "DeepSeek V4 Pro initial snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "deepseek/deepseek-v4-pro-0423",
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-23",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0423",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-23",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepseek/deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
@@ -172469,7 +189176,7 @@
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "deepseek/deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 384000
@@ -172483,7 +189190,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -172898,11 +189605,11 @@
    "google/gemini-3.6-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 0.083,
-     "input": 1.5,
+     "cache_read": 0.075,
+     "cache_write": 0.0415,
+     "input": 0.75,
      "input_audio": 1.5,
-     "output": 7.5
+     "output": 3.75
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -172951,11 +189658,11 @@
    "google/gemini-3.7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 0.083,
-     "input": 1.5,
+     "cache_read": 0.075,
+     "cache_write": 0.0415,
+     "input": 0.75,
      "input_audio": 1.5,
-     "output": 7.5
+     "output": 3.75
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -174361,10 +191068,10 @@
    "openai/gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
-     "input": 5,
-     "output": 30
+     "cache_read": 0.25,
+     "cache_write": 3.125,
+     "input": 2.5,
+     "output": 15
     },
     "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
     "family": "gpt-sol",
@@ -174751,10 +191458,10 @@
    "volcengine/doubao-seed-2.1-pro": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.177,
-     "cache_write": 0.0025,
-     "input": 0.884,
-     "output": 4.42
+     "cache_read": 0.1416,
+     "cache_write": 0.002,
+     "input": 0.7072,
+     "output": 3.536
     },
     "description": "Flagship ByteDance Seed 2.1 model for complex multimodal reasoning, coding, and agents",
     "family": "seed",
@@ -174789,10 +191496,10 @@
    "volcengine/doubao-seed-2.1-turbo": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.085,
-     "cache_write": 0.0024,
-     "input": 0.442,
-     "output": 2.212
+     "cache_read": 0.068,
+     "cache_write": 0.0019,
+     "input": 0.3536,
+     "output": 1.7696
     },
     "description": "Faster ByteDance Seed 2.1 model for multimodal reasoning and latency-sensitive agent workflows",
     "family": "seed",
@@ -175314,9 +192021,9 @@
    "z-ai/glm-5.2": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
+     "cache_read": 0.182,
+     "input": 0.98,
+     "output": 3.08
     },
     "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
     "family": "glm",
@@ -175354,9 +192061,9 @@
    "z-ai/glm-5.3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
+     "cache_read": 0.234,
+     "input": 1.26,
+     "output": 3.96
     },
     "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
     "family": "glm",
@@ -179042,6 +195749,7 @@
      }
     ],
     "release_date": "2026-07-31",
+    "status": "deprecated",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -180682,22 +197390,22 @@
    "gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
+     "cache_read": 0.2,
+     "cache_write": 2.5,
      "context_over_200k": {
-      "cache_read": 1,
-      "cache_write": 12.5,
-      "input": 10,
-      "output": 45
+      "cache_read": 0.4,
+      "cache_write": 5,
+      "input": 4,
+      "output": 15
      },
-     "input": 5,
-     "output": 30,
+     "input": 2,
+     "output": 10,
      "tiers": [
       {
-       "cache_read": 1,
-       "cache_write": 12.5,
-       "input": 10,
-       "output": 45,
+       "cache_read": 0.4,
+       "cache_write": 5,
+       "input": 4,
+       "output": 15,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -181404,6 +198112,7 @@
      }
     ],
     "release_date": "2026-07-21",
+    "status": "deprecated",
     "structured_output": false,
     "temperature": true,
     "tool_call": true
@@ -182007,6 +198716,56 @@
     "temperature": true,
     "tool_call": true
    },
+   "muse-spark-1.2-contributor-free": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Muse Spark 1.2 is a coding-focused update to Muse Spark 1.1 with improvements in code generation, complex debugging, codebase understanding, and end-to-end developer workflows.",
+    "family": "muse-free",
+    "id": "muse-spark-1.2-contributor-free",
+    "last_updated": "2026-08-05",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.2 Free",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "nemotron-3-super-free": {
     "attachment": false,
     "cost": {
@@ -182391,6 +199150,51 @@
     "status": "deprecated",
     "temperature": true,
     "tool_call": true
+   },
+   "x-preview-f-free": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Stealth reasoning model for coding, agentic tasks, and tool use",
+    "id": "x-preview-f-free",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ox Alpha Free (Unlimited)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "OpenCode Zen",
@@ -182445,6 +199249,54 @@
      }
     ],
     "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash-vision-exp",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -183317,7 +200169,51 @@
      }
     ],
     "release_date": "2026-08-05",
-    "status": "deprecated",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "ox-alpha-free": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Stealth reasoning model for coding, agentic tasks, and tool use",
+    "id": "ox-alpha-free",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ox Alpha Free (Unlimited)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -185427,37 +202323,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "deepcogito/cogito-v2.1-671b": {
-    "attachment": false,
-    "cost": {
-     "input": 1.25,
-     "output": 1.25
-    },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "cogito",
-    "id": "deepcogito/cogito-v2.1-671b",
-    "last_updated": "2025-11-13",
-    "limit": {
-     "context": 128000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Cogito v2.1 671B",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-11-13",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
    "deepseek/deepseek-chat": {
     "attachment": false,
     "cost": {
@@ -185523,9 +202388,9 @@
    "deepseek/deepseek-chat-v3.1": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.13,
-     "input": 0.25,
-     "output": 0.95
+     "cache_read": 0.55,
+     "input": 0.55,
+     "output": 1.65
     },
     "description": "DeepSeek chat model for instruction following, coding, and analysis",
     "family": "deepseek",
@@ -185534,7 +202399,7 @@
     "last_updated": "2025-08-21",
     "limit": {
      "context": 163840,
-     "output": 32768
+     "output": 161000
     },
     "modalities": {
      "input": [
@@ -185657,6 +202522,7 @@
    "deepseek/deepseek-v3.1-terminus": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.135,
      "input": 0.27,
      "output": 1
     },
@@ -185667,7 +202533,7 @@
     "last_updated": "2025-09-22",
     "limit": {
      "context": 163840,
-     "output": 163840
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -185693,9 +202559,9 @@
    "deepseek/deepseek-v3.2": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.1345,
-     "input": 0.269,
-     "output": 0.4
+     "cache_read": 0.13,
+     "input": 0.26,
+     "output": 0.38
     },
     "description": "DeepSeek chat model for instruction following, coding, and analysis",
     "family": "deepseek",
@@ -185704,7 +202570,7 @@
     "last_updated": "2025-12-01",
     "limit": {
      "context": 163840,
-     "output": 65536
+     "output": 163840
     },
     "modalities": {
      "input": [
@@ -185766,9 +202632,9 @@
    "deepseek/deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.01652,
-     "input": 0.0826,
-     "output": 0.1652
+     "cache_read": 0.010892,
+     "input": 0.05446,
+     "output": 0.10892
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -185813,9 +202679,9 @@
    "deepseek/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.028,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.016,
+     "input": 0.08,
+     "output": 0.18
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -185824,7 +202690,7 @@
     "last_updated": "2026-07-31",
     "limit": {
      "context": 1310720,
-     "output": 393216
+     "output": 384000
     },
     "modalities": {
      "input": [
@@ -185855,12 +202721,57 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek/deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
+    },
+    "description": "Fast DeepSeek model for efficient chat, coding help, and agent loops",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-vision-exp",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1048576,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepseek/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.1215,
-     "input": 1.44,
-     "output": 2.88
+     "cache_read": 0.034481,
+     "input": 0.413772,
+     "output": 0.827544
     },
     "description": "Open MoE flagship with million-token context for coding and long agent runs",
     "family": "deepseek-thinking",
@@ -185872,7 +202783,7 @@
     "last_updated": "2026-04-24",
     "limit": {
      "context": 1048576,
-     "output": 393216
+     "output": 384000
     },
     "modalities": {
      "input": [
@@ -185905,14 +202816,14 @@
    "deepseek/deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.022,
-     "input": 0.66,
-     "output": 1.98
+     "cache_read": 0.0374,
+     "input": 1.122,
+     "output": 3.366
     },
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "deepseek/deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 384000
@@ -185926,7 +202837,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -186574,7 +203485,7 @@
     "last_updated": "2026-06-30",
     "limit": {
      "context": 65536,
-     "output": 66000
+     "output": 65536
     },
     "modalities": {
      "input": [
@@ -187216,15 +204127,15 @@
      }
     ],
     "release_date": "2026-04-02",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
    "google/gemma-4-31b-it": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.05,
-     "input": 0.09,
+     "cache_read": 0.1,
+     "input": 0.1,
      "output": 0.34
     },
     "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
@@ -187233,7 +204144,7 @@
     "last_updated": "2026-04-02",
     "limit": {
      "context": 262144,
-     "output": 16384
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -187719,6 +204630,37 @@
     "temperature": true,
     "tool_call": true
    },
+   "liquid/lfm-2.5-2.6b:free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Free provider route for experiments, demos, and cost-sensitive chat workloads",
+    "family": "liquid",
+    "id": "liquid/lfm-2.5-2.6b:free",
+    "last_updated": "2026-08-11",
+    "limit": {
+     "context": 65536,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "LFM2.5-2.6B (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-11",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "mancer/weaver": {
     "attachment": false,
     "cost": {
@@ -187746,7 +204688,7 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2023-08-02",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": false
    },
@@ -188176,6 +205118,53 @@
     "temperature": true,
     "tool_call": true
    },
+   "meta/muse-spark-1.2-contributor": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.002,
+     "input": 0.1,
+     "output": 0.2
+    },
+    "description": "Open Llama multimodal model for image understanding and text reasoning",
+    "family": "muse",
+    "id": "meta/muse-spark-1.2-contributor",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.2 Contributor",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "microsoft/phi-4": {
     "attachment": false,
     "cost": {
@@ -188404,9 +205393,9 @@
    "minimax/minimax-m2.5": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.06,
-     "input": 0.225,
-     "output": 0.9
+     "cache_read": 0.027,
+     "input": 0.27,
+     "output": 1.08
     },
     "description": "Prior MiniMax coding model for agent workflows, office edits, and automation",
     "family": "minimax",
@@ -188417,7 +205406,7 @@
     "last_updated": "2026-02-12",
     "limit": {
      "context": 204800,
-     "output": 196608
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -188598,6 +205587,37 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
+   },
+   "mistralai/ministral-8b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.11,
+     "output": 0.11
+    },
+    "description": "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads",
+    "family": "ministral",
+    "id": "mistralai/ministral-8b",
+    "knowledge": "2024-09-30",
+    "last_updated": "2024-10-17",
+    "limit": {
+     "context": 128000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ministral 8B",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-10-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": false
    },
    "mistralai/ministral-8b-2512": {
     "attachment": true,
@@ -189012,8 +206032,8 @@
    "mistralai/mistral-small-3.2-24b-instruct": {
     "attachment": true,
     "cost": {
-     "input": 0.09375,
-     "output": 0.25
+     "input": 0.075,
+     "output": 0.2
     },
     "description": "Efficient Mistral model for fast chat, extraction, and production assistants",
     "family": "mistral-small",
@@ -189021,7 +206041,7 @@
     "knowledge": "2023-10-31",
     "last_updated": "2025-06-20",
     "limit": {
-     "context": 256000,
+     "context": 131072,
      "output": 16384
     },
     "modalities": {
@@ -189245,9 +206265,9 @@
    "moonshotai/kimi-k2.6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0944,
-     "input": 0.5605,
-     "output": 2.36
+     "cache_read": 0.16,
+     "input": 0.95,
+     "output": 4
     },
     "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
     "family": "kimi-k2",
@@ -189282,9 +206302,9 @@
    "moonshotai/kimi-k2.7-code": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "input": 0.71,
-     "output": 3.5
+     "cache_read": 0.17,
+     "input": 0.67,
+     "output": 3.4
     },
     "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
     "family": "kimi-k2",
@@ -189945,7 +206965,7 @@
     "id": "nvidia/nemotron-3.5-lightning",
     "last_updated": "2026-08-11",
     "limit": {
-     "context": 1000000,
+     "context": 262144,
      "output": 131072
     },
     "modalities": {
@@ -191760,22 +208780,22 @@
    "openai/gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
+     "cache_read": 0.2,
+     "cache_write": 2.5,
      "context_over_200k": {
-      "cache_read": 0.5,
-      "cache_write": 6.25,
-      "input": 5,
-      "output": 22.5
+      "cache_read": 0.4,
+      "cache_write": 5,
+      "input": 4,
+      "output": 15
      },
-     "input": 2.5,
-     "output": 15,
+     "input": 2,
+     "output": 10,
      "tiers": [
       {
-       "cache_read": 0.5,
-       "cache_write": 6.25,
-       "input": 5,
-       "output": 22.5,
+       "cache_read": 0.4,
+       "cache_write": 5,
+       "input": 4,
+       "output": 15,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -191827,22 +208847,22 @@
    "openai/gpt-5.6-sol-pro": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
+     "cache_read": 0.2,
+     "cache_write": 2.5,
      "context_over_200k": {
-      "cache_read": 0.5,
-      "cache_write": 6.25,
-      "input": 5,
-      "output": 22.5
+      "cache_read": 0.4,
+      "cache_write": 5,
+      "input": 4,
+      "output": 15
      },
-     "input": 2.5,
-     "output": 15,
+     "input": 2,
+     "output": 10,
      "tiers": [
       {
-       "cache_read": 0.5,
-       "cache_write": 6.25,
-       "input": 5,
-       "output": 22.5,
+       "cache_read": 0.4,
+       "cache_write": 5,
+       "input": 4,
+       "output": 15,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -192125,8 +209145,7 @@
    "openai/gpt-oss-120b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.03,
-     "input": 0.03,
+     "input": 0.037,
      "output": 0.17
     },
     "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
@@ -192187,46 +209206,6 @@
      ]
     },
     "name": "GPT OSS 20B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-08-05",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "openai/gpt-oss-20b:free": {
-    "attachment": false,
-    "cost": {
-     "input": 0,
-     "output": 0
-    },
-    "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
-    "family": "gpt-oss",
-    "id": "openai/gpt-oss-20b:free",
-    "last_updated": "2025-08-05",
-    "limit": {
-     "context": 131072,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "gpt-oss-20b (free)",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -193492,8 +210471,8 @@
    "qwen/qwen3-30b-a3b": {
     "attachment": false,
     "cost": {
-     "input": 0.13,
-     "output": 0.52
+     "input": 0.12,
+     "output": 0.5
     },
     "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
     "family": "qwen",
@@ -193501,7 +210480,7 @@
     "last_updated": "2025-04-28",
     "limit": {
      "context": 131072,
-     "output": 8192
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -193977,7 +210956,8 @@
    "qwen/qwen3-next-80b-a3b-instruct": {
     "attachment": false,
     "cost": {
-     "input": 0.09,
+     "cache_read": 0.07,
+     "input": 0.1,
      "output": 1.1
     },
     "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
@@ -193987,7 +210967,7 @@
     "last_updated": "2025-09",
     "limit": {
      "context": 262144,
-     "output": 16384
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -194609,9 +211589,9 @@
    "qwen/qwen3.6-27b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.03,
-     "input": 0.3,
-     "output": 2
+     "cache_read": 0.12,
+     "input": 0.6,
+     "output": 3.6
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -194619,7 +211599,7 @@
     "last_updated": "2026-04-22",
     "limit": {
      "context": 262144,
-     "output": 65536
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -195033,7 +212013,7 @@
     "last_updated": "2026-08-12",
     "limit": {
      "context": 1048576,
-     "output": 262144
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -195065,15 +212045,15 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.05,
-     "input": 0.45,
-     "output": 3.2
+     "input": 0.4,
+     "output": 3
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
     "id": "qwen/qwen3.8-27b",
     "last_updated": "2026-08-14",
     "limit": {
-     "context": 262144,
+     "context": 1000000,
      "output": 131072
     },
     "modalities": {
@@ -195468,6 +212448,48 @@
     "temperature": true,
     "tool_call": false
    },
+   "stealth/ox-alpha": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "alpha",
+    "id": "stealth/ox-alpha",
+    "last_updated": "2026-08-20",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ox Alpha",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "stepfun/step-3.5-flash": {
     "attachment": false,
     "cost": {
@@ -195571,6 +212593,96 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2025-07-08",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": false
+   },
+   "tencent/hy-mt2-1.8b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.044,
+     "output": 0.177
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "tencent/hy-mt2-1.8b",
+    "last_updated": "2026-08-20",
+    "limit": {
+     "context": 8192,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy-MT2-1.8B",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-08-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "tencent/hy-mt2-30b-a3b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.074,
+     "output": 0.295
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "tencent/hy-mt2-30b-a3b",
+    "last_updated": "2026-08-20",
+    "limit": {
+     "context": 8192,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy-MT2-30B-A3B",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-08-20",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": false
+   },
+   "tencent/hy-mt2-7b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.074,
+     "output": 0.295
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "tencent/hy-mt2-7b",
+    "last_updated": "2026-08-19",
+    "limit": {
+     "context": 8192,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy-MT2-7B",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-08-19",
     "structured_output": true,
     "temperature": true,
     "tool_call": false
@@ -195782,8 +212894,8 @@
    "thinkingmachines/inkling": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.16,
-     "input": 0.95,
+     "cache_read": 0.17,
+     "input": 1,
      "output": 4.05
     },
     "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
@@ -195837,7 +212949,7 @@
     "id": "thinkingmachines/inkling-small",
     "last_updated": "2026-07-30",
     "limit": {
-     "context": 524288,
+     "context": 1048576,
      "output": 262144
     },
     "modalities": {
@@ -195868,6 +212980,96 @@
     ],
     "release_date": "2026-07-30",
     "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "thinkingmachines/inkling-small:free": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "ling",
+    "id": "thinkingmachines/inkling-small:free",
+    "last_updated": "2026-07-30",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Inkling Small (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-30",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "thinkingmachines/inkling:free": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "ling",
+    "id": "thinkingmachines/inkling:free",
+    "last_updated": "2026-07-15",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Inkling (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-15",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -197132,9 +214334,9 @@
    "~deepseek/deepseek-v4-flash-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0153,
-     "input": 0.0765,
-     "output": 0.153
+     "cache_read": 0.01278,
+     "input": 0.0639,
+     "output": 0.1278
     },
     "description": "Fast DeepSeek model for efficient chat, coding help, and agent loops",
     "family": "deepseek",
@@ -197334,22 +214536,22 @@
    "~openai/gpt-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
+     "cache_read": 0.2,
+     "cache_write": 2.5,
      "context_over_200k": {
-      "cache_read": 0.5,
-      "cache_write": 6.25,
-      "input": 5,
-      "output": 22.5
+      "cache_read": 0.4,
+      "cache_write": 5,
+      "input": 4,
+      "output": 15
      },
-     "input": 2.5,
-     "output": 15,
+     "input": 2,
+     "output": 10,
      "tiers": [
       {
-       "cache_read": 0.5,
-       "cache_write": 6.25,
-       "input": 5,
-       "output": 22.5,
+       "cache_read": 0.4,
+       "cache_write": 5,
+       "input": 4,
+       "output": 15,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -198520,11 +215722,11 @@
      "input_audio": 1.5,
      "output": 9
     },
-    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
     "id": "google/gemini-flash-latest",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-19",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
     "limit": {
      "context": 1048576,
      "output": 65536
@@ -198555,7 +215757,7 @@
       ]
      }
     ],
-    "release_date": "2026-05-19",
+    "release_date": "2026-08-13",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -198568,11 +215770,11 @@
      "input_audio": 0.5,
      "output": 1.5
     },
-    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash-lite",
     "id": "google/gemini-flash-lite-latest",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-07",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
     "limit": {
      "context": 1048576,
      "output": 65536
@@ -198603,7 +215805,7 @@
       ]
      }
     ],
-    "release_date": "2026-05-07",
+    "release_date": "2026-07-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -202537,7 +219739,7 @@
     "last_updated": "2026-03-18",
     "limit": {
      "context": 204800,
-     "output": 131072
+     "output": 131000
     },
     "modalities": {
      "input": [
@@ -202733,7 +219935,7 @@
     "last_updated": "2025-04",
     "limit": {
      "context": 131072,
-     "output": 16384
+     "output": 8192
     },
     "modalities": {
      "input": [
@@ -202752,8 +219954,7 @@
       "values": [
        "low",
        "medium",
-       "high",
-       "xhigh"
+       "high"
       ]
      }
     ],
@@ -202819,8 +220020,8 @@
     },
     "last_updated": "2025-07-31",
     "limit": {
-     "context": 262144,
-     "output": 131072
+     "context": 32768,
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -202839,8 +220040,7 @@
       "values": [
        "low",
        "medium",
-       "high",
-       "xhigh"
+       "high"
       ]
      }
     ],
@@ -202865,8 +220065,8 @@
     "knowledge": "2025-03-31",
     "last_updated": "2025-04-28",
     "limit": {
-     "context": 131072,
-     "output": 131072
+     "context": 40960,
+     "output": 40960
     },
     "modalities": {
      "input": [
@@ -202885,8 +220085,7 @@
       "values": [
        "low",
        "medium",
-       "high",
-       "xhigh"
+       "high"
       ]
      }
     ],
@@ -203105,7 +220304,7 @@
     "last_updated": "2026-04-22",
     "limit": {
      "context": 1050000,
-     "output": 131072
+     "output": 131000
     },
     "modalities": {
      "input": [
@@ -204097,8 +221296,8 @@
     "knowledge": "2025-01",
     "last_updated": "2025-12-17",
     "limit": {
-     "context": 1048576,
-     "output": 65535
+     "context": 1000000,
+     "output": 65000
     },
     "modalities": {
      "input": [
@@ -204197,8 +221396,8 @@
     "knowledge": "2025-01",
     "last_updated": "2026-02-19",
     "limit": {
-     "context": 1048576,
-     "output": 65536
+     "context": 1000000,
+     "output": 64000
     },
     "modalities": {
      "input": [
@@ -204247,8 +221446,8 @@
     "knowledge": "2025-01",
     "last_updated": "2026-05-19",
     "limit": {
-     "context": 1048576,
-     "output": 65536
+     "context": 1000000,
+     "output": 64000
     },
     "modalities": {
      "input": [
@@ -204941,7 +222140,7 @@
     "limit": {
      "context": 400000,
      "input": 272000,
-     "output": 128000
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -205428,8 +222627,8 @@
     "knowledge": "2023-12-31",
     "last_updated": "2024-07-23",
     "limit": {
-     "context": 131072,
-     "output": 16384
+     "context": 128000,
+     "output": 8192
     },
     "modalities": {
      "input": [
@@ -205624,8 +222823,8 @@
     "knowledge": "2023-12",
     "last_updated": "2024-12-06",
     "limit": {
-     "context": 131072,
-     "output": 131072
+     "context": 16384,
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -205739,7 +222938,7 @@
     },
     "last_updated": "2026-04-29",
     "limit": {
-     "context": 262144,
+     "context": 256000,
      "output": 131072
     },
     "modalities": {
@@ -205932,7 +223131,7 @@
     "knowledge": "2024-07",
     "last_updated": "2024-07-01",
     "limit": {
-     "context": 131072,
+     "context": 128000,
      "output": 128000
     },
     "modalities": {
@@ -205967,8 +223166,8 @@
     "knowledge": "2025-06",
     "last_updated": "2026-03-16",
     "limit": {
-     "context": 262144,
-     "output": 65536
+     "context": 32000,
+     "output": 32000
     },
     "modalities": {
      "input": [
@@ -206046,7 +223245,7 @@
     "knowledge": "2025-01",
     "last_updated": "2026-04-21",
     "limit": {
-     "context": 262144,
+     "context": 262000,
      "output": 131072
     },
     "modalities": {
@@ -206094,7 +223293,7 @@
     "knowledge": "2025-01",
     "last_updated": "2026-06-12",
     "limit": {
-     "context": 262144,
+     "context": 256000,
      "output": 32768
     },
     "modalities": {
@@ -206232,7 +223431,7 @@
     },
     "last_updated": "2026-03-11",
     "limit": {
-     "context": 1000000,
+     "context": 256000,
      "output": 32000
     },
     "modalities": {
@@ -206304,6 +223503,52 @@
     "temperature": true,
     "tool_call": true
    },
+   "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 0.5,
+     "input": 0.5,
+     "output": 0.5
+    },
+    "description": "Fast NVIDIA Nemotron MoE for reliable agentic tasks across enterprise workloads",
+    "family": "nemotron",
+    "id": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-11",
+    "limit": {
+     "context": 8192,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Nemotron 3.5 Lightning 30B A3B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-11",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "openai/gpt-oss-120b": {
     "attachment": false,
     "cost": {
@@ -206340,8 +223585,7 @@
       "values": [
        "low",
        "medium",
-       "high",
-       "xhigh"
+       "high"
       ]
      }
     ],
@@ -206386,8 +223630,7 @@
       "values": [
        "low",
        "medium",
-       "high",
-       "xhigh"
+       "high"
       ]
      }
     ],
@@ -206537,8 +223780,8 @@
     "knowledge": "2025-04",
     "last_updated": "2026-04-20",
     "limit": {
-     "context": 262144,
-     "output": 65536
+     "context": 240000,
+     "output": 64000
     },
     "modalities": {
      "input": [
@@ -206583,7 +223826,7 @@
     "last_updated": "2026-04-02",
     "limit": {
      "context": 1000000,
-     "output": 65536
+     "output": 64000
     },
     "modalities": {
      "input": [
@@ -206628,8 +223871,8 @@
     },
     "last_updated": "2026-05-21",
     "limit": {
-     "context": 1000000,
-     "output": 65536
+     "context": 991000,
+     "output": 64000
     },
     "modalities": {
      "input": [
@@ -206674,7 +223917,7 @@
     "last_updated": "2026-06-02",
     "limit": {
      "context": 1000000,
-     "output": 65536
+     "output": 64000
     },
     "modalities": {
      "input": [
@@ -206765,7 +224008,7 @@
     },
     "last_updated": "2026-04-07",
     "limit": {
-     "context": 202752,
+     "context": 202000,
      "output": 131072
     },
     "modalities": {
@@ -206810,7 +224053,7 @@
     },
     "last_updated": "2026-06-13",
     "limit": {
-     "context": 1048576,
+     "context": 1040000,
      "output": 128000
     },
     "modalities": {
@@ -215486,10 +232729,10 @@
    "claude-fable-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 1,
-     "cache_write": 12.5,
-     "input": 10,
-     "output": 50
+     "cache_read": 0.9,
+     "cache_write": 11.25,
+     "input": 9,
+     "output": 45
     },
     "description": "Claude model for creative writing, analysis, and controlled agent workflows",
     "family": "claude-fable",
@@ -215536,10 +232779,10 @@
    "claude-fable-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 1.1,
-     "cache_write": 13.75,
-     "input": 11,
-     "output": 55
+     "cache_read": 0.99,
+     "cache_write": 12.375,
+     "input": 9.9,
+     "output": 49.5
     },
     "description": "Claude model for creative writing, analysis, and controlled agent workflows",
     "family": "claude-fable",
@@ -215586,10 +232829,10 @@
    "claude-haiku-4-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
-     "cache_write": 1.25,
-     "input": 1,
-     "output": 5
+     "cache_read": 0.09,
+     "cache_write": 1.125,
+     "input": 0.9,
+     "output": 4.5
     },
     "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
     "family": "claude-haiku",
@@ -215636,10 +232879,10 @@
    "claude-haiku-4-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.11,
-     "cache_write": 1.375,
-     "input": 1.1,
-     "output": 5.5
+     "cache_read": 0.099,
+     "cache_write": 1.2375,
+     "input": 0.99,
+     "output": 4.95
     },
     "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
     "family": "claude-haiku",
@@ -215686,10 +232929,10 @@
    "claude-opus-4-1": {
     "attachment": true,
     "cost": {
-     "cache_read": 1.5,
-     "cache_write": 18.75,
-     "input": 15,
-     "output": 75
+     "cache_read": 1.35,
+     "cache_write": 16.875,
+     "input": 13.5,
+     "output": 67.5
     },
     "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
     "family": "claude-opus",
@@ -215736,10 +232979,10 @@
    "claude-opus-4-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
-     "input": 5,
-     "output": 25
+     "cache_read": 0.45,
+     "cache_write": 5.625,
+     "input": 4.5,
+     "output": 22.5
     },
     "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
     "family": "claude-opus",
@@ -215786,10 +233029,10 @@
    "claude-opus-4-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.55,
-     "cache_write": 6.875,
-     "input": 5.5,
-     "output": 27.5
+     "cache_read": 0.495,
+     "cache_write": 6.1875,
+     "input": 4.95,
+     "output": 24.75
     },
     "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
     "family": "claude-opus",
@@ -215836,10 +233079,10 @@
    "claude-opus-4-6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
-     "input": 5,
-     "output": 25
+     "cache_read": 0.45,
+     "cache_write": 5.625,
+     "input": 4.5,
+     "output": 22.5
     },
     "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
     "family": "claude-opus",
@@ -215886,10 +233129,10 @@
    "claude-opus-4-6@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.55,
-     "cache_write": 6.875,
-     "input": 5.5,
-     "output": 27.5
+     "cache_read": 0.495,
+     "cache_write": 6.1875,
+     "input": 4.95,
+     "output": 24.75
     },
     "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
     "family": "claude-opus",
@@ -215936,10 +233179,10 @@
    "claude-opus-4-7": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
-     "input": 5,
-     "output": 25
+     "cache_read": 0.45,
+     "cache_write": 5.625,
+     "input": 4.5,
+     "output": 22.5
     },
     "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
     "family": "claude-opus",
@@ -215986,10 +233229,10 @@
    "claude-opus-4-7@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.55,
-     "cache_write": 6.875,
-     "input": 5.5,
-     "output": 27.5
+     "cache_read": 0.495,
+     "cache_write": 6.1875,
+     "input": 4.95,
+     "output": 24.75
     },
     "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
     "family": "claude-opus",
@@ -216036,10 +233279,10 @@
    "claude-opus-4-8": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
-     "input": 5,
-     "output": 25
+     "cache_read": 0.45,
+     "cache_write": 5.625,
+     "input": 4.5,
+     "output": 22.5
     },
     "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
     "family": "claude-opus",
@@ -216086,10 +233329,10 @@
    "claude-opus-4-8@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.55,
-     "cache_write": 6.875,
-     "input": 5.5,
-     "output": 27.5
+     "cache_read": 0.495,
+     "cache_write": 6.1875,
+     "input": 4.95,
+     "output": 24.75
     },
     "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
     "family": "claude-opus",
@@ -216136,10 +233379,10 @@
    "claude-opus-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
-     "input": 5,
-     "output": 25
+     "cache_read": 0.45,
+     "cache_write": 5.625,
+     "input": 4.5,
+     "output": 22.5
     },
     "description": "Strongest Claude Opus model for coding, agents, and professional work",
     "family": "claude-opus",
@@ -216186,10 +233429,10 @@
    "claude-opus-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.55,
-     "cache_write": 6.875,
-     "input": 5.5,
-     "output": 27.5
+     "cache_read": 0.495,
+     "cache_write": 6.1875,
+     "input": 4.95,
+     "output": 24.75
     },
     "description": "Strongest Claude Opus model for coding, agents, and professional work",
     "family": "claude-opus",
@@ -216236,22 +233479,22 @@
    "claude-sonnet-4-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.3,
-     "cache_write": 3.75,
+     "cache_read": 0.27,
+     "cache_write": 3.375,
      "context_over_200k": {
-      "cache_read": 0.6,
-      "cache_write": 7.5,
-      "input": 6,
-      "output": 22.5
+      "cache_read": 0.54,
+      "cache_write": 6.75,
+      "input": 5.4,
+      "output": 20.25
      },
-     "input": 3,
-     "output": 15,
+     "input": 2.7,
+     "output": 13.5,
      "tiers": [
       {
-       "cache_read": 0.6,
-       "cache_write": 7.5,
-       "input": 6,
-       "output": 22.5,
+       "cache_read": 0.54,
+       "cache_write": 6.75,
+       "input": 5.4,
+       "output": 20.25,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -216304,22 +233547,22 @@
    "claude-sonnet-4-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.3,
-     "cache_write": 4.125,
+     "cache_read": 0.27,
+     "cache_write": 3.7125,
      "context_over_200k": {
-      "cache_read": 0.6,
-      "cache_write": 8.25,
-      "input": 6.6,
-      "output": 24.75
+      "cache_read": 0.54,
+      "cache_write": 7.425,
+      "input": 5.94,
+      "output": 22.275
      },
-     "input": 3.3,
-     "output": 16.5,
+     "input": 2.97,
+     "output": 14.85,
      "tiers": [
       {
-       "cache_read": 0.6,
-       "cache_write": 8.25,
-       "input": 6.6,
-       "output": 24.75,
+       "cache_read": 0.54,
+       "cache_write": 7.425,
+       "input": 5.94,
+       "output": 22.275,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -216372,10 +233615,10 @@
    "claude-sonnet-4-6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.3,
-     "cache_write": 3.75,
-     "input": 3,
-     "output": 15
+     "cache_read": 0.27,
+     "cache_write": 3.375,
+     "input": 2.7,
+     "output": 13.5
     },
     "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
     "family": "claude-sonnet",
@@ -216422,10 +233665,10 @@
    "claude-sonnet-4-6@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.3,
-     "cache_write": 4.125,
-     "input": 3.3,
-     "output": 16.5
+     "cache_read": 0.27,
+     "cache_write": 3.7125,
+     "input": 2.97,
+     "output": 14.85
     },
     "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
     "family": "claude-sonnet",
@@ -216472,22 +233715,22 @@
    "claude-sonnet-4@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.3,
-     "cache_write": 3.75,
+     "cache_read": 0.27,
+     "cache_write": 3.375,
      "context_over_200k": {
-      "cache_read": 0.6,
-      "cache_write": 7.5,
-      "input": 6,
-      "output": 22.5
+      "cache_read": 0.54,
+      "cache_write": 6.75,
+      "input": 5.4,
+      "output": 20.25
      },
-     "input": 3,
-     "output": 15,
+     "input": 2.7,
+     "output": 13.5,
      "tiers": [
       {
-       "cache_read": 0.6,
-       "cache_write": 7.5,
-       "input": 6,
-       "output": 22.5,
+       "cache_read": 0.54,
+       "cache_write": 6.75,
+       "input": 5.4,
+       "output": 20.25,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -216540,10 +233783,10 @@
    "claude-sonnet-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
-     "cache_write": 2.5,
-     "input": 2,
-     "output": 10
+     "cache_read": 0.18,
+     "cache_write": 2.25,
+     "input": 1.8,
+     "output": 9
     },
     "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
     "family": "claude-sonnet",
@@ -216590,10 +233833,10 @@
    "claude-sonnet-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.22,
-     "cache_write": 2.75,
-     "input": 2.2,
-     "output": 11
+     "cache_read": 0.198,
+     "cache_write": 2.475,
+     "input": 1.98,
+     "output": 9.9
     },
     "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
     "family": "claude-sonnet",
@@ -216640,9 +233883,9 @@
    "deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.014,
-     "input": 0.44,
-     "output": 1.32
+     "cache_read": 0.0126,
+     "input": 0.396,
+     "output": 1.188
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -216672,9 +233915,9 @@
    "deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.07,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.063,
+     "input": 0.126,
+     "output": 0.252
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -216719,9 +233962,9 @@
    "deepseek-v4-flash-0731@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.07,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.063,
+     "input": 0.126,
+     "output": 0.252
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -216766,9 +234009,9 @@
    "deepseek-v4-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.044,
-     "input": 1.32,
-     "output": 3.96
+     "cache_read": 0.0396,
+     "input": 1.188,
+     "output": 3.564
     },
     "description": "Open MoE flagship with million-token context for coding and long agent runs",
     "family": "deepseek-thinking",
@@ -216813,14 +234056,14 @@
    "deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.044,
-     "input": 1.32,
-     "output": 3.96
+     "cache_read": 0.0396,
+     "input": 1.188,
+     "output": 3.564
     },
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
     "id": "deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 131072
@@ -216834,7 +234077,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -216859,9 +234102,9 @@
    "deepseek-v4-pro@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.44,
-     "input": 1.75,
-     "output": 3.5
+     "cache_read": 0.396,
+     "input": 1.575,
+     "output": 3.15
     },
     "description": "Open MoE flagship with million-token context for coding and long agent runs",
     "family": "deepseek-thinking",
@@ -216906,9 +234149,9 @@
    "devstral-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.44,
-     "input": 0.44,
-     "output": 2.2
+     "cache_read": 0.396,
+     "input": 0.396,
+     "output": 1.98
     },
     "description": "An enterprise grade text model, that excels at using tools to explore codebases, editing multiple files and power software engineering agents.",
     "family": "devstral",
@@ -216936,9 +234179,9 @@
    "devstral-latest@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.44,
-     "input": 0.44,
-     "output": 2.2
+     "cache_read": 0.396,
+     "input": 0.396,
+     "output": 1.98
     },
     "description": "An enterprise grade text model, that excels at using tools to explore codebases, editing multiple files and power software engineering agents.",
     "family": "devstral",
@@ -216966,19 +234209,19 @@
    "fugu-ultra": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
+     "cache_read": 0.45,
      "context_over_200k": {
-      "cache_read": 1,
-      "input": 10,
-      "output": 45
+      "cache_read": 0.9,
+      "input": 9,
+      "output": 40.5
      },
-     "input": 5,
-     "output": 30,
+     "input": 4.5,
+     "output": 27,
      "tiers": [
       {
-       "cache_read": 1,
-       "input": 10,
-       "output": 45,
+       "cache_read": 0.9,
+       "input": 9,
+       "output": 40.5,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -217014,10 +234257,10 @@
    "gemini-2.5-flash@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.075,
-     "cache_write": 0.55,
-     "input": 0.3,
-     "output": 2.5
+     "cache_read": 0.0675,
+     "cache_write": 0.495,
+     "input": 0.27,
+     "output": 2.25
     },
     "description": "Fast Gemini workhorse for multimodal apps where latency and price matter",
     "family": "gemini-flash",
@@ -217066,22 +234309,22 @@
    "gemini-3-pro-image": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
-     "cache_write": 4.5,
+     "cache_read": 0.18,
+     "cache_write": 4.05,
      "context_over_200k": {
-      "cache_read": 0.2,
-      "cache_write": 4.5,
-      "input": 4,
-      "output": 18
+      "cache_read": 0.18,
+      "cache_write": 4.05,
+      "input": 3.6,
+      "output": 16.2
      },
-     "input": 2,
-     "output": 12,
+     "input": 1.8,
+     "output": 10.8,
      "tiers": [
       {
-       "cache_read": 0.2,
-       "cache_write": 4.5,
-       "input": 4,
-       "output": 18,
+       "cache_read": 0.18,
+       "cache_write": 4.05,
+       "input": 3.6,
+       "output": 16.2,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -217135,15 +234378,15 @@
     "attachment": true,
     "cost": {
      "context_over_200k": {
-      "input": 0.5,
-      "output": 2
+      "input": 0.45,
+      "output": 1.8
      },
-     "input": 0.5,
-     "output": 2,
+     "input": 0.45,
+     "output": 1.8,
      "tiers": [
       {
-       "input": 0.5,
-       "output": 2,
+       "input": 0.45,
+       "output": 1.8,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -217198,22 +234441,22 @@
    "gemini-3.1-flash-lite": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.025,
-     "cache_write": 0.08333,
+     "cache_read": 0.0225,
+     "cache_write": 0.074997,
      "context_over_200k": {
-      "cache_read": 0.025,
-      "cache_write": 0.08333,
-      "input": 0.5,
-      "output": 2.25
+      "cache_read": 0.0225,
+      "cache_write": 0.074997,
+      "input": 0.45,
+      "output": 2.025
      },
-     "input": 0.25,
-     "output": 1.5,
+     "input": 0.225,
+     "output": 1.35,
      "tiers": [
       {
-       "cache_read": 0.025,
-       "cache_write": 0.08333,
-       "input": 0.5,
-       "output": 2.25,
+       "cache_read": 0.0225,
+       "cache_write": 0.074997,
+       "input": 0.45,
+       "output": 2.025,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -217268,22 +234511,22 @@
    "gemini-3.1-flash-lite@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0275,
-     "cache_write": 0.091663,
+     "cache_read": 0.02475,
+     "cache_write": 0.082497,
      "context_over_200k": {
-      "cache_read": 0.0275,
-      "cache_write": 0.091663,
-      "input": 0.55,
-      "output": 2.475
+      "cache_read": 0.02475,
+      "cache_write": 0.082497,
+      "input": 0.495,
+      "output": 2.2275
      },
-     "input": 0.275,
-     "output": 1.65,
+     "input": 0.2475,
+     "output": 1.485,
      "tiers": [
       {
-       "cache_read": 0.0275,
-       "cache_write": 0.091663,
-       "input": 0.55,
-       "output": 2.475,
+       "cache_read": 0.02475,
+       "cache_write": 0.082497,
+       "input": 0.495,
+       "output": 2.2275,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -217338,22 +234581,22 @@
    "gemini-3.1-pro-preview": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
-     "cache_write": 4.5,
+     "cache_read": 0.18,
+     "cache_write": 4.05,
      "context_over_200k": {
-      "cache_read": 0.2,
-      "cache_write": 4.5,
-      "input": 4,
-      "output": 18
+      "cache_read": 0.18,
+      "cache_write": 4.05,
+      "input": 3.6,
+      "output": 16.2
      },
-     "input": 2,
-     "output": 12,
+     "input": 1.8,
+     "output": 10.8,
      "tiers": [
       {
-       "cache_read": 0.2,
-       "cache_write": 4.5,
-       "input": 4,
-       "output": 18,
+       "cache_read": 0.18,
+       "cache_write": 4.05,
+       "input": 3.6,
+       "output": 16.2,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -217408,10 +234651,10 @@
    "gemini-3.5-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 1.583,
-     "input": 1.5,
-     "output": 9
+     "cache_read": 0.135,
+     "cache_write": 1.4247,
+     "input": 1.35,
+     "output": 8.1
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -217460,9 +234703,9 @@
    "gemini-3.5-flash-lite": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.03,
-     "input": 0.3,
-     "output": 2.5
+     "cache_read": 0.027,
+     "input": 0.27,
+     "output": 2.25
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash-lite",
@@ -217511,9 +234754,9 @@
    "gemini-3.5-flash-lite@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.033,
-     "input": 0.33,
-     "output": 2.75
+     "cache_read": 0.0297,
+     "input": 0.297,
+     "output": 2.475
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash-lite",
@@ -217562,10 +234805,10 @@
    "gemini-3.5-flash@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.165,
-     "cache_write": 1.7413,
-     "input": 1.65,
-     "output": 9.9
+     "cache_read": 0.1485,
+     "cache_write": 1.56717,
+     "input": 1.485,
+     "output": 8.91
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -217614,9 +234857,9 @@
    "gemini-3.6-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "input": 1.5,
-     "output": 7
+     "cache_read": 0.135,
+     "input": 1.35,
+     "output": 6.3
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -217665,9 +234908,9 @@
    "gemini-3.7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.075,
-     "input": 0.75,
-     "output": 3.75
+     "cache_read": 0.06,
+     "input": 0.6,
+     "output": 3
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -217716,9 +234959,9 @@
    "gemini-3.7-flash@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0825,
-     "input": 0.825,
-     "output": 4.125
+     "cache_read": 0.066,
+     "input": 0.66,
+     "output": 3.3
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -217767,9 +235010,9 @@
    "gemma-4-26b-a4b-it": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.07,
-     "input": 0.07,
-     "output": 0.34
+     "cache_read": 0.063,
+     "input": 0.063,
+     "output": 0.306
     },
     "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
     "family": "gemma",
@@ -217860,9 +235103,9 @@
    "glm-5.1": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
+     "cache_read": 0.234,
+     "input": 1.26,
+     "output": 3.96
     },
     "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
     "family": "glm",
@@ -217906,9 +235149,9 @@
    "glm-5.1@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 1.4,
-     "input": 1.4,
-     "output": 4.4
+     "cache_read": 1.26,
+     "input": 1.26,
+     "output": 3.96
     },
     "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
     "family": "glm",
@@ -217952,9 +235195,9 @@
    "glm-5.2": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.2,
-     "output": 4.2
+     "cache_read": 0.234,
+     "input": 1.08,
+     "output": 3.78
     },
     "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
     "family": "glm",
@@ -217998,9 +235241,9 @@
    "glm-5.2-fast": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.21,
-     "input": 2.1,
-     "output": 6.6
+     "cache_read": 0.189,
+     "input": 1.89,
+     "output": 5.94
     },
     "description": "GLM-5.2 introduces a robust 1M-token context and advanced, multi-effort coding capabilities to significantly enhance performance on long-horizon tasks. Its new IndexShare architecture and improved MTP layer simultaneously boost efficiency by reducing per-token FLOPs and increasing speculative decoding lengths. A 743B-parameter model in Zhipu AI's GLM series, designed to plan, execute, and iterate autonomously on extended, engineering-grade tasks.",
     "family": "glm",
@@ -218043,9 +235286,9 @@
    "glm-5.2@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.2,
-     "output": 4.2
+     "cache_read": 0.234,
+     "input": 1.08,
+     "output": 3.78
     },
     "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
     "family": "glm",
@@ -218089,9 +235332,9 @@
    "glm-5.3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
+     "cache_read": 0.234,
+     "input": 1.26,
+     "output": 3.96
     },
     "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
     "family": "glm",
@@ -218135,9 +235378,9 @@
    "gpt-4.1-mini@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.11,
-     "input": 0.44,
-     "output": 1.76
+     "cache_read": 0.099,
+     "input": 0.396,
+     "output": 1.584
     },
     "description": "Affordable GPT-4.1 lane for fast coding help and structured extraction",
     "family": "gpt-mini",
@@ -218169,9 +235412,9 @@
    "gpt-4.1-nano@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0275,
-     "input": 0.11,
-     "output": 0.44
+     "cache_read": 0.02475,
+     "input": 0.099,
+     "output": 0.396
     },
     "description": "Tiny GPT-4.1 option for classification, routing, and very high-volume tasks",
     "family": "gpt-nano",
@@ -218202,9 +235445,9 @@
    "gpt-4.1@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.55,
-     "input": 2.2,
-     "output": 8.8
+     "cache_read": 0.495,
+     "input": 1.98,
+     "output": 7.92
     },
     "description": "Long-lived GPT workhorse for coding, instruction following, and production apps",
     "family": "gpt",
@@ -218236,9 +235479,9 @@
    "gpt-4o-mini@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0825,
-     "input": 0.165,
-     "output": 0.66
+     "cache_read": 0.07425,
+     "input": 0.1485,
+     "output": 0.594
     },
     "description": "Small omni GPT for cheap multimodal assistance and production-scale traffic",
     "family": "gpt-mini",
@@ -218270,9 +235513,9 @@
    "gpt-5-mini@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0275,
-     "input": 0.275,
-     "output": 2.2
+     "cache_read": 0.02475,
+     "input": 0.2475,
+     "output": 1.98
     },
     "description": "Small GPT-5 for responsive agents, coding help, and everyday automation",
     "family": "gpt-mini",
@@ -218318,9 +235561,9 @@
    "gpt-5-nano@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0055,
-     "input": 0.055,
-     "output": 0.44
+     "cache_read": 0.00495,
+     "input": 0.0495,
+     "output": 0.396
     },
     "description": "Tiny GPT-5 lane for routing, extraction, classification, and bulk jobs",
     "family": "gpt-nano",
@@ -218366,9 +235609,9 @@
    "gpt-5.1@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1375,
-     "input": 1.375,
-     "output": 11
+     "cache_read": 0.12375,
+     "input": 1.2375,
+     "output": 9.9
     },
     "description": "Sharper GPT-5 generation for coding, product work, and tool-assisted tasks",
     "family": "gpt",
@@ -218415,9 +235658,9 @@
    "gpt-5.3-chat": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.175,
-     "input": 1.75,
-     "output": 14
+     "cache_read": 0.1575,
+     "input": 1.575,
+     "output": 12.6
     },
     "description": "GPT-5.3 Chat is an update to ChatGPT's most-used model that makes everyday conversations smoother, more useful, and more directly helpful. It delivers more accurate answers with better contextualization and significantly reduces unnecessary refusals, caveats, and overly cautious phrasing that can interrupt conversational flow.",
     "family": "gpt",
@@ -218461,9 +235704,9 @@
    "gpt-5.3-codex": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.175,
-     "input": 1.75,
-     "output": 14
+     "cache_read": 0.1575,
+     "input": 1.575,
+     "output": 12.6
     },
     "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
     "family": "gpt-codex",
@@ -218511,9 +235754,9 @@
    "gpt-5.4": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.275,
-     "input": 2.75,
-     "output": 16.5
+     "cache_read": 0.2475,
+     "input": 2.475,
+     "output": 14.85
     },
     "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
     "family": "gpt",
@@ -218561,9 +235804,9 @@
    "gpt-5.4-mini": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.075,
-     "input": 0.75,
-     "output": 4.5
+     "cache_read": 0.0675,
+     "input": 0.675,
+     "output": 4.05
     },
     "description": "Strong small GPT for coding subagents, quick tool use, and high-volume work",
     "family": "gpt-mini",
@@ -218610,9 +235853,9 @@
    "gpt-5.4-nano": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.02,
-     "input": 0.2,
-     "output": 1.25
+     "cache_read": 0.018,
+     "input": 0.18,
+     "output": 1.125
     },
     "description": "Cheapest GPT-5.4 lane for simple routing, extraction, and bulk automation",
     "family": "gpt-nano",
@@ -218659,9 +235902,9 @@
    "gpt-5.4-pro": {
     "attachment": true,
     "cost": {
-     "cache_read": 30,
-     "input": 30,
-     "output": 180
+     "cache_read": 27,
+     "input": 27,
+     "output": 162
     },
     "description": "More exact GPT-5.4 tier for demanding professional reasoning and agent tasks",
     "family": "gpt-pro",
@@ -218708,19 +235951,19 @@
    "gpt-5.4@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
+     "cache_read": 0.225,
      "context_over_200k": {
-      "cache_read": 0.5,
-      "input": 5,
-      "output": 22.5
+      "cache_read": 0.45,
+      "input": 4.5,
+      "output": 20.25
      },
-     "input": 2.5,
-     "output": 15,
+     "input": 2.25,
+     "output": 13.5,
      "tiers": [
       {
-       "cache_read": 0.5,
-       "input": 5,
-       "output": 22.5,
+       "cache_read": 0.45,
+       "input": 4.5,
+       "output": 20.25,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -218774,9 +236017,9 @@
    "gpt-5.5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.55,
-     "input": 5.5,
-     "output": 33
+     "cache_read": 0.495,
+     "input": 4.95,
+     "output": 29.7
     },
     "description": "Default frontier GPT for coding, computer use, research, and knowledge work",
     "family": "gpt",
@@ -218824,8 +236067,8 @@
    "gpt-5.5-pro": {
     "attachment": true,
     "cost": {
-     "input": 30,
-     "output": 180
+     "input": 27,
+     "output": 162
     },
     "description": "Highest-accuracy GPT-5.5 tier for slower, precision-heavy reasoning and coding",
     "family": "gpt-pro",
@@ -218873,19 +236116,19 @@
    "gpt-5.5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
+     "cache_read": 0.45,
      "context_over_200k": {
-      "cache_read": 1,
-      "input": 10,
-      "output": 45
+      "cache_read": 0.9,
+      "input": 9,
+      "output": 40.5
      },
-     "input": 5,
-     "output": 30,
+     "input": 4.5,
+     "output": 27,
      "tiers": [
       {
-       "cache_read": 1,
-       "input": 10,
-       "output": 45,
+       "cache_read": 0.9,
+       "input": 9,
+       "output": 40.5,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -218939,19 +236182,19 @@
    "gpt-5.6-luna": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.02,
+     "cache_read": 0.018,
      "context_over_200k": {
-      "cache_read": 0.04,
-      "input": 0.4,
-      "output": 1.8
+      "cache_read": 0.036,
+      "input": 0.36,
+      "output": 1.62
      },
-     "input": 0.2,
-     "output": 1.2,
+     "input": 0.18,
+     "output": 1.08,
      "tiers": [
       {
-       "cache_read": 0.04,
-       "input": 0.4,
-       "output": 1.8,
+       "cache_read": 0.036,
+       "input": 0.36,
+       "output": 1.62,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -219005,9 +236248,9 @@
    "gpt-5.6-luna@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.022,
-     "input": 0.22,
-     "output": 1.32
+     "cache_read": 0.0198,
+     "input": 0.198,
+     "output": 1.188
     },
     "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
     "family": "gpt-luna",
@@ -219055,19 +236298,19 @@
    "gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
+     "cache_read": 0.45,
      "context_over_200k": {
-      "cache_read": 1,
-      "input": 10,
-      "output": 45
+      "cache_read": 0.9,
+      "input": 9,
+      "output": 40.5
      },
-     "input": 5,
-     "output": 30,
+     "input": 4.5,
+     "output": 27,
      "tiers": [
       {
-       "cache_read": 1,
-       "input": 10,
-       "output": 45,
+       "cache_read": 0.9,
+       "input": 9,
+       "output": 40.5,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -219121,9 +236364,9 @@
    "gpt-5.6-sol@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.55,
-     "input": 5.5,
-     "output": 33
+     "cache_read": 0.495,
+     "input": 4.95,
+     "output": 29.7
     },
     "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
     "family": "gpt-sol",
@@ -219171,19 +236414,19 @@
    "gpt-5.6-terra": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
+     "cache_read": 0.18,
      "context_over_200k": {
-      "cache_read": 0.4,
-      "input": 4,
-      "output": 18
+      "cache_read": 0.36,
+      "input": 3.6,
+      "output": 16.2
      },
-     "input": 2,
-     "output": 12,
+     "input": 1.8,
+     "output": 10.8,
      "tiers": [
       {
-       "cache_read": 0.4,
-       "input": 4,
-       "output": 18,
+       "cache_read": 0.36,
+       "input": 3.6,
+       "output": 16.2,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -219237,9 +236480,9 @@
    "gpt-5.6-terra@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.22,
-     "input": 2.2,
-     "output": 13.2
+     "cache_read": 0.198,
+     "input": 1.98,
+     "output": 11.88
     },
     "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
     "family": "gpt-terra",
@@ -219287,9 +236530,9 @@
    "gpt-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1375,
-     "input": 1.375,
-     "output": 11
+     "cache_read": 0.12375,
+     "input": 1.2375,
+     "output": 9.9
     },
     "description": "Original GPT-5 workhorse for reasoning, coding, writing, and tool workflows",
     "family": "gpt",
@@ -219336,22 +236579,22 @@
    "grok-4.2-beta": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
-     "cache_write": 2,
+     "cache_read": 0.18,
+     "cache_write": 1.8,
      "context_over_200k": {
-      "cache_read": 0.4,
-      "cache_write": 4,
-      "input": 4,
-      "output": 12
+      "cache_read": 0.36,
+      "cache_write": 3.6,
+      "input": 3.6,
+      "output": 10.8
      },
-     "input": 2,
-     "output": 6,
+     "input": 1.8,
+     "output": 5.4,
      "tiers": [
       {
-       "cache_read": 0.4,
-       "cache_write": 4,
-       "input": 4,
-       "output": 12,
+       "cache_read": 0.36,
+       "cache_write": 3.6,
+       "input": 3.6,
+       "output": 10.8,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -219401,22 +236644,22 @@
    "grok-4.3": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
-     "cache_write": 1.25,
+     "cache_read": 0.18,
+     "cache_write": 1.125,
      "context_over_200k": {
-      "cache_read": 0.4,
-      "cache_write": 2.5,
-      "input": 2.5,
-      "output": 5
+      "cache_read": 0.36,
+      "cache_write": 2.25,
+      "input": 2.25,
+      "output": 4.5
      },
-     "input": 1.25,
-     "output": 2.5,
+     "input": 1.125,
+     "output": 2.25,
      "tiers": [
       {
-       "cache_read": 0.4,
-       "cache_write": 2.5,
-       "input": 2.5,
-       "output": 5,
+       "cache_read": 0.36,
+       "cache_write": 2.25,
+       "input": 2.25,
+       "output": 4.5,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -219468,22 +236711,22 @@
    "grok-4.5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 2,
+     "cache_read": 0.45,
+     "cache_write": 1.8,
      "context_over_200k": {
-      "cache_read": 1,
-      "cache_write": 4,
-      "input": 4,
-      "output": 12
+      "cache_read": 0.9,
+      "cache_write": 3.6,
+      "input": 3.6,
+      "output": 10.8
      },
-     "input": 2,
-     "output": 6,
+     "input": 1.8,
+     "output": 5.4,
      "tiers": [
       {
-       "cache_read": 1,
-       "cache_write": 4,
-       "input": 4,
-       "output": 12,
+       "cache_read": 0.9,
+       "cache_write": 3.6,
+       "input": 3.6,
+       "output": 10.8,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -219534,22 +236777,22 @@
    "grok-4.6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 2,
+     "cache_read": 0.45,
+     "cache_write": 1.8,
      "context_over_200k": {
-      "cache_read": 1,
-      "cache_write": 4,
-      "input": 4,
-      "output": 12
+      "cache_read": 0.9,
+      "cache_write": 3.6,
+      "input": 3.6,
+      "output": 10.8
      },
-     "input": 2,
-     "output": 6,
+     "input": 1.8,
+     "output": 5.4,
      "tiers": [
       {
-       "cache_read": 1,
-       "cache_write": 4,
-       "input": 4,
-       "output": 12,
+       "cache_read": 0.9,
+       "cache_write": 3.6,
+       "input": 3.6,
+       "output": 10.8,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -219601,9 +236844,9 @@
    "grok-build-0.1": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
-     "input": 1,
-     "output": 2
+     "cache_read": 0.09,
+     "input": 0.9,
+     "output": 1.8
     },
     "description": "Fast Grok coding model tuned for agentic engineering and iterative edits",
     "family": "grok-build",
@@ -219634,9 +236877,9 @@
    "hy3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.035,
-     "input": 0.14,
-     "output": 0.58
+     "cache_read": 0.0315,
+     "input": 0.126,
+     "output": 0.522
     },
     "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
     "family": "Hy",
@@ -219680,9 +236923,9 @@
    "inkling": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.374,
-     "input": 1.87,
-     "output": 4.68
+     "cache_read": 0.3366,
+     "input": 1.683,
+     "output": 4.212
     },
     "description": "Multimodal MoE reasoning model (975B total, 41B active) for text, image, and audio",
     "family": "ling",
@@ -219728,9 +236971,9 @@
    "inkling-256k": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.374,
-     "input": 1.87,
-     "output": 4.68
+     "cache_read": 0.2992,
+     "input": 1.496,
+     "output": 3.744
     },
     "description": "Inkling 256K is the extended context variant of Inkling, a large MoE hybrid reasoning model from Thinking Machines with audio and vision input support and a 256K context window.",
     "id": "inkling-256k",
@@ -219773,8 +237016,8 @@
    "kat-coder-pro": {
     "attachment": false,
     "cost": {
-     "input": 0.3,
-     "output": 1.2
+     "input": 0.27,
+     "output": 1.08
     },
     "description": "KAT-Coder-Pro V2 by KwaiKAT is a non-reasoning model optimized for agentic coding. It delivers strong performance on reasoning-style tasks while requiring significantly fewer output tokens than peer models. With the 1210 release, it achieved a score of 64 on the Artificial Analysis Intelligence Index, placing it in the global Top 10 and ranking first among all non-reasoning models.",
     "family": "kat-coder",
@@ -219802,9 +237045,9 @@
    "kimi-k2.6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.16,
-     "input": 0.95,
-     "output": 4
+     "cache_read": 0.144,
+     "input": 0.855,
+     "output": 3.6
     },
     "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
     "family": "kimi-k2",
@@ -219851,9 +237094,9 @@
    "kimi-k2.6@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.95,
-     "input": 0.95,
-     "output": 4
+     "cache_read": 0.855,
+     "input": 0.855,
+     "output": 3.6
     },
     "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
     "family": "kimi-k2",
@@ -219900,9 +237143,9 @@
    "kimi-k2.7-code": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.19,
-     "input": 0.95,
-     "output": 4
+     "cache_read": 0.171,
+     "input": 0.855,
+     "output": 3.6
     },
     "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
     "family": "kimi-k2",
@@ -219949,9 +237192,9 @@
    "kimi-k2.7-code@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.31,
-     "input": 1.25,
-     "output": 4.5
+     "cache_read": 0.279,
+     "input": 1.125,
+     "output": 4.05
     },
     "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
     "family": "kimi-k2",
@@ -219998,9 +237241,9 @@
    "kimi-k3": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.225,
-     "input": 2.25,
-     "output": 11.25
+     "cache_read": 0.2025,
+     "input": 2.025,
+     "output": 10.125
     },
     "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
     "family": "kimi-k3",
@@ -220046,9 +237289,9 @@
    "kimi-k3@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.225,
-     "input": 2.25,
-     "output": 11.25
+     "cache_read": 0.2025,
+     "input": 2.025,
+     "output": 10.125
     },
     "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
     "family": "kimi-k3",
@@ -220240,8 +237483,8 @@
    "ling-2.6-1t": {
     "attachment": false,
     "cost": {
-     "input": 0.3,
-     "output": 2.5
+     "input": 0.27,
+     "output": 2.25
     },
     "description": "Inclusion AI ling-2.6-1t",
     "family": "ling",
@@ -220269,8 +237512,8 @@
    "ling-2.6-flash": {
     "attachment": false,
     "cost": {
-     "input": 0.1,
-     "output": 0.3
+     "input": 0.09,
+     "output": 0.27
     },
     "description": "Inclusion AI ling-2.6-flash",
     "family": "ling",
@@ -220342,9 +237585,9 @@
    "mimo-v2.5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0028,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.00252,
+     "input": 0.126,
+     "output": 0.252
     },
     "description": "Open MiMo model for multimodal coding agents and long-context automation",
     "family": "mimo",
@@ -220377,9 +237620,9 @@
    "mimo-v2.5-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0036,
-     "input": 0.435,
-     "output": 0.87
+     "cache_read": 0.00324,
+     "input": 0.3915,
+     "output": 0.783
     },
     "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
     "family": "mimo",
@@ -220409,10 +237652,10 @@
    "minimax-m2.7": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.06,
-     "cache_write": 1.2,
-     "input": 0.3,
-     "output": 1.2
+     "cache_read": 0.054,
+     "cache_write": 1.08,
+     "input": 0.27,
+     "output": 1.08
     },
     "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
     "family": "minimax",
@@ -220456,10 +237699,10 @@
    "minimax-m2.7-highspeed": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.06,
-     "cache_write": 1.2,
-     "input": 0.6,
-     "output": 2.4
+     "cache_read": 0.054,
+     "cache_write": 1.08,
+     "input": 0.54,
+     "output": 2.16
     },
     "description": "Low-latency M2.7 variant for interactive coding plans and agent loops",
     "family": "minimax",
@@ -220503,9 +237746,9 @@
    "minimax-m3": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.06,
-     "input": 0.3,
-     "output": 1.2
+     "cache_read": 0.048,
+     "input": 0.24,
+     "output": 0.96
     },
     "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
     "family": "minimax",
@@ -220551,9 +237794,9 @@
    "minimax-m3@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
-     "input": 0.4,
-     "output": 2
+     "cache_read": 0.09,
+     "input": 0.36,
+     "output": 1.8
     },
     "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
     "family": "minimax",
@@ -220599,9 +237842,9 @@
    "mistral-medium-3-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 1.65,
-     "input": 1.65,
-     "output": 8.25
+     "cache_read": 1.485,
+     "input": 1.485,
+     "output": 7.425
     },
     "description": "Mistral Medium 3.5 is a dense 128B instruction following model from Mistral AI. It supports text and image inputs with text output, and is designed for agentic workflows, coding, and complex multi step reasoning. It is particularly strong at reliable multi tool calling and long horizon tasks, with a 256K context window, configurable reasoning effort per request, and a custom vision encoder that handles variable image sizes and aspect ratios. Self hostable on as few as four GPUs and available under open weights.",
     "family": "mistral-medium",
@@ -220645,9 +237888,9 @@
    "mistral-medium-3-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 1.65,
-     "input": 1.65,
-     "output": 8.25
+     "cache_read": 1.485,
+     "input": 1.485,
+     "output": 7.425
     },
     "description": "Mistral Medium 3.5 is a dense 128B instruction following model from Mistral AI. It supports text and image inputs with text output, and is designed for agentic workflows, coding, and complex multi step reasoning. It is particularly strong at reliable multi tool calling and long horizon tasks, with a 256K context window, configurable reasoning effort per request, and a custom vision encoder that handles variable image sizes and aspect ratios. Self hostable on as few as four GPUs and available under open weights.",
     "family": "mistral-medium",
@@ -220691,9 +237934,9 @@
    "mistral-medium-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.44,
-     "input": 0.44,
-     "output": 2.2
+     "cache_read": 0.396,
+     "input": 0.396,
+     "output": 1.98
     },
     "description": "Balanced Mistral model for enterprise assistants, multilingual work, and tools",
     "family": "mistral-medium",
@@ -220723,9 +237966,9 @@
    "mistral-medium-latest@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.44,
-     "input": 0.44,
-     "output": 2.2
+     "cache_read": 0.396,
+     "input": 0.396,
+     "output": 1.98
     },
     "description": "Balanced Mistral model for enterprise assistants, multilingual work, and tools",
     "family": "mistral-medium",
@@ -220755,9 +237998,9 @@
    "mistral-small-2603": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.165,
-     "input": 0.165,
-     "output": 0.66
+     "cache_read": 0.1485,
+     "input": 0.1485,
+     "output": 0.594
     },
     "description": "Fast Mistral production model for chat, extraction, and cost-sensitive agents",
     "family": "mistral-small",
@@ -220803,9 +238046,9 @@
    "mistral-small-2603@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.165,
-     "input": 0.165,
-     "output": 0.66
+     "cache_read": 0.1485,
+     "input": 0.1485,
+     "output": 0.594
     },
     "description": "Fast Mistral production model for chat, extraction, and cost-sensitive agents",
     "family": "mistral-small",
@@ -220898,9 +238141,9 @@
    "nemotron-3-nano-omni": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.06,
-     "input": 0.06,
-     "output": 0.24
+     "cache_read": 0.054,
+     "input": 0.054,
+     "output": 0.216
     },
     "description": "The most open, efficient, and accurate omni modal reasoning model for agentic AI.",
     "family": "nemotron",
@@ -220991,9 +238234,9 @@
    "nemotron-3-nano-omni@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.06,
-     "input": 0.06,
-     "output": 0.24
+     "cache_read": 0.054,
+     "input": 0.054,
+     "output": 0.216
     },
     "description": "The most open, efficient, and accurate omni modal reasoning model for agentic AI.",
     "family": "nemotron",
@@ -221126,9 +238369,9 @@
    "nemotron-3-ultra-nvfp4": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.12,
-     "input": 0.6,
-     "output": 2.4
+     "cache_read": 0.108,
+     "input": 0.54,
+     "output": 2.16
     },
     "description": "Nemotron-3-Ultra-550B-A55B-NVFP4 is a frontier-scale large language model (LLM) trained by NVIDIA, designed to deliver strong agentic, reasoning, and conversational capabilities. It is optimized for the most demanding workloads, including complex multi-step agents, long-context analysis, and high-accuracy reasoning over code, math, and science. The model employs a hybrid Latent Mixture-of-Experts (LatentMoE) architecture, utilizing interleaved Mamba-2 and MoE layers, along with select Attention layers. Like the Super model, the Ultra model incorporates Multi-Token Prediction (MTP) layers for faster text generation and improved quality, and it is trained using an NVFP4 pre-training recipe to maximize compute efficiency. The model has 55B active parameters and 550B parameters in total.",
     "family": "nemotron",
@@ -221261,9 +238504,9 @@
    "nemotron-lightning-3.5-30b-a3b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.01,
-     "input": 0.05,
-     "output": 0.2
+     "cache_read": 0.009,
+     "input": 0.045,
+     "output": 0.18
     },
     "description": "Nemotron-Lightning-3.5-30B-A3B is a 30B-parameter Mixture-of-Experts language model (3B active) from NVIDIA's Nemotron-H family, built on a hybrid Mamba-Transformer architecture for efficient long-context inference. Like other models in the family, it responds to queries by first generating a reasoning trace and then concluding with a final response, with reasoning behavior configurable through a flag in the chat template. It includes a multi-token prediction (MTP) speculative decoding head for low-latency serving.",
     "family": "nemotron",
@@ -221306,8 +238549,8 @@
    "nvidia-nemotron-3-super-120b-a12b": {
     "attachment": false,
     "cost": {
-     "input": 0.1,
-     "output": 0.5
+     "input": 0.09,
+     "output": 0.45
     },
     "description": "NVIDIA Nemotron 3 Super is a hybrid Mixture-of-Experts (MoE) model engineered for highest compute efficiency and accuracy in multi-agent applications and specialized agentic systems. It is optimized to run many collaborating agents per application on a single GPU, delivering high accuracy for reasoning, tool use, and instruction following.",
     "family": "nemotron",
@@ -221350,8 +238593,8 @@
    "nvidia-nemotron-3-ultra": {
     "attachment": false,
     "cost": {
-     "input": 0.5,
-     "output": 2.5
+     "input": 0.45,
+     "output": 2.25
     },
     "description": "NVIDIA Nemotron 3 Ultra is NVIDIA's strongest open-weights reasoning model, positioned near GPT-5.4 Mini (xhigh) and ahead of DeepSeek V4-Flash and Qwen3.5-397B-A17B.",
     "family": "nemotron",
@@ -221394,9 +238637,9 @@
    "o4-mini@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.3025,
-     "input": 1.21,
-     "output": 4.84
+     "cache_read": 0.27225,
+     "input": 1.089,
+     "output": 4.356
     },
     "description": "Fast o-series model for compact reasoning, coding, and tool use",
     "family": "o-mini",
@@ -221442,8 +238685,8 @@
    "qwen3.5-27b": {
     "attachment": true,
     "cost": {
-     "input": 0.26,
-     "output": 2.6
+     "input": 0.234,
+     "output": 2.34
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -221490,8 +238733,8 @@
    "qwen3.5-2b": {
     "attachment": true,
     "cost": {
-     "input": 0.02,
-     "output": 0.1
+     "input": 0.018,
+     "output": 0.09
     },
     "description": "Qwen3.5-2B is a compact yet capable model from Alibaba's Qwen3.5 series. It features a 262K token context window, support for 201 languages, thinking/reasoning mode, and tool calling for agentic workflows. A strong choice for prototyping, fine-tuning, and efficient multilingual deployments.",
     "family": "qwen3.5",
@@ -221535,9 +238778,9 @@
    "qwen3.5-35b-a3b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.05,
-     "input": 0.14,
-     "output": 1
+     "cache_read": 0.045,
+     "input": 0.126,
+     "output": 0.9
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -221584,10 +238827,10 @@
    "qwen3.6-plus": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.05,
-     "cache_write": 0.625,
-     "input": 0.5,
-     "output": 3
+     "cache_read": 0.045,
+     "cache_write": 0.5625,
+     "input": 0.45,
+     "output": 2.7
     },
     "description": "Earlier Qwen multimodal workhorse for million-token agent and document tasks",
     "family": "qwen",
@@ -221634,10 +238877,10 @@
    "qwen3.7-max": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
-     "input": 2.5,
-     "output": 7.5
+     "cache_read": 0.225,
+     "cache_write": 2.8125,
+     "input": 2.25,
+     "output": 6.75
     },
     "description": "Qwen frontier model tuned for agent frameworks, coding assistants, and long tasks",
     "family": "qwen",
@@ -221681,10 +238924,10 @@
    "qwen3.7-plus": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.032,
-     "cache_write": 0.4,
-     "input": 0.32,
-     "output": 1.28
+     "cache_read": 0.028,
+     "cache_write": 0.35,
+     "input": 0.28,
+     "output": 1.12
     },
     "description": "Multimodal Qwen workhorse for long-context agents, visual inputs, and coding",
     "family": "qwen",
@@ -221731,9 +238974,9 @@
    "qwen3.8-2.4T-A95B": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.2,
-     "input": 2,
-     "output": 6
+     "cache_read": 0.18,
+     "input": 1.8,
+     "output": 5.4
     },
     "description": "Open-weight sparse MoE (2.4T total, 95B active), the open-weight twin of Qwen3.8 Max for coding, research, complex reasoning, and agentic workflows",
     "family": "qwen",
@@ -221777,10 +239020,10 @@
    "qwen3.8-max": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 2.5,
-     "input": 2,
-     "output": 6
+     "cache_read": 0.225,
+     "cache_write": 2.25,
+     "input": 1.8,
+     "output": 5.4
     },
     "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
     "family": "qwen",
@@ -221827,8 +239070,8 @@
    "ring-2.6-1t": {
     "attachment": false,
     "cost": {
-     "input": 0.3,
-     "output": 2.5
+     "input": 0.27,
+     "output": 2.25
     },
     "description": "Inclusion AI ring-2.6-1t",
     "family": "ring",
@@ -221871,9 +239114,9 @@
    "seed-1.8": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.05,
-     "input": 0.25,
-     "output": 2
+     "cache_read": 0.045,
+     "input": 0.225,
+     "output": 1.8
     },
     "description": "Optimized specifically for multimodal agent scenarios. It features enhanced agent capabilities, upgraded multimodal comprehension, and more flexible context management.",
     "family": "seed",
@@ -221917,9 +239160,9 @@
    "seed-2.0-code": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
-     "input": 0.5,
-     "output": 3
+     "cache_read": 0.09,
+     "input": 0.45,
+     "output": 2.7
     },
     "description": "ByteDance Seed coding model for multimodal software engineering and long-running agents",
     "family": "seed",
@@ -221965,9 +239208,9 @@
    "seed-2.0-mini": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.02,
-     "input": 0.1,
-     "output": 0.4
+     "cache_read": 0.018,
+     "input": 0.09,
+     "output": 0.36
     },
     "description": "Lightweight ByteDance Seed 2.0 model for low-latency multimodal reasoning and high-volume tasks",
     "family": "seed",
@@ -222013,9 +239256,9 @@
    "seed-2.0-pro": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
-     "input": 0.5,
-     "output": 3
+     "cache_read": 0.09,
+     "input": 0.45,
+     "output": 2.7
     },
     "description": "Flagship ByteDance Seed 2.0 model for complex multimodal reasoning and long-horizon agent workflows",
     "family": "seed",
@@ -222061,9 +239304,9 @@
    "step-3.7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.04,
-     "input": 0.2,
-     "output": 1.15
+     "cache_read": 0.036,
+     "input": 0.18,
+     "output": 1.035
     },
     "description": "Newer StepFun flash model for faster agents, coding, and multimodal prompts",
     "id": "step-3.7-flash",
@@ -222109,9 +239352,9 @@
    "thinkingcap-qwen3.6-27b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 0.4,
-     "output": 3
+     "cache_read": 0.234,
+     "input": 0.36,
+     "output": 2.7
     },
     "description": "ThinkingCap-Qwen3.6-27B is a reasoning tuned model from BottlecapAI built on Qwen3.6 27B. It supports extended thinking with tool calling and a 256K context window. Served via Sference.",
     "family": "qwen3.6",
@@ -222154,9 +239397,9 @@
    "thinkingcap-qwen3.6-27b@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 0.4,
-     "output": 3
+     "cache_read": 0.234,
+     "input": 0.36,
+     "output": 2.7
     },
     "description": "ThinkingCap-Qwen3.6-27B is a reasoning tuned model from BottlecapAI built on Qwen3.6 27B. It supports extended thinking with tool calling and a 256K context window. Served via Sference.",
     "family": "qwen3.6",
@@ -222882,6 +240125,42 @@
      }
     ],
     "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-ai/DeepSeek-V4-Pro-0813": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.6,
+     "output": 1.9
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "deepseek-ai/DeepSeek-V4-Pro-0813",
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1048576,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-12",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -225259,6 +242538,52 @@
     "temperature": false,
     "tool_call": false
    },
+   "deepseek-v4-flash-0731": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0936,
+     "input": 0.468,
+     "output": 0.936,
+     "reasoning": 0.936
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash-0731",
+    "interleaved": true,
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 256000,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "status": "beta",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "gemma-4-26b-a4b-it": {
     "attachment": true,
     "cost": {
@@ -225819,6 +243144,100 @@
     "temperature": true,
     "tool_call": true
    },
+   "DeepSeek-V4-Flash-0731": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "DeepSeek-V4-Flash-0731",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "DeepSeek-V4-Pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "DeepSeek-V4-Pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "GLM-5": {
     "attachment": false,
     "cost": {
@@ -226202,6 +243621,47 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-06-01",
+    "temperature": true,
+    "tool_call": true
+   },
+   "Qwen3.8-Max": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "Qwen3.8-Max",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-03",
     "temperature": true,
     "tool_call": true
    }
@@ -234492,9 +251952,9 @@
    "deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.125,
-     "input": 0.7,
-     "output": 1.9
+     "cache_read": 0.06,
+     "input": 0.3,
+     "output": 0.7
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -234706,6 +252166,7 @@
    "kimi-k3": {
     "attachment": true,
     "cost": {
+     "cache_read": 0.8,
      "input": 4,
      "output": 20
     },
@@ -235444,7 +252905,7 @@
     "interleaved": {
      "field": "reasoning_content"
     },
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 384000
@@ -235458,7 +252919,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -236489,7 +253950,7 @@
     "interleaved": {
      "field": "reasoning_content"
     },
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 393215
@@ -236503,7 +253964,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -236568,46 +254029,6 @@
     "release_date": "2026-04-17",
     "structured_output": true,
     "temperature": false,
-    "tool_call": true
-   },
-   "umans-glm-5.1": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.29,
-     "input": 1.4,
-     "output": 4.4
-    },
-    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
-    "family": "glm",
-    "id": "umans-glm-5.1",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-04-07",
-    "limit": {
-     "context": 204800,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5.1",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-04-07",
-    "structured_output": true,
-    "temperature": true,
     "tool_call": true
    },
    "umans-glm-5.2": {
@@ -236856,7 +254277,7 @@
     "interleaved": {
      "field": "reasoning_content"
     },
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1048576,
      "output": 393215
@@ -236870,7 +254291,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -236936,47 +254357,6 @@
     "release_date": "2026-04-17",
     "structured_output": true,
     "temperature": false,
-    "tool_call": true
-   },
-   "umans-glm-5.1": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0,
-     "cache_write": 0,
-     "input": 0,
-     "output": 0
-    },
-    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
-    "family": "glm",
-    "id": "umans-glm-5.1",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-04-07",
-    "limit": {
-     "context": 204800,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5.1",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-04-07",
-    "structured_output": true,
-    "temperature": true,
     "tool_call": true
    },
    "umans-glm-5.2": {
@@ -240206,36 +257586,6 @@
     "structured_output": true,
     "tool_call": true
    },
-   "nvidia-nemotron-3-5-lightning-30b-a3b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.1,
-     "output": 0.25
-    },
-    "description": "Nemotron model for efficient reasoning, coding, and specialized AI agents",
-    "family": "nemotron",
-    "id": "nvidia-nemotron-3-5-lightning-30b-a3b",
-    "last_updated": "2026-08-12",
-    "limit": {
-     "context": 1000000,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "NVIDIA Nemotron 3.5 Lightning 30B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-08-12",
-    "structured_output": true,
-    "tool_call": true
-   },
    "nvidia-nemotron-3-nano-30b-a3b": {
     "attachment": false,
     "cost": {
@@ -241834,6 +259184,49 @@
     "temperature": true,
     "tool_call": true
    },
+   "stealth-ox-alpha": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "alpha",
+    "id": "stealth-ox-alpha",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ox Alpha",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "structured_output": true,
+    "tool_call": true
+   },
    "venice-uncensored-1-2": {
     "attachment": true,
     "cost": {
@@ -243342,7 +260735,8 @@
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
@@ -243369,22 +260763,23 @@
    "alibaba/qwen3.8-27b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.01,
-     "input": 0.1,
-     "output": 0.4
+     "cache_read": 0.11,
+     "input": 0.55,
+     "output": 3.3
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
     "id": "alibaba/qwen3.8-27b",
     "last_updated": "2026-08-14",
     "limit": {
-     "context": 262144,
-     "output": 262133
+     "context": 1000000,
+     "output": 131072
     },
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
@@ -245551,9 +262946,9 @@
    "deepseek/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.028,
-     "input": 0.13,
-     "output": 0.26
+     "cache_read": 0.014,
+     "input": 0.076,
+     "output": 0.153
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -245577,6 +262972,50 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-vision-exp",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -245635,7 +263074,7 @@
     "description": "Flagship DeepSeek model for coding, reasoning, and agentic work",
     "family": "deepseek-thinking",
     "id": "deepseek/deepseek-v4-pro-0813",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 384000
@@ -245649,7 +263088,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -245692,6 +263131,30 @@
     "release_date": "2025-10-20",
     "tool_call": false
    },
+   "fish-audio/s1-free": {
+    "attachment": false,
+    "description": "Speech generation model for controllable voice, narration, and audio delivery",
+    "family": "o",
+    "id": "fish-audio/s1-free",
+    "last_updated": "2025-10-20",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "audio"
+     ]
+    },
+    "name": "S1 (Free)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-10-20",
+    "tool_call": false
+   },
    "fish-audio/s2-pro": {
     "attachment": false,
     "description": "Speech generation model for controllable voice, narration, and audio delivery",
@@ -245711,6 +263174,30 @@
      ]
     },
     "name": "S2 Pro",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-03-09",
+    "tool_call": false
+   },
+   "fish-audio/s2-pro-free": {
+    "attachment": false,
+    "description": "Speech generation model for controllable voice, narration, and audio delivery",
+    "family": "o",
+    "id": "fish-audio/s2-pro-free",
+    "last_updated": "2026-03-09",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "audio"
+     ]
+    },
+    "name": "S2 Pro (Free)",
     "open_weights": false,
     "reasoning": false,
     "release_date": "2026-03-09",
@@ -245740,6 +263227,30 @@
     "release_date": "2026-07-28",
     "tool_call": false
    },
+   "fish-audio/s2.1-pro-free": {
+    "attachment": false,
+    "description": "Speech generation model for controllable voice, narration, and audio delivery",
+    "family": "o",
+    "id": "fish-audio/s2.1-pro-free",
+    "last_updated": "2026-07-28",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "audio"
+     ]
+    },
+    "name": "S2.1 Pro (Free)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-07-28",
+    "tool_call": false
+   },
    "fish-audio/transcribe-1": {
     "attachment": false,
     "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
@@ -245759,6 +263270,30 @@
      ]
     },
     "name": "Transcribe-1",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-03-01",
+    "tool_call": false
+   },
+   "fish-audio/transcribe-1-free": {
+    "attachment": false,
+    "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
+    "family": "o",
+    "id": "fish-audio/transcribe-1-free",
+    "last_updated": "2026-03-01",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Transcribe-1 (Free)",
     "open_weights": false,
     "reasoning": false,
     "release_date": "2026-03-01",
@@ -246560,81 +264095,6 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
-   },
-   "google/imagen-4.0-fast-generate-001": {
-    "attachment": false,
-    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
-    "family": "imagen",
-    "id": "google/imagen-4.0-fast-generate-001",
-    "last_updated": "2025-06",
-    "limit": {
-     "context": 480,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "image"
-     ]
-    },
-    "name": "Imagen 4 Fast",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-06-01",
-    "temperature": true,
-    "tool_call": false
-   },
-   "google/imagen-4.0-generate-001": {
-    "attachment": false,
-    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
-    "family": "imagen",
-    "id": "google/imagen-4.0-generate-001",
-    "last_updated": "2025-05-22",
-    "limit": {
-     "context": 480,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "image"
-     ]
-    },
-    "name": "Imagen 4",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-05-20",
-    "temperature": true,
-    "tool_call": false
-   },
-   "google/imagen-4.0-ultra-generate-001": {
-    "attachment": false,
-    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
-    "family": "imagen",
-    "id": "google/imagen-4.0-ultra-generate-001",
-    "last_updated": "2025-05-24",
-    "limit": {
-     "context": 480,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "image"
-     ]
-    },
-    "name": "Imagen 4 Ultra",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-05-24",
-    "temperature": false,
-    "tool_call": false
    },
    "google/text-embedding-005": {
     "attachment": false,
@@ -248812,17 +266272,16 @@
    "nvidia/nemotron-3.5-lightning": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.01,
-     "input": 0.05,
-     "output": 0.2
+     "input": 0,
+     "output": 0
     },
     "description": "Nemotron model for efficient reasoning, coding, and specialized AI agents",
     "family": "nemotron",
     "id": "nvidia/nemotron-3.5-lightning",
     "last_updated": "2026-08-11",
     "limit": {
-     "context": 262144,
-     "output": 131072
+     "context": 1000000,
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -248838,6 +266297,51 @@
     "reasoning_options": [
      {
       "type": "toggle"
+     },
+     {
+      "max": 32768,
+      "min": 1,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-11",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nvidia/nemotron-3.5-lightning-free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Fast NVIDIA Nemotron MoE for reliable agentic tasks across enterprise workloads",
+    "family": "nemotron",
+    "id": "nvidia/nemotron-3.5-lightning-free",
+    "last_updated": "2026-08-11",
+    "limit": {
+     "context": 1000000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Nemotron 3.5 Lightning 30B (Free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "max": 32768,
+      "min": 1,
+      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-08-11",
@@ -250728,10 +268232,10 @@
    "openai/gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
-     "input": 2.5,
-     "output": 15
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
     },
     "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
     "family": "gpt-sol",
@@ -250777,10 +268281,10 @@
    "openai/gpt-5.6-sol-fast": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 3.125,
-     "input": 5,
-     "output": 30
+     "cache_read": 0.4,
+     "cache_write": 2.5,
+     "input": 4,
+     "output": 20
     },
     "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
     "family": "gpt-sol",
@@ -252363,6 +269867,605 @@
     "release_date": "2026-08-03",
     "tool_call": true
    },
+   "spacexai/grok-4.1-fast-non-reasoning": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.2,
+     "output": 0.5
+    },
+    "description": "Fast Grok model for responsive chat, reasoning, and tool-assisted work",
+    "family": "grok",
+    "id": "spacexai/grok-4.1-fast-non-reasoning",
+    "last_updated": "2025-11-19",
+    "limit": {
+     "context": 1000000,
+     "output": 1000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.1 Fast Non-Reasoning",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-11-19",
+    "tool_call": true
+   },
+   "spacexai/grok-4.1-fast-reasoning": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.2,
+     "output": 0.5
+    },
+    "description": "Fast Grok model for responsive chat, reasoning, and tool-assisted work",
+    "family": "grok",
+    "id": "spacexai/grok-4.1-fast-reasoning",
+    "last_updated": "2025-11-19",
+    "limit": {
+     "context": 1000000,
+     "output": 1000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.1 Fast Reasoning",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-11-19",
+    "tool_call": true
+   },
+   "spacexai/grok-4.20-multi-agent": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1.25,
+     "output": 2.5
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "spacexai/grok-4.20-multi-agent",
+    "last_updated": "2026-03-10",
+    "limit": {
+     "context": 2000000,
+     "output": 2000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.20 Multi-Agent",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-03-10",
+    "tool_call": true
+   },
+   "spacexai/grok-4.20-multi-agent-beta": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1.25,
+     "output": 2.5
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "spacexai/grok-4.20-multi-agent-beta",
+    "last_updated": "2026-03-11",
+    "limit": {
+     "context": 2000000,
+     "output": 2000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.20 Multi Agent Beta",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-03-11",
+    "tool_call": true
+   },
+   "spacexai/grok-4.20-non-reasoning": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1.25,
+     "output": 2.5
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "spacexai/grok-4.20-non-reasoning",
+    "last_updated": "2026-03-10",
+    "limit": {
+     "context": 2000000,
+     "output": 2000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.20 Non-Reasoning",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-03-10",
+    "tool_call": true
+   },
+   "spacexai/grok-4.20-non-reasoning-beta": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.4,
+     "input": 1.25,
+     "output": 2.5
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "spacexai/grok-4.20-non-reasoning-beta",
+    "last_updated": "2026-03-11",
+    "limit": {
+     "context": 2000000,
+     "output": 2000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.20 Beta Non-Reasoning",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-03-11",
+    "tool_call": true
+   },
+   "spacexai/grok-4.20-reasoning": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1.25,
+     "output": 2.5
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "spacexai/grok-4.20-reasoning",
+    "last_updated": "2026-03-10",
+    "limit": {
+     "context": 2000000,
+     "output": 2000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.20 Reasoning",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-03-10",
+    "tool_call": true
+   },
+   "spacexai/grok-4.20-reasoning-beta": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1.25,
+     "output": 2.5
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "spacexai/grok-4.20-reasoning-beta",
+    "last_updated": "2026-03-11",
+    "limit": {
+     "context": 2000000,
+     "output": 2000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.20 Beta Reasoning",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-03-11",
+    "tool_call": true
+   },
+   "spacexai/grok-4.3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1.25,
+     "output": 2.5
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "spacexai/grok-4.3",
+    "last_updated": "2026-04-30",
+    "limit": {
+     "context": 1000000,
+     "output": 1000000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.3",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-04-30",
+    "tool_call": true
+   },
+   "spacexai/grok-4.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 2,
+     "output": 6
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "spacexai/grok-4.5",
+    "last_updated": "2026-07-08",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-08",
+    "tool_call": true
+   },
+   "spacexai/grok-4.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "spacexai/grok-4.6",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-12",
+    "tool_call": true
+   },
+   "spacexai/grok-build-0.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 2
+    },
+    "description": "Grok coding model for agentic engineering, edits, and codebase workflows",
+    "family": "grok-build",
+    "id": "spacexai/grok-build-0.1",
+    "last_updated": "2026-05-20",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok Build 0.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-05-20",
+    "tool_call": true
+   },
+   "spacexai/grok-imagine-image": {
+    "attachment": false,
+    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+    "family": "grok",
+    "id": "spacexai/grok-imagine-image",
+    "last_updated": "2026-01-28",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "image"
+     ]
+    },
+    "name": "Grok Imagine Image",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-01-28",
+    "tool_call": false
+   },
+   "spacexai/grok-imagine-image-2.0": {
+    "attachment": false,
+    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+    "family": "grok",
+    "id": "spacexai/grok-imagine-image-2.0",
+    "last_updated": "2026-08-07",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "image"
+     ]
+    },
+    "name": "Grok Imagine Image 2.0",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-07",
+    "tool_call": false
+   },
+   "spacexai/grok-imagine-video": {
+    "attachment": false,
+    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+    "family": "grok",
+    "id": "spacexai/grok-imagine-video",
+    "last_updated": "2026-01-28",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "video"
+     ]
+    },
+    "name": "Grok Imagine",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-01-28",
+    "tool_call": false
+   },
+   "spacexai/grok-imagine-video-1.5": {
+    "attachment": false,
+    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+    "family": "grok",
+    "id": "spacexai/grok-imagine-video-1.5",
+    "last_updated": "2026-06-22",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "video"
+     ]
+    },
+    "name": "Grok Imagine Video 1.5",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-06-22",
+    "tool_call": false
+   },
+   "spacexai/grok-imagine-video-1.5-preview": {
+    "attachment": false,
+    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+    "family": "grok",
+    "id": "spacexai/grok-imagine-video-1.5-preview",
+    "last_updated": "2026-05-30",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "video"
+     ]
+    },
+    "name": "Grok Imagine Video 1.5 Preview",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-05-30",
+    "tool_call": false
+   },
+   "spacexai/grok-stt": {
+    "attachment": false,
+    "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
+    "family": "grok",
+    "id": "spacexai/grok-stt",
+    "last_updated": "2026-03-16",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok STT",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-03-16",
+    "tool_call": false
+   },
+   "spacexai/grok-tts": {
+    "attachment": false,
+    "description": "Speech generation model for controllable voice, narration, and audio delivery",
+    "family": "grok",
+    "id": "spacexai/grok-tts",
+    "last_updated": "2026-03-16",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "audio"
+     ]
+    },
+    "name": "Grok TTS",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-03-16",
+    "tool_call": false
+   },
+   "spacexai/grok-voice-think-fast-1.0": {
+    "attachment": false,
+    "description": "Speech generation model for controllable voice, narration, and audio delivery",
+    "family": "grok",
+    "id": "spacexai/grok-voice-think-fast-1.0",
+    "last_updated": "2026-04-23",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "audio"
+     ],
+     "output": [
+      "text",
+      "audio"
+     ]
+    },
+    "name": "Grok Voice Think Fast 1.0",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-04-23",
+    "tool_call": false
+   },
+   "spacexai/grok-voice-think-fast-2.0": {
+    "attachment": false,
+    "description": "Speech generation model for controllable voice, narration, and audio delivery",
+    "family": "grok",
+    "id": "spacexai/grok-voice-think-fast-2.0",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "audio"
+     ],
+     "output": [
+      "text",
+      "audio"
+     ]
+    },
+    "name": "Grok Voice Think Fast 2.0",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-07-29",
+    "tool_call": false
+   },
    "stepfun/step-3.5-flash": {
     "attachment": false,
     "cost": {
@@ -252446,20 +270549,104 @@
     "temperature": true,
     "tool_call": true
    },
+   "tencent/hy-mt2-lite": {
+    "attachment": false,
+    "cost": {
+     "input": 0.044,
+     "output": 0.177
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "tencent/hy-mt2-lite",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 8000,
+     "output": 4000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Tencent Hy-MT2-Lite",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-06-12",
+    "tool_call": false
+   },
+   "tencent/hy-mt2-plus": {
+    "attachment": false,
+    "cost": {
+     "input": 0.074,
+     "output": 0.295
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "tencent/hy-mt2-plus",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 8000,
+     "output": 4000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Tencent Hy-MT2-Plus",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-06-12",
+    "tool_call": false
+   },
+   "tencent/hy-mt2-pro": {
+    "attachment": false,
+    "cost": {
+     "input": 0.074,
+     "output": 0.295
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "tencent/hy-mt2-pro",
+    "last_updated": "2026-05-21",
+    "limit": {
+     "context": 8000,
+     "output": 4000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Tencent Hy-MT2-Pro",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-05-21",
+    "tool_call": false
+   },
    "tencent/hy3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.035,
-     "input": 0.14,
-     "output": 0.58
+     "cache_read": 0.033,
+     "input": 0.132,
+     "output": 0.528
     },
     "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
     "family": "Hy",
     "id": "tencent/hy3",
     "last_updated": "2026-07-06",
     "limit": {
-     "context": 262144,
-     "output": 262144
+     "context": 256000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -252878,682 +271065,6 @@
     "temperature": true,
     "tool_call": false
    },
-   "xai/grok-4.1-fast-non-reasoning": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.05,
-     "input": 0.2,
-     "output": 0.5
-    },
-    "description": "Fast Grok model for responsive chat, reasoning, and tool-assisted work",
-    "family": "grok",
-    "id": "xai/grok-4.1-fast-non-reasoning",
-    "knowledge": "2024-10",
-    "last_updated": "2025-07-09",
-    "limit": {
-     "context": 1000000,
-     "output": 1000000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.1 Fast Non-Reasoning",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-11-19",
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-4.1-fast-reasoning": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.05,
-     "input": 0.2,
-     "output": 0.5
-    },
-    "description": "Fast Grok model for responsive chat, reasoning, and tool-assisted work",
-    "family": "grok",
-    "id": "xai/grok-4.1-fast-reasoning",
-    "knowledge": "2024-10",
-    "last_updated": "2025-07-09",
-    "limit": {
-     "context": 1000000,
-     "output": 1000000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.1 Fast Reasoning",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-11-19",
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-4.20-multi-agent": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 1.25,
-     "output": 2.5
-    },
-    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
-    "family": "grok",
-    "id": "xai/grok-4.20-multi-agent",
-    "last_updated": "2026-03-23",
-    "limit": {
-     "context": 2000000,
-     "output": 2000000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.20 Multi-Agent",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high",
-       "xhigh"
-      ]
-     }
-    ],
-    "release_date": "2026-03-10",
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-4.20-multi-agent-beta": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 1.25,
-     "output": 2.5
-    },
-    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
-    "family": "grok",
-    "id": "xai/grok-4.20-multi-agent-beta",
-    "last_updated": "2026-03-13",
-    "limit": {
-     "context": 2000000,
-     "output": 2000000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.20 Multi Agent Beta",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high",
-       "xhigh"
-      ]
-     }
-    ],
-    "release_date": "2026-03-11",
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-4.20-non-reasoning": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 1.25,
-     "output": 2.5
-    },
-    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
-    "family": "grok",
-    "id": "xai/grok-4.20-non-reasoning",
-    "last_updated": "2026-03-23",
-    "limit": {
-     "context": 2000000,
-     "output": 2000000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.20 Non-Reasoning",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-03-10",
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-4.20-non-reasoning-beta": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.4,
-     "input": 1.25,
-     "output": 2.5
-    },
-    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
-    "family": "grok",
-    "id": "xai/grok-4.20-non-reasoning-beta",
-    "last_updated": "2026-03-13",
-    "limit": {
-     "context": 2000000,
-     "output": 2000000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.20 Beta Non-Reasoning",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-03-11",
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-4.20-reasoning": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 1.25,
-     "output": 2.5
-    },
-    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
-    "family": "grok",
-    "id": "xai/grok-4.20-reasoning",
-    "last_updated": "2026-03-23",
-    "limit": {
-     "context": 2000000,
-     "output": 2000000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.20 Reasoning",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-03-10",
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-4.20-reasoning-beta": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 1.25,
-     "output": 2.5
-    },
-    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
-    "family": "grok",
-    "id": "xai/grok-4.20-reasoning-beta",
-    "last_updated": "2026-03-13",
-    "limit": {
-     "context": 2000000,
-     "output": 2000000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.20 Beta Reasoning",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-03-11",
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-4.3": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 1.25,
-     "output": 2.5
-    },
-    "description": "xAI's default Grok for chat, coding, agentic tools, and lower hallucination risk",
-    "family": "grok",
-    "id": "xai/grok-4.3",
-    "last_updated": "2026-04-17",
-    "limit": {
-     "context": 1000000,
-     "output": 1000000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.3",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-04-17",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-4.5": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.3,
-     "input": 2,
-     "output": 6
-    },
-    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
-    "family": "grok",
-    "id": "xai/grok-4.5",
-    "last_updated": "2026-07-08",
-    "limit": {
-     "context": 500000,
-     "output": 500000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.5",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-07-08",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-4.6": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.5,
-     "input": 2,
-     "output": 6
-    },
-    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
-    "family": "grok",
-    "id": "xai/grok-4.6",
-    "knowledge": "2026-02-01",
-    "last_updated": "2026-08-12",
-    "limit": {
-     "context": 500000,
-     "output": 500000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok 4.6",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high",
-       "xhigh"
-      ]
-     }
-    ],
-    "release_date": "2026-08-12",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-build-0.1": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 1,
-     "output": 2
-    },
-    "description": "Fast Grok coding model tuned for agentic engineering and iterative edits",
-    "family": "grok-build",
-    "id": "xai/grok-build-0.1",
-    "last_updated": "2026-04-16",
-    "limit": {
-     "context": 256000,
-     "output": 256000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok Build 0.1",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-04-16",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "xai/grok-imagine-image": {
-    "attachment": false,
-    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
-    "family": "grok",
-    "id": "xai/grok-imagine-image",
-    "last_updated": "2026-02-19",
-    "limit": {
-     "context": 0,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text",
-      "image"
-     ]
-    },
-    "name": "Grok Imagine Image",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-01-28",
-    "temperature": true,
-    "tool_call": false
-   },
-   "xai/grok-imagine-image-2.0": {
-    "attachment": false,
-    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
-    "family": "grok",
-    "id": "xai/grok-imagine-image-2.0",
-    "last_updated": "2026-08-07",
-    "limit": {
-     "context": 0,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "image"
-     ]
-    },
-    "name": "Grok Imagine Image 2.0",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-08-07",
-    "temperature": false,
-    "tool_call": false
-   },
-   "xai/grok-imagine-video": {
-    "attachment": false,
-    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
-    "family": "grok",
-    "id": "xai/grok-imagine-video",
-    "last_updated": "2026-01-28",
-    "limit": {
-     "context": 0,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "video"
-     ]
-    },
-    "name": "Grok Imagine",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-01-28",
-    "temperature": true,
-    "tool_call": false
-   },
-   "xai/grok-imagine-video-1.5": {
-    "attachment": false,
-    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
-    "family": "grok",
-    "id": "xai/grok-imagine-video-1.5",
-    "last_updated": "2026-05-30",
-    "limit": {
-     "context": 0,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "video"
-     ]
-    },
-    "name": "Grok Imagine Video 1.5",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-05-30",
-    "temperature": true,
-    "tool_call": false
-   },
-   "xai/grok-imagine-video-1.5-preview": {
-    "attachment": false,
-    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
-    "family": "grok",
-    "id": "xai/grok-imagine-video-1.5-preview",
-    "last_updated": "2026-05-30",
-    "limit": {
-     "context": 0,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "video"
-     ]
-    },
-    "name": "Grok Imagine Video 1.5 Preview",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-05-30",
-    "temperature": true,
-    "tool_call": false
-   },
-   "xai/grok-stt": {
-    "attachment": false,
-    "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
-    "family": "grok",
-    "id": "xai/grok-stt",
-    "last_updated": "2026-03-16",
-    "limit": {
-     "context": 0,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "audio"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Grok STT",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-03-16",
-    "temperature": true,
-    "tool_call": false
-   },
-   "xai/grok-tts": {
-    "attachment": false,
-    "description": "Speech generation model for controllable voice, narration, and audio delivery",
-    "family": "grok",
-    "id": "xai/grok-tts",
-    "last_updated": "2026-03-16",
-    "limit": {
-     "context": 0,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "audio"
-     ]
-    },
-    "name": "Grok TTS",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-03-16",
-    "temperature": true,
-    "tool_call": false
-   },
-   "xai/grok-voice-think-fast-1.0": {
-    "attachment": false,
-    "description": "Speech generation model for controllable voice, narration, and audio delivery",
-    "family": "grok",
-    "id": "xai/grok-voice-think-fast-1.0",
-    "last_updated": "2026-04-23",
-    "limit": {
-     "context": 0,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "audio"
-     ],
-     "output": [
-      "text",
-      "audio"
-     ]
-    },
-    "name": "Grok Voice Think Fast 1.0",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-04-23",
-    "temperature": true,
-    "tool_call": false
-   },
-   "xai/grok-voice-think-fast-2.0": {
-    "attachment": false,
-    "description": "Speech generation model for controllable voice, narration, and audio delivery",
-    "family": "grok",
-    "id": "xai/grok-voice-think-fast-2.0",
-    "last_updated": "2026-07-29",
-    "limit": {
-     "context": 0,
-     "output": 0
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "audio"
-     ],
-     "output": [
-      "text",
-      "audio"
-     ]
-    },
-    "name": "Grok Voice Think Fast 2.0",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-07-29",
-    "tool_call": false
-   },
    "xiaomi/mimo-v2.5": {
     "attachment": true,
     "cost": {
@@ -253764,77 +271275,6 @@
     },
     "name": "GLM 4.6",
     "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-09-30",
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai/glm-4.6v": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.05,
-     "input": 0.3,
-     "output": 0.9
-    },
-    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
-    "family": "glm",
-    "id": "zai/glm-4.6v",
-    "knowledge": "2025-04",
-    "last_updated": "2025-12-08",
-    "limit": {
-     "context": 128000,
-     "output": 24000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-4.6V",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-12-08",
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai/glm-4.6v-flash": {
-    "attachment": true,
-    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
-    "family": "glm",
-    "id": "zai/glm-4.6v-flash",
-    "knowledge": "2024-10",
-    "last_updated": "2025-09-30",
-    "limit": {
-     "context": 128000,
-     "output": 24000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-4.6V-Flash",
-    "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -256067,7 +273507,7 @@
      "input": 0.4,
      "output": 3
     },
-    "description": "Qwen3.8-27B is a dense multimodal model suited for coding, research, multimodal interaction, and long-running agent tasks.",
+    "description": "Qwen3.8-27B is a dense multimodal model suited for coding, research, vision, and long-running agent tasks.",
     "family": "qwen",
     "id": "Qwen/Qwen3.8-27B",
     "last_updated": "2026-08-14",

--- a/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.meta.json
+++ b/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.meta.json
@@ -1,8 +1,8 @@
 {
   "source": "https://models.dev/api.json",
-  "fetchedUtc": "2026-08-19T17:09:43Z",
-  "providers": 192,
-  "providersWithApiUrl": 166,
-  "sha256": "fbf2d85eaffa22d822ee5b1da047a91ba7d0839f259186250ff90fbfaa96b4dc",
+  "fetchedUtc": "2026-08-23T02:09:32Z",
+  "providers": 193,
+  "providersWithApiUrl": 167,
+  "sha256": "1565e15952a89aef53f6d47c659c57122b59061491ec3ded24295349e60a22ed",
   "license": "MIT (models.dev)"
 }


### PR DESCRIPTION
Pre-release checklist item. Snapshot last fetched **2026-08-19**; this is **2026-08-22**.

## The review the script asks for

`refresh-models-snapshot.sh` pretty-prints with sorted keys specifically so a refresh can be read rather than trusted. Reading it:

```
added   : llmgateway-providers
removed : none
api URL changed: none
providers 192 -> 193;  model entries 6834 -> 7248
```

**The one addition is a protocol we already serve**: `npm=@ai-sdk/openai-compatible`, `api=https://api.llmgateway.io/v1` — a plain absolute https base with a slug id, so it passes `AiPresetSource.SkipReason` and is offered like any other OpenAI-compatible endpoint. It declares `LLMGATEWAY_API_KEY`, so it will also appear under "Found in your environment" for a reader who has that set.

371 of the 414 new model entries belong to it; the other 43 are spread across providers that already existed. **Nothing was removed**, so no reader loses a preset they were relying on, and no `api` URL moved under an existing connection.

## Why this matters little, and still matters

The snapshot is the **last fallback**, behind the runtime cache and the network — so this changes nothing for any reader with either. It is what a fresh install on a machine that cannot reach models.dev gets to choose from.

That is also why skipping the refresh degrades gracefully, and why it is worth doing at the one moment it costs nothing: before the release build, rather than after.

Data only — no code, no tests affected.
