### PR TITLE
Serve the DPD asset that is actually on disk after an update (#869)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
+++ b/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
@@ -175,6 +175,42 @@ public sealed class FirstRunDictionaryVisibilityTests : IDisposable
         Assert.Contains("dpd", PickerIds(prefs));
     }
 
+    /// <summary>
+    /// The dossier cache is cleared alongside the reopen.
+    ///
+    /// <para>A lemma report is assembled from the asset's glosses and corpus counts and stamped with its
+    /// version, and up to 32 are held. Reopening the provider without clearing them left the reader looking
+    /// at the superseded asset's report — footer version and all — for every lemma they had already visited:
+    /// the same staleness as #869 one layer up, and it would have survived that fix untouched.
+    /// <c>InvalidateCache</c> was written for this and had no callers anywhere in the tree. (#869)</para>
+    /// </summary>
+    [Fact]
+    public void The_bound_handler_clears_the_report_cache_when_the_dpd_asset_lands()
+    {
+        var (lemma, _) = BuildApp();
+        var updates = new FakeUpdates();
+        var reports = new CountingReports();
+        Assert.True(App.BindLemmaReopen(updates, lemma, reports));
+
+        BuildDpdAsset(_dpdPath);
+        updates.RaiseAssetInstalled(App.DpdAssetId);
+
+        Assert.Equal(1, reports.Invalidations);
+
+        // And not for somebody else's asset, which does not reopen the provider either.
+        updates.RaiseAssetInstalled("dppn");
+        Assert.Equal(1, reports.Invalidations);
+    }
+
+    private sealed class CountingReports : ILemmaReportService
+    {
+        public int Invalidations { get; private set; }
+        public bool IsAvailable => true;
+        public void InvalidateCache() => Invalidations++;
+        public Task<LemmaReport?> BuildAsync(long lemmaId, CancellationToken ct = default) =>
+            Task.FromResult<LemmaReport?>(null);
+    }
+
     // A lexicon install must not reopen the lemma provider — it is a different asset, and reopening on every
     // event would retire a live inner provider for nothing.
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/LemmaReportCacheTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LemmaReportCacheTests.cs
@@ -1,0 +1,77 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Conversion;
+using CST.Lemma;
+using Moq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// What the dossier cache is allowed to keep across an asset swap. (#869)
+/// </summary>
+public class LemmaReportCacheTests
+{
+    private static DpdLemmaMeta MetaFor(string version) =>
+        new("full", version, "3", "1", "CC BY-NC-SA", "DPD", "dpd", "Bodhirāsa", "https://example.invalid");
+
+    private static LemmaDetail Detail() =>
+        new(1, "dhamma", "nt", "a test gloss", null, null, null, null, null, null,
+            null, null, null, null, null, null);
+
+    /// <summary>
+    /// A report assembled from the asset that was replaced while it was being assembled is handed to the
+    /// caller that asked for it, and NOT put in the cache.
+    ///
+    /// <para>Assembly awaits several corpus searches — seconds, which is the whole reason this cache exists —
+    /// so an install landing inside that window clears the cache before the report arrives. Storing it
+    /// anyway put a dossier built from the superseded asset back into an otherwise clean cache, version
+    /// footer and all, where it sat until 32 other lemmas evicted it. The trigger is ordinary: the reader
+    /// opens a lemma report while the background update installs.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_report_assembled_across_an_asset_swap_is_not_cached()
+    {
+        var meta = MetaFor("v0.4.20260531");
+        var lemma = new Mock<ILemmaProvider>();
+        lemma.SetupGet(l => l.IsAvailable).Returns(true);
+        lemma.SetupGet(l => l.Meta).Returns(() => meta);
+        lemma.Setup(l => l.GetDetail(1)).Returns(Detail());
+
+        var search = new Mock<ILemmaSearchService>();
+        search.Setup(s => s.ExpandAndSearchAsync(
+                It.IsAny<long>(), It.IsAny<bool>(), It.IsAny<BookFilter?>(), It.IsAny<Script>(),
+                It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            // The install lands here, mid-assembly: the cache is cleared and the asset is a different one by
+            // the time this report is finished.
+            .ReturnsAsync(() => { meta = MetaFor("v0.4.20260731"); return null; });
+
+        var service = new LemmaReportService(lemma.Object, search.Object);
+
+        Assert.NotNull(await service.BuildAsync(1));       // the caller still gets what it asked for
+        Assert.NotNull(await service.BuildAsync(1));       // and the second call rebuilds rather than serving it
+
+        lemma.Verify(l => l.GetDetail(1), Times.Exactly(2));
+    }
+
+    /// <summary>The ordinary case still caches — otherwise the fix above would be a cache that never holds
+    /// anything, and every report would pay for several corpus searches again.</summary>
+    [Fact]
+    public async Task A_report_assembled_with_the_asset_unchanged_is_cached()
+    {
+        var lemma = new Mock<ILemmaProvider>();
+        lemma.SetupGet(l => l.IsAvailable).Returns(true);
+        lemma.SetupGet(l => l.Meta).Returns(MetaFor("v0.4.20260531"));
+        lemma.Setup(l => l.GetDetail(1)).Returns(Detail());
+
+        var search = new Mock<ILemmaSearchService>();
+        var service = new LemmaReportService(lemma.Object, search.Object);
+
+        Assert.NotNull(await service.BuildAsync(1));
+        Assert.NotNull(await service.BuildAsync(1));
+
+        lemma.Verify(l => l.GetDetail(1), Times.Once);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/ReopenableLemmaProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/ReopenableLemmaProviderTests.cs
@@ -83,9 +83,80 @@ public sealed class ReopenableLemmaProviderTests : IDisposable
         Assert.False(provider.IsAvailable);
     }
 
+    // ---- an asset REPLACED mid-session, not merely installed (#869) ------------------------------------
+
+    /// <summary>
+    /// After an update replaces the asset in place, the provider serves the new file.
+    ///
+    /// <para>#536's case was a first install, where there is no pool yet and nothing can go wrong. An
+    /// <b>update</b> is the hard one: <c>File.Move(overwrite: true)</c> on macOS and Linux is a rename that
+    /// succeeds over open handles, so the replacement provider used to build the same connection string, be
+    /// handed a pooled handle still bound to the replaced file's old inode, and go on answering from the
+    /// superseded asset — while the log said the new one was active. Until the next launch.</para>
+    ///
+    /// <para>Note what this test does NOT do: clear the pools. The fixture used to, unconditionally, which is
+    /// why this class had four passing tests and the bug shipped anyway.</para>
+    /// </summary>
+    [Fact]
+    public void An_asset_replaced_mid_session_is_served_from_the_new_file()
+    {
+        var path = Path.Combine(_dir, "dpd-cst-subset.db");
+        BuildAssetDb(path, "dhamma");
+
+        using var provider = new ReopenableLemmaProvider(path);
+        Assert.NotNull(provider.ResolveForm("dhammaṃ"));      // pools a handle on the file as it stands now
+
+        // What DpdUpdateService.InstallFromGzip does: build beside it, then rename over the live file.
+        var replacement = path + ".new";
+        BuildAssetDb(replacement, "citta", clearPools: false);
+        File.Move(replacement, path, overwrite: true);
+
+        provider.Reopen();
+
+        Assert.NotNull(provider.ResolveForm("cittaṃ"));
+        Assert.Null(provider.ResolveForm("dhammaṃ"));
+    }
+
+    /// <summary>
+    /// A live connection on the same path cannot pin the replaced file either.
+    ///
+    /// <para>The pool was one of two things holding the old inode. <c>Cache=Shared</c> was the other, and it
+    /// works independently: a shared cache is keyed by file PATH, so while any connection holds one open, a
+    /// brand-new connection on that path joins it and reads through the surviving pager — the replaced
+    /// file's. Clearing the pool does not touch that. The connection here stands in for the ordinary case of
+    /// a GUI lookup in flight while the install completes.</para>
+    /// </summary>
+    [Fact]
+    public void A_shared_cache_connection_held_open_across_the_replacement_does_not_pin_it()
+    {
+        var path = Path.Combine(_dir, "dpd-cst-subset.db");
+        BuildAssetDb(path, "dhamma");
+
+        using var provider = new ReopenableLemmaProvider(path);
+        Assert.NotNull(provider.ResolveForm("dhammaṃ"));
+
+        using var pinned = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = path, Mode = SqliteOpenMode.ReadOnly, Cache = SqliteCacheMode.Shared,
+        }.ToString());
+        pinned.Open();
+
+        var replacement = path + ".new";
+        BuildAssetDb(replacement, "citta", clearPools: false);
+        File.Move(replacement, path, overwrite: true);
+
+        provider.Reopen();
+
+        Assert.NotNull(provider.ResolveForm("cittaṃ"));
+        Assert.Null(provider.ResolveForm("dhammaṃ"));
+    }
+
     // A minimal but VALID dpd-cst-subset asset: the tables SqliteLemmaProvider requires, plus one form→lemma
     // row so a resolve can prove the wrapper is really querying the new file.
-    private static void BuildAssetDb(string path, string lemma = "dhamma")
+    /// <param name="clearPools">Left true for setup. A test reproducing #869 must pass false: clearing every
+    /// pool is exactly what masked the bug here for a release — the pooled handle on the replaced file is the
+    /// whole mechanism, and a fixture that empties the pool tests a state the app is never in.</param>
+    private static void BuildAssetDb(string path, string lemma = "dhamma", bool clearPools = true)
     {
         using (var c = new SqliteConnection($"Data Source={path}"))
         {
@@ -102,7 +173,7 @@ public sealed class ReopenableLemmaProviderTests : IDisposable
             cmd.Parameters.AddWithValue("$form", lemma + "ṃ");   // -ṃ, an accusative singular
             cmd.ExecuteNonQuery();
         }
-        SqliteConnection.ClearAllPools();
+        if (clearPools) SqliteConnection.ClearAllPools();
     }
 
     public void Dispose()

--- a/src/CST.Avalonia.Tests/Services/ReopenableLemmaProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/ReopenableLemmaProviderTests.cs
@@ -97,7 +97,8 @@ public sealed class ReopenableLemmaProviderTests : IDisposable
     /// <para>Note what this test does NOT do: clear the pools. The fixture used to, unconditionally, which is
     /// why this class had four passing tests and the bug shipped anyway.</para>
     /// </summary>
-    [Fact]
+    [UnixFact("File.Move over an open SQLite handle throws on Windows — which is exactly why the "
+        + "installer stages a .pending file there and does not raise AssetInstalled at all")]
     public void An_asset_replaced_mid_session_is_served_from_the_new_file()
     {
         var path = Path.Combine(_dir, "dpd-cst-subset.db");
@@ -126,7 +127,8 @@ public sealed class ReopenableLemmaProviderTests : IDisposable
     /// file's. Clearing the pool does not touch that. The connection here stands in for the ordinary case of
     /// a GUI lookup in flight while the install completes.</para>
     /// </summary>
-    [Fact]
+    [UnixFact("File.Move over an open SQLite handle throws on Windows — which is exactly why the "
+        + "installer stages a .pending file there and does not raise AssetInstalled at all")]
     public void A_shared_cache_connection_held_open_across_the_replacement_does_not_pin_it()
     {
         var path = Path.Combine(_dir, "dpd-cst-subset.db");

--- a/src/CST.Avalonia.Tests/UnixFactAttribute.cs
+++ b/src/CST.Avalonia.Tests/UnixFactAttribute.cs
@@ -10,15 +10,20 @@ namespace CST.Avalonia.Tests;
 /// <c>return</c> leaves a green test that executed no assertions, which is how a platform stops being covered
 /// without anything turning red.</para>
 ///
-/// <para>Used by the tests that spawn a real shell (#817). Those cannot run on Windows, where there is no
-/// probe to test — and should not be faked there, because what they exist to check is the behaviour of an
-/// actual process and an actual pipe.</para>
+/// <para>Used by the tests that spawn a real shell (#817) — those cannot run on Windows, where there is no
+/// probe to test, and should not be faked there, because what they exist to check is the behaviour of an
+/// actual process and an actual pipe — and by the asset-replacement tests (#869), whose whole subject is a
+/// rename succeeding over open handles, which is a POSIX behaviour Windows does not have.</para>
+///
+/// <para>The reason is a parameter because those two are not the same reason, and a skip that explains the
+/// wrong one is worse than no explanation: whoever reads the skipped run has to go and find out which.</para>
 /// </summary>
 public sealed class UnixFactAttribute : FactAttribute
 {
-    public UnixFactAttribute()
+    public UnixFactAttribute(
+        string because = "there is no shell probe on Windows, which inherits its environment normally")
     {
         if (OperatingSystem.IsWindows())
-            Skip = "Unix only: there is no shell probe on Windows, which inherits its environment normally.";
+            Skip = $"Unix only: {because}.";
     }
 }

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -784,7 +784,19 @@ public partial class App : Application
         if (updates is null)
             return;
         var provider = ServiceProvider?.GetService<CST.Lemma.ILemmaProvider>();
-        BindLemmaReopen(updates, provider, ServiceProvider?.GetService<Services.ILemmaReportService>());
+
+        // Resolved here rather than left optional, and complained about when it is missing — the same
+        // loudness the provider half already gets below, and for the same reason: this and the DI
+        // registration are edited in different places, and a registration renamed away would drop the
+        // dossier invalidation silently, leaving stale reports after an asset update with nothing to say so.
+        var reports = ServiceProvider?.GetService<Services.ILemmaReportService>();
+        if (reports is null)
+            Log.Error(
+                "No ILemmaReportService is registered, so cached lemma reports will NOT be invalidated when a "
+                + "dpd asset is installed: the reader keeps seeing the superseded asset's glosses and version "
+                + "for every lemma already visited, until restart (#869).");
+
+        BindLemmaReopen(updates, provider, reports);
     }
 
     /// <summary>

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -784,7 +784,7 @@ public partial class App : Application
         if (updates is null)
             return;
         var provider = ServiceProvider?.GetService<CST.Lemma.ILemmaProvider>();
-        BindLemmaReopen(updates, provider);
+        BindLemmaReopen(updates, provider, ServiceProvider?.GetService<Services.ILemmaReportService>());
     }
 
     /// <summary>
@@ -796,7 +796,11 @@ public partial class App : Application
     /// no failing test — the asset installs, the event fires, and DPD stays dark until the next launch. (fable)</para>
     /// </summary>
     /// <returns>true when the reopen was bound; false when the registered provider cannot be reopened.</returns>
-    internal static bool BindLemmaReopen(IDpdUpdateService updates, CST.Lemma.ILemmaProvider? provider)
+    /// <param name="reports">The dossier cache, cleared alongside the reopen. Optional so the provider half
+    /// can still be tested on its own.</param>
+    internal static bool BindLemmaReopen(
+        IDpdUpdateService updates, CST.Lemma.ILemmaProvider? provider,
+        Services.ILemmaReportService? reports = null)
     {
         if (provider is not Services.ReopenableLemmaProvider reopenable)
         {
@@ -817,6 +821,14 @@ public partial class App : Application
             if (!string.Equals(id, DpdAssetId, StringComparison.OrdinalIgnoreCase))
                 return;
             reopenable.Reopen();
+
+            // A dossier is assembled from this asset's glosses and counts and stamped with its version, and
+            // up to 32 of them are held. Reopening the provider without clearing them leaves the reader
+            // looking at the superseded asset's report — footer version and all — for every lemma they had
+            // already visited, which is the same staleness #869 fixes one layer down and would have survived
+            // the fix. InvalidateCache existed for exactly this and had no callers. (#869, R13-3)
+            reports?.InvalidateCache();
+
             Log.Information("Reopened the lemma provider after the {Id} asset was installed; available={Available}",
                 id, reopenable.IsAvailable);
         };

--- a/src/CST.Avalonia/Services/LemmaReportService.cs
+++ b/src/CST.Avalonia/Services/LemmaReportService.cs
@@ -47,8 +47,17 @@ public sealed class LemmaReportService : ILemmaReportService
         if (!IsAvailable) return null;
         lock (_lock) { if (_cache.TryGet(lemmaId, out var hit) && hit is not null) return hit; }
 
+        // Which asset this is being assembled from, checked again before it is kept. Assembly awaits several
+        // corpus searches — seconds, which is the whole reason this cache exists — and an asset install
+        // landing inside that window clears the cache BEFORE this report arrives, so storing it unconditionally
+        // put a dossier built from the superseded asset back in an otherwise clean cache, version footer and
+        // all, until 32 other lemmas evicted it. The caller still gets what it asked for; it simply is not
+        // kept. (#869)
+        var builtFrom = _lemma.Meta?.DpdVersion;
+
         var report = await AssembleAsync(lemmaId, ct).ConfigureAwait(false);
-        if (report is not null) lock (_lock) _cache.Set(lemmaId, report);
+        if (report is not null && string.Equals(_lemma.Meta?.DpdVersion, builtFrom, StringComparison.Ordinal))
+            lock (_lock) _cache.Set(lemmaId, report);
         return report;
     }
 

--- a/src/CST.Avalonia/Services/ReopenableLemmaProvider.cs
+++ b/src/CST.Avalonia/Services/ReopenableLemmaProvider.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using CST.Lemma;
 
 namespace CST.Avalonia.Services;
@@ -22,16 +20,6 @@ public sealed class ReopenableLemmaProvider : ILemmaProvider
     private readonly object _gate = new();
     private ILemmaProvider _inner;
 
-    /// <summary>
-    /// Superseded inner providers, disposed only when this wrapper is.
-    ///
-    /// A caller can be mid-query on the previous instance when <see cref="Reopen"/> swaps it — every member
-    /// below reads the reference under the lock and then calls OUTSIDE it, so disposing eagerly would race a
-    /// live query into <c>ObjectDisposedException</c>. Retiring instead of disposing costs one idle SQLite
-    /// connection per reopen, and a reopen happens at most once or twice per session (an asset install).
-    /// </summary>
-    private readonly List<ILemmaProvider> _retired = new();
-
     public ReopenableLemmaProvider(string assetPath)
     {
         _assetPath = assetPath;
@@ -41,15 +29,32 @@ public sealed class ReopenableLemmaProvider : ILemmaProvider
     /// <summary>
     /// Rebuild the inner provider from the asset path — call after the asset has been installed and is live.
     /// Safe to call when the asset is still absent (the new inner is simply unavailable, as before).
+    ///
+    /// <para><b>The outgoing provider is disposed BEFORE the replacement is built, and the order is the fix.
+    /// </b> An update replaces the asset in place, which on macOS and Linux is a rename that succeeds over
+    /// open handles; the replacement provider then builds the same connection string, and Microsoft.Data.
+    /// Sqlite pools by connection string — so its first <c>Open()</c> was handed a pooled handle still bound
+    /// to the replaced file's old inode. The app logged the new asset active and went on serving the
+    /// superseded one, in lemma search and the dictionary panel alike, until the next launch. Clearing the
+    /// pool first means the replacement opens the file that is actually there. (#869)</para>
+    ///
+    /// <para>This used to retire the outgoing provider instead, holding it until the wrapper itself was
+    /// disposed, on the reasoning that a caller mid-query would meet <c>ObjectDisposedException</c>. That
+    /// does not apply to this provider: its <c>Dispose</c> only calls <c>SqliteConnection.ClearPool</c>,
+    /// which by contract leaves connections that are in use alone — they are discarded when they close
+    /// rather than returned to the pool — and the instance stays perfectly usable afterwards, merely
+    /// unpooled. So there was nothing to protect, and the protection was what kept the stale handles
+    /// alive.</para>
     /// </summary>
     public void Reopen()
     {
+        ILemmaProvider outgoing;
+        lock (_gate) outgoing = _inner;
+
+        try { outgoing.Dispose(); } catch { /* best effort — a failed pool clear must not block the swap */ }
+
         var fresh = new SqliteLemmaProvider(_assetPath);
-        lock (_gate)
-        {
-            _retired.Add(_inner);
-            _inner = fresh;
-        }
+        lock (_gate) _inner = fresh;
     }
 
     private ILemmaProvider Current
@@ -67,15 +72,8 @@ public sealed class ReopenableLemmaProvider : ILemmaProvider
 
     public void Dispose()
     {
-        List<ILemmaProvider> toDispose;
-        lock (_gate)
-        {
-            toDispose = new List<ILemmaProvider>(_retired) { _inner };
-            _retired.Clear();
-        }
-        foreach (var p in toDispose)
-        {
-            try { p.Dispose(); } catch { /* best effort — teardown */ }
-        }
+        ILemmaProvider inner;
+        lock (_gate) inner = _inner;
+        try { inner.Dispose(); } catch { /* best effort — teardown */ }
     }
 }

--- a/src/CST.Lemma/SqliteLemmaProvider.cs
+++ b/src/CST.Lemma/SqliteLemmaProvider.cs
@@ -22,11 +22,17 @@ public sealed class SqliteLemmaProvider : ILemmaProvider
         if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath))
             return; // IsAvailable stays false
 
