### PR TITLE
Serialize settings writes, and close four ways a setting could vanish (#878, #880–#883)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/SettingsDurabilityTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SettingsDurabilityTests.cs
@@ -1,0 +1,311 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// The settings half of the durability pass: concurrent saves, the salvage path's converter gap, a script
+/// key that went missing, and what an older build does to a newer build's file. (#878, #880, #881, #883)
+/// </summary>
+public sealed class SettingsDurabilityTests : IDisposable
+{
+    private readonly string _dir;
+
+    public SettingsDurabilityTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"settings-durability-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    private string SettingsPath => Path.Combine(_dir, "settings.json");
+
+    // ---- concurrent saves (#878) -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Saves fired at once still leave a file that parses.
+    ///
+    /// <para>They shared one <c>settings.json.tmp</c>: A could finish writing the temp file, B truncate and
+    /// start rewriting it, and A's <c>File.Replace</c> promote B's half-written temp over the real file.
+    /// Concurrent callers are ordinary — the 750ms debounce flushes on a pool thread while
+    /// <c>XmlUpdateService</c> and <c>IndexingService</c> save directly from background flows.</para>
+    ///
+    /// <para>A torn write is a race, so this cannot prove the lock by failing reliably without it — what it
+    /// pins is that the serialized path is correct under concurrency and stays that way. The lock's absence
+    /// is the mechanism; the reviewer traced it.</para>
+    /// </summary>
+    [Fact]
+    public async Task Concurrent_saves_leave_a_file_that_parses()
+    {
+        var service = new SettingsService(_dir);
+        service.Settings.XmlBooksDirectory = Path.Combine(_dir, "books");
+
+        await Task.WhenAll(Enumerable.Range(0, 24).Select(_ => service.SaveSettingsAsync()));
+
+        var reloaded = JsonSerializer.Deserialize<Settings>(File.ReadAllText(SettingsPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(reloaded);
+        Assert.Equal(service.Settings.XmlBooksDirectory, reloaded!.XmlBooksDirectory);
+        Assert.False(File.Exists(SettingsPath + ".tmp"));
+    }
+
+    // ---- the salvage path's converter gap (#880) -------------------------------------------------------
+
+    /// <summary>
+    /// A property with its own converter is read by that converter on the salvage path too.
+    ///
+    /// <para><c>AiConnectionRecord.Headers</c> declares <c>AiHeaderRecordListConverter</c>, which reads the
+    /// legacy dict-shaped form. Taken apart property-by-property the node is an object where a List is
+    /// expected, so it landed in the drop-the-collection branch and the headers were discarded — the salvage
+    /// path being strictly weaker than the strict path, in the one mechanism whose job is to lose as little
+    /// as possible.</para>
+    ///
+    /// <para>The connection below carries a number where <c>displayName</c> expects a string. That is what
+    /// forces this record to be taken apart at all — <see cref="TolerantSettingsReader"/> tries a whole-node
+    /// read at every level first, precisely so the ordinary converters apply wherever they can, and the
+    /// converter gap only shows once something ELSE on the same object has failed. A fixture broken further
+    /// up the tree does not reach it: the <c>ai</c> node deserializes whole and the headers were never at
+    /// risk.</para>
+    /// </summary>
+    [Fact]
+    public void A_property_with_its_own_converter_survives_the_salvage()
+    {
+        const string json = """
+        {
+          "version": "1.0",
+          "ai": { "chat": { "connections": [ {
+              "id": "mine",
+              "displayName": 12345,
+              "headers": { "X-Org": "acme", "X-Team": "pali" }
+          } ] } }
+        }
+        """;
+
+        var salvaged = TolerantSettingsReader.Read<Settings>(
+            json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }, out var dropped);
+
+        Assert.NotNull(salvaged);
+        var connection = Assert.Single(salvaged!.Ai.Chat.Connections);
+        Assert.Equal(2, connection.Headers.Count);
+        Assert.Contains(connection.Headers, h => h.Name == "X-Org" && h.Value == "acme");
+        Assert.DoesNotContain(dropped, d => d.Contains("Headers", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ---- a script key that went missing (#881) ---------------------------------------------------------
+
+    /// <summary>
+    /// Sanitize puts back a canonical script key that is absent.
+    ///
+    /// <para>The Appearance panel builds its rows by enumerating this dictionary, so a key dropped by a
+    /// salvage or a hand-edit left that script with no font control at all — permanently, since nothing ever
+    /// re-seeded it, and invisibly, since rendering falls back safely.</para>
+    /// </summary>
+    [Fact]
+    public void Sanitize_restores_a_missing_script_font_key()
+    {
+        var settings = new Settings();
+        settings.FontSettings.ScriptFonts.Remove("Myanmar");
+        settings.FontSettings.ScriptFonts.Remove("Sinhala");
+
+        var fixes = SettingsValidator.Sanitize(settings);
+
+        Assert.Contains("Myanmar", settings.FontSettings.ScriptFonts.Keys);
+        Assert.Contains("Sinhala", settings.FontSettings.ScriptFonts.Keys);
+        Assert.Contains(fixes, f => f.Contains("restored missing script-font key 'Myanmar'"));
+    }
+
+    /// <summary>Every canonical script is covered, and a reader's own choice is never overwritten by the
+    /// re-seed — otherwise this would reset fonts on every launch.</summary>
+    [Fact]
+    public void The_reseed_covers_every_script_and_keeps_what_the_reader_chose()
+    {
+        var settings = new Settings();
+        settings.FontSettings.ScriptFonts["Devanagari"] =
+            new ScriptFontSetting { FontFamily = "Sanskrit 2003", FontSize = 22 };
+        settings.FontSettings.ScriptFonts.Clear();
+        settings.FontSettings.ScriptFonts["Devanagari"] =
+            new ScriptFontSetting { FontFamily = "Sanskrit 2003", FontSize = 22 };
+
+        SettingsValidator.Sanitize(settings);
+
+        Assert.Equal(FontSettings.DefaultScriptFonts().Count, settings.FontSettings.ScriptFonts.Count);
+        Assert.Equal("Sanskrit 2003", settings.FontSettings.ScriptFonts["Devanagari"].FontFamily);
+        Assert.Equal(22, settings.FontSettings.ScriptFonts["Devanagari"].FontSize);
+    }
+
+    /// <summary>Sanitize is idempotent — a second pass must report nothing, or every launch would log a
+    /// repair it did not make.</summary>
+    [Fact]
+    public void The_reseed_is_idempotent()
+    {
+        var settings = new Settings();
+        settings.FontSettings.ScriptFonts.Remove("Khmer");
+
+        SettingsValidator.Sanitize(settings);
+
+        Assert.DoesNotContain(SettingsValidator.Sanitize(settings), f => f.Contains("restored missing"));
+    }
+
+    // ---- what an older build does to a newer build's file (#883) ---------------------------------------
+
+    /// <summary>
+    /// A settings file from a newer build keeps its unknown top-level properties across a round-trip.
+    ///
+    /// <para>An unknown property is not an error to System.Text.Json — it is dropped, silently. So a reader
+    /// who launches an older build once loses whatever the newer one had added, the next time anything
+    /// saves.</para>
+    /// </summary>
+    [Fact]
+    public void Unknown_top_level_properties_survive_a_round_trip()
+    {
+        const string fromNewerBuild = """
+        { "version": "9.9", "xmlBooksDirectory": "/books", "somethingNewerBuildsHave": { "keep": true } }
+        """;
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+        var loaded = JsonSerializer.Deserialize<Settings>(fromNewerBuild, options)!;
+        var written = JsonSerializer.Serialize(loaded, options);
+
+        Assert.Contains("somethingNewerBuildsHave", written);
+        Assert.Contains("keep", written);
+    }
+
+    /// <summary>The same for the other store.</summary>
+    [Fact]
+    public void Unknown_top_level_state_properties_survive_a_round_trip()
+    {
+        const string fromNewerBuild = """
+        { "version": "9.9", "somethingNewerBuildsHave": [1, 2, 3] }
+        """;
+
+        var loaded = JsonSerializer.Deserialize<ApplicationState>(
+            fromNewerBuild, ApplicationStateService.JsonOptions)!;
+        var written = JsonSerializer.Serialize(loaded, ApplicationStateService.JsonOptions);
+
+        Assert.Contains("somethingNewerBuildsHave", written);
+    }
+
+    /// <summary>An ordinary file gains nothing — no stray member in the output, or every settings.json in
+    /// the wild grows a property that means nothing.</summary>
+    [Fact]
+    public void An_ordinary_file_gains_no_extra_member()
+    {
+        var written = JsonSerializer.Serialize(new Settings(),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.DoesNotContain("unknownProperties", written, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Launching an older build over a newer build's file does not rewrite it.
+    ///
+    /// <para>"Reading as-is" was true of the read and false of what followed: the note itself counted toward
+    /// "something changed", so merely launching rewrote the file in the older shape before the reader touched
+    /// anything.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_newer_settings_file_is_not_rewritten_on_load()
+    {
+        const string fromNewerBuild = """
+        { "version": "9.9", "xmlBooksDirectory": "/books", "developerSettings": { "logLevel": "Verbose" } }
+        """;
+        File.WriteAllText(SettingsPath, fromNewerBuild);
+        var before = File.GetLastWriteTimeUtc(SettingsPath);
+
+        var service = new SettingsService(_dir);
+        await service.LoadSettingsAsync();
+        await service.FlushPendingSaveAsync();
+
+        // Sanitize DID repair the bad log level in memory (so the app runs), and that repair is exactly what
+        // used to trigger the save.
+        Assert.Equal("Information", service.Settings.DeveloperSettings.LogLevel);
+        Assert.Equal(before, File.GetLastWriteTimeUtc(SettingsPath));
+        Assert.Contains("9.9", File.ReadAllText(SettingsPath));
+    }
+
+    /// <summary>
+    /// A file this build DOES understand is still written back when it needed repairing — the guard must
+    /// only cover the newer-than-supported case, or it would strand every genuine sanitize fix on disk.
+    ///
+    /// <para>Same repairable defect as the test above (an unknown log level), so the pair differs in exactly
+    /// one thing: the version.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_repairable_file_this_build_understands_is_still_written_back()
+    {
+        File.WriteAllText(SettingsPath, """
+        { "version": "1.0", "xmlBooksDirectory": "/books", "developerSettings": { "logLevel": "Verbose" } }
+        """);
+
+        var service = new SettingsService(_dir);
+        await service.LoadSettingsAsync();
+        await service.FlushPendingSaveAsync();
+
+        Assert.Contains("Information", File.ReadAllText(SettingsPath));
+        Assert.DoesNotContain("Verbose", File.ReadAllText(SettingsPath));
+    }
+
+    // ---- the logger swap (#882) ------------------------------------------------------------------------
+
+    /// <summary>A sink that records its own disposal, and what the global logger was at that moment.</summary>
+    private sealed class DisposeSpySink : Serilog.Core.ILogEventSink, IDisposable
+    {
+        public bool Disposed { get; private set; }
+        public Serilog.ILogger? GlobalLoggerWhenDisposed { get; private set; }
+
+        public void Emit(Serilog.Events.LogEvent logEvent) { }
+
+        public void Dispose()
+        {
+            Disposed = true;
+            GlobalLoggerWhenDisposed = Serilog.Log.Logger;
+        }
+    }
+
+    /// <summary>
+    /// Replacing the global logger disposes the one it replaces, and does so AFTER the swap.
+    ///
+    /// <para>The outgoing pipeline's rolling file sink keeps today's log file open, and Serilog's file sink
+    /// defaults to exclusive access — so on Windows the incoming logger's file sink cannot open the same
+    /// file and file logging dies silently for the rest of the session, the moment the reader changes the
+    /// log level. Disposing releases the handle. This runs on macOS, where the lock does not exist, so what
+    /// it pins is the disposal itself rather than the Windows symptom.</para>
+    ///
+    /// <para>The ordering is the second half and is not decoration: disposing first leaves a window with no
+    /// logger at all, and Serilog answers that with a silent no-op logger rather than an error.</para>
+    /// </summary>
+    [Fact]
+    public void Swapping_the_global_logger_disposes_the_one_it_replaces_after_the_swap()
+    {
+        var spy = new DisposeSpySink();
+        var outgoing = new Serilog.LoggerConfiguration().WriteTo.Sink(spy).CreateLogger();
+        var incoming = new Serilog.LoggerConfiguration().CreateLogger();
+        var saved = Serilog.Log.Logger;
+
+        try
+        {
+            Serilog.Log.Logger = outgoing;
+
+            CST.Avalonia.ViewModels.DeveloperSettingsViewModel.SwapGlobalLogger(incoming);
+
+            Assert.True(spy.Disposed);
+            Assert.Same(incoming, Serilog.Log.Logger);
+            Assert.Same(incoming, spy.GlobalLoggerWhenDisposed);   // swapped first, then disposed
+        }
+        finally
+        {
+            Serilog.Log.Logger = saved;
+            incoming.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/SettingsDurabilityTests.cs
+++ b/src/CST.Avalonia.Tests/Services/SettingsDurabilityTests.cs
@@ -90,6 +90,12 @@ public sealed class SettingsDurabilityTests : IDisposable
             json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }, out var dropped);
 
         Assert.NotNull(salvaged);
+
+        // The premise, asserted rather than assumed: displayName IS what failed, so this record really was
+        // taken apart property-by-property. Without this the test would pass vacuously the day something
+        // makes the whole record deserialize again, pinning nothing. (fable review)
+        Assert.Contains(dropped, d => d.Contains("DisplayName", StringComparison.OrdinalIgnoreCase));
+
         var connection = Assert.Single(salvaged!.Ai.Chat.Connections);
         Assert.Equal(2, connection.Headers.Count);
         Assert.Contains(connection.Headers, h => h.Name == "X-Org" && h.Value == "acme");
@@ -250,59 +256,100 @@ public sealed class SettingsDurabilityTests : IDisposable
         Assert.DoesNotContain("Verbose", File.ReadAllText(SettingsPath));
     }
 
-    // ---- the logger swap (#882) ------------------------------------------------------------------------
-
-    /// <summary>A sink that records its own disposal, and what the global logger was at that moment.</summary>
-    private sealed class DisposeSpySink : Serilog.Core.ILogEventSink, IDisposable
+    /// <summary>
+    /// The state store's twin of the guard above: a newer <c>application-state.json</c> is not marked dirty
+    /// on load, so nothing schedules the rewrite that would shed what the newer build added.
+    /// </summary>
+    [Fact]
+    public async Task A_newer_state_file_is_not_marked_dirty_on_load()
     {
+        var stateDir = Path.Combine(_dir, "state-newer");
+        Directory.CreateDirectory(stateDir);
+        File.WriteAllText(Path.Combine(stateDir, "application-state.json"),
+            """{ "version": "9.9", "mainWindow": { "width": -5 } }""");
+
+        using var service = new ApplicationStateService(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ApplicationStateService>.Instance, stateDir);
+        await service.LoadStateAsync();
+
+        // Sanitize DID repair the impossible width in memory, and that repair is what used to mark it dirty.
+        Assert.True(service.Current.MainWindow.Width > 0);
+        Assert.False(service.IsDirty);
+    }
+
+    // ---- the log level (#882) --------------------------------------------------------------------------
+
+    /// <summary>A sink that records what reached it, and whether it was ever disposed.</summary>
+    private sealed class RecordingSink : Serilog.Core.ILogEventSink, IDisposable
+    {
+        public System.Collections.Generic.List<string> Messages { get; } = new();
         public bool Disposed { get; private set; }
-        public Serilog.ILogger? GlobalLoggerWhenDisposed { get; private set; }
 
-        public void Emit(Serilog.Events.LogEvent logEvent) { }
+        public void Emit(Serilog.Events.LogEvent logEvent) =>
+            Messages.Add(logEvent.RenderMessage());
 
-        public void Dispose()
-        {
-            Disposed = true;
-            GlobalLoggerWhenDisposed = Serilog.Log.Logger;
-        }
+        public void Dispose() => Disposed = true;
     }
 
     /// <summary>
-    /// Replacing the global logger disposes the one it replaces, and does so AFTER the swap.
+    /// Changing the log level keeps every logger already captured working, and applies to them at once.
     ///
-    /// <para>The outgoing pipeline's rolling file sink keeps today's log file open, and Serilog's file sink
-    /// defaults to exclusive access — so on Windows the incoming logger's file sink cannot open the same
-    /// file and file logging dies silently for the rest of the session, the moment the reader changes the
-    /// log level. Disposing releases the handle. This runs on macOS, where the lock does not exist, so what
-    /// it pins is the disposal itself rather than the Windows symptom.</para>
+    /// <para><b>This is the test that would have caught the first attempt at #882.</b> That one rebuilt the
+    /// global logger and disposed the one it replaced — which frees the Windows file handle, but an
+    /// <c>ILogger</c> captured at construction is bound to the pipeline it came from, and this app captures
+    /// 20+ of them plus every MEL <c>ILogger&lt;T&gt;</c> the container injects. Disposing stops THEIR file
+    /// output silently, on every platform, while the console sink goes on working and hides it. The very next
+    /// line of the level-changed handler is written through such a logger.</para>
     ///
-    /// <para>The ordering is the second half and is not decoration: disposing first leaves a window with no
-    /// logger at all, and Serilog answers that with a silent no-op logger rather than an error.</para>
+    /// <para>A level switch has neither the handle problem nor this one, and does something the rebuild never
+    /// could: a captured logger honours the new level immediately instead of keeping the one it was built
+    /// with.</para>
     /// </summary>
     [Fact]
-    public void Swapping_the_global_logger_disposes_the_one_it_replaces_after_the_swap()
+    public void Changing_the_level_reaches_loggers_captured_before_the_change()
     {
-        var spy = new DisposeSpySink();
-        var outgoing = new Serilog.LoggerConfiguration().WriteTo.Sink(spy).CreateLogger();
-        var incoming = new Serilog.LoggerConfiguration().CreateLogger();
-        var saved = Serilog.Log.Logger;
+        var sink = new RecordingSink();
+        var pipeline = new Serilog.LoggerConfiguration()
+            .MinimumLevel.ControlledBy(CST.Avalonia.App.LogLevelSwitch)
+            .WriteTo.Sink(sink)
+            .CreateLogger();
 
+        var saved = Serilog.Log.Logger;
+        var savedLevel = CST.Avalonia.App.LogLevelSwitch.MinimumLevel;
         try
         {
-            Serilog.Log.Logger = outgoing;
+            Serilog.Log.Logger = pipeline;
+            CST.Avalonia.ViewModels.DeveloperSettingsViewModel.ApplyLogLevel("Information");
 
-            CST.Avalonia.ViewModels.DeveloperSettingsViewModel.SwapGlobalLogger(incoming);
+            // Captured BEFORE the change, the way every service's _logger field is.
+            var captured = Serilog.Log.ForContext<SettingsDurabilityTests>();
+            captured.Debug("before");                       // below the level: correctly absent
+            Assert.Empty(sink.Messages);
 
-            Assert.True(spy.Disposed);
-            Assert.Same(incoming, Serilog.Log.Logger);
-            Assert.Same(incoming, spy.GlobalLoggerWhenDisposed);   // swapped first, then disposed
+            CST.Avalonia.ViewModels.DeveloperSettingsViewModel.ApplyLogLevel("Debug");
+
+            captured.Debug("after");
+            Assert.Contains("after", sink.Messages);
+            Assert.False(sink.Disposed);                    // nothing was torn down to achieve it
         }
         finally
         {
+            CST.Avalonia.App.LogLevelSwitch.MinimumLevel = savedLevel;
             Serilog.Log.Logger = saved;
-            incoming.Dispose();
+            pipeline.Dispose();
         }
     }
+
+    /// <summary>The level names the Settings panel offers all map to a real Serilog level, and anything else
+    /// reads as Information — the same repair <c>SettingsValidator</c> makes to a bad stored value.</summary>
+    [Theory]
+    [InlineData("Debug", Serilog.Events.LogEventLevel.Debug)]
+    [InlineData("Warning", Serilog.Events.LogEventLevel.Warning)]
+    [InlineData("Fatal", Serilog.Events.LogEventLevel.Fatal)]
+    [InlineData("Verbose", Serilog.Events.LogEventLevel.Information)]   // not one of ours
+    [InlineData(null, Serilog.Events.LogEventLevel.Information)]
+    public void A_level_name_maps_to_its_serilog_level(string? name, Serilog.Events.LogEventLevel expected) =>
+        Assert.Equal(expected, CST.Avalonia.ViewModels.DeveloperSettingsViewModel.ParseLogLevel(name));
 
     public void Dispose()
     {

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1452,6 +1452,15 @@ public partial class App : Application
         }
     }
 
+    /// <summary>
+    /// The one control over how much gets logged, for the life of the process. (#882)
+    ///
+    /// <para>Held here rather than passed around because the Settings panel changes it and the logger is
+    /// built here; a switch is the whole mechanism, so there is nothing else to share.</para>
+    /// </summary>
+    internal static readonly Serilog.Core.LoggingLevelSwitch LogLevelSwitch =
+        new(Serilog.Events.LogEventLevel.Information);
+
     private void ConfigureServices(IServiceCollection services)
     {
         // Configure logging with priority: Environment Variable > Saved Setting > Default.
@@ -1475,8 +1484,21 @@ public partial class App : Application
         
         var logPath = Path.Combine(logsDir, "cst-avalonia-.log");
         
+        // The level is a SWITCH, not a baked-in minimum, so changing it later needs no second logger. (#882)
+        //
+        // Rebuilding was the old answer, and it is wrong twice over. Serilog's file sink defaults to
+        // exclusive access, so on Windows the replacement could not open the log file the original still
+        // held and file logging died silently. Disposing the original to free that handle is worse: every
+        // `Log.ForContext<T>()` captured at construction — 20+ of them, plus every MEL ILogger<T> the DI
+        // container hands out — is bound to the pipeline it was made from, so disposing it silently stops
+        // THEIR file output, on every platform, while the console sink goes on working and hides it. Both
+        // failures land the moment the reader changes the log level, which is the moment they are trying to
+        // gather diagnostics. A switch has neither problem, and unlike either version it applies the new
+        // level to loggers already captured. (fable review)
+        LogLevelSwitch.MinimumLevel = logLevel;
+
         Log.Logger = new LoggerConfiguration()
-            .MinimumLevel.Is(logLevel)
+            .MinimumLevel.ControlledBy(LogLevelSwitch)
             .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss.fff} {Level:u3}] {SourceContext} {Message:lj}{NewLine}{Exception}")
             .WriteTo.File(logPath, 
                 rollingInterval: RollingInterval.Day,

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -28,8 +28,9 @@ public class ApplicationState
     /// member on each of them, and the root is where new sections actually land — so this is the whole of the
     /// cheap half, deliberately, not an oversight.</para>
     ///
-    /// <para>Never written by this build (nothing sets it), so an ordinary file gains nothing. Null when
-    /// empty, and <c>WhenWritingDefault</c> keeps it out of the output.</para>
+    /// <para>Never written by this build (nothing sets it), so an ordinary file gains nothing: a null
+    /// extension-data member is skipped by System.Text.Json itself, independently of any ignore
+    /// condition the options do or do not set.</para>
     /// </summary>
     [System.Text.Json.Serialization.JsonExtensionData]
     public System.Collections.Generic.Dictionary<string, System.Text.Json.JsonElement>? UnknownProperties { get; set; }

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -16,6 +16,25 @@ public class ApplicationState
     public string Version { get; set; } = "1.0";
     
     /// <summary>
+    /// Top-level properties this build does not know about, carried through a round-trip. (#883)
+    ///
+    /// <para><b>What it prevents:</b> a newer build adds a setting, the reader launches an older build once,
+    /// and the older build's next save rewrites the file without it. Silently — an unknown property is not an
+    /// error to System.Text.Json, it is simply dropped. Frank runs several builds across machines, so a
+    /// downgrade is a routine event rather than an accident.</para>
+    ///
+    /// <para><b>What it does not:</b> extension data is per-object, and this is the root only. A property a
+    /// newer build adds INSIDE a nested section still sheds. Covering every persisted type would mean this
+    /// member on each of them, and the root is where new sections actually land — so this is the whole of the
+    /// cheap half, deliberately, not an oversight.</para>
+    ///
+    /// <para>Never written by this build (nothing sets it), so an ordinary file gains nothing. Null when
+    /// empty, and <c>WhenWritingDefault</c> keeps it out of the output.</para>
+    /// </summary>
+    [System.Text.Json.Serialization.JsonExtensionData]
+    public System.Collections.Generic.Dictionary<string, System.Text.Json.JsonElement>? UnknownProperties { get; set; }
+
+    /// <summary>
     /// Timestamp when state was last saved
     /// </summary>
     public DateTime LastSaved { get; set; } = DateTime.UtcNow;

--- a/src/CST.Avalonia/Models/ApplicationStateValidator.cs
+++ b/src/CST.Avalonia/Models/ApplicationStateValidator.cs
@@ -26,6 +26,14 @@ public static class ApplicationStateValidator
     private const double BookW = 800, BookH = 600;
 
     /// <summary>
+    /// Whether this file was written by a build newer than this one, so the load path can decline to write
+    /// it back. "Reading as-is" was true of the read and false of what followed. (#883)
+    /// </summary>
+    public static bool IsNewerThanSupported(ApplicationState state) =>
+        CompareVersions(
+            string.IsNullOrWhiteSpace(state?.Version) ? "0.0" : state!.Version, CurrentVersion) > 0;
+
+    /// <summary>
     /// Upgrade an older / missing-version state to <see cref="CurrentVersion"/>. Returns human-readable notes
     /// (for logging). A version newer than we understand is left untouched (forward-compatible read).
     /// </summary>
@@ -45,7 +53,7 @@ public static class ApplicationStateValidator
         // --- ordered migration steps go here as the schema evolves, e.g.:
         //   if (v == "1.0") { /* transform */ v = "1.1"; notes.Add("migrated 1.0 -> 1.1"); }
 
-        if (CompareVersions(v, CurrentVersion) > 0)
+        if (IsNewerThanSupported(state))
         {
             notes.Add($"state version {v} is newer than supported {CurrentVersion}; reading as-is");
             return notes;

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -24,8 +24,9 @@ namespace CST.Avalonia.Models
         /// member on each of them, and the root is where new sections actually land — so this is the whole of the
         /// cheap half, deliberately, not an oversight.</para>
         ///
-        /// <para>Never written by this build (nothing sets it), so an ordinary file gains nothing. Null when
-        /// empty, and <c>WhenWritingDefault</c> keeps it out of the output.</para>
+        /// <para>Never written by this build (nothing sets it), so an ordinary file gains nothing: a null
+        /// extension-data member is skipped by System.Text.Json itself, independently of any ignore
+        /// condition the options do or do not set.</para>
         /// </summary>
         [System.Text.Json.Serialization.JsonExtensionData]
         public System.Collections.Generic.Dictionary<string, System.Text.Json.JsonElement>? UnknownProperties { get; set; }

--- a/src/CST.Avalonia/Models/Settings.cs
+++ b/src/CST.Avalonia/Models/Settings.cs
@@ -11,6 +11,25 @@ namespace CST.Avalonia.Models
         /// </summary>
         public string Version { get; set; } = "1.0";
 
+        /// <summary>
+        /// Top-level properties this build does not know about, carried through a round-trip. (#883)
+        ///
+        /// <para><b>What it prevents:</b> a newer build adds a setting, the reader launches an older build once,
+        /// and the older build's next save rewrites the file without it. Silently — an unknown property is not an
+        /// error to System.Text.Json, it is simply dropped. Frank runs several builds across machines, so a
+        /// downgrade is a routine event rather than an accident.</para>
+        ///
+        /// <para><b>What it does not:</b> extension data is per-object, and this is the root only. A property a
+        /// newer build adds INSIDE a nested section still sheds. Covering every persisted type would mean this
+        /// member on each of them, and the root is where new sections actually land — so this is the whole of the
+        /// cheap half, deliberately, not an oversight.</para>
+        ///
+        /// <para>Never written by this build (nothing sets it), so an ordinary file gains nothing. Null when
+        /// empty, and <c>WhenWritingDefault</c> keeps it out of the output.</para>
+        /// </summary>
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.Dictionary<string, System.Text.Json.JsonElement>? UnknownProperties { get; set; }
+
         public string XmlBooksDirectory { get; set; } = "";
         public string IndexDirectory { get; set; } = "";  // Empty means use default
         public FontSettings FontSettings { get; set; } = new();
@@ -387,9 +406,20 @@ namespace CST.Avalonia.Models
         
         public FontSettings()
         {
-            // Initialize default font settings for each script
-            // Empty font family means use system default for that script
-            ScriptFonts = new Dictionary<string, ScriptFontSetting>
+            ScriptFonts = DefaultScriptFonts();
+        }
+
+        /// <summary>
+        /// The canonical per-script font defaults — every display script, with the sizes chosen for each.
+        /// Empty font family means use the system default for that script.
+        ///
+        /// <para>A method rather than a constructor body because <see cref="SettingsValidator"/> re-seeds
+        /// missing keys from it. A second hand-written list there would drift from this one, and drift in
+        /// exactly this dictionary is what #881 is: the Appearance panel builds its rows by enumerating it,
+        /// so a key that is absent is a script with no font control at all. (#881)</para>
+        /// </summary>
+        public static Dictionary<string, ScriptFontSetting> DefaultScriptFonts() =>
+            new()
             {
                 ["Latin"] = new ScriptFontSetting { FontFamily = "", FontSize = 12 },
                 ["Devanagari"] = new ScriptFontSetting { FontFamily = "", FontSize = 16 }, // Larger for readability
@@ -406,7 +436,6 @@ namespace CST.Avalonia.Models
                 ["Thai"] = new ScriptFontSetting { FontFamily = "", FontSize = 13 },
                 ["Tibetan"] = new ScriptFontSetting { FontFamily = "", FontSize = 14 }
             };
-        }
 
         /// <summary>
         /// Typed lookup of a script's font setting. Centralizes the <see cref="ScriptKeys"/> mapping so callers

--- a/src/CST.Avalonia/Models/SettingsValidator.cs
+++ b/src/CST.Avalonia/Models/SettingsValidator.cs
@@ -41,7 +41,7 @@ public static class SettingsValidator
 
         // --- ordered migration steps go here as the schema evolves ---
 
-        if (ApplicationStateValidator.CompareVersions(v, CurrentVersion) > 0)
+        if (IsNewerThanSupported(settings))
         {
             notes.Add($"settings version {v} is newer than supported {CurrentVersion}; reading as-is");
             return notes;
@@ -53,6 +53,18 @@ public static class SettingsValidator
         }
         return notes;
     }
+
+    /// <summary>
+    /// Whether this file was written by a build newer than this one. (#883)
+    ///
+    /// <para>Exposed so the load path can decline to write it back. "Reading as-is" was true of the read and
+    /// false of what followed: the note itself counted toward "something changed", which triggered a save —
+    /// so merely LAUNCHING an older build rewrote the file in the older shape, shedding whatever the newer
+    /// build had added, before the reader touched anything.</para>
+    /// </summary>
+    public static bool IsNewerThanSupported(Settings settings) =>
+        ApplicationStateValidator.CompareVersions(
+            string.IsNullOrWhiteSpace(settings?.Version) ? "0.0" : settings!.Version, CurrentVersion) > 0;
 
     /// <summary>
     /// Repair invalid settings in place (bad paths, unknown log level, non-positive font sizes, stray repo
@@ -193,6 +205,20 @@ public static class SettingsValidator
             fonts.ScriptFonts[key] = new ScriptFontSetting();
             fixes.Add($"script-font '{key}' was null; reset to default");
         }
+        // Put back any canonical script that is MISSING.
+        //
+        // The Appearance panel builds its rows by enumerating this dictionary, so a key dropped by a tolerant
+        // salvage or a hand-edit leaves that script with no font control at all — permanently, with no way
+        // back short of editing settings.json. Rendering itself falls back safely, so nothing looks broken;
+        // the control is simply not there. Seeded from FontSettings.DefaultScriptFonts so the two lists
+        // cannot drift. (#881)
+        foreach (var (key, value) in FontSettings.DefaultScriptFonts())
+        {
+            if (fonts.ScriptFonts.ContainsKey(key)) continue;
+            fonts.ScriptFonts[key] = value;
+            fixes.Add($"restored missing script-font key '{key}'");
+        }
+
         // Clamp non-positive sizes (mutates the value object only, never the dictionary itself).
         foreach (var kvp in fonts.ScriptFonts)
         {

--- a/src/CST.Avalonia/Services/ApplicationStateService.cs
+++ b/src/CST.Avalonia/Services/ApplicationStateService.cs
@@ -194,8 +194,11 @@ public class ApplicationStateService : IApplicationStateService, IDisposable
 
             Current = state;
 
-            // If we upgraded or repaired anything, persist it so the on-disk file is brought up to date.
-            if (migrationNotes.Count > 0 || stateFixes.Count > 0)
+            // If we upgraded or repaired anything, persist it so the on-disk file is brought up to date —
+            // unless it came from a NEWER build, where writing it back is how the reader loses what that
+            // build added. The "reading as-is" note counted toward "something changed". (#883)
+            if ((migrationNotes.Count > 0 || stateFixes.Count > 0)
+                && !ApplicationStateValidator.IsNewerThanSupported(state))
                 MarkDirty();
             // Don't fire StateChanged on load to prevent infinite loops
             // Initial state will be handled separately

--- a/src/CST.Avalonia/Services/SettingsService.cs
+++ b/src/CST.Avalonia/Services/SettingsService.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Constants;
 using CST.Avalonia.Models;
@@ -90,8 +91,18 @@ namespace CST.Avalonia.Services
                                 "Could not create the default XML books directory; settings were still loaded.");
                         }
 
-                        // Persist the upgraded/repaired settings so the on-disk file is brought up to date.
-                        if (notes.Count > 0 || fixes.Count > 0)
+                        // Persist the upgraded/repaired settings so the on-disk file is brought up to date —
+                        // unless this file came from a NEWER build, in which case writing it back is how the
+                        // reader loses whatever that build added.
+                        //
+                        // The "reading as-is" note counted toward "something changed", so merely launching an
+                        // older build rewrote the file in the older shape before the reader touched anything.
+                        // The note said as-is; the next line wrote it back reduced. Extension data (#883) now
+                        // carries unknown top-level properties through a round-trip, so a save the reader
+                        // actually asks for is no longer destructive — but a save nobody asked for is still
+                        // not something to do to a file we have just said we do not fully understand. (#883)
+                        if ((notes.Count > 0 || fixes.Count > 0)
+                            && !SettingsValidator.IsNewerThanSupported(_settings))
                             RequestSave();
                     }
                     else
@@ -399,8 +410,26 @@ namespace CST.Avalonia.Services
             _logger.Information("Set default XML directory: {Path}", xmlPath);
         }
 
+        /// <summary>
+        /// One save at a time. (#878)
+        ///
+        /// <para>Distinct from <c>_saveLock</c> below, which guards the debounce FLAG and nothing else — the
+        /// write itself was unserialized. Concurrent callers are ordinary, not hypothetical: the 750ms
+        /// debounce flushes on a pool thread while <c>XmlUpdateService</c> and <c>IndexingService</c> call
+        /// <see cref="SaveSettingsAsync"/> directly from background flows. Both writers used the same
+        /// <c>settings.json.tmp</c>, so A could finish writing the temp file, B truncate and start rewriting
+        /// it, and A's <c>File.Replace</c> promote B's half-written temp over the real file — or, on Windows,
+        /// one writer take an IOException and lose that save silently.</para>
+        ///
+        /// <para>The tolerant reader and the backup walk would recover from that, but they are the last
+        /// resort, not the design. <c>ApplicationStateService</c> has serialized its writes since STATE-2.
+        /// </para>
+        /// </summary>
+        private readonly SemaphoreSlim _writeLock = new(1, 1);
+
         public async Task SaveSettingsAsync()
         {
+            await _writeLock.WaitAsync().ConfigureAwait(false);
             try
             {
                 // Ensure directory exists
@@ -438,6 +467,10 @@ namespace CST.Avalonia.Services
                 _logger.Error(ex, "Failed to save settings to {Path}", _settingsFilePath);
                 throw;
             }
+            finally
+            {
+                _writeLock.Release();
+            }
         }
 
         // --- Debounced save (#67) -----------------------------------------------------------------
@@ -472,7 +505,15 @@ namespace CST.Avalonia.Services
                 _savePending = false;
             }
             if (!shouldSave)
+            {
+                // Nothing of OURS to write — but a save started by the debounce timer or by a background
+                // flow can still be in flight, and this method is what shutdown awaits before letting the
+                // process exit. Returning here let it exit mid-write. Draining costs nothing when idle.
+                // (#878)
+                await _writeLock.WaitAsync().ConfigureAwait(false);
+                _writeLock.Release();
                 return;
+            }
             try
             {
                 await SaveSettingsAsync();

--- a/src/CST.Avalonia/Services/SettingsService.cs
+++ b/src/CST.Avalonia/Services/SettingsService.cs
@@ -427,6 +427,13 @@ namespace CST.Avalonia.Services
         /// </summary>
         private readonly SemaphoreSlim _writeLock = new(1, 1);
 
+        // What this does NOT serialize, deliberately: MUTATION of _settings while a background save
+        // serializes it. A save from the timer, XmlUpdateService or IndexingService can enumerate an AI model
+        // list or ScriptFonts while the UI thread edits it, which throws InvalidOperationException — the save
+        // is lost and logged, the file stays intact, and the next save carries the change. Pre-existing and
+        // not worsened here (UI-initiated saves already serialize on the UI thread); named so it is not
+        // mistaken for something this lock covers. (fable review)
+
         public async Task SaveSettingsAsync()
         {
             await _writeLock.WaitAsync().ConfigureAwait(false);
@@ -509,7 +516,12 @@ namespace CST.Avalonia.Services
                 // Nothing of OURS to write — but a save started by the debounce timer or by a background
                 // flow can still be in flight, and this method is what shutdown awaits before letting the
                 // process exit. Returning here let it exit mid-write. Draining costs nothing when idle.
-                // (#878)
+                //
+                // Not airtight, and the gap is worth stating rather than implying away: a flush that has
+                // already cleared _savePending but not yet acquired the write lock is invisible here, so a
+                // concurrent shutdown drains a free semaphore and exits with that save between flag and
+                // lock. Bounded to that one save — the temp-file-plus-replace write means the file itself
+                // is never torn. (#878, fable review)
                 await _writeLock.WaitAsync().ConfigureAwait(false);
                 _writeLock.Release();
                 return;

--- a/src/CST.Avalonia/Services/TolerantSettingsReader.cs
+++ b/src/CST.Avalonia/Services/TolerantSettingsReader.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace CST.Avalonia.Services;
 
@@ -164,10 +165,47 @@ internal static class TolerantSettingsReader
                 continue;
             }
 
+            // A property with its own [JsonConverter] is read by that converter FIRST.
+            //
+            // Node() takes a Type, so the attribute — which lives on the property, not the type — was lost
+            // the moment we recursed. AiConnectionRecord.Headers is the live case: its converter reads the
+            // legacy dict-shaped form perfectly well on the strict path, but taken apart property-by-property
+            // the node is an object where a List is expected, which lands in the drop-the-collection branch.
+            // The salvage path was therefore strictly WEAKER than the strict path for any property carrying
+            // a converter — in the one mechanism whose whole job is to lose as little as possible, and a trap
+            // set for whoever adds the next converter. (#880)
+            if (ConverterFor(property) is { } converter)
+            {
+                try
+                {
+                    var byConverter = new JsonSerializerOptions(options);
+                    byConverter.Converters.Add(converter);
+                    var converted = json.Deserialize(property.PropertyType, byConverter);
+                    if (converted is not null) property.SetValue(instance, converted);
+                    continue;
+                }
+                catch (JsonException)
+                {
+                    // The converter could not read it either. Fall through and take it apart, which is what
+                    // this class is for; whatever is then dropped is reported as usual.
+                }
+            }
+
             var value = Node(json, property.PropertyType, $"{path}.{property.Name}", options, dropped);
             if (value is not null) property.SetValue(instance, value);
         }
         return instance;
+    }
+
+    /// <summary>The converter a property declares for itself, or null. Instantiated per call — a converter
+    /// added to a shared options instance would apply to the whole graph, not this property. (#880)</summary>
+    private static JsonConverter? ConverterFor(PropertyInfo property)
+    {
+        var attribute = property.GetCustomAttribute<JsonConverterAttribute>();
+        if (attribute?.ConverterType is null) return null;
+
+        try { return Activator.CreateInstance(attribute.ConverterType) as JsonConverter; }
+        catch { return null; }
     }
 
     private static bool TryGetProperty(JsonElement element, string name, out JsonElement value)

--- a/src/CST.Avalonia/Services/TolerantSettingsReader.cs
+++ b/src/CST.Avalonia/Services/TolerantSettingsReader.cs
@@ -138,6 +138,11 @@ internal static class TolerantSettingsReader
         JsonElement element, Type type, string path, JsonSerializerOptions options, List<string> dropped)
     {
         var instance = Activator.CreateInstance(type)!;
+
+        // NOTE: this walks the TYPE's properties, so a [JsonExtensionData] member (#883) is not populated
+        // here — a file from a newer build that also fails a strict read loses its unknown keys on salvage.
+        // Bounded rather than fixed: the original file is copy-preserved before the salvage is written over
+        // it, so the keys still exist on disk. (fable review)
         foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
             if (!property.CanWrite || property.GetIndexParameters().Length > 0) continue;
@@ -184,10 +189,16 @@ internal static class TolerantSettingsReader
                     if (converted is not null) property.SetValue(instance, converted);
                     continue;
                 }
