### PR TITLE
Test the tool guards by interface, so they match this app's panels (#886)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
@@ -370,4 +370,51 @@ public class CstDockFactoryTests
         var middle = 1.0 - 0.25 - assistant.Proportion;
         Assert.True(middle / 2 > assistant.Proportion, "a split book would be narrower than the assistant");
     }
+
+    /// <summary>
+    /// A tool panel is recognised as one. (R9-1, #886)
+    ///
+    /// <para><b>This is the defect.</b> Both guards keeping tools out of the document tab area asked
+    /// <c>is Tool</c> — Dock's Mvvm class — and no panel in this app derives from it. Every one is a
+    /// <c>ReactiveTool</c>: a <c>ReactiveDockableBase</c> implementing <c>ITool</c>. So the guards were dead
+    /// for the exact case they were written for, and centre-dropping Search or the Dictionary onto the
+    /// document tabs docked it there as a tab.</para>
+    ///
+    /// <para>Against the old test this fails, which is the only reason it is worth having.</para>
+    /// </summary>
+    [Fact]
+    public void A_ReactiveTool_is_recognised_as_a_tool()
+    {
+        Assert.True(CstDockFactory.IsToolDockable(new CST.Avalonia.ViewModels.Dock.ReactiveTool()));
+    }
+
+    /// <summary>
+    /// A document is not, so books are untouched by the guards.
+    ///
+    /// <para>The half that must not regress: widening the test to catch tools must never start catching the
+    /// documents the document dock exists to hold. <c>ReactiveDocument</c> implements <c>IDocument</c> only —
+    /// whereas a <c>ReactiveTool</c> implements both, which is why this asks whether a thing IS a tool rather
+    /// than whether it is not a document.</para>
+    /// </summary>
+    [Fact]
+    public void A_ReactiveDocument_is_not_a_tool()
+    {
+        Assert.False(CstDockFactory.IsToolDockable(new CST.Avalonia.ViewModels.Dock.ReactiveDocument()));
+    }
+
+    /// <summary>A dock full of tools counts too — that half of the guard always worked, and must keep
+    /// working.</summary>
+    [Fact]
+    public void A_tool_dock_is_recognised_as_a_tool_dockable()
+    {
+        Assert.True(CstDockFactory.IsToolDockable(new CstDockFactory().CreateToolDock()));
+    }
+
+    /// <summary>Null is not a tool, rather than an exception on the drag path.</summary>
+    [Fact]
+    public void Null_is_not_a_tool()
+    {
+        Assert.False(CstDockFactory.IsToolDockable(null));
+    }
+
 }

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -202,7 +202,12 @@ namespace CST.Avalonia.Services
                             
                             // Prevent Tools and ToolDocks from being added to DocumentDock
                             // This handles the center-drop case that bypasses SplitToDock
-                            if (item is Tool || item is ToolDock)
+                            //
+                            // ITool, not Tool. Every panel here is a ReactiveTool - ReactiveDockableBase
+                            // implementing ITool - and none derives from Dock's Mvvm Tool class, so the
+                            // concrete test never matched and this guard was dead for the exact case it
+                            // was written for. The DOCK-7 rescue below gets this right. (R9-1, #886)
+                            if (IsToolDockable(item as IDockable))
                             {
                                 Log.Warning("*** Tool/ToolDock being added to DocumentDock - preventing tab docking ***");
                                 // Remove it and float it instead
@@ -1144,6 +1149,26 @@ namespace CST.Avalonia.Services
         }
         
         // Override split operations with simplified approach - let framework handle splits, then fix proportions
