### PR TITLE
Teach WalkForward that a danda inside a note is not a sentence end

### DIFF
--- a/src/CST.Avalonia.Tests/Search/PassageFidelityTests.cs
+++ b/src/CST.Avalonia.Tests/Search/PassageFidelityTests.cs
@@ -45,6 +45,43 @@ namespace CST.Avalonia.Tests.Search
             Assert.DoesNotContain("sigla", w.Text);
         }
 
+        // A danda INSIDE the note, positioned so a modest budget runs out while the walk is in the apparatus.
+        private const string DandaInNoteXml =
+            "<body><div id=\"dn1\" type=\"book\">" +
+            "<p rend=\"bodytext\" n=\"5\">alpha bravo charlie<note>one two\u0964 three</note> delta echo\u0964 " +
+            "foxtrot golf\u0964</p>" +
+            "</div></body>";
+
+        [Fact]
+        public void A_danda_inside_a_note_does_not_end_the_window()
+        {
+            var markers = BookMarkers.Build(DandaInNoteXml);
+            int start = markers.PositionOfParagraph(5);
+
+            // Apparatus rendered inline, and a budget that is reached while the walk is inside the note, so
+            // the note's own danda is the first boundary the walk meets after the budget.
+            var w = TeiPassageReader.ReadWindow(DandaInNoteXml, start, maxChars: 22,
+                includeVariants: true, outputScript: Script.Devanagari, markers);
+
+            // Whatever it decides, it must not close BETWEEN the braces.
+            Assert.Equal(w.Text.Split('{').Length, w.Text.Split('}').Length);
+        }
+
+        [Fact]
+        public void The_hard_cap_ends_before_a_note_rather_than_inside_it()
+        {
+            var markers = BookMarkers.Build(LongNoteXml);
+            int start = markers.PositionOfParagraph(5);
+
+            // No danda anywhere before the cap falls, so the walk runs to the hard cap - which the boundary
+            // guard cannot help with, because it is unconditional.
+            var w = TeiPassageReader.ReadWindow(LongNoteXml, start, maxChars: 14,
+                includeVariants: true, outputScript: Script.Devanagari, markers);
+
+            Assert.Equal(w.Text.Split('{').Length, w.Text.Split('}').Length);
+            Assert.Contains("alpha", w.Text);
+        }
+
         private static int InsideTheNote(string xml)
         {
             int open = xml.IndexOf("<note>", StringComparison.Ordinal) + "<note>".Length;

--- a/src/CST.Core/Search/TeiPassageReader.cs
+++ b/src/CST.Core/Search/TeiPassageReader.cs
@@ -715,6 +715,14 @@ namespace CST.Search
             int i = start, rendered = 0;
             long hardCap = (long)maxChars + maxChars / 2;
             bool budgetReached = false;
+
+            // How deep in apparatus the walk currently is, and where the outermost open note began. Only ever
+            // non-zero when includeNotes is set: otherwise the branch below strips each note's subtree and the
+            // walk is never inside one. Counted from the tags as they pass rather than scanned up front, which
+            // costs nothing on a path that runs for every window — and is exact, because every caller starts
+            // outside a note (the #913 nudge guarantees it for the one that could not otherwise). (#917)
+            int noteDepth = 0, noteOpenedAt = -1;
+
             while (i < limit)
             {
                 char c = xml[i];
@@ -724,24 +732,45 @@ namespace CST.Search
                     if (gt < 0) break;
                     string tag = xml.Substring(i, gt - i + 1);
                     string name = TeiText.TagName(tag);
-                    if (name == "note" && !includeNotes && !tag.EndsWith("/>", StringComparison.Ordinal))
+                    bool selfClosing = tag.EndsWith("/>", StringComparison.Ordinal);
+                    if (name == "note" && !includeNotes && !selfClosing)
                         // Open <note> strips its subtree; a lone </note> (walk began inside a note) is zero-width,
                         // never a subtree — else SkipSubtree jumps to the next </note>, silently skipping text. (#310 A4-2)
                         i = tag.StartsWith("</", StringComparison.Ordinal)
                             ? gt + 1
                             : TeiText.SkipSubtree(xml, gt + 1, "note", limit);
-                    else if (name == "hi" && TeiText.IsStructuralHi(tag) && !tag.EndsWith("/>", StringComparison.Ordinal))
+                    else if (name == "hi" && TeiText.IsStructuralHi(tag) && !selfClosing)
                         i = TeiText.SkipSubtree(xml, gt + 1, "hi", limit);
-                    else i = gt + 1;
+                    else
+                    {
+                        if (name == "note" && !selfClosing)
+                        {
+                            if (tag.StartsWith("</", StringComparison.Ordinal))
+                            {
+                                if (noteDepth > 0) noteDepth--;
+                            }
+                            else if (noteDepth++ == 0) noteOpenedAt = i;
+                        }
+                        i = gt + 1;
+                    }
                 }
                 else
                 {
-                    if (budgetReached && TeiText.IsBoundary(c)) return i + 1;   // stop just past a sentence end
+                    // A danda inside a <note> is apparatus punctuation, not a base-text sentence end. Stopping
+                    // there would close the window between <note> and </note>, and Clean would emit an opening
+                    // brace with nothing to match it. The other four boundary checks in this file have carried
+                    // this guard since #310; this one did not. (#917)
+                    if (budgetReached && noteDepth == 0 && TeiText.IsBoundary(c)) return i + 1;
                     rendered++;
                     i++;
                     if (rendered >= maxChars) budgetReached = true;
                     if (rendered >= hardCap)
                     {
+                        // The cap is unconditional, so it can fall inside a note where the boundary check now
+                        // cannot. End before the note opened rather than inside it — same reason — but only
+                        // when that still advances, or the window's end becomes its own nextCursor.
+                        if (noteDepth > 0 && noteOpenedAt > start) return noteOpenedAt;
+
                         // No boundary found: hard cap. Back off any half-cut akṣara — but not to nothing, or
                         // this window's end becomes its own nextCursor and the caller pages forever. (#871)
                         int cut = ClusterStart(xml, i, start);


### PR DESCRIPTION
Fixes #917.

> **Stacked on #916** — it branches from that PR's head, so this diff shows #916's commits until that merges. Merge #916 first; this is a follow-up to a finding its ultra review raised.

## The inconsistency

Four of the five sentence-boundary checks in `TeiPassageReader` have carried an `!TeiText.InNote` guard since #310. The fifth — `WalkForward`, which decides where every passage window *ends* — did not:

```
WalkBackSentences        IsBoundary(...) && !InNote(...)
ExtendToSentenceEnd      IsBoundary(...) && !InNote(...)
WalkForwardSentences     IsBoundary(...) && !InNote(...)
SnapBackToSentenceStart  IsBoundary(...) && !InNote(...)
WalkForward              IsBoundary(...)                  <-- no guard
```

With the apparatus rendered inline, the walk could stop just past a danda inside a footnote. The window then opened before `<note>` and closed before `</note>`, and `TeiText.Clean` emitted an opening brace with nothing to match it — the mirror image of the tail #913 fixed at the other end of the same window.

## Approach

Note depth is counted from the tags as they pass, not scanned up front. That costs nothing on a path that runs for every window, and it is **exact** here because every `WalkForward` caller starts outside a note — the #913 nudge guarantees it for the one that otherwise could not. Depth is only ever non-zero when `includeNotes` is set; otherwise each note's subtree is stripped and the walk is never inside one.

The **hard cap** needed the same treatment and could not get it from the guard, being unconditional by design. It now ends before the note opened rather than inside it, but only where that still advances — otherwise a window's end becomes its own `nextCursor` and paging never terminates.

## What this does *not* retire

The whole-note-must-fit condition added in #916 for the same malformation stays necessary. A walk beginning **at** a note's start has `noteOpenedAt == start`, so the cap cannot retreat to it without returning the position it came from. The two guards cover different halves, which the tests exercise separately.

## Tests

| Mutation | Fails |
|---|---|
| Restore the unguarded boundary check (the pre-fix state) | the danda test alone — the reviewer's claim demonstrated, not assumed |
| Remove the cap's retreat | both note tests |

Full suite: **2720 passed, 0 failed, 17 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)