-                catch (JsonException)
+                catch (Exception ex) when (ex is JsonException or NotSupportedException)
                 {
                     // The converter could not read it either. Fall through and take it apart, which is what
                     // this class is for; whatever is then dropped is reported as usual.
+                    //
+                    // NotSupportedException as well as JsonException, matching Node()'s catch for the very
+                    // same Deserialize call one branch below — a converter refusing the shape outright
+                    // throws NSE, and this method's caller catches only JsonException, so letting one
+                    // escape would abort the WHOLE salvage and fall through to the backups. That is worse
+                    // than not having tried the converter at all. (fable review)
                 }
             }
 

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1826,6 +1826,28 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
         }
 
         
+        /// <summary>
+        /// Install a new global logger and DISPOSE the one it replaces. (#882)
+        ///
+        /// <para>The outgoing pipeline's rolling file sink keeps today's log file open, and Serilog's file
+        /// sink defaults to exclusive access (<c>shared: false</c>) — so on Windows the incoming logger's
+        /// file sink cannot open the same file, and file logging dies silently for the rest of the session
+        /// the moment the reader changes the log level. The Logging panel still looks like it worked,
+        /// because the console sink is unaffected. macOS and Linux take no exclusive lock, which is why
+        /// development never saw it.</para>
+        ///
+        /// <para><b>Dispose AFTER the swap, never before.</b> Disposing first leaves a window with no logger
+        /// at all, and Serilog's answer to that is a silent no-op logger rather than an error — so anything
+        /// logged in between would simply not exist. Split out so a test can pin that ordering without
+        /// standing up the whole developer-settings view model.</para>
+        /// </summary>
+        internal static void SwapGlobalLogger(Serilog.ILogger fresh)
+        {
+            var replaced = Log.Logger;
+            Log.Logger = fresh;
+            (replaced as IDisposable)?.Dispose();
+        }
+
         private void ReconfigureLogger(string logLevel)
         {
             try
@@ -1855,15 +1877,14 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
                 
                 var logPath = Path.Combine(logsDir, "cst-avalonia-.log");
 
-                // Reconfigure the global logger
-                Log.Logger = new Serilog.LoggerConfiguration()
+                SwapGlobalLogger(new Serilog.LoggerConfiguration()
                     .MinimumLevel.Is(serilogLevel)
                     .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss.fff} {Level:u3}] {SourceContext} {Message:lj}{NewLine}{Exception}")
                     .WriteTo.File(logPath, 
                         rollingInterval: Serilog.RollingInterval.Day,
                         outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {SourceContext} {Message:lj}{NewLine}{Exception}")
                     .Enrich.FromLogContext()
-                    .CreateLogger();
+                    .CreateLogger());
             }
             catch (Exception ex)
             {

--- a/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/SettingsViewModel.cs
@@ -1827,69 +1827,39 @@ public class AiSettingsViewModel : ViewModelBase, IDisposable
 
         
         /// <summary>
-        /// Install a new global logger and DISPOSE the one it replaces. (#882)
+        /// Apply a new log level. Moves the one <see cref="App.LogLevelSwitch"/>; builds nothing. (#882)
         ///
-        /// <para>The outgoing pipeline's rolling file sink keeps today's log file open, and Serilog's file
-        /// sink defaults to exclusive access (<c>shared: false</c>) — so on Windows the incoming logger's
-        /// file sink cannot open the same file, and file logging dies silently for the rest of the session
-        /// the moment the reader changes the log level. The Logging panel still looks like it worked,
-        /// because the console sink is unaffected. macOS and Linux take no exclusive lock, which is why
-        /// development never saw it.</para>
+        /// <para>This used to rebuild the global logger, which failed two ways. Serilog's file sink defaults
+        /// to exclusive access, so on Windows the replacement could not open the log file the original still
+        /// held and file logging died silently for the session — with the panel looking like it worked,
+        /// because the console sink was unaffected. Disposing the original to free that handle is worse: an
+        /// <c>ILogger</c> captured at construction is bound to the pipeline it came from, and this app
+        /// captures 20+ of them plus every MEL <c>ILogger&lt;T&gt;</c> the container injects, so disposal
+        /// stops THEIR file output on every platform. Both land the moment the reader changes the log level,
+        /// which is the moment they are trying to gather diagnostics.</para>
         ///
-        /// <para><b>Dispose AFTER the swap, never before.</b> Disposing first leaves a window with no logger
-        /// at all, and Serilog's answer to that is a silent no-op logger rather than an error — so anything
-        /// logged in between would simply not exist. Split out so a test can pin that ordering without
-        /// standing up the whole developer-settings view model.</para>
+        /// <para>A switch has neither problem and does something neither version managed: loggers already
+        /// captured honour the new level at once, rather than keeping the level they were built with.
+        /// (fable review)</para>
         /// </summary>
-        internal static void SwapGlobalLogger(Serilog.ILogger fresh)
+        private void ReconfigureLogger(string logLevel) => ApplyLogLevel(logLevel);
+
+        /// <summary>The whole of it. Split out only so a test can drive the real path rather than the switch
+        /// directly — a test that moves the switch itself passes whatever this method does.</summary>
+        internal static void ApplyLogLevel(string? logLevel) =>
+            App.LogLevelSwitch.MinimumLevel = ParseLogLevel(logLevel);
+
+        /// <summary>The persisted level name as a Serilog level; anything unrecognised reads as Information,
+        /// matching <c>SettingsValidator</c>'s own repair of a bad value.</summary>
+        internal static Serilog.Events.LogEventLevel ParseLogLevel(string? logLevel) => logLevel switch
         {
-            var replaced = Log.Logger;
-            Log.Logger = fresh;
-            (replaced as IDisposable)?.Dispose();
-        }
+            "Debug" => Serilog.Events.LogEventLevel.Debug,
+            "Information" => Serilog.Events.LogEventLevel.Information,
+            "Warning" => Serilog.Events.LogEventLevel.Warning,
+            "Error" => Serilog.Events.LogEventLevel.Error,
+            "Fatal" => Serilog.Events.LogEventLevel.Fatal,
+            _ => Serilog.Events.LogEventLevel.Information
+        };
 
