### PR TITLE
Move the Assistant into the left tool dock (#906)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
@@ -221,68 +221,8 @@ public class CstDockFactoryTests
         Assert.Equal(before, mainDock.VisibleDockables!.Count);  // nothing inserted
     }
 
-    // ---- The assistant's own container (#656) ----
 
-    [Fact]
-    public void EnsureRightToolDock_RecreatesUnderMainDock_WhenMissing()
-    {
-        // The assistant can be floated into its own window and that window closed, which takes the panel out
-        // of the layout entirely. It is the only tool whose dock is on the right, so it needs its own
-        // recreate path — and since the panel holds the whole session's transcript, having no way back lost
-        // that too.
-        var f = new CstDockFactory();
-        var doc = new DocumentDock { Id = "MainDocumentDock", VisibleDockables = List() };
-        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(doc) };
-        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
-        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
-        f._rootDock = root;
-        f._mainDock = mainDock;
 
-        var dock = f.EnsureRightToolDock();
-
-        Assert.NotNull(dock);
-        Assert.Equal("RightToolDock", dock!.Id);
-        Assert.Contains(mainDock.VisibleDockables!, d => d.Id == "RightTools");
-    }
-
-    [Fact]
-    public void EnsureRightToolDock_AppendsAfterTheDocuments()
-    {
-        // Right of the books, not left of them: it is inserted by position, and getting the ends confused
-        // would put the assistant where the book tree lives.
-        var f = new CstDockFactory();
-        var doc = new DocumentDock { Id = "MainDocumentDock", VisibleDockables = List() };
-        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(doc) };
-        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
-        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
-        f._rootDock = root;
-        f._mainDock = mainDock;
-
-        f.EnsureRightToolDock();
-
-        var ids = mainDock.VisibleDockables!.Select(d => d.Id).ToList();
-        Assert.True(ids.IndexOf("RightTools") > ids.IndexOf("MainDocumentDock"));
-    }
-
-    [Fact]
-    public void EnsureRightToolDock_ReusesExisting_WhenPresent()
-    {
-        var f = new CstDockFactory();
-        var existing = new ToolDock { Id = "RightToolDock", VisibleDockables = List() };
-        var rightTools = new ProportionalDock { Id = "RightTools", VisibleDockables = List(existing) };
-        var doc = new DocumentDock { Id = "MainDocumentDock", VisibleDockables = List() };
-        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(doc, rightTools) };
-        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
-        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
-        f._rootDock = root;
-        f._mainDock = mainDock;
-        var before = mainDock.VisibleDockables!.Count;
-
-        var dock = f.EnsureRightToolDock();
-
-        Assert.Same(existing, dock);
-        Assert.Equal(before, mainDock.VisibleDockables!.Count);
-    }
 
     [Fact]
     public void The_assistant_is_off_when_neither_switch_is_on()
@@ -296,39 +236,14 @@ public class CstDockFactoryTests
         Assert.False(CstDockFactory.AssistantEnabled());
     }
 
-    [Fact]
-    public void A_recreated_assistant_column_gets_a_real_share_of_the_window()
-    {
-        // Reported: reopening it from the View menu brought it back about a quarter of an inch wide -- worse
-        // than not coming back, since a reader who did not know to drag it would think the menu had failed.
-        //
-        // Closing empties the ToolDock, the cleanup pass collapses the wrapper and its splitter, and what is
-        // left no longer sums to one -- so the framework rebalances around it. Re-inserting a dock that says
-        // 0.18 into a row that has already been rebalanced gives it 18% of nothing in particular. The whole
-        // row has to be restated, which is what this asserts.
-        var f = new CstDockFactory();
-        // The drifted state a hide leaves behind: two columns sharing the whole window between them.
-        var doc = new DocumentDock { Id = "MainDocumentDock", Proportion = 0.75, VisibleDockables = List() };
-        var leftTools = new ProportionalDock { Id = "LeftTools", Proportion = 0.25, VisibleDockables = List() };
-        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(leftTools, doc) };
-        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
-        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
-        f._rootDock = root;
-        f._mainDock = mainDock;
-
-        f.EnsureRightToolDock();
-
-        var assistant = mainDock.VisibleDockables!.First(d => d.Id == "RightTools");
-        Assert.True(assistant.Proportion > 0.1, $"came back at {assistant.Proportion}");
-
-        // And the row adds up, so nothing is left for the framework to guess about.
-        var total = leftTools.Proportion + doc.Proportion + assistant.Proportion;
-        Assert.Equal(1.0, total, 3);
-    }
 
     [Fact]
