### PR TITLE
Paste, Enter, done: keyboard flow in the provider editor (#854)

### DIFF
--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -456,11 +456,17 @@
                         <StackPanel IsVisible="{Binding ShowKeyField}">
                             <TextBlock Text="API key" Classes="SettingLabel"/>
                             <StackPanel Orientation="Horizontal" Spacing="6">
+                                <!-- Focused as it appears, because pasting a key is the only reason this
+                                     sheet is open. Reaching it meant a click into a box that was already the
+                                     obvious next move. Loaded on the box itself rather than a lookup from
+                                     the view: it lives in a DataTemplate, so there is no named control to
+                                     find. -->
                                 <TextBox Text="{Binding ApiKeyEntry}"
                                          PasswordChar="●"
                                          IsEnabled="{Binding CanStoreKeys}"
                                          Watermark="Paste a key"
-                                         Width="320"/>
+                                         Width="320"
+                                         Loaded="OnApiKeyBoxLoaded"/>
                                 <Button Content="Remove stored key" Classes="Link"
                                         IsVisible="{Binding HasStoredKey}"
                                         Command="{Binding RemoveKeyCommand}"
@@ -540,7 +546,11 @@
                         </ItemsControl>
 
                         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
-                            <Button Content="{Binding SaveText}" Command="{Binding SaveCommand}"/>
+                            <!-- IsDefault so Enter commits from anywhere in the form, which pairs with the
+                                 key box taking focus above: paste, Enter, done, no mouse. A single-line
+                                 TextBox does not handle Enter itself, so it reaches the default button. -->
+                            <Button Content="{Binding SaveText}" Command="{Binding SaveCommand}"
+                                    IsDefault="True"/>
                             <Button Content="Cancel" Classes="Link" Command="{Binding CancelCommand}"/>
                         </StackPanel>
                     </StackPanel>

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml.cs
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.VisualTree;
 using CST.Avalonia.ViewModels;
@@ -47,6 +48,26 @@ namespace CST.Avalonia.Views
         {
             if (e.PropertyName != nameof(AiConnectionsViewModel.IsListing)) return;
             if (this.FindAncestorOfType<ScrollViewer>() is { } scroll) scroll.Offset = default;
+        }
+
+        /// <summary>
+        /// Focuses the API key box as the editor sheet appears.
+        ///
+        /// <para>Pasting a key is the only reason a provider sheet is open, and reaching the box took a click
+        /// into the field that was already the obvious next move. With Save marked <c>IsDefault</c>, the whole
+        /// interaction becomes paste-and-Enter.</para>
+        ///
+        /// <para><b>Wired to the box's own Loaded rather than driven from the view.</b> It lives inside a
+        /// <c>DataTemplate</c>, so there is no named control for the view to find; and the sheet is created
+        /// fresh each time it opens, so Loaded fires exactly when focus should move. It is also why this
+        /// cannot steal focus mid-edit: a control that is loading is not one the reader is typing in.</para>
+        ///
+        /// <para>Disabled where the credential store is unavailable (<c>CanStoreKeys</c>) — focusing a box
+        /// that cannot be typed in would be worse than leaving focus alone, so that case is skipped.</para>
+        /// </summary>
+        private void OnApiKeyBoxLoaded(object? sender, RoutedEventArgs e)
+        {
+            if (sender is TextBox { IsEnabled: true, IsVisible: true } box) box.Focus();
         }
     }
 }


### PR DESCRIPTION
Closes #854.

Adding a named provider took four actions — Add on the catalogue row, click into the API key box, paste, click Add — and two were clicks onto the only thing a reader could sensibly do next.

Now: **paste, Enter, done.**

## Changes

**Focus the API key box as the sheet appears.** Wired to the box's own `Loaded` rather than driven from the view, for two reasons: it lives inside a `DataTemplate`, so there is no named control to look up; and `Loaded` fires exactly when the sheet is built fresh, which is why this cannot take focus from a reader mid-edit — a control that is loading is not one anybody is typing in.

**`IsDefault="True"` on Save.** A single-line `TextBox` does not handle Enter itself, so it reaches the default button from anywhere in the form.

**Skipped when the box is disabled.** `CanStoreKeys` is false where no OS credential store exists (the designed-in Linux case). Focusing a box that cannot be typed into would be worse than leaving focus alone.

## Precedent

`AiProvidersView.axaml.cs` already argues this shape for scrolling — it resets the offset when the sheet opens because *"a screen the reader has not seen before starts at its beginning."* Focus is the same point one step further in.

## Deliberately not included

**Escape to cancel** (`IsCancel`). Escape discarding a half-typed key is a different risk from Enter committing a finished one, and wants deciding on its own rather than riding along.

## Verification

Build clean; suite **2610 passed, 0 failed, 17 skipped**.

**No test.** Focus and default-button routing are rendered facts and this project has no headless Avalonia harness. Three things want looking at:

1. Opening a provider sheet puts the cursor in the API key box, and pasting works with no click.
2. Enter commits from the key box, and from the other fields.
3. **Where the credential store is unavailable, focus does not move** — the case the guard exists for.
