### PR TITLE
Point the welcome page at Settings sections that exist

### DIFF
--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -359,9 +359,10 @@
         <div class="focus-item">
             <strong>The AI Assistant &mdash; brand new</strong>
             <ul>
+                <li>Opens as a fourth tab in the left tool dock, beside Search, Open a Book and Dictionary</li>
                 <li>Select a passage and ask for a translation, a word-by-word breakdown, or an explanation</li>
-                <li>Turn it on under Settings &rsaquo; AI Assistant, and add a provider you have an account with under Providers</li>
-                <li>Your API key goes to the macOS Keychain or Windows Credential store &mdash; never into the app's settings file</li>
+                <li>Turn it on under Settings &rsaquo; AI &mdash; then add a provider you have an account with under Settings &rsaquo; AI &rsaquo; Providers, a tab that appears once it is on</li>
+                <li>Your API key goes to the macOS Keychain or, on Windows, DPAPI under your user account &mdash; never into the app's settings file</li>
                 <li>If a key is already in your environment, the Providers tab offers it; nothing connects until you say so</li>
                 <li>Every answer shows what was actually sent to the model &mdash; is it the passage you meant?</li>
             </ul>
@@ -381,7 +382,7 @@
             <ul>
                 <li>A native arm64 build, alongside the existing x64 one</li>
                 <li>Install and first launch: does the text download and index build complete?</li>
-                <li>If book text appears blank, turn off hardware acceleration in Settings and restart</li>
+                <li>If book text appears blank, turn off &ldquo;Use hardware acceleration&rdquo; under Settings &rsaquo; Configuration &rsaquo; Graphics, and restart</li>
             </ul>
         </div>
 
@@ -390,7 +391,7 @@
             <ul>
                 <li><strong>Find in Page</strong> &mdash; &#8984;F / Ctrl+F searches within the book you are reading</li>
                 <li><strong>Text zoom</strong> &mdash; &#8984;/Ctrl with +, &minus; and 0, or the percentage control in the book toolbar</li>
-                <li><strong>Book fonts</strong> &mdash; choose a face for each script under Settings &rsaquo; Fonts</li>
+                <li><strong>Book fonts</strong> &mdash; choose a face for each script under Settings &rsaquo; Pali Script Fonts</li>
                 <li>Does your reading position survive zooming, switching tabs and restarting?</li>
             </ul>
         </div>
@@ -403,6 +404,7 @@
                 <li>Books that were floated or moved should all reopen when you restart</li>
             </ul>
         </div>
+    </div>
 
     <div class="quick-start">
         <h3>🚀 Quick Start</h3>


### PR DESCRIPTION
Pre-release pass over `welcome-content.html`, found while reviewing it against current source ahead of Beta 6.

## Wayfinding that was wrong

Four of these name a Settings location a tester cannot find:

| Was | Now | Evidence |
|---|---|---|
| "Windows Credential store" | "on Windows, DPAPI under your user account" | `WindowsDpapiStore.cs` — DPAPI over one file per provider, and its doc comment explicitly **rejects** the Credential Manager ("buys visibility we do not want and no protection DPAPI lacks") |
| "Settings ▸ Fonts" | "Settings ▸ Pali Script Fonts" | `SettingsViewModel.cs:75` — nothing named "Fonts" is in the left nav |
| "Settings ▸ AI Assistant" | "Settings ▸ AI" | `SettingsViewModel.cs:79`; "AI Assistant" is the toggle label inside it (`SettingsWindow.axaml:551`), not a category |
| "under Providers" | full path + "a tab that appears once it is on" | `SettingsWindow.axaml:650` — bound to `ShowConnectionTabs`, so it is not rendered until the assistant is enabled |
| "turn off hardware acceleration in Settings" | names the checkbox and Configuration ▸ Graphics | `SettingsWindow.axaml:338-346`. That bullet sits in the *Windows on ARM* focus item, so its reader is on a VM — the case the setting's own help text calls out |

The credential one is the one that would actually cost a report: a Windows tester opens Credential Manager, finds nothing, and files it.

## Added

Where the AI Assistant lives — a fourth tab in the left tool dock, beside Search, Open a Book and Dictionary — now that #906/#908 put it there. Quick Start already teaches the other three tabs but not this one.

## Layout fix worth a look

`<div class="focus-areas">` was never closed (pre-existing — the same 17-open/16-close imbalance is in the unmodified file). That div carries a green background, a 2px border and 24px padding, so **everything below it** — Quick Start, Send Us Feedback, Known Limitations, About, footer — was rendering inside the green Beta Testing panel. Closing it ends the panel after the last focus item.

This is what the CSS plainly intends, but it does change how the page looks. Worth an eyeball on first launch.

## Verification

- `dotnet build src/CST.Avalonia` — succeeded, 0 warnings, 0 errors
- All tag pairs balance: div 17/17, ul 8/8, li 30/30, p 20/20
- Full suite was green at 2723 passed / 0 failed before this edit; not re-run, as this file is a resource with no compiled surface
- Both "August 2026" strings left as-is

## Not changed

The macOS idle-CPU limitation ("Beta 6 reduces how often that timer fires") — a claim about a measurement I did not verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)