### PR TITLE
Cut a passage at an akṣara boundary, not at an arbitrary index (#871)

### DIFF
--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -837,5 +837,137 @@ namespace CST.Avalonia.Tests.Search
             Assert.Equal(5, window.ParagraphNumber);
             Assert.Contains(window.Pages, p => p.Edition == PageEdition.Vri && p.Number == 1);
         }
+    
+        // ---- akṣara-aware cuts (#871) -------------------------------------------------------------------
+
+        /// <summary>
+        /// One Devanagari word in a paragraph with no danda, so the count-based cuts are the only ones that
+        /// can fire. Rendered whole this is "ka buddhīkakakaka"; cut between the conjunct and its vowel sign
+        /// it reads "ka buddha", which is why this bug is worth a test at all.
+        /// </summary>
+        private const string NoDanda =
+            "<body><div id=\"dn1\" type=\"book\">" +
+            "<p rend=\"bodytext\" n=\"5\">" +
+            // ka + space + b-u-d-virama-dh-ii, then four more ka.
+            "\u0915 \u092C\u0941\u0926\u094D\u0927\u0940\u0915\u0915\u0915\u0915</p>" +
+            "</div></body>";
+
+        /// <summary>Where the paragraph's TEXT begins. The paragraph marker points at the opening tag, which
+        /// is zero-width forwards but not a position to do character arithmetic from.</summary>
+        private static int TextStart(string xml) => xml.IndexOf('\u0915');
+
+        /// <summary>
+        /// The hard cap backs off a half-cut akṣara instead of inventing a word.
+        ///
+        /// <para>The budget ran out between the <c>dh</c> (U+0927) and its <c>ī</c> sign (U+0940), leaving a
+        /// bare consonant that <c>Deva2Latn</c> then gave its inherent 'a' — so the window ended "…buddha"
+        /// where the text says "buddhī". Not visible damage: a different, entirely plausible Pāli word, in
+        /// the surface an agent quotes the corpus from.</para>
+        /// </summary>
+        [Fact]
+        public void The_hard_cap_does_not_cut_an_aksara_in_half()
+        {
+            var markers = BookMarkers.Build(NoDanda);
+
+            // maxChars 5 puts the hard cap (maxChars + maxChars/2) exactly on the vowel sign.
+            var w = TeiPassageReader.ReadWindow(NoDanda, TextStart(NoDanda), maxChars: 5,
+                includeVariants: false, outputScript: Script.Latin, markers);
+
+            Assert.Equal("ka bu", w.Text);
+            Assert.DoesNotContain("buddha", w.Text);
+        }
+
+        /// <summary>
+        /// Paging across the cut stitches back to the text, which is the reason the fix retreats rather than
+        /// advances: the window end IS the next window's cursor, so moving it back puts the whole akṣara at
+        /// the head of the next page. Left where the count landed, page two opened on an orphaned vowel sign
+        /// ("īkakakaka") and no amount of stitching recovered "buddhī".
+        /// </summary>
+        [Fact]
+        public void Paging_across_a_half_cut_aksara_stitches_back_to_the_word()
+        {
+            var markers = BookMarkers.Build(NoDanda);
+
+            var w1 = TeiPassageReader.ReadWindow(NoDanda, TextStart(NoDanda), maxChars: 5,
+                includeVariants: false, outputScript: Script.Latin, markers);
+            var w2 = TeiPassageReader.ReadWindow(NoDanda, w1.NextCursor!.Value, maxChars: 50,
+                includeVariants: false, outputScript: Script.Latin, markers);
+
+            Assert.StartsWith("ddhī", w2.Text);
+            Assert.Equal("ka buddhīkakakaka", w1.Text + w2.Text);
+        }
+
+        /// <summary>
+        /// A window narrower than the akṣara it starts on keeps the raw cut rather than coming back empty.
+        ///
+        /// <para>Retreating to nothing would make the window's end its own <c>NextCursor</c>, and a client
+        /// paging forward would never advance — a hang is worse than the boundary letter this fix exists to
+        /// get right.</para>
+        /// </summary>
+        [Fact]
+        public void A_window_narrower_than_one_aksara_still_advances()
+        {
+            var markers = BookMarkers.Build(NoDanda);
+            int start = TextStart(NoDanda) + 4;             // onto the d of the d-virama-dh conjunct
+
+            var w = TeiPassageReader.ReadWindow(NoDanda, start, maxChars: 1, includeVariants: false,
+                outputScript: Script.Latin, markers);
+
+            Assert.NotEmpty(w.Text);
+            Assert.True(w.NextCursor > start);
+        }
+
+        /// <summary>
+        /// The previous-page cursor opens on an akṣara start too. With no sentence boundary behind it the
+        /// backward walk falls back to a raw character count, which used to open the previous page on the
+        /// orphaned vowel sign ("īkakakaka").
+        /// </summary>
+        [Fact]
+        public void The_previous_page_cursor_does_not_open_mid_aksara()
+        {
+            var markers = BookMarkers.Build(NoDanda);
+
+            var w = TeiPassageReader.ReadWindow(NoDanda, TextStart(NoDanda) + 11, maxChars: 4,
+                includeVariants: false, outputScript: Script.Latin, markers);
+
+            var prev = TeiPassageReader.ReadWindow(NoDanda, w.PrevCursor!.Value, maxChars: 50,
+                includeVariants: false, outputScript: Script.Latin, markers);
+
+            Assert.StartsWith("ddhī", prev.Text);
+            Assert.False(prev.Text.StartsWith("ī"));        // the stranded matra
+        }
+
+        /// <summary>
+        /// The selection path's cut is akṣara-aware as well.
+        ///
+        /// <para>It is <c>ExtendToSentenceEnd</c> that has to do this, not the selection clamp: every
+        /// selection end is passed through the sentence extension, so the clamp's own cut never ends a
+        /// window. Where a danda is near, the extension lands on it and there was never a problem; where none
+        /// is — front matter, headings, a verse index, the danda-free text this reader already documents
+        /// having to cope with — the extension gives up on its 4,000-character cap, and that cap is a raw
+        /// count like any other.</para>
+        /// </summary>
+        [Fact]
+        public void The_sentence_extension_cap_does_not_cut_an_aksara_in_half()
+        {
+            // Filler so the 4,000-char extension cap lands exactly on the vowel sign, and no danda anywhere
+            // for it to prefer.
+            const int Cap = 4000;
+            string filler = new string('\u0915', Cap - 4);
+            string xml =
+                "<body><p rend=\"bodytext\" n=\"1\">"
+                + filler + "\u092C\u0941\u0926\u094D\u0927\u0940" + new string('\u0915', 20)
+                + "</p></body>";
+
+            var markers = BookMarkers.Build(xml);
+            int from = TextStart(xml);
+
+            var w = TeiPassageReader.ReadWindowAroundSelection(
+                xml, from, from + 1, maxChars: 100000, includeVariants: false,
+                outputScript: Script.Latin, markers, contextSentences: 0);
+
+            Assert.EndsWith("kabu", w.Text);
+            Assert.DoesNotContain("buddha", w.Text);
+        }
     }
 }

