### PR TITLE
Call it the "AI Assistant" where the reader can see it (#899)

### DIFF
--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1831,7 +1831,7 @@ public partial class App : Application
                                     }
                                     // Must stay in lockstep with the View-menu header in
                                     // SimpleTabbedWindow.axaml: the toggle is wired by matching that string.
-                                    else if (viewSubItem.Header?.ToString() == "Assistant")
+                                    else if (viewSubItem.Header?.ToString() == "AI Assistant")
                                     {
                                         _assistantMenuItems.Add(viewSubItem);
                                         viewSubItem.ToggleType = NativeMenuItemToggleType.CheckBox;
@@ -2066,7 +2066,7 @@ public partial class App : Application
             // Without an entry here a reader who did that from a floating window had no way back to it.
             var assistantItem = new NativeMenuItem
             {
-                Header = "Assistant",
+                Header = "AI Assistant",
                 ToggleType = NativeMenuItemToggleType.CheckBox,
                 IsChecked = layoutViewModel?.IsAssistantPanelVisible ?? false
             };

--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -357,10 +357,10 @@
         <p>Beta 5 reached feature parity with CST4. Beta 6 adds a great deal on top of it, and these areas are the newest &mdash; feedback on them is especially valuable:</p>
 
         <div class="focus-item">
-            <strong>The Assistant &mdash; brand new</strong>
+            <strong>The AI Assistant &mdash; brand new</strong>
             <ul>
                 <li>Select a passage and ask for a translation, a word-by-word breakdown, or an explanation</li>
-                <li>Turn it on under Settings &rsaquo; Assistant, and add a provider you have an account with under Providers</li>
+                <li>Turn it on under Settings &rsaquo; AI Assistant, and add a provider you have an account with under Providers</li>
                 <li>Your API key goes to the macOS Keychain or Windows Credential store &mdash; never into the app's settings file</li>
                 <li>If a key is already in your environment, the Providers tab offers it; nothing connects until you say so</li>
                 <li>Every answer shows what was actually sent to the model &mdash; is it the passage you meant?</li>
@@ -448,7 +448,7 @@
             <li>The texts are presented in Pāli only &mdash; CST Reader does not include translations. The built-in dictionaries give the meaning of individual words.</li>
             <li>Menus and dialogs are English only. CST4 offers 24 interface languages; that work is still ahead.</li>
             <li>macOS: idle CPU is higher than it should be, from a framework-level timer amplified by the text view. Beta 6 reduces how often that timer fires; the underlying issue is not ours to fix and is not yet closed</li>
-            <li>The Assistant can read a selection of roughly 1,100 characters in Devanāgarī, Myanmar and other non-Latin scripts, or about 2,900 in Latin. Beyond that the answer covers the surrounding passage instead, and says so</li>
+            <li>The AI Assistant can read a selection of roughly 1,100 characters in Devanāgarī, Myanmar and other non-Latin scripts, or about 2,900 in Latin. Beyond that the answer covers the surrounding passage instead, and says so</li>
         </ul>
     </div>
 

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -297,7 +297,7 @@ namespace CST.Avalonia.Services
             var rightToolDock = new ToolDock
             {
                 Id = "RightToolDock",
-                Title = "Assistant",
+                Title = "AI Assistant",
                 ActiveDockable = assistantTool,
                 VisibleDockables = assistantTool is null
                     ? CreateList<IDockable>()
@@ -1751,7 +1751,7 @@ namespace CST.Avalonia.Services
             var rightToolDock = new ToolDock
             {
                 Id = "RightToolDock",
-                Title = "Assistant",
+                Title = "AI Assistant",
                 Alignment = Alignment.Right,
                 GripMode = GripMode.Visible,
                 CanDrag = true,

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -97,7 +97,7 @@ public class AiAssistantViewModel : ReactiveTool
         EffortPicker = new AiEffortPickerViewModel(connections, settings);
 
         Id = "AiAssistantTool";
-        Title = "Assistant";
+        Title = "AI Assistant";
         CanClose = false;
         CanFloat = true;
         CanPin = false;

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -282,11 +282,11 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public void ShowAssistantPanel() =>
             ShowToolPanel("AiAssistantTool", () => App.ServiceProvider?.GetRequiredService<AiAssistantViewModel>(),
-                () => IsAssistantPanelVisible = true, "Assistant", right: true);
+                () => IsAssistantPanelVisible = true, "AI Assistant", right: true);
 
         public void HideAssistantPanel()
         {
-            HideToolPanel("AiAssistantTool", () => IsAssistantPanelVisible = false, "Assistant");
+            HideToolPanel("AiAssistantTool", () => IsAssistantPanelVisible = false, "AI Assistant");
 
             // Hand the freed width to the documents rather than leaving it unclaimed. (#656)
             if (_factory is CstDockFactory factory) factory.RebalanceMainDock();

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -52,7 +52,7 @@
     </UserControl.Styles>
 
     <StackPanel>
-        <TextBlock Text="Choose the models you want to switch between. They are what the Assistant offers when you ask a question."
+        <TextBlock Text="Choose the models you want to switch between. They are what the AI Assistant offers when you ask a question."
                    Classes="SettingDescription"/>
 
         <TextBlock IsVisible="{Binding HasNoConnections}"

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -548,7 +548,7 @@
                                      models reject sampling parameters with a 400. -->
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
-                                        <TextBlock Text="Assistant" Classes="SettingLabel"/>
+                                        <TextBlock Text="AI Assistant" Classes="SettingLabel"/>
 
                                         <CheckBox IsChecked="{Binding ChatEnabled}"
                                                  IsEnabled="{Binding SubPermissionsEnabled}"

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -41,7 +41,7 @@
                     <NativeMenuItem Header="Open a Book" />
                     <NativeMenuItem Header="Search" />
                     <NativeMenuItem Header="Dictionary" />
-                    <NativeMenuItem Header="Assistant" />
+                    <NativeMenuItem Header="AI Assistant" />
                     <NativeMenuItemSeparator />
                     <!-- #572 book zoom. The menu carries the discoverability: a beta tester asked for a way
                          to enlarge the text and, finding none, invented a copy-a-line-then-search ritual


### PR DESCRIPTION
Closes #899. Suite green: 2708 passed, 0 failed.

Renames the user-facing label in the tab title, the View menu (both the macOS `NativeMenuItem` and the code-built one), the Settings category, and the three welcome-page mentions.

**Three sites that were not a find-and-replace:**

- **The View-menu header is matched by string.** `App.axaml.cs` locates the item with `Header?.ToString() == "Assistant"` to turn it into a checkbox, and its own comment warns it must stay in lockstep with the XAML. Renaming one alone leaves a menu item that silently stops toggling.
- **The dock title appears twice** — `CreateLayout` and `EnsureRightToolDock`, the latter rebuilding the column after it is closed or floated out. Changing one gives a panel whose title changes on reopen.
- **`Settings > Assistant` on the welcome page is wayfinding**, naming the category renamed here.

**Deliberately unchanged:** the `"AiAssistantTool"` dock id (how the panel is found and its visibility restored), all `AiAssistant*` type names, and `ChatRole.Assistant` (a wire protocol value).

**Needs your eye:** the right column is 0.18 of the window and "AI Assistant" is a third longer — worth confirming the tab and dock header do not truncate at the default width, and that View → AI Assistant still checks/unchecks.