### PR TITLE
Stop asking fonts to draw a joiner they never need (R15-1)

### DIFF
--- a/docs/development/CODE_REVIEW_2026-08_FINDINGS.md
+++ b/docs/development/CODE_REVIEW_2026-08_FINDINGS.md
@@ -12,7 +12,7 @@ Deleted files are excluded — the CST4/MAUI removal (Aug 2026) accounts for mos
 
 **Status legend:** ✅ verified real · ❓ plausible, needs verification · ✖ rejected on verification
 
-> **What has since been fixed (2026-08-28).** All four HIGHs are merged. Each fix was reviewed by a second
+> **What has since been fixed (updated 2026-08-29).** All four HIGHs are merged, as is the whole of area R11. Each fix was reviewed by a second
 > Fable pass before merge, which found a defect in three of the four — recorded in the PR discussions.
 >
 > | Finding | Issue | Merged | Note |
@@ -22,7 +22,10 @@ Deleted files are excluded — the CST4/MAUI removal (Aug 2026) accounts for mos
 > | R5-1 + R4-3 | [#870](https://github.com/fsnow/cst/issues/870) | `7f721dd` | Guard + trim as prescribed, plus a first-wins repair in `SettingsValidator`: the models tab tolerating the pair repairs only the models tab, and the per-turn picker has no dedupe either. |
 > | R14-2 | [#871](https://github.com/fsnow/cst/issues/871) | `fa3d9e6` | Filed and fixed as HIGH (see the dissent below). **The third cut site named here is wrong:** `RawForwardCap`'s cut never ends a window — every selection end passes through `ExtendToSentenceEnd`, whose 4,000-char cap is the cut that lands. A *fourth* site the list missed, `WalkBackSentences`' scan floor, was fixed too. |
 >
-> **Everything else in this document is as written at review time** — the 26 MED and 51 LOW findings are
+> | R11-1 … R11-7 | [#877](https://github.com/fsnow/cst/issues/877)–[#883](https://github.com/fsnow/cst/issues/883) | `7d50ded`, `eb5eddb` | The whole area, filed as seven issues and fixed across two PRs: application-state recovery (preserve-aside, backup-before-defaults, dirty-flag) then settings durability (write serialization, converter-aware salvage, `ScriptFonts` re-seed, version guard). #882 (R11-6, the Serilog level swap) is **merged but reopened** pending verification on Windows — the symptom cannot be reproduced on macOS. |
+> | R15-1 | — | — | **✖ Rejected on verification.** Scanned every font on macOS and Windows: 0 of 11 Sinhala-capable faces omit U+200C. Fixed anyway as a LOW, for a different reason. See the resolution note in area R15. |
+>
+> **Everything else in this document is as written at review time** — the remaining MED and LOW findings are
 > unfixed and unfiled, and the fix order below is complete only through item 5.
 
 **Regenerate the scope:**
@@ -466,9 +469,48 @@ This area covers per-script font selection and coverage detection (`ScriptFontSe
 
 | # | Sev | File:line | Finding | Status |
 |---|---|---|---|---|
-| R15-1 | MED | `src/CST.Avalonia/Services/Platform/ScriptCoverage.cs:44-62`, `ScriptFontService.cs:154-157` | The Sinhala probe set includes ZWNJ: `Deva2Sinh.cs:88` maps every virama to virama+U+200C, and `CodepointsFor` filters only whitespace, so U+200C (a default-ignorable format control) lands in the required list and `Supports()` then demands a cmap glyph for it from every candidate font. A correct Sinhala font that omits the ZWNJ cmap entry — legal, since shapers render default-ignorables without a glyph — is silently excluded from the Windows/Linux picker, and if no installed font maps it the picker goes empty with "no font can render Sinhala" despite a working font being present; the same check also nulls `GetSystemDefaultFontForScript`. I could not produce a victim font (all three Sinhala-capable fonts on this machine map U+200C, and no test covers the case — `ScriptCoverageTests` asserts only `>= 0x80`, which U+200C passes), hence ❓. Fix: skip `UnicodeCategory.Format` in `CodepointsFor`, exactly as `RepresentativeCodepoint` (lines 76-84) already does. Sinhala is the only affected script — no other converter emits joiners into this sample. | ❓ |
+| R15-1 | MED | `src/CST.Avalonia/Services/Platform/ScriptCoverage.cs:44-62`, `ScriptFontService.cs:154-157` | The Sinhala probe set includes ZWNJ: `Deva2Sinh.cs:88` maps every virama to virama+U+200C, and `CodepointsFor` filters only whitespace, so U+200C (a default-ignorable format control) lands in the required list and `Supports()` then demands a cmap glyph for it from every candidate font. A correct Sinhala font that omits the ZWNJ cmap entry — legal, since shapers render default-ignorables without a glyph — is silently excluded from the Windows/Linux picker, and if no installed font maps it the picker goes empty with "no font can render Sinhala" despite a working font being present; the same check also nulls `GetSystemDefaultFontForScript`. I could not produce a victim font (all three Sinhala-capable fonts on this machine map U+200C, and no test covers the case — `ScriptCoverageTests` asserts only `>= 0x80`, which U+200C passes), hence ❓. Fix: skip `UnicodeCategory.Format` in `CodepointsFor`, exactly as `RepresentativeCodepoint` (lines 76-84) already does. Sinhala is the only affected script — no other converter emits joiners into this sample. **✖ Rejected on verification (2026-08-29) — see the resolution note below.** | ✖ |
 | R15-2 | LOW | `src/CST.Core/Conversion/Deva2Latn.cs:123-146`, `ScriptConverter.cs:112-113` | The #42 stylesheet-PI rewrite (`tipitaka-deva.xsl` → `tipitaka.xsl`) landed identically in twelve converters but not in the other two scripts: `Deva2Latn.ConvertBook` has no rewrite and the Devanagari branch returns the input unchanged, so Latin- and Devanagari-script documents still carry a PI naming a stylesheet that no longer ships while the other twelve now name the real one. Functionally inert today (the app transforms via `BookDisplayViewModel.cs:1464` and never resolves the PI — the change's own comment says so), but the comment's stated rationale ("a document should not name a file that no longer exists") is met for only 12 of 14 scripts, and any future PI consumer would behave differently by script. | ✅ |
 | R15-3 | LOW | `src/CST.Avalonia/Views/OpenBookPanel.axaml.cs:43` | `FocusBookTree` still resolves the tree with null-tolerant `this.FindControl<TreeView>("BookTreeView")` and returns silently on null, while the constructor (lines 21-24) was deliberately switched to the generated `BookTreeView` field with a comment naming exactly this pattern as the #658 failure mode ("a null-tolerant lookup here would silently detach"). A rename of the x:Name now breaks Cmd+O focus/scroll/highlight silently while the Enter handler fails loudly at compile time — the file enforces its own invariant in one of its two places. | ✅ |
+
+**R15-1 resolution (2026-08-29).** The premise — that a real Sinhala font omits U+200C — does not hold, on
+either shipping platform. Every font on both machines was scanned by reading its `cmap` directly (fontTools
+`getBestCmap`, the same test `TryGetGlyph` performs):
+
+| | faces scanned | omit U+200C | Sinhala-capable | of those, omit U+200C |
+|---|---|---|---|---|
+| macOS (Egret) | 784 | 400 (51%) | 5 | **0** |
+| Windows 11 ARM64 (Merlin) | 162 | 91 (56%) | 6 | **0** |
+
+Half of all faces omit ZWNJ and not one Indic-capable face does. There is a mechanism behind that: in Sinhala
+and Devanagari a joiner is not a mere default-ignorable but part of the script's shaping model — ZWNJ is what
+blocks conjunct formation to force the visible al-lakuna — so a vendor shipping Indic coverage maps it as a
+matter of course. The catastrophic branch needs more than one victim font anyway: the picker can only go empty
+if *every* Sinhala face omits ZWNJ, and on a base Windows 11 install the sole Sinhala family is Nirmala (six
+faces, all mapping it). Iskoola Pota is not present on Merlin — it arrives with the Sinhala language pack — so
+it is formally untested, but as a counterexample it could only cost one row in the picker, never empty it.
+Hunting a counterexample further is not worth a machine: a synthetic ZWNJ-less font would only demonstrate the
+code path we can already read, and the claim was about fonts that exist.
+
+**Two corrections to the finding as written**, both of which survive the font question because they are about
+the code rather than any machine:
+
+1. **The exposure is Sinhala-only, and the finding's own scope line is the accurate part.** Devanagari's
+   required list contains no joiner at all — the ZWNJ comes from `Deva2Sinh`'s virama rule, which no other
+   converter has. Any reading that puts Devanagari alongside Sinhala here is wrong; the mutation test on the
+   fix confirms it, failing on Sinhala's theory case and no other script's.
+2. **The requirement is derived from a probe phrase, so what it demands can change without anyone touching
+   the font logic.** `Deva2Sinh.cs:158-164` rewrites the joiner to **ZWJ (U+200D)** before *ya*, before *ra*,
+   and between *kk*; `PaliSample` (`mahāsatipaṭṭhānasuttaṃ`) happens to contain none of those three, so ZWJ has
+   never reached the required list — by accident of the phrase, not by design. Change the phrase and the
+   picker would start demanding a codepoint no survey has checked fonts for.
+
+**Fixed anyway** — `CodepointsFor` now skips `UnicodeCategory.Format`, as `RepresentativeCodepoint` already
+did — but for reason 2 rather than the one the finding gave: the fix makes the requirement independent of the
+sample it is derived from. Regraded **LOW**, and not a beta 6 blocker. Pinned by
+`No_font_is_asked_to_draw_a_formatting_character` (every renderable script, category-based so it catches ZWJ
+if the phrase ever changes) and `Sinhala_requires_its_virama_but_not_the_joiner_that_follows_it` (which also
+asserts the al-lakuna U+0DCA survives — dropping the joiner must not drop the mark).
 
 **Verified-solid (not findings):**
 - **Twelve converters**: `git diff` on all twelve `Deva2*.cs` shows byte-identical changes (same comment, same `Replace("tipitaka-deva.xsl", "tipitaka.xsl")`); changed lines are pure ASCII, complying with the `\uXXXX` rule. The target `src/CST.Avalonia/xsl/tipitaka.xsl` exists in the tree.
@@ -504,7 +546,7 @@ This area covers per-script font selection and coverage detection (`ScriptFontSe
 1. ~~**R13-2**~~ — live, trivially reachable, wrong answers to a reader today. **Done** (`df81e63`).
 2. ~~**R13-1 / R12-1**~~ — one fix; copy the pattern from `LexiconReader` next door. **Done** (`a8f02e7`).
 3. ~~**R5-1 + R4-3**~~ — the only finding that can lock a reader out of the UI that would let them recover. **Done** (`7f721dd`).
-4. **R11-2** — session data loss: defaults become the newest backup and permanently shadow the real state file. **Still open**, and the highest-value thing left in this document.
+4. ~~**R11-2**~~ — session data loss: defaults become the newest backup and permanently shadow the real state file. **Done** (`7d50ded`), with the rest of area R11.
 5. ~~**R14-2**~~ — see the severity dissent below. **Done** (`fa3d9e6`), filed as high.
 
 ### Severity dissent to settle at triage
@@ -545,7 +587,6 @@ Two secondary patterns:
 
 - **R11-6** (Serilog file-sink swap killing file logging) — needs **Placid or Merlin**; cannot be settled on macOS.
 - **R8-1** (Chromium title-length clamp bounding selection size) — needs an empirical test against the shipped CEF build.
-- **R15-1** (ZWNJ in the Sinhala coverage requirement) — needs a Sinhala font whose cmap lacks U+200C; all three on this machine map it.
 
 ### Housekeeping
 

--- a/src/CST.Avalonia.Tests/Services/Platform/ScriptCoverageTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Platform/ScriptCoverageTests.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using CST.Avalonia.Services.Platform;
 using CST.Conversion;
 using Xunit;
@@ -23,6 +25,13 @@ public class ScriptCoverageTests
     private const int ALongA = 0x0101;      // a with macron
     private const int TUnderdot = 0x1E6D;   // t with dot below
     private const int MUnderdot = 0x1E43;   // m with dot below
+
+    // Sinhala's al-lakuna and the two joiners that can follow it. Deva2Sinh maps every virama to al-lakuna +
+    // ZWNJ, then rewrites that joiner to ZWJ before ya, before ra, and between kk - so which joiner appears in
+    // any given phrase is a property of the phrase.
+    private const int SinhalaAlLakuna = 0x0DCA;
+    private const int Zwnj = 0x200C;
+    private const int Zwj = 0x200D;
 
     [Theory]
     [InlineData(Script.Latin)]
@@ -54,6 +63,48 @@ public class ScriptCoverageTests
         // Unknown is not a script and Ipe is the internal search encoding, never shown to a reader. Filtering
         // a font list for either would be inventing a requirement out of nothing.
         Assert.Empty(ScriptCoverage.CodepointsFor(script));
+    }
+
+    [Theory]
+    [InlineData(Script.Latin)]
+    [InlineData(Script.Devanagari)]
+    [InlineData(Script.Bengali)]
+    [InlineData(Script.Cyrillic)]
+    [InlineData(Script.Gujarati)]
+    [InlineData(Script.Gurmukhi)]
+    [InlineData(Script.Kannada)]
+    [InlineData(Script.Khmer)]
+    [InlineData(Script.Malayalam)]
+    [InlineData(Script.Myanmar)]
+    [InlineData(Script.Sinhala)]
+    [InlineData(Script.Telugu)]
+    [InlineData(Script.Thai)]
+    [InlineData(Script.Tibetan)]
+    public void No_font_is_asked_to_draw_a_formatting_character(Script script)
+    {
+        // A joiner instructs the shaper; it is not a glyph, and a font that omits it from its cmap can still
+        // render the text. Requiring one could only exclude a font that works.
+        //
+        // Written over every script rather than over Sinhala alone because the requirement is derived from the
+        // probe phrase: change PaliSample to something containing a virama before ya or ra, and Sinhala would
+        // start demanding ZWJ instead of ZWNJ - a codepoint no survey has ever checked fonts for. This fails
+        // when that happens, which is the point of testing the category rather than the two known joiners.
+        Assert.All(ScriptCoverage.CodepointsFor(script), cp =>
+            Assert.False(Rune.GetUnicodeCategory(new Rune(cp)) == UnicodeCategory.Format,
+                $"{script} would require U+{cp:X4}, a formatting character no font need draw."));
+    }
+
+    [Fact]
+    public void Sinhala_requires_its_virama_but_not_the_joiner_that_follows_it()
+    {
+        // Sinhala is the only script whose conversion emits a joiner at all, so it is the only one where the
+        // Format filter does any work today. Both halves matter: dropping the joiner must not also drop the
+        // al-lakuna, which is a real mark that a Sinhala font genuinely has to draw.
+        var codepoints = ScriptCoverage.CodepointsFor(Script.Sinhala);
+
+        Assert.Contains(SinhalaAlLakuna, codepoints);
+        Assert.DoesNotContain(Zwnj, codepoints);
+        Assert.DoesNotContain(Zwj, codepoints);
     }
 
     [Fact]

--- a/src/CST.Avalonia/Services/Platform/ScriptCoverage.cs
+++ b/src/CST.Avalonia/Services/Platform/ScriptCoverage.cs
@@ -54,6 +54,22 @@ namespace CST.Avalonia.Services.Platform
             foreach (var rune in sample.EnumerateRunes())
             {
                 if (Rune.IsWhiteSpace(rune)) continue;
+
+                // Formatting characters are instructions to the shaper, not glyphs to draw, so a font that
+                // maps none of them can still render this text correctly - a conformant shaper hides a
+                // default-ignorable whether or not the font has a glyph for it. Asking for a cmap entry would
+                // demand more than rendering does, and could only ever exclude a working font.
+                //
+                // Live case: Deva2Sinh maps every virama to al-lakuna + ZWNJ (Deva2Sinh.cs:88), so U+200C
+                // reaches this loop for Sinhala and no other script. Whether ZWJ (U+200D) arrives too is a
+                // property of the probe PHRASE rather than of this code - Deva2Sinh rewrites the joiner
+                // before ya, before ra, and between kk (:158-164), and PaliSample happens to contain none of
+                // those three. That is the reason to filter by category here instead of naming U+200C: the
+                // requirement is derived from a sample, so what it demands must not change when the sample
+                // does. RepresentativeCodepoint already skips Format for its own reasons; this is the same
+                // rule, applied where the requirement is built rather than where one is chosen from it.
+                if (Rune.GetUnicodeCategory(rune) == UnicodeCategory.Format) continue;
+
                 if (!codepoints.Contains(rune.Value)) codepoints.Add(rune.Value);
             }
 


### PR DESCRIPTION
Closes the R15-1 code-review finding — by rejecting its premise and fixing the underlying issue for a better reason.

## What the finding claimed

`CodepointsFor` filters only whitespace out of the converted probe phrase, so every codepoint it yields becomes one a font must have a cmap glyph for. `Deva2Sinh.cs:88` maps every virama to al-lakuna + ZWNJ, so U+200C lands in Sinhala's required list and `ScriptFontService.Supports` demands it of every candidate font. The claim: a correct Sinhala font omitting ZWNJ from its cmap is silently dropped from the picker, and if none map it the picker goes empty with "no font can render Sinhala".

The reviewer graded it ❓ because they could not produce a victim font.

## The premise does not hold

Every font on both shipping platforms, cmaps read directly (fontTools `getBestCmap`, the same test `TryGetGlyph` performs):

| | faces scanned | omit U+200C | Sinhala-capable | of those, omit U+200C |
|---|---|---|---|---|
| macOS (Egret) | 784 | 400 (51%) | 5 | **0** |
| Windows 11 ARM64 (Merlin) | 162 | 91 (56%) | 6 | **0** |

Half of all faces omit ZWNJ and not one Indic-capable face does. There is a mechanism behind that: in Sinhala and Devanagari a joiner is not a mere default-ignorable but part of the script's shaping model — ZWNJ is what blocks conjunct formation to force the visible al-lakuna — so a vendor shipping Indic coverage maps it as a matter of course.

The catastrophic branch needs more than one victim font anyway: the picker can only go empty if *every* Sinhala face omits ZWNJ, and on a base Windows 11 install the sole Sinhala family is Nirmala (six faces, all mapping it). Iskoola Pota is not present on Merlin — it arrives with the Sinhala language pack — so it is formally untested, but as a counterexample it could only cost one row in the picker, never empty it.

## Why fix it anyway

The requirement is **derived from a probe phrase**, so what it demands of every font can change without anyone touching the font logic. `Deva2Sinh.cs:158-164` rewrites the joiner to **ZWJ (U+200D)** before *ya*, before *ra*, and between *kk*; `PaliSample` (`mahāsatipaṭṭhānasuttaṃ`) happens to contain none of those three, so ZWJ has never reached the required list — by accident of the phrase, not by design. Change the phrase and the picker would start demanding a codepoint no survey has ever checked fonts for.

Filtering by `UnicodeCategory.Format` rather than naming U+200C makes the requirement independent of the sample it is derived from, and matches what `RepresentativeCodepoint` already does 30 lines down. One line.

Regraded **LOW**. Not a beta 6 blocker.

## Also corrects the finding's scope

Devanagari's required list contains **no joiner at all** — the ZWNJ comes from `Deva2Sinh`'s virama rule, which no other converter has. Sinhala was always the only exposed script. The mutation test confirms it: with the fix reverted, Sinhala's theory case fails and no other script's does.

## Tests

- `No_font_is_asked_to_draw_a_formatting_character` — every renderable script, asserting the *category* rather than the two known joiners, so it fails if a future phrase change ever admits ZWJ.
- `Sinhala_requires_its_virama_but_not_the_joiner_that_follows_it` — also asserts U+0DCA survives; dropping the joiner must not drop the mark.

**Mutation-tested:** with the `Format` skip removed, exactly those two fail (Sinhala only) and the other 48 pass. Full suite: 2687 passed, 0 failed, 17 skipped.

## Doc

Records the resolution and the survey in area R15, and corrects two status-block claims that had gone stale: area R11 is filed and fixed (#877–#883, `7d50ded` + `eb5eddb`), so the fix-order note calling R11-2 "**Still open**, and the highest-value thing left in this document" is no longer true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)