--- a/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
+++ b/src/CST.Avalonia.Tests/Search/TeiPassageReaderTests.cs
@@ -969,5 +969,117 @@ namespace CST.Avalonia.Tests.Search
             Assert.EndsWith("kabu", w.Text);
             Assert.DoesNotContain("buddha", w.Text);
         }
+
+        /// <summary>
+        /// The retreat stops at markup rather than stepping into it.
+        ///
+        /// <para>The corpus carries a niggahita immediately after a close tag in 23 places
+        /// (<c>&lt;hi rend="bold"&gt;…&lt;/hi&gt;</c> + U+0902) and opens one paragraph with a vowel sign, so
+        /// the mark's base sits on the far side of the markup. Stepping back onto the <c>&gt;</c> would hand
+        /// back a cursor INSIDE the tag, and the previous page would open by rendering the tag's own text —
+        /// a markup leak where there had only been a stranded mark. The mark stays stranded at those points,
+        /// which is what this reader did before #871. (fable review)</para>
+        /// </summary>
+        [Fact]
+        public void The_retreat_does_not_step_into_a_tag()
+        {
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\"><p rend=\"bodytext\" n=\"7\">"
+                // kakaka <hi>nesa</hi> niggahita, then six more ka. No danda anywhere.
+                + "\u0915\u0915\u0915<hi rend=\"bold\">\u0928\u0947\u0938</hi>\u0902"
+                + "\u0915\u0915\u0915\u0915\u0915\u0915"
+                + "</p></div></body>";
+
+            var markers = BookMarkers.Build(xml);
+            int mark = xml.IndexOf('\u0902');
+
+            var w = TeiPassageReader.ReadWindow(xml, mark + 4, maxChars: 4, includeVariants: false,
+                outputScript: Script.Latin, markers);
+            var prev = TeiPassageReader.ReadWindow(xml, w.PrevCursor!.Value, maxChars: 50,
+                includeVariants: false, outputScript: Script.Latin, markers);
+
+            Assert.DoesNotContain(">", prev.Text);
+            Assert.StartsWith("ṃ", prev.Text);        // the stranded niggahita, not the tag
+        }
+
+        /// <summary>
+        /// A conjunct written in the corpus's open form retreats whole.
+        ///
+        /// <para>A ZWJ between the virama and the consonant asks for the half-form rather than the stacked
+        /// ligature, and it is not a curiosity: it sits in 15% of the corpus's viramas, concentrated in the
+        /// same danda-free runs where these count-based cuts fire. Without the joiner rule the retreat stops
+        /// on the far side of it and the window ends "pañ" — a visible cut rather than a wrong word, but not
+        /// the akṣara boundary this is supposed to return. (fable review)</para>
+        /// </summary>
+        [Fact]
+        public void A_conjunct_joined_by_zwj_retreats_whole()
+        {
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\"><p rend=\"bodytext\" n=\"7\">"
+                // pa-nya-virama-ZWJ-nya-aa ("paññā"), then filler.
+                + "\u092A\u091E\u094D\u200D\u091E\u093E\u0915\u0915\u0915\u0915"
+                + "</p></div></body>";
+
+            var markers = BookMarkers.Build(xml);
+
+            var w = TeiPassageReader.ReadWindow(xml, xml.IndexOf('\u092A'), maxChars: 3, includeVariants: false,
+                outputScript: Script.Latin, markers);
+
+            Assert.Equal("pa", w.Text);
+            Assert.DoesNotContain("pañ", w.Text);
+        }
+
+        /// <summary>
+        /// The niggahita is the other silent-wrong-word shape: cut before it, "nesaṃ" reads "nesa" — again a
+        /// real word, again with nothing to say it was cut.
+        /// </summary>
+        [Fact]
+        public void A_cut_before_a_niggahita_does_not_drop_it_silently()
+        {
+            const string xml =
+                "<body><div id=\"dn1\" type=\"book\"><p rend=\"bodytext\" n=\"7\">"
+                + "\u0928\u0947\u0938\u0902\u0915\u0915\u0915\u0915"   // ne-sa-niggahita, then filler
+                + "</p></div></body>";
+
+            var markers = BookMarkers.Build(xml);
+
+            var w = TeiPassageReader.ReadWindow(xml, xml.IndexOf('\u0928'), maxChars: 2, includeVariants: false,
+                outputScript: Script.Latin, markers);
+
+            Assert.Equal("ne", w.Text);
+            Assert.DoesNotContain("nesa", w.Text);
+        }
+
+        /// <summary>
+        /// The backward sentence scan's floor is akṣara-aware too — the fourth count-based cut, and the one
+        /// the issue's list missed.
+        ///
+        /// <para>When no danda lies within the 2,000-character scan cap behind a selection and no paragraph
+        /// opens in the gap, the expansion falls back to the raw scan floor. Fourteen books carry danda-free
+        /// runs past that cap — the Paṭṭhāna mūla files worst, the longest 19,010 characters — so a selection
+        /// inside one opened its window on an orphaned vowel sign. (fable review)</para>
+        /// </summary>
+        [Fact]
+        public void The_backward_scan_floor_does_not_open_mid_aksara()
+        {
+            // The word sits exactly one scan cap (2,000) behind the selection, so the floor lands on its
+            // vowel sign, and there is no danda and no paragraph opening in between.
+            string xml =
+                "<body><p rend=\"bodytext\" n=\"1\">"
+                + new string('\u0915', 2000)
+                + "\u092C\u0941\u0926\u094D\u0927\u0940"
+                + new string('\u0915', 2100)
+                + "</p></body>";
+
+            var markers = BookMarkers.Build(xml);
+            int from = TextStart(xml) + 4005;
+
+            var w = TeiPassageReader.ReadWindowAroundSelection(
+                xml, from, from + 1, maxChars: 100000, includeVariants: false,
+                outputScript: Script.Latin, markers, contextSentences: 1);
+
+            Assert.StartsWith("ddhī", w.Text);
+            Assert.False(w.Text.StartsWith("ī"));          // the stranded matra
+        }
     }
 }

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -515,6 +515,13 @@ namespace CST.Search
                 seen++;
             }
 
