### PR TITLE
Size the expander headers through the theme's resource keys (#863)

### DIFF
--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -9,6 +9,29 @@
         MinWidth="700" MinHeight="400"
         WindowStartupLocation="CenterOwner">
     
+    <!-- Expander sizing is set through the theme's own resource keys, NOT by styling the header. (#863)
+
+         The header is a ToggleButton whose MinHeight is {TemplateBinding MinHeight} on the Expander, and the
+         Expander's theme binds that to ExpanderMinHeight = 48. A Style setter loses to that: template
+         bindings outrank style setters, so MinHeight="0" never applied — and Height="32" did apply and was
+         then clamped back up by the MinHeight it could not change. Which is why an earlier attempt looked
+         inert and was removed.
+
+         The chevron box has to come down too: at its default 32 (+2px border) it would out-vote a 32
+         MinHeight on its own.
+
+         32 and a 12pt left padding are the Fluent ComboBox defaults, so these headers match the script and
+         chapter pickers they sit beside and already resemble.
+
+         Scoped to this window. DynamicResource lookup stops at the nearest definition, so the Assistant
+         panel keeps its own tighter overrides and every other Expander keeps the Fluent default. Same
+         technique as AiAssistantPanel.axaml, which found this first. -->
+    <Window.Resources>
+        <x:Double x:Key="ExpanderMinHeight">32</x:Double>
+        <x:Double x:Key="ExpanderChevronButtonSize">24</x:Double>
+        <Thickness x:Key="ExpanderHeaderPadding">12,0,0,0</Thickness>
+    </Window.Resources>
+
     <Window.Styles>
         <Style Selector="TextBlock.SectionTitle">
             <Setter Property="FontSize" Value="18"/>


### PR DESCRIPTION
Closes #863.

The two sample expanders in AI settings had headers at **47pt** beside a **31pt** text field. My earlier attempt styled the header `ToggleButton` and had no effect, so I removed it rather than ship inert setters.

## Why that attempt failed

Adversarial review established it from the Avalonia 11.3.6 source:

- The header is `ToggleButton x:Name="ExpanderHeader"`, and its `MinHeight` is `{TemplateBinding MinHeight}` on the **Expander**, whose theme binds that to `ExpanderMinHeight` = **48**.
- **Template bindings outrank style setters**, so `MinHeight="0"` never applied.
- `Height="32"` *did* apply — nothing competes for `Height` — and layout then clamped it back up by the `MinHeight` it could not reach.

So the selector was matching all along and the setters were losing on priority. Neither of my probes could distinguish those cases, which is why I drew the wrong conclusion twice.

## The fix, which this project already had

`AiAssistantPanel.axaml:21-25` overrides these same theme keys in scoped resources for its own expanders — with a comment recording the same 48px finding. I had reimplemented the wrong half of a problem solved twelve lines from where I was working.

```xml
<Window.Resources>
    <x:Double x:Key="ExpanderMinHeight">32</x:Double>
    <x:Double x:Key="ExpanderChevronButtonSize">24</x:Double>
    <Thickness x:Key="ExpanderHeaderPadding">12,0,0,0</Thickness>
</Window.Resources>
```

**32 and 12pt left padding are the Fluent `ComboBox` defaults** — which is what these were asked to match, since they sit beside the script and chapter pickers and already resemble them. The chevron box drops to 24 because at its default 32 (+2px border) it would out-vote a 32 MinHeight on its own.

**Scoped to this window.** `DynamicResource` lookup stops at the nearest definition, so the Assistant panel keeps its own tighter overrides and every other Expander keeps the Fluent default.

## Verification

Build clean; suite unaffected.

**Not runtime-verified** — a rendered fact, and this project has no headless harness. Worth an eye on three things: the headers match the script picker's height, the Assistant's reasoning expanders are unchanged, and the chevrons still look right at 24.