### PR TITLE
Refuse a repeated model id, and open over one that is already there (#870)

### DIFF
--- a/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
+++ b/src/CST.Avalonia.Tests/Models/StateValidationTests.cs
@@ -383,6 +383,37 @@ public class StateValidationTests
     }
 
     [Fact]
+    public void Settings_Sanitize_trims_and_collapses_repeated_model_ids()
+    {
+        // #870: two records with one id used to throw ArgumentException out of the models tab — inside the
+        // Settings window's construction, so the window would not reopen. Repaired at load rather than
+        // tolerated per-screen: the per-turn picker has no dedupe either, and with BOTH records enabled (the
+        // shape both real routes produce) it listed the model twice, while a toggle reached only the first —
+        // so switching it off left the twin on and answering.
+        var s = new Settings();
+        s.Ai.Chat.Connections.Add(new AiConnectionRecord
+        {
+            Id = "mine",
+            Models =
+            {
+                new AiModelRecord { Id = "gpt-4o", DisplayName = "GPT-4o", Enabled = true },
+                new AiModelRecord { Id = " gpt-4o ", DisplayName = "GPT-4o again", Enabled = true },
+                new AiModelRecord { Id = "claude-opus-5", DisplayName = "Opus", Enabled = true },
+            },
+        });
+
+        var fixes = SettingsValidator.Sanitize(s);
+
+        var models = s.Ai.Chat.Connections.Single().Models;
+        Assert.Equal(new[] { "gpt-4o", "claude-opus-5" }, models.Select(m => m.Id));
+        Assert.Equal("GPT-4o", models[0].DisplayName);           // first wins, the row a toggle acts on
+        Assert.Contains(fixes, f => f.Contains("repeated model id"));
+
+        // Idempotent, like every other repair here.
+        Assert.DoesNotContain(SettingsValidator.Sanitize(s), f => f.Contains("repeated model id"));
+    }
+
+    [Fact]
     public void Settings_Sanitize_ClampsNonPositiveFontSizes()
     {
         var s = new Settings();

--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -44,6 +44,83 @@ public class AiConnectionServiceTests
         Assert.Contains("already", second.Problem);
     }
 