+            // Falling out of the loop means the 4,000-char cap or the section ran out before any danda did,
+            // so this return is a raw count like the hard cap — and on the selection path it is the cut that
+            // actually ends the window, since every selection end is passed through here. Back off a half-cut
+            // akṣara, but never below where we started: returning less than `from` would shorten the
+            // selection the caller asked to keep whole. (#871)
+            if (i > from) i = Math.Max(ClusterStart(xml, i, from), from);
+
             return Math.Min(i, limit);
         }
 
@@ -598,6 +605,48 @@ namespace CST.Search
             return 0;
         }
 
+        /// <summary>
+        /// Retreat a raw cut position to the start of the akṣara it falls inside. (#871)
+        ///
+        /// <para><b>A character count is not a letter count.</b> The corpus is Devanagari at this layer, and
+        /// three of this reader's cuts are pure counts that stop wherever the budget runs out — so a cut can
+        /// land between a consonant and its dependent vowel sign, or just after a virama. What comes back is
+        /// not visible damage: <c>Deva2Latn</c> gives a bare consonant its inherent 'a', so a window cut
+        /// inside <c>\u092C\u0941\u0926\u094D\u0927\u0940</c> ("buddhī") ends "…buddha" — a different,
+        /// entirely plausible Pāli word, with nothing to tell a reader or an agent that it was cut. This is
+        /// the citation path, so subtly wrong Pāli is the worst output the reader can produce.</para>
+        ///
+        /// <para><b>Retreat rather than advance, because the cut is also the next page's cursor.</b> Moving
+        /// it back to the cluster start puts the whole akṣara at the head of the next window, so paging
+        /// through stitches back to the original text; advancing past the cluster would drop it from both.
+        /// </para>
+        ///
+        /// <para>Two rules, applied until neither fires: a combining mark AT the cut belongs to the character
+        /// before it, and a virama immediately BEFORE the cut binds to the consonant that follows. Marks are
+        /// recognised by Unicode category rather than by a Devanagari range, so a conjunct of any depth
+        /// unwinds without a table to keep current.</para>
+        /// </summary>
+        /// <param name="floor">Never retreat below this. The result may equal it; callers cutting a window
+        /// must reject that themselves, since an empty window makes nextCursor point at its own start.</param>
+        private static int ClusterStart(string xml, int cut, int floor)
+        {
+            while (cut > floor)
+            {
+                if (cut < xml.Length && IsCombining(xml[cut])) { cut--; continue; }
+                if (xml[cut - 1] == Virama) { cut--; continue; }
+                break;
+            }
+
+            return cut;
+        }
+
+        private const char Virama = '\u094D';
+
+        private static bool IsCombining(char c) =>
+            System.Globalization.CharUnicodeInfo.GetUnicodeCategory(c) is
+                System.Globalization.UnicodeCategory.NonSpacingMark or
+                System.Globalization.UnicodeCategory.SpacingCombiningMark;
+
         // Raw end position after accumulating ~maxChars rendered chars, then extending to the next sentence
         // boundary (capped) so we never cut mid-sentence. Tags and stripped subtrees cost zero budget.
         private static int WalkForward(string xml, int start, int maxChars, bool includeNotes, int limit)
