### PR TITLE
Signpost the AI client access, without restating it (#857)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Print a whole book, or print the current selection.
 ### AI and Agent Access (optional, off by default)
 An optional loopback HTTP API and **MCP server** let an AI assistant search the corpus, read passages with their apparatus, use the dictionaries, resolve inflected forms to lemmas, and drive the reader's navigation — returning real references rather than recalled text. It binds only to the loopback interface, requires a per-session token, and stays off until enabled in Settings.
 
+**To start:** enable it under **Settings ▸ AI ▸ Access for AI Clients**. That panel carries what a client needs — a ready-made MCP configuration, and a sample prompt for an agent that speaks plain HTTP.
+
 ### Technical Architecture
 - **Stack**: .NET 10, Avalonia UI 11.3, ReactiveUI, Dock.Avalonia, dependency injection
 - **WebView Rendering**: WebViewControl-Avalonia (CEF) for book content and search highlighting

--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -369,6 +369,14 @@
         </div>
 
         <div class="focus-item">
+            <strong>Access for AI clients &mdash; first release with testers</strong>
+            <ul>
+                <li>Off by default. Turn it on under Settings &rsaquo; AI &rsaquo; Access for AI Clients, which carries what a client needs</li>
+                <li>Does your agent get from there to reading the corpus without further help?</li>
+            </ul>
+        </div>
+
+        <div class="focus-item">
             <strong>Windows on ARM &mdash; brand new</strong>
             <ul>
                 <li>A native arm64 build, alongside the existing x64 one</li>


### PR DESCRIPTION
The loopback API and MCP server were named in the README and nowhere a reader would meet them. `local-api.json` appeared only in one planned-feature doc and three testing docs; the settings UI mentioned it **not at all**. Knowing the feature existed was a matter of having built it.

The fix for that is the Settings panel itself (#857/#858) — instructions where they are needed, when they are needed. **These two are signposts to it, not second copies of it.**

- **README** — one sentence: it exists, it is off, here is where to turn it on.
- **Welcome page** — a focus-area entry phrased as a testing prompt rather than a description, since this is the first release with testers on these surfaces.

The first draft of both explained the two routes and the handshake file as well. That is the panel's job, and a second copy drifts from it the first time either changes.

The draft release notes got the same treatment separately.

Build clean.