+        // No Cache=Shared. A shared cache is keyed by FILE PATH, so after the delivery layer replaces this
+        // asset in place (File.Move over the live file — a POSIX rename, which succeeds over open handles),
+        // a brand-new connection opened on the same path attaches to the surviving shared pager, which is
+        // still bound to the replaced file's old inode. That pinned the superseded DPD data independently of
+        // the connection pool, and no amount of reopening shook it loose before a restart. It bought nothing
+        // here either: connections are short-lived and read-only, and shared cache adds cross-connection
+        // table locking between the GUI and the API for the privilege. (#869)
         var connString = new SqliteConnectionStringBuilder
         {
             DataSource = assetPath,
             Mode = SqliteOpenMode.ReadOnly,
-            Cache = SqliteCacheMode.Shared,
             Pooling = true,
         }.ToString();
 


### PR DESCRIPTION
Fixes #869.

On macOS and Linux an in-place asset update is a `File.Move(overwrite: true)` — a POSIX rename, which silently succeeds over open handles. **Two separate things** then went on pointing at the replaced file's old inode, and the app logged the new asset active while answering from the superseded one, in lemma search and the dictionary panel alike, until the next launch.

### 1. The pool — `Reopen` now disposes the outgoing provider *first*

Microsoft.Data.Sqlite pools by connection string, and the replacement provider builds the *same* string, so its very first `Open()` was handed a pooled handle on the old inode. Clearing the pool before constructing the replacement means it opens the file that is actually there.