@@ -632,7 +681,13 @@ namespace CST.Search
                     rendered++;
                     i++;
                     if (rendered >= maxChars) budgetReached = true;
-                    if (rendered >= hardCap) return i;                          // no boundary found: hard cap
+                    if (rendered >= hardCap)
+                    {
+                        // No boundary found: hard cap. Back off any half-cut akṣara — but not to nothing, or
+                        // this window's end becomes its own nextCursor and the caller pages forever. (#871)
+                        int cut = ClusterStart(xml, i, start);
+                        return cut > start ? cut : i;
+                    }
                 }
             }
             return i;
@@ -679,7 +734,10 @@ namespace CST.Search
             // No boundary found: the raw fallback can land mid-note, so the previous page would render that note's
             // tail as base text (and Clean from mid-note emits an unbalanced brace). Snap out to the enclosing note's
             // start so the cursor sits on a clean (base-text) boundary. (#355)
-            int fallback = Math.Max(i + 1, limit);
+            // A start position, so there is no empty window to guard against: retreating merely begins the
+            // previous page a letter earlier. Left where the count landed, that page opened on an orphaned
+            // vowel sign. (#871)
+            int fallback = ClusterStart(xml, Math.Max(i + 1, limit), limit);
             foreach (var (s, e) in notes)
                 if (fallback > s && fallback < e) { fallback = Math.Max(s, limit); break; }
             return fallback;

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -388,7 +388,13 @@ namespace CST.Search
                 // has no danda in front of it, so a selection in the second sentence would get no context at
                 // all despite a whole sentence sitting right there. Falling back to the scan floor keeps that
                 // sentence and still bounds the front-matter case the cap exists for. (#672)
