### PR TITLE
A sample prompt for agents that speak HTTP rather than MCP (#857)

### DIFF
--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1548,6 +1548,55 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
         public string McpClientConfigJson => CST.Avalonia.Services.LocalApi.McpClientConfig.ClaudeDesktop(
             System.Environment.ProcessPath ?? "CST Reader");
 
+        /// <summary>
+        /// A prompt a reader can paste into a coding agent to get it talking to the local API.
+        ///
+        /// <para><b>It points at <c>/llms.txt</c> rather than listing the endpoints.</b> The server already
+        /// serves a thin index and a full one for exactly this purpose, and a copy of the route list living
+        /// in a settings string is a copy that goes stale the first time a route is added — silently, and in
+        /// the one place nobody thinks to check.</para>
+        ///
+        /// <para>The handshake path is computed, not written down, so it names the real file on whichever
+        /// platform is asking rather than a macOS path shown to a Windows reader.</para>
+        ///
+        /// <para><b>It tells the agent to read the file rather than remember it.</b> Port and token change on
+        /// every start (#278), so an agent that caches them works until the app restarts and then fails in a
+        /// way that looks like the API is broken.</para>
+        /// </summary>
+        public string LocalApiSamplePrompt
+        {
+            get
+            {
+                var path = System.IO.Path.Combine(
+                    System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData),
+                    AppConstants.AppDataDirectoryName,
+                    Services.LocalApi.LocalApiInfo.FileName);
+
+                return string.Join(System.Environment.NewLine, new[]
+                {
+                    "CST Reader is running on this machine and exposes a local HTTP API over the",
+                    "Chaṭṭha Saṅgāyana Tipiṭaka — the Pāli canon, its commentaries and sub-commentaries,",
+                    "plus dictionaries and script conversion.",
+                    "",
+                    "Connection details are in this file:",
+                    "",
+                    "    " + path,
+                    "",
+                    "It holds a \"port\" and a \"token\". The server listens on http://127.0.0.1:<port> and",
+                    "every request must carry:",
+                    "",
+                    "    Authorization: Bearer <token>",
+                    "",
+                    "Start by fetching http://127.0.0.1:<port>/llms.txt — it lists what the API offers and",
+                    "how to call it. /llms-full.txt has the detail if you need more.",
+                    "",
+                    "Read the file each time rather than remembering the port and token: both change every",
+                    "time CST Reader starts. The app must be running for any of this to answer.",
+                    "",
+                });
+            }
+        }
+
         /// <summary>The local-API sub-permissions are editable only when the master switch is on.</summary>
         public bool SubPermissionsEnabled => AiEnabled;
 

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1551,10 +1551,17 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
         /// <summary>
         /// A prompt a reader can paste into a coding agent to get it talking to the local API.
         ///
-        /// <para><b>It points at <c>/llms.txt</c> rather than listing the endpoints.</b> The server already
-        /// serves a thin index and a full one for exactly this purpose, and a copy of the route list living
-        /// in a settings string is a copy that goes stale the first time a route is added — silently, and in
-        /// the one place nobody thinks to check.</para>
+        /// <para><b>It names no endpoint at all — not even the orientation doc.</b> The handshake file already
+        /// carries a <c>docs</c> field for precisely this reason ("so a client needn't guess",
+        /// <c>LocalApiInfo.Docs</c>), so the prompt sends the agent to the file and the file sends it onward.
+        /// An earlier draft hardcoded <c>/llms.txt</c>, which duplicated a value the app already publishes and
+        /// would have gone quietly wrong the day that value changed. Same argument as not listing the routes,
+        /// one level further up.</para>
+        ///
+        /// <para>Shaped after the cold-agent prompt in <c>docs/testing/ai-prompts/navigate-show-me.md</c>,
+        /// which is re-run against new models to see how well this surface teaches an agent that has never
+        /// met it. Keeping the two aligned means the thing shipped to readers is the thing that gets
+        /// tested.</para>
         ///
         /// <para>The handshake path is computed, not written down, so it names the real file on whichever
         /// platform is asking rather than a macOS path shown to a Windows reader.</para>
@@ -1582,13 +1589,12 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
                     "",
                     "    " + path,
                     "",
-                    "It holds a \"port\" and a \"token\". The server listens on http://127.0.0.1:<port> and",
-                    "every request must carry:",
+                    "It contains a port, a bearer token, and the path to the API's own documentation.",
+                    "Read that documentation before you do anything else, and follow it.",
+                    "",
+                    "The server listens on http://127.0.0.1:<port>, and every request must carry:",
                     "",
                     "    Authorization: Bearer <token>",
-                    "",
-                    "Start by fetching http://127.0.0.1:<port>/llms.txt — it lists what the API offers and",
-                    "how to call it. /llms-full.txt has the detail if you need more.",
                     "",
                     "Read the file each time rather than remembering the port and token: both change every",
                     "time CST Reader starts. The app must be running for any of this to answer.",

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -592,6 +592,33 @@
                                                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
                                                     ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                                         </Expander>
