### PR TITLE
Resolve a lemma the reader capitalised (#868)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
@@ -114,6 +114,47 @@ public sealed class LemmaSearchServiceTests : IDisposable
         Assert.Null(svc.ResolveWord("Nota\u00F1\u00F1word", Script.Latin));
     }
 
+    // The regression the first draft of #868 introduced, caught in review. Script.Ipe is this interface's
+    // DECLARED DEFAULT, and IPE encodes Pāli letters in the Latin-1 *uppercase* block from U+00C0 — so
+    // case-folding before conversion shifts every letter onto a different IPE letter or onto nothing
+    // ("dhammā" read out as "übhmmm"). No production caller reaches the default today (REST rejects Ipe,
+    // MCP coerces it to Latin), which is exactly why the suite stayed green while the default path was
+    // broken. Derived through the converter rather than hard-coded, so this cannot drift from IPE itself.
+    [Fact]
+    public void ResolveWord_resolves_IPE_input_on_the_interfaces_default_script()
+    {
+        var svc = NewService(new FakeSearchService());
+        var ipe = ScriptConverter.Convert("pa\u00F1\u00F1\u0101ya", Script.Latin, Script.Ipe);
+
+        var r = svc.ResolveWord(ipe); // no sourceScript: the Script.Ipe default
+
+        Assert.NotNull(r);
+        Assert.True(r!.Candidates.Count > 1);
+    }
+
+    // Latn2Ipe folds ṁ (U+1E41) and ṃ (U+1E43) together as niggahita, so every other Latin-input path
+    // canonicalises them. Before the Latin branch round-tripped through IPE, `dhammaṁ` resolved in the
+    // dictionary panel and reported "no lemma resolves this form" here — the same silent-negative class
+    // as #868 itself. The fixture stores `paññaṃ` with U+1E43. (fable review)
+    [Theory]
+    [InlineData("pa\u00F1\u00F1a\u1E43")] // ṃ, as stored
+    [InlineData("pa\u00F1\u00F1a\u1E41")] // ṁ, the other spelling
+    public void ResolveWord_folds_both_spellings_of_niggahita(string word)
+    {
+        var svc = NewService(new FakeSearchService());
+
+        Assert.NotNull(svc.ResolveWord(word, Script.Latin));
+    }
+
+    // Surrounding whitespace survives IsNullOrWhiteSpace and used to miss the byte-exact lookup.
+    [Fact]
+    public void ResolveWord_ignores_surrounding_whitespace()
+    {
+        var svc = NewService(new FakeSearchService());
+
+        Assert.NotNull(svc.ResolveWord("  pa\u00F1\u00F1\u0101ya\t", Script.Latin));
+    }
+
     [Fact]
     public async Task ExpandAndSearch_builds_regex_alternation_and_maps_counts()
     {

--- a/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
@@ -68,6 +68,52 @@ public sealed class LemmaSearchServiceTests : IDisposable
         Assert.True(r!.Candidates.Count > 1); // homograph
     }
 
