### PR TITLE
Stop destroying the reader's saved tool tab, two ways (#919)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/AddWithoutActivatingTests.cs
+++ b/src/CST.Avalonia.Tests/Services/AddWithoutActivatingTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.ObjectModel;
+using CST.Avalonia.Services;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services;
+
+/// <summary>
+/// Adding a tool to a dock must not make it the active tab. (#919)
+///
+/// <para><b>The defect this pins.</b> All four tools share one rail since #906. Startup builds the layout
+/// about 7ms before settings finish loading, so a reader who has the assistant switched on gets a rail
+/// without it; the reconcile adds it once the settings are real. That add used to activate the panel, which
+/// landed after #91 had restored the reader's saved tab — so the rail always opened on the assistant, and
+/// the monitor then persisted the assistant as the reader's choice, destroying the preference. Before #906
+/// the assistant went into a dock of its own, where activating it could disturb nothing.</para>
+///
+/// <para><b>Why this test and not the call site.</b> <c>LayoutViewModel</c>'s constructor builds a real
+/// layout and initialises host windows, so the call-site half cannot be tested until #655 lands headless
+/// support — the same limit <c>MainDockRowTests</c> records. What is testable is the assumption the fix
+/// rests on: that adding a dockable is not itself an activation. If a future Dock.Avalonia made
+/// <c>AddDockable</c> activate what it adds, the fix would be undone silently and every other test would
+/// still pass.</para>
+/// </summary>
+public class AddWithoutActivatingTests
+{
+    private static ToolDock Rail(params IDockable[] tools)
+    {
+        var dock = new ToolDock
+        {
+            Id = "LeftToolDock",
+            VisibleDockables = new ObservableCollection<IDockable>(tools),
+        };
+        if (tools.Length > 0) dock.ActiveDockable = tools[0];
+        return dock;
+    }
+
+    private static Tool Tool(string id) => new() { Id = id, Title = id };
+
+    [Fact]
+    public void Adding_a_tool_leaves_the_active_tab_alone()
+    {
+        var factory = new CstDockFactory();
+        var restored = Tool("SearchTool");
+        var rail = Rail(Tool("OpenBookTool"), restored);
+        rail.ActiveDockable = restored;          // as #91's restore leaves it
+        rail.Factory = factory;
+
+        var assistant = Tool("AiAssistantTool");
+        assistant.Factory = factory;
+        factory.AddDockable(rail, assistant);
+
+        Assert.Same(restored, rail.ActiveDockable);
+        Assert.Contains(assistant, rail.VisibleDockables!);
+    }
+
+    /// <summary>
+    /// And the opposite half, so the test cannot pass by the framework simply never activating anything:
+    /// an explicit activation still works. A reader choosing View → AI Assistant must land on it.
+    /// </summary>
+    [Fact]
+    public void An_explicit_activation_still_takes_the_tab()
+    {
+        var factory = new CstDockFactory();
+        var rail = Rail(Tool("OpenBookTool"), Tool("SearchTool"));
+        rail.Factory = factory;
+
+        var assistant = Tool("AiAssistantTool");
+        assistant.Factory = factory;
+        factory.AddDockable(rail, assistant);
+        factory.SetActiveDockable(assistant);
+
+        Assert.Same(assistant, rail.ActiveDockable);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/AddWithoutActivatingTests.cs
+++ b/src/CST.Avalonia.Tests/Services/AddWithoutActivatingTests.cs
@@ -57,6 +57,40 @@ public class AddWithoutActivatingTests
     }
 
     /// <summary>
+    /// Removing a tool straight from the collection leaves the dock pointing at it, silently. (#919)
+    ///
+    /// <para>This is the hazard <c>RemoveToolFromLayout</c> compensates for, pinned because it is the whole
+    /// reason those lines exist. <c>VisibleDockables.Remove</c> is not <c>Factory.RemoveDockable</c>: it does
+    /// not touch <c>ActiveDockable</c> and raises no PropertyChanged, so the dock keeps a dangling active tab
+    /// AND the monitor that persists the reader's tab never hears of it. Turning the assistant off while its
+    /// tab is active would otherwise leave "AiAssistantTool" saved as the reader's choice, and #91 would then
+    /// restore nothing at all — dropping them on the default rather than the tab they had been using.</para>
+    ///
+    /// <para>If a future Dock.Avalonia starts clearing the active tab on removal, this fails and the
+    /// compensation can go.</para>
+    /// </summary>
+    [Fact]
+    public void Raw_removal_leaves_the_active_tab_dangling_and_raises_nothing()
+    {
+        var rail = Rail(Tool("OpenBookTool"), Tool("SearchTool"));
+        var assistant = Tool("AiAssistantTool");
+        rail.VisibleDockables!.Add(assistant);
+        rail.ActiveDockable = assistant;
+
+        var announced = 0;
+        ((System.ComponentModel.INotifyPropertyChanged)rail).PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(rail.ActiveDockable)) announced++;
+        };
+
+        rail.VisibleDockables!.Remove(assistant);
+
+        Assert.Same(assistant, rail.ActiveDockable);                       // still pointing at it
+        Assert.DoesNotContain(assistant, rail.VisibleDockables!);          // though it is gone
+        Assert.Equal(0, announced);                                        // and nothing was announced
+    }
+
+    /// <summary>
     /// And the opposite half, so the test cannot pass by the framework simply never activating anything:
     /// an explicit activation still works. A reader choosing View → AI Assistant must land on it.
     /// </summary>