+    // ---- duplicate model ids (#870) --------------------------------------------------------------------
+
+    private static AiConnectionDraft DraftWith(params AiModelEntry[] models) =>
+        new("My box", ChatProviderKind.OpenAiCompatible, "http://localhost:8000/v1",
+            models, Array.Empty<AiHeader>(), new Dictionary<string, string>());
+
+    /// <summary>
+    /// Two rows with one id are refused on the way in, the way two headers with one name already were.
+    ///
+    /// <para>Nothing used to stop them: the sheet let a reader paste an id twice, the draft was copied
+    /// verbatim into the record, and the models tab then threw <c>ArgumentException</c> keying its stored
+    /// list — inside the Settings window's own construction, so the window would not open again. (#870)</para>
+    /// </summary>
+    [Fact]
+    public void Two_models_with_one_id_are_refused_on_add()
+    {
+        var (service, settings) = Make();
+
+        var result = service.Add("mine", DraftWith(
+            new AiModelEntry("llama3.1:8b", "Llama"), new AiModelEntry("llama3.1:8b", "Llama again")));
+
+        Assert.False(result.Ok);
+        Assert.Contains("llama3.1:8b", result.Problem);
+        Assert.Empty(settings.Ai.Chat.Connections);
+    }
+
+    /// <summary>The same refusal on the edit path — where it is likelier, since the sheet opens with the
+    /// existing rows and a reader adds one more.</summary>
+    [Fact]
+    public void Two_models_with_one_id_are_refused_on_update()
+    {
+        var (service, settings) = Make();
+        Assert.True(service.Add("mine", DraftWith(new AiModelEntry("a", "A"))).Ok);
+
+        var result = service.Update("mine", DraftWith(
+            new AiModelEntry("a", "A"), new AiModelEntry("a", "A again")));
+
+        Assert.False(result.Ok);
+        Assert.Single(settings.Ai.Chat.Connections.Single().Models);
+    }
+
+    /// <summary>Whitespace is what makes the pair, so it is trimmed before the comparison rather than after —
+    /// the record stores trimmed ids, so an untrimmed match would let the pair through to the same crash.
+    /// </summary>
+    [Fact]
+    public void A_padded_repeat_of_a_model_id_is_refused()
+    {
+        var (service, _) = Make();
+
+        var result = service.Add("mine", DraftWith(
+            new AiModelEntry("a", "A"), new AiModelEntry(" a ", "A padded")));
+
+        Assert.False(result.Ok);
+    }
+
+    /// <summary>
+    /// A listing id carrying whitespace does not append a second record on every toggle.
+    ///
+    /// <para><c>EnableModel</c> looked the id up untrimmed and stored it trimmed, so the padded id never
+    /// matched what the previous toggle had written and each pass added another record under the same
+    /// trimmed id — the editor's guard cannot see this route at all, since nobody typed it. (#870)</para>
+    /// </summary>
+    [Fact]
+    public void A_padded_listing_id_does_not_append_a_second_model()
+    {
+        var (service, settings) = Make();
+        Assert.True(service.Add("mine", DraftWith()).Ok);
+
+        service.EnableModel("mine", " gpt-4o ", "GPT-4o", enabled: true);
+        service.EnableModel("mine", " gpt-4o ", "GPT-4o", enabled: false);
+        service.EnableModel("mine", " gpt-4o ", "GPT-4o", enabled: true);
+
+        var model = Assert.Single(settings.Ai.Chat.Connections.Single().Models);
+        Assert.Equal("gpt-4o", model.Id);
+        Assert.True(model.Enabled);
+    }
+
     /// <summary>Preset ids are reserved: taking one by hand would collide with the built-in the reader might
     /// add later, and the collision would be a credential mix-up rather than a visible error.</summary>
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -22,6 +22,26 @@ public class AiModelCatalogTests
 {
     // ---- the three shapes one parser has to serve ------------------------------------------------------
 
+    /// <summary>
+    /// A padded id is trimmed at the parse seam, so every later ordinal join agrees on it.
+    ///
+    /// <para>Untrimmed, a gateway that pads its ids gave the reader a stored model and its own listing entry
+    /// that could never match each other: two rows for one model on the Models tab, published facts that
+    /// never reattached to the stored row, and a completed fetch marking the model they had just enabled "no
+    /// longer listed". (#870)</para>
+    /// </summary>
+    [Fact]
+    public void A_padded_listing_id_is_trimmed()
+    {
+        var models = AiModelCatalog.Parse("""
+        {"data":[{"id":"  gpt-4o  "},{"id":"   "}]}
+        """);
+
+        var model = Assert.Single(models);
+        Assert.Equal("gpt-4o", model.Id);
+        Assert.Equal("gpt-4o", model.DisplayName);   // the name falls back to the id, trimmed too
+    }
+
     /// <summary>OpenRouter: everything published at once. The fields are pulled by name — never "whatever
     /// the source says" — because a listing can gain a ranking field in a release nobody read.</summary>
     [Fact]

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelsViewModelTests.cs
@@ -42,9 +42,9 @@ public class AiModelsViewModelTests
 
     private static (AiModelsViewModel Vm, AiConnectionService Service) Make(
         IAiModelCatalog? catalog = null, IAiProviderLogos? logos = null,
-        IAiModelListingCache? listings = null)
+        IAiModelListingCache? listings = null, Settings? settings = null)
     {
-        var settings = new Settings();
+        settings ??= new Settings();
         var svc = new Mock<ISettingsService>();
         svc.SetupGet(s => s.Settings).Returns(settings);
         var service = new AiConnectionService(svc.Object);
@@ -1121,5 +1121,44 @@ public class AiModelsViewModelTests
         service.Add("mine", Draft());   // "later" is not here yet
 
         Assert.Single(listings.Get("later"));
+    }
+
+    // ---- opening over a file that already carries duplicates (#870) -------------------------------------
+
+    /// <summary>
+    /// A settings.json holding two model records with one id opens, showing the id once.
+    ///
+    /// <para>This half of #870 is the way back in. Keying the stored list with <c>ToDictionary</c> threw
+    /// <c>ArgumentException</c> on the pair, and this method runs from the <c>AiSettingsViewModel</c>
+    /// constructor — so a file that already held duplicates crashed the Settings window on every open, and
+    /// the only screen that could have removed the duplicate was the one that would not open. Refusing new
+    /// duplicates at the service does nothing for a reader whose file already has a pair, which is why the
+    /// tolerance is not redundant with the guard.</para>
+    ///
+    /// <para>First wins, and that is the row a toggle acts on: <c>EnableModel</c>/<c>SetModelEnabled</c>
+    /// resolve an id by <c>FirstOrDefault</c>.</para>
+    /// </summary>
+    [Fact]
+    public void A_stored_list_that_already_holds_a_duplicate_id_still_opens()
+    {
+        var settings = new Settings();
+        settings.Ai.Chat.Connections.Add(new AiConnectionRecord
+        {
+            Id = "mine",
+            DisplayName = "My box",
+            BaseUrl = "http://localhost:8000/v1",
+            Models =
+            {
+                new AiModelRecord { Id = "llama3.1:8b", DisplayName = "Llama", Enabled = true },
+                new AiModelRecord { Id = "llama3.1:8b", DisplayName = "Llama again", Enabled = false },
+            },
+        });
+
+        var (vm, _) = Make(settings: settings);
+        Group(vm).IsExpanded = true;
+
+        var row = Assert.Single(Rows(vm));
+        Assert.Equal("Llama", row.DisplayName);
+        Assert.True(row.Enabled);
     }
 }

