### PR TITLE
Put each sample under the switch it belongs to

### DIFF
--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -10,23 +10,6 @@
         WindowStartupLocation="CenterOwner">
     
     <Window.Styles>
-        <!-- The stock Expander header is sized for a section heading, not for a label on a box you open
-             once, and two stacked under the AI-client switches read as furniture.
-
-             32 to match a plain ComboBox — the Pāli script picker sets no height of its own, so it renders
-             at Fluent's standard control height, and a header sitting beside controls of that size should
-             be one of them rather than half again as tall.
-
-             Targets the header ToggleButton inside the template rather than a named part, so it does not
-             depend on the theme's internal naming. Scoped to this window: Expanders elsewhere — the
-             Assistant's reasoning panel among them — keep the default. -->
-        <Style Selector="Expander /template/ ToggleButton">
-            <Setter Property="MinHeight" Value="32"/>
-            <Setter Property="Height" Value="32"/>
-            <Setter Property="Padding" Value="8,0"/>
-            <Setter Property="VerticalContentAlignment" Value="Center"/>
-        </Style>
-
         <Style Selector="TextBlock.SectionTitle">
             <Setter Property="FontSize" Value="18"/>
             <Setter Property="FontWeight" Value="Bold"/>

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -10,6 +10,15 @@
         WindowStartupLocation="CenterOwner">
     
     <Window.Styles>
+        <!-- The stock Expander header is sized for a section heading, not for a label on a box you open
+             once. Two of them stacked under the AI-client switches read as furniture. Targets the header
+             ToggleButton in the template rather than a named part, so it does not depend on the theme's
+             internal naming. Scoped to this window: Expanders elsewhere keep the default. -->
+        <Style Selector="Expander /template/ ToggleButton">
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="Padding" Value="8,4"/>
+        </Style>
+
         <Style Selector="TextBlock.SectionTitle">
             <Setter Property="FontSize" Value="18"/>
             <Setter Property="FontWeight" Value="Bold"/>
@@ -565,9 +574,7 @@
                                                         AcceptsReturn="True"
                                                         TextWrapping="NoWrap"
                                                         FontFamily="Consolas,Menlo,Courier New,monospace"
-                                                        MaxHeight="150"
-                                                        Padding="6,4"
-                                                        FontSize="12"
+                                                        MaxHeight="220"
                                                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
                                                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                                                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
@@ -598,9 +605,7 @@
                                                         AcceptsReturn="True"
                                                         TextWrapping="NoWrap"
                                                         FontFamily="Consolas,Menlo,Courier New,monospace"
-                                                        MaxHeight="150"
-                                                        Padding="6,4"
-                                                        FontSize="12"
+                                                        MaxHeight="220"
                                                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
                                                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                                                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -548,56 +548,17 @@
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
                                         <TextBlock Text="Access for AI Clients" Classes="SettingLabel"/>
+                                        <!-- EACH SWITCH OWNS ITS SAMPLE. The two surfaces are alternatives - REST for a coding
+                                             agent, MCP for a chat client - and the sample that serves each sat below both,
+                                             leaving the reader to work out which belonged to what they had just enabled. -->
+
                                         <!-- REST surface (/v1): for code agents. -->
                                         <CheckBox IsChecked="{Binding LocalApiEnabled}"
                                                  IsEnabled="{Binding SubPermissionsEnabled}"
                                                  Content="Run the local API server (Claude Code &amp; tool-calling agents)"
                                                  Margin="0,10,0,0"/>
 