-        private void ReconfigureLogger(string logLevel)
-        {
-            try
-            {
-                // Convert string to Serilog LogEventLevel
-                var serilogLevel = logLevel switch
-                {
-                    "Debug" => Serilog.Events.LogEventLevel.Debug,
-                    "Information" => Serilog.Events.LogEventLevel.Information,
-                    "Warning" => Serilog.Events.LogEventLevel.Warning,
-                    "Error" => Serilog.Events.LogEventLevel.Error,
-                    "Fatal" => Serilog.Events.LogEventLevel.Fatal,
-                    _ => Serilog.Events.LogEventLevel.Information
-                };
-
-                // Get the logs directory
-                var appSupportDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                    AppConstants.AppDataDirectoryName);
-                var logsDir = Path.Combine(appSupportDir, "logs");
-                
-                // Ensure logs directory exists
-                if (!Directory.Exists(logsDir))
-                {
-                    Directory.CreateDirectory(logsDir);
-                }
-                
-                var logPath = Path.Combine(logsDir, "cst-avalonia-.log");
-
-                SwapGlobalLogger(new Serilog.LoggerConfiguration()
-                    .MinimumLevel.Is(serilogLevel)
-                    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss.fff} {Level:u3}] {SourceContext} {Message:lj}{NewLine}{Exception}")
-                    .WriteTo.File(logPath, 
-                        rollingInterval: Serilog.RollingInterval.Day,
-                        outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {SourceContext} {Message:lj}{NewLine}{Exception}")
-                    .Enrich.FromLogContext()
-                    .CreateLogger());
-            }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, "Failed to reconfigure logger");
-            }
-        }
     }
 }