--- a/src/CST.Avalonia.Tests/Services/AddWithoutActivatingTests.cs
+++ b/src/CST.Avalonia.Tests/Services/AddWithoutActivatingTests.cs
@@ -9,12 +9,13 @@ namespace CST.Avalonia.Tests.Services;
 /// <summary>
 /// Adding a tool to a dock must not make it the active tab. (#919)
 ///
-/// <para><b>The defect this pins.</b> All four tools share one rail since #906. Startup builds the layout
-/// about 7ms before settings finish loading, so a reader who has the assistant switched on gets a rail
-/// without it; the reconcile adds it once the settings are real. That add used to activate the panel, which
-/// landed after #91 had restored the reader's saved tab — so the rail always opened on the assistant, and
-/// the monitor then persisted the assistant as the reader's choice, destroying the preference. Before #906
-/// the assistant went into a dock of its own, where activating it could disturb nothing.</para>
+/// <para><b>The defect this pins.</b> All four tools share one rail since #906. The layout is always built
+/// before settings load — deterministically, not as a race — so a reader with the assistant switched on gets
+/// a rail without it, and the reconcile adds it once the settings are real. That add used to activate the
+/// panel, and the dock monitor records every activation as the reader's saved tab, unable to tell the app's
+/// own from a click. The write landed after the state file was read and before #91 captured the saved id, so
+/// #91 restored the assistant faithfully — from a value the app had just written over the reader's. Before
+/// #906 the assistant went into a dock of its own, where activating it could disturb nothing.</para>
 ///
 /// <para><b>Why this test and not the call site.</b> <c>LayoutViewModel</c>'s constructor builds a real
 /// layout and initialises host windows, so the call-site half cannot be tested until #655 lands headless

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -507,7 +507,11 @@ public partial class App : Application
                 if (MainWindow?.DataContext is LayoutViewModel layout && !layout.IsAssistantPanelVisible)
                 {
                     Log.Information("Assistant is enabled but its panel was not built at startup; adding it now");
-                    layout.ShowAssistantPanel();
+                    // activate: false — this is the app catching up with settings that loaded after the
+                    // layout was built, not the reader asking for the assistant. Activating here would take
+                    // the rail's active tab from the one #91 restored a moment earlier, and the monitor would
+                    // then persist the assistant as the reader's choice. (#919)
+                    layout.ShowAssistantPanel(activate: false);
                 }
             });
         }

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -508,9 +508,17 @@ public partial class App : Application
                 {
                     Log.Information("Assistant is enabled but its panel was not built at startup; adding it now");
                     // activate: false — this is the app catching up with settings that loaded after the
-                    // layout was built, not the reader asking for the assistant. Activating here would take
-                    // the rail's active tab from the one #91 restored a moment earlier, and the monitor would
-                    // then persist the assistant as the reader's choice. (#919)
+                    // layout was built, not the reader asking for the assistant.
+                    //
+                    // It does NOT override the #91 restore; it runs BEFORE it, and corrupts its input.
+                    // Activating fires AttachLeftToolDockMonitor, which cannot tell an app-initiated
+                    // activation from a reader's click — Dock's PropertyChanged carries no provenance — so it
+                    // writes "AiAssistantTool" into Current.ActiveLeftToolId. That write lands after the
+                    // state file has been read into Current and before #91 captures state.ActiveLeftToolId
+                    // (state IS Current, as the capture's own comment notes). #91 then restores faithfully,
+                    // from a value the app wrote a moment earlier, and the reader's saved tab is gone.
+                    // Logged on 2026-08-30: add at 22.864, then "[#91] Restored active left-tool tab:
+                    // AiAssistantTool" at 22.972. Not activating is what stops the write. (#919)
                     layout.ShowAssistantPanel(activate: false);
                 }
             });

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -158,8 +158,17 @@ namespace CST.Avalonia.ViewModels
         // a ReactiveTool (its Id/Title/flags are set in its constructor), so it's added directly — exactly as
         // CreateLayout does at startup; wrapping it in a generic Tool { Context } renders an empty panel
         // because the view locator resolves by dockable type. (#84)