-                                        <!-- MCP surface (/mcp): for chat clients, reached via the app's mcp-bridge relay. #280 -->
-                                        <CheckBox IsChecked="{Binding McpEnabled}"
-                                                 IsEnabled="{Binding SubPermissionsEnabled}"
-                                                 Content="Enable MCP access (Claude Desktop &amp; other chat clients)"
-                                                 Margin="0,5,0,0"/>
-
-                                        <!-- Cross-cutting capability: navigate/highlight is offered over BOTH surfaces, so this
-                                             is enabled whenever either one is on (RemoteControlEnabled). #440 -->
-                                        <CheckBox IsChecked="{Binding AllowRemoteControl}"
-                                                 IsEnabled="{Binding RemoteControlEnabled}"
-                                                 Content="Allow agents to drive the reader (navigate and highlight)"
-                                                 Margin="0,5,0,0"/>
-
-                                        <!-- Copy the ready-made Claude Desktop MCP config: it launches CST Reader's
-                                             mcp-bridge relay and carries no port/token. Clipboard is done in
-                                             code-behind (OnCopyMcpConfig) since the VM has no TopLevel. -->
-                                        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                            <Button Content="Copy MCP configuration"
-                                                    Click="OnCopyMcpConfig"
-                                                    IsEnabled="{Binding SubPermissionsEnabled}"
-                                                    HorizontalAlignment="Left"/>
-                                            <TextBlock Name="CopyMcpConfirm" Text="Copied ✓"
-                                                      Foreground="{DynamicResource DockApplicationAccentBrushLow}"
-                                                      VerticalAlignment="Center" Margin="10,0,0,0" IsVisible="False"/>
-                                        </StackPanel>
-                                        <TextBlock Text="Paste into the Claude Desktop config (~/Library/Application Support/Claude/claude_desktop_config.json) under &quot;mcpServers&quot;. It launches CST Reader's --mcp-bridge relay and embeds no port or token, so you copy it just once — no Node.js needed. Enable MCP access above; CST Reader must be running, and can auto-launch when a client connects."
-                                                  Classes="SettingDescription" Margin="0,4,0,0"/>
-
-                                        <Expander Header="Show configuration" Margin="0,4,0,0">
-                                            <TextBox Text="{Binding McpClientConfigJson, Mode=OneWay}"
-                                                    IsReadOnly="True"
-                                                    AcceptsReturn="True"
-                                                    TextWrapping="NoWrap"
-                                                    FontFamily="Consolas,Menlo,Courier New,monospace"
-                                                    MaxHeight="220"
-                                                    ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                                                    ScrollViewer.VerticalScrollBarVisibility="Auto"/>
-                                        </Expander>
-
-                                        <!-- For an agent that talks HTTP rather than MCP. The prompt names the
-                                             handshake file and sends the agent to /llms.txt; it does not list
-                                             the endpoints, because the server already does and a second copy
-                                             would go stale the first time a route is added. -->
-                                        <Expander Header="Sample prompt" Margin="0,4,0,0">
+                                        <Expander Header="Sample agent prompt" Margin="24,4,0,0">
                                             <StackPanel>
                                                 <TextBox Text="{Binding LocalApiSamplePrompt, Mode=OneWay}"
                                                         IsReadOnly="True"
@@ -614,11 +575,49 @@
                                                             HorizontalAlignment="Left"/>
                                                     <TextBlock Name="CopySampleConfirm" Text="Copied ✓"
                                                               Foreground="{DynamicResource DockApplicationAccentBrushLow}"
-                                                              VerticalAlignment="Center" Margin="10,0,0,0"
-                                                              IsVisible="False"/>
+                                                              VerticalAlignment="Center" Margin="10,0,0,0" IsVisible="False"/>
                                                 </StackPanel>
                                             </StackPanel>
                                         </Expander>
+
+                                        <!-- MCP surface (/mcp): for chat clients, reached via the app's mcp-bridge relay. #280 -->
+                                        <CheckBox IsChecked="{Binding McpEnabled}"
+                                                 IsEnabled="{Binding SubPermissionsEnabled}"
+                                                 Content="Enable MCP access (Claude Desktop &amp; other chat clients)"
+                                                 Margin="0,10,0,0"/>
+
+                                        <!-- Copy sits at the bottom of the expander, matching the prompt above: the button
+                                             follows the thing it copies rather than preceding a collapsed panel. Clipboard is
+                                             done in code-behind since the view model has no TopLevel. -->
+                                        <Expander Header="Sample MCP configuration" Margin="24,4,0,0">
+                                            <StackPanel>
+                                                <TextBox Text="{Binding McpClientConfigJson, Mode=OneWay}"
+                                                        IsReadOnly="True"
+                                                        AcceptsReturn="True"
+                                                        TextWrapping="NoWrap"
+                                                        FontFamily="Consolas,Menlo,Courier New,monospace"
+                                                        MaxHeight="220"
+                                                        ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                                        ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                                                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                                    <Button Content="Copy MCP configuration"
+                                                            Click="OnCopyMcpConfig"
+                                                            IsEnabled="{Binding SubPermissionsEnabled}"
+                                                            HorizontalAlignment="Left"/>
+                                                    <TextBlock Name="CopyMcpConfirm" Text="Copied ✓"
+                                                              Foreground="{DynamicResource DockApplicationAccentBrushLow}"
+                                                              VerticalAlignment="Center" Margin="10,0,0,0" IsVisible="False"/>
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </Expander>
+
+                                        <!-- Cross-cutting capability: navigate/highlight is offered over BOTH surfaces, so this
+                                             is enabled whenever either one is on (RemoteControlEnabled). #440 -->
+                                        <CheckBox IsChecked="{Binding AllowRemoteControl}"
+                                                 IsEnabled="{Binding RemoteControlEnabled}"
+                                                 Content="Allow agents to drive the reader (navigate and highlight)"
+                                                 Margin="0,10,0,0"/>
+
                                     </StackPanel>
                                 </Border>
 

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -565,7 +565,9 @@
                                                         AcceptsReturn="True"
                                                         TextWrapping="NoWrap"
                                                         FontFamily="Consolas,Menlo,Courier New,monospace"