-    public void Hiding_the_assistant_hands_its_width_to_the_documents()
+    public void The_documents_get_every_share_the_tool_rail_does_not_take()
     {
+        // One tool column, so the row is two members and the documents are whatever is left. Before #906 a
+        // second column sat on the right and this sum had three terms; the assertion that matters is the
+        // same either way — the row adds to one, with nothing left for the framework to guess about.
+
         var f = new CstDockFactory();
         var doc = new DocumentDock { Id = "MainDocumentDock", Proportion = 0.57, VisibleDockables = List() };
         var leftTools = new ProportionalDock { Id = "LeftTools", Proportion = 0.25, VisibleDockables = List() };
@@ -338,38 +253,12 @@ public class CstDockFactoryTests
         f._rootDock = root;
         f._mainDock = mainDock;
 
-        // The assistant is already gone, as it is by the time the hide path rebalances.
         f.RebalanceMainDock();
 
         Assert.Equal(0.75, doc.Proportion, 3);
         Assert.Equal(1.0, leftTools.Proportion + doc.Proportion, 3);
     }
 
-    [Fact]
-    public void The_assistant_opens_narrower_than_the_documents()
-    {
-        // Reported: "the default width of the Assistant is too wide — often wider than the book area". Split
-        // the documents into two books side by side and each gets half the middle column, so a quarter-width
-        // assistant is exactly as wide as either book. The middle column has to stay wide enough that a split
-        // book is still the widest thing on screen.
-        var f = new CstDockFactory();
-        f.EnsureRightToolDock();   // no MainDock: just proves the constant is not the old 0.25
-
-        var doc = new DocumentDock { Id = "MainDocumentDock", VisibleDockables = List() };
-        var mainDock = new ProportionalDock { Id = "MainDock", VisibleDockables = List(doc) };
-        var windowLayout = new RootDock { Id = "WindowLayout", VisibleDockables = List(mainDock) };
-        var root = new RootDock { Id = "Root", VisibleDockables = List(windowLayout) };
-        f._rootDock = root;
-        f._mainDock = mainDock;
-
-        f.EnsureRightToolDock();
-        var assistant = mainDock.VisibleDockables!.First(d => d.Id == "RightTools");
-
-        Assert.True(assistant.Proportion < 0.25, $"assistant opens at {assistant.Proportion}");
-        // Half the middle column, which is what a side-by-side book gets, must still beat it.
-        var middle = 1.0 - 0.25 - assistant.Proportion;
-        Assert.True(middle / 2 > assistant.Proportion, "a split book would be narrower than the assistant");
-    }
 
     /// <summary>
     /// A tool panel is recognised as one. (R9-1, #886)

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -37,7 +37,6 @@ namespace CST.Avalonia.Services
         // Misnomer kept for the smaller diff: this is the DOCUMENT dock's proportion, which used to be the
         // rightmost thing in MainDock. Since #586 the assistant sits to its right and has its own field below.
         private double _mainDockRightProportion = 0.50;
-        private double _mainDockAssistantProportion = AssistantProportion;
 
         /// <summary>
         /// How wide the assistant column opens. Narrower than the tool rail on the left: that one holds a
@@ -45,7 +44,6 @@ namespace CST.Avalonia.Services
         /// a narrow measure than a wide one — and every pixel it takes comes off the book. A starting point,
         /// not a verdict; the splitter beside it is the answer to disagreeing.
         /// </summary>
-        private const double AssistantProportion = 0.18;
 
         // Typed references to two spine docks, set in CreateLayout, used to recreate the tool container
         // on demand (see EnsureLeftToolDock). Reference-stable: MainDock is protected and never removed.
@@ -112,7 +110,10 @@ namespace CST.Avalonia.Services
                 Id = "LeftToolDock",
                 Title = "Tools",
                 ActiveDockable = openBookTool,