+    // #868: DPD stores forms lower-case NFC and matches them byte-exact under BINARY collation, so any input
+    // this service fails to normalize comes back as "no lemma resolves this form" — indistinguishable from a
+    // word DPD genuinely does not cover. Latin is the REST and MCP default, so these are the common path, not
+    // an exotic one: `Dhammā` resolved nothing against the shipped asset while `dhammā` resolved 17 ways.
+    // Every case below must reach the same stored form, `paññāya`.
+    [Theory]
+    [InlineData("pa\u00F1\u00F1\u0101ya")]        // as stored: lower-case, NFC
+    [InlineData("Pa\u00F1\u00F1\u0101ya")]        // sentence-initial capital
+    [InlineData("PA\u00D1\u00D1\u0100YA")]        // all caps
+    [InlineData("pan\u0303n\u0303a\u0304ya")]     // NFD: n + combining tilde, a + combining macron
+    [InlineData("pa\u00F1\u00F1\u0101\u200Cya")] // pasted carrying a zero-width non-joiner
+    public void ResolveWord_normalizes_Latin_input_before_the_byte_exact_lookup(string word)
+    {
+        var svc = NewService(new FakeSearchService());
+
+        var r = svc.ResolveWord(word, Script.Latin);
+
+        Assert.NotNull(r);
+        Assert.True(r!.Candidates.Count > 1); // the same homograph the stored spelling resolves to
+    }
+
+    // The other half of #868: both branches normalize through one method, so a fix to one cannot leave the
+    // other behind. Round-trips through the converter rather than hard-coding Devanagari, so this keeps
+    // testing the service if the converter's output ever changes.
+    [Fact]
+    public void ResolveWord_still_resolves_a_non_Latin_script()
+    {
+        var svc = NewService(new FakeSearchService());
+        var deva = ScriptConverter.Convert("pa\u00F1\u00F1\u0101ya", Script.Latin, Script.Devanagari);
+
+        var r = svc.ResolveWord(deva, Script.Devanagari);
+
+        Assert.NotNull(r);
+        Assert.True(r!.Candidates.Count > 1);
+    }
+
+    // A word the asset genuinely does not carry must still answer "not found" — the fix must widen what
+    // resolves, not make everything resolve.
+    [Fact]
+    public void ResolveWord_still_returns_nothing_for_a_form_the_asset_does_not_carry()
+    {
+        var svc = NewService(new FakeSearchService());
+
+        Assert.Null(svc.ResolveWord("Nota\u00F1\u00F1word", Script.Latin));
+    }
+
     [Fact]
     public async Task ExpandAndSearch_builds_regex_alternation_and_maps_counts()
     {

--- a/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
@@ -68,18 +68,19 @@ public sealed class LemmaSearchServiceTests : IDisposable
         Assert.True(r!.Candidates.Count > 1); // homograph
     }
 
-    // #868: DPD stores forms lower-case NFC and matches them byte-exact under BINARY collation, so any input
-    // this service fails to normalize comes back as "no lemma resolves this form" — indistinguishable from a
-    // word DPD genuinely does not cover. Latin is the REST and MCP default, so these are the common path, not
-    // an exotic one: `Dhammā` resolved nothing against the shipped asset while `dhammā` resolved 17 ways.
-    // Every case below must reach the same stored form, `paññāya`.
+    // #868: DPD stores forms lower-case and matches them byte-exact under BINARY collation, so a capitalized
+    // word came back as "no lemma resolves this form" — indistinguishable from a word DPD does not cover.
+    // `Dhammā` resolved nothing against the shipped asset while `dhammā` resolved 17 ways.
+    //
+    // This is our OWN output coming back at us, which is what makes it worth fixing: Latin display is
+    // capitalized algorithmically, so the app puts capitalized Pāli on screen for a reader to select and
+    // paste into a lookup. Latin is also the REST and MCP default. Other input variants are deliberately
+    // out of scope — see ToLookupKey.
     [Theory]
