### PR TITLE
Tell the UI when the environment finally answers (#852)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using CST.Avalonia.Models;
 using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
 using CST.Avalonia.Services;
 using CST.Avalonia.Services.Ai;
 using Moq;
@@ -848,5 +849,52 @@ public class AiConnectionServiceTests
     {
         Assert.NotEqual(AiCredentialNames.Input("token"), AiCredentialNames.Header("token"));
         Assert.NotEqual(AiCredentialNames.Input("token"), AiCredentialNames.Primary);
+    }
+
+    /// <summary>
+    /// The login-shell probe answering is a change to what this service reports, so it must reach the UI.
+    /// (#852)
+    ///
+    /// <para><b>The defect.</b> <c>SourceFor</c> consults the environment live, so an adopted connection's
+    /// KeySource changes the instant the probe lands — and nothing was listening. The probe starts at launch
+    /// and finishes a few hundred milliseconds later; by then the model picker had already asked, been told
+    /// <c>None</c>, and greyed out every model as "no API key stored". Opening Settings &gt; Providers fixed
+    /// it only as a side effect of constructing a view model that rebinds, so the Assistant announced itself
+    /// unconfigured on every launch and the cure was to open a tab and change nothing.</para>
+    ///
+    /// <para>Asserted on the event rather than on KeySource: the value was always going to be right once
+    /// asked again: what was missing was anything telling the UI to ask.</para>
+    /// </summary>
+    [Fact]
+    public void The_environment_answering_later_reaches_the_connections_changed_event()
+    {
+        var settings = new Settings();
+        var svc = new Mock<ISettingsService>();
+        svc.SetupGet(s => s.Settings).Returns(settings);
+        var env = new ChangingKeys();
+
+        var service = new AiConnectionService(svc.Object, environmentKeys: env);
+
+        var raised = 0;
+        service.ConnectionsChanged += (_, _) => raised++;
+
+        env.RaiseChanged();
+
+        Assert.Equal(1, raised);
+    }
+
+    /// <summary>An environment-keys source that can announce that its answer has changed, as the real one
+    /// does when the login-shell probe lands.</summary>
+    private sealed class ChangingKeys : IAiEnvironmentKeys
+    {
+        public event EventHandler? Changed;
+        public void RaiseChanged() => Changed?.Invoke(this, EventArgs.Empty);
+
+        public string? VariableFor(AiProviderPreset preset) => null;
+        public string? ValueFor(AiProviderPreset preset) => null;
+        public string? Read(string variableName) => null;
+        public IReadOnlyList<AiEnvironmentKey> Discover(IEnumerable<AiProviderPreset> presets) =>
+            Array.Empty<AiEnvironmentKey>();
+        public Task Ready => Task.CompletedTask;
     }
 }

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -187,6 +187,20 @@ namespace CST.Avalonia.Services.Ai
             // one event it already binds to rather than through a second channel.
             if (_presets is not null)
                 _presets.PresetsChanged += (_, _) => RaiseChanged();
+
+            // AND SO IS THE ENVIRONMENT ANSWERING. SourceFor consults _environmentKeys live, so a connection
+            // adopted from the environment reports Keychain/Environment/None according to what the variable
+            // holds at the moment it is asked — which means the answer CHANGES the instant the login-shell
+            // probe lands, without anything here doing so.
+            //
+            // Nothing was listening. The probe is started at launch (App.axaml.cs PrimeShellEnvironment) and
+            // finishes a few hundred milliseconds later; by then the model picker had already asked, been
+            // told None, and greyed out every model with "no API key stored". Opening Settings > Providers
+            // repaired it only as a side effect of constructing a view model that rebinds. So the Assistant
+            // announced itself unconfigured on every launch to exactly the readers #714 and #817 exist for,
+            // and the cure was to open a tab and change nothing. (#852)
+            if (_environmentKeys is not null)
+                _environmentKeys.Changed += (_, _) => RaiseChanged();
         }
 
         public event EventHandler? ConnectionsChanged;


### PR DESCRIPTION
Closes #852.

Opening the app on a machine whose provider key comes from the environment showed the Assistant's model picker greyed out, every model labelled **"no API key stored"**. Opening Settings ▸ Providers cleared it, having changed nothing.

## What was happening

`SourceFor` consults the environment **live**, so an adopted connection's `KeySource` is correct whenever it is asked. The login-shell probe starts at launch (`App.axaml.cs:450`) and lands a few hundred milliseconds later. By then the picker had already asked, been told `None`, and drawn itself.

`Probed` had two subscribers — `AiConnectionsViewModel`, which does not exist until the Providers tab is opened, and `AiEnvironmentKeys`, which re-raises it as `Changed`. **Nothing subscribed to `Changed` at all.** Opening Providers repaired the picker only as a side effect of constructing a view model that rebinds.

So the value was never wrong. What was missing was anything telling the UI to ask again.

## The change

```csharp
if (_environmentKeys is not null)
    _environmentKeys.Changed += (_, _) => RaiseChanged();
```

Three lines below the identical treatment already given to `PresetsChanged`, and for the same stated reason: *a change to what this service reports reaches the UI on the one event it already binds to, rather than through a second channel.* `RaiseChanged` already marshals to the UI thread.

## The test asserts the event, not the value

Deliberately. Asserting `KeySource` would pass against the broken version too — the broken version also returns the right answer **when asked**. Only the event distinguishes them.

Mutation-verified: removing the subscription fails `The_environment_answering_later_reaches_the_connections_changed_event` and no other test.

## Verification

Build clean; suite **2611 passed, 0 failed, 17 skipped**.

## Why it survived this long

A key pasted into the app is in the credential store before any UI asks, so it was never affected. The defect lands only on keys discovered from the environment — the readers #714 and #817 were built for, for whom the Assistant announced itself unconfigured at every launch.