The retire-don't-dispose this replaces was guarding an `ObjectDisposedException` that cannot happen here: `SqliteLemmaProvider.Dispose` only calls `SqliteConnection.ClearPool`, which by contract leaves in-use connections alone — they are discarded when they close rather than returned — and the instance stays perfectly usable afterwards, merely unpooled. There was nothing to protect, and the protection was what kept the stale handles alive. With nothing retired, the `_retired` list goes with it.

### 2. The shared cache — `Cache=Shared` dropped

A shared cache is keyed by file **path**, so while any connection holds one open, a brand-new connection on that path joins it and reads through the surviving pager. That pinned the old data *independently* of the pool — clearing the pool does not touch it — and the two tests below prove them apart. It bought nothing here either: connections are short-lived and read-only, and shared cache adds cross-connection table locking between the GUI and the API for the privilege.

This is what `LexiconReader` already documents and avoids (`Pooling=false`, *"pooled handle pointing at the unlinked old inode"*), which is why DPPN never had this bug.

### 3. `InvalidateCache`, folded in per the issue (R13-3)

It had **no callers anywhere in the tree**, so up to 32 assembled dossiers kept serving the old asset's glosses, corpus counts and `DpdVersion` footer for every lemma the reader had already visited — the same staleness one layer up, and it would have survived the fix below it untouched. Now called from the same `AssetInstalled` handler, for the dpd asset only.

### Why the tests did not catch it

`ReopenableLemmaProviderTests`' fixture called `SqliteConnection.ClearAllPools()` unconditionally — precisely the state the app is never in. Four tests passed and the bug shipped. The clear is now opt-out and the new tests pass `false`.

### Tests

Three added, each mutation-checked — and the two mechanisms discriminate **independently**:

| mutation | fails |
|---|---|
| `Reopen` doesn't dispose the outgoing provider | both replacement tests |
| put `Cache=Shared` back | only `A_shared_cache_connection_held_open_…` |
| drop the `InvalidateCache` call | only the report-cache test |

`An_asset_replaced_mid_session_is_served_from_the_new_file` does the real sequence: resolve a form (pooling a handle), build the replacement beside it, `File.Move` over the live file, `Reopen`, then assert the new form resolves **and the old one no longer does**.

Full suite: **2640 passed, 0 failed, 17 skipped**.

Windows is unaffected either way — the move throws there and takes the staged `.pending` path, which deliberately does not fire `AssetInstalled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)