-                VisibleDockables = CreateList<IDockable>(openBookTool, searchTool, dictionaryTool),
+                // The assistant is the fourth tab when it is switched on. (#906)
+                VisibleDockables = assistantTool is null
+                    ? CreateList<IDockable>(openBookTool, searchTool, dictionaryTool)
+                    : CreateList<IDockable>(openBookTool, searchTool, dictionaryTool, assistantTool),
                 Alignment = Alignment.Left,
                 GripMode = GripMode.Visible,
                 CanDrag = true,
@@ -159,7 +160,7 @@ namespace CST.Avalonia.Services
             {
                 Id = "MainDocumentDock",
                 Title = "Documents",
-                Proportion = 1.0 - 0.25 - AssistantProportion,  // the middle column: tools left, assistant right (#586)
+                Proportion = 1.0 - 0.25,  // everything the tool rail does not take (#906)
                 ActiveDockable = welcomeDocument,
                 VisibleDockables = CreateList<IDockable>(welcomeDocument),
                 CanCreateDocument = false, // Disable "+" button - books opened via "Select a Book" panel
@@ -287,42 +288,15 @@ namespace CST.Avalonia.Services
                 Title = "MainSplitter"
             };
 
-            // The assistant sits on the RIGHT, opposite the tools. (#586)
+            // The assistant is a tab in the LEFT tool dock, not a column of its own. (#906)
             //
-            // It began as a fourth tab in the left tool dock, which was wrong twice over: a generated answer
-            // is prose to be read ALONGSIDE the passage, and the left rail is the narrowest column on screen;
-            // and selecting it cost the reader whichever of Open Book, Search or Dictionary they were using.
-            // On the right it is a second reading column beside the book, and nothing has to be given up to
-            // see it.
-            var rightToolDock = new ToolDock
-            {
-                Id = "RightToolDock",
-                Title = "AI Assistant",
-                ActiveDockable = assistantTool,
-                VisibleDockables = assistantTool is null
-                    ? CreateList<IDockable>()
-                    : CreateList<IDockable>(assistantTool),
-                Alignment = Alignment.Right,
-                GripMode = GripMode.Visible,
-                CanDrag = true,
-                CanDrop = true
-            };
-
-            var rightTools = new ProportionalDock
-            {
-                Id = "RightTools",
-                Proportion = AssistantProportion,
-                Orientation = Orientation.Vertical,
-                IsCollapsable = false,
-                CanDrop = true,
-                VisibleDockables = CreateList<IDockable>(rightToolDock)
-            };
-
-            var rightSplitter = new ProportionalDockSplitter
-            {
-                Id = "RightSplitter",
-                Title = "RightSplitter"
-            };
+            // Moved here 2026-08-30 at the maintainer's request, from using the feature: two tool docks left
+            // the documents at 0.57 of the window, and the books are what the application exists to show.
+            // Four tabs fit the left rail's existing width, so the second column bought nothing. Reading side
+            // by side is still a float or a drag away; it is simply no longer the default.
+            //
+            // Nothing here needs the CEF float protections that guard the book views: the assistant renders
+            // in Avalonia controls, never in a WebView (AiAssistantPanel.axaml).
 
             // Create main proportional dock (horizontal split) with splitter for resizing
             var mainDock = new ProportionalDock
@@ -332,9 +306,7 @@ namespace CST.Avalonia.Services
                 Orientation = Orientation.Horizontal,
                 IsCollapsable = false,  // Like Notepad sample
                 CanDrop = true,  // Allow dropping dockables here
-                VisibleDockables = assistantEnabled
-                    ? CreateList<IDockable>(leftTools, splitter, documentDock, rightSplitter, rightTools)
-                    : CreateList<IDockable>(leftTools, splitter, documentDock)
+                VisibleDockables = CreateList<IDockable>(leftTools, splitter, documentDock)
             };
 
             // Create inner root dock (window layout) with pinned dockables for edge drop indicators
@@ -1707,15 +1679,6 @@ namespace CST.Avalonia.Services
         }
 
         /// <summary>
-        /// The RightToolDock that hosts the assistant, recreating it (and its RightTools wrapper) under the
-        /// protected MainDock if it has been removed. (#656)
-        ///
-        /// <para>The assistant can be floated into its own window, and closing that window takes the panel out
-        /// of the layout entirely. Without this there was no way back: it is the only tool with no View-menu
-        /// entry, so a reader who floated it and closed the window lost it for the rest of the session — and
-        /// since the panel holds the whole transcript, they lost that too.</para>
-        /// </summary>
-        /// <summary>
         /// Whether the assistant is switched on: the AI master switch AND the assistant's own. Read from
         /// settings rather than cached, because Settings toggles it while the app runs. (#667)
         /// </summary>