-                if (found < 0) return Math.Min(start, AdvanceToParagraph(xml, floor, start));
+                // The scan floor is a raw character count like the forward caps, so it can open a window
+                // mid-akṣara — the same orphaned vowel sign #871 fixes at the other three cuts. Reachable:
+                // 14 books carry danda-free runs past this cap, the longest 19,010 characters. Aligned
+                // against the SECTION start, not the floor, so the retreat cannot leave the section.
+                // (#871, fable review)
+                if (found < 0)
+                    return Math.Min(start, ClusterStart(xml, AdvanceToParagraph(xml, floor, start), limit));
                 boundary = found;
                 at = found;
             }
@@ -624,7 +630,16 @@ namespace CST.Search
         /// <para>Two rules, applied until neither fires: a combining mark AT the cut belongs to the character
         /// before it, and a virama immediately BEFORE the cut binds to the consonant that follows. Marks are
         /// recognised by Unicode category rather than by a Devanagari range, so a conjunct of any depth
-        /// unwinds without a table to keep current.</para>
+        /// unwinds without a table to keep current — and the virama is itself a mark, so a cut landing ON one
+        /// is already covered by the first rule.</para>
+        ///
+        /// <para><b>Never across markup.</b> The retreat crosses text characters only; it stops at a tag's
+        /// <c>&gt;</c> rather than stepping onto it. That is what keeps it from moving a cut across a note
+        /// boundary, and the alternative is worse than the bug: 23 places in the corpus carry a mark
+        /// immediately after a close tag (<c>&lt;hi rend="bold"&gt;…&lt;/hi&gt;</c> + niggahita), and one
+        /// opens a paragraph with a vowel sign, so stepping back would return a position INSIDE the tag and
+        /// the window would render the markup's own text. At those points the mark is left stranded, which is
+        /// what this reader did before. (fable review)</para>
         /// </summary>
         /// <param name="floor">Never retreat below this. The result may equal it; callers cutting a window
         /// must reject that themselves, since an empty window makes nextCursor point at its own start.</param>