--- a/src/CST.Avalonia/Models/SettingsValidator.cs
+++ b/src/CST.Avalonia/Models/SettingsValidator.cs
@@ -122,6 +122,22 @@ public static class SettingsValidator
             int badModels = connection.Models.RemoveAll(m => m == null || string.IsNullOrWhiteSpace(m.Id));
             if (badModels > 0)
                 fixes.Add($"removed {badModels} model(s) with no id from connection '{connection.Id}'");
+
+            // Trim, then collapse repeats. Every consumer compares a model id ordinally against what the
+            // record holds, so a padded id is a model nothing can match and a repeated one is a model two
+            // rows claim: the picker listed both and a toggle only ever reached the first, so switching a
+            // model off left its twin on and answering. This is the file-level repair for #870 — the
+            // service now refuses to write either shape, but a file written before it did still holds them,
+            // and repairing here fixes the picker, the models tab and the edit sheet at once rather than
+            // each learning to tolerate the pair. Self-heals: the next save writes the collapsed list.
+            foreach (var model in connection.Models)
+                model.Id = model.Id.Trim();
+
+            var seenModels = new HashSet<string>(StringComparer.Ordinal);
+            int repeatedModels = connection.Models.RemoveAll(m => !seenModels.Add(m.Id));
+            if (repeatedModels > 0)
+                fixes.Add($"removed {repeatedModels} repeated model id(s) from connection '{connection.Id}'");
+
             if (connection.Inputs == null)
             {
                 connection.Inputs = new Dictionary<string, string>();

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -286,6 +286,7 @@ namespace CST.Avalonia.Services.Ai
             if (problem is not null) return AiConnectionResult.Fail(problem);
 
             if (DuplicateHeader(draft) is { } duplicate) return AiConnectionResult.Fail(duplicate);
+            if (DuplicateModel(draft) is { } repeated) return AiConnectionResult.Fail(repeated);
             if (CollidingSecretHeader(draft) is { } collision) return AiConnectionResult.Fail(collision);
             if (UnfilledInput(id, draft) is { } unfilled) return AiConnectionResult.Fail(unfilled);
 
@@ -377,6 +378,7 @@ namespace CST.Avalonia.Services.Ai
             if (Find(id) is not { } record) return AiConnectionResult.Fail($"No connection called '{id}'.");
 
             if (DuplicateHeader(draft) is { } duplicate) return AiConnectionResult.Fail(duplicate);
+            if (DuplicateModel(draft) is { } repeated) return AiConnectionResult.Fail(repeated);
             if (CollidingSecretHeader(draft) is { } collision) return AiConnectionResult.Fail(collision);
             if (UnfilledInput(id, draft) is { } unfilled) return AiConnectionResult.Fail(unfilled);
 
@@ -449,6 +451,29 @@ namespace CST.Avalonia.Services.Ai
             foreach (var header in draft.Headers.Where(h => !string.IsNullOrWhiteSpace(h.Name)))
                 if (!seen.Add(header.Name.Trim()))
                     return $"There are two {header.Name.Trim()} headers. Remove one.";
+
+            return null;
+        }
+
+        /// <summary>
+        /// Two model rows carrying one id, or null when there are none. (#870)
+        ///
+        /// <para>Ordinal and trimmed, because that is the comparison everything downstream makes: the models
+        /// tab keys its stored list by the id verbatim, and <see cref="EnableModel"/> resolves a toggle by an
+        /// ordinal match. Refused rather than silently collapsed because the reader typed both rows and only
+        /// they know which one they meant — a save that quietly dropped one would look like the sheet had
+        /// lost an edit.</para>
+        ///
+        /// <para>The same shape as <see cref="DuplicateHeader"/>, which the models never got: a repeated id
+        /// used to reach settings.json and then throw out of the models tab on every subsequent Settings
+        /// open, which is a lockout rather than a bad row.</para>
+        /// </summary>
+        private static string? DuplicateModel(AiConnectionDraft draft)
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var model in draft.Models.Where(m => !string.IsNullOrWhiteSpace(m.Id)))
+                if (!seen.Add(model.Id.Trim()))
+                    return $"There are two {model.Id.Trim()} models. Remove one.";
 
             return null;
         }