@@ -1733,71 +1696,6 @@ namespace CST.Avalonia.Services
             }
         }
 
-        internal ToolDock? EnsureRightToolDock()
-        {
-            if (_rootDock != null && FindDockByIdRecursive(_rootDock, "RightToolDock") is ToolDock existing)
-            {
-                return existing;
-            }
-
-            if (_mainDock?.VisibleDockables == null)
-            {
-                Log.Error("*** EnsureRightToolDock: MainDock unavailable - cannot recreate tool container ***");
-                return null;
-            }
-
-            Log.Information("*** EnsureRightToolDock: RightToolDock missing - recreating tool container under MainDock ***");
-
-            var rightToolDock = new ToolDock
-            {
-                Id = "RightToolDock",
-                Title = "AI Assistant",
-                Alignment = Alignment.Right,
-                GripMode = GripMode.Visible,
-                CanDrag = true,
-                CanDrop = true,
-                VisibleDockables = CreateList<IDockable>(),
-                Factory = this
-            };
-
-            var rightTools = new ProportionalDock
-            {
-                Id = "RightTools",
-                Proportion = AssistantProportion,
-                Orientation = Orientation.Vertical,
-                IsCollapsable = false,
-                CanDrop = true,
-                VisibleDockables = CreateList<IDockable>(rightToolDock),
-                Factory = this
-            };
-
-            // Appended at the right of MainDock (mirrors CreateLayout: [... documents, splitter, rightTools]).
-            var splitter = new ProportionalDockSplitter { Id = "RightSplitter", Title = "RightSplitter" };
-            _mainDock.VisibleDockables.Add(splitter);
-            _mainDock.VisibleDockables.Add(rightTools);
-
-            // Owner/Factory wiring, as EnsureLeftToolDock does: without a proper Owner, base.FloatDockable
-            // cannot detach these, so floating a recreated panel would silently no-op.
-            InitDockable(rightTools, _mainDock);
-            InitDockable(rightToolDock, rightTools);
-
-            // A recreated column comes back a quarter of an inch wide without this, which is worse than not
-            // coming back at all: a reader who did not know to drag it would think the menu item had failed.
-            //
-            // Closing the panel empties its ToolDock, and the cleanup pass then collapses the wrapper and its
-            // splitter — so what is left in MainDock no longer sums to one, and the framework rebalances
-            // around it. Re-inserting a dock with a Proportion of 0.18 into a MainDock that has already been
-            // rebalanced does not give it 18% of anything. So the whole row is restated, not just the new
-            // member, and restated again after layout has run, because the framework recomputes proportions
-            // on its own schedule and the last writer wins.
-            _mainDockAssistantProportion = AssistantProportion;
-            ApplyMainDockProportions();
-            Dispatcher.UIThread.Post(ApplyMainDockProportions, DispatcherPriority.Render);
-            Dispatcher.UIThread.Post(ApplyMainDockProportions, DispatcherPriority.Loaded);
-
-            return rightToolDock;
-        }
-        
         // Override to prevent accidental closes during drag operations
         // The app-wide ControlRecycling instance (App.axaml resource, shared by every DockControl).
         private IControlRecycling? GetControlRecycling()
@@ -3197,22 +3095,18 @@ namespace CST.Avalonia.Services
                 var left = _mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "LeftTools")
                            ?? _mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "LeftToolDock");
                 var documents = _mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "MainDocumentDock");
-                var assistant = _mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "RightTools")
-                                ?? _mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "RightToolDock");
 
                 // Only the columns actually present get a share, so hiding one hands its width to the
                 // documents rather than leaving a gap the framework has to guess about.
                 var leftShare = left != null ? _mainDockLeftProportion : 0;
-                var assistantShare = assistant != null ? _mainDockAssistantProportion : 0;
 
                 if (left != null) left.Proportion = leftShare;
-                if (assistant != null) assistant.Proportion = assistantShare;
-                if (documents != null) documents.Proportion = 1.0 - leftShare - assistantShare;
+                if (documents != null) documents.Proportion = 1.0 - leftShare;
 