@@ -632,8 +647,15 @@ namespace CST.Search
         {
             while (cut > floor)
             {
-                if (cut < xml.Length && IsCombining(xml[cut])) { cut--; continue; }
+                if (cut < xml.Length && IsCombining(xml[cut]) && xml[cut - 1] != '>') { cut--; continue; }
                 if (xml[cut - 1] == Virama) { cut--; continue; }
+
+                // The same bond written in the corpus's open form. A ZWJ between the virama and the consonant
+                // asks for the half-form rather than the stacked ligature, and it is not a rarity to reason
+                // about hypothetically: it sits in 15% of the corpus's viramas, concentrated in exactly the
+                // danda-free runs where these count-based cuts fire. (fable review)
+                if (xml[cut - 1] == Zwj && cut - 2 >= floor && xml[cut - 2] == Virama) { cut -= 2; continue; }
+
                 break;
             }
 
@@ -641,6 +663,7 @@ namespace CST.Search
         }
 
         private const char Virama = '\u094D';
+        private const char Zwj = '\u200D';
 
         private static bool IsCombining(char c) =>
             System.Globalization.CharUnicodeInfo.GetUnicodeCategory(c) is


### PR DESCRIPTION
Fixes #871.

Three of the passage reader's cuts are pure character counts that stop wherever the budget runs out. Land one between a consonant and its dependent vowel sign and `Deva2Latn` gives the bare consonant its inherent 'a':

| | rendered |
|---|---|
| source | `ka buddhīkakakaka` |
| cut at the vowel sign | `ka buddha` ← a different, entirely plausible Pāli word |
| next page from that cut | `īkakakaka` ← the orphaned mātrā |

Nothing tells a reader or an agent the text was cut, and stitching the pages back together does **not** recover `buddhī`. This is the surface an agent quotes the corpus from.

### The fix

`ClusterStart` retreats a raw cut to the start of the akṣara it falls inside. Two rules, applied until neither fires: a combining mark **at** the cut belongs to the character before it, and a virama immediately **before** the cut binds to the consonant that follows. Marks are recognised by Unicode category rather than by a Devanagari range, so a conjunct of any depth unwinds without a table to keep current.

**Retreat rather than advance**, because the cut is also the next page's cursor — moving it back puts the whole akṣara at the head of the next window, so paging stitches back to the original text (`"ka bu"` + `"ddhī…"`). Advancing would drop the akṣara from both pages.

One exception: a window narrower than the akṣara it starts on keeps the raw cut. Retreating to nothing would make the window's end its own `NextCursor`, and a client paging forward would never advance — a hang is worse than the boundary letter this fix exists to get right.

### Where it is applied

Two of the three sites are as the issue prescribes: the hard cap in `WalkForward`, and the no-boundary prev-cursor fallback in `WalkBackward`.

**The third is `ExtendToSentenceEnd`'s 4,000-character cap, not `RawForwardCap`.** Every selection end is passed through the sentence extension (`WalkForwardSentences` calls `ExtendToSentenceEnd` unconditionally to finish the selection's own sentence), so the selection clamp's cut never ends a window — where a danda is near, the extension lands on it and there was never a problem. Where none is — front matter, headings, a verse index, the same danda-free text this reader already documents having to cope with — the extension gives up on its 4,000-char cap, and *that* is the raw cut that lands. Aligning `RawForwardCap` would have been unobservable, so it is left alone.

### Tests

Five added, all mutation-checked. Each of the three sites and each of the two rules fails a test independently when reverted:

| mutation | fails |
|---|---|
| hard cap keeps the raw index | `The_hard_cap_…`, `Paging_across_…` |
| prev-cursor fallback keeps the raw index | `The_previous_page_cursor_…` |
| sentence-extension cap keeps the raw index | `The_sentence_extension_cap_…` |
| drop the virama rule only | all four |
| drop the empty-window guard | `A_window_narrower_than_one_aksara_still_advances` |

`Paging_across_a_half_cut_aksara_stitches_back_to_the_word` asserts the whole point: `w1.Text + w2.Text == "ka buddhīkakakaka"`.

Devanagari test data is written as `\uXXXX` escapes per the house rule.

Full suite: **2633 passed, 0 failed, 17 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)