+        /// <param name="activate">
+        /// Whether to make the panel the active tab. True for anything the reader asked for; false when the
+        /// app is putting the layout in step with itself.
+        ///
+        /// <para>All four tools share one dock (#906), so activating a panel takes the rail's active tab from
+        /// whatever was there — including the one #91 has just restored. Before #906 the assistant went into a
+        /// dock of its own, where activating it could disturb nothing. (#919)</para>
+        /// </param>
         private void ShowToolPanel(
-            string toolId, Func<IDockable?> resolveVm, Action markVisible, string panelName)
+            string toolId, Func<IDockable?> resolveVm, Action markVisible, string panelName,
+            bool activate = true)
         {
             Log.Information("[Layout] Show {Panel} panel requested", panelName);
 
@@ -189,8 +198,11 @@ namespace CST.Avalonia.ViewModels
 
             tool.Factory = _factory;
             _factory.AddDockable(toolDock, tool);
-            _factory.SetActiveDockable(tool);
-            _factory.SetFocusedDockable(toolDock, tool);
+            if (activate)
+            {
+                _factory.SetActiveDockable(tool);
+                _factory.SetFocusedDockable(toolDock, tool);
+            }
 
             Log.Information("[Layout] {Panel} panel added to {Dock}", panelName, toolDock.Id);
 
@@ -283,9 +295,14 @@ namespace CST.Avalonia.ViewModels
         /// holds the whole session's transcript, losing it lost that too. The view model is a singleton, so
         /// what comes back is the same panel with its turns intact.</para>
         /// </summary>
-        public void ShowAssistantPanel() =>
+        /// <param name="activate">
+        /// False when startup is reconciling the panel against settings that loaded after the layout was
+        /// built — that is the app catching up with itself, not the reader asking for the assistant, and it
+        /// must not take the rail's active tab from the one #91 restored. (#919)
+        /// </param>
+        public void ShowAssistantPanel(bool activate = true) =>
             ShowToolPanel("AiAssistantTool", () => App.ServiceProvider?.GetRequiredService<AiAssistantViewModel>(),
-                () => IsAssistantPanelVisible = true, "AI Assistant");
+                () => IsAssistantPanelVisible = true, "AI Assistant", activate);
 
         public void HideAssistantPanel() =>
             HideToolPanel("AiAssistantTool", () => IsAssistantPanelVisible = false, "AI Assistant");

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -163,8 +163,10 @@ namespace CST.Avalonia.ViewModels
         /// app is putting the layout in step with itself.
         ///
         /// <para>All four tools share one dock (#906), so activating a panel takes the rail's active tab from