-                _mainDockRightProportion = 1.0 - leftShare - assistantShare;
+                _mainDockRightProportion = 1.0 - leftShare;
 
-                Log.Debug("*** ApplyMainDockProportions: left={Left:F3}, documents={Docs:F3}, assistant={Assistant:F3} ***",
-                    leftShare, 1.0 - leftShare - assistantShare, assistantShare);
+                Log.Debug("*** ApplyMainDockProportions: left={Left:F3}, documents={Docs:F3} ***",
+                    leftShare, 1.0 - leftShare);
             }
             catch (Exception ex)
             {
@@ -3251,8 +3145,6 @@ namespace CST.Avalonia.Services
                     var leftDock = mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "LeftTools")
                                    ?? mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "LeftToolDock");
                     var documentDock = mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "MainDocumentDock");
-                    var assistantDock = mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "RightTools")
-                                        ?? mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "RightToolDock");
 
                     if (leftDock != null && documentDock != null)
                     {
@@ -3261,9 +3153,6 @@ namespace CST.Avalonia.Services
 
                         _mainDockLeftProportion = leftDock.Proportion;
                         _mainDockRightProportion = documentDock.Proportion;
-                        // Captured on the same terms as the other two, or opening a book would silently
-                        // resize the assistant column the reader had just set. (#586)
-                        if (assistantDock != null) _mainDockAssistantProportion = assistantDock.Proportion;
 
                         Log.Debug("*** CaptureMainDockProportions: Captured Left={Left:F3} (ID: {LeftId}), Right={Right:F3} (was Left={OldLeft:F3}, Right={OldRight:F3}) ***",
                             _mainDockLeftProportion, leftDock.Id, _mainDockRightProportion, oldLeft, oldRight);
@@ -3325,23 +3214,18 @@ namespace CST.Avalonia.Services
                     var leftDock = mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "LeftTools")
                                    ?? mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "LeftToolDock");
                     var documentDock = mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "MainDocumentDock");
-                    var assistantDock = mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "RightTools")
-                                        ?? mainDock.VisibleDockables.FirstOrDefault(d => d.Id == "RightToolDock");
 
                     if (leftDock != null && documentDock != null)
                     {
                         var currentLeft = leftDock.Proportion;
                         var currentRight = documentDock.Proportion;
-                        var currentAssistant = assistantDock?.Proportion ?? _mainDockAssistantProportion;
 
                         // Only restore if proportions have changed significantly (framework recalculated)
                         if (Math.Abs(currentLeft - _mainDockLeftProportion) > 0.01 ||
-                            Math.Abs(currentRight - _mainDockRightProportion) > 0.01 ||
-                            Math.Abs(currentAssistant - _mainDockAssistantProportion) > 0.01)
+                            Math.Abs(currentRight - _mainDockRightProportion) > 0.01)
                         {
                             leftDock.Proportion = _mainDockLeftProportion;
                             documentDock.Proportion = _mainDockRightProportion;
-                            if (assistantDock != null) assistantDock.Proportion = _mainDockAssistantProportion;
 
                             Log.Debug("*** RestoreMainDockProportions: Restored proportions from Left={CurrentLeft:F3} (ID: {LeftId}), Right={CurrentRight:F3} to Left={TargetLeft:F3}, Right={TargetRight:F3} ***",
                                 currentLeft, leftDock.Id, currentRight, _mainDockLeftProportion, _mainDockRightProportion);

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -158,11 +158,8 @@ namespace CST.Avalonia.ViewModels
         // a ReactiveTool (its Id/Title/flags are set in its constructor), so it's added directly — exactly as
         // CreateLayout does at startup; wrapping it in a generic Tool { Context } renders an empty panel
         // because the view locator resolves by dockable type. (#84)
-        private void ShowToolPanel(string toolId, Func<IDockable?> resolveVm, Action markVisible, string panelName)
-            => ShowToolPanel(toolId, resolveVm, markVisible, panelName, right: false);
-
         private void ShowToolPanel(
-            string toolId, Func<IDockable?> resolveVm, Action markVisible, string panelName, bool right)
+            string toolId, Func<IDockable?> resolveVm, Action markVisible, string panelName)
         {
             Log.Information("[Layout] Show {Panel} panel requested", panelName);
 
@@ -182,8 +179,8 @@ namespace CST.Avalonia.ViewModels
                 return;
             }
 