-                                                        MaxHeight="220"
+                                                        MaxHeight="150"
+                                                        Padding="6,4"
+                                                        FontSize="12"
                                                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
                                                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                                                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
@@ -596,7 +598,9 @@
                                                         AcceptsReturn="True"
                                                         TextWrapping="NoWrap"
                                                         FontFamily="Consolas,Menlo,Courier New,monospace"
-                                                        MaxHeight="220"
+                                                        MaxHeight="150"
+                                                        Padding="6,4"
+                                                        FontSize="12"
                                                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
                                                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                                                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -11,12 +11,20 @@
     
     <Window.Styles>
         <!-- The stock Expander header is sized for a section heading, not for a label on a box you open
-             once. Two of them stacked under the AI-client switches read as furniture. Targets the header
-             ToggleButton in the template rather than a named part, so it does not depend on the theme's
-             internal naming. Scoped to this window: Expanders elsewhere keep the default. -->
+             once, and two stacked under the AI-client switches read as furniture.
+
+             32 to match a plain ComboBox — the Pāli script picker sets no height of its own, so it renders
+             at Fluent's standard control height, and a header sitting beside controls of that size should
+             be one of them rather than half again as tall.
+
+             Targets the header ToggleButton inside the template rather than a named part, so it does not
+             depend on the theme's internal naming. Scoped to this window: Expanders elsewhere — the
+             Assistant's reasoning panel among them — keep the default. -->
         <Style Selector="Expander /template/ ToggleButton">
-            <Setter Property="MinHeight" Value="0"/>
-            <Setter Property="Padding" Value="8,4"/>
+            <Setter Property="MinHeight" Value="32"/>
+            <Setter Property="Height" Value="32"/>
+            <Setter Property="Padding" Value="8,0"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
 
         <Style Selector="TextBlock.SectionTitle">


### PR DESCRIPTION
Follows #857/#858. Maintainer's layout.

## Before

Both samples sat below both checkboxes:

```
[ ] Run the local API server
[ ] Enable MCP access
[ ] Allow agents to drive the reader
    [Copy MCP configuration]
    <a paragraph about the Claude Desktop config path, the bridge relay and Node.js>
    > Show configuration
    > Sample prompt
```

The two surfaces are **alternatives** — the local API for a coding agent, MCP for a chat client — so a reader who enabled one had to work out which sample went with it.

## After

```
[ ] Run the local API server
    > Sample agent prompt        (textbox, then Copy)
[ ] Enable MCP access
    > Sample MCP configuration   (textbox, then Copy)
[ ] Allow agents to drive the reader
```

Three changes beyond the move:

- **"Show configuration" → "Sample MCP configuration".** The old name said nothing about *which* configuration, which only worked while there was one of them.
- **The MCP Copy button moves to the bottom of its expander**, where the prompt already had it. It had sat above a collapsed panel — offering to copy something the reader could not see.
- **The paragraph is deleted.** Claude Desktop's config path, the bridge relay, no-Node.js: that is documentation, and it belongs in the docs and the screencasts rather than under a checkbox.

Build clean; suite **2611 passed, 0 failed, 17 skipped**. Layout is a rendered fact — worth an eye on the indentation and on both Copy buttons flashing their confirm.