### PR TITLE
Capture the token first, from a control hoisted once (#891)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/FinalPositionCaptureTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/FinalPositionCaptureTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.ViewModels;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// The commit policy of the final pre-shutdown position capture. (#891)
+///
+/// <para>
+/// The stored anchor and #434 token must describe the SAME moment, because restore prefers the token: a
+/// fresh anchor committed beside a staler token is silently ignored in the token's favour, and the reader
+/// reopens "a bit off" (#551, #537). The original code captured anchor-then-token off an unhoisted
+/// property, so a drag-teardown between the two awaits produced exactly that half-update — the NRE it
+/// also threw was caught and merely logged. These tests pin the policy that replaces it:
+/// token first, and never a fresh anchor beside a stale token.
+/// </para>
+///
+/// <para>
+/// Honest limit: the race itself — ControlRecycling nulling BookDisplayControl between two UI-thread
+/// awaits — needs a live view and dispatcher and is NOT reproduced here. What is tested is the policy
+/// core the instance method delegates to, whose delegates close over a control hoisted ONCE; the hoist
+/// itself is three lines verified by reading, not by a test.
+/// </para>
+/// </summary>
+public class FinalPositionCaptureTests
+{
+    private static readonly ReadingPositionToken FreshToken = new()
+    {
+        Above = "para42",
+        Below = "para43",
+        Fraction = 0.25,
+    };
+
+    private static Func<Task<ReadingPositionToken?>> Token(ReadingPositionToken? value)
+        => () => Task.FromResult(value);
+
+    private static Func<Task<string?>> Anchor(string? value)
+        => () => Task.FromResult(value);
+
+    // ---- the happy path ----
+
+    [Theory]
+    [InlineData(true)]    // hasStoredToken must not suppress a SUCCESSFUL capture
+    [InlineData(false)]
+    public async Task Both_captures_succeeding_commit_a_fresh_consistent_pair(bool hasStoredToken)
+    {
+        var (token, anchor) = await BookDisplayViewModel.CaptureFinalPositionCoreAsync(
+            Token(FreshToken), Anchor("para42"), hasStoredToken);
+
+        Assert.Same(FreshToken, token);
+        Assert.Equal("para42", anchor);
+    }
+
+    // ---- the #891 half-update, both directions ----
+
+    [Fact]
+    public async Task Token_lost_with_a_stored_token_commits_nothing_and_never_asks_for_the_anchor()
+    {
+        // The stored pair is at most one 200ms tick stale and self-consistent. A fresh anchor would be
+        // ignored on restore (token preferred) while desynchronizing the pair — the #891 drift.
+        var anchorAsked = false;
+        var (token, anchor) = await BookDisplayViewModel.CaptureFinalPositionCoreAsync(
+            Token(null),
+            () => { anchorAsked = true; return Task.FromResult<string?>("para42"); },
+            hasStoredToken: true);
+
+        Assert.Null(token);
+        Assert.Null(anchor);
+        Assert.False(anchorAsked);
+    }
+
+    [Fact]
+    public async Task Token_captured_then_control_dies_still_commits_the_token()
+    {
+        // Interrupted between the two captures: "fresh token + stale anchor" is the CORRECT partial
+        // state — the token wins on restore. This is why the token goes first.
+        var (token, anchor) = await BookDisplayViewModel.CaptureFinalPositionCoreAsync(
+            Token(FreshToken), Anchor(null), hasStoredToken: true);
+
+        Assert.Same(FreshToken, token);
+        Assert.Null(anchor);
+    }
+
+    [Fact]
+    public async Task Token_is_captured_before_the_anchor()
+    {
+        var calls = new List<string>();
+        await BookDisplayViewModel.CaptureFinalPositionCoreAsync(
+            () => { calls.Add("token"); return Task.FromResult<ReadingPositionToken?>(FreshToken); },
+            () => { calls.Add("anchor"); return Task.FromResult<string?>("para42"); },
+            hasStoredToken: false);
+
+        Assert.Equal(new[] { "token", "anchor" }, calls);
+    }
+
+    // ---- the no-token-yet book ----
+
+    [Fact]
+    public async Task With_no_stored_token_a_failed_token_capture_still_takes_the_anchor()
+    {
+        // A book closed within its first status tick has no token at all; the anchor is then the only
+        // thing restore can use, so skipping it here would lose the position entirely.
+        var (token, anchor) = await BookDisplayViewModel.CaptureFinalPositionCoreAsync(
+            Token(null), Anchor("para7"), hasStoredToken: false);
+
+        Assert.Null(token);
+        Assert.Equal("para7", anchor);
+    }
+
+    // ---- anchor normalization ----
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("null")]   // the JS side reports "no anchor" as the literal string
+    public async Task Non_answers_from_the_anchor_capture_leave_the_stored_anchor_alone(string? raw)
+    {
+        var (token, anchor) = await BookDisplayViewModel.CaptureFinalPositionCoreAsync(
+            Token(FreshToken), Anchor(raw), hasStoredToken: false);
+
+        Assert.Same(FreshToken, token);
+        Assert.Null(anchor);
+    }
+
+    [Fact]
+    public async Task Genuinely_asynchronous_captures_complete_the_same_way()
+    {
+        // The awaits must survive delegates that actually yield — the real captures are CEF round trips,
+        // never synchronously complete. Catches a rewrite that only works when awaits run inline.
+        var (token, anchor) = await BookDisplayViewModel.CaptureFinalPositionCoreAsync(
+            async () => { await Task.Yield(); return FreshToken; },
+            async () => { await Task.Yield(); return "para42"; },
+            hasStoredToken: true);
+
+        Assert.Same(FreshToken, token);
+        Assert.Equal("para42", anchor);
+    }
+}

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -656,32 +656,76 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public async Task CaptureCurrentPositionAsync()
         {
-            if (BookDisplayControl != null)
-            {
-                try
-                {
-                    var anchor = await BookDisplayControl.GetCurrentParagraphAnchorAsync();
-                    if (!string.IsNullOrEmpty(anchor) && anchor != "null")
-                    {
-                        _lastCapturedAnchor = anchor;
-                        _logger.Information("Captured final position before shutdown: {Anchor}", anchor);
-                    }
+            // Hoisted ONCE: ControlRecycling nulls BookDisplayControl (View.OnDataContextChanged) when a
+            // drag rebuilds this book's view, and both captures below yield to the same UI-thread
+            // dispatcher that delivers that change. The old shape re-read the property after each await,
+            // threw NRE mid-capture, and left a fresh anchor beside a stale token. (#891)
+            var control = BookDisplayControl;
+            if (control == null) return;
 
-                    // Also refresh the #434 token — it is PREFERRED over _lastCapturedAnchor on restore, so a
-                    // scroll in the final sub-tick window must update the token too, or the fresh anchor above
-                    // would be ignored in favour of an up-to-one-tick-staler token. (Fable cross-run review §2)
-                    var token = await BookDisplayControl.GetCurrentPositionTokenAsync();
-                    if (token != null)
-                    {
-                        _lastPositionToken = token;
-                        _logger.Debug("Captured final reading-position token before shutdown");
-                    }
-                }
-                catch (Exception ex)
+            try
+            {
+                var (token, anchor) = await CaptureFinalPositionCoreAsync(
+                    () => control.GetCurrentPositionTokenAsync(),
+                    () => control.GetCurrentParagraphAnchorAsync(),
+                    hasStoredToken: _lastPositionToken != null);
+
+                if (token != null)
                 {
-                    _logger.Warning(ex, "Failed to capture final position before shutdown");
+                    _lastPositionToken = token;
+                    _logger.Debug("Captured final reading-position token before shutdown");
                 }
+                if (anchor != null)
+                {
+                    _lastCapturedAnchor = anchor;
+                    _logger.Information("Captured final position before shutdown: {Anchor}", anchor);
+                }
+                if (token == null && anchor == null)
+                    _logger.Debug("Final position capture unavailable - keeping the last consistent anchor/token pair");
             }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "Failed to capture final position before shutdown");
+            }
+        }
+
+        /// <summary>
+        /// Decides what the final pre-shutdown capture commits, given the two capture calls and whether a
+        /// rolling #434 token is already stored. Policy over injected captures so it is unit-testable
+        /// without a live WebView (InternalsVisibleTo CST.Avalonia.Tests). (#891)
+        ///
+        /// <para>
+        /// The invariant: the stored anchor and token must describe the SAME moment, because restore
+        /// PREFERS the token — a fresh anchor beside a staler token is silently ignored in the token's
+        /// favour, which is exactly the "reopened a bit off" drift of #551/#537. Hence:
+        /// </para>
+        /// <list type="bullet">
+        ///   <item>The token is captured FIRST. If teardown interrupts between the two calls, the partial
+        ///     result is "fresh token + stale anchor" — the token wins on restore, so that is correct —
+        ///     never the reverse.</item>
+        ///   <item>If the token cannot be captured but one is already stored, the anchor is NOT captured
+        ///     either: restore would ignore a fresh anchor anyway, and refreshing it would desynchronize
+        ///     the pair. The stored pair is at most one 200ms status tick stale, both halves from the
+        ///     same tick.</item>
+        ///   <item>If NO token was ever captured (a book closed within its first tick), the anchor is all
+        ///     restore has, so a fresh one is taken.</item>
+        /// </list>
+        /// A null in the result means "leave that field alone". The anchor is normalized: empty or the JS
+        /// literal "null" count as no capture.
+        /// </summary>
+        internal static async Task<(ReadingPositionToken? Token, string? Anchor)> CaptureFinalPositionCoreAsync(
+            Func<Task<ReadingPositionToken?>> captureToken,
+            Func<Task<string?>> captureAnchor,
+            bool hasStoredToken)
+        {
+            var token = await captureToken();
+            if (token == null && hasStoredToken)
+                return (null, null);
+
+            var anchor = await captureAnchor();
+            if (string.IsNullOrEmpty(anchor) || anchor == "null")
+                anchor = null;
+            return (token, anchor);
         }
 
         public string CurrentParagraph