+        /// <summary>
+        /// Whether a dockable is a tool panel, or a dock full of them — the things this app keeps out of the
+        /// document tab area. (R9-1, #886)
+        ///
+        /// <para><b>Tested by interface, and that is the whole point.</b> Both guards used to ask
+        /// <c>is Tool</c>, meaning Dock's Mvvm <c>Tool</c> class. No panel here derives from it: every one is
+        /// a <see cref="ViewModels.Dock.ReactiveTool"/>, which is a <c>ReactiveDockableBase</c> implementing
+        /// <see cref="ITool"/>. So both guards were dead for exactly the case they existed for, and a
+        /// centre-drop tab-docked Search or the Dictionary into the document dock.</para>
+        ///
+        /// <para><c>ReactiveDocument</c> implements <c>IDocument</c> only, so books never match this. A
+        /// <c>ReactiveTool</c> implements BOTH interfaces — tools are documents too in this layout — which is
+        /// why the test asks specifically whether it is a tool rather than whether it is not a document.</para>
+        ///
+        /// <para>Extracted so it can be tested: the guards themselves end in <c>FloatDockable</c>, which
+        /// needs a host window and cannot run headless.</para>
+        /// </summary>
+        internal static bool IsToolDockable(IDockable? dockable) =>
+            dockable is ITool || dockable is IToolDock;
+
         public override void SplitToDock(IDock dock, IDockable dockable, DockOperation operation)
         {
             // Detailed logging for debugging drag operations
@@ -1155,7 +1180,10 @@ namespace CST.Avalonia.Services
             
             // Prevent Tools and ToolDocks from being docked into DocumentDock as tabbed documents
             // But allow split operations (Left, Right, Top, Bottom)
-            if ((dockable is Tool || dockable is ToolDock) && dock is DocumentDock)
+            // ITool/IToolDock rather than the concrete Mvvm classes - see the note on the
+            // collection-changed guard above. ReactiveDocument implements IDocument only, so books are
+            // untouched by this. (R9-1, #886)
+            if (IsToolDockable(dockable) && dock is IDocumentDock)
             {
                 // Check if this is a split operation (has direction) or tab operation
                 var operationStr = operation.ToString();


### PR DESCRIPTION
Closes #886 — finding **R9-1** from the 2026-08 code review.

Both guards keeping tool panels out of the document tab area asked `is Tool` (Dock's Mvvm class). No panel in this app derives from it: every one is a `ReactiveTool` — `ReactiveDockableBase` implementing `ITool`. So both were dead for exactly the case they were written for, and the DOCK-7 rescue in the same file had it right all along.

Both now call one predicate:

```csharp
internal static bool IsToolDockable(IDockable? dockable) =>
    dockable is ITool || dockable is IToolDock;
```

## Checked before touching the dock subsystem

- **`ReactiveDocument` implements `IDocument` only**, so books cannot match. Verified for `WelcomeViewModel`, `BookDisplayViewModel`, `PdfDisplayViewModel` and every add path.
- **No `ReactiveTool` is deliberately placed in a document dock.** The call site that looked like it — logged "SEARCH DOCUMENT ADDED" — adds a `BookDisplayViewModel` opened *from* a search hit.
- A `ReactiveTool` implements **both** `ITool` and `IDocument`, so the test must ask whether a thing *is* a tool. Review confirmed Dock's own `Tool` implements `IDocument` too, so a not-a-document test could never have worked.
- `DocumentDock` → `IDocumentDock` was not required by R9-1. Review confirmed **zero behaviour change** — the only `IDocumentDock` implementation in the app or Dock 11.3.6.5 is `DocumentDock` — and it matches the framework's own routing, which tests `is IDocumentDock`. Kept.

## What the review established about waking a guard that never ran

My main worry was that the dead test had been hiding a broken remedy. Two findings, both **pre-existing** rather than introduced here, and both filed as follow-ups:

- **#889** — the remedy leaves `MainDocumentDock.ActiveDockable` pointing at a dockable that now lives in another window. In practice the tab strip re-selects a neighbour and repairs it, but that is control-layer luck.
- **#890** — only the main document dock carries this guard. A split document dock, or a floating window's document tabs, still accept a tool.

**The CEF risk does not fire**, which was the thing worth being afraid of: the Dictionary is the only WebView-hosting tool, and the float path disposes-and-evicts its browser before window creation, per the existing #466/#39 discipline. No variant carries a live browser across a window boundary.

**No persisted-layout hazard**: the dock tree is never serialized. A tool tab-docked under the old dead guard simply evaporates at shutdown and returns to its rail.

## Tests

Build clean; suite **2676 passed, 0 failed, 17 skipped**.

Predicate mutation-tested — five mutants, all killed, including reverting to `is Tool || is ToolDock`, which fails the `ReactiveTool` test and nothing else.

**Not covered, and worth stating:** the guard *bodies* are untested. Replacing either call with `false`, or dropping the `&& dock is IDocumentDock`, fails no test — the remedies end in `FloatDockable`, which needs a host window and cannot run headless.

## Before merging

**Centre-drop each panel onto the document tabs**, especially the Dictionary. This code has never executed for a `ReactiveTool`, and code-level verification is all this and the original review have.