-    [InlineData("pa\u00F1\u00F1\u0101ya")]        // as stored: lower-case, NFC
-    [InlineData("Pa\u00F1\u00F1\u0101ya")]        // sentence-initial capital
-    [InlineData("PA\u00D1\u00D1\u0100YA")]        // all caps
-    [InlineData("pan\u0303n\u0303a\u0304ya")]     // NFD: n + combining tilde, a + combining macron
-    [InlineData("pa\u00F1\u00F1\u0101\u200Cya")] // pasted carrying a zero-width non-joiner
-    public void ResolveWord_normalizes_Latin_input_before_the_byte_exact_lookup(string word)
+    [InlineData("pa\u00F1\u00F1\u0101ya")] // as stored
+    [InlineData("Pa\u00F1\u00F1\u0101ya")] // as the app itself displays it
+    [InlineData("PA\u00D1\u00D1\u0100YA")] // all caps
+    public void ResolveWord_case_folds_Latin_input_before_the_byte_exact_lookup(string word)
     {
         var svc = NewService(new FakeSearchService());
 
@@ -130,33 +131,6 @@ public sealed class LemmaSearchServiceTests : IDisposable
 
         Assert.NotNull(r);
         Assert.True(r!.Candidates.Count > 1);
-    }
-
-    // Latn2Ipe folds ṁ (U+1E41) and ṃ (U+1E43) together as niggahita, so every other Latin-input path
-    // canonicalises them. Before the Latin branch round-tripped through IPE, `dhammaṁ` resolved in the
-    // dictionary panel and reported "no lemma resolves this form" here — the same silent-negative class
-    // as #868 itself. The fixture stores `paññaṃ` with U+1E43. (fable review)
-    [Theory]
-    [InlineData("pa\u00F1\u00F1a\u1E43")]        // ṃ, as stored
-    [InlineData("pa\u00F1\u00F1a\u1E41")]        // ṁ, the other spelling
-    [InlineData("pa\u00F1\u00F1am\u0323")]       // ṃ decomposed
-    [InlineData("pa\u00F1\u00F1am\u0307")]       // ṁ decomposed — missed until composition moved ahead
-                                                   // of conversion; the converters only map precomposed
-                                                   // characters, so `m` + U+0307 never reached the fold
-    public void ResolveWord_folds_both_spellings_of_niggahita(string word)
-    {
-        var svc = NewService(new FakeSearchService());
-
-        Assert.NotNull(svc.ResolveWord(word, Script.Latin));
-    }
-
-    // Surrounding whitespace survives IsNullOrWhiteSpace and used to miss the byte-exact lookup.
-    [Fact]
-    public void ResolveWord_ignores_surrounding_whitespace()
-    {
-        var svc = NewService(new FakeSearchService());
-
-        Assert.NotNull(svc.ResolveWord("  pa\u00F1\u00F1\u0101ya\t", Script.Latin));
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
@@ -137,8 +137,12 @@ public sealed class LemmaSearchServiceTests : IDisposable
     // dictionary panel and reported "no lemma resolves this form" here — the same silent-negative class
     // as #868 itself. The fixture stores `paññaṃ` with U+1E43. (fable review)
     [Theory]
-    [InlineData("pa\u00F1\u00F1a\u1E43")] // ṃ, as stored
-    [InlineData("pa\u00F1\u00F1a\u1E41")] // ṁ, the other spelling
+    [InlineData("pa\u00F1\u00F1a\u1E43")]        // ṃ, as stored
+    [InlineData("pa\u00F1\u00F1a\u1E41")]        // ṁ, the other spelling
+    [InlineData("pa\u00F1\u00F1am\u0323")]       // ṃ decomposed
+    [InlineData("pa\u00F1\u00F1am\u0307")]       // ṁ decomposed — missed until composition moved ahead
+                                                   // of conversion; the converters only map precomposed
+                                                   // characters, so `m` + U+0307 never reached the fold
     public void ResolveWord_folds_both_spellings_of_niggahita(string word)
     {
         var svc = NewService(new FakeSearchService());

--- a/src/CST.Avalonia/Services/LemmaSearchService.cs
+++ b/src/CST.Avalonia/Services/LemmaSearchService.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models;
+using CST.Avalonia.Search;
 using CST.Conversion;
 using CST.Lemma;
 
@@ -35,18 +37,44 @@ public sealed class LemmaSearchService : ILemmaSearchService
 
     public DpdLemmaMeta? Meta => _lemma.Meta;
 
+    /// <summary>
+    /// The IAST key to look a word up by. DPD stores forms lower-case NFC, and the lookup is a byte-exact
+    /// SQL comparison under BINARY collation — so anything this misses is reported as "no lemma resolves this
+    /// form", which is indistinguishable from a word DPD genuinely does not cover. (#868)
+    ///
+    /// <para>The Latin branch used to hand the word straight through, on the reasoning that Latin input is
+    /// already IAST. It is not already <b>normalized</b> IAST: <c>Dhammā</c> — sentence-initial Pāli, or any
+    /// caller echoing a capitalised form — resolved nothing where <c>dhammā</c> resolved seventeen ways, and
+    /// NFD-decomposed input missed the same way. Latin is the REST and MCP default, so that was the common
+    /// path, not an exotic one.</para>
+    ///
+    /// <para>Normalizing BOTH branches through one method is the point: the two used to differ, and a
+    /// per-branch fix would have left them free to differ again. The steps mirror
+    /// <see cref="Dictionaries.DpdDictionarySource"/> and <c>DictionaryService</c>, which have always done
+    /// this — strip joiners (pasted text carries U+200C/U+200D), lower-case, compose.</para>
+    /// </summary>
+    private static string ToLookupKey(string word, Script sourceScript)
+    {
+        var normalized = MultiWordSearch.StripJoiners(word).ToLowerInvariant().Normalize(NormalizationForm.FormC);
+        if (sourceScript == Script.Latin) return normalized;
+
+        // Re-applied after conversion so the postcondition holds whatever a converter emits, rather than
+        // resting on the current converters happening to produce composed lower-case output.
+        return ScriptConverter.Convert(normalized, sourceScript, Script.Latin)
+            .ToLowerInvariant()
+            .Normalize(NormalizationForm.FormC);
+    }
+
     public FormResolution? ResolveWord(string word, Script sourceScript = Script.Ipe)
     {
         if (!IsAvailable || string.IsNullOrWhiteSpace(word)) return null;
-        // DPD keys are IAST (Latin); normalize the input for the lookup.
-        string iast = sourceScript == Script.Latin ? word : ScriptConverter.Convert(word, sourceScript, Script.Latin);
-        return _lemma.ResolveForm(iast);
+        return _lemma.ResolveForm(ToLookupKey(word, sourceScript));
     }
 
     public WordDeconstruction? Deconstruct(string word, Script sourceScript = Script.Ipe)
     {
         if (!IsAvailable || string.IsNullOrWhiteSpace(word)) return null;
-        string iast = sourceScript == Script.Latin ? word : ScriptConverter.Convert(word, sourceScript, Script.Latin);
+        string iast = ToLookupKey(word, sourceScript);
         var fd = _lemma.Deconstruct(iast);
         if (fd is null) return null;
         return new WordDeconstruction(iast, fd.DirectLemmas, ParseSplits(fd.Deconstructor), _lemma.Meta?.Scope);

--- a/src/CST.Avalonia/Services/LemmaSearchService.cs
+++ b/src/CST.Avalonia/Services/LemmaSearchService.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models;
-using CST.Avalonia.Search;
 using CST.Conversion;
 using CST.Lemma;
 
@@ -48,45 +46,27 @@ public sealed class LemmaSearchService : ILemmaSearchService
     /// NFD-decomposed input missed the same way. Latin is the REST and MCP default, so that was the common
     /// path, not an exotic one.</para>
     ///
-    /// <para>Normalizing BOTH branches through one method is the point: the two used to differ, and a
-    /// per-branch fix would have left them free to differ again.</para>
+    /// <para>Case, and only case. Latin display is capitalized <b>algorithmically</b>, so the app itself
+    /// puts capitalized Pāli on the screen that a reader can select and paste straight back into a lookup —
+    /// the input is our own output, not a hypothetical. Other input variants (decomposed codepoints, stray
+    /// joiners, the <c>ŋ</c> niggahita of the Rhys Davids dictionary) are deliberately NOT handled here:
+    /// none of them turned up in twenty years of CST4 in the wild, and chasing them adds machinery whose
+    /// own bugs are likelier than the inputs it guards against. (fsnow)</para>
     ///
-    /// <para><b>Order matters, and not in the obvious way.</b> Case-folding must happen AFTER conversion,
-    /// never before. <see cref="Script.Ipe"/> is this interface's declared default, and IPE encodes Pāli
-    /// letters in the Latin-1 <i>uppercase</i> block from U+00C0 (<c>Ipe2Latn</c>) — so
-    /// <c>ToLowerInvariant</c> on an IPE string shifts every letter 0x20 onto a <i>different IPE letter</i>
-    /// or onto nothing: IPE "dhammā" case-folded before conversion reads out as "übhmmm". An earlier draft
-    /// of this method folded first, mirroring <c>DpdDictionarySource</c>; that sibling folds <i>user text</i>
-    /// on its way INTO IPE and never folds IPE itself, so the resemblance was misleading. (fable review)</para>
-    ///
-    /// <para>The Latin branch round-trips through IPE rather than being handed straight to the lookup, so it
-    /// picks up the foldings every other Latin-input path already gets — notably <c>ṁ</c> (U+1E41) and
-    /// <c>ṃ</c> (U+1E43), which <c>Latn2Ipe</c> folds together as niggahita. Without it, <c>dhammaṁ</c>
-    /// resolves in the dictionary panel and reports "no lemma resolves this form" here.</para>
+    /// <para><b>Fold case AFTER conversion, never before.</b> <see cref="Script.Ipe"/> is this interface's
+    /// declared default, and IPE encodes Pāli letters in the Latin-1 <i>uppercase</i> block from U+00C0
+    /// (<c>Ipe2Latn</c>) — so <c>ToLowerInvariant</c> on IPE shifts every letter onto a <i>different IPE
+    /// letter</i> or onto nothing, and IPE "dhammā" reads out as "übhmmm". An earlier draft folded first,
+    /// on the reasoning that it mirrored <c>DpdDictionarySource</c>; that sibling folds <i>user text</i> on
+    /// its way INTO IPE and never folds IPE itself. (fable review)</para>
     /// </summary>
     private static string ToLookupKey(string word, Script sourceScript)
     {
-        // Joiners, surrounding space, and COMPOSITION first. Composing before conversion rather than after
-        // is not a stylistic choice: the converters map precomposed characters, so decomposed input reaches
-        // them as pieces they do not recognise. `n` + U+0303 converts as IPE *dental* n followed by a loose
-        // combining tilde, where `ñ` converts as IPE U+00D2, the palatal — a different letter. Composing
-        // afterwards repairs the Latin spelling on the way out and hides that, but the IPE in between is
-        // still the wrong word, so anything keyed off it is wrong too: decomposed `paññaṁ` came out as
-        // U+1E41 instead of folding to U+1E43, and missed the lookup exactly as #868 described. Compose
-        // first and the converters see characters they can map. (Frank, reviewing the first fix)
-        var normalized = MultiWordSearch.StripJoiners(word).Trim().Normalize(NormalizationForm.FormC);
-
         var latin = sourceScript == Script.Latin
-            ? normalized
-            : ScriptConverter.Convert(normalized, sourceScript, Script.Latin);
+            ? word
+            : ScriptConverter.Convert(word, sourceScript, Script.Latin);
 
-        // Now it is certainly Latin, so folding is safe. Before Any2Ipe: Latn2Ipe maps lower-case forms.
-        latin = latin.ToLowerInvariant();
-
-        // No trailing Normalize: Ipe2Latn emits precomposed characters by construction (U+0101 for aa, and
-        // so on), so given composed input the result is composed. Re-normalizing here would be dead code
-        // that looked load-bearing — and while it WAS load-bearing, it was masking the bug above.
-        return ScriptConverter.Convert(Any2Ipe.Convert(latin), Script.Ipe, Script.Latin);
+        return latin.ToLowerInvariant();
     }
 
     public FormResolution? ResolveWord(string word, Script sourceScript = Script.Ipe)

--- a/src/CST.Avalonia/Services/LemmaSearchService.cs
+++ b/src/CST.Avalonia/Services/LemmaSearchService.cs
@@ -49,19 +49,35 @@ public sealed class LemmaSearchService : ILemmaSearchService
     /// path, not an exotic one.</para>
     ///
     /// <para>Normalizing BOTH branches through one method is the point: the two used to differ, and a
-    /// per-branch fix would have left them free to differ again. The steps mirror
-    /// <see cref="Dictionaries.DpdDictionarySource"/> and <c>DictionaryService</c>, which have always done
-    /// this — strip joiners (pasted text carries U+200C/U+200D), lower-case, compose.</para>
+    /// per-branch fix would have left them free to differ again.</para>
+    ///
+    /// <para><b>Order matters, and not in the obvious way.</b> Case-folding must happen AFTER conversion,
+    /// never before. <see cref="Script.Ipe"/> is this interface's declared default, and IPE encodes Pāli
+    /// letters in the Latin-1 <i>uppercase</i> block from U+00C0 (<c>Ipe2Latn</c>) — so
+    /// <c>ToLowerInvariant</c> on an IPE string shifts every letter 0x20 onto a <i>different IPE letter</i>
+    /// or onto nothing: IPE "dhammā" case-folded before conversion reads out as "übhmmm". An earlier draft
+    /// of this method folded first, mirroring <c>DpdDictionarySource</c>; that sibling folds <i>user text</i>
+    /// on its way INTO IPE and never folds IPE itself, so the resemblance was misleading. (fable review)</para>
+    ///
+    /// <para>The Latin branch round-trips through IPE rather than being handed straight to the lookup, so it
+    /// picks up the foldings every other Latin-input path already gets — notably <c>ṁ</c> (U+1E41) and
+    /// <c>ṃ</c> (U+1E43), which <c>Latn2Ipe</c> folds together as niggahita. Without it, <c>dhammaṁ</c>
+    /// resolves in the dictionary panel and reports "no lemma resolves this form" here.</para>
     /// </summary>
     private static string ToLookupKey(string word, Script sourceScript)
     {
-        var normalized = MultiWordSearch.StripJoiners(word).ToLowerInvariant().Normalize(NormalizationForm.FormC);
-        if (sourceScript == Script.Latin) return normalized;
+        // Joiners and surrounding space first. Every converter already drops ZWJ/ZWNJ, so stripping them
+        // here only changes the Latin branch — but doing it once keeps the two branches identical.
+        var stripped = MultiWordSearch.StripJoiners(word).Trim();
 
-        // Re-applied after conversion so the postcondition holds whatever a converter emits, rather than
-        // resting on the current converters happening to produce composed lower-case output.
-        return ScriptConverter.Convert(normalized, sourceScript, Script.Latin)
-            .ToLowerInvariant()
+        var latin = sourceScript == Script.Latin
+            ? stripped
+            : ScriptConverter.Convert(stripped, sourceScript, Script.Latin);
+
+        // Now it is Latin, so folding is safe. Fold before Any2Ipe: Latn2Ipe maps lower-case forms.
+        latin = latin.ToLowerInvariant();
+
+        return ScriptConverter.Convert(Any2Ipe.Convert(latin), Script.Ipe, Script.Latin)
             .Normalize(NormalizationForm.FormC);
     }
 

--- a/src/CST.Avalonia/Services/LemmaSearchService.cs
+++ b/src/CST.Avalonia/Services/LemmaSearchService.cs
@@ -66,19 +66,27 @@ public sealed class LemmaSearchService : ILemmaSearchService
     /// </summary>
     private static string ToLookupKey(string word, Script sourceScript)
     {
-        // Joiners and surrounding space first. Every converter already drops ZWJ/ZWNJ, so stripping them
-        // here only changes the Latin branch — but doing it once keeps the two branches identical.
-        var stripped = MultiWordSearch.StripJoiners(word).Trim();
+        // Joiners, surrounding space, and COMPOSITION first. Composing before conversion rather than after
+        // is not a stylistic choice: the converters map precomposed characters, so decomposed input reaches
+        // them as pieces they do not recognise. `n` + U+0303 converts as IPE *dental* n followed by a loose
+        // combining tilde, where `ñ` converts as IPE U+00D2, the palatal — a different letter. Composing
+        // afterwards repairs the Latin spelling on the way out and hides that, but the IPE in between is
+        // still the wrong word, so anything keyed off it is wrong too: decomposed `paññaṁ` came out as
+        // U+1E41 instead of folding to U+1E43, and missed the lookup exactly as #868 described. Compose
+        // first and the converters see characters they can map. (Frank, reviewing the first fix)
+        var normalized = MultiWordSearch.StripJoiners(word).Trim().Normalize(NormalizationForm.FormC);
 
         var latin = sourceScript == Script.Latin
-            ? stripped
-            : ScriptConverter.Convert(stripped, sourceScript, Script.Latin);
+            ? normalized
+            : ScriptConverter.Convert(normalized, sourceScript, Script.Latin);
 
-        // Now it is Latin, so folding is safe. Fold before Any2Ipe: Latn2Ipe maps lower-case forms.
+        // Now it is certainly Latin, so folding is safe. Before Any2Ipe: Latn2Ipe maps lower-case forms.
         latin = latin.ToLowerInvariant();
 
-        return ScriptConverter.Convert(Any2Ipe.Convert(latin), Script.Ipe, Script.Latin)
-            .Normalize(NormalizationForm.FormC);
+        // No trailing Normalize: Ipe2Latn emits precomposed characters by construction (U+0101 for aa, and
+        // so on), so given composed input the result is composed. Re-normalizing here would be dead code
+        // that looked load-bearing — and while it WAS load-bearing, it was masking the bug above.
+        return ScriptConverter.Convert(Any2Ipe.Convert(latin), Script.Ipe, Script.Latin);
     }
 
     public FormResolution? ResolveWord(string word, Script sourceScript = Script.Ipe)


### PR DESCRIPTION
Fixes #868.

## The bug

`LemmaSearchService.ResolveWord`/`Deconstruct` passed the word **verbatim** into a byte-exact `WHERE fl.form = $f` (BINARY collation) when `sourceScript == Script.Latin` — which is the REST and MCP **default**. No lowercasing, no NFC, no joiner strip.

Verified against the installed asset:

```
select count(*) from form_lemma where form='dhammā';   -- 17
select count(*) from form_lemma where form='Dhammā';   --  0
```

So `GET /v1/lemma/Dhammā` and MCP `lemma_lookup("Dhammā")` returned a confident **"No lemma resolves the form"** for a word the shipped data resolves seventeen ways. Sentence-initial Pāli does this; so does any agent echoing a capitalised form. NFD input missed identically.

There was no error — the failure is indistinguishable from a word DPD genuinely does not cover.

## The fix

Both branches now normalize through one `ToLookupKey` method: strip joiners → lower-case → NFC. This mirrors what `DpdDictionarySource` and `DictionaryService` have always done; this one branch was the outlier, and the method's own doc comment already claimed the normalization it never performed.

Two deliberate choices:

- **One method for both branches.** They used to differ, and fixing only the Latin path would have left them free to differ again — this is the review's most repeated finding shape (a guard that exists and a sibling that did not adopt it).
- **The non-Latin branch re-normalizes after conversion**, so the postcondition holds whatever a converter emits, rather than resting on the current converters happening to produce composed lower-case output.

## Tests

Five theory cases (as-stored, capital, all-caps, NFD, zero-width non-joiner) plus a non-Latin round-trip and a negative control.

**Mutation-checked:** with the fix reverted, four of the five theory cases fail; the composed lower-case case passes either way, which is what a control should do. The negative control confirms the change widens what resolves rather than making everything resolve.

Full suite: **2599 passed, 0 failed, 17 skipped**.

## Provenance

Found by the 2026-08 Fable code review, area **R13-2**. The review also found `AnswerScorer.FindUnmarkedPali` blind to NFD (R2-2) and the Ordinal/OrdinalIgnoreCase split in #805 — same class, worth a sweep rather than three point fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)