### PR DESCRIPTION
Closes #891. Found in a live drag test, fixed and reviewed by Fable.

## The failure

Once in a whole day's log, 47 ms after the R9-1 tool guard fired for the first time:

```
[INF] Captured final position before shutdown: mn3
[WRN] Failed to capture final position before shutdown
      System.NullReferenceException at CaptureCurrentPositionAsync() … line 673
```

`BookDisplayControl` was null-checked once, then dereferenced after two awaits. `BookDisplayView.OnDataContextChanged:684` nulls that property when ControlRecycling rebuilds the view during a drag, and both captures yield to the same UI-thread dispatcher that delivers the change.

## Hoisting alone would not have fixed it

That was my proposed fix in the issue, and it is insufficient. With a hoisted local, a view torn down between the two calls makes `GetCurrentPositionTokenAsync` return null **from its own guard** — so the anchor is refreshed and the token is not, silently. Same harm, no exception to notice it by.

The harm was never the NRE. It is that restore **prefers the token**, so a fresh anchor beside a stale token means the fresh anchor is ignored — the drift this project has chased twice (#551, #537).

## What the fix decides

Hoist once, and extract the commit policy into a testable core:

- **Token first.** An interruption between the two calls now yields *fresh token + stale anchor* — token wins on restore, which is correct — never the reverse.
- **Token unavailable but one is stored → commit nothing.** Verified: a single 200 ms status tick updates both (`BookDisplayView.axaml.cs:3004` and `:3021` from one status message), so the stored pair is self-consistent and at most one tick stale. A partial update only desynchronizes it. **Partial capture is worse than none** — the issue suspected this; the review confirmed it.
- **No token ever captured** (book closed inside its first tick) → the anchor is all restore has, so it is still taken.

## Behaviour change worth knowing

When the token cannot be refreshed but one is stored, the shutdown capture now **skips the anchor refresh too**. Previously it always committed a fresh anchor. That is the point of the change, not a side effect.

## Verification

Build clean, 0 warnings. Suite **2701 passed, 0 failed, 17 skipped**.

`FinalPositionCaptureTests` — 10 cases pinning both partial-interruption end states, call order, the no-stored-token path, and anchor normalization. Fable ran 7 mutants, all killed; I re-ran the load-bearing one independently — removing the commit-nothing guard fails `Token_lost_with_a_stored_token_commits_nothing_and_never_asks_for_the_anchor` and nothing else.

**Honest limit:** the race itself needs a live view and dispatcher, and there is no Avalonia.Headless in this test project. The three-line hoist is verified by reading; the policy around it is what the tests pin.

## Sweep

Four other await-boundary sites checked and found safe or bounded; two are note-worthy and deliberately left alone rather than sprawling this PR — the View's `_webView` dereferences after `_jsExecutionLock.WaitAsync` (each inside a catch that degrades to a no-op), and `GetCurrentParagraphAnchorAsync`'s unbounded lock-contention recursion, which unlike the token method's bounded retry could loop on a wedged lock. Worth issues of their own.