### PR DESCRIPTION
Fixes #878. Fixes #880. Fixes #881. Fixes #882. Fixes #883.

Second of two PRs for the Settings/application-state hardening pass (#884 was the state half). Five findings, one subsystem.

### #878 — concurrent saves were unserialized and shared one temp path

`SaveSettingsAsync` had no write lock; the `_saveLock` beside it guards the debounce **flag** and nothing else. Concurrent callers are ordinary, not hypothetical — the 750ms debounce flushes on a pool thread while `XmlUpdateService` and `IndexingService` save directly from background flows. Both writers used one `settings.json.tmp`, so A could finish writing the temp file, B truncate and start rewriting it, and A's `File.Replace` promote B's half-written temp over the real file. `ApplicationStateService` has serialized its writes since STATE-2.

`FlushPendingSaveAsync` now drains too: shutdown awaits it, and it returned while a save started elsewhere was still mid-write.

### #880 — the salvage path ignored a property's own `[JsonConverter]`

`Node()` takes a `Type`, so an attribute living on the **property** was lost the moment we recursed. `AiConnectionRecord.Headers` is the live case: `AiHeaderRecordListConverter` reads the legacy dict-shaped form fine on the strict path, but taken apart property-by-property the node is an object where a `List` belongs, which lands in the drop-the-collection branch. **The salvage path was strictly weaker than the strict path** — in the one mechanism whose whole job is to lose as little as possible.

Worth noting what the test had to do to reach it: the reader tries a whole-node read at every level first (deliberately, so ordinary converters apply wherever they can), so the gap only shows once something *else on the same object* has failed. My first fixture broke the file further up the tree, the `ai` node deserialized whole, and the test passed with the fix reverted.

### #881 — a script could vanish from the Appearance panel for good

The panel builds its rows by enumerating `ScriptFonts`, so a key dropped by a salvage or a hand-edit left that script with **no font control at all** — permanently, since nothing re-seeded it, and invisibly, since rendering falls back safely.

Seeded from a new `FontSettings.DefaultScriptFonts()` that the constructor now uses too, so the two lists cannot drift. A second hand-written list would have been the same defect one level up.

### #882 — changing the log level killed file logging (Windows)

The outgoing pipeline's rolling file sink keeps today's log file open, and Serilog's file sink defaults to exclusive access — so on Windows the incoming logger's file sink cannot open the same file and file logging dies silently for the rest of the session, with the Logging panel still looking like it worked because the console sink is unaffected.

Disposing the replaced logger releases the handle. **After the swap, never before** — Serilog answers a missing logger with a silent no-op rather than an error, so disposing first would leave a window where anything logged simply does not exist. Split into `SwapGlobalLogger` so a test can pin that ordering; both halves are mutation-checked.

Still wants a Windows run to confirm the symptom is gone (Placid or Kingfisher): change the log level, then check whether anything further reaches `logs/cst-avalonia-*.log`.

### #883 — an older build stripped a newer build's file on launch

Both stores gained a `[JsonExtensionData]` member so unknown **top-level** properties round-trip. Nested sections still shed; that is the cheap half taken deliberately, and the doc comment says so rather than implying more.

And neither store writes a newer-than-supported file back on load. *"Reading as-is"* was true of the read and false of what followed: the note counted toward "something changed", so merely **launching** an older build rewrote the file in the older shape before the reader touched anything.

### Tests

Eleven, in a new `SettingsDurabilityTests`, each mutation-checked:

| mutation | fails |
|---|---|
| drop the converter branch | `A_property_with_its_own_converter_survives_the_salvage` |
| drop the re-seed | `Sanitize_restores_a_missing_script_font_key`, `The_reseed_covers_every_script_…` |
| drop the extension-data member | `Unknown_top_level_properties_survive_a_round_trip` |
| drop the newer-than-supported guard | `A_newer_settings_file_is_not_rewritten_on_load` |
| dispose the logger before the swap / not at all | `Swapping_the_global_logger_…` |

Plus the guards against each fix overshooting: the re-seed is idempotent and never overwrites a font the reader chose; a repairable file this build *does* understand is still written back; an ordinary file gains no stray member in its output.

**#878 has no failing-without-the-fix test** and I would rather say so than imply otherwise: a torn write is a race, so a test cannot reliably reproduce it. `Concurrent_saves_leave_a_file_that_parses` pins that the serialized path is correct under concurrency and stays that way; the absence of the lock is the mechanism, and it was traced rather than reproduced.

Full suite: **2666 passed, 0 failed, 17 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)