### PR TITLE
Mark provenance in anything another session acts on

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,21 @@ Several Claude sessions work this repo (different machines, plus review subagent
 - **"Working as designed" is never a conclusion to post on your own.** It contradicts a human's report, and the maintainer owns intent. Bring the evidence to him first.
 - **Brief a review subagent with the maintainer's verbatim words, not your summary** — and say where you have already been wrong. A reviewer inherits the frame it is given, and your summary is least reliable exactly where you are most mistaken: a #846 brief that opened with the author's inverted premise would have produced a rigorous confirmation of a fix nobody wanted. Tell it to attack the premise, not only the code. A subagent is strong on "is this code correct" and structurally blind to "is this the right thing to build" — that second question is the maintainer's.
 
+## Mark provenance: whose idea is it
+Anything another session will act on — issues, design docs, prompts for other sessions, review briefs — mixes the maintainer's decisions with an agent's reasoning, written in the same confident register. The reader cannot tell them apart, and the next session implements both as rules.
+
+> "we have a pattern here of something I say being embellished or taken out of context. The other half of it is that in implementation it is followed as a rule." — fsnow, 2026-08-18
+
+> "I had to fight with Kestrel today to get the UI implemented as I intended -- as much like OpenCode as possible -- because of embellishments that it found in the issues" — fsnow, same day
+
+Mark every load-bearing claim:
+
+- **[fsnow]** — his decision. **Quote him; never paraphrase into a rule.** Binding.
+- **[suggestion]** — an agent's. Advisory, and say so.
+- **[observed]** — a fact from code, a measurement, or a named source. Cite it.
+
+Unmarked text is context, not instruction. Reserve imperatives ("must", "never") for his decisions and verified constraints; use "I'd suggest" or "this follows if…" for reasoning. **Check the transcript before attributing anything to him.** The failure is rarely an invented quote — it is a real remark attached to an invented conclusion: his note that OpenCode picked up his existing `GOOGLE_API_KEY` became an invented `CST_AI_*` namespace, which then travelled with his remark as its provenance. Uniform confidence is the defect, not any single embellishment.
+
 ## Documentation workflow
 Docs live in `docs/` (`architecture/`, `implementation/`, `features/{planned,in-progress,implemented}`, `research/`, `development/`, `testing/`). Feature docs move planned → in-progress → implemented. **When adding/removing a doc, update [docs/README.md](docs/README.md).** Bugs/features are tracked as GitHub issues, not in markdown backlogs.
 


### PR DESCRIPTION
Requested by the maintainer: move the provenance-marking rule out of one session's private memory and into `CLAUDE.md`, so it carries across all CST sessions.

## Why

`CLAUDE.md`'s **Working with issues** section already states the premise — several sessions work this repo, they share no memory, and anything that should bind all of them lives in this file. This is one of those things, and it has been living in a single session's notes since 2026-08-18.

The failure it addresses: an issue or design doc carries the maintainer's decisions and an agent's reasoning in the same confident register. A downstream session cannot tell them apart, so it implements both as rules.

Documented instances, all 2026-08-17/18: the model registry (a preference about model quality became a JSON schema, a screening rule and a Settings verdict); `AI_INTEGRATION.md` §11.1's "curate a recommended-for-translation frontier tier"; #573 (an anecdote about one lost font became a filed defect with a priority); "keep the preset list short"; "default all-off"; "no provider logos"; and `CST_AI_*` — the sharpest one, a **substitution** where the maintainer's remark about OpenCode picking up his existing `GOOGLE_API_KEY` became an invented namespace, carried forward with his real remark attached as its provenance.

## What it adds

A `## Mark provenance: whose idea is it` section between **Working with issues** and **Documentation workflow**, with three tags — **[fsnow]** (his decision, quoted not paraphrased, binding), **[suggestion]** (an agent's, advisory), **[observed]** (a fact from code, a measurement or a named source, cited) — plus: unmarked text is context not instruction; reserve imperatives for decisions and verified constraints; check the transcript before attributing anything.

It sits directly above the existing **Brief a review subagent with the maintainer's verbatim words, not your summary** bullet, which is the same principle applied to subagent briefs.

## Two notes for review, in the spirit of the rule itself

- **The three tag names are [suggestion], not [fsnow].** `[fsnow]` / `[suggestion]` / `[observed]` is my construction from the maintainer's feedback, not his wording — rename freely if something else reads better in an issue body.
- **The two quotes are verbatim**, including the literal `--` as typed. Paraphrasing them into a tidier rule is the exact failure the section exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)