-            // The assistant lives in its own dock on the right; the other three share the left rail.
-            var toolDock = right ? _factory.EnsureRightToolDock() : _factory.EnsureLeftToolDock();
+            // All four tools share the left rail, the assistant included. (#906)
+            var toolDock = _factory.EnsureLeftToolDock();
             if (toolDock == null)
             {
                 Log.Error("[Layout] Cannot add {Panel} panel - MainDock unavailable.", panelName);
@@ -282,7 +279,7 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public void ShowAssistantPanel() =>
             ShowToolPanel("AiAssistantTool", () => App.ServiceProvider?.GetRequiredService<AiAssistantViewModel>(),
-                () => IsAssistantPanelVisible = true, "AI Assistant", right: true);
+                () => IsAssistantPanelVisible = true, "AI Assistant");
 
         public void HideAssistantPanel()
         {


### PR DESCRIPTION
Closes #906, #904, #898.

The Assistant had a tool dock to itself on the right, so the books sat squeezed between two tool columns. It is now a fourth tab beside Open a Book, Search and Dictionary.

| Column | Before | After |
|---|---|---|
| Tool rail | 0.25 | 0.25 |
| **Documents** | **0.57** | **0.75** |
| Assistant column | 0.18 | — |

Decided from use rather than argument: the right-hand column came from a design expectation recorded in #586, and living with the feature produced the opposite verdict. Four tabs fit the left rail's existing width, so the second column bought nothing that was not already there.

**Side-by-side reading is not lost, only un-defaulted** — the Assistant can still be floated or dragged out into a right-hand split. Nothing in that path needs the CEF float protections that guard the book views: the Assistant renders in Avalonia controls, never in a WebView.

## Deleted rather than left inert

Git is the history, so none of this is commented out or annotated:

- `RightToolDock`, `RightTools`, `RightSplitter`
- `EnsureRightToolDock` — and the **orphaned doc comment** that described it while sitting above `AssistantEnabled`, documenting the wrong method
- `AssistantProportion`, `_mainDockAssistantProportion`
- the assistant terms in `ApplyMainDockProportions`, `CaptureMainDockProportions` and `RestoreMainDockProportionsImpl`, including three `?? "RightToolDock"` fallbacks
- `ShowToolPanel`'s `right` parameter and its two-overload split — it selected a dock that no longer exists

Net **-258 / +28** lines.

## Tests

Five that exercised the right column are gone with it. The one that survives asserted the *invariant* rather than the arrangement — the row sums to one, documents take whatever the tool rail does not — so it is restated under a name that says so, and passes with two members instead of three.

## Verified on Windows 11 ARM64, Assistant enabled

```
Layout created - Root: 1 dockables, Main: 3, LeftTool: 3, Document: 1
Assistant is enabled but its panel was not built at startup; adding it now
*** AddDockable called - Dock: LeftToolDock, Dockable: AiAssistantTool ***
[Layout] Assistant panel added to LeftToolDock
[#91] Restored active left-tool tab: SearchTool
```

`Main` has three members rather than five, and neither `RightToolDock` nor `RightTools` appears anywhere in the log.

Worth explaining the third line, since it reads oddly: the Assistant reaches `LeftToolDock` through the **existing** startup reconciliation, not through `CreateLayout`, because settings are not yet loaded when the layout is built. That is unchanged by this commit, and it is why the creation line says three tools rather than four.

**2707 pass, 13 skipped, 0 warnings** (exit code checked, not read off a filtered window).

## On the two issues this also closes

**#904** asked whether to put the choice to Beta 6 testers. Moot for the reason that issue identified itself — dock arrangement is not persisted, so a tester could drag the Assistant left, relaunch, and find it back on the right. They could not have kept the arrangement long enough to judge it.

**#898** asked why `RightTools` lacked the single-child collapse exclusion `LeftTools` has. There is no `RightTools` now. The more interesting half of that question — whether the `LeftTools` exclusion is load-bearing or redundant beside its `??` fallback — is recorded on the issue as still open, and deliberately not reopened: nothing observable is wrong and each mechanism costs a line.