@@ -585,6 +610,12 @@ namespace CST.Avalonia.Services.Ai
             if (string.IsNullOrWhiteSpace(modelId))
                 return AiConnectionResult.Fail("A model needs an id.");
 
+            // Trim ONCE, before the lookup. Looking up the untrimmed id and storing the trimmed one meant a
+            // provider listing whose id carries whitespace never matched what the last toggle had stored, so
+            // every toggle appended another record under the same trimmed id — a duplicate the models tab
+            // then threw on. (#870)
+            modelId = modelId.Trim();
+
             var model = record.Models.FirstOrDefault(
                 m => string.Equals(m.Id, modelId, StringComparison.Ordinal));
 
@@ -592,8 +623,8 @@ namespace CST.Avalonia.Services.Ai
             {
                 model = new AiModelRecord
                 {
-                    Id = modelId.Trim(),
-                    DisplayName = string.IsNullOrWhiteSpace(displayName) ? modelId.Trim() : displayName.Trim(),
+                    Id = modelId,
+                    DisplayName = string.IsNullOrWhiteSpace(displayName) ? modelId : displayName.Trim(),
                 };
                 record.Models.Add(model);
             }

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -560,7 +560,12 @@ namespace CST.Avalonia.Services.Ai
             foreach (var item in data.EnumerateArray())
             {
                 if (item.ValueKind != JsonValueKind.Object) continue;
-                if (Text(item, "id") is not { Length: > 0 } id) continue;
+                // Trimmed here, at the one place a listing id enters, so every later ordinal join
+                // agrees on it. A gateway that pads its ids used to have a stored model and its own
+                // listing entry miss each other: two rows for one model, published facts that never
+                // reattached, and a completed fetch marking the reader's enabled model "no longer
+                // listed". (#870, fable review)
+                if (Text(item, "id")?.Trim() is not { Length: > 0 } id) continue;
 
                 var architecture = Object(item, "architecture");
                 var pricing = Object(item, "pricing");

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -389,11 +389,12 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         internal void ApplyFilter(string search, bool freeOnly, bool searching)
         {
-            // First-wins over the stored list rather than one row per record. Two records CAN share an id —
-            // the seams that write them now refuse it, but a settings.json written before they did still
-            // holds the pair, and this method runs inside the AiSettingsViewModel constructor: throwing here
-            // (ToDictionary did) locks the reader out of the entire Settings window, with no way back in to
-            // remove the duplicate that closed it. First-wins also matches what a toggle acts on, since
+            // First-wins over the stored list rather than one row per record, and never a throw. The pair
+            // this guards against is repaired at load (SettingsValidator) and refused on the way in
+            // (AiConnectionService.DuplicateModel), so nothing should reach here — but this method runs
+            // inside the AiSettingsViewModel constructor, where an ArgumentException (ToDictionary threw
+            // one) is not a bad row: it locks the reader out of the entire Settings window, with no way
+            // back in to remove whatever closed it. First-wins also matches what a toggle acts on, since
             // EnableModel/SetModelEnabled resolve an id by FirstOrDefault. (#870)
             var stored = new HashSet<string>(StringComparer.Ordinal);
             var rows = new List<AiCatalogRowViewModel>();

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -389,19 +389,27 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         internal void ApplyFilter(string search, bool freeOnly, bool searching)
         {
-
-            var stored = _connection.Models.ToDictionary(m => m.Id, StringComparer.Ordinal);
+            // First-wins over the stored list rather than one row per record. Two records CAN share an id —
+            // the seams that write them now refuse it, but a settings.json written before they did still
+            // holds the pair, and this method runs inside the AiSettingsViewModel constructor: throwing here
+            // (ToDictionary did) locks the reader out of the entire Settings window, with no way back in to
+            // remove the duplicate that closed it. First-wins also matches what a toggle acts on, since
+            // EnableModel/SetModelEnabled resolve an id by FirstOrDefault. (#870)
+            var stored = new HashSet<string>(StringComparer.Ordinal);
             var rows = new List<AiCatalogRowViewModel>();
 
             foreach (var model in _connection.Models)
+            {
+                if (!stored.Add(model.Id)) continue;
                 rows.Add(new AiCatalogRowViewModel(
                     this, model.Id, model.DisplayName,
                     _fetched.FirstOrDefault(f => string.Equals(f.Id, model.Id, StringComparison.Ordinal)),
                     model.Enabled, model.Missing));
+            }
 
             foreach (var model in _fetched)
             {
-                if (stored.ContainsKey(model.Id)) continue;
+                if (stored.Contains(model.Id)) continue;
                 if (freeOnly && model.CostsMoney) continue;
                 rows.Add(new AiCatalogRowViewModel(
                     this, model.Id, model.DisplayName, model, enabled: false));


### PR DESCRIPTION
Fixes #870.

Two model rows with one id had nothing to stop them. The sheet let a reader paste an id twice, `Add`/`Update` copied the draft verbatim into the record, and `AiModelsViewModel.ApplyFilter` then threw `ArgumentException` keying its stored list with `ToDictionary`. That throw happens inside the `AiSettingsViewModel` constructor — so once the debounced save had committed the pair, **every subsequent Settings open crashed**, and the only screen that could have removed the duplicate was the one that would not open.

### Three parts

The guard alone does nothing for a reader whose `settings.json` already holds a pair, which is why the tolerance is not redundant with it.

| | |
|---|---|
| `AiConnectionService.DuplicateModel` | Refuses a repeat at `Add` and `Update`, the same shape as the existing `DuplicateHeader`. Trimmed + ordinal, matching what the record stores and what a toggle resolves. Refused rather than silently collapsed: the reader typed both rows, and a save that quietly dropped one would look like a lost edit. |
| `AiModelsViewModel.ApplyFilter` | First-wins over the stored list instead of keying it — the way back in for a file that already carries duplicates. First-wins is also the row a toggle acts on, since `EnableModel`/`SetModelEnabled` both resolve an id by `FirstOrDefault`. |
| `AiConnectionService.EnableModel` | Trims the model id **once, before the lookup**. It looked up untrimmed and stored trimmed, so a provider listing id carrying whitespace never matched the previous toggle's record and appended another one on every pass — the same duplicate, by a route no editor-side guard can see (R4-3). |

### Tests

Five added, each mutation-checked (revert the corresponding fix, confirm only that test fails):

- `Two_models_with_one_id_are_refused_on_add` / `_on_update` / `A_padded_repeat_of_a_model_id_is_refused`
- `A_padded_listing_id_does_not_append_a_second_model`
- `A_stored_list_that_already_holds_a_duplicate_id_still_opens` — seeds the duplicate straight into `Settings`, since the service now refuses to create one

Full suite: **2626 passed, 0 failed, 17 skipped**.

Found by the August Fable review (R5-1, with R4-3 as the second route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)