-        /// whatever was there — including the one #91 has just restored. Before #906 the assistant went into a
-        /// dock of its own, where activating it could disturb nothing. (#919)</para>
+        /// whatever was there. Worse, it is recorded: the dock monitor persists every activation as the
+        /// reader's saved tab, having no way to tell the app's own from a click. An activation during startup
+        /// therefore overwrites the saved preference before #91 has read it. Before #906 the assistant went
+        /// into a dock of its own, where activating it could disturb nothing. (#919)</para>
         /// </param>
         private void ShowToolPanel(
             string toolId, Func<IDockable?> resolveVm, Action markVisible, string panelName,
@@ -297,8 +299,9 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         /// <param name="activate">
         /// False when startup is reconciling the panel against settings that loaded after the layout was
-        /// built — that is the app catching up with itself, not the reader asking for the assistant, and it
-        /// must not take the rail's active tab from the one #91 restored. (#919)
+        /// built — the app catching up with itself, not the reader asking for the assistant. Activating there
+        /// would be recorded by the dock monitor as the reader's own choice and destroy their saved tab
+        /// before #91 reads it. (#919)
         /// </param>
         public void ShowAssistantPanel(bool activate = true) =>
             ShowToolPanel("AiAssistantTool", () => App.ServiceProvider?.GetRequiredService<AiAssistantViewModel>(),

--- a/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/LayoutViewModel.cs
@@ -374,9 +374,28 @@ namespace CST.Avalonia.ViewModels
                 if (sourceHostWindow != null && tool is DictionaryViewModel && _factory is CstDockFactory cefFactory)
                     cefFactory.DisposeAndEvictRecycledView(tool);
 
+                var wasActive = ReferenceEquals(parentDock.ActiveDockable, tool);
                 parentDock.VisibleDockables.Remove(tool);
-                Log.Information("[Layout] Removed tool {ToolId} from parent dock {ParentId}",
-                    tool.Id, parentDock.Id);
+
+                // Removing straight from the collection does not disturb ActiveDockable, so the dock is left
+                // pointing at a tool it no longer contains — measured, not assumed. Two things follow, and
+                // the second is the damaging one:
+                //
+                //   * the dock has a dangling active dockable for the rest of the session; and
+                //   * no PropertyChanged fires, so AttachLeftToolDockMonitor never hears of it and
+                //     ActiveLeftToolId keeps naming the removed tool.
+                //
+                // Turn the assistant off in Settings while its tab is active and the saved id stays
+                // "AiAssistantTool". Next launch #91 looks for a tool that is not there, finds nothing, and
+                // silently leaves the rail on CreateLayout's default — so the reader loses the tab they were
+                // actually using before they ever opened the assistant. Handing the active tab to a survivor
+                // both fixes the dangling reference and gives the monitor something true to record.
+                // (#919, and the factory's own RemoveDockable does the same for the same reason.)
+                if (wasActive)
+                    parentDock.ActiveDockable = parentDock.VisibleDockables.FirstOrDefault();
+
+                Log.Information("[Layout] Removed tool {ToolId} from parent dock {ParentId} (was active: {WasActive})",
+                    tool.Id, parentDock.Id, wasActive);
 
                 // If the parent dock is now empty, collapse what the removal left behind
                 if (parentDock.VisibleDockables.Count == 0 && _factory is CstDockFactory cstFactory)


### PR DESCRIPTION
Closes #919. Suite green: 2710 passed, 0 failed, 17 skipped.

Two ways the reader's saved tool tab was being destroyed. Both are consequences of #906 moving the assistant into the shared rail — before that it lived in a dock of its own, where neither could reach the left rail's state.

### 1. The startup reconcile wrote a false preference

The layout is built before settings load — deterministically, not as a race: `MainWindow` is constructed at `App.axaml.cs:235`, `LoadSettingsAsync` runs at `:279`. So `AssistantEnabled()` always reads `new Settings()` with the master switch off, the four-tool branch in `CreateLayout` is dead on any real launch, and the assistant is *always* added afterwards by `ReconcileAssistantPanel`.

That add activated the panel. Activation fires `AttachLeftToolDockMonitor`, which cannot tell an app-initiated activation from a reader's click — Dock's `PropertyChanged` carries no provenance — so it wrote `AiAssistantTool` into `Current.ActiveLeftToolId`. The write landed after the state file was read into `Current` and before #91 captured `state.ActiveLeftToolId` (`state` IS `Current`, as the capture's own comment notes).

**#91 then restored faithfully, from a value the app had just written over the reader's.** From the launch log:

```
22.802  Assistant is enabled but its panel was not built at startup; adding it now
22.818  Application state loaded successfully
22.864  [Layout] AI Assistant panel added to LeftToolDock
22.972  [#91] Restored active left-tool tab: AiAssistantTool
```

Fixed by not activating on the reconcile path: `ShowToolPanel` gains `activate` (default true), and only the reconcile passes false. Every reader-initiated route — View menu, toggle, Settings switch — is unchanged.

### 2. Removing a tool left a stale preference

Raised by the maintainer: what if the assistant is the active tool and is then switched off in Settings?

`RemoveToolFromLayout` uses `VisibleDockables.Remove(tool)`, not `Factory.RemoveDockable`. Measured: that leaves `ActiveDockable` pointing at a tool the dock no longer contains, and raises no `PropertyChanged`. So `ActiveLeftToolId` keeps naming `AiAssistantTool`, and the next launch finds no such tool in the rail, no-ops, and drops the reader on Open a Book rather than the tab they had been using.

Fixed by handing the active tab to a survivor on removal — clearing the dangling reference and giving the monitor something true to record, which is what the factory's own `RemoveDockable` already does.

### Tests

Three facts, pinning the two framework premises the fixes rest on: that adding is not activating, that explicit activation still works (so the first cannot pass vacuously), and that raw collection removal leaves the active tab dangling and silent. The call sites are not testable until #655 lands headless support — the limit `MainDockRowTests` already records.

### Reviewed

Fable reviewed at `e459be4` and **refuted the mechanism I had written into the comments** — I had claimed the activation overrode the restore, when it in fact precedes it and corrupts its input. It established the true order from the app's own logs. The code was already correct; three comments and a test doc were teaching the wrong reason, and are fixed in `f35a0de`. It also confirmed the dead-code claim and found nothing broken by `activate: false`.

### Not addressed here — both are maintainer calls

Fable's structural finding: #91 worked *by circumstance*, on an unstated precondition that nothing programmatically activates a rail tab between state load and capture. The three original tools satisfy it by being unconditional; the assistant is the first case to test it. Two larger fixes exist — load settings before building the layout (which would retire #836, #667, #817 and #919, all documented in `App.axaml.cs` as the same root), or capture the saved id at true state-load time. Neither belongs in this PR.

**One residue for testing:** this does not repair an already-poisoned state file. A tester whose `ActiveLeftToolId` was corrupted before the fix sees the assistant once more and may report it unfixed.