+
+                                        <!-- For an agent that talks HTTP rather than MCP. The prompt names the
+                                             handshake file and sends the agent to /llms.txt; it does not list
+                                             the endpoints, because the server already does and a second copy
+                                             would go stale the first time a route is added. -->
+                                        <Expander Header="Sample prompt" Margin="0,4,0,0">
+                                            <StackPanel>
+                                                <TextBox Text="{Binding LocalApiSamplePrompt, Mode=OneWay}"
+                                                        IsReadOnly="True"
+                                                        AcceptsReturn="True"
+                                                        TextWrapping="NoWrap"
+                                                        FontFamily="Consolas,Menlo,Courier New,monospace"
+                                                        MaxHeight="220"
+                                                        ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                                        ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                                                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                                    <Button Content="Copy sample prompt"
+                                                            Click="OnCopySamplePrompt"
+                                                            IsEnabled="{Binding SubPermissionsEnabled}"
+                                                            HorizontalAlignment="Left"/>
+                                                    <TextBlock Name="CopySampleConfirm" Text="Copied ✓"
+                                                              Foreground="{DynamicResource DockApplicationAccentBrushLow}"
+                                                              VerticalAlignment="Center" Margin="10,0,0,0"
+                                                              IsVisible="False"/>
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </Expander>
                                     </StackPanel>
                                 </Border>
 

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml.cs
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml.cs
@@ -124,6 +124,41 @@ namespace CST.Avalonia.Views
         // in the ViewModel because the clipboard is reached through the window's TopLevel, which the VM
         // has no handle to. The confirmation TextBlock lives inside the AI DataTemplate (a separate
         // namescope from the window), so we find it as a sibling of the button rather than by FindControl.
+        /// <summary>
+        /// Copies the sample prompt — the same shape as <see cref="OnCopyMcpConfig"/>, and here for the same
+        /// reason: the clipboard needs a TopLevel, which the view model has no access to.
+        /// </summary>
+        private async void OnCopySamplePrompt(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (sender is not Button button || button.DataContext is not AiSettingsViewModel ai)
+                    return;
+
+                var clipboard = Clipboard ?? TopLevel.GetTopLevel(this)?.Clipboard;
+                if (clipboard == null)
+                {
+                    _logger.Warning("No clipboard available to copy the sample prompt");
+                    return;
+                }
+
+                await clipboard.SetTextAsync(ai.LocalApiSamplePrompt);
+                _logger.Information("Copied the local-API sample prompt to clipboard");
+
+                if (button.Parent is Panel panel &&
+                    panel.Children.OfType<TextBlock>().FirstOrDefault(t => t.Name == "CopySampleConfirm") is { } confirm)
+                {
+                    confirm.IsVisible = true;
+                    await Task.Delay(1500);
+                    confirm.IsVisible = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to copy the sample prompt");
+            }
+        }
+
         private async void OnCopyMcpConfig(object? sender, RoutedEventArgs e)
         {
             try


### PR DESCRIPTION
Closes #857.

The MCP path already had a Copy-configuration button and a Show-configuration expander. An agent that speaks plain HTTP — Claude Code, or anything driving `curl` — had nothing.

## What the prompt carries

Four facts and a pointer:

1. **The handshake file, by its real path** — computed at read time, so a Windows reader is not shown a macOS path.
2. **What is in it** — `port` and `token`.
3. **How the token is used** — `Authorization: Bearer <token>` against `http://127.0.0.1:<port>`.
4. **Read it each time, do not remember it** — port and token change on every start (#278). An agent that caches them works until the app restarts, then fails in a way that looks like the API is broken.
5. **Then fetch `/llms.txt`.**

## What it deliberately does not carry

**The endpoint list.** The server already serves `/llms.txt` (thin index) and `/llms-full.txt` (detail) for exactly this purpose. A copy of the route list living in a settings string is one that goes stale the first time a route is added — silently, in the place nobody thinks to check.

Anything beyond the five points above duplicates `/llms.txt`, which is the thing designed to be authoritative.

## Placement

A second expander beside the MCP configuration, with its own Copy button and confirm flash, mirroring `OnCopyMcpConfig`. The copy handler is in code-behind for the same stated reason as the existing one: the clipboard needs a `TopLevel` and the view model has none.

The two are alternatives — MCP for a client that speaks it, the prompt for an agent that does not.

## Verification

Build clean; suite **2611 passed, 0 failed, 17 skipped**.

**No test.** The property is a formatted string with no branching worth pinning, and the expander and its copy button are rendered facts this project has no headless harness for.

Worth checking by eye: the path shown is the real one for the platform, the Copy button flashes its confirm, and the prompt actually works — paste it into a coding agent with CST Reader running and see whether it gets to `/llms.txt` unaided. That last one is the only test that matters.
