### PR TITLE
Refresh the models.dev snapshot for the Beta 6 release

### DIFF
--- a/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.json
+++ b/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.json
@@ -5230,7 +5230,7 @@
     "reasoning_options": [],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.1-chat-latest": {
@@ -5366,7 +5366,7 @@
     "reasoning_options": [],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.2-chat-latest": {
@@ -5499,7 +5499,7 @@
     "reasoning_options": [],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.3-codex-xhigh": {
@@ -5568,7 +5568,7 @@
     "reasoning_options": [],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -5603,7 +5603,7 @@
     "reasoning_options": [],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-nano": {
@@ -5638,7 +5638,7 @@
     "reasoning_options": [],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
@@ -7056,6 +7056,682 @@
   "name": "abliteration.ai",
   "npm": "@ai-sdk/openai-compatible"
  },
+ "above": {
+  "api": "https://api.above.dev/v1",
+  "doc": "https://above.dev/docs",
+  "env": [
+   "ABOVE_API_KEY"
+  ],
+  "id": "above",
+  "models": {
+   "deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0077,
+     "input": 0.242,
+     "output": 0.726,
+     "reasoning": 0.726
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.0077,
+     "input": 0.242,
+     "output": 0.726,
+     "reasoning": 0.726
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash-vision-exp",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision (Exp)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0242,
+     "input": 0.726,
+     "output": 2.178,
+     "reasoning": 2.178
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.154,
+     "input": 1.54,
+     "output": 4.84
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.2",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.2-fast": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.231,
+     "input": 2.31,
+     "output": 7.26
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "glm-5.2-fast",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.2 Fast",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.0319,
+     "input": 0.165,
+     "output": 0.55
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "mimo-v2.5-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0042,
+     "input": 0.5077,
+     "output": 1.0154
+    },
+    "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
+    "family": "mimo",
+    "id": "mimo-v2.5-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2024-12",
+    "last_updated": "2026-04-22",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiMo V2.5 Pro",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-04-22",
+    "temperature": true,
+    "tool_call": true
+   },
+   "mimo-v2.5-pro-ultraspeed": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0127,
+     "input": 1.5231,
+     "output": 3.0462
+    },
+    "description": "MiMo pro model for strong multimodal reasoning and agent execution",
+    "family": "mimo",
+    "id": "mimo-v2.5-pro-ultraspeed",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2024-12",
+    "last_updated": "2026-06-09",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiMo V2.5 Pro UltraSpeed",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-08",
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-max": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.275,
+     "input": 2.2,
+     "output": 6.6
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "qwen3.8-max",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen 3.8 Max",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-03",
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "above.dev",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "agentrouter": {
+  "api": "https://agentrouter.org/v1",
+  "doc": "https://agentrouter.org/docs/opencode.html",
+  "env": [
+   "AGENTROUTER_API_KEY"
+  ],
+  "id": "agentrouter",
+  "models": {
+   "claude-opus-4-8": {
+    "attachment": true,
+    "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "claude-opus-4-8",
+    "knowledge": "2026-01",
+    "last_updated": "2026-05-28",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.8",
+    "open_weights": false,
+    "provider": {
+     "api": "https://agentrouter.org/v1",
+     "npm": "@ai-sdk/anthropic"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-05-28",
+    "temperature": false,
+    "tool_call": true
+   },
+   "claude-opus-5": {
+    "attachment": true,
+    "description": "Strongest Claude Opus model for coding, agents, and professional work",
+    "family": "claude-opus",
+    "id": "claude-opus-5",
+    "knowledge": "2026-05",
+    "last_updated": "2026-07-24",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 5",
+    "open_weights": false,
+    "provider": {
+     "api": "https://agentrouter.org/v1",
+     "npm": "@ai-sdk/anthropic"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-24",
+    "temperature": false,
+    "tool_call": true
+   },
+   "gpt-5.6-sol": {
+    "attachment": true,
+    "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+    "family": "gpt-sol",
+    "id": "gpt-5.6-sol",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Sol",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   }
+  },
+  "name": "AgentRouter",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "agnes": {
+  "api": "https://apihub.agnes-ai.com/v1",
+  "doc": "https://agnes-ai.com/doc",
+  "env": [
+   "AGNES_API_KEY"
+  ],
+  "id": "agnes",
+  "models": {
+   "agnes-2.0-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Fast and efficient model for agent workflows, tool calling, coding, and image understanding.",
+    "id": "agnes-2.0-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-05-25",
+    "limit": {
+     "context": 512000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Agnes 2.0 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-05-25",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "agnes-2.5-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Upgraded model with improved coding, agent workflows, tool calling, and multimodal understanding.",
+    "id": "agnes-2.5-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-07",
+    "limit": {
+     "context": 512000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Agnes 2.5 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-07",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "agnes-2.5-pro-alpha": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.0038,
+     "input": 0.45,
+     "output": 0.9
+    },
+    "description": "Paid reasoning model for advanced coding, scientific reasoning, long-context analysis, agentic workflows, and multimodal understanding.",
+    "id": "agnes-2.5-pro-alpha",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-07-24",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Agnes 2.5 Pro Alpha",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-07-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "Agnes AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
  "ai-router": {
   "api": "https://api.ai-router.dev/v1",
   "doc": "https://ai-router.dev/openai-compatible-api-gateway/",
@@ -7108,7 +7784,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
@@ -7656,6 +8332,51 @@
     "temperature": true,
     "tool_call": true
    },
+   "qwen/qwen3.8-27b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 0.4,
+     "output": 3
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-27b",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "zai-org/glm-5.2": {
     "attachment": false,
     "cost": {
@@ -7695,6 +8416,48 @@
      }
     ],
     "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai-org/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 1,
+     "output": 4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "zai-org/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -11311,6 +12074,52 @@
   "name": "AIHubMix",
   "npm": "@aihubmix/ai-sdk-provider"
  },
+ "aixy": {
+  "api": "https://api.aixy-gateway.com/v1",
+  "doc": "https://docs.aixy-gateway.com/integrations/overview",
+  "env": [
+   "AIXY_API_KEY"
+  ],
+  "id": "aixy",
+  "models": {
+   "openai/gpt-4.1-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.4,
+     "output": 1.6
+    },
+    "description": "Affordable GPT-4.1 lane for fast coding help and structured extraction",
+    "family": "gpt-mini",
+    "id": "openai/gpt-4.1-mini",
+    "knowledge": "2024-04",
+    "last_updated": "2025-04-14",
+    "limit": {
+     "context": 1047576,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-4.1 mini",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-04-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "Aixy",
+  "npm": "@ai-sdk/openai-compatible"
+ },
  "aki-io": {
   "api": "https://aki.io/v1",
   "doc": "https://aki.io/docs/",
@@ -11319,6 +12128,49 @@
   ],
   "id": "aki-io",
   "models": {
+   "deepseek-v4-flash-0731-284b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.2,
+     "output": 0.5
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash-0731-284b",
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1048576,
+     "output": 81920
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "gemma4-26b": {
     "attachment": false,
     "cost": {
@@ -11402,6 +12254,7 @@
    "kimi-k2.7-code-1100b": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.18,
      "input": 0.86,
      "output": 3
     },
@@ -11430,36 +12283,6 @@
     "release_date": "2026-06-12",
     "structured_output": true,
     "temperature": false,
-    "tool_call": true
-   },
-   "minimax-m2.5-230b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.25,
-     "output": 1.2
-    },
-    "description": "Prior MiniMax coding model for agent workflows, office edits, and automation",
-    "family": "minimax",
-    "id": "minimax-m2.5-230b",
-    "last_updated": "2026-02-12",
-    "limit": {
-     "context": 196608,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "MiniMax-M2.5",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-02-12",
-    "temperature": true,
     "tool_call": true
    },
    "mistral4-119b": {
@@ -11538,6 +12361,49 @@
      }
     ],
     "release_date": "2026-04-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-27b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.3,
+     "output": 2.2
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen3.8-27b",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -12489,7 +13355,25 @@
     "attachment": false,
     "cost": {
      "input": 0.45,
-     "output": 2.25
+     "output": 2.25,
+     "tiers": [
+      {
+       "input": 0.75,
+       "output": 3.75,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "input": 1.2,
+       "output": 6,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
     },
     "description": "Smaller Qwen coder for efficient local agents and repo-level fixes",
     "family": "qwen",
@@ -12519,7 +13403,25 @@
     "attachment": false,
     "cost": {
      "input": 1.5,
-     "output": 7.5
+     "output": 7.5,
+     "tiers": [
+      {
+       "input": 2.7,
+       "output": 13.5,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "input": 4.5,
+       "output": 22.5,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
     },
     "description": "Open Qwen coding heavyweight for repository reasoning and agentic engineering",
     "family": "qwen",
@@ -13454,6 +14356,59 @@
     "temperature": true,
     "tool_call": true
    },
+   "qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.15,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen3.8-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "max": 262144,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "tool_call": true
+   },
    "qwen3.8-max": {
     "attachment": true,
     "cost": {
@@ -14042,8 +14997,18 @@
    "glm-5": {
     "attachment": false,
     "cost": {
-     "input": 0.86,
-     "output": 3.15
+     "input": 0.573,
+     "output": 2.58,
+     "tiers": [
+      {
+       "input": 0.86,
+       "output": 3.154,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      }
+     ]
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
@@ -14084,8 +15049,18 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.17,
-     "input": 0.87,
-     "output": 3.48
+     "input": 0.825,
+     "output": 3.301,
+     "tiers": [
+      {
+       "input": 1.1,
+       "output": 3.851,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      }
+     ]
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
@@ -14744,6 +15719,8 @@
    "qwen-plus": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.012,
+     "cache_write": 0.144,
      "input": 0.115,
      "output": 0.287,
      "reasoning": 1.147
@@ -15475,7 +16452,25 @@
     "attachment": false,
     "cost": {
      "input": 0.216,
-     "output": 0.861
+     "output": 0.861,
+     "tiers": [
+      {
+       "input": 0.323,
+       "output": 1.291,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "input": 0.538,
+       "output": 2.151,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
     },
     "description": "Qwen coding model for software agents, repository edits, and code reasoning",
     "family": "qwen",
@@ -15505,7 +16500,25 @@
     "attachment": false,
     "cost": {
      "input": 0.861,
-     "output": 3.441
+     "output": 3.441,
+     "tiers": [
+      {
+       "input": 1.291,
+       "output": 5.161,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "input": 2.151,
+       "output": 8.602,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
     },
     "description": "Qwen coding model for software agents, repository edits, and code reasoning",
     "family": "qwen",
@@ -15872,9 +16885,20 @@
    "qwen3.5-397b-a17b": {
     "attachment": false,
     "cost": {
-     "input": 0.43,
-     "output": 2.58,
-     "reasoning": 2.58
+     "input": 0.172,
+     "output": 1.032,
+     "reasoning": 1.032,
+     "tiers": [
+      {
+       "input": 0.43,
+       "output": 2.58,
+       "reasoning": 2.58,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -16298,6 +17322,59 @@
     ],
     "release_date": "2026-06-02",
     "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01187,
+     "cache_write": 0.14844,
+     "input": 0.11875,
+     "output": 0.40073
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen3.8-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "max": 262144,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "tool_call": true
    },
    "qwen3.8-max": {
@@ -18353,6 +19430,59 @@
     "temperature": true,
     "tool_call": true
    },
+   "qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "cache_write": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen3.8-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "max": 262144,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "tool_call": true
+   },
    "qwen3.8-max": {
     "attachment": true,
     "cost": {
@@ -19375,6 +20505,59 @@
     "release_date": "2026-06-02",
     "structured_output": true,
     "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "cache_write": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen3.8-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "max": 262144,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "tool_call": true
    },
    "qwen3.8-max": {
@@ -21555,22 +22738,22 @@
    "global.openai.gpt-5.6-luna": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.022,
-     "cache_write": 0.275,
+     "cache_read": 0.02,
+     "cache_write": 0.25,
      "context_over_200k": {
-      "cache_read": 0.044,
-      "cache_write": 0.55,
-      "input": 0.44,
-      "output": 1.98
+      "cache_read": 0.04,
+      "cache_write": 0.5,
+      "input": 0.4,
+      "output": 1.8
      },
-     "input": 0.22,
-     "output": 1.32,
+     "input": 0.2,
+     "output": 1.2,
      "tiers": [
       {
-       "cache_read": 0.044,
-       "cache_write": 0.55,
-       "input": 0.44,
-       "output": 1.98,
+       "cache_read": 0.04,
+       "cache_write": 0.5,
+       "input": 0.4,
+       "output": 1.8,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -21615,29 +22798,29 @@
      }
     ],
     "release_date": "2026-07-09",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": false,
     "tool_call": true
    },
    "global.openai.gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.55,
-     "cache_write": 6.875,
+     "cache_read": 0.4,
+     "cache_write": 5,
      "context_over_200k": {
-      "cache_read": 1.1,
-      "cache_write": 13.75,
-      "input": 11,
-      "output": 49.5
+      "cache_read": 0.8,
+      "cache_write": 10,
+      "input": 8,
+      "output": 30
      },
-     "input": 5.5,
-     "output": 33,
+     "input": 4,
+     "output": 20,
      "tiers": [
       {
-       "cache_read": 1.1,
-       "cache_write": 13.75,
-       "input": 11,
-       "output": 49.5,
+       "cache_read": 0.8,
+       "cache_write": 10,
+       "input": 8,
+       "output": 30,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -21682,29 +22865,29 @@
      }
     ],
     "release_date": "2026-07-09",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": false,
     "tool_call": true
    },
    "global.openai.gpt-5.6-terra": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.22,
-     "cache_write": 2.75,
+     "cache_read": 0.2,
+     "cache_write": 2.5,
      "context_over_200k": {
-      "cache_read": 0.44,
-      "cache_write": 5.5,
-      "input": 4.4,
-      "output": 19.8
+      "cache_read": 0.4,
+      "cache_write": 5,
+      "input": 4,
+      "output": 18
      },
-     "input": 2.2,
-     "output": 13.2,
+     "input": 2,
+     "output": 12,
      "tiers": [
       {
-       "cache_read": 0.44,
-       "cache_write": 5.5,
-       "input": 4.4,
-       "output": 19.8,
+       "cache_read": 0.4,
+       "cache_write": 5,
+       "input": 4,
+       "output": 18,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -21749,7 +22932,7 @@
      }
     ],
     "release_date": "2026-07-09",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": false,
     "tool_call": true
    },
@@ -22924,7 +24107,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai.gpt-5.5": {
@@ -23053,22 +24236,22 @@
    "openai.gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.55,
-     "cache_write": 6.875,
+     "cache_read": 0.44,
+     "cache_write": 5.5,
      "context_over_200k": {
-      "cache_read": 1.1,
-      "cache_write": 13.75,
-      "input": 11,
-      "output": 49.5
+      "cache_read": 0.88,
+      "cache_write": 11,
+      "input": 8.8,
+      "output": 33
      },
-     "input": 5.5,
-     "output": 33,
+     "input": 4.4,
+     "output": 22,
      "tiers": [
       {
-       "cache_read": 1.1,
-       "cache_write": 13.75,
-       "input": 11,
-       "output": 49.5,
+       "cache_read": 0.88,
+       "cache_write": 11,
+       "input": 8.8,
+       "output": 33,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -23217,7 +24400,7 @@
      ]
     },
     "name": "gpt-oss-120b",
-    "open_weights": false,
+    "open_weights": true,
     "provider": {
      "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
      "npm": "@ai-sdk/amazon-bedrock/mantle",
@@ -23262,7 +24445,7 @@
      ]
     },
     "name": "gpt-oss-120b",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -23302,7 +24485,7 @@
      ]
     },
     "name": "gpt-oss-20b",
-    "open_weights": false,
+    "open_weights": true,
     "provider": {
      "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
      "npm": "@ai-sdk/amazon-bedrock/mantle",
@@ -23347,7 +24530,7 @@
      ]
     },
     "name": "gpt-oss-20b",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -23387,7 +24570,7 @@
      ]
     },
     "name": "GPT OSS Safeguard 120B",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": false,
     "release_date": "2025-10-29",
     "structured_output": true,
@@ -23417,7 +24600,7 @@
      ]
     },
     "name": "GPT OSS Safeguard 20B",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": false,
     "release_date": "2025-10-29",
     "structured_output": true,
@@ -24975,6 +26158,47 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
+   },
+   "Qwen3.8-Flash-Next": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.016,
+     "input": 0.15,
+     "output": 0.47
+    },
+    "description": "Open-weight experimental preview of the Qwen4 architecture: hybrid-attention MoE (125B total, 6B active) with vision encoder for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "Qwen3.8-Flash-Next",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 262144,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash Next",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-27",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "AMD",
@@ -26433,7 +27657,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2": {
@@ -26472,7 +27696,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4": {
@@ -26528,7 +27752,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/o3": {
@@ -29888,7 +31112,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -29935,7 +31159,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-nano": {
@@ -29982,7 +31206,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-pro": {
@@ -33167,7 +34391,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -33214,7 +34438,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-nano": {
@@ -33261,7 +34485,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-pro": {
@@ -35262,6 +36486,94 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
+   },
+   "zai-org/GLM-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.14,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai-org/GLM-5.3-Flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3-Flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "Baseten",
@@ -35612,6 +36924,94 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
+   },
+   "zai-org/GLM-5.3": {
+    "attachment": false,
+    "cost": {
+     "input": 1.75,
+     "output": 5.82
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-29",
+    "limit": {
+     "context": 327680,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai-org/GLM-5.3-Flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0.29,
+     "output": 0.58
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3-Flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-29",
+    "limit": {
+     "context": 327680,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "Berget.AI",
@@ -35683,6 +37083,95 @@
    }
   },
   "name": "Blue Claw",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "bothub": {
+  "api": "https://openai.bothub.ru/v1",
+  "doc": "https://bothub.ru/models",
+  "env": [
+   "BOTHUB_API_KEY"
+  ],
+  "id": "bothub",
+  "models": {
+   "gemma-4-31b-it:free": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
+    "family": "gemma",
+    "id": "gemma-4-31b-it:free",
+    "interleaved": true,
+    "last_updated": "2026-04-02",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 31B IT (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-04-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "nemotron-3-ultra-550b-a55b:free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Largest Nemotron 3 model for maximum open-weight reasoning and agent accuracy",
+    "family": "nemotron",
+    "id": "nemotron-3-ultra-550b-a55b:free",
+    "interleaved": true,
+    "last_updated": "2026-06-04",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Nemotron 3 Ultra (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-04",
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "Bothub",
   "npm": "@ai-sdk/openai-compatible"
  },
  "cerebras": {
@@ -35970,9 +37459,9 @@
    "Qwen/Qwen3.8-27B-TEE": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.039999999999999994,
-     "input": 0.4,
-     "output": 3
+     "cache_read": 0.03499999999999999,
+     "input": 0.35,
+     "output": 2.75
     },
     "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
     "family": "qwen",
@@ -36043,9 +37532,9 @@
    "deepseek-ai/DeepSeek-V4-Flash-0731-TEE": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.013999999999999999,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.04399999999999999,
+     "input": 0.44,
+     "output": 1.32
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -36926,6 +38415,50 @@
     "temperature": true,
     "tool_call": true
    },
+   "cline-pass/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "cline-pass/glm-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "cline-pass/kimi-k2.6": {
     "attachment": true,
     "cost": {
@@ -37164,8 +38697,8 @@
     "id": "cline-pass/minimax-m3",
     "last_updated": "2026-06-01",
     "limit": {
-     "context": 512000,
-     "output": 128000
+     "context": 1048576,
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -37300,6 +38833,53 @@
      }
     ],
     "release_date": "2026-06-02",
+    "temperature": true,
+    "tool_call": true
+   },
+   "cline-pass/qwen3.8-max": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "cline-pass/qwen3.8-max",
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-03",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    }
@@ -37491,6 +39071,210 @@
   ],
   "id": "cloudflare-ai-gateway",
   "models": {
+   "alibaba/qwen3-max": {
+    "attachment": false,
+    "cost": {
+     "input": 1.2,
+     "output": 6
+    },
+    "description": "Flagship Qwen3 model for coding agents, complex reasoning, and tool use",
+    "family": "qwen",
+    "id": "alibaba/qwen3-max",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09-23",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Max",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-09-23",
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.5-397b-a17b": {
+    "attachment": true,
+    "cost": {
+     "input": 0.6,
+     "output": 3.6
+    },
+    "description": "Large open Qwen multimodal MoE for visual agents and long technical tasks",
+    "family": "qwen",
+    "id": "alibaba/qwen3.5-397b-a17b",
+    "last_updated": "2026-02-15",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.5 397B-A17B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-02-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.7-max": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.25,
+     "input": 1.25,
+     "output": 3.75
+    },
+    "description": "Qwen frontier model tuned for agent frameworks, coding assistants, and long tasks",
+    "family": "qwen",
+    "id": "alibaba/qwen3.7-max",
+    "last_updated": "2026-05-21",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.7 Max",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-05-21",
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.7-plus": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.064,
+     "input": 0.32,
+     "output": 1.28
+    },
+    "description": "Multimodal Qwen workhorse for long-context agents, visual inputs, and coding",
+    "family": "qwen",
+    "id": "alibaba/qwen3.7-plus",
+    "knowledge": "2025-04",
+    "last_updated": "2026-06-02",
+    "limit": {
+     "context": 1000000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.7 Plus",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-06-02",
+    "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.8-max": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "input": 2,
+     "output": 6
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "alibaba/qwen3.8-max",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "max": 262144,
+      "min": 0,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-03",
+    "temperature": true,
+    "tool_call": true
+   },
    "anthropic/claude-fable-5": {
     "attachment": true,
     "cost": {
@@ -37520,6 +39304,9 @@
     },
     "name": "Claude Fable 5",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/anthropic"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -37533,7 +39320,7 @@
       ]
      }
     ],
-    "release_date": "2026-06-07",
+    "release_date": "2026-06-09",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -37567,6 +39354,9 @@
     },
     "name": "Claude Haiku 4.5 (latest)",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/anthropic"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -37608,6 +39398,9 @@
     },
     "name": "Claude Opus 4.5 (latest)",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/anthropic"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -37657,6 +39450,9 @@
     },
     "name": "Claude Opus 4.6",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/anthropic"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -37673,7 +39469,7 @@
       "type": "budget_tokens"
      }
     ],
-    "release_date": "2026-02-04",
+    "release_date": "2026-02-05",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -37723,7 +39519,7 @@
       ]
      }
     ],
-    "release_date": "2026-04-14",
+    "release_date": "2026-04-16",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -37757,6 +39553,9 @@
     },
     "name": "Claude Opus 4.8",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/anthropic"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -37804,6 +39603,9 @@
     },
     "name": "Claude Opus 5",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/anthropic"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -37851,6 +39653,9 @@
     },
     "name": "Claude Sonnet 4.5 (latest)",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/anthropic"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -37893,7 +39698,7 @@
     "name": "Claude Sonnet 4.6",
     "open_weights": false,
     "provider": {
-     "npm": "ai-gateway-provider"
+     "npm": "@ai-sdk/anthropic"
     },
     "reasoning": true,
     "reasoning_options": [
@@ -37945,6 +39750,9 @@
     },
     "name": "Claude Sonnet 5",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/anthropic"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -37961,26 +39769,26 @@
       ]
      }
     ],
-    "release_date": "2026-06-29",
+    "release_date": "2026-06-30",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
    },
-   "openai/gpt-3.5-turbo": {
+   "deepseek/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0,
-     "input": 0.5,
-     "output": 1.5
+     "cache_read": 0.145,
+     "input": 1.74,
+     "output": 3.48
     },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "gpt",
-    "id": "openai/gpt-3.5-turbo",
-    "knowledge": "2021-09-01",
-    "last_updated": "2023-11-06",
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "deepseek/deepseek-v4-pro",
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
     "limit": {
-     "context": 16385,
-     "output": 4096
+     "context": 131072,
+     "output": 384000
     },
     "modalities": {
      "input": [
@@ -37990,78 +39798,70 @@
       "text"
      ]
     },
-    "name": "GPT-3.5-turbo",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2023-03-01",
-    "status": "deprecated",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "openai/gpt-4": {
-    "attachment": true,
-    "cost": {
-     "input": 30,
-     "output": 60
-    },
-    "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
-    "family": "gpt",
-    "id": "openai/gpt-4",
-    "knowledge": "2023-11",
-    "last_updated": "2024-04-09",
-    "limit": {
-     "context": 8192,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-4",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2023-11-06",
-    "status": "deprecated",
-    "structured_output": false,
+    "name": "DeepSeek V4 Pro",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
-   "openai/gpt-4-turbo": {
+   "moonshotai/kimi-k3": {
     "attachment": true,
     "cost": {
-     "input": 10,
-     "output": 30
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 15
     },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "gpt",
-    "id": "openai/gpt-4-turbo",
-    "knowledge": "2023-12",
-    "last_updated": "2024-04-09",
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "moonshotai/kimi-k3",
+    "last_updated": "2026-07-16",
     "limit": {
-     "context": 128000,
-     "output": 4096
+     "context": 1048576,
+     "output": 131072
     },
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "video"
      ],
      "output": [
       "text"
      ]
     },
-    "name": "GPT-4 Turbo",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2023-11-06",
-    "status": "deprecated",
-    "structured_output": false,
-    "temperature": true,
+    "name": "Kimi K3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": true,
+    "temperature": false,
     "tool_call": true
    },
    "openai/gpt-4.1": {
@@ -38092,6 +39892,9 @@
     },
     "name": "GPT-4.1",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": false,
     "release_date": "2025-04-14",
     "structured_output": true,
@@ -38126,6 +39929,9 @@
     },
     "name": "GPT-4.1 mini",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": false,
     "release_date": "2025-04-14",
     "structured_output": true,
@@ -38145,7 +39951,7 @@
     "knowledge": "2024-04",
     "last_updated": "2025-04-14",
     "limit": {
-     "context": 1047576,
+     "context": 1000000,
      "output": 32768
     },
     "modalities": {
@@ -38159,9 +39965,11 @@
     },
     "name": "GPT-4.1 nano",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": false,
     "release_date": "2025-04-14",
-    "status": "deprecated",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -38194,6 +40002,9 @@
     },
     "name": "GPT-4o",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": false,
     "release_date": "2024-05-13",
     "structured_output": true,
@@ -38228,6 +40039,9 @@
     },
     "name": "GPT-4o mini",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": false,
     "release_date": "2024-07-18",
     "structured_output": true,
@@ -38247,7 +40061,7 @@
     "knowledge": "2024-09-30",
     "last_updated": "2025-08-07",
     "limit": {
-     "context": 400000,
+     "context": 128000,
      "input": 272000,
      "output": 128000
     },
@@ -38262,6 +40076,9 @@
     },
     "name": "GPT-5",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -38292,7 +40109,7 @@
     "knowledge": "2024-05-30",
     "last_updated": "2025-08-07",
     "limit": {
-     "context": 400000,
+     "context": 128000,
      "input": 272000,
      "output": 128000
     },
@@ -38307,6 +40124,9 @@
     },
     "name": "GPT-5 Mini",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -38337,7 +40157,7 @@
     "knowledge": "2024-05-30",
     "last_updated": "2025-08-07",
     "limit": {
-     "context": 400000,
+     "context": 128000,
      "input": 272000,
      "output": 128000
     },
@@ -38352,6 +40172,9 @@
     },
     "name": "GPT-5 Nano",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -38369,47 +40192,6 @@
     "temperature": false,
     "tool_call": true
    },
-   "openai/gpt-5-pro": {
-    "attachment": true,
-    "cost": {
-     "input": 15,
-     "output": 120
-    },
-    "description": "Higher-accuracy GPT-5 tier for tough analysis, coding reviews, and planning",
-    "family": "gpt-pro",
-    "id": "openai/gpt-5-pro",
-    "knowledge": "2024-09-30",
-    "last_updated": "2025-10-06",
-    "limit": {
-     "context": 400000,
-     "input": 272000,
-     "output": 272000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5 Pro",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-10-06",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
    "openai/gpt-5.1": {
     "attachment": true,
     "cost": {
@@ -38423,7 +40205,7 @@
     "knowledge": "2024-09-30",
     "last_updated": "2025-11-13",
     "limit": {
-     "context": 400000,
+     "context": 128000,
      "input": 272000,
      "output": 128000
     },
@@ -38438,6 +40220,9 @@
     },
     "name": "GPT-5.1",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -38452,291 +40237,15 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "openai/gpt-5.2": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.175,
-     "input": 1.75,
-     "output": 14
-    },
-    "description": "Reliable GPT generation for broad coding, writing, and tool-assisted product work",
-    "family": "gpt",
-    "id": "openai/gpt-5.2",
-    "knowledge": "2025-08-31",
-    "last_updated": "2025-12-11",
-    "limit": {
-     "context": 400000,
-     "input": 272000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5.2",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "xhigh"
-      ]
-     }
-    ],
-    "release_date": "2025-12-11",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "openai/gpt-5.2-chat-latest": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.175,
-     "input": 1.75,
-     "output": 14
-    },
-    "description": "Chat-tuned GPT model for conversational assistance, writing, and tool workflows",
-    "family": "gpt-codex",
-    "id": "openai/gpt-5.2-chat-latest",
-    "knowledge": "2025-08-31",
-    "last_updated": "2025-12-11",
-    "limit": {
-     "context": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5.2 Chat",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "medium"
-      ]
-     }
-    ],
-    "release_date": "2025-12-11",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "openai/gpt-5.2-pro": {
-    "attachment": true,
-    "cost": {
-     "input": 21,
-     "output": 168
-    },
-    "description": "Higher-accuracy GPT-5.2 variant for tougher reasoning and review workflows",
-    "family": "gpt-pro",
-    "id": "openai/gpt-5.2-pro",
-    "knowledge": "2025-08-31",
-    "last_updated": "2025-12-11",
-    "limit": {
-     "context": 400000,
-     "input": 272000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5.2 Pro",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "medium",
-       "high",
-       "xhigh"
-      ]
-     }
-    ],
-    "release_date": "2025-12-11",
-    "structured_output": false,
-    "temperature": false,
-    "tool_call": true
-   },
-   "openai/gpt-5.3-chat-latest": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.175,
-     "input": 1.75,
-     "output": 14
-    },
-    "description": "Chat-tuned GPT model for conversational assistance, writing, and tool workflows",
-    "family": "gpt",
-    "id": "openai/gpt-5.3-chat-latest",
-    "knowledge": "2025-08-31",
-    "last_updated": "2026-03-03",
-    "limit": {
-     "context": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5.3 Chat (latest)",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-03-03",
-    "structured_output": true,
     "temperature": true,
-    "tool_call": true
-   },
-   "openai/gpt-5.3-codex": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.175,
-     "input": 1.75,
-     "output": 14
-    },
-    "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
-    "family": "gpt-codex",
-    "id": "openai/gpt-5.3-codex",
-    "knowledge": "2025-08-31",
-    "last_updated": "2026-02-05",
-    "limit": {
-     "context": 400000,
-     "input": 272000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5.3 Codex",
-    "open_weights": false,
-    "provider": {
-     "npm": "ai-gateway-provider"
-    },
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "xhigh"
-      ]
-     }
-    ],
-    "release_date": "2026-02-05",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "openai/gpt-5.3-codex-spark": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.175,
-     "input": 1.75,
-     "output": 14
-    },
-    "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
-    "family": "gpt-codex-spark",
-    "id": "openai/gpt-5.3-codex-spark",
-    "knowledge": "2025-08-31",
-    "last_updated": "2026-02-05",
-    "limit": {
-     "context": 128000,
-     "input": 100000,
-     "output": 32000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5.3 Codex Spark",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "xhigh"
-      ]
-     }
-    ],
-    "release_date": "2026-02-05",
-    "structured_output": true,
-    "temperature": false,
     "tool_call": true
    },
    "openai/gpt-5.4": {
     "attachment": true,
     "cost": {
      "cache_read": 0.25,
-     "context_over_200k": {
-      "cache_read": 0.5,
-      "input": 5,
-      "output": 22.5
-     },
      "input": 2.5,
-     "output": 15,
-     "tiers": [
-      {
-       "cache_read": 0.5,
-       "input": 5,
-       "output": 22.5,
-       "tier": {
-        "size": 272000,
-        "type": "context"
-       }
-      }
-     ]
+     "output": 15
     },
     "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
     "family": "gpt",
@@ -38744,7 +40253,7 @@
     "knowledge": "2025-08-31",
     "last_updated": "2026-03-05",
     "limit": {
-     "context": 1050000,
+     "context": 1000000,
      "input": 922000,
      "output": 128000
     },
@@ -38761,7 +40270,7 @@
     "name": "GPT-5.4",
     "open_weights": false,
     "provider": {
-     "npm": "ai-gateway-provider"
+     "npm": "@ai-sdk/openai"
     },
     "reasoning": true,
     "reasoning_options": [
@@ -38778,7 +40287,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -38794,7 +40303,7 @@
     "knowledge": "2025-08-31",
     "last_updated": "2026-03-17",
     "limit": {
-     "context": 400000,
+     "context": 128000,
      "input": 272000,
      "output": 128000
     },
@@ -38809,6 +40318,9 @@
     },
     "name": "GPT-5.4 mini",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -38824,7 +40336,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -38840,7 +40352,7 @@
     "knowledge": "2025-08-31",
     "last_updated": "2026-03-17",
     "limit": {
-     "context": 400000,
+     "context": 128000,
      "input": 272000,
      "output": 128000
     },
@@ -38855,6 +40367,9 @@
     },
     "name": "GPT-5.4 nano",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -38870,28 +40385,14 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-pro": {
     "attachment": true,
     "cost": {
-     "context_over_200k": {
-      "input": 60,
-      "output": 270
-     },
      "input": 30,
-     "output": 180,
-     "tiers": [
-      {
-       "input": 60,
-       "output": 270,
-       "tier": {
-        "size": 272000,
-        "type": "context"
-       }
-      }
-     ]
+     "output": 180
     },
     "description": "More exact GPT-5.4 tier for demanding professional reasoning and agent tasks",
     "family": "gpt-pro",
@@ -38899,7 +40400,7 @@
     "knowledge": "2025-08-31",
     "last_updated": "2026-03-05",
     "limit": {
-     "context": 1050000,
+     "context": 1000000,
      "input": 922000,
      "output": 128000
     },
@@ -38914,6 +40415,9 @@
     },
     "name": "GPT-5.4 Pro",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -38933,25 +40437,8 @@
    "openai/gpt-5.5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "context_over_200k": {
-      "cache_read": 1,
-      "input": 10,
-      "output": 45
-     },
      "input": 5,
-     "output": 30,
-     "tiers": [
-      {
-       "cache_read": 1,
-       "input": 10,
-       "output": 45,
-       "tier": {
-        "size": 272000,
-        "type": "context"
-       }
-      }
-     ]
+     "output": 30
     },
     "description": "Default frontier GPT for coding, computer use, research, and knowledge work",
     "family": "gpt",
@@ -38959,7 +40446,7 @@
     "knowledge": "2025-12-01",
     "last_updated": "2026-04-23",
     "limit": {
-     "context": 1050000,
+     "context": 1000000,
      "input": 922000,
      "output": 128000
     },
@@ -38975,6 +40462,9 @@
     },
     "name": "GPT-5.5",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -38996,22 +40486,8 @@
    "openai/gpt-5.5-pro": {
     "attachment": true,
     "cost": {
-     "context_over_200k": {
-      "input": 60,
-      "output": 270
-     },
      "input": 30,
-     "output": 180,
-     "tiers": [
-      {
-       "input": 60,
-       "output": 270,
-       "tier": {
-        "size": 272000,
-        "type": "context"
-       }
-      }
-     ]
+     "output": 180
     },
     "description": "Highest-accuracy GPT-5.5 tier for slower, precision-heavy reasoning and coding",
     "family": "gpt-pro",
@@ -39019,7 +40495,7 @@
     "knowledge": "2025-12-01",
     "last_updated": "2026-04-23",
     "limit": {
-     "context": 1050000,
+     "context": 1000000,
      "input": 922000,
      "output": 128000
     },
@@ -39035,6 +40511,9 @@
     },
     "name": "GPT-5.5 Pro",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -39051,98 +40530,13 @@
     "temperature": false,
     "tool_call": true
    },
-   "openai/gpt-5.6": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
-     "context_over_200k": {
-      "cache_read": 1,
-      "cache_write": 12.5,
-      "input": 10,
-      "output": 45
-     },
-     "input": 5,
-     "output": 30,
-     "tiers": [
-      {
-       "cache_read": 1,
-       "cache_write": 12.5,
-       "input": 10,
-       "output": 45,
-       "tier": {
-        "size": 272000,
-        "type": "context"
-       }
-      }
-     ]
-    },
-    "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
-    "family": "gpt-sol",
-    "id": "openai/gpt-5.6",
-    "knowledge": "2026-02-16",
-    "last_updated": "2026-07-09",
-    "limit": {
-     "context": 1050000,
-     "input": 922000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5.6",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-07-09",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
    "openai/gpt-5.6-luna": {
     "attachment": true,
     "cost": {
      "cache_read": 0.02,
      "cache_write": 0.25,
-     "context_over_200k": {
-      "cache_read": 0.04,
-      "cache_write": 0.5,
-      "input": 0.4,
-      "output": 1.8
-     },
      "input": 0.2,
-     "output": 1.2,
-     "tiers": [
-      {
-       "cache_read": 0.04,
-       "cache_write": 0.5,
-       "input": 0.4,
-       "output": 1.8,
-       "tier": {
-        "size": 272000,
-        "type": "context"
-       }
-      }
-     ]
+     "output": 1.2
     },
     "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
     "family": "gpt-luna",
@@ -39166,6 +40560,9 @@
     },
     "name": "GPT-5.6 Luna",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -39188,28 +40585,10 @@
    "openai/gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
-     "context_over_200k": {
-      "cache_read": 1,
-      "cache_write": 12.5,
-      "input": 10,
-      "output": 45
-     },
-     "input": 5,
-     "output": 30,
-     "tiers": [
-      {
-       "cache_read": 1,
-       "cache_write": 12.5,
-       "input": 10,
-       "output": 45,
-       "tier": {
-        "size": 272000,
-        "type": "context"
-       }
-      }
-     ]
+     "cache_read": 0.25,
+     "cache_write": 3.125,
+     "input": 2,
+     "output": 10
     },
     "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
     "family": "gpt-sol",
@@ -39233,6 +40612,9 @@
     },
     "name": "GPT-5.6 Sol",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -39257,26 +40639,8 @@
     "cost": {
      "cache_read": 0.2,
      "cache_write": 2.5,
-     "context_over_200k": {
-      "cache_read": 0.4,
-      "cache_write": 5,
-      "input": 4,
-      "output": 18
-     },
      "input": 2,
-     "output": 12,
-     "tiers": [
-      {
-       "cache_read": 0.4,
-       "cache_write": 5,
-       "input": 4,
-       "output": 18,
-       "tier": {
-        "size": 272000,
-        "type": "context"
-       }
-      }
-     ]
+     "output": 12
     },
     "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
     "family": "gpt-terra",
@@ -39300,6 +40664,9 @@
     },
     "name": "GPT-5.6 Terra",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -39315,94 +40682,6 @@
      }
     ],
     "release_date": "2026-07-09",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "openai/o1": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 7.5,
-     "input": 15,
-     "output": 60
-    },
-    "description": "O-series reasoning model for hard analysis, math, coding, and planning",
-    "family": "o",
-    "id": "openai/o1",
-    "knowledge": "2023-09",
-    "last_updated": "2024-12-05",
-    "limit": {
-     "context": 200000,
-     "output": 100000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "o1",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2024-12-05",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "openai/o1-pro": {
-    "attachment": true,
-    "cost": {
-     "input": 150,
-     "output": 600
-    },
-    "description": "O-series reasoning model for hard analysis, math, coding, and planning",
-    "family": "o-pro",
-    "id": "openai/o1-pro",
-    "knowledge": "2023-09",
-    "last_updated": "2025-03-19",
-    "limit": {
-     "context": 200000,
-     "output": 100000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "o1-pro",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-03-19",
-    "status": "deprecated",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -39435,6 +40714,9 @@
     },
     "name": "o3",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -39477,6 +40759,9 @@
     },
     "name": "o3-mini",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -39489,49 +40774,6 @@
      }
     ],
     "release_date": "2024-12-20",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "openai/o3-pro": {
-    "attachment": true,
-    "cost": {
-     "input": 20,
-     "output": 80
-    },
-    "description": "High-effort o3 tier for difficult technical reasoning and careful answers",
-    "family": "o-pro",
-    "id": "openai/o3-pro",
-    "knowledge": "2024-05",
-    "last_updated": "2025-06-10",
-    "limit": {
-     "context": 200000,
-     "output": 100000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "o3-pro",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-06-10",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -39563,6 +40805,9 @@
     },
     "name": "o4-mini",
     "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
     "reasoning": true,
     "reasoning_options": [
      {
@@ -39575,86 +40820,135 @@
      }
     ],
     "release_date": "2025-04-16",
-    "status": "deprecated",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
    },
-   "workers-ai/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
-    "attachment": false,
+   "xai/grok-4.20-0309-non-reasoning": {
+    "attachment": true,
     "cost": {
-     "input": 0.351,
-     "output": 0.555
+     "cache_read": 0.2,
+     "input": 2,
+     "output": 6
     },
-    "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
-    "family": "gemma",
-    "id": "workers-ai/@cf/aisingapore/gemma-sea-lion-v4-27b-it",
-    "last_updated": "2025-09-23",
+    "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
+    "family": "grok",
+    "id": "xai/grok-4.20-0309-non-reasoning",
+    "last_updated": "2026-03-09",
     "limit": {
-     "context": 128000,
-     "output": 128000
+     "context": 2000000,
+     "output": 30000
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
      ]
     },
-    "name": "Gemma Sea Lion V4 27B It",
-    "open_weights": true,
+    "name": "Grok 4.20 (Non-Reasoning)",
+    "open_weights": false,
     "reasoning": false,
-    "release_date": "2025-09-23",
-    "structured_output": false,
+    "release_date": "2026-03-09",
+    "structured_output": true,
     "temperature": true,
-    "tool_call": false
+    "tool_call": true
    },
-   "workers-ai/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
-    "attachment": false,
+   "xai/grok-4.20-0309-reasoning": {
+    "attachment": true,
     "cost": {
-     "input": 0.497,
-     "output": 4.881
+     "cache_read": 0.2,
+     "input": 2,
+     "output": 6
     },
-    "description": "R1 reasoning distilled into Qwen 2.5 32B for efficient open-weight step-by-step problem solving",
-    "family": "deepseek-thinking",
-    "id": "workers-ai/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
-    "last_updated": "2025-01-20",
+    "description": "Reasoning Grok for document-heavy analysis and long-horizon tool use",
+    "family": "grok",
+    "id": "xai/grok-4.20-0309-reasoning",
+    "last_updated": "2026-03-09",
     "limit": {
-     "context": 80000,
-     "output": 80000
+     "context": 2000000,
+     "output": 30000
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image",
+      "pdf"
      ],
      "output": [
       "text"
      ]
     },
-    "name": "Deepseek R1 Distill Qwen 32B",
-    "open_weights": true,
+    "name": "Grok 4.20 (Reasoning)",
+    "open_weights": false,
     "reasoning": true,
     "reasoning_options": [],
-    "release_date": "2025-01-20",
-    "structured_output": false,
+    "release_date": "2026-03-09",
+    "structured_output": true,
     "temperature": true,
-    "tool_call": false
+    "tool_call": true
    },
-   "workers-ai/@cf/google/gemma-4-26b-a4b-it": {
+   "xai/grok-4.3": {
     "attachment": true,
     "cost": {
-     "input": 0.1,
-     "output": 0.3
+     "cache_read": 0.2,
+     "input": 1.25,
+     "output": 2.5
     },
-    "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
-    "family": "gemma",
-    "id": "workers-ai/@cf/google/gemma-4-26b-a4b-it",
-    "interleaved": true,
-    "last_updated": "2026-04-02",
+    "description": "xAI's default Grok for chat, coding, agentic tools, and lower hallucination risk",
+    "family": "grok",
+    "id": "xai/grok-4.3",
+    "last_updated": "2026-04-17",
     "limit": {
-     "context": 256000,
-     "output": 16384
+     "context": 1000000,
+     "output": 30000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.3",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-4.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 2,
+     "output": 6
+    },
+    "description": "xAI's Grok model for chat, coding, agentic tools, and lower hallucination risk",
+    "family": "grok",
+    "id": "xai/grok-4.5",
+    "last_updated": "2026-07-08",
+    "limit": {
+     "context": 500000,
+     "output": 500000
     },
     "modalities": {
      "input": [
@@ -39665,13 +40959,10 @@
       "text"
      ]
     },
-    "name": "Gemma 4 26B A4B IT",
-    "open_weights": true,
+    "name": "Grok 4.5",
+    "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -39681,86 +40972,26 @@
       ]
      }
     ],
-    "release_date": "2026-04-02",
+    "release_date": "2026-07-08",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
-   "workers-ai/@cf/ibm-granite/granite-4.0-h-micro": {
-    "attachment": false,
-    "cost": {
-     "input": 0.017,
-     "output": 0.112
-    },
-    "description": "Efficient model for low-latency assistance, extraction, and routine automation",
-    "family": "granite",
-    "id": "workers-ai/@cf/ibm-granite/granite-4.0-h-micro",
-    "last_updated": "2025-10-02",
-    "limit": {
-     "context": 131000,
-     "output": 131000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Granite 4.0 H Micro",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-10-02",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/meta/llama-3.1-8b-instruct-fp8": {
-    "attachment": false,
-    "cost": {
-     "input": 0.152,
-     "output": 0.287
-    },
-    "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
-    "family": "llama",
-    "id": "workers-ai/@cf/meta/llama-3.1-8b-instruct-fp8",
-    "knowledge": "2023-12",
-    "last_updated": "2024-07-23",
-    "limit": {
-     "context": 32000,
-     "output": 32000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama 3.1 8B Instruct fp8",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-07-23",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "workers-ai/@cf/meta/llama-3.2-11b-vision-instruct": {
+   "xai/grok-4.6": {
     "attachment": true,
     "cost": {
-     "input": 0.0485,
-     "output": 0.676
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 6
     },
-    "description": "Open Llama multimodal model for image understanding and text reasoning",
-    "family": "llama",
-    "id": "workers-ai/@cf/meta/llama-3.2-11b-vision-instruct",
-    "knowledge": "2023-12",
-    "last_updated": "2024-09-25",
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "xai/grok-4.6",
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-12",
     "limit": {
-     "context": 128000,
-     "output": 128000
+     "context": 500000,
+     "output": 500000
     },
     "modalities": {
      "input": [
@@ -39771,364 +41002,8 @@
       "text"
      ]
     },
-    "name": "Llama 3.2 11B Vision Instruct",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-09-25",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "workers-ai/@cf/meta/llama-3.2-1b-instruct": {
-    "attachment": false,
-    "cost": {
-     "input": 0.027,
-     "output": 0.201
-    },
-    "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
-    "family": "llama",
-    "id": "workers-ai/@cf/meta/llama-3.2-1b-instruct",
-    "knowledge": "2023-12",
-    "last_updated": "2024-09-25",
-    "limit": {
-     "context": 60000,
-     "output": 60000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama 3.2 1B Instruct",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-09-25",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "workers-ai/@cf/meta/llama-3.2-3b-instruct": {
-    "attachment": false,
-    "cost": {
-     "input": 0.0509,
-     "output": 0.335
-    },
-    "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
-    "family": "llama",
-    "id": "workers-ai/@cf/meta/llama-3.2-3b-instruct",
-    "knowledge": "2023-12",
-    "last_updated": "2024-09-25",
-    "limit": {
-     "context": 80000,
-     "output": 80000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama 3.2 3B Instruct",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-09-25",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
-    "attachment": false,
-    "cost": {
-     "input": 0.293,
-     "output": 2.253
-    },
-    "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
-    "family": "llama",
-    "id": "workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-    "knowledge": "2023-12",
-    "last_updated": "2024-12-06",
-    "limit": {
-     "context": 24000,
-     "output": 24000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama 3.3 70B Instruct fp8 Fast",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-12-06",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/meta/llama-4-scout-17b-16e-instruct": {
-    "attachment": true,
-    "cost": {
-     "input": 0.27,
-     "output": 0.85
-    },
-    "description": "Open Llama with long-context vision for efficient multimodal agents",
-    "family": "llama",
-    "id": "workers-ai/@cf/meta/llama-4-scout-17b-16e-instruct",
-    "knowledge": "2024-08",
-    "last_updated": "2025-04-05",
-    "limit": {
-     "context": 131000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama 4 Scout 17B 16E Instruct",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-04-05",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/meta/llama-guard-3-8b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.484,
-     "output": 0.03
-    },
-    "description": "Safety model for policy screening, moderation, and risk-aware routing workflows",
-    "family": "llama",
-    "id": "workers-ai/@cf/meta/llama-guard-3-8b",
-    "knowledge": "2023-12",
-    "last_updated": "2024-07-23",
-    "limit": {
-     "context": 131072,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama Guard 3 8B",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-07-23",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "workers-ai/@cf/mistralai/mistral-small-3.1-24b-instruct": {
-    "attachment": false,
-    "cost": {
-     "input": 0.351,
-     "output": 0.555
-    },
-    "description": "Efficient Mistral model for fast chat, extraction, and production assistants",
-    "family": "mistral-small",
-    "id": "workers-ai/@cf/mistralai/mistral-small-3.1-24b-instruct",
-    "knowledge": "2024-06",
-    "last_updated": "2025-03-17",
-    "limit": {
-     "context": 128000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Mistral Small 3.1 24B Instruct",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-03-17",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/moonshotai/kimi-k2.6": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.16,
-     "input": 0.95,
-     "output": 4
-    },
-    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
-    "family": "kimi-k2",
-    "id": "workers-ai/@cf/moonshotai/kimi-k2.6",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-01",
-    "last_updated": "2026-04-21",
-    "limit": {
-     "context": 262144,
-     "output": 256000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.6",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-04-21",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/moonshotai/kimi-k2.7-code": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.19,
-     "input": 0.95,
-     "output": 4
-    },
-    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
-    "family": "kimi-k2",
-    "id": "workers-ai/@cf/moonshotai/kimi-k2.7-code",
-    "knowledge": "2025-01",
-    "last_updated": "2026-06-12",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.7 Code",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-06-12",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/nvidia/nemotron-3-120b-a12b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.5,
-     "output": 1.5
-    },
-    "description": "Nemotron middle tier for collaborative agents and high-volume reasoning workloads",
-    "family": "nemotron",
-    "id": "workers-ai/@cf/nvidia/nemotron-3-120b-a12b",
-    "interleaved": true,
-    "last_updated": "2026-03-11",
-    "limit": {
-     "context": 256000,
-     "output": 256000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Super 120B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-03-11",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/openai/gpt-oss-120b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.35,
-     "output": 0.75
-    },
-    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
-    "family": "gpt-oss",
-    "id": "workers-ai/@cf/openai/gpt-oss-120b",
-    "last_updated": "2025-08-05",
-    "limit": {
-     "context": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT OSS 120B",
-    "open_weights": true,
+    "name": "Grok 4.6",
+    "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -40140,222 +41015,7 @@
       ]
      }
     ],
-    "release_date": "2025-08-05",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/openai/gpt-oss-20b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.2,
-     "output": 0.3
-    },
-    "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
-    "family": "gpt-oss",
-    "id": "workers-ai/@cf/openai/gpt-oss-20b",
-    "last_updated": "2025-08-05",
-    "limit": {
-     "context": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT OSS 20B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-08-05",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/qwen/qwen2.5-coder-32b-instruct": {
-    "attachment": false,
-    "cost": {
-     "input": 0.66,
-     "output": 1
-    },
-    "description": "Qwen coding model for software agents, repository edits, and code reasoning",
-    "family": "qwen",
-    "id": "workers-ai/@cf/qwen/qwen2.5-coder-32b-instruct",
-    "last_updated": "2024-11-12",
-    "limit": {
-     "context": 32768,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen2.5 Coder 32B Instruct",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-11-12",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "workers-ai/@cf/qwen/qwen3-30b-a3b-fp8": {
-    "attachment": false,
-    "cost": {
-     "input": 0.0509,
-     "output": 0.335
-    },
-    "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
-    "family": "qwen",
-    "id": "workers-ai/@cf/qwen/qwen3-30b-a3b-fp8",
-    "last_updated": "2025-04-28",
-    "limit": {
-     "context": 32768,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3 30B A3b fp8",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-04-28",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/qwen/qwq-32b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.66,
-     "output": 1
-    },
-    "description": "Qwen reasoning model for deliberate problem solving, math, and coding",
-    "family": "qwen",
-    "id": "workers-ai/@cf/qwen/qwq-32b",
-    "knowledge": "2024-04",
-    "last_updated": "2025-03-05",
-    "limit": {
-     "context": 24000,
-     "output": 24000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwq 32B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-03-05",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "workers-ai/@cf/zai-org/glm-4.7-flash": {
-    "attachment": false,
-    "cost": {
-     "input": 0.0605,
-     "output": 0.4
-    },
-    "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
-    "family": "glm-flash",
-    "id": "workers-ai/@cf/zai-org/glm-4.7-flash",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-04",
-    "last_updated": "2026-01-19",
-    "limit": {
-     "context": 131072,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-4.7-Flash",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-01-19",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "workers-ai/@cf/zai-org/glm-5.2": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
-    },
-    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
-    "family": "glm",
-    "id": "workers-ai/@cf/zai-org/glm-5.2",
-    "last_updated": "2026-06-13",
-    "limit": {
-     "context": 262144,
-     "output": 256000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Glm 5.2",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-06-13",
+    "release_date": "2026-08-12",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -41281,6 +41941,83 @@
      }
     ],
     "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "@cf/zai-org/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+    "family": "glm",
+    "id": "@cf/zai-org/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1310720,
+     "output": 1310720
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Glm 5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "@cf/zai-org/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "@cf/zai-org/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1310720,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Glm 5.3 Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -43286,6 +44023,89 @@
     "temperature": true,
     "tool_call": true
    },
+   "glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.438,
+     "input": 1.75,
+     "output": 4.499
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.201,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "glm-5v-turbo": {
     "attachment": true,
     "cost": {
@@ -43664,7 +44484,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": false,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4": {
@@ -43708,7 +44528,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.6-luna": {
@@ -44757,8 +45577,9 @@
    "mistral-medium-3.5": {
     "attachment": true,
     "cost": {
-     "input": 1.671,
-     "output": 5.57
+     "cache_read": 0.139,
+     "input": 1.393,
+     "output": 7.13
     },
     "description": "Mistral Medium 3.5 is a frontier multimodal 128B model combining reasoning, coding, and instruction-following with strong agentic performance and efficient deployment.",
     "id": "mistral-medium-3.5",
@@ -45715,6 +46536,48 @@
     "temperature": true,
     "tool_call": true
    },
+   "qwen3.8-flash-next": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.201,
+     "output": 0.5
+    },
+    "description": "Open-weight experimental preview of the Qwen4 architecture: hybrid-attention MoE (125B total, 6B active) with vision encoder for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen3.8-flash-next",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 262144,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash Next",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-27",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "qwen3guard-gen-0.6b": {
     "attachment": false,
     "cost": {
@@ -45899,8 +46762,8 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.003,
-     "input": 0.12,
-     "output": 0.21
+     "input": 0.08,
+     "output": 0.1
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -45993,21 +46856,20 @@
     "temperature": true,
     "tool_call": true
    },
-   "deepseek-v4-pro-lightning": {
+   "deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.02,
-     "input": 0.8,
-     "output": 1.6
+     "cache_read": 0.01,
+     "input": 0.35,
+     "output": 0.8
     },
-    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
-    "id": "deepseek-v4-pro-lightning",
+    "id": "deepseek-v4-pro-0813",
     "interleaved": {
      "field": "reasoning_content"
     },
-    "knowledge": "2025-05",
-    "last_updated": "2026-04-24",
+    "last_updated": "2026-08-22",
     "limit": {
      "context": 1000000,
      "output": 131072
@@ -46020,7 +46882,7 @@
       "text"
      ]
     },
-    "name": "DeepSeek V4 Pro Lightning",
+    "name": "DeepSeek V4 Pro (0813)",
     "open_weights": true,
     "provider": {
      "npm": "@ai-sdk/openai-compatible"
@@ -46037,7 +46899,7 @@
       ]
      }
     ],
-    "release_date": "2026-04-24",
+    "release_date": "2026-08-12",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -46181,6 +47043,105 @@
      }
     ],
     "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.4,
+     "output": 1.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "provider": {
+     "npm": "@ai-sdk/openai-compatible"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.07,
+     "output": 0.22
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3-Flash",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai-compatible"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -46715,9 +47676,9 @@
    "qwen3.8-27b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.06,
-     "input": 0.25,
-     "output": 2.1
+     "cache_read": 0.03,
+     "input": 0.2,
+     "output": 1.5
     },
     "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
     "family": "qwen",
@@ -47285,9 +48246,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -47335,9 +48293,6 @@
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -48076,7 +49031,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -48123,7 +49078,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -48170,7 +49125,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.5": {
@@ -48673,10 +49628,10 @@
    "qwen/qwen3.7-max": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.3,
-     "cache_write": 1.88,
-     "input": 1.504,
-     "output": 4.504
+     "cache_read": 0.375,
+     "cache_write": 2.35,
+     "input": 1.88,
+     "output": 5.63
     },
     "description": "Qwen frontier model tuned for agent frameworks, coding assistants, and long tasks",
     "family": "qwen",
@@ -48710,22 +49665,22 @@
    "qwen/qwen3.7-plus": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0288,
-     "cache_write": 0.36,
+     "cache_read": 0.032,
+     "cache_write": 0.4,
      "context_over_200k": {
-      "cache_read": 0.0864,
-      "cache_write": 1.08,
-      "input": 0.864,
-      "output": 3.375
+      "cache_read": 0.096,
+      "cache_write": 1.2,
+      "input": 0.96,
+      "output": 3.75
      },
-     "input": 0.288,
-     "output": 1.125,
+     "input": 0.32,
+     "output": 1.25,
      "tiers": [
       {
-       "cache_read": 0.0864,
-       "cache_write": 1.08,
-       "input": 0.864,
-       "output": 3.375,
+       "cache_read": 0.096,
+       "cache_write": 1.2,
+       "input": 0.96,
+       "output": 3.75,
        "tier": {
         "size": 256000,
         "type": "context"
@@ -48763,6 +49718,52 @@
     "release_date": "2026-06-02",
     "structured_output": true,
     "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.13,
+     "output": 0.43
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "tool_call": true
    },
    "qwen/qwen3.8-max": {
@@ -48829,7 +49830,7 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -48844,9 +49845,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -48857,6 +49855,46 @@
     ],
     "release_date": "2026-07-06",
     "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "tencent/hy4-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.048,
+     "cache_write": 0.96,
+     "input": 0.96,
+     "output": 2.88
+    },
+    "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+    "family": "Hy",
+    "id": "tencent/hy4-preview",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy4 preview",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-28",
     "temperature": true,
     "tool_call": true
    },
@@ -48907,9 +49945,6 @@
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -49132,9 +50167,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -49178,9 +50210,6 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -49455,7 +50484,7 @@
      ]
     },
     "name": "GLM-5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -49468,6 +50497,50 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "cache_write": 0.075,
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "z-ai/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -50006,7 +51079,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
@@ -51000,7 +52073,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "databricks-gpt-5-2": {
@@ -51045,7 +52118,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "databricks-gpt-5-4": {
@@ -51122,7 +52195,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "databricks-gpt-5-4-mini": {
@@ -51182,7 +52255,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "databricks-gpt-5-4-nano": {
@@ -51226,7 +52299,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "databricks-gpt-5-5": {
@@ -51937,7 +53010,7 @@
     "last_updated": "2026-06-01",
     "limit": {
      "context": 524288,
-     "output": 128000
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -53965,6 +55038,91 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
+   },
+   "zai-org/GLM-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.24,
+     "input": 1.2,
+     "output": 4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai-org/GLM-5.3-Flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3-Flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "Deep Infra",
@@ -53978,73 +55136,6 @@
   ],
   "id": "deepseek",
   "models": {
-   "deepseek-chat": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.0028,
-     "input": 0.14,
-     "output": 0.28
-    },
-    "description": "DeepSeek chat model for instruction following, coding, and analysis",
-    "family": "deepseek",
-    "id": "deepseek-chat",
-    "knowledge": "2025-09",
-    "last_updated": "2026-02-28",
-    "limit": {
-     "context": 1000000,
-     "output": 384000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek Chat",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-12-01",
-    "temperature": true,
-    "tool_call": true
-   },
-   "deepseek-reasoner": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.0028,
-     "input": 0.14,
-     "output": 0.28,
-     "reasoning": 0.28
-    },
-    "description": "DeepSeek reasoning model for multi-step analysis, math, coding, and tools",
-    "family": "deepseek-thinking",
-    "id": "deepseek-reasoner",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-09",
-    "last_updated": "2026-02-28",
-    "limit": {
-     "context": 1000000,
-     "output": 384000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek Reasoner",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-12-01",
-    "temperature": true,
-    "tool_call": true
-   },
    "deepseek-v4-flash": {
     "attachment": false,
     "cost": {
@@ -55767,6 +56858,90 @@
     "temperature": true,
     "tool_call": true
    },
+   "glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM5.3 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "gte-large-en-v1.5": {
     "attachment": false,
     "cost": {
@@ -57197,19 +58372,19 @@
    "openai-gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
+     "cache_read": 0.4,
      "context_over_200k": {
-      "cache_read": 1,
-      "input": 10,
-      "output": 45
+      "cache_read": 0.8,
+      "input": 8,
+      "output": 30
      },
-     "input": 5,
-     "output": 30,
+     "input": 4,
+     "output": 20,
      "tiers": [
       {
-       "cache_read": 1,
-       "input": 10,
-       "output": 45,
+       "cache_read": 0.8,
+       "input": 8,
+       "output": 30,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -58481,68 +59656,6 @@
     "temperature": false,
     "tool_call": true
    },
-   "amazon/nvidia.nemotron-nano-9b-v2": {
-    "attachment": false,
-    "cost": {
-     "input": 0.06,
-     "output": 0.23
-    },
-    "description": "Compact Nemotron model for efficient reasoning and deployable AI agents",
-    "family": "nemotron",
-    "id": "amazon/nvidia.nemotron-nano-9b-v2",
-    "last_updated": "2025-08-18",
-    "limit": {
-     "context": 128000,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron Nano 9B v2",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-08-18",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "amazon/nvidia.nemotron-nano-9b-v2@us": {
-    "attachment": false,
-    "cost": {
-     "input": 0.06,
-     "output": 0.23
-    },
-    "description": "Compact Nemotron model for efficient reasoning and deployable AI agents",
-    "family": "nemotron",
-    "id": "amazon/nvidia.nemotron-nano-9b-v2@us",
-    "last_updated": "2025-08-18",
-    "limit": {
-     "context": 128000,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron Nano 9B v2 (US)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-08-18",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
    "amazon/zai.glm-4.7-flash": {
     "attachment": false,
     "cost": {
@@ -59802,6 +60915,8 @@
    "databricks/databricks-gpt-oss-120b": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.15001,
+     "cache_write": 0.15001,
      "input": 0.15001,
      "output": 0.59997
     },
@@ -59839,9 +60954,53 @@
     "temperature": true,
     "tool_call": true
    },
+   "databricks/databricks-gpt-oss-120b@eu": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.15001,
+     "cache_write": 0.15001,
+     "input": 0.15001,
+     "output": 0.59997
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "databricks/databricks-gpt-oss-120b@eu",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B (EU)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "databricks/databricks-gpt-oss-20b": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.07,
+     "cache_write": 0.07,
      "input": 0.07,
      "output": 0.30002
     },
@@ -59862,6 +61021,48 @@
      ]
     },
     "name": "GPT OSS 20B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "databricks/databricks-gpt-oss-20b@eu": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.07,
+     "cache_write": 0.07,
+     "input": 0.07,
+     "output": 0.30002
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "databricks/databricks-gpt-oss-20b@eu",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 20B (EU)",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -59918,9 +61119,9 @@
      }
     ],
     "release_date": "2026-02-14",
-    "structured_output": false,
+    "structured_output": true,
     "temperature": true,
-    "tool_call": false
+    "tool_call": true
    },
    "deepinfra/ByteDance/Seed-2.0-mini": {
     "attachment": true,
@@ -59962,9 +61163,9 @@
      }
     ],
     "release_date": "2026-02-14",
-    "structured_output": false,
+    "structured_output": true,
     "temperature": true,
-    "tool_call": false
+    "tool_call": true
    },
    "deepinfra/deepseek-ai/DeepSeek-R1": {
     "attachment": false,
@@ -60140,9 +61341,9 @@
      }
     ],
     "release_date": "2026-08-12",
-    "structured_output": false,
+    "structured_output": true,
     "temperature": true,
-    "tool_call": false
+    "tool_call": true
    },
    "deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct": {
     "attachment": true,
@@ -60582,6 +61783,47 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepinfra/tencent/Hy3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.035,
+     "input": 0.14,
+     "output": 0.58
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "deepinfra/tencent/Hy3",
+    "last_updated": "2026-07-06",
+    "limit": {
+     "context": 262144,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-06",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepinfra/thinkingmachines/Inkling": {
     "attachment": true,
     "cost": {
@@ -60738,39 +61980,6 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
-   },
-   "deepseek/deepseek-reasoner": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.028,
-     "input": 0.28,
-     "output": 0.42
-    },
-    "description": "DeepSeek reasoning model for multi-step analysis, math, coding, and tools",
-    "family": "deepseek-thinking",
-    "id": "deepseek/deepseek-reasoner",
-    "knowledge": "2025-09",
-    "last_updated": "2026-02-28",
-    "limit": {
-     "context": 131072,
-     "output": 384000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek Reasoner",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-12-01",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
    },
    "deepseek/deepseek-v4-flash": {
     "attachment": false,
@@ -61026,47 +62235,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "fireworks_ai/accounts/fireworks/models/gpt-oss-20b": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.035,
-     "input": 0.07,
-     "output": 0.3
-    },
-    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
-    "family": "gpt-oss",
-    "id": "fireworks_ai/accounts/fireworks/models/gpt-oss-20b",
-    "last_updated": "2025-08-05",
-    "limit": {
-     "context": 131072,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT OSS 20B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-08-05",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "fireworks_ai/accounts/fireworks/models/muse-glimmer-30b": {
     "attachment": true,
     "cost": {
@@ -61152,94 +62320,11 @@
     "temperature": true,
     "tool_call": true
    },
-   "fireworks_ai/gpt-oss-20b": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.035,
-     "input": 0.07,
-     "output": 0.3
-    },
-    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
-    "family": "gpt-oss",
-    "id": "fireworks_ai/gpt-oss-20b",
-    "last_updated": "2025-08-05",
-    "limit": {
-     "context": 131072,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT OSS 20B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-08-05",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "flexai/DeepSeek-V4-Flash-0731": {
-    "attachment": false,
-    "cost": {
-     "input": 0.08,
-     "output": 0.18
-    },
-    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
-    "family": "deepseek-flash",
-    "id": "flexai/DeepSeek-V4-Flash-0731",
-    "knowledge": "2025-05",
-    "last_updated": "2026-07-31",
-    "limit": {
-     "context": 1000000,
-     "output": 384000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek V4 Flash 0731",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-07-31",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
    "flexai/Muse-Glimmer-30B": {
     "attachment": true,
     "cost": {
      "input": 0.3,
-     "output": 1.2
+     "output": 1.1
     },
     "description": "Muse Glimmer is a 30-billion-parameter open-weight multimodal model from Meta Superintelligence Labs, distilled from Muse Spark for always-on local agents, tool use, coding, and image understanding.",
     "family": "muse",
@@ -61330,7 +62415,7 @@
     "knowledge": "2025-05",
     "last_updated": "2026-07-31",
     "limit": {
-     "context": 1000000,
+     "context": 786432,
      "output": 384000
     },
     "modalities": {
@@ -61403,8 +62488,8 @@
    "flexai/gpt-oss-20b": {
     "attachment": false,
     "cost": {
-     "input": 0.03,
-     "output": 0.13
+     "input": 0.02,
+     "output": 0.1
     },
     "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
     "family": "gpt-oss",
@@ -62283,38 +63368,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "google/lyria-3-clip-preview": {
-    "attachment": true,
-    "cost": {
-     "input": 0,
-     "output": 0
-    },
-    "description": "Music generation model for short 30-second clips, loops, and previews from text or image prompts",
-    "family": "lyria",
-    "id": "google/lyria-3-clip-preview",
-    "last_updated": "2026-03-25",
-    "limit": {
-     "context": 1048576,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text",
-      "audio"
-     ]
-    },
-    "name": "Lyria 3 Clip Preview",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-03-25",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
    "groq/openai/gpt-oss-120b": {
     "attachment": false,
     "cost": {
@@ -62400,8 +63453,8 @@
    "ionos/meta-llama/Llama-3.3-70B-Instruct": {
     "attachment": false,
     "cost": {
-     "input": 0.760435,
-     "output": 0.760435
+     "input": 0.75374,
+     "output": 0.75374
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
     "family": "llama",
@@ -62431,8 +63484,8 @@
    "ionos/openai/gpt-oss-120b": {
     "attachment": false,
     "cost": {
-     "input": 0.175485,
-     "output": 0.760435
+     "input": 0.17394,
+     "output": 0.75374
     },
     "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
     "family": "gpt-oss",
@@ -62480,7 +63533,7 @@
     "last_updated": "2025-10-27",
     "limit": {
      "context": 204800,
-     "output": 128000
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -62608,7 +63661,7 @@
     "last_updated": "2026-06-01",
     "limit": {
      "context": 524288,
-     "output": 128000
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -62632,6 +63685,7 @@
    "mistral/codestral-latest": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.03,
      "input": 0.3,
      "output": 0.9
     },
@@ -62663,6 +63717,7 @@
    "mistral/devstral-2512": {
     "attachment": true,
     "cost": {
+     "cache_read": 0.04,
      "input": 0.4,
      "output": 2
     },
@@ -62859,6 +63914,7 @@
    "mistral/mistral-medium-2604": {
     "attachment": true,
     "cost": {
+     "cache_read": 0.15,
      "input": 1.5,
      "output": 7.5
     },
@@ -62899,6 +63955,7 @@
    "mistral/mistral-medium-latest": {
     "attachment": true,
     "cost": {
+     "cache_read": 0.15,
      "input": 1.5,
      "output": 7.5
     },
@@ -62981,6 +64038,7 @@
    "mistral/mistral-small-latest": {
     "attachment": true,
     "cost": {
+     "cache_read": 0.015,
      "input": 0.15,
      "output": 0.6
     },
@@ -63015,6 +64073,37 @@
      }
     ],
     "release_date": "2026-03-16",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "mistral/voxtral-small-latest": {
+    "attachment": true,
+    "cost": {
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Instruct model with native audio input for speech understanding and tool use",
+    "family": "voxtral",
+    "id": "mistral/voxtral-small-latest",
+    "last_updated": "2025-07-15",
+    "limit": {
+     "context": 32768,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Voxtral Small (latest)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-07-15",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -63144,7 +64233,7 @@
     "knowledge": "2025-05",
     "last_updated": "2026-07-31",
     "limit": {
-     "context": 1048576,
+     "context": 1024000,
      "output": 384000
     },
     "modalities": {
@@ -63885,7 +64974,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2": {
@@ -63932,7 +65021,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2-pro": {
@@ -64023,7 +65112,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4": {
@@ -64086,7 +65175,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -64133,7 +65222,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -64180,7 +65269,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-pro": {
@@ -64680,7 +65769,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-pro-latest": {
@@ -65280,8 +66369,8 @@
    "qwen/deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
-     "input": 0.627,
-     "output": 1.881
+     "input": 0.5808,
+     "output": 1.7424
     },
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
@@ -65574,6 +66663,37 @@
     "temperature": true,
     "tool_call": true
    },
+   "qwen/qwen3-coder-next@eu": {
+    "attachment": false,
+    "cost": {
+     "input": 0.3,
+     "output": 1.5
+    },
+    "description": "Open-weight Qwen coding model for agents, repository edits, and multi-turn tool use",
+    "family": "qwen",
+    "id": "qwen/qwen3-coder-next@eu",
+    "knowledge": "2025-09",
+    "last_updated": "2026-02-03",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Coder Next (EU)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-02-03",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "qwen/qwen3-coder-plus": {
     "attachment": false,
     "cost": {
@@ -65633,6 +66753,39 @@
      ]
     },
     "name": "Qwen3 Max",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2025-09-23",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3-max@eu": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.24,
+     "cache_write": 1.5,
+     "input": 1.2,
+     "output": 6
+    },
+    "description": "Flagship Qwen3 model for coding agents, complex reasoning, and tool use",
+    "family": "qwen",
+    "id": "qwen/qwen3-max@eu",
+    "knowledge": "2025-04",
+    "last_updated": "2025-09-23",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 Max (EU)",
     "open_weights": false,
     "reasoning": false,
     "release_date": "2025-09-23",
@@ -65857,6 +67010,50 @@
     "temperature": true,
     "tool_call": true
    },
+   "qwen/qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.16,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "tool_call": true
+   },
    "qwen/qwen3.8-max": {
     "attachment": true,
     "cost": {
@@ -65937,8 +67134,8 @@
    "scaleway/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "input": 0.46796,
-     "output": 0.93592
+     "input": 0.46384,
+     "output": 0.92768
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -65979,8 +67176,8 @@
    "scaleway/gpt-oss-120b": {
     "attachment": false,
     "cost": {
-     "input": 0.175485,
-     "output": 0.70194
+     "input": 0.17394,
+     "output": 0.69576
     },
     "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
     "family": "gpt-oss",
@@ -66019,8 +67216,8 @@
    "scaleway/llama-3.3-70b-instruct": {
     "attachment": false,
     "cost": {
-     "input": 1.05291,
-     "output": 1.05291
+     "input": 1.04364,
+     "output": 1.04364
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
     "family": "llama",
@@ -66086,6 +67283,48 @@
      }
     ],
     "release_date": "2026-07-31",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "tensorx/deepseek/deepseek-v4-pro-0813": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 4
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "tensorx/deepseek/deepseek-v4-pro-0813",
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1048576,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
     "structured_output": false,
     "temperature": true,
     "tool_call": true
@@ -66253,47 +67492,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "together_ai/nvidia/nemotron-3-ultra-550b-a55b": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 0.6,
-     "output": 3.6
-    },
-    "description": "Largest Nemotron 3 model for maximum open-weight reasoning and agent accuracy",
-    "family": "nemotron",
-    "id": "together_ai/nvidia/nemotron-3-ultra-550b-a55b",
-    "last_updated": "2026-06-04",
-    "limit": {
-     "context": 512288,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Ultra 550B A55B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-06-04",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "together_ai/openai/gpt-oss-120b": {
     "attachment": false,
     "cost": {
@@ -66416,7 +67614,7 @@
      }
     ],
     "release_date": "2026-07-15",
-    "structured_output": false,
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -66642,6 +67840,56 @@
     "temperature": true,
     "tool_call": false
    },
+   "vertex/gemini-3.1-flash-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "cache_write": 0.083333,
+     "input": 0.25,
+     "input_audio": 0.5,
+     "output": 1.5,
+     "reasoning": 1.5
+    },
+    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "family": "gemini-flash-lite",
+    "id": "vertex/gemini-3.1-flash-lite",
+    "knowledge": "2025-01",
+    "last_updated": "2026-05-07",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Flash Lite",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-07",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "vertex/gemini-3.1-flash-lite-image": {
     "attachment": true,
     "cost": {
@@ -66683,6 +67931,106 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": false
+   },
+   "vertex/gemini-3.1-flash-lite@eu": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "cache_write": 0.083333,
+     "input": 0.25,
+     "input_audio": 0.5,
+     "output": 1.5,
+     "reasoning": 1.5
+    },
+    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "family": "gemini-flash-lite",
+    "id": "vertex/gemini-3.1-flash-lite@eu",
+    "knowledge": "2025-01",
+    "last_updated": "2026-05-07",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Flash Lite (EU)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-07",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertex/gemini-3.1-flash-lite@us": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.025,
+     "cache_write": 0.083333,
+     "input": 0.25,
+     "input_audio": 0.5,
+     "output": 1.5,
+     "reasoning": 1.5
+    },
+    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "family": "gemini-flash-lite",
+    "id": "vertex/gemini-3.1-flash-lite@us",
+    "knowledge": "2025-01",
+    "last_updated": "2026-05-07",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Flash Lite (US)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-07",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    },
    "vertex/gemini-3.1-pro-preview": {
     "attachment": true,
@@ -68113,7 +69461,7 @@
      ]
     },
     "name": "GLM-5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -68126,6 +69474,49 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "zai/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -68205,9 +69596,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -68257,7 +69645,14 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
      },
      {
       "max": 393216,
@@ -68299,7 +69694,19 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "max": 393216,
+      "min": 1,
+      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-07-31",
@@ -68336,7 +69743,14 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
      },
      {
       "max": 393216,
@@ -68376,9 +69790,6 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -68545,9 +69956,6 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -68718,7 +70126,14 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
      },
      {
       "max": 38912,
@@ -68758,9 +70173,6 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -68803,7 +70215,7 @@
      ]
     },
     "name": "GLM 5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -68816,6 +70228,50 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5-3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5-3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -68851,7 +70307,19 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "max": 81920,
+      "min": 1,
+      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-04-21",
@@ -69167,38 +70635,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "mistral-medium-3": {
-    "attachment": true,
-    "cost": {
-     "input": 0,
-     "output": 0
-    },
-    "description": "Mistral model for multilingual chat, reasoning, and tool-assisted workflows",
-    "family": "mistral-medium",
-    "id": "mistral-medium-3",
-    "knowledge": "2025-05",
-    "last_updated": "2025-05-07",
-    "limit": {
-     "context": 130000,
-     "output": 40000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Mistral Medium 3",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-05-07",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "mistral-small-4": {
     "attachment": true,
     "cost": {
@@ -69410,9 +70846,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -69473,9 +70906,6 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -69538,9 +70968,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -69602,9 +71029,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -69653,9 +71077,6 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -69706,9 +71127,6 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -69853,9 +71271,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -69903,9 +71318,6 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -69968,9 +71380,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -70030,9 +71439,6 @@
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -70160,9 +71566,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -70210,9 +71613,6 @@
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -70281,9 +71681,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -70334,9 +71731,6 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
@@ -70347,6 +71741,56 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3-8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.16,
+     "input": 0.16,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen3-8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "max": 262144,
+      "min": 1,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -70380,9 +71824,6 @@
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
-     {
-      "type": "toggle"
-     },
      {
       "type": "effort",
       "values": [
@@ -70946,7 +72387,7 @@
     "release_date": "2025-07-30",
     "tool_call": false
    },
-   "Qwen/Qwen3.6-35B-A3B-FP8": {
+   "Qwen/Qwen3.6-35B-A3B": {
     "attachment": true,
     "cost": {
      "input": 0.345,
@@ -70954,7 +72395,7 @@
     },
     "description": "Open multimodal Qwen MoE for local agents that need vision, audio, and code",
     "family": "qwen",
-    "id": "Qwen/Qwen3.6-35B-A3B-FP8",
+    "id": "Qwen/Qwen3.6-35B-A3B",
     "last_updated": "2026-04-17",
     "limit": {
      "context": 262144,
@@ -70980,6 +72421,50 @@
      }
     ],
     "release_date": "2026-04-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "Qwen/Qwen3.8-27B": {
+    "attachment": true,
+    "cost": {
+     "input": 0.87,
+     "output": 3.5
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "Qwen/Qwen3.8-27B",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8-27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -71354,7 +72839,6 @@
      {
       "type": "effort",
       "values": [
-       "none",
        "high",
        "max"
       ]
@@ -72409,7 +73893,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -72452,7 +73936,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -72495,7 +73979,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.5": {
@@ -73038,53 +74522,6 @@
   ],
   "id": "fireworks-ai",
   "models": {
-   "accounts/fireworks/models/deepseek-v4-flash": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.028,
-     "input": 0.14,
-     "output": 0.28
-    },
-    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
-    "family": "deepseek-flash",
-    "id": "accounts/fireworks/models/deepseek-v4-flash",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-05",
-    "last_updated": "2026-06-16",
-    "limit": {
-     "context": 1000000,
-     "output": 384000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek V4 Flash",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-04-24",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "accounts/fireworks/models/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
@@ -73129,53 +74566,6 @@
      }
     ],
     "release_date": "2026-07-31",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "accounts/fireworks/models/deepseek-v4-pro": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.145,
-     "input": 1.74,
-     "output": 3.48
-    },
-    "description": "Open MoE flagship with million-token context for coding and long agent runs",
-    "family": "deepseek-thinking",
-    "id": "accounts/fireworks/models/deepseek-v4-pro",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-05",
-    "last_updated": "2026-04-24",
-    "limit": {
-     "context": 1000000,
-     "output": 384000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek V4 Pro",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-04-24",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -73271,6 +74661,95 @@
     "temperature": true,
     "tool_call": true
    },
+   "accounts/fireworks/models/glm-5p3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "accounts/fireworks/models/glm-5p3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "accounts/fireworks/models/glm-5p3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.029,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "accounts/fireworks/models/glm-5p3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "accounts/fireworks/models/gpt-oss-120b": {
     "attachment": false,
     "cost": {
@@ -73295,46 +74774,6 @@
      ]
     },
     "name": "GPT OSS 120B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-08-05",
-    "temperature": true,
-    "tool_call": true
-   },
-   "accounts/fireworks/models/gpt-oss-20b": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.035,
-     "input": 0.07,
-     "output": 0.3
-    },
-    "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
-    "family": "gpt-oss",
-    "id": "accounts/fireworks/models/gpt-oss-20b",
-    "last_updated": "2025-08-05",
-    "limit": {
-     "context": 131072,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT OSS 20B",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -73513,49 +74952,6 @@
     "release_date": "2026-07-27",
     "structured_output": true,
     "temperature": false,
-    "tool_call": true
-   },
-   "accounts/fireworks/models/minimax-m2p7": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.06,
-     "input": 0.3,
-     "output": 1.2
-    },
-    "description": "MiniMax model for chat, coding, office work, and agentic tasks",
-    "family": "minimax",
-    "id": "accounts/fireworks/models/minimax-m2p7",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-04-12",
-    "limit": {
-     "context": 196608,
-     "output": 196608
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "MiniMax-M2.7",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-04-12",
-    "temperature": true,
     "tool_call": true
    },
    "accounts/fireworks/models/minimax-m3": {
@@ -73843,123 +75239,6 @@
      }
     ],
     "release_date": "2026-06-26",
-    "temperature": true,
-    "tool_call": true
-   },
-   "accounts/fireworks/routers/kimi-k2p6-fast": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.3,
-     "input": 2,
-     "output": 8
-    },
-    "description": "Kimi reasoning model for long-horizon research, planning, and tool use",
-    "family": "kimi-thinking",
-    "id": "accounts/fireworks/routers/kimi-k2p6-fast",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-06-05",
-    "limit": {
-     "context": 262000,
-     "output": 262000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.6 Fast",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-04-17",
-    "temperature": true,
-    "tool_call": true
-   },
-   "accounts/fireworks/routers/kimi-k2p6-turbo": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.3,
-     "input": 2,
-     "output": 8
-    },
-    "description": "Kimi reasoning model for long-horizon research, planning, and tool use",
-    "family": "kimi-thinking",
-    "id": "accounts/fireworks/routers/kimi-k2p6-turbo",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-04-17",
-    "limit": {
-     "context": 262000,
-     "output": 262000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.6 Turbo",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-04-17",
-    "temperature": true,
-    "tool_call": true
-   },
-   "accounts/fireworks/routers/kimi-k2p7-code-fast": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.38,
-     "input": 1.9,
-     "output": 8
-    },
-    "description": "Kimi coding model for software agents, refactors, and repository reasoning",
-    "family": "kimi-k2",
-    "id": "accounts/fireworks/routers/kimi-k2p7-code-fast",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-06-16",
-    "limit": {
-     "context": 262000,
-     "output": 262000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.7 Code Fast",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-06-12",
     "temperature": true,
     "tool_call": true
    },
@@ -74353,7 +75632,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4": {
@@ -74405,7 +75684,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -74456,7 +75735,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
@@ -74707,6 +75986,55 @@
      }
     ],
     "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai-org/GLM-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "max": 1048576,
+      "min": -1,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -76414,9 +77742,9 @@
    "gemini-3.6-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "input": 1.5,
-     "output": 7.5
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 3.75
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -76617,7 +77945,7 @@
     "reasoning_options": [],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.2-codex": {
@@ -76699,7 +78027,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4": {
@@ -76762,7 +78090,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -76808,7 +78136,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-nano": {
@@ -76843,7 +78171,7 @@
     "reasoning_options": [],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
@@ -76913,8 +78241,10 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.02,
+     "cache_write": 0.25,
      "context_over_200k": {
       "cache_read": 0.04,
+      "cache_write": 0.5,
       "input": 0.4,
       "output": 1.8
      },
@@ -76923,6 +78253,7 @@
      "tiers": [
       {
        "cache_read": 0.04,
+       "cache_write": 0.5,
        "input": 0.4,
        "output": 1.8,
        "tier": {
@@ -76976,22 +78307,22 @@
    "gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
+     "cache_read": 0.2,
+     "cache_write": 2.5,
      "context_over_200k": {
-      "cache_read": 0.5,
-      "cache_write": 6.25,
-      "input": 5,
-      "output": 22.5
+      "cache_read": 0.4,
+      "cache_write": 5,
+      "input": 4,
+      "output": 15
      },
-     "input": 2.5,
-     "output": 15,
+     "input": 2,
+     "output": 10,
      "tiers": [
       {
-       "cache_read": 0.5,
-       "cache_write": 6.25,
-       "input": 5,
-       "output": 22.5,
+       "cache_read": 0.4,
+       "cache_write": 5,
+       "input": 4,
+       "output": 15,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -77044,8 +78375,10 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.2,
+     "cache_write": 2.5,
      "context_over_200k": {
       "cache_read": 0.4,
+      "cache_write": 5,
       "input": 4,
       "output": 18
      },
@@ -77054,6 +78387,7 @@
      "tiers": [
       {
        "cache_read": 0.4,
+       "cache_write": 5,
        "input": 4,
        "output": 18,
        "tier": {
@@ -78251,6 +79585,90 @@
   ],
   "id": "gmicloud",
   "models": {
+   "MiniMaxAI/MiniMax-M2.7": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+    "family": "minimax",
+    "id": "MiniMaxAI/MiniMax-M2.7",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 196608,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax-M2.7",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-03-18",
+    "temperature": true,
+    "tool_call": true
+   },
+   "MiniMaxAI/MiniMax-M3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.12,
+     "context_over_200k": {
+      "cache_read": 0.24,
+      "input": 1.2,
+      "output": 4.8
+     },
+     "input": 0.6,
+     "output": 2.4,
+     "tiers": [
+      {
+       "cache_read": 0.24,
+       "input": 1.2,
+       "output": 4.8,
+       "tier": {
+        "size": 512000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "family": "minimax",
+    "id": "MiniMaxAI/MiniMax-M3",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 1048576,
+     "output": 512000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax-M3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-01",
+    "temperature": true,
+    "tool_call": true
+   },
    "Qwen/Qwen3.7-Max": {
     "attachment": false,
     "cost": {
@@ -88460,7 +89878,7 @@
     "last_updated": "2025-10-27",
     "limit": {
      "context": 204800,
-     "output": 128000
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -88593,7 +90011,7 @@
     "last_updated": "2026-06-01",
     "limit": {
      "context": 524288,
-     "output": 128000
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -89357,6 +90775,47 @@
      }
     ],
     "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "Qwen/Qwen3.8-27B": {
+    "attachment": true,
+    "cost": {
+     "input": 0.4,
+     "output": 3
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "Qwen/Qwen3.8-27B",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -90786,6 +92245,87 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
+   },
+   "zai-org/GLM-5.3": {
+    "attachment": false,
+    "cost": {
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai-org/GLM-5.3-Flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3-Flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "Hugging Face",
@@ -90843,9 +92383,9 @@
    "deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.015243,
-     "input": 0.479072,
-     "output": 1.437216
+     "cache_read": 0.044,
+     "input": 0.44,
+     "output": 1.32
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -90853,7 +92393,7 @@
     "knowledge": "2025-05",
     "last_updated": "2026-08-02",
     "limit": {
-     "context": 1048576,
+     "context": 1000000,
      "output": 384000
     },
     "modalities": {
@@ -90872,11 +92412,8 @@
       "type": "effort",
       "values": [
        "none",
-       "minimal",
        "low",
-       "medium",
        "high",
-       "xhigh",
        "max"
       ]
      }
@@ -90958,8 +92495,9 @@
       "type": "effort",
       "values": [
        "none",
+       "low",
        "high",
-       "xhigh"
+       "max"
       ]
      }
     ],
@@ -90971,9 +92509,9 @@
    "gemma-4-26b-a4b-it": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.055,
-     "input": 0.11,
-     "output": 0.408
+     "cache_write": 0.06,
+     "input": 0.12,
+     "output": 0.42
     },
     "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
     "family": "gemma",
@@ -91034,9 +92572,9 @@
    "glm-5.1": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.68,
-     "input": 1.36,
-     "output": 4.4
+     "cache_write": 0.666,
+     "input": 1.332,
+     "output": 4.312
     },
     "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
     "family": "glm",
@@ -91064,7 +92602,7 @@
     "tool_call": true
    },
    "glm-5.2": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
      "cache_read": 0.152432,
      "input": 1.52432,
@@ -91075,13 +92613,12 @@
     "id": "glm-5.2",
     "last_updated": "2026-07-22",
     "limit": {
-     "context": 1048576,
+     "context": 1000000,
      "output": 32768
     },
     "modalities": {
      "input": [
-      "text",
-      "image"
+      "text"
      ],
      "output": [
       "text"
@@ -91094,13 +92631,95 @@
      {
       "type": "effort",
       "values": [
-       "none",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-06-30",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.283088,
+     "input": 1.52432,
+     "output": 4.79072
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "last_updated": "2026-08-31",
+    "limit": {
+     "context": 1048576,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
        "high",
        "max"
       ]
      }
     ],
-    "release_date": "2026-06-30",
+    "release_date": "2026-08-28",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.031575,
+     "input": 0.16332,
+     "output": 0.5444
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "last_updated": "2026-08-31",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -91117,7 +92736,7 @@
     "id": "gpt-oss-120b",
     "last_updated": "2026-07-22",
     "limit": {
-     "context": 131072,
+     "context": 128072,
      "output": 13107
     },
     "modalities": {
@@ -91135,9 +92754,13 @@
      {
       "type": "effort",
       "values": [
+       "none",
+       "minimal",
        "low",
        "medium",
-       "high"
+       "high",
+       "xhigh",
+       "max"
       ]
      }
     ],
@@ -91207,7 +92830,16 @@
     "name": "Kimi K2.6",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2026-07-03",
     "structured_output": true,
     "temperature": true,
@@ -91226,7 +92858,7 @@
     "knowledge": "2025-01",
     "last_updated": "2026-07-22",
     "limit": {
-     "context": 256000,
+     "context": 262000,
      "output": 16000
     },
     "modalities": {
@@ -91292,9 +92924,9 @@
    "llama-3.3-70b-instruct": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.319,
-     "input": 0.638,
-     "output": 0.768
+     "cache_write": 0.3033,
+     "input": 0.6066,
+     "output": 1.0386
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
     "family": "llama",
@@ -91354,9 +92986,9 @@
    "minimax-m2.7": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.204,
-     "input": 0.408,
-     "output": 1.512
+     "cache_write": 0.212,
+     "input": 0.424,
+     "output": 1.612
     },
     "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
     "family": "minimax",
@@ -91682,6 +93314,103 @@
     "reasoning_options": [],
     "release_date": "2026-06-15",
     "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-2.4t-a95b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.25,
+     "input": 2,
+     "output": 6
+    },
+    "description": "Open-weight sparse MoE (2.4T total, 95B active), the open-weight twin of Qwen3.8 Max for coding, research, complex reasoning, and agentic workflows",
+    "family": "qwen",
+    "id": "qwen3.8-2.4t-a95b",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 2.4T A95B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-27b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.5,
+     "output": 3
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen3.8-27b",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "input": 0.15,
+     "output": 0.47
+    },
+    "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+    "family": "qwen",
+    "id": "qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "tool_call": true
    },
    "qwen3.8-max": {
@@ -93833,7 +95562,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.1-codex": {
@@ -93967,7 +95696,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2-codex": {
@@ -94060,7 +95789,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4": {
@@ -94123,7 +95852,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -94169,7 +95898,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -94215,7 +95944,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-pro": {
@@ -95631,10 +97360,10 @@
    "moonshotai/Kimi-K2.6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
+     "cache_read": 0.17,
      "cache_write": 0,
-     "input": 0.6,
-     "output": 3.41
+     "input": 0.53,
+     "output": 3.39
     },
     "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
     "family": "kimi-k2",
@@ -95669,9 +97398,9 @@
    "moonshotai/Kimi-K2.7-Code": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.17,
+     "cache_read": 0.18,
      "cache_write": 0,
-     "input": 0.67,
+     "input": 0.66,
      "output": 3.4
     },
     "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
@@ -95707,10 +97436,10 @@
    "zai-org/GLM-5.2": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.17,
+     "cache_read": 0.12,
      "cache_write": 0,
-     "input": 0.75,
-     "output": 2.9
+     "input": 0.71,
+     "output": 2.35
     },
     "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
     "family": "glm",
@@ -97362,6 +99091,62 @@
   "name": "IO.NET",
   "npm": "@ai-sdk/openai-compatible"
  },
+ "iteracompute": {
+  "api": "https://api.iteracompute.com/v1",
+  "doc": "https://iteracompute.com/docs.html",
+  "env": [
+   "ITERACOMPUTE_API_KEY"
+  ],
+  "id": "iteracompute",
+  "models": {
+   "iteracompute/qwen3.8-27b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.35,
+     "output": 3
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "iteracompute/qwen3.8-27b",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "IteraCompute",
+  "npm": "@ai-sdk/openai-compatible"
+ },
  "jalapeno": {
   "api": "https://api.jalapeno-cloud.ai/v1",
   "doc": "https://www.jalapeno-cloud.ai/docs/",
@@ -97695,7 +99480,7 @@
     "last_updated": "2026-06-01",
     "limit": {
      "context": 524288,
-     "output": 128000
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -100203,6 +101988,93 @@
     "temperature": false,
     "tool_call": true
    },
+   "claude-opus-5": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Strongest Claude Opus model for coding, agents, and professional work",
+    "family": "claude-opus",
+    "id": "claude-opus-5",
+    "knowledge": "2026-05",
+    "last_updated": "2026-07-24",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-24",
+    "temperature": false,
+    "tool_call": true
+   },
+   "claude-sonnet-4-6": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
+    "family": "claude-sonnet",
+    "id": "claude-sonnet-4-6",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-13",
+    "limit": {
+     "context": 1000000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.6",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-17",
+    "temperature": true,
+    "tool_call": true
+   },
    "claude-sonnet-5": {
     "attachment": true,
     "cost": {
@@ -100485,6 +102357,218 @@
     "temperature": true,
     "tool_call": true
    },
+   "gemini-3-1-flash-tts": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Low-latency speech generation with steerable prompts and expressive audio tags",
+    "family": "gemini-flash",
+    "id": "gemini-3-1-flash-tts",
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-15",
+    "limit": {
+     "context": 8192,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "audio"
+     ]
+    },
+    "name": "Gemini 3.1 Flash TTS Preview",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-04-15",
+    "temperature": true,
+    "tool_call": false
+   },
+   "gemini-3-1-pro": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
+    "family": "gemini-pro",
+    "id": "gemini-3-1-pro",
+    "knowledge": "2025-01",
+    "last_updated": "2026-02-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Pro Preview",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-02-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gemini-3-5-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "gemini-3-5-flash",
+    "knowledge": "2025-01",
+    "last_updated": "2026-05-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gemini-3-6-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "gemini-3-6-flash",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.6 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gemini-3-7-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
+    "family": "gemini-flash",
+    "id": "gemini-3-7-flash",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.7 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "gemma-4-31b-it": {
     "attachment": true,
     "cost": {
@@ -100618,6 +102702,89 @@
     "temperature": true,
     "tool_call": true
    },
+   "glm-5-3": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5-3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5-3-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5-3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "gpt-5-4-mini": {
     "attachment": true,
     "cost": {
@@ -100660,7 +102827,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5-5": {
@@ -100996,6 +103163,49 @@
     "temperature": true,
     "tool_call": true
    },
+   "grok-4-6": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "grok-4-6",
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "grok-build-0-1": {
     "attachment": true,
     "cost": {
@@ -101026,6 +103236,114 @@
     "reasoning_options": [],
     "release_date": "2026-04-16",
     "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "grok-imagine-image-2-0": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+    "family": "grok",
+    "id": "grok-imagine-image-2-0",
+    "last_updated": "2026-08-07",
+    "limit": {
+     "context": 8000,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "image"
+     ]
+    },
+    "name": "Grok Imagine Image 2.0",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-07",
+    "temperature": false,
+    "tool_call": false
+   },
+   "hy3": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "hy3",
+    "last_updated": "2026-07-06",
+    "limit": {
+     "context": 256000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-06",
+    "temperature": true,
+    "tool_call": true
+   },
+   "hy3:free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "hy3:free",
+    "last_updated": "2026-07-06",
+    "limit": {
+     "context": 256000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy3 (Free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-06",
     "temperature": true,
     "tool_call": true
    },
@@ -101306,6 +103624,66 @@
     "temperature": true,
     "tool_call": true
    },
+   "minimax-m2-7": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+    "family": "minimax",
+    "id": "minimax-m2-7",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 204800,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax-M2.7",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-03-18",
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax-m2-7-highspeed": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Low-latency M2.7 variant for interactive coding plans and agent loops",
+    "family": "minimax",
+    "id": "minimax-m2-7-highspeed",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 204800,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax-M2.7-highspeed",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-03-18",
+    "temperature": true,
+    "tool_call": true
+   },
    "minimax-m3": {
     "attachment": true,
     "cost": {
@@ -101317,8 +103695,8 @@
     "id": "minimax-m3",
     "last_updated": "2026-06-01",
     "limit": {
-     "context": 512000,
-     "output": 128000
+     "context": 1048576,
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -101335,6 +103713,77 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-06-01",
+    "temperature": true,
+    "tool_call": true
+   },
+   "mistral-large:free": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Flagship Mistral model for advanced reasoning, coding, and multilingual work",
+    "family": "mistral-large",
+    "id": "mistral-large:free",
+    "knowledge": "2024-11",
+    "last_updated": "2025-12-02",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Mistral Large (Free)",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2024-11-01",
+    "temperature": true,
+    "tool_call": true
+   },
+   "mistral-medium-3-5:free": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Balanced Mistral model for enterprise assistants, multilingual work, and tools",
+    "family": "mistral-medium",
+    "id": "mistral-medium-3-5:free",
+    "last_updated": "2026-04-29",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Mistral Medium 3.5 (Free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-29",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -101514,6 +103963,162 @@
     "release_date": "2026-06-02",
     "temperature": true,
     "tool_call": true
+   },
+   "qwen3-8-max": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "qwen3-8-max",
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-03",
+    "temperature": true,
+    "tool_call": true
+   },
+   "step-3-7-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Newer StepFun flash model for faster agents, coding, and multimodal prompts",
+    "id": "step-3-7-flash",
+    "knowledge": "2026-03-01",
+    "last_updated": "2026-05-29",
+    "limit": {
+     "context": 256000,
+     "input": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Step 3.7 Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-29",
+    "temperature": true,
+    "tool_call": true
+   },
+   "step-3-7-flash:free": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Newer StepFun flash model for faster agents, coding, and multimodal prompts",
+    "id": "step-3-7-flash:free",
+    "knowledge": "2026-03-01",
+    "last_updated": "2026-05-29",
+    "limit": {
+     "context": 256000,
+     "input": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Step 3.7 Flash (Free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-29",
+    "temperature": true,
+    "tool_call": true
+   },
+   "whisper-large-v3-turbo": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
+    "family": "whisper",
+    "id": "whisper-large-v3-turbo",
+    "last_updated": "2024-10-01",
+    "limit": {
+     "context": 448,
+     "output": 448
+    },
+    "modalities": {
+     "input": [
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Whisper Large v3 Turbo",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2024-10-01",
+    "tool_call": false
    }
   },
   "name": "Kenari",
@@ -101653,7 +104258,7 @@
     "last_updated": "2025-02-04",
     "limit": {
      "context": 32768,
-     "output": 32768
+     "output": 29491
     },
     "modalities": {
      "input": [
@@ -101668,44 +104273,6 @@
     "reasoning": false,
     "release_date": "2025-02-04",
     "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "allenai/olmo-3-32b-think": {
-    "attachment": false,
-    "cost": {
-     "input": 0.15,
-     "output": 0.5
-    },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "allenai",
-    "id": "allenai/olmo-3-32b-think",
-    "last_updated": "2025-11-21",
-    "limit": {
-     "context": 65536,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "AllenAI: Olmo 3 32B Think",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-11-21",
-    "structured_output": true,
     "temperature": true,
     "tool_call": false
    },
@@ -102690,7 +105257,7 @@
     "last_updated": "2026-05-28",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 80000
     },
     "modalities": {
      "input": [
@@ -102713,35 +105280,6 @@
     ],
     "release_date": "2026-04-01",
     "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "arcee-ai/virtuoso-large": {
-    "attachment": false,
-    "cost": {
-     "input": 0.75,
-     "output": 1.2
-    },
-    "description": "Flagship model for demanding analysis, coding, and production agent workflows",
-    "id": "arcee-ai/virtuoso-large",
-    "last_updated": "2025-05-05",
-    "limit": {
-     "context": 131072,
-     "output": 64000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Arcee AI: Virtuoso Large",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-05-05",
-    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -102879,7 +105417,7 @@
     "last_updated": "2026-08-12",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -103265,8 +105803,8 @@
    "deepseek/deepseek-chat": {
     "attachment": false,
     "cost": {
-     "input": 0.4,
-     "output": 1.3
+     "input": 0.2574,
+     "output": 1.0287
     },
     "description": "DeepSeek chat model for instruction following, coding, and analysis",
     "family": "deepseek",
@@ -103296,9 +105834,8 @@
    "deepseek/deepseek-chat-v3-0324": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.135,
-     "input": 0.27,
-     "output": 1.12
+     "input": 0.25,
+     "output": 1
     },
     "description": "DeepSeek chat model for instruction following, coding, and analysis",
     "family": "deepseek",
@@ -103306,7 +105843,7 @@
     "last_updated": "2025-03-24",
     "limit": {
      "context": 163840,
-     "output": 163840
+     "output": 147456
     },
     "modalities": {
      "input": [
@@ -103337,7 +105874,7 @@
     "last_updated": "2025-08-21",
     "limit": {
      "context": 161000,
-     "output": 161000
+     "output": 144900
     },
     "modalities": {
      "input": [
@@ -103454,7 +105991,7 @@
     "last_updated": "2025-01-23",
     "limit": {
      "context": 8192,
-     "output": 8192
+     "output": 7372
     },
     "modalities": {
      "input": [
@@ -103535,7 +106072,7 @@
     "last_updated": "2025-12-01",
     "limit": {
      "context": 163840,
-     "output": 163840
+     "output": 65536
     },
     "modalities": {
      "input": [
@@ -103657,7 +106194,7 @@
     "last_updated": "2026-07-31",
     "limit": {
      "context": 1048576,
-     "output": 384000
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -103689,9 +106226,9 @@
    "deepseek/deepseek-v4-flash-vision-exp": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.007,
-     "input": 0.22,
-     "output": 0.66
+     "cache_read": 0.028,
+     "input": 0.44,
+     "output": 1.32
     },
     "description": "DeepSeek V4 Flash Vision Exp is an experimental vision-enabled version of [DeepSeek V4 Flash 0731](https://openrouter.ai/deepseek/deepseek-v4-flash-0731) from DeepSeek, adding image understanding while matching the base model on text capabilities including agents,...",
     "family": "deepseek-flash",
@@ -103783,7 +106320,7 @@
     "id": "deepseek/deepseek-v4-pro-0813",
     "last_updated": "2026-08-22",
     "limit": {
-     "context": 1048575,
+     "context": 1048576,
      "output": 384000
     },
     "modalities": {
@@ -103824,7 +106361,7 @@
     "last_updated": "2026-08-14",
     "limit": {
      "context": 512000,
-     "output": 512000
+     "output": 460800
     },
     "modalities": {
      "input": [
@@ -104182,7 +106719,7 @@
     "knowledge": "2025-01",
     "last_updated": "2026-05-28",
     "limit": {
-     "context": 65536,
+     "context": 131072,
      "output": 32768
     },
     "modalities": {
@@ -104314,7 +106851,7 @@
     "last_updated": "2026-02-26",
     "limit": {
      "context": 65536,
-     "output": 65536
+     "output": 58982
     },
     "modalities": {
      "input": [
@@ -104408,7 +106945,7 @@
     "last_updated": "2026-06-30",
     "limit": {
      "context": 65536,
-     "output": 65536
+     "output": 58982
     },
     "modalities": {
      "input": [
@@ -104853,7 +107390,7 @@
     "last_updated": "2025-03-12",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -104903,41 +107440,11 @@
     "temperature": true,
     "tool_call": false
    },
-   "google/gemma-3n-e4b-it": {
-    "attachment": false,
-    "cost": {
-     "input": 0.06,
-     "output": 0.12
-    },
-    "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
-    "family": "gemma",
-    "id": "google/gemma-3n-e4b-it",
-    "last_updated": "2025-05-20",
-    "limit": {
-     "context": 32768,
-     "output": 6554
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Google: Gemma 3n 4B",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-05-20",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
    "google/gemma-4-26b-a4b-it": {
     "attachment": true,
     "cost": {
-     "input": 0.05,
-     "output": 0.25
+     "input": 0.042,
+     "output": 0.22
     },
     "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
     "family": "gemma",
@@ -104977,9 +107484,9 @@
    "google/gemma-4-31b-it": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.01,
-     "input": 0.08,
-     "output": 0.35
+     "cache_read": 0.05,
+     "input": 0.09,
+     "output": 0.34
     },
     "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
     "family": "gemma",
@@ -104987,7 +107494,7 @@
     "last_updated": "2026-04-02",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -105091,7 +107598,7 @@
     "last_updated": "2023-07-02",
     "limit": {
      "context": 4096,
-     "output": 4096
+     "output": 3686
     },
     "modalities": {
      "input": [
@@ -105121,7 +107628,7 @@
     "last_updated": "2025-10-20",
     "limit": {
      "context": 131000,
-     "output": 131000
+     "output": 117900
     },
     "modalities": {
      "input": [
@@ -105152,7 +107659,7 @@
     "last_updated": "2026-04-30",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -105212,68 +107719,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "inclusionai/ling-2.6-1t": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.06,
-     "input": 0.3,
-     "output": 2.5
-    },
-    "description": "Tool-capable chat model for instruction following and agentic application workflows",
-    "family": "ling",
-    "id": "inclusionai/ling-2.6-1t",
-    "last_updated": "2026-04-23",
-    "limit": {
-     "context": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "inclusionAI: Ling-2.6-1T (retires Aug 24)",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-04-23",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "inclusionai/ling-2.6-flash": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.02,
-     "input": 0.1,
-     "output": 0.3
-    },
-    "description": "Efficient model for low-latency assistance, extraction, and routine automation",
-    "family": "ling",
-    "id": "inclusionai/ling-2.6-flash",
-    "last_updated": "2026-04-21",
-    "limit": {
-     "context": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "inclusionAI: Ling-2.6-flash (retires Aug 24)",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-04-21",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "inclusionai/ling-3.0-flash": {
     "attachment": false,
     "cost": {
@@ -105314,20 +107759,19 @@
     "temperature": true,
     "tool_call": true
    },
-   "inclusionai/ring-2.6-1t": {
+   "inclusionai/ling-3.0-flash-fin:free": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.06,
-     "input": 0.3,
-     "output": 2.5
+     "input": 0,
+     "output": 0
     },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "ring",
-    "id": "inclusionai/ring-2.6-1t",
-    "last_updated": "2026-05-08",
+    "description": "Ling 3.0 Flash Fin is a finance-focused mixture-of-experts model from InclusionAI, built on Ling 3.0 Flash with 5.1B active parameters out of 124B total. It is designed for real-world investment...",
+    "family": "ling",
+    "id": "inclusionai/ling-3.0-flash-fin:free",
+    "last_updated": "2026-08-27",
     "limit": {
      "context": 262144,
-     "output": 65536
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -105337,19 +107781,19 @@
       "text"
      ]
     },
-    "name": "inclusionAI: Ring-2.6-1T (retires Aug 24)",
+    "name": "Ling 3.0 Flash Fin (free)",
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
      {
       "type": "effort",
       "values": [
-       "high",
-       "xhigh"
+       "none",
+       "high"
       ]
      }
     ],
-    "release_date": "2026-05-08",
+    "release_date": "2026-08-27",
     "structured_output": false,
     "temperature": true,
     "tool_call": true
@@ -105528,37 +107972,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "kwaipilot/kat-coder-air-v2.5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.03,
-     "input": 0.15,
-     "output": 0.6
-    },
-    "description": "KAT-Coder-Air V2.5 is a flagship-level Agentic Coding model that can directly hand over an entire issue or an entire business workflow to it, allowing it to autonomously locate and make...",
-    "family": "kat-coder",
-    "id": "kwaipilot/kat-coder-air-v2.5",
-    "last_updated": "2026-07-10",
-    "limit": {
-     "context": 256000,
-     "output": 80000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kwaipilot: KAT-Coder-Air V2.5",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-07-10",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "kwaipilot/kat-coder-pro-v2": {
     "attachment": false,
     "cost": {
@@ -105571,8 +107984,8 @@
     "id": "kwaipilot/kat-coder-pro-v2",
     "last_updated": "2026-03-27",
     "limit": {
-     "context": 256000,
-     "output": 80000
+     "context": 262144,
+     "output": 144000
     },
     "modalities": {
      "input": [
@@ -105602,8 +108015,8 @@
     "id": "kwaipilot/kat-coder-pro-v2.5",
     "last_updated": "2026-07-10",
     "limit": {
-     "context": 256000,
-     "output": 80000
+     "context": 262144,
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -105813,7 +108226,7 @@
     "last_updated": "2024-07-23",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -105843,7 +108256,7 @@
     "last_updated": "2024-09-25",
     "limit": {
      "context": 60000,
-     "output": 60000
+     "output": 54000
     },
     "modalities": {
      "input": [
@@ -105873,7 +108286,7 @@
     "last_updated": "2024-09-25",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -105903,8 +108316,8 @@
     "knowledge": "2023-12",
     "last_updated": "2024-12-06",
     "limit": {
-     "context": 131072,
-     "output": 16384
+     "context": 128000,
+     "output": 115200
     },
     "modalities": {
      "input": [
@@ -105933,8 +108346,8 @@
     "id": "meta-llama/llama-4-maverick",
     "last_updated": "2025-04-05",
     "limit": {
-     "context": 1048576,
-     "output": 16384
+     "context": 128000,
+     "output": 115200
     },
     "modalities": {
      "input": [
@@ -105964,8 +108377,8 @@
     "id": "meta-llama/llama-4-scout",
     "last_updated": "2025-04-05",
     "limit": {
-     "context": 327680,
-     "output": 16384
+     "context": 131072,
+     "output": 8192
     },
     "modalities": {
      "input": [
@@ -106029,7 +108442,7 @@
     "last_updated": "2026-08-10",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -106073,7 +108486,7 @@
     "last_updated": "2026-07-09",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -106120,7 +108533,7 @@
     "last_updated": "2026-08-05",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -106167,7 +108580,7 @@
     "last_updated": "2026-08-21",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -106213,7 +108626,7 @@
     "last_updated": "2025-01-10",
     "limit": {
      "context": 16384,
-     "output": 16384
+     "output": 14745
     },
     "modalities": {
      "input": [
@@ -106272,7 +108685,7 @@
     "last_updated": "2025-01-15",
     "limit": {
      "context": 1000192,
-     "output": 1000192
+     "output": 900172
     },
     "modalities": {
      "input": [
@@ -106516,6 +108929,46 @@
     "temperature": true,
     "tool_call": true
    },
+   "minimax/minimax-m2.7:free": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0,
+     "reasoning": 0
+    },
+    "description": "MiniMax-M2.7 is a next-generation large language model designed for autonomous, real-world productivity and continuous improvement. Built to actively participate in its own evolution, M2.7 integrates advanced agentic capabilities through multi-agent...",
+    "family": "minimax",
+    "id": "minimax/minimax-m2.7:free",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 196608,
+     "output": 196608
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax: MiniMax M2.7 (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-03-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "minimax/minimax-m3": {
     "attachment": true,
     "cost": {
@@ -106558,6 +109011,48 @@
     "temperature": true,
     "tool_call": true
    },
+   "minimax/minimax-m3:free": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0,
+     "reasoning": 0
+    },
+    "description": "MiniMax-M3 is a multimodal foundation model from MiniMax. It supports text, image, and video inputs with text output, a 1M-token context window, and is suited for long-horizon agentic work, coding,...",
+    "family": "minimax",
+    "id": "minimax/minimax-m3:free",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax: MiniMax M3 (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-01",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "mistralai/codestral-2508": {
     "attachment": true,
     "cost": {
@@ -106571,7 +109066,7 @@
     "last_updated": "2025-08-01",
     "limit": {
      "context": 256000,
-     "output": 51200
+     "output": 204800
     },
     "modalities": {
      "input": [
@@ -106590,6 +109085,39 @@
     "temperature": true,
     "tool_call": true
    },
+   "mistralai/devstral-2512": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.04,
+     "input": 0.4,
+     "output": 2
+    },
+    "description": "Devstral 2 is a state-of-the-art open-source model by Mistral AI specializing in agentic coding. It is a 123B-parameter dense transformer model supporting a 256K context window. Devstral 2 supports exploring...",
+    "family": "devstral",
+    "id": "mistralai/devstral-2512",
+    "knowledge": "2025-12",
+    "last_updated": "2025-12-09",
+    "limit": {
+     "context": 262144,
+     "output": 209715
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Devstral 2",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-12-09",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "mistralai/ministral-14b-2512": {
     "attachment": true,
     "cost": {
@@ -106603,7 +109131,7 @@
     "last_updated": "2025-12-02",
     "limit": {
      "context": 262144,
-     "output": 52429
+     "output": 209715
     },
     "modalities": {
      "input": [
@@ -106635,7 +109163,7 @@
     "last_updated": "2025-12-02",
     "limit": {
      "context": 131072,
-     "output": 32768
+     "output": 104857
     },
     "modalities": {
      "input": [
@@ -106654,36 +109182,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "mistralai/ministral-8b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.11,
-     "output": 0.11
-    },
-    "description": "Ministral 8B is an 8B parameter model featuring a unique interleaved sliding-window attention pattern for faster, memory-efficient inference. Designed for edge use cases, it supports up to 128k context length...",
-    "family": "ministral",
-    "id": "mistralai/ministral-8b",
-    "last_updated": "2024-10-17",
-    "limit": {
-     "context": 128000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Mistral: Ministral 8B",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-10-17",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
    "mistralai/ministral-8b-2512": {
     "attachment": true,
     "cost": {
@@ -106697,7 +109195,7 @@
     "last_updated": "2025-12-02",
     "limit": {
      "context": 262144,
-     "output": 32768
+     "output": 209715
     },
     "modalities": {
      "input": [
@@ -106729,7 +109227,7 @@
     "last_updated": "2024-02-26",
     "limit": {
      "context": 128000,
-     "output": 25600
+     "output": 102400
     },
     "modalities": {
      "input": [
@@ -106761,7 +109259,7 @@
     "last_updated": "2024-11-19",
     "limit": {
      "context": 131072,
-     "output": 32768
+     "output": 104857
     },
     "modalities": {
      "input": [
@@ -106794,7 +109292,7 @@
     "last_updated": "2025-12-02",
     "limit": {
      "context": 262144,
-     "output": 52429
+     "output": 209715
     },
     "modalities": {
      "input": [
@@ -106827,7 +109325,7 @@
     "last_updated": "2025-05-07",
     "limit": {
      "context": 131072,
-     "output": 26215
+     "output": 104857
     },
     "modalities": {
      "input": [
@@ -106859,7 +109357,7 @@
     "last_updated": "2026-04-30",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 209715
     },
     "modalities": {
      "input": [
@@ -106901,7 +109399,7 @@
     "last_updated": "2025-08-13",
     "limit": {
      "context": 131072,
-     "output": 26215
+     "output": 104857
     },
     "modalities": {
      "input": [
@@ -106965,7 +109463,7 @@
     "last_updated": "2025-02-17",
     "limit": {
      "context": 32768,
-     "output": 32768
+     "output": 26214
     },
     "modalities": {
      "input": [
@@ -107028,7 +109526,7 @@
     "last_updated": "2026-03-16",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 209715
     },
     "modalities": {
      "input": [
@@ -107068,7 +109566,7 @@
     "last_updated": "2025-03-17",
     "limit": {
      "context": 128000,
-     "output": 128000
+     "output": 102400
     },
     "modalities": {
      "input": [
@@ -107131,7 +109629,7 @@
     "last_updated": "2024-04-17",
     "limit": {
      "context": 65536,
-     "output": 13108
+     "output": 52428
     },
     "modalities": {
      "input": [
@@ -107162,8 +109660,8 @@
     "id": "mistralai/voxtral-small-24b-2507",
     "last_updated": "2025-10-30",
     "limit": {
-     "context": 32000,
-     "output": 6400
+     "context": 32768,
+     "output": 26214
     },
     "modalities": {
      "input": [
@@ -107297,7 +109795,7 @@
     "last_updated": "2026-01",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -107339,7 +109837,7 @@
     "last_updated": "2026-04-21",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -107381,7 +109879,7 @@
     "last_updated": "2026-06-12",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -107421,7 +109919,7 @@
     "last_updated": "2026-07-16",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -107524,7 +110022,7 @@
     "last_updated": "2026-06-24",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -107565,7 +110063,7 @@
     "last_updated": "2026-06-08",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -107665,7 +110163,7 @@
     "last_updated": "2025-08-26",
     "limit": {
      "context": 131072,
-     "output": 26215
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -107704,7 +110202,7 @@
     "last_updated": "2025-08-26",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -107744,7 +110242,7 @@
     "last_updated": "2025-12-15",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 228000
     },
     "modalities": {
      "input": [
@@ -107865,7 +110363,7 @@
     "last_updated": "2026-03-11",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -107905,8 +110403,8 @@
     "id": "nvidia/nemotron-3-ultra-550b-a55b",
     "last_updated": "2026-06-04",
     "limit": {
-     "context": 512288,
-     "output": 512288
+     "context": 262144,
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -108137,7 +110635,7 @@
     "last_updated": "2024-01-25",
     "limit": {
      "context": 4095,
-     "output": 4096
+     "output": 3685
     },
     "modalities": {
      "input": [
@@ -108199,7 +110697,7 @@
     "last_updated": "2023-09-28",
     "limit": {
      "context": 4095,
-     "output": 4096
+     "output": 3685
     },
     "modalities": {
      "input": [
@@ -110058,7 +112556,7 @@
     "last_updated": "2025-08-05",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -110089,9 +112587,8 @@
    "openai/gpt-oss-20b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.03,
-     "input": 0.03,
-     "output": 0.13
+     "input": 0.02,
+     "output": 0.1
     },
     "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
     "family": "gpt-oss",
@@ -110099,7 +112596,7 @@
     "last_updated": "2025-08-05",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -110675,7 +113172,7 @@
     "last_updated": "2025-01-27",
     "limit": {
      "context": 127072,
-     "output": 25415
+     "output": 114364
     },
     "modalities": {
      "input": [
@@ -110707,7 +113204,7 @@
     "last_updated": "2025-03-07",
     "limit": {
      "context": 128000,
-     "output": 25600
+     "output": 115200
     },
     "modalities": {
      "input": [
@@ -110816,7 +113313,7 @@
     "last_updated": "2025-03-07",
     "limit": {
      "context": 128000,
-     "output": 25600
+     "output": 115200
     },
     "modalities": {
      "input": [
@@ -111044,7 +113541,7 @@
     "last_updated": "2024-10-16",
     "limit": {
      "context": 32768,
-     "output": 32768
+     "output": 29491
     },
     "modalities": {
      "input": [
@@ -111074,7 +113571,7 @@
     "last_updated": "2024-11-11",
     "limit": {
      "context": 32768,
-     "output": 32768
+     "output": 29491
     },
     "modalities": {
      "input": [
@@ -111155,59 +113652,19 @@
     "temperature": true,
     "tool_call": true
    },
-   "qwen/qwen-plus-2025-07-28:thinking": {
-    "attachment": false,
-    "cost": {
-     "input": 0.26,
-     "output": 0.78
-    },
-    "description": "Qwen reasoning model for deliberate problem solving, math, and coding",
-    "family": "qwen",
-    "id": "qwen/qwen-plus-2025-07-28:thinking",
-    "last_updated": "2025-09-08",
-    "limit": {
-     "context": 1000000,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen: Qwen Plus 0728 (thinking)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-09-08",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "qwen/qwen2.5-vl-72b-instruct": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.4,
-     "input": 0.8,
-     "output": 1
+     "input": 0.25,
+     "output": 0.75
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
     "id": "qwen/qwen2.5-vl-72b-instruct",
     "last_updated": "2025-02-01",
     "limit": {
-     "context": 128000,
-     "output": 128000
+     "context": 32000,
+     "output": 28800
     },
     "modalities": {
      "input": [
@@ -111317,7 +113774,7 @@
     "last_updated": "2025-07-21",
     "limit": {
      "context": 262144,
-     "output": 16384
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -111347,7 +113804,7 @@
     "last_updated": "2025-07-25",
     "limit": {
      "context": 131072,
-     "output": 262144
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -111602,7 +114059,7 @@
     "last_updated": "2025-04",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -111666,7 +114123,7 @@
     "last_updated": "2026-02-03",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -111802,7 +114259,7 @@
     "last_updated": "2025-09",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -111942,8 +114399,8 @@
     "id": "qwen/qwen3-vl-30b-a3b-instruct",
     "last_updated": "2025-10-06",
     "limit": {
-     "context": 131072,
-     "output": 32768
+     "context": 262144,
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -112114,7 +114571,7 @@
     "last_updated": "2026-02-23",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 81920
     },
     "modalities": {
      "input": [
@@ -112196,7 +114653,7 @@
     "last_updated": "2026-02-23",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -112278,7 +114735,7 @@
     "last_updated": "2026-02-23",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -112443,7 +114900,7 @@
     "last_updated": "2026-04-22",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -112476,8 +114933,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.05,
-     "input": 0.14,
-     "output": 1
+     "input": 0.1,
+     "output": 0.9
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -112485,7 +114942,7 @@
     "last_updated": "2026-04-17",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -112781,7 +115238,7 @@
     "id": "qwen/qwen3.8-2.4t-a95b",
     "last_updated": "2026-08-12",
     "limit": {
-     "context": 1048576,
+     "context": 262144,
      "output": 131072
     },
     "modalities": {
@@ -112813,17 +115270,17 @@
    "qwen/qwen3.8-27b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
-     "cache_write": 0.625,
-     "input": 0.5,
-     "output": 3
+     "cache_read": 0.085,
+     "cache_write": 0.53125,
+     "input": 0.425,
+     "output": 2.55
     },
     "description": "Qwen3.8 27B is an open-weight dense vision-language model from Qwen. It is suited for coding, professional workflows, research, multimodal interaction, and long-running agent tasks, with flexible thinking that can be...",
     "family": "qwen",
     "id": "qwen/qwen3.8-27b",
     "last_updated": "2026-08-14",
     "limit": {
-     "context": 262144,
+     "context": 1000000,
      "output": 131072
     },
     "modalities": {
@@ -112851,6 +115308,49 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.15,
+     "output": 0.47
+    },
+    "description": "Qwen3.8 Flash is a multimodal reasoning model from Alibaba. It is suited for coding assistance, agentic workflows, visual understanding, document and codebase analysis, desktop interaction, chart analysis, and long-video analysis.",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -112913,7 +115413,7 @@
     "last_updated": "2026-03-20",
     "limit": {
      "context": 16384,
-     "output": 16384
+     "output": 14745
     },
     "modalities": {
      "input": [
@@ -112945,7 +115445,7 @@
     "last_updated": "2025-03-12",
     "limit": {
      "context": 65536,
-     "output": 65536
+     "output": 58982
     },
     "modalities": {
      "input": [
@@ -113125,7 +115625,7 @@
     "last_updated": "2024-08-13",
     "limit": {
      "context": 8192,
-     "output": 16384
+     "output": 7372
     },
     "modalities": {
      "input": [
@@ -113395,48 +115895,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "stealth/ox-alpha": {
-    "attachment": true,
-    "cost": {
-     "input": 0,
-     "output": 0
-    },
-    "description": "Ox Alpha is a reasoning model designed for coding, sustained agentic work, and production workloads. It is suited for long-horizon software engineering, complex reasoning, and workflows that combine text with...",
-    "family": "alpha",
-    "id": "stealth/ox-alpha",
-    "last_updated": "2026-08-20",
-    "limit": {
-     "context": 1048576,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ox Alpha",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-08-20",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
    "stealth/qwen3.6-plus": {
     "attachment": true,
     "cost": {
@@ -113535,7 +115993,7 @@
     "limit": {
      "context": 256000,
      "input": 256000,
-     "output": 256000
+     "output": 230400
     },
     "modalities": {
      "input": [
@@ -113620,7 +116078,7 @@
     "last_updated": "2025-07-08",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -113740,9 +116198,9 @@
    "tencent/hy3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.033,
-     "input": 0.132,
-     "output": 0.528
+     "cache_read": 0.020625,
+     "input": 0.0825,
+     "output": 0.33
     },
     "description": "Hy3 is a 295B-parameter Mixture-of-Experts model from Tencent (21B active, 192 experts with top-8 routing) built for reasoning, agentic workflows, and real-world production use. It supports a configurable reasoning effort:...",
     "family": "Hy",
@@ -113791,7 +116249,7 @@
     "last_updated": "2026-04-20",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -113819,21 +116277,20 @@
     "temperature": true,
     "tool_call": true
    },
-   "tencent/hy3:free": {
+   "tencent/hy4-preview": {
     "attachment": false,
     "cost": {
-     "cache_read": 0,
-     "input": 0,
-     "output": 0,
-     "reasoning": 0
+     "cache_read": 0.042,
+     "input": 0.834,
+     "output": 2.501
     },
-    "description": "Hy3 is a 295B-parameter Mixture-of-Experts model from Tencent, activating 21B parameters per token. It supports configurable reasoning effort, agentic workflows, reliable tool calling, and long-context tasks across coding, document processing, financial analysis, and frontend development.",
+    "description": "Tencent: Hy4 preview is a mixture-of-experts model from Tencent, with 49B active parameters out of 770B total. It is designed for coding agents, complex tool-use workflows, and productivity tasks that...",
     "family": "Hy",
-    "id": "tencent/hy3:free",
-    "last_updated": "2026-07-06",
+    "id": "tencent/hy4-preview",
+    "last_updated": "2026-08-28",
     "limit": {
-     "context": 262144,
-     "output": 128000
+     "context": 1048576,
+     "output": 64000
     },
     "modalities": {
      "input": [
@@ -113843,7 +116300,7 @@
       "text"
      ]
     },
-    "name": "Tencent: Hy3 (free)",
+    "name": "Hy4 preview",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -113856,8 +116313,8 @@
       ]
      }
     ],
-    "release_date": "2026-07-06",
-    "structured_output": false,
+    "release_date": "2026-08-28",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -113873,7 +116330,7 @@
     "last_updated": "2025-09-27",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -113891,35 +116348,6 @@
     "temperature": true,
     "tool_call": false
    },
-   "thedrummer/rocinante-12b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.25,
-     "output": 0.5
-    },
-    "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
-    "id": "thedrummer/rocinante-12b",
-    "last_updated": "2024-09-30",
-    "limit": {
-     "context": 65536,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "TheDrummer: Rocinante 12B",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-09-30",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
    "thedrummer/skyfall-36b-v2": {
     "attachment": false,
     "cost": {
@@ -113932,7 +116360,7 @@
     "last_updated": "2025-03-10",
     "limit": {
      "context": 32768,
-     "output": 32768
+     "output": 29491
     },
     "modalities": {
      "input": [
@@ -113960,8 +116388,8 @@
     "id": "thedrummer/unslopnemo-12b",
     "last_updated": "2024-11-08",
     "limit": {
-     "context": 1024000,
-     "output": 1024000
+     "context": 32768,
+     "output": 26214
     },
     "modalities": {
      "input": [
@@ -113992,7 +116420,7 @@
     "last_updated": "2026-07-15",
     "limit": {
      "context": 524288,
-     "output": 262144
+     "output": 471859
     },
     "modalities": {
      "input": [
@@ -114067,7 +116495,7 @@
      }
     ],
     "release_date": "2026-07-30",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -114082,7 +116510,7 @@
     "id": "thinkingmachines/inkling-small:free",
     "last_updated": "2026-07-30",
     "limit": {
-     "context": 262144,
+     "context": 1048576,
      "output": 262144
     },
     "modalities": {
@@ -114127,7 +116555,7 @@
     "id": "thinkingmachines/inkling:free",
     "last_updated": "2026-07-15",
     "limit": {
-     "context": 262144,
+     "context": 1048576,
      "output": 262144
     },
     "modalities": {
@@ -114172,7 +116600,7 @@
     "last_updated": "2023-07-22",
     "limit": {
      "context": 6144,
-     "output": 6144
+     "output": 4096
     },
     "modalities": {
      "input": [
@@ -114203,7 +116631,7 @@
     "last_updated": "2026-01-27",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -114313,7 +116741,7 @@
     "last_updated": "2026-03-31",
     "limit": {
      "context": 2000000,
-     "output": 2000000
+     "output": 1800000
     },
     "modalities": {
      "input": [
@@ -114355,7 +116783,7 @@
     "last_updated": "2026-03-31",
     "limit": {
      "context": 2000000,
-     "output": 2000000
+     "output": 1800000
     },
     "modalities": {
      "input": [
@@ -114399,7 +116827,7 @@
     "last_updated": "2026-04-17",
     "limit": {
      "context": 1000000,
-     "output": 4096
+     "output": 900000
     },
     "modalities": {
      "input": [
@@ -114443,7 +116871,7 @@
     "last_updated": "2026-07-08",
     "limit": {
      "context": 500000,
-     "output": 500000
+     "output": 450000
     },
     "modalities": {
      "input": [
@@ -114487,7 +116915,7 @@
     "last_updated": "2026-08-12",
     "limit": {
      "context": 500000,
-     "output": 500000
+     "output": 450000
     },
     "modalities": {
      "input": [
@@ -114531,7 +116959,7 @@
     "last_updated": "2026-04-16",
     "limit": {
      "context": 256000,
-     "output": 256000
+     "output": 230400
     },
     "modalities": {
      "input": [
@@ -114809,9 +117237,9 @@
    "z-ai/glm-4.6": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.1,
-     "input": 0.5,
-     "output": 2
+     "cache_read": 0.08,
+     "input": 0.43,
+     "output": 1.75
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
@@ -114819,8 +117247,8 @@
     "knowledge": "2025-04",
     "last_updated": "2025-09-30",
     "limit": {
-     "context": 202752,
-     "output": 131072
+     "context": 198000,
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -115105,7 +117533,7 @@
     "last_updated": "2026-06-13",
     "limit": {
      "context": 1048576,
-     "output": 131072
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -115157,7 +117585,7 @@
      ]
     },
     "name": "GLM-5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -115170,7 +117598,50 @@
      }
     ],
     "release_date": "2026-08-14",
-    "structured_output": false,
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "GLM-5.3-Flash is a native multimodal model from Z.ai. It is suited for efficient coding and long-horizon agent tasks. Its hybrid sparse and linear attention architecture maintains accurate long-context behavior while...",
+    "family": "glm",
+    "id": "z-ai/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -115403,17 +117874,17 @@
    "~deepseek/deepseek-v4-flash-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.01278,
-     "input": 0.0639,
-     "output": 0.1278
+     "cache_read": 0.013,
+     "input": 0.03,
+     "output": 0.16
     },
     "description": "This model always redirects to the latest model in the DeepSeek V4 Flash family.",
     "family": "deepseek",
     "id": "~deepseek/deepseek-v4-flash-latest",
     "last_updated": "2026-08-01",
     "limit": {
-     "context": 262144,
-     "output": 262144
+     "context": 1048576,
+     "output": 393216
     },
     "modalities": {
      "input": [
@@ -115445,11 +117916,11 @@
    "~google/gemini-flash-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0375,
-     "cache_write": 0.020833,
-     "input": 0.375,
-     "output": 1.875,
-     "reasoning": 1.875
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -115539,17 +118010,17 @@
    "~moonshotai/kimi-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.29,
-     "input": 2.6,
-     "output": 13
+     "cache_read": 0.256,
+     "input": 2.55,
+     "output": 12.75
     },
     "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
     "family": "kimi",
     "id": "~moonshotai/kimi-latest",
     "last_updated": "2026-04-27",
     "limit": {
-     "context": 974842,
-     "output": 974842
+     "context": 1048576,
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -115685,7 +118156,7 @@
     "last_updated": "2026-07-08",
     "limit": {
      "context": 500000,
-     "output": 500000
+     "output": 450000
     },
     "modalities": {
      "input": [
@@ -115719,16 +118190,16 @@
    "~z-ai/glm-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
+     "cache_read": 0.247,
+     "input": 1.1875,
+     "output": 4.18
     },
     "description": "This model always redirects to the latest GLM model from Z.ai.",
     "family": "glm",
     "id": "~z-ai/glm-latest",
     "last_updated": "2026-08-19",
     "limit": {
-     "context": 1048576,
+     "context": 262144,
      "output": 131072
     },
     "modalities": {
@@ -115753,7 +118224,7 @@
      }
     ],
     "release_date": "2026-08-19",
-    "structured_output": false,
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    }
@@ -115934,6 +118405,108 @@
   },
   "name": "Kimi For Coding",
   "npm": "@ai-sdk/anthropic"
+ },
+ "klokintegration": {
+  "api": "https://api-gw.klok.ipaas.se/proxy/kloker-key/v1",
+  "doc": "https://klokintegration.se/docs/ai-api",
+  "env": [
+   "KLOKINTEGRATION_API_KEY"
+  ],
+  "id": "klokintegration",
+  "models": {
+   "Kloker": {
+    "attachment": false,
+    "cost": {
+     "input": 0.23,
+     "output": 1.16
+    },
+    "description": "Cheap general model with a clean context. Nothing from the customer environment is packed in. It tracks the current best open source model. The Klok team verifies it and upgrades it periodically.",
+    "id": "Kloker",
+    "last_updated": "2026-08-29",
+    "limit": {
+     "context": 200000,
+     "output": 50000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kloker",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-29",
+    "status": "beta",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "Kloker-Integration-Architect": {
+    "attachment": false,
+    "cost": {
+     "input": 0.23,
+     "output": 1.16
+    },
+    "description": "Knows the customer integration environment and Klok best practices. Opinionated about structure. The gateway runs ecosystem lookup tools server-side and appends a system-prompt injection (data contracts, CloudEvents, event-driven flows). Client system prompts and OpenAI tool calls are preserved.",
+    "id": "Kloker-Integration-Architect",
+    "last_updated": "2026-08-29",
+    "limit": {
+     "context": 200000,
+     "output": 50000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kloker Integration Architect",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-29",
+    "status": "beta",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "Kloker-Integration-Developer": {
+    "attachment": false,
+    "cost": {
+     "input": 0.23,
+     "output": 1.16
+    },
+    "description": "Knows the customer integration environment and Klok best practices. Opinionated about implementation. The gateway runs ecosystem lookup tools server-side and appends a system-prompt injection. Client system prompts and OpenAI tool calls are preserved.",
+    "id": "Kloker-Integration-Developer",
+    "last_updated": "2026-08-29",
+    "limit": {
+     "context": 200000,
+     "output": 50000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kloker Integration Developer",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-29",
+    "status": "beta",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "klokintegration.se",
+  "npm": "@ai-sdk/openai-compatible"
  },
  "kosmik": {
   "api": "https://api.koscompute.com/v1",
@@ -117245,9 +119818,9 @@
    "deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.014,
-     "input": 0.076,
-     "output": 0.153
+     "cache_read": 0.0097,
+     "input": 0.051,
+     "output": 0.104
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -117287,6 +119860,49 @@
      }
     ],
     "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.0028,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash-vision-exp",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1050000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -118709,16 +121325,16 @@
    "glm-5.3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
+     "cache_read": 0.25,
+     "input": 1.3,
+     "output": 4
     },
     "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
     "family": "glm",
     "id": "glm-5.3",
     "last_updated": "2026-08-14",
     "limit": {
-     "context": 1000000,
+     "context": 1048576,
      "output": 131072
     },
     "modalities": {
@@ -118730,7 +121346,7 @@
      ]
     },
     "name": "GLM-5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -118743,6 +121359,50 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.024,
+     "input": 0.13,
+     "output": 0.4
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -119293,7 +121953,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.1-codex": {
@@ -119427,7 +122087,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.2-codex": {
@@ -119562,7 +122222,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4": {
@@ -119609,7 +122269,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -119655,7 +122315,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-nano": {
@@ -119701,7 +122361,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-pro": {
@@ -120905,9 +123565,9 @@
    "kimi-k2.7-code": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.19,
-     "input": 0.95,
-     "output": 4
+     "cache_read": 0.18,
+     "input": 0.89,
+     "output": 3.71
     },
     "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
     "family": "kimi-k2",
@@ -120938,6 +123598,8 @@
      {
       "type": "effort",
       "values": [
+       "none",
+       "minimal",
        "low",
        "medium",
        "high",
@@ -121003,9 +123665,9 @@
    "kimi-k3": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.3,
-     "input": 3,
-     "output": 15
+     "cache_read": 0.28,
+     "input": 2.83,
+     "output": 14.13
     },
     "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
     "family": "kimi-k3",
@@ -121549,7 +124211,7 @@
     "last_updated": "2025-10-27",
     "limit": {
      "context": 196608,
-     "output": 128000
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -121846,7 +124508,7 @@
     "last_updated": "2026-06-01",
     "limit": {
      "context": 1048576,
-     "output": 128000
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -122999,10 +125661,10 @@
    "qwen3-coder-plus": {
     "attachment": false,
     "cost": {
-     "cache_read": 1.2,
-     "cache_write": 7.5,
-     "input": 6,
-     "output": 60
+     "cache_read": 0.2,
+     "cache_write": 1.25,
+     "input": 1,
+     "output": 5
     },
     "description": "Hosted Qwen coder for software agents, repo edits, and long-context code",
     "family": "qwen",
@@ -123488,7 +126150,7 @@
     "knowledge": "2025-04",
     "last_updated": "2026-04-02",
     "limit": {
-     "context": 262144,
+     "context": 1000000,
      "output": 65536
     },
     "modalities": {
@@ -123659,6 +126321,87 @@
     ],
     "release_date": "2026-06-02",
     "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-27b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.085,
+     "input": 0.42,
+     "output": 3
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen3.8-27b",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.15,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "tool_call": true
    },
    "qwen3.8-max": {
@@ -124511,10 +127254,10 @@
    "alibaba/qwen3-coder-plus": {
     "attachment": false,
     "cost": {
-     "cache_read": 1.2,
-     "cache_write": 7.5,
-     "input": 6,
-     "output": 60
+     "cache_read": 0.2,
+     "cache_write": 1.25,
+     "input": 1,
+     "output": 5
     },
     "description": "Hosted Qwen coder for software agents, repo edits, and long-context code",
     "family": "qwen",
@@ -124544,10 +127287,10 @@
    "alibaba/qwen3-max": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.6,
-     "cache_write": 3.75,
-     "input": 3,
-     "output": 15
+     "cache_read": 0.24,
+     "cache_write": 1.5,
+     "input": 1.2,
+     "output": 6
     },
     "description": "Flagship Qwen3 model for coding agents, complex reasoning, and tool use",
     "family": "qwen",
@@ -124643,8 +127386,8 @@
    "alibaba/qwen3.6-35b-a3b": {
     "attachment": true,
     "cost": {
-     "input": 0.248,
-     "output": 1.485
+     "input": 0.375,
+     "output": 2.25
     },
     "description": "Open multimodal Qwen MoE for local agents that need vision, audio, and code",
     "family": "qwen",
@@ -124772,6 +127515,7 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.05,
+     "cache_write": 0.625,
      "context_over_200k": {
       "cache_read": 0.2,
       "cache_write": 2.5,
@@ -124799,7 +127543,7 @@
     "knowledge": "2025-04",
     "last_updated": "2026-04-02",
     "limit": {
-     "context": 262144,
+     "context": 1000000,
      "output": 65536
     },
     "modalities": {
@@ -124976,6 +127720,53 @@
     "release_date": "2026-06-02",
     "structured_output": false,
     "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.15,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "alibaba/qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash (Alibaba Cloud)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "tool_call": true
    },
    "alibaba/qwen3.8-max": {
@@ -126762,6 +129553,287 @@
     "temperature": true,
     "tool_call": true
    },
+   "azure-anthropic/claude-fable-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 1,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "id": "azure-anthropic/claude-fable-5",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-09",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5 (Azure Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure-anthropic/claude-opus-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
+    "family": "claude-opus",
+    "id": "azure-anthropic/claude-opus-4-6",
+    "knowledge": "2025-05-31",
+    "last_updated": "2026-03-13",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.6 (Azure Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "azure-anthropic/claude-opus-4-7": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
+    "family": "claude-opus",
+    "id": "azure-anthropic/claude-opus-4-7",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-04-16",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.7 (Azure Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure-anthropic/claude-opus-4-8": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "azure-anthropic/claude-opus-4-8",
+    "knowledge": "2026-01",
+    "last_updated": "2026-05-28",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.8 (Azure Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-05-28",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure-anthropic/claude-opus-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Strongest Claude Opus model for coding, agents, and professional work",
+    "family": "claude-opus",
+    "id": "azure-anthropic/claude-opus-5",
+    "knowledge": "2026-05",
+    "last_updated": "2026-07-24",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 5 (Azure Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-24",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "azure-anthropic/claude-sonnet-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
+    },
+    "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+    "family": "claude-sonnet",
+    "id": "azure-anthropic/claude-sonnet-5",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-30",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 5 (Azure Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-30",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
    "azure/gpt-3.5-turbo": {
     "attachment": false,
     "cost": {
@@ -127169,7 +130241,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "azure/gpt-5.1-codex": {
@@ -127302,7 +130374,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "azure/gpt-5.2-codex": {
@@ -127437,7 +130509,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": false,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "azure/gpt-5.4": {
@@ -127484,7 +130556,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "azure/gpt-5.4-mini": {
@@ -127530,7 +130602,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "azure/gpt-5.4-nano": {
@@ -127576,7 +130648,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "azure/gpt-5.4-pro": {
@@ -128028,9 +131100,9 @@
    "baidu/deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.028,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.044,
+     "input": 0.44,
+     "output": 1.32
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -128077,9 +131149,9 @@
    "baidu/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.14,
-     "input": 1.69,
-     "output": 3.38
+     "cache_read": 0.132,
+     "input": 1.32,
+     "output": 3.96
     },
     "description": "Open MoE flagship with million-token context for coding and long agent runs",
     "family": "deepseek-thinking",
@@ -128263,6 +131335,47 @@
      }
     ],
     "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "baidu/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "baidu/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 (Baidu)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
     "structured_output": false,
     "temperature": true,
     "tool_call": true
@@ -129183,6 +132296,52 @@
     "temperature": true,
     "tool_call": true
    },
+   "consensusprotocol/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.02,
+     "input": 0.13,
+     "output": 0.27
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "consensusprotocol/deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 524288,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (Consensus Protocol)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepinfra/deepseek-v3.2": {
     "attachment": false,
     "cost": {
@@ -129862,6 +133021,49 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek/deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.0028,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-vision-exp",
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1050000,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp (DeepSeek)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepseek/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
@@ -130245,9 +133447,9 @@
    "fireworks/deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.028,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -130433,9 +133635,9 @@
    "gonka24/deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0155,
-     "input": 0.075,
-     "output": 0.175
+     "cache_read": 0.0097,
+     "input": 0.051,
+     "output": 0.104
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -131696,163 +134898,6 @@
     ],
     "release_date": "2025-08-05",
     "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "iceberg/gemini-3-flash-preview": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.05,
-     "input": 0.5,
-     "output": 3
-    },
-    "description": "New Gemini flash lane bringing frontier-style multimodal reasoning to cheaper runs",
-    "family": "gemini-flash",
-    "id": "iceberg/gemini-3-flash-preview",
-    "knowledge": "2025-01",
-    "last_updated": "2025-12-17",
-    "limit": {
-     "context": 1048576,
-     "output": 65535
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video",
-      "audio",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Gemini 3 Flash (Preview) (Iceberg)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "minimal",
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-12-17",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "iceberg/gemini-3.1-pro-preview": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.2,
-     "context_over_200k": {
-      "cache_read": 0.4,
-      "input": 4,
-      "output": 18
-     },
-     "input": 2,
-     "output": 12,
-     "tiers": [
-      {
-       "cache_read": 0.4,
-       "input": 4,
-       "output": 18,
-       "tier": {
-        "size": 200000,
-        "type": "context"
-       }
-      }
-     ]
-    },
-    "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
-    "family": "gemini-pro",
-    "id": "iceberg/gemini-3.1-pro-preview",
-    "knowledge": "2025-01",
-    "last_updated": "2026-02-19",
-    "limit": {
-     "context": 1048576,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video",
-      "audio",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Gemini 3.1 Pro (Preview) (Iceberg)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-02-19",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "iceberg/gemini-3.6-flash": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.075,
-     "cache_write": 0.08333,
-     "input": 0.75,
-     "output": 3.75
-    },
-    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
-    "family": "gemini-flash",
-    "id": "iceberg/gemini-3.6-flash",
-    "knowledge": "2026-03",
-    "last_updated": "2026-07-21",
-    "limit": {
-     "context": 1048576,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video",
-      "audio",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Gemini 3.6 Flash (Iceberg)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "minimal",
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-07-21",
-    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -133453,7 +136498,7 @@
     "last_updated": "2026-06-01",
     "limit": {
      "context": 1048576,
-     "output": 128000
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -134265,6 +137310,47 @@
      }
     ],
     "release_date": "2026-06-13",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "novita/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
     "structured_output": false,
     "temperature": true,
     "tool_call": true
@@ -135337,6 +138423,82 @@
     "temperature": true,
     "tool_call": true
    },
+   "novita/qwen3.8-27b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.085,
+     "input": 0.42,
+     "output": 3
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "novita/qwen3.8-27b",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B (NovitaAI)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-14",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "novita/qwen3.8-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.016,
+     "input": 0.15,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "novita/qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash (NovitaAI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "tool_call": true
+   },
    "novita/qwen3.8-max": {
     "attachment": true,
     "cost": {
@@ -135973,7 +139135,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2": {
@@ -136019,7 +139181,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2-pro": {
@@ -136108,7 +139270,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": false,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4": {
@@ -136155,7 +139317,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -136201,7 +139363,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -136247,7 +139409,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-pro": {
@@ -136711,53 +139873,6 @@
     ],
     "release_date": "2025-04-16",
     "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "permafrost/kimi-k3": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.6,
-     "input": 3,
-     "output": 15
-    },
-    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
-    "family": "kimi-k3",
-    "id": "permafrost/kimi-k3",
-    "last_updated": "2026-07-16",
-    "limit": {
-     "context": 1048576,
-     "output": 1048576
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K3 (Permafrost)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "minimal",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-07-16",
-    "structured_output": false,
     "temperature": false,
     "tool_call": true
    },
@@ -137362,6 +140477,185 @@
     "temperature": true,
     "tool_call": true
    },
+   "scx-ai-gp/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.25,
+     "input": 1.3,
+     "output": 4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "scx-ai-gp/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 (SCX.ai)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "scx-ai-gp/glm-5.3-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.024,
+     "input": 0.13,
+     "output": 0.4
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "scx-ai-gp/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 Flash (SCX.ai)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "scx-ai-gp/kimi-k2.7-code": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.18,
+     "input": 0.89,
+     "output": 3.71
+    },
+    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+    "family": "kimi-k2",
+    "id": "scx-ai-gp/kimi-k2.7-code",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code (SCX.ai)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-06-12",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "scx-ai-gp/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.28,
+     "input": 2.83,
+     "output": 14.13
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "scx-ai-gp/kimi-k3",
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3 (SCX.ai)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
    "scx-ai-gp/qwen3.8-max": {
     "attachment": true,
     "cost": {
@@ -137913,55 +141207,6 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": false
-   },
-   "tundra/kimi-k2.6": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.08,
-     "input": 0.4,
-     "output": 2.2
-    },
-    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
-    "family": "kimi-k2",
-    "id": "tundra/kimi-k2.6",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-01",
-    "last_updated": "2026-04-21",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.6 (Tundra)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "minimal",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-04-21",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
    },
    "vertex-anthropic/claude-haiku-4-5": {
     "attachment": true,
@@ -139771,7 +143016,7 @@
      ]
     },
     "name": "GLM-5.3 (Z AI)",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -139787,9 +143032,106 @@
     "structured_output": false,
     "temperature": true,
     "tool_call": true
+   },
+   "zai/glm-5.3-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "zai/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 Flash (Z AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "LLM Gateway",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "llmtech": {
+  "api": "https://api.llmtech.eu/v1",
+  "doc": "https://llmtech.eu/models/qwen3.8-27b",
+  "env": [
+   "LLMTECH_API_KEY"
+  ],
+  "id": "llmtech",
+  "models": {
+   "unsloth/Qwen3.8-27B-NVFP4": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.04,
+     "input": 0.25,
+     "output": 2.09
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "unsloth/Qwen3.8-27B-NVFP4",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "LLM Tech",
   "npm": "@ai-sdk/openai-compatible"
  },
  "llmtr": {
@@ -142598,8 +145940,8 @@
     "cost": {
      "cache_read": 0.2,
      "cache_write": 2.5,
-     "input": 2,
-     "output": 10
+     "input": 3,
+     "output": 15
     },
     "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
     "family": "claude-sonnet",
@@ -143198,7 +146540,21 @@
     "name": "DeepSeek V4 Pro 0423",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-04-23",
     "structured_output": false,
     "temperature": true,
@@ -145212,7 +148568,23 @@
     "name": "Kimi K3",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-07-16",
     "structured_output": true,
     "temperature": false,
@@ -145780,7 +149152,7 @@
     "reasoning": false,
     "release_date": "2025-08-07",
     "structured_output": true,
-    "temperature": true,
+    "temperature": false,
     "tool_call": false
    },
    "openai/gpt-5-mini": {
@@ -145918,7 +149290,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.1-chat-latest": {
@@ -145999,7 +149371,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2-chat-latest": {
@@ -146146,7 +149518,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -146209,7 +149581,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -146256,7 +149628,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.5": {
@@ -146342,6 +149714,7 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.02,
+     "cache_write": 0.25,
      "input": 0.2,
      "output": 1.2
     },
@@ -146390,8 +149763,9 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.5,
-     "input": 4,
-     "output": 24
+     "cache_write": 5,
+     "input": 5,
+     "output": 30
     },
     "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
     "family": "gpt-sol",
@@ -146438,6 +149812,7 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.2,
+     "cache_write": 2.5,
      "input": 2,
      "output": 12
     },
@@ -146735,7 +150110,17 @@
     "name": "o4 Mini",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
     "release_date": "2025-04-16",
     "structured_output": true,
     "temperature": false,
@@ -147134,7 +150519,7 @@
       "text"
      ]
     },
-    "name": "Qwen3 Next 80B A3B Instruct",
+    "name": "Qwen3-Next 80B-A3B Instruct",
     "open_weights": true,
     "reasoning": false,
     "release_date": "2025-09",
@@ -147165,7 +150550,7 @@
       "text"
      ]
     },
-    "name": "Qwen3 Next 80B A3B Thinking",
+    "name": "Qwen3-Next 80B-A3B (Thinking)",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [],
@@ -147316,7 +150701,7 @@
     "tool_call": true
    },
    "qwen/qwen3.5-27b": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
      "cache_read": 0.0172,
      "input": 0.086,
@@ -147327,13 +150712,12 @@
     "id": "qwen/qwen3.5-27b",
     "last_updated": "2026-02-23",
     "limit": {
-     "context": 256000,
-     "output": 64000
+     "context": 131072,
+     "output": 32768
     },
     "modalities": {
      "input": [
-      "text",
-      "image"
+      "text"
      ],
      "output": [
       "text"
@@ -147353,7 +150737,7 @@
     "tool_call": true
    },
    "qwen/qwen3.5-35b-a3b": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
      "cache_read": 0.020357,
      "input": 0.057,
@@ -147364,13 +150748,12 @@
     "id": "qwen/qwen3.5-35b-a3b",
     "last_updated": "2026-02-23",
     "limit": {
-     "context": 256000,
-     "output": 64000
+     "context": 131072,
+     "output": 32768
     },
     "modalities": {
      "input": [
-      "text",
-      "image"
+      "text"
      ],
      "output": [
       "text"
@@ -147390,7 +150773,7 @@
     "tool_call": true
    },
    "qwen/qwen3.5-397b-a17b": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
      "cache_read": 0.0344,
      "input": 0.172,
@@ -147401,13 +150784,12 @@
     "id": "qwen/qwen3.5-397b-a17b",
     "last_updated": "2026-02-15",
     "limit": {
-     "context": 256000,
-     "output": 64000
+     "context": 131072,
+     "output": 32768
     },
     "modalities": {
      "input": [
-      "text",
-      "image"
+      "text"
      ],
      "output": [
       "text"
@@ -148182,9 +151564,9 @@
    "xai/grok-4.6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.375,
-     "input": 1.5,
-     "output": 4.5
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 6
     },
     "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
     "family": "grok",
@@ -148704,7 +152086,7 @@
      ]
     },
     "name": "GLM-5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -148717,6 +152099,50 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.003,
+     "input": 0.015,
+     "output": 0.05
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "zai/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": false,
     "temperature": true,
     "tool_call": true
@@ -148896,8 +152322,8 @@
     "id": "MiniMax-M2",
     "last_updated": "2025-10-27",
     "limit": {
-     "context": 196608,
-     "output": 128000
+     "context": 204800,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -149103,8 +152529,8 @@
     "id": "MiniMax-M3",
     "last_updated": "2026-06-25",
     "limit": {
-     "context": 1000000,
-     "output": 128000
+     "context": 1048576,
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -149151,8 +152577,8 @@
     "id": "MiniMax-M2",
     "last_updated": "2025-10-27",
     "limit": {
-     "context": 196608,
-     "output": 128000
+     "context": 204800,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -149358,8 +152784,8 @@
     "id": "MiniMax-M3",
     "last_updated": "2026-06-25",
     "limit": {
-     "context": 1000000,
-     "output": 128000
+     "context": 1048576,
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -149406,8 +152832,8 @@
     "id": "MiniMax-M2",
     "last_updated": "2025-10-27",
     "limit": {
-     "context": 196608,
-     "output": 128000
+     "context": 204800,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -149598,8 +153024,8 @@
     "id": "MiniMax-M3",
     "last_updated": "2026-06-25",
     "limit": {
-     "context": 1000000,
-     "output": 128000
+     "context": 1048576,
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -149646,8 +153072,8 @@
     "id": "MiniMax-M2",
     "last_updated": "2025-10-27",
     "limit": {
-     "context": 196608,
-     "output": 128000
+     "context": 204800,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -149838,8 +153264,8 @@
     "id": "MiniMax-M3",
     "last_updated": "2026-06-25",
     "limit": {
-     "context": 1000000,
-     "output": 128000
+     "context": 1048576,
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -150910,6 +154336,47 @@
     "release_date": "2025-07-15",
     "temperature": true,
     "tool_call": true
+   },
+   "zai-glm-5-2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.14,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "zai-glm-5-2",
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "status": "beta",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "Mistral",
@@ -151183,6 +154650,50 @@
   ],
   "id": "modal",
   "models": {
+   "Qwen/Qwen3.8-2.4T-A95B": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.25,
+     "input": 2,
+     "output": 6
+    },
+    "description": "Open-weight sparse MoE (2.4T total, 95B active), the open-weight twin of Qwen3.8 Max for coding, research, complex reasoning, and agentic workflows",
+    "family": "qwen",
+    "id": "Qwen/Qwen3.8-2.4T-A95B",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 1010000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8-Max",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "moonshotai/Kimi-K3": {
     "attachment": true,
     "cost": {
@@ -151254,6 +154765,52 @@
     "reasoning_options": [],
     "release_date": "2026-07-15",
     "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai-org/GLM-5.3-Flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.09,
+     "input": 0.45,
+     "output": 1.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3-Flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    }
@@ -151687,7 +155244,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -151727,7 +155284,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-nano": {
@@ -151767,7 +155324,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
@@ -153372,37 +156929,6 @@
   ],
   "id": "nano-gpt",
   "models": {
-   "Baichuan-M2": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 7.865,
-     "input": 15.73,
-     "output": 15.73
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "baichuan",
-    "id": "Baichuan-M2",
-    "last_updated": "2025-08-19",
-    "limit": {
-     "context": 32768,
-     "input": 32768,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Baichuan M2 32B Medical",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-08-19",
-    "structured_output": false,
-    "tool_call": false
-   },
    "Baichuan4-Air": {
     "attachment": false,
     "cost": {
@@ -153709,7 +157235,15 @@
     "name": "GLM 4.6 Derestricted v5",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-12-23",
     "structured_output": false,
     "tool_call": true
@@ -153745,6 +157279,72 @@
     "structured_output": false,
     "tool_call": false
    },
+   "Gemma-4-26B-A4B-MeroMero": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Gemma 4 26B A4B MeroMero is an NVFP4 multimodal mixture-of-experts fine-tune for emotive dialogue, relationship scenes, creative writing, and roleplay.",
+    "family": "gemma",
+    "id": "Gemma-4-26B-A4B-MeroMero",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 26B A4B MeroMero",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "Gemma-4-26B-A4B-MeroMero:thinking": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Gemma 4 26B A4B MeroMero with thinking enabled for more deliberate emotive dialogue, relationship scenes, creative writing, and multimodal roleplay.",
+    "family": "gemma",
+    "id": "Gemma-4-26B-A4B-MeroMero:thinking",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 26B A4B MeroMero Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
    "Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled": {
     "attachment": true,
     "cost": {
@@ -153773,7 +157373,15 @@
     "name": "Gemma 4 31B Claude 4.6 Opus Reasoning Distilled",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2026-05-01",
     "structured_output": false,
     "tool_call": true
@@ -153808,7 +157416,11 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
      }
     ],
     "release_date": "2026-05-01",
@@ -153845,7 +157457,11 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
      }
     ],
     "release_date": "2026-05-01",
@@ -153882,10 +157498,80 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
      }
     ],
     "release_date": "2026-05-01",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "Gemma-4-31B-MeroMero-v2": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.45
+    },
+    "description": "Gemma 4 31B MeroMero v2 is a LoRA finetune for emotive dialogue, relationship scenes, creative writing, and multimodal roleplay.",
+    "family": "gemma",
+    "id": "Gemma-4-31B-MeroMero-v2",
+    "last_updated": "2026-08-23",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 31B MeroMero v2",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "Gemma-4-31B-MeroMero-v2:thinking": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.45
+    },
+    "description": "Gemma 4 31B MeroMero v2 with thinking enabled for more deliberate emotive dialogue, relationship scenes, creative writing, and multimodal roleplay.",
+    "family": "gemma",
+    "id": "Gemma-4-31B-MeroMero-v2:thinking",
+    "last_updated": "2026-08-24",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 31B MeroMero v2 Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
     "structured_output": false,
     "tool_call": true
    },
@@ -153919,7 +157605,11 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
      }
     ],
     "release_date": "2026-05-01",
@@ -154392,12 +158082,11 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
-      "max": 81920,
-      "min": 1024,
-      "type": "budget_tokens"
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
      }
     ],
     "release_date": "2026-04-30",
@@ -154434,12 +158123,11 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
-      "max": 81920,
-      "min": 1024,
-      "type": "budget_tokens"
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
      }
     ],
     "release_date": "2026-04-30",
@@ -154854,39 +158542,8 @@
     "temperature": true,
     "tool_call": true
    },
-   "TEE/gemma-3-27b-it": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1,
-     "input": 0.2,
-     "output": 0.8
-    },
-    "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
-    "family": "gemma",
-    "id": "TEE/gemma-3-27b-it",
-    "last_updated": "2025-03-10",
-    "limit": {
-     "context": 131072,
-     "input": 131072,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Gemma 3 27B TEE",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
    "TEE/gemma-4-26b-a4b-uncensored": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
      "cache_read": 0.075,
      "input": 0.15,
@@ -154903,8 +158560,7 @@
     },
     "modalities": {
      "input": [
-      "text",
-      "image"
+      "text"
      ],
      "output": [
       "text"
@@ -155211,6 +158867,91 @@
     "temperature": true,
     "tool_call": true
    },
+   "TEE/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "TEE/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 TEE",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "TEE/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "TEE/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Flash TEE",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "TEE/gpt-oss-120b": {
     "attachment": false,
     "cost": {
@@ -155496,43 +159237,6 @@
     "structured_output": false,
     "tool_call": false
    },
-   "TEE/qwen3.5-122b-a10b": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.23,
-     "input": 0.46,
-     "output": 3.68
-    },
-    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
-    "family": "qwen",
-    "id": "TEE/qwen3.5-122b-a10b",
-    "last_updated": "2026-02-23",
-    "limit": {
-     "context": 262144,
-     "input": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3.5 122B A10B TEE",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-02-23",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
    "TEE/qwen3.5-27b": {
     "attachment": true,
     "cost": {
@@ -155705,6 +159409,41 @@
     ],
     "release_date": "2026-05-23",
     "structured_output": true,
+    "tool_call": true
+   },
+   "TEE/qwen3.8-27b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 0.4,
+     "output": 3
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "TEE/qwen3.8-27b",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B TEE",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
     "tool_call": true
    },
    "THUDM/GLM-4-32B-0414": {
@@ -156176,8 +159915,8 @@
     "id": "abacusai/Dracarys-72B-Instruct",
     "last_updated": "2025-08-02",
     "limit": {
-     "context": 16384,
-     "input": 16384,
+     "context": 32768,
+     "input": 32768,
      "output": 8192
     },
     "modalities": {
@@ -156193,6 +159932,135 @@
     "reasoning": false,
     "release_date": "2025-08-02",
     "structured_output": false,
+    "tool_call": false
+   },
+   "abliteration-ai/abliterated-model": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 3
+    },
+    "description": "Abliteration.ai's multimodal reasoning model supports text and image input, structured output, automatic prompt caching, and a 262K-token context window.",
+    "id": "abliteration-ai/abliterated-model",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 262134
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Abliterated Model",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-27",
+    "structured_output": true,
+    "tool_call": false
+   },
+   "abliteration-ai/abliterated-model-large": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 5,
+     "output": 5
+    },
+    "description": "Abliteration.ai's large text reasoning model is derived from GLM-5.2 and supports native tool calling, structured output, automatic prompt caching, and a one-million-token context window.",
+    "id": "abliteration-ai/abliterated-model-large",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 1000000,
+     "input": 1000000,
+     "output": 999990
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Abliterated Model Large",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-27",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "abliteration-ai/abliterated-model-large-v2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 5,
+     "output": 5
+    },
+    "description": "Abliteration.ai's default large text reasoning model is derived from GLM-5.3 for harder reasoning and evaluation workloads, with automatic prompt caching and a one-million-token context window.",
+    "id": "abliteration-ai/abliterated-model-large-v2",
+    "last_updated": "2026-08-31",
+    "limit": {
+     "context": 1000000,
+     "input": 1000000,
+     "output": 999990
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Abliterated Model Large V2",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-31",
+    "structured_output": true,
     "tool_call": false
    },
    "aion-labs/aion-2.0": {
@@ -156428,6 +160296,49 @@
     "temperature": true,
     "tool_call": false
    },
+   "alibaba/qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.16,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "alibaba/qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 991808,
+     "input": 991808,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "tool_call": true
+   },
    "amazon/nova-2-lite-v1": {
     "attachment": false,
     "cost": {
@@ -156487,37 +160398,6 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2024-12-03",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "amazon/nova-micro-v1": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.01785,
-     "input": 0.0357,
-     "output": 0.1394
-    },
-    "description": "Efficient model for low-latency assistance, extraction, and routine automation",
-    "family": "nova-micro",
-    "id": "amazon/nova-micro-v1",
-    "last_updated": "2024-12-03",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 5120
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Amazon Nova Micro 1.0",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
     "structured_output": false,
     "tool_call": false
    },
@@ -158375,42 +162255,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "claude-opus-4-1-thinking:32000": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1.5,
-     "input": 15,
-     "output": 75
-    },
-    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-    "family": "claude-opus",
-    "id": "claude-opus-4-1-thinking:32000",
-    "knowledge": "2025-03-31",
-    "last_updated": "2025-08-05",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 32000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude 4.1 Opus Thinking (32K)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-08-05",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "claude-opus-4-1-thinking:32768": {
     "attachment": true,
     "cost": {
@@ -158676,42 +162520,6 @@
      ]
     },
     "name": "Claude 4 Opus Thinking (1K)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-05-22",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "claude-opus-4-thinking:32000": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1.5,
-     "input": 15,
-     "output": 75
-    },
-    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-    "family": "claude-opus",
-    "id": "claude-opus-4-thinking:32000",
-    "knowledge": "2025-03-31",
-    "last_updated": "2025-05-22",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 32000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude 4 Opus Thinking (32K)",
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [],
@@ -159102,25 +162910,23 @@
     "tool_call": true
    },
    "claw-high": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
-     "cache_read": 2.5,
-     "input": 5,
-     "output": 25
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
     },
     "description": "Compact GPT model for low-latency assistance and high-volume workloads",
     "id": "claw-high",
     "last_updated": "2026-05-11",
     "limit": {
-     "context": 1000000,
-     "input": 1000000,
-     "output": 128000
+     "context": 1048576,
+     "input": 1048576,
+     "output": 131072
     },
     "modalities": {
      "input": [
-      "text",
-      "image",
-      "pdf"
+      "text"
      ],
      "output": [
       "text"
@@ -159129,18 +162935,27 @@
     "name": "Claw High",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-05-11",
     "structured_output": true,
     "tool_call": true
    },
    "claw-low": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
-     "cache_read": 0.025,
+     "cache_read": 0.2,
      "cache_write": 0.08333,
-     "input": 0.25,
-     "output": 1.5
+     "input": 1,
+     "output": 3.2
     },
     "description": "Compact GPT model for low-latency assistance and high-volume workloads",
     "id": "claw-low",
@@ -159148,14 +162963,11 @@
     "limit": {
      "context": 1048576,
      "input": 1048576,
-     "output": 65536
+     "output": 131072
     },
     "modalities": {
      "input": [
-      "text",
-      "image",
-      "video",
-      "pdf"
+      "text"
      ],
      "output": [
       "text"
@@ -159164,7 +162976,16 @@
     "name": "Claw Low",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-05-11",
     "structured_output": true,
     "tool_call": true
@@ -159172,16 +162993,16 @@
    "claw-medium": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.1575,
-     "input": 0.315,
-     "output": 1.26
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
     },
     "description": "Compact GPT model for low-latency assistance and high-volume workloads",
     "id": "claw-medium",
     "last_updated": "2026-05-11",
     "limit": {
-     "context": 204800,
-     "input": 204800,
+     "context": 1048576,
+     "input": 1048576,
      "output": 131072
     },
     "modalities": {
@@ -159195,7 +163016,16 @@
     "name": "Claw Medium",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-05-11",
     "structured_output": true,
     "tool_call": true
@@ -160231,9 +164061,9 @@
    "deepseek/deepseek-v4-flash-vision-exp": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.014,
-     "input": 0.44,
-     "output": 1.32
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
     },
     "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
     "family": "deepseek-flash",
@@ -160486,37 +164316,6 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
-   },
-   "dmind/dmind-1-mini": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1,
-     "input": 0.2,
-     "output": 0.4
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "gpt",
-    "id": "dmind/dmind-1-mini",
-    "last_updated": "2025-06-01",
-    "limit": {
-     "context": 32768,
-     "input": 32768,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DMind-1-Mini",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
    },
    "dots-studio/dots-3-note-preview": {
     "attachment": true,
@@ -161944,9 +165743,9 @@
    "gemma-4-12b-it": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.03,
-     "input": 0.06,
-     "output": 0.3
+     "cache_read": 0.025,
+     "input": 0.05,
+     "output": 0.25
     },
     "description": "Google's Gemma 4 12B Instruct is an open-weight multimodal model for text, image, audio, and video understanding, with tool calling and structured output support.",
     "family": "gemma",
@@ -161973,6 +165772,533 @@
     "reasoning": false,
     "release_date": "2026-08-01",
     "structured_output": true,
+    "tool_call": true
+   },
+   "gemma-4-26b-a4b-it-chimerax": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Chimera X is a Gemma 4 26B A4B multimodal mixture-of-experts fine-tune for creative writing, expressive dialogue, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-26b-a4b-it-chimerax",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Chimera X",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-26b-a4b-it-darksoul": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Dark Soul is a Gemma 4 26B A4B multimodal mixture-of-experts fine-tune for creative writing, expressive dialogue, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-26b-a4b-it-darksoul",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Dark Soul",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-26b-a4b-it-luminous": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Luminous Mirror is a Gemma 4 26B A4B multimodal mixture-of-experts fine-tune for creative writing, expressive dialogue, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-26b-a4b-it-luminous",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Luminous Mirror",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-26b-a4b-it-moonlight": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Moonlight Dusk is a Gemma 4 26B A4B multimodal mixture-of-experts fine-tune for creative writing, expressive dialogue, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-26b-a4b-it-moonlight",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Moonlight Dusk",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-26b-a4b-it-musica": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Musica is a Gemma 4 26B A4B multimodal mixture-of-experts fine-tune for creative writing, expressive dialogue, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-26b-a4b-it-musica",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Musica",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-26b-a4b-it-opusdistill": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Opus Distill is a Gemma 4 26B A4B multimodal mixture-of-experts fine-tune for creative writing, expressive dialogue, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-26b-a4b-it-opusdistill",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Opus Distill",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-26b-a4b-it-shadowsiren": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Shadow Siren is a Gemma 4 26B A4B multimodal mixture-of-experts fine-tune for creative writing, expressive dialogue, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-26b-a4b-it-shadowsiren",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Shadow Siren",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-26b-a4b-uncensored": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Gemma 4 26B A4B Uncensored is an FP8 open-weight multimodal mixture-of-experts model LoRA-tuned for fewer refusals across chat, coding, tool use, and long-context work.",
+    "family": "gemma",
+    "id": "gemma-4-26b-a4b-uncensored",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 26B A4B Uncensored",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "gemma-4-26b-a4b-uncensored:thinking": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Gemma 4 26B A4B Uncensored with thinking enabled for more deliberate coding, multimodal analysis, tool use, and long-context problem solving.",
+    "family": "gemma",
+    "id": "gemma-4-26b-a4b-uncensored:thinking",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemma 4 26B A4B Uncensored Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "gemma-4-31b-it-darkidol": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.45
+    },
+    "description": "DarkIdol is a multimodal Gemma 4 31B creative finetune for expressive dialogue, long-form storytelling, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-31b-it-darkidol",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DarkIdol",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-31b-it-fabled": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.45
+    },
+    "description": "Fabled is a multimodal Gemma 4 31B creative finetune for expressive dialogue, long-form storytelling, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-31b-it-fabled",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Fabled",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-31b-it-garnet": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.45
+    },
+    "description": "Garnet is a multimodal Gemma 4 31B creative finetune for expressive dialogue, long-form storytelling, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-31b-it-garnet",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Garnet",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-31b-it-gembrain": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.45
+    },
+    "description": "Gembrain is a multimodal Gemma 4 31B creative finetune for expressive dialogue, long-form storytelling, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-31b-it-gembrain",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gembrain",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-31b-it-gemsicle": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.45
+    },
+    "description": "Gemsicle is a multimodal Gemma 4 31B creative finetune for expressive dialogue, long-form storytelling, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-31b-it-gemsicle",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemsicle",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-31b-it-isometry": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.45
+    },
+    "description": "Isometry is a multimodal Gemma 4 31B creative finetune for expressive dialogue, long-form storytelling, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-31b-it-isometry",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Isometry",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "gemma-4-31b-it-novelist": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.45
+    },
+    "description": "Novelist is a multimodal Gemma 4 31B creative finetune for expressive dialogue, long-form storytelling, and roleplay.",
+    "family": "gemma",
+    "id": "gemma-4-31b-it-novelist",
+    "last_updated": "2026-07-29",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Novelist",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
     "tool_call": true
    },
    "gemma-4-e2b-it": {
@@ -162045,68 +166371,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "glm-4": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 7.497,
-     "input": 14.994,
-     "output": 14.994
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "glm",
-    "id": "glm-4",
-    "last_updated": "2024-01-16",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-4",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "glm-4-air": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1003,
-     "input": 0.2006,
-     "output": 0.2006
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "glm",
-    "id": "glm-4-air",
-    "last_updated": "2024-06-05",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-4 Air",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
    "glm-4-air-0111": {
     "attachment": false,
     "cost": {
@@ -162138,68 +166402,6 @@
     "structured_output": false,
     "tool_call": false
    },
-   "glm-4-airx": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 1.003,
-     "input": 2.006,
-     "output": 2.006
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "glm",
-    "id": "glm-4-airx",
-    "last_updated": "2024-06-05",
-    "limit": {
-     "context": 8000,
-     "input": 8000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-4 AirX",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "glm-4-flash": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.05015,
-     "input": 0.1003,
-     "output": 0.1003
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "glm",
-    "id": "glm-4-flash",
-    "last_updated": "2024-08-01",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-4 Flash",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
    "glm-4-long": {
     "attachment": false,
     "cost": {
@@ -162228,37 +166430,6 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "glm-4-plus": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 3.7485,
-     "input": 7.497,
-     "output": 7.497
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "glm",
-    "id": "glm-4-plus",
-    "last_updated": "2024-08-01",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-4 Plus",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-09-20",
     "structured_output": false,
     "tool_call": false
    },
@@ -162418,37 +166589,6 @@
     "release_date": "2025-04-15",
     "structured_output": true,
     "tool_call": true
-   },
-   "glm-zero-preview": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.901,
-     "input": 1.802,
-     "output": 1.802
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "glm",
-    "id": "glm-zero-preview",
-    "last_updated": "2024-12-01",
-    "limit": {
-     "context": 8000,
-     "input": 8000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM Zero Preview",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-12-20",
-    "structured_output": false,
-    "tool_call": false
    },
    "google/gemini-3-flash-preview": {
     "attachment": true,
@@ -163139,9 +167279,9 @@
    "google/gemma-4-26b-a4b-it": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.04,
-     "input": 0.08,
-     "output": 0.33
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.38
     },
     "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
     "family": "gemma",
@@ -163208,44 +167348,12 @@
     "temperature": true,
     "tool_call": true
    },
-   "google/gemma-4-26b-a4b-uncensored": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.04,
-     "input": 0.08,
-     "output": 0.33
-    },
-    "description": "Gemma 4 26B A4B Uncensored is an NVFP4 open-weight multimodal mixture-of-experts model tuned for fewer refusals across chat, coding, tool use, and long-context work.",
-    "family": "gemma",
-    "id": "google/gemma-4-26b-a4b-uncensored",
-    "last_updated": "2026-08-22",
-    "limit": {
-     "context": 131072,
-     "input": 131072,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Gemma 4 26B A4B Uncensored",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2026-08-22",
-    "structured_output": true,
-    "tool_call": true
-   },
    "google/gemma-4-31b-it": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.04,
-     "input": 0.08,
-     "output": 0.33
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.45
     },
     "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
     "family": "gemma",
@@ -163313,26 +167421,24 @@
     "tool_call": true
    },
    "hermes-high": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
-     "cache_read": 2.5,
-     "input": 5,
-     "output": 25
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
     },
     "description": "Compact GPT model for low-latency assistance and high-volume workloads",
     "family": "hermes",
     "id": "hermes-high",
     "last_updated": "2026-05-11",
     "limit": {
-     "context": 1000000,
-     "input": 1000000,
-     "output": 128000
+     "context": 1048576,
+     "input": 1048576,
+     "output": 131072
     },
     "modalities": {
      "input": [
-      "text",
-      "image",
-      "pdf"
+      "text"
      ],
      "output": [
       "text"
@@ -163341,18 +167447,27 @@
     "name": "Hermes High",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-05-11",
     "structured_output": true,
     "tool_call": true
    },
    "hermes-low": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
-     "cache_read": 0.025,
+     "cache_read": 0.2,
      "cache_write": 0.08333,
-     "input": 0.25,
-     "output": 1.5
+     "input": 1,
+     "output": 3.2
     },
     "description": "Compact GPT model for low-latency assistance and high-volume workloads",
     "family": "hermes",
@@ -163361,14 +167476,11 @@
     "limit": {
      "context": 1048576,
      "input": 1048576,
-     "output": 65536
+     "output": 131072
     },
     "modalities": {
      "input": [
-      "text",
-      "image",
-      "video",
-      "pdf"
+      "text"
      ],
      "output": [
       "text"
@@ -163377,7 +167489,16 @@
     "name": "Hermes Low",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-05-11",
     "structured_output": true,
     "tool_call": true
@@ -163385,17 +167506,17 @@
    "hermes-medium": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.1575,
-     "input": 0.315,
-     "output": 1.26
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
     },
     "description": "Compact GPT model for low-latency assistance and high-volume workloads",
     "family": "hermes",
     "id": "hermes-medium",
     "last_updated": "2026-05-11",
     "limit": {
-     "context": 204800,
-     "input": 204800,
+     "context": 1048576,
+     "input": 1048576,
      "output": 131072
     },
     "modalities": {
@@ -163409,7 +167530,16 @@
     "name": "Hermes Medium",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-05-11",
     "structured_output": true,
     "tool_call": true
@@ -163608,37 +167738,6 @@
     "structured_output": false,
     "tool_call": false
    },
-   "hunyuan-turbos-20250226": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.0935,
-     "input": 0.187,
-     "output": 0.374
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "hunyuan",
-    "id": "hunyuan-turbos-20250226",
-    "last_updated": "2025-02-27",
-    "limit": {
-     "context": 24000,
-     "input": 24000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Hunyuan Turbo S",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-02-27",
-    "structured_output": false,
-    "tool_call": false
-   },
    "ibm-granite/granite-4.1-8b": {
     "attachment": false,
     "cost": {
@@ -163667,68 +167766,6 @@
     "open_weights": true,
     "reasoning": false,
     "release_date": "2026-04-29",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "inclusionai/ling-2.6-1t": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.06,
-     "input": 0.3,
-     "output": 2.5
-    },
-    "description": "Tool-capable chat model for instruction following and agentic application workflows",
-    "family": "ling",
-    "id": "inclusionai/ling-2.6-1t",
-    "last_updated": "2026-04-23",
-    "limit": {
-     "context": 262144,
-     "input": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ling 2.6 1T",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-04-23",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "inclusionai/ling-2.6-flash": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.02,
-     "input": 0.1,
-     "output": 0.3
-    },
-    "description": "Efficient model for low-latency assistance, extraction, and routine automation",
-    "family": "ling",
-    "id": "inclusionai/ling-2.6-flash",
-    "last_updated": "2026-04-21",
-    "limit": {
-     "context": 262144,
-     "input": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ling 2.6 Flash",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2026-04-21",
     "structured_output": true,
     "tool_call": true
    },
@@ -163807,38 +167844,6 @@
     "structured_output": false,
     "tool_call": true
    },
-   "inclusionai/ring-2.6-1t": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.06,
-     "input": 0.3,
-     "output": 2.5
-    },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "ring",
-    "id": "inclusionai/ring-2.6-1t",
-    "last_updated": "2026-05-08",
-    "limit": {
-     "context": 262144,
-     "input": 262144,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ring 2.6 1T",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-05-08",
-    "structured_output": true,
-    "tool_call": true
-   },
    "inflatebot/MN-12B-Mag-Mell-R1": {
     "attachment": false,
     "cost": {
@@ -163867,254 +167872,6 @@
     "open_weights": true,
     "reasoning": false,
     "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "inflection/inflection-3-pi": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 1.2495,
-     "input": 2.499,
-     "output": 9.996
-    },
-    "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
-    "family": "gpt",
-    "id": "inflection/inflection-3-pi",
-    "last_updated": "2024-10-11",
-    "limit": {
-     "context": 8000,
-     "input": 8000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Inflection 3 Pi",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-11-21",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "inflection/inflection-3-productivity": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 1.2495,
-     "input": 2.499,
-     "output": 9.996
-    },
-    "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
-    "family": "gpt",
-    "id": "inflection/inflection-3-productivity",
-    "last_updated": "2024-10-11",
-    "limit": {
-     "context": 8000,
-     "input": 8000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Inflection 3 Productivity",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-11-21",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "jamba-large": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.9945,
-     "input": 1.989,
-     "output": 7.99
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "jamba",
-    "id": "jamba-large",
-    "last_updated": "2025-07-09",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Jamba Large",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-07-09",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "jamba-large-1.6": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.9945,
-     "input": 1.989,
-     "output": 7.99
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "jamba",
-    "id": "jamba-large-1.6",
-    "last_updated": "2025-03-12",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Jamba Large 1.6",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-03-12",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "jamba-large-1.7": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.9945,
-     "input": 1.989,
-     "output": 7.99
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "jamba",
-    "id": "jamba-large-1.7",
-    "last_updated": "2025-07-09",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Jamba Large 1.7",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-07-09",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "jamba-mini": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.09945,
-     "input": 0.1989,
-     "output": 0.408
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "jamba",
-    "id": "jamba-mini",
-    "last_updated": "2025-07-09",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Jamba Mini",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-07-09",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "jamba-mini-1.6": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.09945,
-     "input": 0.1989,
-     "output": 0.408
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "jamba",
-    "id": "jamba-mini-1.6",
-    "last_updated": "2025-03-01",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Jamba Mini 1.6",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "jamba-mini-1.7": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.09945,
-     "input": 0.1989,
-     "output": 0.408
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "jamba",
-    "id": "jamba-mini-1.7",
-    "last_updated": "2025-07-09",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Jamba Mini 1.7",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-07-09",
     "structured_output": false,
     "tool_call": false
    },
@@ -164242,37 +167999,6 @@
     "release_date": "2026-07-14",
     "structured_output": true,
     "tool_call": true
-   },
-   "learnlm-1.5-pro-experimental": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 1.751,
-     "input": 3.502,
-     "output": 10.506
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "gemini",
-    "id": "learnlm-1.5-pro-experimental",
-    "last_updated": "2024-05-14",
-    "limit": {
-     "context": 32767,
-     "input": 32767,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Gemini LearnLM Experimental",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
    },
    "liquid/lfm-2.5-2.6b": {
     "attachment": false,
@@ -166277,9 +170003,9 @@
    "moonshotai/kimi-k3": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "input": 2.5,
-     "output": 13.5
+     "cache_read": 0.2,
+     "input": 2,
+     "output": 10
     },
     "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
     "family": "kimi-k3",
@@ -166321,9 +170047,9 @@
    "moonshotai/kimi-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "input": 2.5,
-     "output": 13.5
+     "cache_read": 0.2,
+     "input": 2,
+     "output": 10
     },
     "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
     "family": "kimi",
@@ -166970,7 +170696,7 @@
      }
     ],
     "release_date": "2026-08-11",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -167011,7 +170737,7 @@
      }
     ],
     "release_date": "2026-08-11",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -167668,7 +171394,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.1-2025-11-13": {
@@ -167893,7 +171619,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2-codex": {
@@ -167985,7 +171711,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4": {
@@ -168032,7 +171758,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -168079,7 +171805,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -168126,7 +171852,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.5": {
@@ -168179,10 +171905,10 @@
    "openai/gpt-5.6-luna": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.01,
-     "cache_write": 0.125,
-     "input": 0.1,
-     "output": 0.6
+     "cache_read": 0.02,
+     "cache_write": 0.25,
+     "input": 0.2,
+     "output": 1.2
     },
     "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
     "family": "gpt-luna",
@@ -168228,10 +171954,10 @@
    "openai/gpt-5.6-luna-pro": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.01,
-     "cache_write": 0.125,
-     "input": 0.1,
-     "output": 0.6
+     "cache_read": 0.02,
+     "cache_write": 0.25,
+     "input": 0.2,
+     "output": 1.2
     },
     "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
     "family": "gpt-luna",
@@ -168277,10 +172003,10 @@
    "openai/gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
-     "input": 2.5,
-     "output": 15
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
     },
     "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
     "family": "gpt-sol",
@@ -168326,10 +172052,10 @@
    "openai/gpt-5.6-sol-pro": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
-     "input": 2.5,
-     "output": 15
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
     },
     "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
     "family": "gpt-sol",
@@ -168375,10 +172101,10 @@
    "openai/gpt-5.6-terra": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
-     "cache_write": 1.25,
-     "input": 1,
-     "output": 6
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 12
     },
     "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
     "family": "gpt-terra",
@@ -168424,10 +172150,10 @@
    "openai/gpt-5.6-terra-pro": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
-     "cache_write": 1.25,
-     "input": 1,
-     "output": 6
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 12
     },
     "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
     "family": "gpt-terra",
@@ -168473,10 +172199,10 @@
    "openai/gpt-chat-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
-     "input": 2.5,
-     "output": 15
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
     },
     "description": "Chat-tuned GPT model for conversational assistance, writing, and tool workflows",
     "family": "gpt",
@@ -168520,10 +172246,10 @@
    "openai/gpt-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
-     "cache_write": 3.125,
-     "input": 2.5,
-     "output": 15
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
     },
     "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
     "family": "gpt",
@@ -169183,7 +172909,7 @@
    "ornith-ai/ornith-1.5-35b-a3b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.01,
+     "cache_read": 0.05,
      "input": 0.1,
      "output": 0.4
     },
@@ -169209,14 +172935,14 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [],
-    "release_date": "2026-08-20",
+    "release_date": "2026-07-29",
     "structured_output": true,
     "tool_call": true
    },
    "ornith-ai/ornith-1.5-35b-a3b:thinking": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.01,
+     "cache_read": 0.05,
      "input": 0.1,
      "output": 0.4
     },
@@ -169242,7 +172968,73 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [],
-    "release_date": "2026-08-20",
+    "release_date": "2026-07-29",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "ornith-ai/ornith-1.5-9b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.2
+    },
+    "description": "Ornith 1.5 9B is an FP8 dense open-weight reasoning model built for agentic coding, tool use, visual understanding, and efficient long-context work.",
+    "family": "ornith",
+    "id": "ornith-ai/ornith-1.5-9b",
+    "last_updated": "2026-08-23",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ornith 1.5 9B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "ornith-ai/ornith-1.5-9b:thinking": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.2
+    },
+    "description": "Ornith 1.5 9B with thinking enabled for more deliberate agentic coding, tool use, visual understanding, and long-context work.",
+    "family": "ornith",
+    "id": "ornith-ai/ornith-1.5-9b:thinking",
+    "last_updated": "2026-08-24",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ornith 1.5 9B Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
     "structured_output": true,
     "tool_call": true
    },
@@ -169434,38 +173226,6 @@
     "release_date": "2026-08-04",
     "structured_output": true,
     "tool_call": true
-   },
-   "poolside/laguna-m.1": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1,
-     "input": 0.2,
-     "output": 0.4
-    },
-    "description": "Poolside's open-weight model for agentic coding and long-horizon work",
-    "family": "laguna",
-    "id": "poolside/laguna-m.1",
-    "last_updated": "2026-06-13",
-    "limit": {
-     "context": 262144,
-     "input": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Laguna M.1",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2026-04-28",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
    },
    "poolside/laguna-s-2.1": {
     "attachment": false,
@@ -170560,15 +174320,15 @@
     "cost": {
      "cache_read": 0.075,
      "input": 0.15,
-     "output": 0.5
+     "output": 0.95
     },
     "description": "Qwen 3.6 35B A3B Uncensored is an FP8 open-weight mixture-of-experts model tuned for fewer refusals across chat, coding, tool use, and multimodal tasks.",
     "family": "qwen3.6",
     "id": "qwen/qwen3.6-35b-a3b-uncensored",
     "last_updated": "2026-08-21",
     "limit": {
-     "context": 65536,
-     "input": 65536,
+     "context": 262144,
+     "input": 262144,
      "output": 32768
     },
     "modalities": {
@@ -170582,25 +174342,194 @@
     },
     "name": "Qwen 3.6 35B A3B Uncensored",
     "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.6-35b-a3b-uncensored:thinking": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.15,
+     "output": 0.95
+    },
+    "description": "Qwen 3.6 35B A3B Uncensored with thinking enabled for more deliberate coding, multimodal analysis, tool use, and complex chat tasks.",
+    "family": "qwen3.6",
+    "id": "qwen/qwen3.6-35b-a3b-uncensored:thinking",
+    "last_updated": "2026-08-24",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen 3.6 35B A3B Uncensored Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-2.4t-a95b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "Open-weight sparse MoE (2.4T total, 95B active), the open-weight twin of Qwen3.8 Max for coding, research, complex reasoning, and agentic workflows",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-2.4t-a95b",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 991000,
+     "input": 991000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 2.4T A95B (Max)",
+    "open_weights": true,
     "reasoning": false,
-    "release_date": "2026-08-21",
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-27b-fable": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.125,
+     "input": 0.25,
+     "output": 1.5
+    },
+    "description": "Qwen 3.8 27B Fable is an open-weight multimodal creative finetune for expressive dialogue, long-form storytelling, character work, and roleplay.",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-27b-fable",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen 3.8 27B Fable",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-27b-obliterated": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.125,
+     "input": 0.25,
+     "output": 1.5
+    },
+    "description": "Qwen 3.8 27B Obliterated is an open-weight multimodal model LoRA-tuned for fewer refusals across chat, coding, reasoning, tool use, and long-context work.",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-27b-obliterated",
+    "last_updated": "2026-08-24",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen 3.8 27B Obliterated",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-27b-obliterated:thinking": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.125,
+     "input": 0.25,
+     "output": 1.5
+    },
+    "description": "Qwen 3.8 27B Obliterated with thinking enabled for more deliberate creative work, coding, multimodal analysis, tool use, and long-context problem solving.",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-27b-obliterated:thinking",
+    "last_updated": "2026-08-24",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen 3.8 27B Obliterated Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
     "structured_output": true,
     "tool_call": true
    },
    "qwen/qwen3.8-27b-uncensored": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.075,
-     "input": 0.18,
-     "output": 0.5
+     "cache_read": 0.125,
+     "input": 0.25,
+     "output": 1.5
     },
-    "description": "Qwen 3.8 27B Uncensored is an FP8 open-weight multimodal model tuned for fewer refusals across chat, coding, tool use, and long-context work.",
+    "description": "Qwen 3.8 27B Uncensored is an NVFP4 open-weight multimodal model LoRA-tuned for fewer refusals across chat, coding, reasoning, tool use, and long-context work.",
     "family": "qwen",
     "id": "qwen/qwen3.8-27b-uncensored",
     "last_updated": "2026-08-21",
     "limit": {
-     "context": 131072,
-     "input": 131072,
+     "context": 262144,
+     "input": 262144,
      "output": 32768
     },
     "modalities": {
@@ -170614,8 +174543,42 @@
     },
     "name": "Qwen 3.8 27B Uncensored",
     "open_weights": true,
-    "reasoning": false,
-    "release_date": "2026-08-21",
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-27b-uncensored:thinking": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.125,
+     "input": 0.25,
+     "output": 1.5
+    },
+    "description": "Qwen 3.8 27B Uncensored with thinking enabled for more deliberate creative work, coding, multimodal analysis, tool use, and long-context problem solving.",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-27b-uncensored:thinking",
+    "last_updated": "2026-08-25",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen 3.8 27B Uncensored Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-29",
     "structured_output": true,
     "tool_call": true
    },
@@ -171575,8 +175538,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.04,
-     "input": 0.2,
-     "output": 1.4
+     "input": 0.15,
+     "output": 0.7
     },
     "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
     "family": "qwen",
@@ -171609,8 +175572,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.04,
-     "input": 0.2,
-     "output": 1.4
+     "input": 0.15,
+     "output": 0.7
     },
     "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
     "family": "qwen",
@@ -172179,79 +176142,6 @@
     "structured_output": false,
     "tool_call": false
    },
-   "stealth/ox-alpha": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.025,
-     "input": 0.05,
-     "output": 0.05
-    },
-    "description": "Ox Alpha is an experimental stealth model with long-context reasoning, vision, tool calling, and structured output support. Prompts and responses are logged and retained by the provider.",
-    "family": "alpha",
-    "id": "stealth/ox-alpha",
-    "last_updated": "2026-08-21",
-    "limit": {
-     "context": 1000000,
-     "input": 1000000,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ox Alpha",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-08-21",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "step-r1-v-mini": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 1.25,
-     "input": 2.5,
-     "output": 11
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "step",
-    "id": "step-r1-v-mini",
-    "last_updated": "2025-04-08",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Step R1 V Mini",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
    "stepfun-ai/step-3.5-flash": {
     "attachment": false,
     "cost": {
@@ -172450,6 +176340,48 @@
      }
     ],
     "release_date": "2026-07-06",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "tencent/hy4-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.042,
+     "input": 0.834,
+     "output": 2.501
+    },
+    "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+    "family": "Hy",
+    "id": "tencent/hy4-preview",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Tencent Hy4 Preview",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-28",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -173501,37 +177433,6 @@
     "structured_output": false,
     "tool_call": false
    },
-   "yi-lightning": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1003,
-     "input": 0.2006,
-     "output": 0.2006
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "yi",
-    "id": "yi-lightning",
-    "last_updated": "2024-10-16",
-    "limit": {
-     "context": 12000,
-     "input": 12000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Yi Lightning",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-06-15",
-    "structured_output": false,
-    "tool_call": false
-   },
    "yi-medium-200k": {
     "attachment": false,
     "cost": {
@@ -173561,6 +177462,203 @@
     "reasoning": false,
     "release_date": "2024-01-01",
     "structured_output": false,
+    "tool_call": false
+   },
+   "z-ai/GLM-4.5-Air": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.8
+    },
+    "description": "Lighter GLM-4.5 variant for fast coding assistance and cheaper agents",
+    "family": "glm-air",
+    "id": "z-ai/GLM-4.5-Air",
+    "knowledge": "2025-04",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 128000,
+     "input": 128000,
+     "output": 98304
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.5 Air",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-07-28",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/GLM-4.5-Air:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.12,
+     "output": 0.8
+    },
+    "description": "Lighter GLM-4.5 variant for fast coding assistance and cheaper agents",
+    "family": "glm-air",
+    "id": "z-ai/GLM-4.5-Air:thinking",
+    "knowledge": "2025-04",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 128000,
+     "input": 128000,
+     "output": 98304
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.5 Air (Thinking)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-07-28",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/GLM-4.5:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 0.3,
+     "output": 1.3
+    },
+    "description": "Hybrid-reasoning GLM release that made the 4.5 line broadly useful",
+    "family": "glm",
+    "id": "z-ai/GLM-4.5:thinking",
+    "knowledge": "2025-04",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 128000,
+     "input": 128000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.5 (Thinking)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-07-28",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "z-ai/GLM-4.6-turbo": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 1,
+     "output": 3
+    },
+    "description": "Fast variant of GLM 4.6 for general chat, coding, and analysis with improved latency and strong reasoning.",
+    "family": "glm",
+    "id": "z-ai/GLM-4.6-turbo",
+    "last_updated": "2025-10-02",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 204800
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.6 Turbo",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-10-02",
+    "structured_output": false,
+    "tool_call": false
+   },
+   "z-ai/GLM-4.6-turbo:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 1,
+     "output": 3
+    },
+    "description": "GLM 4.6 Turbo with thinking mode enabled for enhanced reasoning; shows internal reasoning and supports long context.",
+    "family": "glm",
+    "id": "z-ai/GLM-4.6-turbo:thinking",
+    "last_updated": "2025-10-02",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 204800
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.6 Turbo (Thinking)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-10-02",
+    "structured_output": false,
+    "tool_call": false
+   },
+   "z-ai/glm-4.5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 0.3,
+     "output": 1.3
+    },
+    "description": "Hybrid-reasoning GLM release that made the 4.5 line broadly useful",
+    "family": "glm",
+    "id": "z-ai/glm-4.5",
+    "knowledge": "2025-04",
+    "last_updated": "2025-07-28",
+    "limit": {
+     "context": 128000,
+     "input": 128000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.5",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-07-28",
+    "structured_output": false,
+    "temperature": true,
     "tool_call": false
    },
    "z-ai/glm-4.5v": {
@@ -173680,6 +177778,38 @@
     "temperature": true,
     "tool_call": true
    },
+   "z-ai/glm-4.6-original": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.175,
+     "input": 0.35,
+     "output": 1.4
+    },
+    "description": "GLM-4.6, Zhipu's flagship text model with 256K context window and advanced reasoning capabilities. Direct via Z-AI (Zhipu).",
+    "family": "glm",
+    "id": "z-ai/glm-4.6-original",
+    "last_updated": "2025-12-11",
+    "limit": {
+     "context": 256000,
+     "input": 256000,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.6 Original",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-12-11",
+    "structured_output": false,
+    "tool_call": true
+   },
    "z-ai/glm-4.6:thinking": {
     "attachment": false,
     "cost": {
@@ -173723,6 +177853,465 @@
     "temperature": true,
     "tool_call": true
    },
+   "z-ai/glm-4.6v": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 0.3,
+     "output": 0.9
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "z-ai/glm-4.6v",
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-08",
+    "limit": {
+     "context": 128000,
+     "input": 128000,
+     "output": 24000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.6V",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-12-08",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
+   "z-ai/glm-4.6v-flash-original": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "GLM-4.6V-Flash (9B), a lightweight model optimized for local deployment and low-latency applications. Scales context window to 128k tokens and achieves SoTA performance in visual understanding among similar-scale models.",
+    "family": "glm",
+    "id": "z-ai/glm-4.6v-flash-original",
+    "last_updated": "2025-12-08",
+    "limit": {
+     "context": 128000,
+     "input": 128000,
+     "output": 24000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.6V Flash",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-12-08",
+    "structured_output": false,
+    "tool_call": false
+   },
+   "z-ai/glm-4.6v-original": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 0.6,
+     "output": 0.9
+    },
+    "description": "GLM-4.6V scales its context window to 128k tokens in training, and achieves SoTA performance in visual understanding among models of similar parameter scales. Integrates native Function Calling capabilities, bridging 'visual perception' and 'executable action' for multimodal agents. Direct via Z-AI (Zhipu).",
+    "family": "glm",
+    "id": "z-ai/glm-4.6v-original",
+    "last_updated": "2025-12-08",
+    "limit": {
+     "context": 128000,
+     "input": 128000,
+     "output": 24000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.6V Original",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-12-08",
+    "structured_output": false,
+    "tool_call": false
+   },
+   "z-ai/glm-4.7": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.2,
+     "output": 0.8
+    },
+    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
+    "family": "glm",
+    "id": "z-ai/glm-4.7",
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.7",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-12-22",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-4.7-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.035,
+     "input": 0.07,
+     "output": 0.4
+    },
+    "description": "Budget GLM lane for fast coding help, routing, and everyday automation",
+    "family": "glm-flash",
+    "id": "z-ai/glm-4.7-flash",
+    "knowledge": "2025-04",
+    "last_updated": "2026-01-19",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.7 Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-01-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-4.7-flash-original": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.035,
+     "input": 0.07,
+     "output": 0.4
+    },
+    "description": "GLM-4.7-Flash is a lightweight 30B model optimized for coding and agentic tasks. Balances high performance with efficiency, perfect for local deployment.",
+    "family": "glm",
+    "id": "z-ai/glm-4.7-flash-original",
+    "last_updated": "2026-01-19",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.7 Flash Original",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-01-19",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "z-ai/glm-4.7-flash-original:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.035,
+     "input": 0.07,
+     "output": 0.4
+    },
+    "description": "GLM-4.7-Flash with extended thinking capabilities for complex reasoning. Lightweight 30B model optimized for coding and agentic tasks.",
+    "family": "glm",
+    "id": "z-ai/glm-4.7-flash-original:thinking",
+    "last_updated": "2026-01-19",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.7 Flash Original Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-01-19",
+    "structured_output": false,
+    "tool_call": true
+   },
+   "z-ai/glm-4.7-flash:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.035,
+     "input": 0.07,
+     "output": 0.4
+    },
+    "description": "Budget GLM lane for fast coding help, routing, and everyday automation",
+    "family": "glm-flash",
+    "id": "z-ai/glm-4.7-flash:thinking",
+    "knowledge": "2025-04",
+    "last_updated": "2026-01-19",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.7 Flash Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-01-19",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-4.7-original": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.6,
+     "output": 2.2
+    },
+    "description": "GLM-4.7 is a next-gen GLM series text model with stronger reasoning, long-context chat, and reliable tool use. Routed directly via Z-AI (Zhipu).",
+    "family": "glm",
+    "id": "z-ai/glm-4.7-original",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.7 Original",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-12-22",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "z-ai/glm-4.7-original:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.11,
+     "input": 0.6,
+     "output": 2.2
+    },
+    "description": "GLM-4.7 original with extended thinking capabilities for complex reasoning.",
+    "family": "glm",
+    "id": "z-ai/glm-4.7-original:thinking",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.7 Original Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-12-22",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "z-ai/glm-4.7:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.2,
+     "output": 0.8
+    },
+    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
+    "family": "glm",
+    "id": "z-ai/glm-4.7:thinking",
+    "knowledge": "2025-04",
+    "last_updated": "2025-12-22",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 4.7 Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-12-22",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.13,
+     "input": 0.5,
+     "output": 2.55
+    },
+    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
+    "family": "glm",
+    "id": "z-ai/glm-5",
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-02-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5-original": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
+    },
+    "description": "GLM-5 is Zhipu's latest flagship model with advanced reasoning and instruction following. Routed directly via Z-AI (Zhipu).",
+    "family": "glm",
+    "id": "z-ai/glm-5-original",
+    "last_updated": "2026-02-11",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5 Original",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-02-11",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5-original:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
+    },
+    "description": "GLM-5 original with extended thinking capabilities for complex reasoning.",
+    "family": "glm",
+    "id": "z-ai/glm-5-original:thinking",
+    "last_updated": "2026-02-11",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5 Original Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-02-11",
+    "structured_output": true,
+    "tool_call": true
+   },
    "z-ai/glm-5-turbo": {
     "attachment": false,
     "cost": {
@@ -173751,6 +178340,372 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2026-03-16",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.1": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 0.75,
+     "output": 2.6
+    },
+    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
+    "family": "glm",
+    "id": "z-ai/glm-5.1",
+    "last_updated": "2026-04-07",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.1",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-07",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.1:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 0.75,
+     "output": 2.6
+    },
+    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
+    "family": "glm",
+    "id": "z-ai/glm-5.1:thinking",
+    "last_updated": "2026-04-07",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.1 Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-07",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.078,
+     "input": 0.42,
+     "output": 1.32
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "z-ai/glm-5.2",
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.2",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.2:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.078,
+     "input": 0.42,
+     "output": 1.32
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "z-ai/glm-5.2:thinking",
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.2 Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "z-ai/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "z-ai/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3-flash-uncensored": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.175,
+     "input": 0.35,
+     "output": 1.4
+    },
+    "description": "GLM 5.3 Flash Uncensored is an uncensored fine-tune of the efficient 320B mixture-of-experts reasoning model, built for unrestricted chat, creative writing, coding, agentic work, tool use, and long-context tasks.",
+    "family": "glm",
+    "id": "z-ai/glm-5.3-flash-uncensored",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 262144,
+     "input": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Flash Uncensored",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-29",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "z-ai/glm-5.3:thinking",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5:thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.13,
+     "input": 0.5,
+     "output": 2.55
+    },
+    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
+    "family": "glm",
+    "id": "z-ai/glm-5:thinking",
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 200000,
+     "input": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5 Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-02-12",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -173822,1013 +178777,16 @@
     "temperature": true,
     "tool_call": true
    },
-   "zai-org/GLM-4.5-Air": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.06,
-     "input": 0.12,
-     "output": 0.8
-    },
-    "description": "Lighter GLM-4.5 variant for fast coding assistance and cheaper agents",
-    "family": "glm-air",
-    "id": "zai-org/GLM-4.5-Air",
-    "knowledge": "2025-04",
-    "last_updated": "2025-07-28",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 98304
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.5 Air",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-07-28",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/GLM-4.5-Air:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.06,
-     "input": 0.12,
-     "output": 0.8
-    },
-    "description": "Lighter GLM-4.5 variant for fast coding assistance and cheaper agents",
-    "family": "glm-air",
-    "id": "zai-org/GLM-4.5-Air:thinking",
-    "knowledge": "2025-04",
-    "last_updated": "2025-07-28",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 98304
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.5 Air (Thinking)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-07-28",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/GLM-4.5:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.15,
-     "input": 0.3,
-     "output": 1.3
-    },
-    "description": "Hybrid-reasoning GLM release that made the 4.5 line broadly useful",
-    "family": "glm",
-    "id": "zai-org/GLM-4.5:thinking",
-    "knowledge": "2025-04",
-    "last_updated": "2025-07-28",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.5 (Thinking)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-07-28",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "zai-org/GLM-4.6-turbo": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.5,
-     "input": 1,
-     "output": 3
-    },
-    "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
-    "family": "glm",
-    "id": "zai-org/GLM-4.6-turbo",
-    "last_updated": "2025-10-02",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 204800
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.6 Turbo",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-10-02",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "zai-org/GLM-4.6-turbo:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.5,
-     "input": 1,
-     "output": 3
-    },
-    "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
-    "family": "glm",
-    "id": "zai-org/GLM-4.6-turbo:thinking",
-    "last_updated": "2025-10-02",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 204800
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.6 Turbo (Thinking)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-10-02",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "zai-org/glm-4.5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.15,
-     "input": 0.3,
-     "output": 1.3
-    },
-    "description": "Hybrid-reasoning GLM release that made the 4.5 line broadly useful",
-    "family": "glm",
-    "id": "zai-org/glm-4.5",
-    "knowledge": "2025-04",
-    "last_updated": "2025-07-28",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.5",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-07-28",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "zai-org/glm-4.6-original": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.175,
-     "input": 0.35,
-     "output": 1.4
-    },
-    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
-    "family": "glm",
-    "id": "zai-org/glm-4.6-original",
-    "last_updated": "2025-12-11",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 65535
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.6 Original",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-12-11",
-    "structured_output": false,
-    "tool_call": true
-   },
-   "zai-org/glm-4.6v": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.15,
-     "input": 0.3,
-     "output": 0.9
-    },
-    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
-    "family": "glm",
-    "id": "zai-org/glm-4.6v",
-    "knowledge": "2025-04",
-    "last_updated": "2025-12-08",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 24000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.6V",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-12-08",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "zai-org/glm-4.6v-flash-original": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.05,
-     "input": 0.1,
-     "output": 0.4
-    },
-    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
-    "family": "glm",
-    "id": "zai-org/glm-4.6v-flash-original",
-    "last_updated": "2025-12-08",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 24000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.6V Flash",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-12-08",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "zai-org/glm-4.6v-original": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.3,
-     "input": 0.6,
-     "output": 0.9
-    },
-    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
-    "family": "glm",
-    "id": "zai-org/glm-4.6v-original",
-    "last_updated": "2025-12-08",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 24000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.6V Original",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-12-08",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "zai-org/glm-4.7": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1,
-     "input": 0.2,
-     "output": 0.8
-    },
-    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
-    "family": "glm",
-    "id": "zai-org/glm-4.7",
-    "knowledge": "2025-04",
-    "last_updated": "2025-12-22",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 65535
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.7",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-12-22",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-4.7-flash": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.035,
-     "input": 0.07,
-     "output": 0.4
-    },
-    "description": "Budget GLM lane for fast coding help, routing, and everyday automation",
-    "family": "glm-flash",
-    "id": "zai-org/glm-4.7-flash",
-    "knowledge": "2025-04",
-    "last_updated": "2026-01-19",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.7 Flash",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-01-19",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-4.7-flash-original": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.035,
-     "input": 0.07,
-     "output": 0.4
-    },
-    "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
-    "family": "glm",
-    "id": "zai-org/glm-4.7-flash-original",
-    "last_updated": "2026-01-19",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.7 Flash Original",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-01-19",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "zai-org/glm-4.7-flash-original:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.035,
-     "input": 0.07,
-     "output": 0.4
-    },
-    "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
-    "family": "glm",
-    "id": "zai-org/glm-4.7-flash-original:thinking",
-    "last_updated": "2026-01-19",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.7 Flash Original Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-01-19",
-    "structured_output": false,
-    "tool_call": true
-   },
-   "zai-org/glm-4.7-flash:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.035,
-     "input": 0.07,
-     "output": 0.4
-    },
-    "description": "Budget GLM lane for fast coding help, routing, and everyday automation",
-    "family": "glm-flash",
-    "id": "zai-org/glm-4.7-flash:thinking",
-    "knowledge": "2025-04",
-    "last_updated": "2026-01-19",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.7 Flash Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-01-19",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-4.7-original": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.11,
-     "input": 0.6,
-     "output": 2.2
-    },
-    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
-    "family": "glm",
-    "id": "zai-org/glm-4.7-original",
-    "last_updated": "2025-12-22",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 65535
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.7 Original",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-12-22",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "zai-org/glm-4.7-original:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.11,
-     "input": 0.6,
-     "output": 2.2
-    },
-    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
-    "family": "glm",
-    "id": "zai-org/glm-4.7-original:thinking",
-    "last_updated": "2025-12-22",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 65535
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.7 Original Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-12-22",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "zai-org/glm-4.7:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1,
-     "input": 0.2,
-     "output": 0.8
-    },
-    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
-    "family": "glm",
-    "id": "zai-org/glm-4.7:thinking",
-    "knowledge": "2025-04",
-    "last_updated": "2025-12-22",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 65535
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.7 Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-12-22",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.13,
-     "input": 0.5,
-     "output": 2.55
-    },
-    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
-    "family": "glm",
-    "id": "zai-org/glm-5",
-    "last_updated": "2026-02-12",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-02-12",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-5-original": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 1,
-     "output": 3.2
-    },
-    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
-    "family": "glm",
-    "id": "zai-org/glm-5-original",
-    "last_updated": "2026-02-11",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5 Original",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-02-11",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "zai-org/glm-5-original:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 1,
-     "output": 3.2
-    },
-    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
-    "family": "glm",
-    "id": "zai-org/glm-5-original:thinking",
-    "last_updated": "2026-02-11",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5 Original Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-02-11",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "zai-org/glm-5.1": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.15,
-     "input": 0.75,
-     "output": 2.6
-    },
-    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
-    "family": "glm",
-    "id": "zai-org/glm-5.1",
-    "last_updated": "2026-04-07",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5.1",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-04-07",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-5.1:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.15,
-     "input": 0.75,
-     "output": 2.6
-    },
-    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
-    "family": "glm",
-    "id": "zai-org/glm-5.1:thinking",
-    "last_updated": "2026-04-07",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5.1 Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-04-07",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-5.2": {
+   "z-ai/glm-latest": {
     "attachment": false,
     "cost": {
      "cache_read": 0.078,
      "input": 0.42,
      "output": 1.32
     },
-    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "description": "Compatibility alias that routes to the newest thinking GLM model. Currently routes to GLM 5.2 Thinking.",
     "family": "glm",
-    "id": "zai-org/glm-5.2",
-    "last_updated": "2026-06-13",
-    "limit": {
-     "context": 1048576,
-     "input": 1048576,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5.2",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-06-13",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-5.2:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.078,
-     "input": 0.42,
-     "output": 1.32
-    },
-    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
-    "family": "glm",
-    "id": "zai-org/glm-5.2:thinking",
-    "last_updated": "2026-06-13",
-    "limit": {
-     "context": 1048576,
-     "input": 1048576,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5.2 Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-06-13",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-5.3": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
-    },
-    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
-    "family": "glm",
-    "id": "zai-org/glm-5.3",
-    "last_updated": "2026-08-14",
-    "limit": {
-     "context": 1048576,
-     "input": 1048576,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5.3 Preview",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-08-14",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-5.3:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
-    },
-    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
-    "family": "glm",
-    "id": "zai-org/glm-5.3:thinking",
-    "last_updated": "2026-08-14",
-    "limit": {
-     "context": 1048576,
-     "input": 1048576,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5.3 Preview Thinking",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-08-14",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-5:thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.13,
-     "input": 0.5,
-     "output": 2.55
-    },
-    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
-    "family": "glm",
-    "id": "zai-org/glm-5:thinking",
-    "last_updated": "2026-02-12",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5 Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-02-12",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/glm-latest": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.078,
-     "input": 0.42,
-     "output": 1.32
-    },
-    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
-    "family": "glm",
-    "id": "zai-org/glm-latest",
+    "id": "z-ai/glm-latest",
     "last_updated": "2026-05-03",
     "limit": {
      "context": 1048576,
@@ -174846,15 +178804,7 @@
     "name": "GLM Latest",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "high",
-       "xhigh"
-      ]
-     }
-    ],
+    "reasoning_options": [],
     "release_date": "2026-05-03",
     "structured_output": true,
     "tool_call": true
@@ -175858,7 +179808,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2": {
@@ -175904,7 +179854,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4": {
@@ -175967,7 +179917,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -176013,7 +179963,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -176059,7 +180009,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.5": {
@@ -179730,69 +183680,28 @@
   "name": "Neon",
   "npm": "@ai-sdk/openai-compatible"
  },
- "neuralwatt": {
-  "api": "https://api.neuralwatt.com/v1",
-  "doc": "https://portal.neuralwatt.com/docs",
+ "neosmith": {
+  "api": "https://router.neosmith.ai/v1",
+  "doc": "https://neosmith.ai/docs",
   "env": [
-   "NEURALWATT_API_KEY"
+   "NEOSMITH_API_KEY"
   ],
-  "id": "neuralwatt",
+  "id": "neosmith",
   "models": {
-   "Qwen/Qwen3.5-397B-A17B-FP8": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1725,
-     "input": 0.69,
-     "output": 4.14
-    },
-    "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
-    "family": "qwen",
-    "id": "Qwen/Qwen3.5-397B-A17B-FP8",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-02-01",
-    "limit": {
-     "context": 262128,
-     "output": 262128
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3.5 397B A17B FP8",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-02-01",
-    "temperature": true,
-    "tool_call": true
-   },
-   "Qwen/Qwen3.6-35B-A3B": {
+   "neosmith.intelligent-basic": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0725,
-     "input": 0.29,
-     "output": 1.15
+     "cache_read": 0.22,
+     "cache_write": 0,
+     "input": 1.17,
+     "output": 4.37
     },
-    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
-    "family": "qwen3.6",
-    "id": "Qwen/Qwen3.6-35B-A3B",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-04-01",
+    "description": "Cost-capped tier. Intelligent routing with a Claude Sonnet ceiling — Opus is never invoked.",
+    "id": "neosmith.intelligent-basic",
+    "last_updated": "2026-08-03",
     "limit": {
-     "context": 131056,
-     "output": 131056
+     "context": 1000000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -179803,28 +183712,137 @@
       "text"
      ]
     },
-    "name": "Qwen3.6 35B A3B",
-    "open_weights": true,
+    "name": "NeoSmith Basic",
+    "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-04-01",
+    "reasoning_options": [],
+    "release_date": "2026-04-26",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
+   "neosmith.intelligent-maestro": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.35,
+     "cache_write": 0,
+     "input": 2.4,
+     "output": 12
+    },
+    "description": "Highest-accuracy coding tier. Hard, self-contained problems run NeoSmith's premium multi-model solver; everything else gets the strongest intelligence tier.",
+    "id": "neosmith.intelligent-maestro",
+    "last_updated": "2026-08-08",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "NeoSmith Maestro",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-03",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "neosmith.intelligent-pro": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 0,
+     "input": 1.81,
+     "output": 8.39
+    },
+    "description": "Default production tier. Intelligent NeoSmith routing with a Claude Opus ceiling on escalation.",
+    "id": "neosmith.intelligent-pro",
+    "last_updated": "2026-07-18",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "NeoSmith Pro",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-04-26",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "neosmith.neolite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.08,
+     "cache_write": 0,
+     "input": 0.6,
+     "output": 2.4
+    },
+    "description": "Sealed single-model budget tier. 512K context, text and images, tool use, and no escalation of any kind.",
+    "id": "neosmith.neolite",
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 512000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "NeoSmith NeoLite",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-06-20",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "NeoSmith",
+  "npm": "@ai-sdk/openai"
+ },
+ "neuralwatt": {
+  "api": "https://api.neuralwatt.com/v1",
+  "doc": "https://portal.neuralwatt.com/docs",
+  "env": [
+   "NEURALWATT_API_KEY"
+  ],
+  "id": "neuralwatt",
+  "models": {
    "deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.026,
-     "input": 0.104,
-     "output": 0.207
+     "cache_read": 0.028,
+     "input": 0.14,
+     "output": 0.28
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
     "id": "deepseek-v4-flash",
+    "interleaved": true,
     "knowledge": "2025-05",
     "last_updated": "2026-04-24",
     "limit": {
@@ -179846,6 +183864,7 @@
      {
       "type": "effort",
       "values": [
+       "none",
        "high",
        "max"
       ]
@@ -179856,16 +183875,108 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek-v4-flash-flex": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0182,
+     "input": 0.091,
+     "output": 0.182
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash-flex",
+    "interleaved": true,
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048560,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Flex",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 1,
+     "output": 3
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "deepseek-v4-pro",
+    "interleaved": true,
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1048560,
+     "output": 393216
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-04-24",
+    "status": "beta",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "gemma-4-31b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.036,
+     "cache_read": 0.0144,
      "input": 0.144,
      "output": 0.42
     },
     "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
     "family": "gemma",
     "id": "gemma-4-31b",
+    "interleaved": true,
     "last_updated": "2026-04-02",
     "limit": {
      "context": 262128,
@@ -179885,7 +183996,11 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "none",
+       "max"
+      ]
      }
     ],
     "release_date": "2026-04-02",
@@ -179896,13 +184011,14 @@
    "glm-5.2": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.3625,
+     "cache_read": 0.145,
      "input": 1.45,
      "output": 4.5
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
     "id": "glm-5.2",
+    "interleaved": true,
     "last_updated": "2026-06-17",
     "limit": {
      "context": 1048560,
@@ -179921,17 +184037,10 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
-       "minimal",
-       "low",
-       "medium",
        "high",
-       "xhigh",
        "max"
       ]
      },
@@ -179940,19 +184049,21 @@
      }
     ],
     "release_date": "2026-06-17",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
    "glm-5.2-fast": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.3625,
+     "cache_read": 0.145,
      "input": 1.45,
      "output": 4.5
     },
     "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
     "family": "glm",
     "id": "glm-5.2-fast",
+    "interleaved": true,
     "last_updated": "2026-06-17",
     "limit": {
      "context": 1048560,
@@ -179968,21 +184079,36 @@
     },
     "name": "GLM 5.2 Fast",
     "open_weights": true,
-    "reasoning": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-06-17",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
    "glm-5.2-flex": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.18125,
-     "input": 0.725,
-     "output": 2.25
+     "cache_read": 0.09425,
+     "input": 0.9425,
+     "output": 2.925
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
     "id": "glm-5.2-flex",
+    "interleaved": true,
     "last_updated": "2026-06-17",
     "limit": {
      "context": 1048560,
@@ -180001,17 +184127,10 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
-       "minimal",
-       "low",
-       "medium",
        "high",
-       "xhigh",
        "max"
       ]
      },
@@ -180020,23 +184139,25 @@
      }
     ],
     "release_date": "2026-06-17",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
    "glm-5.2-short": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.3625,
+     "cache_read": 0.145,
      "input": 1.45,
      "output": 4.5
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
     "id": "glm-5.2-short",
+    "interleaved": true,
     "last_updated": "2026-06-17",
     "limit": {
      "context": 199984,
-     "output": 199984
+     "output": 32000
     },
     "modalities": {
      "input": [
@@ -180051,17 +184172,10 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
-       "minimal",
-       "low",
-       "medium",
        "high",
-       "xhigh",
        "max"
       ]
      },
@@ -180070,23 +184184,25 @@
      }
     ],
     "release_date": "2026-06-17",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
    "glm-5.2-short-fast": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.3625,
+     "cache_read": 0.145,
      "input": 1.45,
      "output": 4.5
     },
     "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
     "family": "glm",
     "id": "glm-5.2-short-fast",
+    "interleaved": true,
     "last_updated": "2026-06-17",
     "limit": {
      "context": 199984,
-     "output": 199984
+     "output": 32000
     },
     "modalities": {
      "input": [
@@ -180098,25 +184214,40 @@
     },
     "name": "GLM 5.2 Short Fast",
     "open_weights": true,
-    "reasoning": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-06-17",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
    "glm-5.2-short-fast-flex": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.18125,
-     "input": 0.725,
-     "output": 2.25
+     "cache_read": 0.09425,
+     "input": 0.9425,
+     "output": 2.925
     },
     "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
     "family": "glm",
     "id": "glm-5.2-short-fast-flex",
+    "interleaved": true,
     "last_updated": "2026-06-17",
     "limit": {
      "context": 199984,
-     "output": 199984
+     "output": 32000
     },
     "modalities": {
      "input": [
@@ -180128,25 +184259,40 @@
     },
     "name": "GLM 5.2 Short Fast Flex",
     "open_weights": true,
-    "reasoning": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-06-17",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
    "glm-5.2-short-flex": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.18125,
-     "input": 0.725,
-     "output": 2.25
+     "cache_read": 0.09425,
+     "input": 0.9425,
+     "output": 2.925
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
     "id": "glm-5.2-short-flex",
+    "interleaved": true,
     "last_updated": "2026-06-17",
     "limit": {
      "context": 199984,
-     "output": 199984
+     "output": 32000
     },
     "modalities": {
      "input": [
@@ -180161,17 +184307,10 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
        "none",
-       "minimal",
-       "low",
-       "medium",
        "high",
-       "xhigh",
        "max"
       ]
      },
@@ -180180,125 +184319,150 @@
      }
     ],
     "release_date": "2026-06-17",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
-   "kimi-k2.5-fast": {
-    "attachment": true,
+   "glm-5.3": {
+    "attachment": false,
     "cost": {
-     "cache_read": 0.13,
-     "input": 0.52,
-     "output": 2.59
+     "cache_read": 0.145,
+     "input": 1.45,
+     "output": 4.5
     },
-    "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
-    "family": "kimi-k2",
-    "id": "kimi-k2.5-fast",
-    "last_updated": "2026-01-27",
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "interleaved": true,
+    "last_updated": "2026-08-14",
     "limit": {
-     "context": 262128,
-     "output": 262128
+     "context": 1048560,
+     "output": 1048560
     },
     "modalities": {
      "input": [
-      "text",
-      "image"
+      "text"
      ],
      "output": [
       "text"
      ]
     },
-    "name": "Kimi K2.5 Fast",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2026-01-27",
-    "temperature": true,
-    "tool_call": true
-   },
-   "kimi-k2.6-fast": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.1725,
-     "input": 0.69,
-     "output": 3.22
-    },
-    "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
-    "family": "kimi-k2",
-    "id": "kimi-k2.6-fast",
-    "last_updated": "2026-04-21",
-    "limit": {
-     "context": 262128,
-     "output": 262128
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.6 Fast",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2026-04-21",
-    "temperature": true,
-    "tool_call": true
-   },
-   "kimi-k2.6-flex": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.08625,
-     "input": 0.345,
-     "output": 1.61
-    },
-    "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
-    "family": "kimi-k2",
-    "id": "kimi-k2.6-flex",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-04-21",
-    "limit": {
-     "context": 262128,
-     "output": 262128
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.6 Flex",
+    "name": "GLM 5.3",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
      }
     ],
-    "release_date": "2026-04-21",
+    "release_date": "2026-08-14",
+    "status": "beta",
+    "structured_output": false,
     "temperature": true,
+    "tool_call": true
+   },
+   "kimi-k2.7-code": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.095,
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+    "family": "kimi-k2",
+    "id": "kimi-k2.7-code",
+    "interleaved": true,
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262128,
+     "output": 262128
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-06-12",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "kimi-k2.7-code-fast": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.095,
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Kimi K2.7 Code with reasoning capped to a short budget for lower latency; reasoning cannot be disabled on this model",
+    "family": "kimi-k2",
+    "id": "kimi-k2.7-code-fast",
+    "interleaved": true,
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262128,
+     "output": 262128
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code Fast",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-06-12",
+    "structured_output": true,
+    "temperature": false,
     "tool_call": true
    },
    "kimi-k2.7-code-flex": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.11875,
-     "input": 0.475,
-     "output": 2
+     "cache_read": 0.06175,
+     "input": 0.6175,
+     "output": 2.6
     },
     "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
     "family": "kimi-k2",
     "id": "kimi-k2.7-code-flex",
+    "interleaved": true,
     "knowledge": "2025-01",
     "last_updated": "2026-06-12",
     "limit": {
-     "context": 262144,
-     "output": 262144
+     "context": 262128,
+     "output": 262128
     },
     "modalities": {
      "input": [
@@ -180312,7 +184476,11 @@
     "name": "Kimi K2.7 Code Flex",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-06-12",
     "structured_output": true,
     "temperature": false,
@@ -180328,9 +184496,7 @@
     "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
     "family": "kimi-k3",
     "id": "kimi-k3",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
+    "interleaved": true,
     "last_updated": "2026-07-16",
     "limit": {
      "context": 1048560,
@@ -180350,15 +184516,16 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
+       "none",
        "low",
        "high",
        "max"
       ]
+     },
+     {
+      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-07-16",
@@ -180398,23 +184565,21 @@
     "temperature": false,
     "tool_call": true
    },
-   "moonshotai/Kimi-K2.5": {
+   "kimi-k3-flex": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.13,
-     "input": 0.52,
-     "output": 2.59
+     "cache_read": 0.195,
+     "input": 1.95,
+     "output": 9.75
     },
-    "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
-    "family": "kimi-k2",
-    "id": "moonshotai/Kimi-K2.5",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-01-27",
+    "description": "Kimi K3 on the flex tier: discounted, best-effort latency, requests may be held under load",
+    "family": "kimi-k3",
+    "id": "kimi-k3-flex",
+    "interleaved": true,
+    "last_updated": "2026-07-16",
     "limit": {
-     "context": 262128,
-     "output": 262128
+     "context": 1048560,
+     "output": 1048560
     },
     "modalities": {
      "input": [
@@ -180425,125 +184590,125 @@
       "text"
      ]
     },
-    "name": "Kimi K2.5",
+    "name": "Kimi K3 Flex",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-01-27",
-    "temperature": true,
-    "tool_call": true
-   },
-   "moonshotai/Kimi-K2.6": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.1725,
-     "input": 0.69,
-     "output": 3.22
-    },
-    "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
-    "family": "kimi-k2",
-    "id": "moonshotai/Kimi-K2.6",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-04-21",
-    "limit": {
-     "context": 262128,
-     "output": 262128
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.6",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     },
      {
-      "type": "toggle"
+      "type": "budget_tokens"
      }
     ],
-    "release_date": "2026-04-21",
-    "temperature": true,
-    "tool_call": true
-   },
-   "moonshotai/Kimi-K2.7-Code": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.2375,
-     "input": 0.95,
-     "output": 4
-    },
-    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
-    "family": "kimi-k2",
-    "id": "moonshotai/Kimi-K2.7-Code",
-    "knowledge": "2025-01",
-    "last_updated": "2026-06-12",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.7 Code",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-06-12",
+    "release_date": "2026-07-16",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
    },
-   "qwen3.5-397b-fast": {
-    "attachment": false,
+   "qwen-3.8-27b": {
+    "attachment": true,
     "cost": {
-     "cache_read": 0.1725,
-     "input": 0.69,
-     "output": 4.14
+     "cache_read": 0.25,
+     "input": 0.45,
+     "output": 3.2
     },
-    "description": "Efficient Qwen model for fast chat, extraction, and high-volume workloads",
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
     "family": "qwen",
-    "id": "qwen3.5-397b-fast",
-    "last_updated": "2026-02-01",
+    "id": "qwen-3.8-27b",
+    "interleaved": true,
+    "last_updated": "2026-08-14",
     "limit": {
      "context": 262128,
-     "output": 262128
+     "output": 65536
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
      ]
     },
-    "name": "Qwen3.5 397B Fast",
+    "name": "Qwen3.8 27B",
     "open_weights": true,
-    "reasoning": false,
-    "release_date": "2026-02-01",
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-14",
+    "status": "beta",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.6-35b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.029,
+     "input": 0.29,
+     "output": 1.15
+    },
+    "description": "Open multimodal Qwen MoE for local agents that need vision, audio, and code",
+    "family": "qwen",
+    "id": "qwen3.6-35b",
+    "interleaved": true,
+    "last_updated": "2026-04-17",
+    "limit": {
+     "context": 131056,
+     "output": 131056
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.6 35B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-04-17",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
    "qwen3.6-35b-fast": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0725,
+     "cache_read": 0.029,
      "input": 0.29,
      "output": 1.15
     },
@@ -180568,6 +184733,7 @@
     "open_weights": true,
     "reasoning": false,
     "release_date": "2026-04-01",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    }
@@ -184579,6 +188745,49 @@
      }
     ],
     "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-ai/deepseek-v4-pro-0813": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "deepseek-ai/deepseek-v4-pro-0813",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -189718,8 +193927,8 @@
     "id": "minimax/m2-her",
     "last_updated": "2026-01-23",
     "limit": {
-     "context": 200000,
-     "output": 131000
+     "context": 65536,
+     "output": 2048
     },
     "modalities": {
      "input": [
@@ -189750,8 +193959,8 @@
     "id": "minimax/minimax-m2",
     "last_updated": "2025-10-27",
     "limit": {
-     "context": 196608,
-     "output": 128000
+     "context": 204800,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -189973,8 +194182,8 @@
     "id": "minimax/minimax-m3",
     "last_updated": "2026-06-01",
     "limit": {
-     "context": 512000,
-     "output": 128000
+     "context": 1048576,
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -190513,7 +194722,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.1-codex-max": {
@@ -190659,7 +194868,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2-codex": {
@@ -190760,7 +194969,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4": {
@@ -190811,7 +195020,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -190861,7 +195070,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -190911,7 +195120,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-pro": {
@@ -191203,11 +195412,12 @@
      }
     ],
     "release_date": "2025-10-15",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
    "volcengine/doubao-seed-1-6-flash": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.0043,
      "input": 0.03,
@@ -191223,7 +195433,8 @@
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
@@ -191233,6 +195444,7 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2025-08-28",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -191264,11 +195476,12 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2025-08-15",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
    "volcengine/doubao-seed-1-8": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.023,
      "input": 0.12,
@@ -191284,7 +195497,8 @@
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
@@ -191299,6 +195513,7 @@
      }
     ],
     "release_date": "2025-12-28",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -191376,6 +195591,7 @@
      }
     ],
     "release_date": "2026-02-14",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -191414,6 +195630,7 @@
      }
     ],
     "release_date": "2026-02-14",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -191452,6 +195669,7 @@
      }
     ],
     "release_date": "2026-02-14",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -191490,6 +195708,7 @@
      }
     ],
     "release_date": "2026-06-23",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -191528,6 +195747,7 @@
      }
     ],
     "release_date": "2026-06-23",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -191566,6 +195786,7 @@
      }
     ],
     "release_date": "2026-06-23",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -191604,6 +195825,7 @@
      }
     ],
     "release_date": "2026-06-23",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -192082,7 +196304,7 @@
      ]
     },
     "name": "GLM-5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -192095,6 +196317,50 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "z-ai/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -192357,6 +196623,87 @@
      }
     ],
     "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3": {
+    "attachment": false,
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -193431,7 +197778,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.2": {
@@ -193477,7 +197824,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.2-chat-latest": {
@@ -193641,7 +197988,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.3-codex-spark": {
@@ -193767,7 +198114,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -193829,7 +198176,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-nano": {
@@ -193875,7 +198222,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-pro": {
@@ -194075,22 +198422,22 @@
    "gpt-5.6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
+     "cache_read": 0.4,
+     "cache_write": 5,
      "context_over_200k": {
-      "cache_read": 1,
-      "cache_write": 12.5,
-      "input": 10,
-      "output": 45
+      "cache_read": 0.8,
+      "cache_write": 10,
+      "input": 8,
+      "output": 30
      },
-     "input": 5,
-     "output": 30,
+     "input": 4,
+     "output": 20,
      "tiers": [
       {
-       "cache_read": 1,
-       "cache_write": 12.5,
-       "input": 10,
-       "output": 45,
+       "cache_read": 0.8,
+       "cache_write": 10,
+       "input": 8,
+       "output": 30,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -194103,10 +198450,10 @@
      "modes": {
       "fast": {
        "cost": {
-        "cache_read": 1,
-        "cache_write": 12.5,
-        "input": 10,
-        "output": 60
+        "cache_read": 0.8,
+        "cache_write": 10,
+        "input": 8,
+        "output": 40
        },
        "provider": {
         "body": {
@@ -194261,22 +198608,22 @@
    "gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
-     "cache_write": 6.25,
+     "cache_read": 0.4,
+     "cache_write": 5,
      "context_over_200k": {
-      "cache_read": 1,
-      "cache_write": 12.5,
-      "input": 10,
-      "output": 45
+      "cache_read": 0.8,
+      "cache_write": 10,
+      "input": 8,
+      "output": 30
      },
-     "input": 5,
-     "output": 30,
+     "input": 4,
+     "output": 20,
      "tiers": [
       {
-       "cache_read": 1,
-       "cache_write": 12.5,
-       "input": 10,
-       "output": 45,
+       "cache_read": 0.8,
+       "cache_write": 10,
+       "input": 8,
+       "output": 30,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -194289,10 +198636,10 @@
      "modes": {
       "fast": {
        "cost": {
-        "cache_read": 1,
-        "cache_write": 12.5,
-        "input": 10,
-        "output": 60
+        "cache_read": 0.8,
+        "cache_write": 10,
+        "input": 8,
+        "output": 40
        },
        "provider": {
         "body": {
@@ -197052,7 +201399,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -197530,9 +201877,9 @@
    "grok-4.5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
+     "cache_read": 0.3,
      "context_over_200k": {
-      "cache_read": 1,
+      "cache_read": 0.6,
       "input": 4,
       "output": 12
      },
@@ -197540,7 +201887,7 @@
      "output": 6,
      "tiers": [
       {
-       "cache_read": 1,
+       "cache_read": 0.6,
        "input": 4,
        "output": 12,
        "tier": {
@@ -197764,6 +202111,7 @@
      }
     ],
     "release_date": "2026-07-06",
+    "status": "deprecated",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -198145,6 +202493,42 @@
     "reasoning": false,
     "release_date": "2026-04-21",
     "status": "deprecated",
+    "temperature": true,
+    "tool_call": true
+   },
+   "ling-3.0-flash-fin-free": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Finance-enhanced model for financial research, multi-step investment workflows, and long-horizon planning and execution",
+    "family": "ling",
+    "id": "ling-3.0-flash-fin-free",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ling 3.0 Flash Fin Free",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-27",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -199192,6 +203576,7 @@
      }
     ],
     "release_date": "2026-08-21",
+    "status": "deprecated",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -199486,7 +203871,7 @@
      ]
     },
     "name": "GLM-5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -199499,6 +203884,53 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash (2x usage)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -199576,9 +204008,9 @@
    "grok-4.5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.5,
+     "cache_read": 0.3,
      "context_over_200k": {
-      "cache_read": 1,
+      "cache_read": 0.6,
       "input": 4,
       "output": 12
      },
@@ -199586,7 +204018,7 @@
      "output": 6,
      "tiers": [
       {
-       "cache_read": 1,
+       "cache_read": 0.6,
        "input": 4,
        "output": 12,
        "tier": {
@@ -199630,6 +204062,70 @@
      }
     ],
     "release_date": "2026-07-08",
+    "status": "deprecated",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "grok-4.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "context_over_200k": {
+      "cache_read": 1,
+      "input": 4,
+      "output": 12
+     },
+     "input": 2,
+     "output": 6,
+     "tiers": [
+      {
+       "cache_read": 1,
+       "input": 4,
+       "output": 12,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "grok-4.6",
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -199637,9 +204133,9 @@
    "hy3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.004375,
-     "input": 0.0175,
-     "output": 0.0725
+     "cache_read": 0.035,
+     "input": 0.14,
+     "output": 0.58
     },
     "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
     "family": "Hy",
@@ -199657,7 +204153,7 @@
       "text"
      ]
     },
-    "name": "Hy3 (8x usage)",
+    "name": "Hy3",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -199671,6 +204167,45 @@
      }
     ],
     "release_date": "2026-07-06",
+    "temperature": true,
+    "tool_call": true
+   },
+   "hy4-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.042,
+     "input": 0.834,
+     "output": 2.501
+    },
+    "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+    "family": "Hy",
+    "id": "hy4-preview",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 1024000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy4 preview",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-28",
     "temperature": true,
     "tool_call": true
    },
@@ -199829,6 +204364,44 @@
     "release_date": "2026-07-16",
     "structured_output": true,
     "temperature": false,
+    "tool_call": true
+   },
+   "longcat-2.0": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.006,
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "Meituan LongCat-2.0, a reasoning model with tool calling and a 1M-token context window",
+    "family": "longcat",
+    "id": "longcat-2.0",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-30",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "LongCat-2.0",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-30",
+    "temperature": true,
     "tool_call": true
    },
    "mimo-v2-omni": {
@@ -200214,6 +204787,7 @@
      }
     ],
     "release_date": "2026-08-21",
+    "status": "deprecated",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -200423,6 +204997,59 @@
     "temperature": true,
     "tool_call": true
    },
+   "qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.15,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/anthropic"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "qwen3.8-max": {
     "attachment": true,
     "cost": {
@@ -200457,6 +205084,14 @@
       "type": "toggle"
      },
      {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
       "max": 262144,
       "type": "budget_tokens"
      }
@@ -200468,6 +205103,149 @@
    }
   },
   "name": "OpenCode Go",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "openreason": {
+  "api": "https://api.openreason.app/v1",
+  "doc": "https://openreason.app/docs",
+  "env": [
+   "OPENREASON_API_KEY"
+  ],
+  "id": "openreason",
+  "models": {
+   "deepseek-ai/deepseek-v4-flash-0731": {
+    "attachment": false,
+    "cost": {
+     "input": 0.1371,
+     "output": 0.2743
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "deepseek-ai/deepseek-v4-flash-0731",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "moonshotai/kimi-k2.7-code": {
+    "attachment": true,
+    "cost": {
+     "input": 1.0022,
+     "output": 4.22
+    },
+    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+    "family": "kimi-k2",
+    "id": "moonshotai/kimi-k2.7-code",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-oss-120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.1055,
+     "output": 0.422
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "openai/gpt-oss-120b",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "OpenReason",
   "npm": "@ai-sdk/openai-compatible"
  },
  "openrouter": {
@@ -200584,7 +205362,7 @@
     "last_updated": "2025-02-04",
     "limit": {
      "context": 32768,
-     "output": 32768
+     "output": 29491
     },
     "modalities": {
      "input": [
@@ -200599,37 +205377,6 @@
     "reasoning": false,
     "release_date": "2025-02-04",
     "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "allenai/olmo-3-32b-think": {
-    "attachment": false,
-    "cost": {
-     "input": 0.15,
-     "output": 0.5
-    },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "allenai",
-    "id": "allenai/olmo-3-32b-think",
-    "last_updated": "2025-11-21",
-    "limit": {
-     "context": 65536,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Olmo 3 32B Think",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-11-21",
-    "structured_output": true,
     "temperature": true,
     "tool_call": false
    },
@@ -200661,7 +205408,11 @@
     "name": "Nova 2 Lite",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-12-02",
     "structured_output": false,
     "temperature": true,
@@ -200938,11 +205689,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 63999,
-      "min": 1024,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2025-10-15",
@@ -200983,11 +205729,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 31999,
-      "min": 1024,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2025-05-22",
@@ -201028,11 +205769,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 31999,
-      "min": 1024,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2025-08-05",
@@ -201073,19 +205809,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     },
-     {
-      "max": 63999,
-      "min": 1024,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2025-11-24",
@@ -201532,11 +206255,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 63999,
-      "min": 1024,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2025-05-22",
@@ -201595,11 +206313,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 63999,
-      "min": 1024,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2025-09-29",
@@ -201728,8 +206441,8 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.06,
-     "input": 0.22,
-     "output": 0.85
+     "input": 0.25,
+     "output": 0.8
     },
     "description": "Reasoning-optimized 398B MoE agent model with extended thinking for long-horizon and multi-turn tool use",
     "family": "trinity",
@@ -201737,7 +206450,7 @@
     "last_updated": "2026-05-28",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 80000
     },
     "modalities": {
      "input": [
@@ -201753,36 +206466,6 @@
     "reasoning_options": [],
     "release_date": "2026-04-01",
     "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "arcee-ai/virtuoso-large": {
-    "attachment": false,
-    "cost": {
-     "input": 0.75,
-     "output": 1.2
-    },
-    "description": "Flagship model for demanding analysis, coding, and production agent workflows",
-    "id": "arcee-ai/virtuoso-large",
-    "knowledge": "2025-03-31",
-    "last_updated": "2025-05-05",
-    "limit": {
-     "context": 131072,
-     "output": 64000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Virtuoso Large",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-05-05",
-    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -201813,7 +206496,11 @@
     "name": "ERNIE 4.5 VL 424B A47B ",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-06-30",
     "structured_output": false,
     "temperature": true,
@@ -201856,7 +206543,11 @@
     "name": "Seed 1.6",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-12-23",
     "structured_output": true,
     "temperature": true,
@@ -201899,7 +206590,11 @@
     "name": "Seed 1.6 Flash",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-12-23",
     "structured_output": true,
     "temperature": true,
@@ -201917,7 +206612,7 @@
     "last_updated": "2026-08-12",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -201932,7 +206627,11 @@
     "name": "Seed 2.1 Turbo",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-08-12",
     "structured_output": true,
     "temperature": true,
@@ -202317,7 +207016,11 @@
     "name": "North Mini Code (free)",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-06-17",
     "structured_output": false,
     "temperature": true,
@@ -202367,7 +207070,7 @@
     "last_updated": "2025-03-24",
     "limit": {
      "context": 163840,
-     "output": 163840
+     "output": 147456
     },
     "modalities": {
      "input": [
@@ -202399,7 +207102,7 @@
     "last_updated": "2025-08-21",
     "limit": {
      "context": 163840,
-     "output": 161000
+     "output": 144900
     },
     "modalities": {
      "input": [
@@ -202500,7 +207203,7 @@
     "last_updated": "2025-01-23",
     "limit": {
      "context": 8192,
-     "output": 8192
+     "output": 7372
     },
     "modalities": {
      "input": [
@@ -202513,7 +207216,11 @@
     "name": "R1 Distill Llama 70B",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-01-23",
     "structured_output": false,
     "temperature": true,
@@ -202559,9 +207266,9 @@
    "deepseek/deepseek-v3.2": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.13,
-     "input": 0.26,
-     "output": 0.38
+     "cache_read": 0.1345,
+     "input": 0.269,
+     "output": 0.4
     },
     "description": "DeepSeek chat model for instruction following, coding, and analysis",
     "family": "deepseek",
@@ -202570,7 +207277,7 @@
     "last_updated": "2025-12-01",
     "limit": {
      "context": 163840,
-     "output": 163840
+     "output": 65536
     },
     "modalities": {
      "input": [
@@ -202632,9 +207339,9 @@
    "deepseek/deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.010892,
-     "input": 0.05446,
-     "output": 0.10892
+     "cache_read": 0.016492,
+     "input": 0.08246,
+     "output": 0.16492
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -202680,7 +207387,7 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.016,
-     "input": 0.08,
+     "input": 0.065,
      "output": 0.18
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
@@ -202690,7 +207397,7 @@
     "last_updated": "2026-07-31",
     "limit": {
      "context": 1310720,
-     "output": 384000
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -202769,9 +207476,9 @@
    "deepseek/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.034481,
-     "input": 0.413772,
-     "output": 0.827544
+     "cache_read": 0.086188,
+     "input": 1.034256,
+     "output": 2.068512
     },
     "description": "Open MoE flagship with million-token context for coding and long agent runs",
     "family": "deepseek-thinking",
@@ -202816,9 +207523,9 @@
    "deepseek/deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0374,
-     "input": 1.122,
-     "output": 3.366
+     "cache_read": 0.022,
+     "input": 0.66,
+     "output": 1.98
     },
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
@@ -202868,7 +207575,7 @@
     "last_updated": "2026-08-14",
     "limit": {
      "context": 512000,
-     "output": 512000
+     "output": 460800
     },
     "modalities": {
      "input": [
@@ -202882,7 +207589,11 @@
     "name": "Dots3-Note Preview (free)",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
@@ -202924,11 +207635,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 24576,
-      "min": 0,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2025-06-17",
@@ -203007,11 +207713,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 24576,
-      "min": 512,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2025-06-17",
@@ -203388,7 +208089,7 @@
     "last_updated": "2026-02-26",
     "limit": {
      "context": 65536,
-     "output": 65536
+     "output": 58982
     },
     "modalities": {
      "input": [
@@ -203485,7 +208186,7 @@
     "last_updated": "2026-06-30",
     "limit": {
      "context": 65536,
-     "output": 65536
+     "output": 58982
     },
     "modalities": {
      "input": [
@@ -203853,11 +208554,11 @@
    "google/gemini-3.7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0375,
-     "cache_write": 0.020833,
-     "input": 0.375,
-     "output": 1.875,
-     "reasoning": 1.875
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -203974,8 +208675,8 @@
     "knowledge": "2024-08-31",
     "last_updated": "2025-03-12",
     "limit": {
-     "context": 262144,
-     "output": 131072
+     "context": 131072,
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -204022,37 +208723,6 @@
     "open_weights": true,
     "reasoning": false,
     "release_date": "2025-03-13",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
-   "google/gemma-3n-e4b-it": {
-    "attachment": false,
-    "cost": {
-     "input": 0.06,
-     "output": 0.12
-    },
-    "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
-    "family": "gemma",
-    "id": "google/gemma-3n-e4b-it",
-    "knowledge": "2024-08-31",
-    "last_updated": "2025-05-20",
-    "limit": {
-     "context": 32768,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Gemma 3n 4B",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-05-20",
     "structured_output": true,
     "temperature": true,
     "tool_call": false
@@ -204134,8 +208804,8 @@
    "google/gemma-4-31b-it": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
-     "input": 0.1,
+     "cache_read": 0.05,
+     "input": 0.09,
      "output": 0.34
     },
     "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
@@ -204144,7 +208814,7 @@
     "last_updated": "2026-04-02",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -204282,7 +208952,7 @@
     "last_updated": "2023-07-02",
     "limit": {
      "context": 8192,
-     "output": 4096
+     "output": 3686
     },
     "modalities": {
      "input": [
@@ -204312,7 +208982,7 @@
     "last_updated": "2025-10-20",
     "limit": {
      "context": 131000,
-     "output": 131000
+     "output": 117900
     },
     "modalities": {
      "input": [
@@ -204343,7 +209013,7 @@
     "last_updated": "2026-04-30",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -204403,68 +209073,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "inclusionai/ling-2.6-1t": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.015,
-     "input": 0.075,
-     "output": 0.625
-    },
-    "description": "Tool-capable chat model for instruction following and agentic application workflows",
-    "family": "ling",
-    "id": "inclusionai/ling-2.6-1t",
-    "last_updated": "2026-04-23",
-    "limit": {
-     "context": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ling-2.6-1T",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-04-23",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "inclusionai/ling-2.6-flash": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.002,
-     "input": 0.01,
-     "output": 0.03
-    },
-    "description": "Efficient model for low-latency assistance, extraction, and routine automation",
-    "family": "ling",
-    "id": "inclusionai/ling-2.6-flash",
-    "last_updated": "2026-04-21",
-    "limit": {
-     "context": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ling-2.6-flash",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-04-21",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "inclusionai/ling-3.0-flash": {
     "attachment": false,
     "cost": {
@@ -204491,26 +209099,29 @@
     "name": "Ling-3.0-flash",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-07-23",
     "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
-   "inclusionai/ring-2.6-1t": {
+   "inclusionai/ling-3.0-flash-fin:free": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.015,
-     "input": 0.075,
-     "output": 0.625
+     "input": 0,
+     "output": 0
     },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "ring",
-    "id": "inclusionai/ring-2.6-1t",
-    "last_updated": "2026-05-08",
+    "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+    "family": "ling",
+    "id": "inclusionai/ling-3.0-flash-fin:free",
+    "last_updated": "2026-08-27",
     "limit": {
      "context": 262144,
-     "output": 65536
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -204520,51 +209131,16 @@
       "text"
      ]
     },
-    "name": "Ring-2.6-1T",
+    "name": "Ling 3.0 Flash Fin (free)",
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "effort",
-      "values": [
-       "high",
-       "xhigh"
-      ]
+      "type": "toggle"
      }
     ],
-    "release_date": "2026-05-08",
+    "release_date": "2026-08-27",
     "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "kwaipilot/kat-coder-air-v2.5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.03,
-     "input": 0.15,
-     "output": 0.6
-    },
-    "description": "Coding model for repository understanding, refactors, and agentic engineering tasks",
-    "family": "kat-coder",
-    "id": "kwaipilot/kat-coder-air-v2.5",
-    "last_updated": "2026-07-10",
-    "limit": {
-     "context": 256000,
-     "output": 80000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "KAT-Coder-Air V2.5",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-07-10",
-    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -204581,7 +209157,7 @@
     "last_updated": "2026-03-27",
     "limit": {
      "context": 262144,
-     "output": 80000
+     "output": 144000
     },
     "modalities": {
      "input": [
@@ -204611,8 +209187,8 @@
     "id": "kwaipilot/kat-coder-pro-v2.5",
     "last_updated": "2026-07-10",
     "limit": {
-     "context": 256000,
-     "output": 80000
+     "context": 262144,
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -204720,6 +209296,9 @@
     "reasoning": true,
     "reasoning_options": [
      {
+      "type": "toggle"
+     },
+     {
       "type": "budget_tokens"
      }
     ],
@@ -204773,7 +209352,7 @@
     "last_updated": "2024-07-23",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -204804,7 +209383,7 @@
     "last_updated": "2024-09-25",
     "limit": {
      "context": 60000,
-     "output": 60000
+     "output": 54000
     },
     "modalities": {
      "input": [
@@ -204835,7 +209414,7 @@
     "last_updated": "2024-09-25",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -204856,8 +209435,9 @@
    "meta-llama/llama-3.3-70b-instruct": {
     "attachment": false,
     "cost": {
-     "input": 0.1,
-     "output": 0.32
+     "cache_read": 0.71,
+     "input": 0.71,
+     "output": 0.71
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
     "family": "llama",
@@ -204866,7 +209446,7 @@
     "last_updated": "2024-12-06",
     "limit": {
      "context": 131072,
-     "output": 16384
+     "output": 115200
     },
     "modalities": {
      "input": [
@@ -204888,7 +209468,7 @@
     "attachment": true,
     "cost": {
      "input": 0.2,
-     "output": 0.8
+     "output": 0.696
     },
     "description": "Open multimodal Llama model for strong reasoning and fast responses",
     "family": "llama",
@@ -204897,7 +209477,7 @@
     "last_updated": "2025-04-05",
     "limit": {
      "context": 1048576,
-     "output": 16384
+     "output": 115200
     },
     "modalities": {
      "input": [
@@ -204919,8 +209499,9 @@
    "meta-llama/llama-4-scout": {
     "attachment": true,
     "cost": {
-     "input": 0.1,
-     "output": 0.3
+     "cache_read": 0.055,
+     "input": 0.11,
+     "output": 0.34
     },
     "description": "Open multimodal Llama model for long-context analysis and efficient agents",
     "family": "llama",
@@ -204929,7 +209510,7 @@
     "last_updated": "2025-04-05",
     "limit": {
      "context": 1310720,
-     "output": 16384
+     "output": 8192
     },
     "modalities": {
      "input": [
@@ -204960,7 +209541,7 @@
     "knowledge": "2024-08-31",
     "last_updated": "2025-04-30",
     "limit": {
-     "context": 1048576,
+     "context": 163840,
      "output": 16384
     },
     "modalities": {
@@ -204984,8 +209565,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.04,
-     "input": 0.35,
-     "output": 1.5
+     "input": 0.3,
+     "output": 1.2
     },
     "description": "Muse Glimmer is a 30-billion-parameter open-weight multimodal model from Meta Superintelligence Labs, distilled from Muse Spark for always-on local agents, tool use, coding, and image understanding.",
     "family": "muse",
@@ -204994,7 +209575,7 @@
     "last_updated": "2026-08-10",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -205037,7 +209618,7 @@
     "last_updated": "2026-07-09",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -205084,7 +209665,7 @@
     "last_updated": "2026-08-05",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -205131,7 +209712,7 @@
     "last_updated": "2026-08-21",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -205178,7 +209759,7 @@
     "last_updated": "2025-01-10",
     "limit": {
      "context": 16384,
-     "output": 16384
+     "output": 14745
     },
     "modalities": {
      "input": [
@@ -205239,7 +209820,7 @@
     "last_updated": "2025-01-15",
     "limit": {
      "context": 1000192,
-     "output": 1000192
+     "output": 900172
     },
     "modalities": {
      "input": [
@@ -205284,7 +209865,11 @@
     "name": "MiniMax M1",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-06-17",
     "structured_output": false,
     "temperature": true,
@@ -205457,6 +210042,37 @@
     "temperature": true,
     "tool_call": true
    },
+   "minimax/minimax-m2.7:free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "MiniMax model for chat, coding, office work, and agentic tasks",
+    "family": "minimax",
+    "id": "minimax/minimax-m2.7:free",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 196608,
+     "output": 176947
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M2.7 (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-03-18",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "minimax/minimax-m3": {
     "attachment": true,
     "cost": {
@@ -205485,9 +210101,50 @@
     "name": "MiniMax-M3",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-06-01",
     "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m3:free": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "MiniMax multimodal coding model for long-context reasoning and agent tasks",
+    "family": "minimax",
+    "id": "minimax/minimax-m3:free",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 1048576,
+     "output": 943718
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M3 (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-01",
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -205505,7 +210162,7 @@
     "last_updated": "2025-08-01",
     "limit": {
      "context": 256000,
-     "output": 256000
+     "output": 204800
     },
     "modalities": {
      "input": [
@@ -205524,6 +210181,39 @@
     "temperature": true,
     "tool_call": true
    },
+   "mistralai/devstral-2512": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.04,
+     "input": 0.4,
+     "output": 2
+    },
+    "description": "Mistral coding agent model for repository tasks and software engineering workflows",
+    "family": "devstral",
+    "id": "mistralai/devstral-2512",
+    "knowledge": "2025-12",
+    "last_updated": "2025-12-09",
+    "limit": {
+     "context": 262144,
+     "output": 209715
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Devstral 2",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-12-09",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "mistralai/ministral-14b-2512": {
     "attachment": true,
     "cost": {
@@ -205537,7 +210227,7 @@
     "last_updated": "2025-12-02",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 209715
     },
     "modalities": {
      "input": [
@@ -205569,7 +210259,7 @@
     "last_updated": "2025-12-02",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 104857
     },
     "modalities": {
      "input": [
@@ -205588,37 +210278,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "mistralai/ministral-8b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.11,
-     "output": 0.11
-    },
-    "description": "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads",
-    "family": "ministral",
-    "id": "mistralai/ministral-8b",
-    "knowledge": "2024-09-30",
-    "last_updated": "2024-10-17",
-    "limit": {
-     "context": 128000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ministral 8B",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-10-17",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
    "mistralai/ministral-8b-2512": {
     "attachment": true,
     "cost": {
@@ -205632,7 +210291,7 @@
     "last_updated": "2025-12-02",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 209715
     },
     "modalities": {
      "input": [
@@ -205665,7 +210324,7 @@
     "last_updated": "2024-02-26",
     "limit": {
      "context": 128000,
-     "output": 128000
+     "output": 102400
     },
     "modalities": {
      "input": [
@@ -205698,7 +210357,7 @@
     "last_updated": "2024-11-19",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 104857
     },
     "modalities": {
      "input": [
@@ -205731,7 +210390,7 @@
     "last_updated": "2025-12-02",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 209715
     },
     "modalities": {
      "input": [
@@ -205765,7 +210424,7 @@
     "last_updated": "2025-05-07",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 104857
     },
     "modalities": {
      "input": [
@@ -205797,7 +210456,7 @@
     "last_updated": "2026-04-30",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 209715
     },
     "modalities": {
      "input": [
@@ -205840,7 +210499,7 @@
     "last_updated": "2025-08-13",
     "limit": {
      "context": 131072,
-     "output": 262144
+     "output": 104857
     },
     "modalities": {
      "input": [
@@ -205905,7 +210564,7 @@
     "last_updated": "2025-02-17",
     "limit": {
      "context": 32768,
-     "output": 32768
+     "output": 26214
     },
     "modalities": {
      "input": [
@@ -205969,7 +210628,7 @@
     "last_updated": "2026-03-16",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 209715
     },
     "modalities": {
      "input": [
@@ -206010,7 +210669,7 @@
     "last_updated": "2025-03-17",
     "limit": {
      "context": 128000,
-     "output": 128000
+     "output": 102400
     },
     "modalities": {
      "input": [
@@ -206075,7 +210734,7 @@
     "last_updated": "2024-04-17",
     "limit": {
      "context": 65536,
-     "output": 65536
+     "output": 52428
     },
     "modalities": {
      "input": [
@@ -206106,8 +210765,8 @@
     "id": "mistralai/voxtral-small-24b-2507",
     "last_updated": "2025-10-30",
     "limit": {
-     "context": 32000,
-     "output": 32000
+     "context": 32768,
+     "output": 26214
     },
     "modalities": {
      "input": [
@@ -206242,7 +210901,7 @@
     "last_updated": "2026-01",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -206256,7 +210915,11 @@
     "name": "Kimi K2.5",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-01",
     "structured_output": true,
     "temperature": true,
@@ -206279,7 +210942,7 @@
     "last_updated": "2026-04-21",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -206293,7 +210956,11 @@
     "name": "Kimi K2.6",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-04-21",
     "structured_output": true,
     "temperature": true,
@@ -206302,8 +210969,8 @@
    "moonshotai/kimi-k2.7-code": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.17,
-     "input": 0.67,
+     "cache_read": 0.18,
+     "input": 0.66,
      "output": 3.4
     },
     "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
@@ -206313,7 +210980,7 @@
     "last_updated": "2026-06-12",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -206346,7 +211013,7 @@
     "last_updated": "2026-07-16",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -206452,7 +211119,7 @@
     "last_updated": "2026-06-24",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -206466,7 +211133,11 @@
     "name": "Nex-N2-Mini",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-06-24",
     "structured_output": true,
     "temperature": true,
@@ -206485,7 +211156,7 @@
     "last_updated": "2026-06-08",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -206499,7 +211170,11 @@
     "name": "Nex-N2-Pro",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-06-08",
     "structured_output": false,
     "temperature": true,
@@ -206580,7 +211255,7 @@
     "last_updated": "2025-08-26",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -206616,7 +211291,7 @@
     "last_updated": "2025-08-26",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -206642,7 +211317,7 @@
    "nvidia/nemotron-3-nano-30b-a3b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.03,
+     "cache_read": 0.025,
      "input": 0.05,
      "output": 0.2
     },
@@ -206652,7 +211327,7 @@
     "last_updated": "2025-12-15",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 228000
     },
     "modalities": {
      "input": [
@@ -206665,40 +211340,13 @@
     "name": "Nemotron 3 Nano 30B A3B",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-12-15",
     "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nvidia/nemotron-3-nano-30b-a3b:free": {
-    "attachment": false,
-    "cost": {
-     "input": 0,
-     "output": 0
-    },
-    "description": "Small Nemotron 3 MoE for efficient coding, math, and long-context agents",
-    "family": "nemotron",
-    "id": "nvidia/nemotron-3-nano-30b-a3b:free",
-    "last_updated": "2025-12-15",
-    "limit": {
-     "context": 256000,
-     "output": 256000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Nano 30B A3B (free)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-12-15",
-    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -206731,6 +211379,9 @@
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
+     {
+      "type": "toggle"
+     },
      {
       "type": "budget_tokens"
      }
@@ -206797,7 +211448,7 @@
     "last_updated": "2026-03-11",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -206833,16 +211484,16 @@
    "nvidia/nemotron-3-ultra-550b-a55b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.2,
-     "input": 0.6,
-     "output": 3.6
+     "cache_read": 0.1,
+     "input": 0.5,
+     "output": 2.2
     },
     "description": "Largest Nemotron 3 model for maximum open-weight reasoning and agent accuracy",
     "family": "nemotron",
     "id": "nvidia/nemotron-3-ultra-550b-a55b",
     "last_updated": "2026-06-04",
     "limit": {
-     "context": 512288,
+     "context": 262144,
      "output": 16384
     },
     "modalities": {
@@ -206947,7 +211598,11 @@
     "name": "Nemotron 3.5 Content Safety (free)",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-06-04",
     "structured_output": false,
     "temperature": true,
@@ -207024,70 +211679,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "nvidia/nemotron-nano-12b-v2-vl:free": {
-    "attachment": true,
-    "cost": {
-     "input": 0,
-     "output": 0
-    },
-    "description": "Nemotron multimodal model for visual reasoning and agentic AI workflows",
-    "family": "nemotron",
-    "id": "nvidia/nemotron-nano-12b-v2-vl:free",
-    "last_updated": "2025-10-28",
-    "limit": {
-     "context": 128000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron Nano 12B 2 VL (free)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-10-28",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nvidia/nemotron-nano-9b-v2:free": {
-    "attachment": false,
-    "cost": {
-     "input": 0,
-     "output": 0
-    },
-    "description": "Compact Nemotron model for efficient reasoning and deployable AI agents",
-    "family": "nemotron",
-    "id": "nvidia/nemotron-nano-9b-v2:free",
-    "last_updated": "2025-08-18",
-    "limit": {
-     "context": 128000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron Nano 9B V2 (free)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-08-18",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "openai/gpt-3.5-turbo": {
     "attachment": false,
     "cost": {
@@ -207132,7 +211723,7 @@
     "last_updated": "2024-01-25",
     "limit": {
      "context": 4095,
-     "output": 4096
+     "output": 3685
     },
     "modalities": {
      "input": [
@@ -207194,7 +211785,7 @@
     "last_updated": "2023-09-28",
     "limit": {
      "context": 4095,
-     "output": 4096
+     "output": 3685
     },
     "modalities": {
      "input": [
@@ -209154,7 +213745,7 @@
     "last_updated": "2025-08-05",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -209195,7 +213786,7 @@
     "last_updated": "2025-08-05",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -209295,12 +213886,7 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
+      "type": "toggle"
      }
     ],
     "release_date": "2024-12-05",
@@ -209336,7 +213922,11 @@
     "name": "o1-pro",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-03-19",
     "structured_output": true,
     "temperature": false,
@@ -209373,12 +213963,7 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
+      "type": "toggle"
      }
     ],
     "release_date": "2025-04-16",
@@ -209416,12 +214001,7 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
+      "type": "toggle"
      }
     ],
     "release_date": "2024-12-20",
@@ -209500,12 +214080,7 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
+      "type": "toggle"
      }
     ],
     "release_date": "2025-06-10",
@@ -209544,12 +214119,7 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
+      "type": "toggle"
      }
     ],
     "release_date": "2025-04-16",
@@ -209764,7 +214334,11 @@
     "name": "Perceptron Mk1",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-05-12",
     "structured_output": true,
     "temperature": true,
@@ -209782,7 +214356,7 @@
     "last_updated": "2025-01-27",
     "limit": {
      "context": 127072,
-     "output": 127072
+     "output": 114364
     },
     "modalities": {
      "input": [
@@ -209814,7 +214388,7 @@
     "last_updated": "2025-03-07",
     "limit": {
      "context": 128000,
-     "output": 128000
+     "output": 115200
     },
     "modalities": {
      "input": [
@@ -209827,7 +214401,11 @@
     "name": "Sonar Deep Research",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-03-07",
     "structured_output": false,
     "temperature": true,
@@ -209908,7 +214486,7 @@
     "last_updated": "2025-03-07",
     "limit": {
      "context": 128000,
-     "output": 128000
+     "output": 115200
     },
     "modalities": {
      "input": [
@@ -209922,7 +214500,11 @@
     "name": "Sonar Reasoning Pro",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-03-07",
     "structured_output": false,
     "temperature": true,
@@ -209954,7 +214536,11 @@
     "name": "Laguna S 2.1",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-07-21",
     "structured_output": false,
     "temperature": true,
@@ -209985,7 +214571,11 @@
     "name": "Laguna S 2.1 (free)",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-07-21",
     "structured_output": false,
     "temperature": true,
@@ -210017,7 +214607,11 @@
     "name": "Laguna XS 2.1",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-07-02",
     "structured_output": false,
     "temperature": true,
@@ -210048,7 +214642,11 @@
     "name": "Laguna XS 2.1 (free)",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-07-02",
     "structured_output": false,
     "temperature": true,
@@ -210098,7 +214696,7 @@
     "last_updated": "2024-10-16",
     "limit": {
      "context": 32768,
-     "output": 32768
+     "output": 29491
     },
     "modalities": {
      "input": [
@@ -210129,7 +214727,7 @@
     "last_updated": "2024-11-11",
     "limit": {
      "context": 32768,
-     "output": 32768
+     "output": 29491
     },
     "modalities": {
      "input": [
@@ -210243,64 +214841,11 @@
     "temperature": true,
     "tool_call": true
    },
-   "qwen/qwen-plus-2025-07-28:thinking": {
-    "attachment": false,
-    "cost": {
-     "context_over_200k": {
-      "input": 0.78,
-      "output": 2.34
-     },
-     "input": 0.26,
-     "output": 0.78,
-     "tiers": [
-      {
-       "input": 0.78,
-       "output": 2.34,
-       "tier": {
-        "size": 256000,
-        "type": "context"
-       }
-      }
-     ]
-    },
-    "description": "Qwen reasoning model for deliberate problem solving, math, and coding",
-    "family": "qwen",
-    "id": "qwen/qwen-plus-2025-07-28:thinking",
-    "knowledge": "2025-03-31",
-    "last_updated": "2025-09-08",
-    "limit": {
-     "context": 1000000,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen Plus 0728 (thinking)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "max": 81920,
-      "min": 1,
-      "type": "budget_tokens"
-     }
-    ],
-    "release_date": "2025-09-08",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "qwen/qwen2.5-vl-72b-instruct": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.4,
-     "input": 0.8,
-     "output": 1
+     "input": 0.25,
+     "output": 0.75
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -210309,7 +214854,7 @@
     "last_updated": "2025-02-01",
     "limit": {
      "context": 128000,
-     "output": 128000
+     "output": 28800
     },
     "modalities": {
      "input": [
@@ -210393,11 +214938,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 38912,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2025-04",
@@ -210408,8 +214948,9 @@
    "qwen/qwen3-235b-a22b-2507": {
     "attachment": false,
     "cost": {
-     "input": 0.09,
-     "output": 0.55
+     "cache_read": 0.0175,
+     "input": 0.0875,
+     "output": 0.35
     },
     "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
     "family": "qwen",
@@ -210418,7 +214959,7 @@
     "last_updated": "2025-07-21",
     "limit": {
      "context": 262144,
-     "output": 16384
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -210448,8 +214989,8 @@
     "knowledge": "2025-06-30",
     "last_updated": "2025-07-25",
     "limit": {
-     "context": 262144,
-     "output": 32768
+     "context": 131072,
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -210683,7 +215224,7 @@
     "last_updated": "2025-04",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -210770,7 +215311,7 @@
     "last_updated": "2026-02-03",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -210943,9 +215484,7 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "max": 81920,
-      "min": 1,
-      "type": "budget_tokens"
+      "type": "toggle"
      }
     ],
     "release_date": "2026-02-09",
@@ -210956,8 +215495,7 @@
    "qwen/qwen3-next-80b-a3b-instruct": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.07,
-     "input": 0.1,
+     "input": 0.09,
      "output": 1.1
     },
     "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
@@ -210967,7 +215505,7 @@
     "last_updated": "2025-09",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -211086,8 +215624,8 @@
    "qwen/qwen3-vl-30b-a3b-instruct": {
     "attachment": true,
     "cost": {
-     "input": 0.13,
-     "output": 0.52
+     "input": 0.15,
+     "output": 0.6
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -211096,7 +215634,7 @@
     "last_updated": "2025-10-06",
     "limit": {
      "context": 262144,
-     "output": 32768
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -211245,8 +215783,8 @@
    "qwen/qwen3.5-122b-a10b": {
     "attachment": true,
     "cost": {
-     "input": 0.26,
-     "output": 2.08
+     "input": 0.29,
+     "output": 2.4
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -211254,7 +215792,7 @@
     "last_updated": "2026-02-23",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 81920
     },
     "modalities": {
      "input": [
@@ -211329,7 +215867,7 @@
     "last_updated": "2026-02-23",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -211403,7 +215941,7 @@
     "last_updated": "2026-02-23",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -211458,11 +215996,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 81920,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-02-25",
@@ -211515,11 +216048,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 81920,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-02-16",
@@ -211574,11 +216102,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 81920,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-04-27",
@@ -211599,7 +216122,7 @@
     "last_updated": "2026-04-22",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -211628,8 +216151,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.05,
-     "input": 0.14,
-     "output": 1
+     "input": 0.1,
+     "output": 0.9
     },
     "description": "Open multimodal Qwen MoE for local agents that need vision, audio, and code",
     "family": "qwen",
@@ -211637,7 +216160,7 @@
     "last_updated": "2026-04-17",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -211709,11 +216232,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 81920,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-04-27",
@@ -211762,11 +216280,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 131072,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-04-20",
@@ -211822,11 +216335,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 81920,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-04-02",
@@ -211888,6 +216396,9 @@
     "reasoning": true,
     "reasoning_options": [
      {
+      "type": "toggle"
+     },
+     {
       "type": "budget_tokens"
      }
     ],
@@ -211926,11 +216437,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 262144,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-05-21",
@@ -211988,11 +216494,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 262144,
-      "min": 1,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-06-02",
@@ -212003,7 +216504,7 @@
    "qwen/qwen3.8-2.4t-a95b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.25,
+     "cache_read": 0.2,
      "input": 2,
      "output": 6
     },
@@ -212044,9 +216545,10 @@
    "qwen/qwen3.8-27b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.05,
-     "input": 0.4,
-     "output": 3
+     "cache_read": 0.085,
+     "cache_write": 0.53125,
+     "input": 0.425,
+     "output": 2.55
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -212083,6 +216585,48 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.15,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -212145,7 +216689,7 @@
     "last_updated": "2026-03-20",
     "limit": {
      "context": 16384,
-     "output": 16384
+     "output": 14745
     },
     "modalities": {
      "input": [
@@ -212178,7 +216722,7 @@
     "last_updated": "2025-03-12",
     "limit": {
      "context": 65536,
-     "output": 65536
+     "output": 58982
     },
     "modalities": {
      "input": [
@@ -212368,7 +216912,7 @@
     "last_updated": "2024-08-13",
     "limit": {
      "context": 8192,
-     "output": 16384
+     "output": 7372
     },
     "modalities": {
      "input": [
@@ -212448,48 +216992,6 @@
     "temperature": true,
     "tool_call": false
    },
-   "stealth/ox-alpha": {
-    "attachment": true,
-    "cost": {
-     "input": 0,
-     "output": 0
-    },
-    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
-    "family": "alpha",
-    "id": "stealth/ox-alpha",
-    "last_updated": "2026-08-20",
-    "limit": {
-     "context": 1048576,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ox Alpha",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-08-20",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
    "stepfun/step-3.5-flash": {
     "attachment": false,
     "cost": {
@@ -212535,7 +217037,7 @@
     "limit": {
      "context": 262144,
      "input": 256000,
-     "output": 256000
+     "output": 230400
     },
     "modalities": {
      "input": [
@@ -212578,7 +217080,7 @@
     "last_updated": "2025-07-08",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -212591,7 +217093,11 @@
     "name": "Hunyuan A13B Instruct",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-07-08",
     "structured_output": true,
     "temperature": true,
@@ -212690,9 +217196,9 @@
    "tencent/hy3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.033,
-     "input": 0.132,
-     "output": 0.528
+     "cache_read": 0.020625,
+     "input": 0.0825,
+     "output": 0.33
     },
     "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
     "family": "Hy",
@@ -212741,7 +217247,7 @@
     "last_updated": "2026-04-20",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -212769,6 +217275,47 @@
     "temperature": true,
     "tool_call": true
    },
+   "tencent/hy4-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.042,
+     "input": 0.834,
+     "output": 2.501
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "tencent/hy4-preview",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 1048576,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy4 preview",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-28",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "thedrummer/cydonia-24b-v4.1": {
     "attachment": false,
     "cost": {
@@ -212782,7 +217329,7 @@
     "last_updated": "2025-09-27",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -212800,36 +217347,6 @@
     "temperature": true,
     "tool_call": false
    },
-   "thedrummer/rocinante-12b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.25,
-     "output": 0.5
-    },
-    "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
-    "id": "thedrummer/rocinante-12b",
-    "knowledge": "2024-04-30",
-    "last_updated": "2024-09-30",
-    "limit": {
-     "context": 65536,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Rocinante 12B",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-09-30",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
    "thedrummer/skyfall-36b-v2": {
     "attachment": false,
     "cost": {
@@ -212843,7 +217360,7 @@
     "last_updated": "2025-03-10",
     "limit": {
      "context": 32768,
-     "output": 32768
+     "output": 29491
     },
     "modalities": {
      "input": [
@@ -212873,7 +217390,7 @@
     "last_updated": "2024-11-08",
     "limit": {
      "context": 1024000,
-     "output": 1024000
+     "output": 26214
     },
     "modalities": {
      "input": [
@@ -212904,7 +217421,7 @@
     "last_updated": "2026-07-15",
     "limit": {
      "context": 1048576,
-     "output": 262144
+     "output": 471859
     },
     "modalities": {
      "input": [
@@ -212979,7 +217496,7 @@
      }
     ],
     "release_date": "2026-07-30",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -212994,7 +217511,7 @@
     "id": "thinkingmachines/inkling-small:free",
     "last_updated": "2026-07-30",
     "limit": {
-     "context": 262144,
+     "context": 1048576,
      "output": 262144
     },
     "modalities": {
@@ -213039,7 +217556,7 @@
     "id": "thinkingmachines/inkling:free",
     "last_updated": "2026-07-15",
     "limit": {
-     "context": 262144,
+     "context": 1048576,
      "output": 262144
     },
     "modalities": {
@@ -213085,7 +217602,7 @@
     "last_updated": "2023-07-22",
     "limit": {
      "context": 6144,
-     "output": 6144
+     "output": 4096
     },
     "modalities": {
      "input": [
@@ -213116,7 +217633,7 @@
     "last_updated": "2026-01-27",
     "limit": {
      "context": 131072,
-     "output": 131072
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -213129,7 +217646,11 @@
     "name": "Solar Pro 3",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-01-27",
     "structured_output": true,
     "temperature": true,
@@ -213161,7 +217682,11 @@
     "name": "Solar Pro 4",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-08-10",
     "structured_output": true,
     "temperature": true,
@@ -213227,7 +217752,7 @@
     "last_updated": "2026-03-31",
     "limit": {
      "context": 2000000,
-     "output": 2000000
+     "output": 1800000
     },
     "modalities": {
      "input": [
@@ -213242,7 +217767,11 @@
     "name": "Grok 4.20",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-03-31",
     "structured_output": true,
     "temperature": true,
@@ -213278,7 +217807,7 @@
     "last_updated": "2026-03-31",
     "limit": {
      "context": 2000000,
-     "output": 2000000
+     "output": 1800000
     },
     "modalities": {
      "input": [
@@ -213338,7 +217867,7 @@
     "last_updated": "2026-04-17",
     "limit": {
      "context": 1000000,
-     "output": 1000000
+     "output": 900000
     },
     "modalities": {
      "input": [
@@ -213398,7 +217927,7 @@
     "last_updated": "2026-07-08",
     "limit": {
      "context": 500000,
-     "output": 500000
+     "output": 450000
     },
     "modalities": {
      "input": [
@@ -213458,7 +217987,7 @@
     "last_updated": "2026-08-12",
     "limit": {
      "context": 500000,
-     "output": 500000
+     "output": 450000
     },
     "modalities": {
      "input": [
@@ -213518,7 +218047,7 @@
     "last_updated": "2026-04-16",
     "limit": {
      "context": 256000,
-     "output": 256000
+     "output": 230400
     },
     "modalities": {
      "input": [
@@ -213737,9 +218266,9 @@
    "z-ai/glm-4.6": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.1,
-     "input": 0.5,
-     "output": 2
+     "cache_read": 0.08,
+     "input": 0.43,
+     "output": 1.75
     },
     "description": "Late GLM-4 workhorse for coding agents, reasoning, and structured tasks",
     "family": "glm",
@@ -213748,7 +218277,7 @@
     "last_updated": "2025-09-30",
     "limit": {
      "context": 204800,
-     "output": 131072
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -213761,7 +218290,11 @@
     "name": "GLM-4.6",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-09-30",
     "structured_output": true,
     "temperature": true,
@@ -213796,7 +218329,11 @@
     "name": "GLM-4.6V",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-12-08",
     "structured_output": false,
     "temperature": true,
@@ -213832,7 +218369,11 @@
     "name": "GLM-4.7",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-12-22",
     "structured_output": true,
     "temperature": true,
@@ -213868,7 +218409,11 @@
     "name": "GLM-4.7-Flash",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-01-19",
     "structured_output": true,
     "temperature": true,
@@ -213903,7 +218448,11 @@
     "name": "GLM-5",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-02-12",
     "structured_output": true,
     "temperature": true,
@@ -213938,7 +218487,11 @@
     "name": "GLM-5-Turbo",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-03-16",
     "structured_output": false,
     "temperature": true,
@@ -213973,7 +218526,11 @@
     "name": "GLM-5.1",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-04-07",
     "structured_output": true,
     "temperature": true,
@@ -213982,9 +218539,9 @@
    "z-ai/glm-5.2": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.1932,
-     "input": 0.966,
-     "output": 3.036
+     "cache_read": 0.221,
+     "input": 1.19,
+     "output": 3.74
     },
     "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
     "family": "glm",
@@ -213995,7 +218552,7 @@
     "last_updated": "2026-06-13",
     "limit": {
      "context": 1048576,
-     "output": 131072
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -214037,7 +218594,7 @@
     "last_updated": "2026-06-13",
     "limit": {
      "context": 256000,
-     "output": 256000
+     "output": 230400
     },
     "modalities": {
      "input": [
@@ -214079,7 +218636,7 @@
     "id": "z-ai/glm-5.3",
     "last_updated": "2026-08-14",
     "limit": {
-     "context": 1048576,
+     "context": 1310720,
      "output": 131072
     },
     "modalities": {
@@ -214091,7 +218648,7 @@
      ]
     },
     "name": "GLM-5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -214104,7 +218661,50 @@
      }
     ],
     "release_date": "2026-08-14",
-    "structured_output": false,
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "z-ai/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1310720,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -214136,7 +218736,11 @@
     "name": "GLM-5V-Turbo",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-04-01",
     "structured_output": false,
     "temperature": true,
@@ -214220,11 +218824,6 @@
     "reasoning_options": [
      {
       "type": "toggle"
-     },
-     {
-      "max": 63999,
-      "min": 1024,
-      "type": "budget_tokens"
      }
     ],
     "release_date": "2026-04-27",
@@ -214334,9 +218933,9 @@
    "~deepseek/deepseek-v4-flash-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.01278,
-     "input": 0.0639,
-     "output": 0.1278
+     "cache_read": 0.013,
+     "input": 0.03,
+     "output": 0.16
     },
     "description": "Fast DeepSeek model for efficient chat, coding help, and agent loops",
     "family": "deepseek",
@@ -214344,7 +218943,7 @@
     "last_updated": "2026-08-01",
     "limit": {
      "context": 1310720,
-     "output": 262144
+     "output": 393216
     },
     "modalities": {
      "input": [
@@ -214378,11 +218977,11 @@
    "~google/gemini-flash-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0375,
-     "cache_write": 0.020833,
-     "input": 0.375,
-     "output": 1.875,
-     "reasoning": 1.875
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -214490,9 +219089,9 @@
    "~moonshotai/kimi-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.29,
-     "input": 2.6,
-     "output": 13
+     "cache_read": 0.256,
+     "input": 2.55,
+     "output": 12.75
     },
     "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
     "family": "kimi",
@@ -214500,7 +219099,7 @@
     "last_updated": "2026-04-27",
     "limit": {
      "context": 1048576,
-     "output": 974842
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -214674,7 +219273,7 @@
     "last_updated": "2026-07-08",
     "limit": {
      "context": 500000,
-     "output": 1000000
+     "output": 450000
     },
     "modalities": {
      "input": [
@@ -214708,16 +219307,16 @@
    "~z-ai/glm-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
+     "cache_read": 0.247,
+     "input": 1.1875,
+     "output": 4.18
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
     "id": "~z-ai/glm-latest",
     "last_updated": "2026-08-19",
     "limit": {
-     "context": 1048576,
+     "context": 1310720,
      "output": 131072
     },
     "modalities": {
@@ -214742,13 +219341,1997 @@
      }
     ],
     "release_date": "2026-08-19",
-    "structured_output": false,
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    }
   },
   "name": "OpenRouter",
   "npm": "@openrouter/ai-sdk-provider"
+ },
+ "opper": {
+  "api": "https://api.opper.ai/v3/compat",
+  "doc": "https://opper.ai/models",
+  "env": [
+   "OPPER_API_KEY"
+  ],
+  "id": "opper",
+  "models": {
+   "anthropic/claude-fable-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 1,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-09",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-haiku-4-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "cache_write": 1.25,
+     "input": 1,
+     "output": 5
+    },
+    "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
+    "family": "claude-haiku",
+    "id": "anthropic/claude-haiku-4-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-02-28",
+    "last_updated": "2025-10-15",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Haiku 4.5 (latest)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-10-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-4-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-4-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2025-11-24",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.5 (latest)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-11-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-4-6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05-31",
+    "last_updated": "2026-03-13",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.6",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-4-7": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-4-7",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-04-16",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.7",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-4-8": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-4-8",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2026-01",
+    "last_updated": "2026-05-28",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 4.8",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-05-28",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Strongest Claude Opus model for coding, agents, and professional work",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2026-05",
+    "last_updated": "2026-07-24",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-24",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-sonnet-4-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
+    "family": "claude-sonnet",
+    "id": "anthropic/claude-sonnet-4-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-07-31",
+    "last_updated": "2025-09-29",
+    "limit": {
+     "context": 200000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.5 (latest)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2025-09-29",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-sonnet-4-6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
+    "family": "claude-sonnet",
+    "id": "anthropic/claude-sonnet-4-6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-13",
+    "limit": {
+     "context": 1000000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 4.6",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "anthropic/claude-sonnet-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
+    },
+    "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+    "family": "claude-sonnet",
+    "id": "anthropic/claude-sonnet-5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-30",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-30",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "gemini/gemini-3-flash-preview": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.5,
+     "output": 3
+    },
+    "description": "New Gemini flash lane bringing frontier-style multimodal reasoning to cheaper runs",
+    "family": "gemini-flash",
+    "id": "gemini/gemini-3-flash-preview",
+    "knowledge": "2025-01",
+    "last_updated": "2025-12-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3 Flash Preview",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-12-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gemini/gemini-3.1-pro-preview": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 4,
+      "output": 18
+     },
+     "input": 2,
+     "output": 12,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 4,
+       "output": 18,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
+    "family": "gemini-pro",
+    "id": "gemini/gemini-3.1-pro-preview",
+    "knowledge": "2025-01",
+    "last_updated": "2026-02-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.1 Pro Preview",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-02-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gemini/gemini-3.5-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.5,
+     "output": 9
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "gemini/gemini-3.5-flash",
+    "knowledge": "2025-01",
+    "last_updated": "2026-05-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gemini/gemini-3.5-flash-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.3,
+     "output": 2.5
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash-lite",
+    "id": "gemini/gemini-3.5-flash-lite",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Flash Lite",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.2": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.25,
+     "output": 4.25
+    },
+    "description": "Muse Spark 1.2 is a coding-focused update to Muse Spark 1.1 with improvements in code generation, complex debugging, codebase understanding, and end-to-end developer workflows.",
+    "family": "muse",
+    "id": "meta/muse-spark-1.2",
+    "last_updated": "2026-08-05",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.2",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/m3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.12,
+     "context_over_200k": {
+      "cache_read": 0.24,
+      "input": 1.2,
+      "output": 4.8
+     },
+     "input": 0.6,
+     "output": 2.4,
+     "tiers": [
+      {
+       "cache_read": 0.24,
+       "input": 1.2,
+       "output": 4.8,
+       "tier": {
+        "size": 524288,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "family": "minimax",
+    "id": "minimax/m3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 1048576,
+     "output": 512000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax-M3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-06-01",
+    "temperature": true,
+    "tool_call": true
+   },
+   "mistral/devstral-2512": {
+    "attachment": false,
+    "cost": {
+     "input": 0.4,
+     "output": 2
+    },
+    "description": "Mistral's coding-agent model for repository work, terminal tasks, and software fixes",
+    "family": "devstral",
+    "id": "mistral/devstral-2512",
+    "knowledge": "2025-12",
+    "last_updated": "2025-12-09",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Devstral 2",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-12-09",
+    "temperature": true,
+    "tool_call": true
+   },
+   "mistral/mistral-large-2512": {
+    "attachment": true,
+    "cost": {
+     "input": 0.5,
+     "output": 1.5
+    },
+    "description": "Mistral's largest general model for enterprise agents, coding, and multilingual reasoning",
+    "family": "mistral-large",
+    "id": "mistral/mistral-large-2512",
+    "knowledge": "2024-11",
+    "last_updated": "2025-12-02",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Mistral Large 3",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2024-11-01",
+    "temperature": true,
+    "tool_call": true
+   },
+   "mistral/mistral-small-2603": {
+    "attachment": true,
+    "cost": {
+     "input": 0.15,
+     "output": 0.6
+    },
+    "description": "Fast Mistral production model for chat, extraction, and cost-sensitive agents",
+    "family": "mistral-small",
+    "id": "mistral/mistral-small-2603",
+    "knowledge": "2025-06",
+    "last_updated": "2026-03-16",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Mistral Small 4",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-03-16",
+    "temperature": true,
+    "tool_call": true
+   },
+   "moonshot/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "moonshot/kimi-k3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.3-chat-latest": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.175,
+     "input": 1.75,
+     "output": 14
+    },
+    "description": "Chat-tuned GPT model for conversational assistance, writing, and tool workflows",
+    "family": "gpt",
+    "id": "openai/gpt-5.3-chat-latest",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-03",
+    "limit": {
+     "context": 128000,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.3 Chat (latest)",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-03-03",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-5.3-codex": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.175,
+     "input": 1.75,
+     "output": 14
+    },
+    "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
+    "family": "gpt-codex",
+    "id": "openai/gpt-5.3-codex",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-02-05",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.3 Codex",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-02-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-5.4": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "context_over_200k": {
+      "cache_read": 0.5,
+      "input": 5,
+      "output": 22.5
+     },
+     "input": 2.5,
+     "output": 15,
+     "tiers": [
+      {
+       "cache_read": 0.5,
+       "input": 5,
+       "output": 22.5,
+       "tier": {
+        "size": 272000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
+    "family": "gpt",
+    "id": "openai/gpt-5.4",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-05",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-5.4-mini": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 4.5
+    },
+    "description": "Strong small GPT for coding subagents, quick tool use, and high-volume work",
+    "family": "gpt-mini",
+    "id": "openai/gpt-5.4-mini",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-17",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 mini",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-5.4-nano": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02,
+     "input": 0.2,
+     "output": 1.25
+    },
+    "description": "Cheapest GPT-5.4 lane for simple routing, extraction, and bulk automation",
+    "family": "gpt-nano",
+    "id": "openai/gpt-5.4-nano",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-17",
+    "limit": {
+     "context": 400000,
+     "input": 272000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 nano",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "openai/gpt-5.4-pro": {
+    "attachment": true,
+    "cost": {
+     "context_over_200k": {
+      "input": 60,
+      "output": 270
+     },
+     "input": 30,
+     "output": 180,
+     "tiers": [
+      {
+       "input": 60,
+       "output": 270,
+       "tier": {
+        "size": 272000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "More exact GPT-5.4 tier for demanding professional reasoning and agent tasks",
+    "family": "gpt-pro",
+    "id": "openai/gpt-5.4-pro",
+    "knowledge": "2025-08-31",
+    "last_updated": "2026-03-05",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.4 Pro",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-03-05",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "context_over_200k": {
+      "cache_read": 1,
+      "input": 10,
+      "output": 45
+     },
+     "input": 5,
+     "output": 30,
+     "tiers": [
+      {
+       "cache_read": 1,
+       "input": 10,
+       "output": 45,
+       "tier": {
+        "size": 272000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Default frontier GPT for coding, computer use, research, and knowledge work",
+    "family": "gpt",
+    "id": "openai/gpt-5.5",
+    "knowledge": "2025-12-01",
+    "last_updated": "2026-04-23",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-04-23",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.5-pro": {
+    "attachment": true,
+    "cost": {
+     "context_over_200k": {
+      "input": 60,
+      "output": 270
+     },
+     "input": 30,
+     "output": 180,
+     "tiers": [
+      {
+       "input": 60,
+       "output": 270,
+       "tier": {
+        "size": 272000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Highest-accuracy GPT-5.5 tier for slower, precision-heavy reasoning and coding",
+    "family": "gpt-pro",
+    "id": "openai/gpt-5.5-pro",
+    "knowledge": "2025-12-01",
+    "last_updated": "2026-04-23",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.5 Pro",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-04-23",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.6-luna": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02,
+     "cache_write": 0.25,
+     "context_over_200k": {
+      "cache_read": 0.04,
+      "cache_write": 0.5,
+      "input": 0.4,
+      "output": 1.8
+     },
+     "input": 0.2,
+     "output": 1.2,
+     "tiers": [
+      {
+       "cache_read": 0.04,
+       "cache_write": 0.5,
+       "input": 0.4,
+       "output": 1.8,
+       "tier": {
+        "size": 272000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+    "family": "gpt-luna",
+    "id": "openai/gpt-5.6-luna",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Luna",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.6-sol": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "context_over_200k": {
+      "cache_read": 1,
+      "cache_write": 12.5,
+      "input": 10,
+      "output": 45
+     },
+     "input": 5,
+     "output": 30,
+     "tiers": [
+      {
+       "cache_read": 1,
+       "cache_write": 12.5,
+       "input": 10,
+       "output": 45,
+       "tier": {
+        "size": 272000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+    "family": "gpt-sol",
+    "id": "openai/gpt-5.6-sol",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Sol",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.6-terra": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "cache_write": 5,
+      "input": 4,
+      "output": 18
+     },
+     "input": 2,
+     "output": 12,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "cache_write": 5,
+       "input": 4,
+       "output": 18,
+       "tier": {
+        "size": 272000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+    "family": "gpt-terra",
+    "id": "openai/gpt-5.6-terra",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Terra",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "perplexity/sonar": {
+    "attachment": false,
+    "cost": {
+     "input": 1,
+     "output": 1
+    },
+    "description": "Fast web-grounded Sonar for current answers, citations, and lightweight retrieval",
+    "family": "sonar",
+    "id": "perplexity/sonar",
+    "knowledge": "2025-09-01",
+    "last_updated": "2025-09-01",
+    "limit": {
+     "context": 128000,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Sonar",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-01-01",
+    "temperature": true,
+    "tool_call": false
+   },
+   "perplexity/sonar-pro": {
+    "attachment": true,
+    "cost": {
+     "input": 3,
+     "output": 15
+    },
+    "description": "Deeper Sonar search model with broader retrieval and stronger synthesis",
+    "family": "sonar-pro",
+    "id": "perplexity/sonar-pro",
+    "knowledge": "2025-09-01",
+    "last_updated": "2025-09-01",
+    "limit": {
+     "context": 200000,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Sonar Pro",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2024-01-01",
+    "temperature": true,
+    "tool_call": false
+   },
+   "perplexity/sonar-reasoning-pro": {
+    "attachment": true,
+    "cost": {
+     "input": 2,
+     "output": 8
+    },
+    "description": "Web-grounded Sonar for multi-step research questions that need cited reasoning",
+    "family": "sonar-reasoning",
+    "id": "perplexity/sonar-reasoning-pro",
+    "knowledge": "2025-09-01",
+    "last_updated": "2025-09-01",
+    "limit": {
+     "context": 128000,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Sonar Reasoning Pro",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2024-01-01",
+    "temperature": true,
+    "tool_call": false
+   },
+   "vertexai/gemini-3.7-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
+    "family": "gemini-flash",
+    "id": "vertexai/gemini-3.7-flash",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.7 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "vertexai/gemini-3.7-flash-eu": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
+    "family": "gemini-flash",
+    "id": "vertexai/gemini-3.7-flash-eu",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.7 Flash (EU)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-4.3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2.5,
+      "output": 5
+     },
+     "input": 1.25,
+     "output": 2.5,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2.5,
+       "output": 5,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "xAI's default Grok for chat, coding, agentic tools, and lower hallucination risk",
+    "family": "grok",
+    "id": "xai/grok-4.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-04-17",
+    "limit": {
+     "context": 1000000,
+     "output": 30000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.3",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-4.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "context_over_200k": {
+      "cache_read": 0.6,
+      "input": 4,
+      "output": 12
+     },
+     "input": 2,
+     "output": 6,
+     "tiers": [
+      {
+       "cache_read": 0.6,
+       "input": 4,
+       "output": 12,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "xAI's Grok model for chat, coding, agentic tools, and lower hallucination risk",
+    "family": "grok",
+    "id": "xai/grok-4.5",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-07-08",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-08",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-4.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "context_over_200k": {
+      "cache_read": 1,
+      "input": 4,
+      "output": 12
+     },
+     "input": 2,
+     "output": 6,
+     "tiers": [
+      {
+       "cache_read": 1,
+       "input": 4,
+       "output": 12,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "xai/grok-4.6",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "xai/grok-build-0.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "context_over_200k": {
+      "cache_read": 0.4,
+      "input": 2,
+      "output": 4
+     },
+     "input": 1,
+     "output": 2,
+     "tiers": [
+      {
+       "cache_read": 0.4,
+       "input": 2,
+       "output": 4,
+       "tier": {
+        "size": 200000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Fast Grok coding model tuned for agentic engineering and iterative edits",
+    "family": "grok-build",
+    "id": "xai/grok-build-0.1",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-04-16",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok Build 0.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-04-16",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "Opper",
+  "npm": "@ai-sdk/openai-compatible"
  },
  "orcarouter": {
   "api": "https://api.orcarouter.ai/v1",
@@ -214758,6 +221341,50 @@
   ],
   "id": "orcarouter",
   "models": {
+   "anthropic/claude-fable-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 1,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-5",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-09",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-09",
+    "temperature": false,
+    "tool_call": true
+   },
    "anthropic/claude-haiku-4.5": {
     "attachment": true,
     "cost": {
@@ -214788,78 +221415,17 @@
     "name": "Claude Haiku 4.5 (latest)",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-10-15",
-    "temperature": true,
-    "tool_call": true
-   },
-   "anthropic/claude-opus-4": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1.5,
-     "cache_write": 18.75,
-     "input": 15,
-     "output": 75
-    },
-    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-    "family": "claude-opus",
-    "id": "anthropic/claude-opus-4",
-    "knowledge": "2025-03-31",
-    "last_updated": "2025-05-22",
-    "limit": {
-     "context": 200000,
-     "output": 32000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude Opus 4 (latest)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-05-22",
-    "temperature": true,
-    "tool_call": true
-   },
-   "anthropic/claude-opus-4.1": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1.5,
-     "cache_write": 18.75,
-     "input": 15,
-     "output": 75
-    },
-    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-    "family": "claude-opus",
-    "id": "anthropic/claude-opus-4.1",
-    "knowledge": "2025-03-31",
-    "last_updated": "2025-08-05",
-    "limit": {
-     "context": 200000,
-     "output": 32000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude Opus 4.1 (latest)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-08-05",
     "temperature": true,
     "tool_call": true
    },
@@ -214893,7 +221459,16 @@
     "name": "Claude Opus 4.5 (latest)",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-11-24",
     "temperature": true,
     "tool_call": true
@@ -215026,22 +221601,22 @@
     "temperature": false,
     "tool_call": true
    },
-   "anthropic/claude-sonnet-4": {
+   "anthropic/claude-opus-4.8": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.3,
-     "cache_write": 3.75,
-     "input": 3,
-     "output": 15
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
     },
-    "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
-    "family": "claude-sonnet",
-    "id": "anthropic/claude-sonnet-4",
-    "knowledge": "2025-03-31",
-    "last_updated": "2025-05-22",
+    "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-4.8",
+    "knowledge": "2026-01",
+    "last_updated": "2026-05-28",
     "limit": {
-     "context": 200000,
-     "output": 64000
+     "context": 1000000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -215053,12 +221628,65 @@
       "text"
      ]
     },
-    "name": "Claude Sonnet 4 (latest)",
+    "name": "Claude Opus 4.8",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-05-22",
-    "temperature": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-28",
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-opus-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "cache_write": 10,
+     "input": 5,
+     "output": 25
+    },
+    "description": "Strongest Claude Opus model for coding, agents, and professional work",
+    "family": "claude-opus",
+    "id": "anthropic/claude-opus-5",
+    "knowledge": "2026-05",
+    "last_updated": "2026-07-24",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Opus 5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-24",
+    "temperature": false,
     "tool_call": true
    },
    "anthropic/claude-sonnet-4.5": {
@@ -215075,7 +221703,7 @@
     "knowledge": "2025-07-31",
     "last_updated": "2025-09-29",
     "limit": {
-     "context": 200000,
+     "context": 1000000,
      "output": 64000
     },
     "modalities": {
@@ -215091,7 +221719,16 @@
     "name": "Claude Sonnet 4.5 (latest)",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-09-29",
     "temperature": true,
     "tool_call": true
@@ -215140,12 +221777,56 @@
     "temperature": true,
     "tool_call": true
    },
+   "anthropic/claude-sonnet-5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
+    },
+    "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+    "family": "claude-sonnet",
+    "id": "anthropic/claude-sonnet-5",
+    "knowledge": "2026-01-31",
+    "last_updated": "2026-06-30",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Sonnet 5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-30",
+    "temperature": false,
+    "tool_call": true
+   },
    "deepseek/deepseek-chat": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.028,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.02,
+     "input": 0.147,
+     "output": 0.295
     },
     "description": "DeepSeek chat model for instruction following, coding, and analysis",
     "family": "deepseek",
@@ -215175,8 +221856,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.028,
-     "input": 0.435,
-     "output": 0.87
+     "input": 0.147,
+     "output": 0.295
     },
     "description": "DeepSeek reasoning model for multi-step analysis, math, coding, and tools",
     "family": "deepseek-thinking",
@@ -215209,9 +221890,9 @@
    "deepseek/deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0028,
-     "input": 0.19,
-     "output": 0.37
+     "cache_read": 0.02,
+     "input": 0.147,
+     "output": 0.295
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -215236,8 +221917,163 @@
     "name": "DeepSeek V4 Flash",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-flash-0731": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.02,
+     "input": 0.147,
+     "output": 0.295
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-0731",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-flash-free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-free",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02,
+     "input": 0.147,
+     "output": 0.295
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-vision-exp",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -215245,9 +222081,9 @@
    "deepseek/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.003625,
-     "input": 0.56,
-     "output": 1.12
+     "cache_read": 0.06,
+     "input": 0.442,
+     "output": 0.884
     },
     "description": "Open MoE flagship with million-token context for coding and long agent runs",
     "family": "deepseek-thinking",
@@ -215272,8 +222108,65 @@
     "name": "DeepSeek V4 Pro",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-pro-0813": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.442,
+     "output": 0.884
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "deepseek/deepseek-v4-pro-0813",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -215381,8 +222274,8 @@
       "input": 2.5,
       "output": 15
      },
-     "input": 2.5,
-     "output": 15,
+     "input": 1.25,
+     "output": 10,
      "tiers": [
       {
        "cache_read": 0.25,
@@ -215470,6 +222363,7 @@
      {
       "type": "effort",
       "values": [
+       "minimal",
        "low",
        "medium",
        "high"
@@ -215481,34 +222375,19 @@
     "temperature": true,
     "tool_call": true
    },
-   "google/gemini-3-pro-preview": {
+   "google/gemini-3.1-flash-lite": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
-     "context_over_200k": {
-      "cache_read": 0.4,
-      "input": 4,
-      "output": 18
-     },
-     "input": 4,
-     "output": 18,
-     "tiers": [
-      {
-       "cache_read": 0.4,
-       "input": 4,
-       "output": 18,
-       "tier": {
-        "size": 200000,
-        "type": "context"
-       }
-      }
-     ]
+     "cache_read": 0.025,
+     "input": 0.25,
+     "input_audio": 0.5,
+     "output": 1.5
     },
-    "description": "Preview Gemini flagship for complex reasoning, coding, and rich multimodal prompts",
-    "family": "gemini-pro",
-    "id": "google/gemini-3-pro-preview",
+    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "family": "gemini-flash-lite",
+    "id": "google/gemini-3.1-flash-lite",
     "knowledge": "2025-01",
-    "last_updated": "2025-11-18",
+    "last_updated": "2026-05-07",
     "limit": {
      "context": 1048576,
      "output": 65536
@@ -215525,20 +222404,21 @@
       "text"
      ]
     },
-    "name": "Gemini 3 Pro Preview",
+    "name": "Gemini 3.1 Flash Lite",
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
      {
       "type": "effort",
       "values": [
+       "minimal",
        "low",
        "medium",
        "high"
       ]
      }
     ],
-    "release_date": "2025-11-18",
+    "release_date": "2026-05-07",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -215579,6 +222459,7 @@
      {
       "type": "effort",
       "values": [
+       "minimal",
        "low",
        "medium",
        "high"
@@ -215599,8 +222480,9 @@
       "input": 4,
       "output": 18
      },
-     "input": 4,
-     "output": 18,
+     "input": 2,
+     "input_audio": 2,
+     "output": 12,
      "tiers": [
       {
        "cache_read": 0.4,
@@ -215661,8 +222543,8 @@
       "input": 4,
       "output": 18
      },
-     "input": 4,
-     "output": 18,
+     "input": 2,
+     "output": 12,
      "tiers": [
       {
        "cache_read": 0.4,
@@ -215714,13 +222596,155 @@
     "temperature": true,
     "tool_call": true
    },
-   "google/gemini-flash-latest": {
+   "google/gemini-3.5-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "cache_write": 0.08333,
+     "input": 1.5,
+     "input_audio": 3,
+     "output": 9
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "google/gemini-3.5-flash",
+    "knowledge": "2025-01",
+    "last_updated": "2026-05-19",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-19",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google/gemini-3.5-flash-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.3,
+     "output": 2.5
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash-lite",
+    "id": "google/gemini-3.5-flash-lite",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Flash Lite",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google/gemini-3.6-flash": {
     "attachment": true,
     "cost": {
      "cache_read": 0.15,
      "input": 1.5,
-     "input_audio": 1.5,
-     "output": 9
+     "output": 7.5
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "google/gemini-3.6-flash",
+    "knowledge": "2026-03",
+    "last_updated": "2026-07-21",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.6 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google/gemini-flash-latest": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.1,
+     "input": 0.5,
+     "output": 3
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -215750,7 +222774,6 @@
      {
       "type": "effort",
       "values": [
-       "minimal",
        "low",
        "medium",
        "high"
@@ -215810,9 +222833,53 @@
     "temperature": true,
     "tool_call": true
    },
+   "google/gemini-robotics-er-1.6-preview": {
+    "attachment": true,
+    "cost": {
+     "input": 1,
+     "output": 5
+    },
+    "description": "Vision-language model for embodied reasoning: spatial understanding, task planning, and physical-world agentic robotics",
+    "family": "gemini",
+    "id": "google/gemini-robotics-er-1.6-preview",
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-14",
+    "limit": {
+     "context": 131072,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini Robotics-ER 1.6 Preview",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "min": 0,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-04-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "google/gemma-4-26b-a4b-it": {
     "attachment": true,
     "cost": {
+     "cache_read": 0.0075,
      "input": 0.06,
      "output": 0.33
     },
@@ -215845,6 +222912,7 @@
    "google/gemma-4-31b-it": {
     "attachment": true,
     "cost": {
+     "cache_read": 0.02,
      "input": 0.13,
      "output": 0.38
     },
@@ -215918,8 +222986,104 @@
     "name": "Grok 4.3",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2026-04-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "grok/grok-4.5": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "xAI's Grok model for chat, coding, agentic tools, and lower hallucination risk",
+    "family": "grok",
+    "id": "grok/grok-4.5",
+    "last_updated": "2026-07-08",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.5",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-08",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "grok/grok-4.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "grok/grok-4.6",
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -215928,6 +223092,7 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.1,
+     "cache_write": 0,
      "input": 0.6,
      "output": 3
     },
@@ -215941,7 +223106,7 @@
     "last_updated": "2026-01",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -215956,7 +223121,11 @@
     "name": "Kimi K2.5",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-01",
     "structured_output": true,
     "temperature": false,
@@ -215979,7 +223148,7 @@
     "last_updated": "2026-04-21",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -215994,8 +223163,192 @@
     "name": "Kimi K2.6",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-04-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "kimi/kimi-k2.7-code": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.19,
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+    "family": "kimi-k2",
+    "id": "kimi/kimi-k2.7-code",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-06-12",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "kimi/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.33,
+     "input": 3.3,
+     "output": 16.5
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "kimi/kimi-k3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.25,
+     "output": 4.25
+    },
+    "description": "Muse Spark is a natively multimodal reasoning model with support for tool-use, visual chain of thought, and multi-agent orchestration.",
+    "family": "muse",
+    "id": "meta/muse-spark-1.1",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1000000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-04-08",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.2": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.25,
+     "output": 4.25
+    },
+    "description": "Muse Spark 1.2 is a coding-focused update to Muse Spark 1.1 with improvements in code generation, complex debugging, codebase understanding, and end-to-end developer workflows.",
+    "family": "muse",
+    "id": "meta/muse-spark-1.2",
+    "last_updated": "2026-08-05",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.2",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-05",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -216035,7 +223388,7 @@
    "minimax/minimax-m2.5-highspeed": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.06,
+     "cache_read": 0.03,
      "cache_write": 0.375,
      "input": 0.6,
      "output": 2.4
@@ -216125,6 +223478,43 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-03-18",
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "family": "minimax",
+    "id": "minimax/minimax-m3",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 1048576,
+     "output": 512000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax-M3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-01",
     "temperature": true,
     "tool_call": true
    },
@@ -216519,7 +223909,17 @@
     "name": "GPT-5",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-08-07",
     "structured_output": true,
     "temperature": false,
@@ -216540,7 +223940,7 @@
     "limit": {
      "context": 400000,
      "input": 272000,
-     "output": 128000
+     "output": 100000
     },
     "modalities": {
      "input": [
@@ -216557,43 +223957,8 @@
     "reasoning_options": [],
     "release_date": "2025-08-07",
     "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
-   "openai/gpt-5-codex": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.125,
-     "input": 1.25,
-     "output": 10
-    },
-    "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
-    "family": "gpt-codex",
-    "id": "openai/gpt-5-codex",
-    "knowledge": "2024-09-30",
-    "last_updated": "2025-09-15",
-    "limit": {
-     "context": 400000,
-     "input": 272000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5-Codex",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-09-15",
-    "structured_output": true,
     "temperature": false,
-    "tool_call": true
+    "tool_call": false
    },
    "openai/gpt-5-mini": {
     "attachment": true,
@@ -216624,7 +223989,17 @@
     "name": "GPT-5 Mini",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-08-07",
     "structured_output": true,
     "temperature": false,
@@ -216659,7 +224034,17 @@
     "name": "GPT-5 Nano",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-08-07",
     "structured_output": true,
     "temperature": false,
@@ -216697,8 +224082,6 @@
      {
       "type": "effort",
       "values": [
-       "low",
-       "medium",
        "high"
       ]
      }
@@ -216737,10 +224120,20 @@
     "name": "GPT-5.1",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.1-chat-latest": {
@@ -216806,42 +224199,16 @@
     "name": "GPT-5.1 Codex",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-11-13",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "openai/gpt-5.1-codex-max": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.125,
-     "input": 1.25,
-     "output": 10
-    },
-    "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
-    "family": "gpt-codex",
-    "id": "openai/gpt-5.1-codex-max",
-    "knowledge": "2024-09-30",
-    "last_updated": "2025-11-13",
-    "limit": {
-     "context": 400000,
-     "input": 272000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5.1 Codex Max",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-11-13",
     "structured_output": true,
     "temperature": false,
@@ -216876,7 +224243,16 @@
     "name": "GPT-5.1 Codex mini",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-11-13",
     "structured_output": true,
     "temperature": false,
@@ -216911,10 +224287,21 @@
     "name": "GPT-5.2",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2-chat-latest": {
@@ -216945,7 +224332,14 @@
     "name": "GPT-5.2 Chat",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "medium"
+      ]
+     }
+    ],
     "release_date": "2025-12-11",
     "structured_output": true,
     "temperature": false,
@@ -216981,7 +224375,17 @@
     "name": "GPT-5.2 Codex",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
     "release_date": "2025-12-11",
     "structured_output": true,
     "temperature": false,
@@ -217019,48 +224423,15 @@
      {
       "type": "effort",
       "values": [
-       "low",
        "medium",
-       "high"
+       "high",
+       "xhigh"
       ]
      }
     ],
     "release_date": "2025-12-11",
     "structured_output": false,
     "temperature": false,
-    "tool_call": true
-   },
-   "openai/gpt-5.3-chat-latest": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.175,
-     "input": 1.75,
-     "output": 14
-    },
-    "description": "Chat-tuned GPT model for conversational assistance, writing, and tool workflows",
-    "family": "gpt",
-    "id": "openai/gpt-5.3-chat-latest",
-    "knowledge": "2025-08-31",
-    "last_updated": "2026-03-03",
-    "limit": {
-     "context": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5.3 Chat (latest)",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-03-03",
-    "structured_output": true,
-    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.3-codex": {
@@ -217093,10 +224464,21 @@
     "name": "GPT-5.3 Codex",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4": {
@@ -217108,8 +224490,8 @@
       "input": 5,
       "output": 22.5
      },
-     "input": 5,
-     "output": 22.5,
+     "input": 2.5,
+     "output": 15,
      "tiers": [
       {
        "cache_read": 0.5,
@@ -217161,10 +224543,21 @@
     "name": "GPT-5.4",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -217212,10 +224605,21 @@
     "name": "GPT-5.4 mini",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -217247,10 +224651,21 @@
     "name": "GPT-5.4 nano",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-pro": {
@@ -217260,8 +224675,8 @@
       "input": 60,
       "output": 270
      },
-     "input": 60,
-     "output": 270,
+     "input": 30,
+     "output": 180,
      "tiers": [
       {
        "input": 60,
@@ -217299,9 +224714,9 @@
      {
       "type": "effort",
       "values": [
-       "low",
        "medium",
-       "high"
+       "high",
+       "xhigh"
       ]
      }
     ],
@@ -217372,7 +224787,18 @@
     "name": "GPT-5.5",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
     "release_date": "2026-04-23",
     "structured_output": true,
     "temperature": false,
@@ -217406,7 +224832,7 @@
     "limit": {
      "context": 1050000,
      "input": 922000,
-     "output": 128000
+     "output": 100000
     },
     "modalities": {
      "input": [
@@ -217425,15 +224851,202 @@
      {
       "type": "effort",
       "values": [
-       "low",
        "medium",
-       "high"
+       "high",
+       "xhigh"
       ]
      }
     ],
     "release_date": "2026-04-23",
     "structured_output": true,
     "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.6-luna": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02,
+     "cache_write": 0.25,
+     "input": 0.2,
+     "output": 1.2
+    },
+    "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+    "family": "gpt-luna",
+    "id": "openai/gpt-5.6-luna",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Luna",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.6-sol": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.4,
+     "cache_write": 5,
+     "input": 4,
+     "output": 20
+    },
+    "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+    "family": "gpt-sol",
+    "id": "openai/gpt-5.6-sol",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Sol",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-5.6-terra": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 12
+    },
+    "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+    "family": "gpt-terra",
+    "id": "openai/gpt-5.6-terra",
+    "knowledge": "2026-02-16",
+    "last_updated": "2026-07-09",
+    "limit": {
+     "context": 1050000,
+     "input": 922000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT-5.6 Terra",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "openai/gpt-oss-120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.03,
+     "output": 0.17
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "openai/gpt-oss-120b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": true,
+    "temperature": true,
     "tool_call": true
    },
    "orcarouter/auto": {
@@ -217467,6 +225080,149 @@
     "temperature": true,
     "tool_call": true
    },
+   "orcarouter/free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Built-in router over the free tier that scores each request's difficulty and sends light work to the smaller free model and harder work to the stronger one. Priced at zero and never falls back to a paid model.",
+    "family": "auto",
+    "id": "orcarouter/free",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 65536,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "OrcaRouter Free",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-27",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "orcarouter/fusion": {
+    "attachment": true,
+    "description": "Curated fan-out router that runs Claude Opus 4.8, GPT-5.5 and Gemini 3.1 Pro in parallel on hard requests, then has a Claude Opus 4.8 judge return the strongest single answer verbatim. Easy requests fall through to a cheaper default and bill as one call.",
+    "family": "model-router",
+    "id": "orcarouter/fusion",
+    "last_updated": "2026-06-15",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "OrcaRouter Fusion",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-15",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "orcarouter/fusion-flash": {
+    "attachment": false,
+    "description": "Budget Fusion panel that runs Gemini 3.5 Flash, MiniMax M2.7 and GLM 5.1 in parallel on hard requests, then has a Claude Opus 4.8 judge return the strongest single answer verbatim. Cost-sensitive fan-out over a 200K window.",
+    "family": "model-router",
+    "id": "orcarouter/fusion-flash",
+    "last_updated": "2026-06-15",
+    "limit": {
+     "context": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "OrcaRouter Fusion Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "orcarouter/fusion-mini": {
+    "attachment": true,
+    "description": "Leaner two-model Fusion panel that runs Claude Opus 4.8 and GPT-5.5 in parallel on hard requests, then has a Claude Opus 4.8 judge return the strongest single answer verbatim. Easy requests fall through to a cheaper default and bill as one call.",
+    "family": "model-router",
+    "id": "orcarouter/fusion-mini",
+    "last_updated": "2026-06-15",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "OrcaRouter Fusion Mini",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-15",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
    "qwen/qwen3-max": {
     "attachment": false,
     "cost": {
@@ -217494,6 +225250,77 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2025-09-23",
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3-vl-235b-a22b-instruct": {
+    "attachment": true,
+    "cost": {
+     "input": 0.4,
+     "output": 1.6
+    },
+    "description": "Qwen vision-language instruct model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen/qwen3-vl-235b-a22b-instruct",
+    "knowledge": "2025-03-31",
+    "last_updated": "2025-09-23",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 VL 235B A22B Instruct",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-09-23",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3-vl-235b-a22b-thinking": {
+    "attachment": true,
+    "cost": {
+     "input": 0.4,
+     "output": 4
+    },
+    "description": "Qwen vision-language thinking model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen/qwen3-vl-235b-a22b-thinking",
+    "knowledge": "2025-03-31",
+    "last_updated": "2025-09-23",
+    "limit": {
+     "context": 131072,
+     "output": 40960
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3 VL 235B A22B Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "max": 81920,
+      "min": 1024,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2025-09-23",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -217525,7 +225352,14 @@
     "name": "Qwen3.5 122B-A10B",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-02-23",
     "structured_output": true,
     "temperature": true,
@@ -217559,7 +225393,14 @@
     "name": "Qwen3.5 27B",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-02-23",
     "structured_output": true,
     "temperature": true,
@@ -217593,7 +225434,14 @@
     "name": "Qwen3.5 35B-A3B",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-02-23",
     "structured_output": true,
     "temperature": true,
@@ -217627,8 +225475,57 @@
     "name": "Qwen3.5 397B-A17B",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-02-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.5-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen/qwen3.5-flash",
+    "last_updated": "2026-02-23",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.5 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "max": 81920,
+      "min": 1,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-02-23",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -217662,7 +225559,14 @@
     "name": "Qwen3.5 Plus",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-02-16",
     "temperature": true,
     "tool_call": true
@@ -217695,8 +225599,55 @@
     "name": "Qwen3.6 35B-A3B",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-04-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.6-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0.25,
+     "output": 1.5
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen3.6",
+    "id": "qwen/qwen3.6-flash",
+    "last_updated": "2026-04-27",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.6 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-04-27",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -217749,8 +225700,358 @@
     "name": "Qwen3.6 Plus",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-04-02",
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.7-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.006,
+     "cache_write": 0.038,
+     "input": 0.03,
+     "output": 0.13
+    },
+    "description": "Lightweight multimodal Qwen model for high-throughput text, image, and video tasks",
+    "family": "qwen",
+    "id": "qwen/qwen3.7-flash",
+    "last_updated": "2026-07-15",
+    "limit": {
+     "context": 1000000,
+     "input": 991000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.7 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-07-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.7-max": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 1.563,
+     "input": 1.25,
+     "output": 3.75
+    },
+    "description": "Qwen frontier model tuned for agent frameworks, coding assistants, and long tasks",
+    "family": "qwen",
+    "id": "qwen/qwen3.7-max",
+    "last_updated": "2026-05-21",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.7 Max",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-05-21",
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.7-plus": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.071,
+     "input": 0.35,
+     "output": 1.42
+    },
+    "description": "Multimodal Qwen workhorse for long-context agents, visual inputs, and coding",
+    "family": "qwen",
+    "id": "qwen/qwen3.7-plus",
+    "knowledge": "2025-04",
+    "last_updated": "2026-06-02",
+    "limit": {
+     "context": 1000000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.7 Plus",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-06-02",
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-27b": {
+    "attachment": true,
+    "cost": {
+     "input": 0.33,
+     "output": 2.4
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-27b",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-27b-free": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-27b-free",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 65536,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-max": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-max",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "max": 262144,
+      "min": 0,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-03",
+    "temperature": true,
+    "tool_call": true
+   },
+   "tencent/hy3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.059,
+     "input": 0.18,
+     "output": 0.59
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "tencent/hy3",
+    "last_updated": "2026-07-06",
+    "limit": {
+     "context": 256000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-06",
+    "temperature": true,
+    "tool_call": true
+   },
+   "tencent/hy3-free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+    "family": "Hy",
+    "id": "tencent/hy3-free",
+    "last_updated": "2026-07-06",
+    "limit": {
+     "context": 256000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy3 (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-06",
     "temperature": true,
     "tool_call": true
    },
@@ -217782,7 +226083,11 @@
     "name": "GLM-4.5",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-07-28",
     "temperature": true,
     "tool_call": true
@@ -217815,7 +226120,11 @@
     "name": "GLM-4.5-Air",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-07-28",
     "temperature": true,
     "tool_call": true
@@ -217848,7 +226157,11 @@
     "name": "GLM-4.6",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-09-30",
     "temperature": true,
     "tool_call": true
@@ -217884,7 +226197,11 @@
     "name": "GLM-4.7",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2025-12-22",
     "temperature": true,
     "tool_call": true
@@ -217892,7 +226209,7 @@
    "z-ai/glm-5": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.2,
+     "cache_read": 0.26,
      "cache_write": 0,
      "input": 1,
      "output": 3.2
@@ -217919,7 +226236,11 @@
     "name": "GLM-5",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-02-12",
     "temperature": true,
     "tool_call": true
@@ -217954,8 +226275,145 @@
     "name": "GLM-5.1",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
     "release_date": "2026-04-07",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "z-ai/glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.234,
+     "input": 1.26,
+     "output": 3.96
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "z-ai/glm-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "z-ai/glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -218432,6 +226890,222 @@
    }
   },
   "name": "OVHcloud AI Endpoints",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "pendra": {
+  "api": "https://api.pendra.ai/api/v1",
+  "doc": "https://pendra.ai/docs/integrations/opencode",
+  "env": [
+   "PENDRA_API_KEY"
+  ],
+  "id": "pendra",
+  "models": {
+   "deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash",
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-4.7-flash": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Budget GLM lane for fast coding help, routing, and everyday automation",
+    "family": "glm-flash",
+    "id": "glm-4.7-flash",
+    "knowledge": "2025-04",
+    "last_updated": "2026-01-19",
+    "limit": {
+     "context": 200000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-4.7-Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-01-19",
+    "temperature": true,
+    "tool_call": true
+   },
+   "gpt-oss:120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "gpt-oss:120b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 131072,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 120B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "llama3.3:70b": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
+    "family": "llama",
+    "id": "llama3.3:70b",
+    "knowledge": "2023-12",
+    "last_updated": "2024-12-06",
+    "limit": {
+     "context": 128000,
+     "output": 4096
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Llama-3.3-70B-Instruct",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2024-12-06",
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3-coder:30b": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Smaller Qwen coder for efficient local agents and repo-level fixes",
+    "family": "qwen",
+    "id": "qwen3-coder:30b",
+    "knowledge": "2025-04",
+    "last_updated": "2025-04",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3-Coder 30B-A3B Instruct",
+    "open_weights": true,
+    "reasoning": false,
+    "release_date": "2025-04",
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.6:27b": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen3.6:27b",
+    "last_updated": "2026-04-22",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.6 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-04-22",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "Pendra",
   "npm": "@ai-sdk/openai-compatible"
  },
  "perplexity": {
@@ -222167,7 +230841,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.3-codex": {
@@ -222216,7 +230890,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4": {
@@ -222265,7 +230939,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -222314,7 +230988,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-nano": {
@@ -222362,7 +231036,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
@@ -232677,16 +241351,16 @@
     "temperature": true,
     "tool_call": true
    },
-   "qwen3.6-27b": {
+   "qwen3.8-27b": {
     "attachment": true,
     "cost": {
      "input": 0.58,
      "output": 2.42
     },
-    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
     "family": "qwen",
-    "id": "qwen3.6-27b",
-    "last_updated": "2026-04-22",
+    "id": "qwen3.8-27b",
+    "last_updated": "2026-08-14",
     "limit": {
      "context": 120000,
      "output": 120000
@@ -232701,7 +241375,7 @@
       "text"
      ]
     },
-    "name": "Qwen3.6 27B",
+    "name": "Qwen3.8 27B",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -232709,7 +241383,7 @@
       "type": "toggle"
      }
     ],
-    "release_date": "2026-04-22",
+    "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -232729,10 +241403,10 @@
    "claude-fable-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.9,
-     "cache_write": 11.25,
-     "input": 9,
-     "output": 45
+     "cache_read": 1,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
     },
     "description": "Claude model for creative writing, analysis, and controlled agent workflows",
     "family": "claude-fable",
@@ -232779,10 +241453,10 @@
    "claude-fable-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.99,
-     "cache_write": 12.375,
-     "input": 9.9,
-     "output": 49.5
+     "cache_read": 1.1,
+     "cache_write": 13.75,
+     "input": 11,
+     "output": 55
     },
     "description": "Claude model for creative writing, analysis, and controlled agent workflows",
     "family": "claude-fable",
@@ -232829,10 +241503,10 @@
    "claude-haiku-4-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.09,
-     "cache_write": 1.125,
-     "input": 0.9,
-     "output": 4.5
+     "cache_read": 0.1,
+     "cache_write": 1.25,
+     "input": 1,
+     "output": 5
     },
     "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
     "family": "claude-haiku",
@@ -232879,10 +241553,10 @@
    "claude-haiku-4-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.099,
-     "cache_write": 1.2375,
-     "input": 0.99,
-     "output": 4.95
+     "cache_read": 0.11,
+     "cache_write": 1.375,
+     "input": 1.1,
+     "output": 5.5
     },
     "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
     "family": "claude-haiku",
@@ -232929,10 +241603,10 @@
    "claude-opus-4-1": {
     "attachment": true,
     "cost": {
-     "cache_read": 1.35,
-     "cache_write": 16.875,
-     "input": 13.5,
-     "output": 67.5
+     "cache_read": 1.5,
+     "cache_write": 18.75,
+     "input": 15,
+     "output": 75
     },
     "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
     "family": "claude-opus",
@@ -232979,10 +241653,10 @@
    "claude-opus-4-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.45,
-     "cache_write": 5.625,
-     "input": 4.5,
-     "output": 22.5
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
     },
     "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
     "family": "claude-opus",
@@ -233029,10 +241703,10 @@
    "claude-opus-4-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.495,
-     "cache_write": 6.1875,
-     "input": 4.95,
-     "output": 24.75
+     "cache_read": 0.55,
+     "cache_write": 6.875,
+     "input": 5.5,
+     "output": 27.5
     },
     "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
     "family": "claude-opus",
@@ -233079,10 +241753,10 @@
    "claude-opus-4-6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.45,
-     "cache_write": 5.625,
-     "input": 4.5,
-     "output": 22.5
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
     },
     "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
     "family": "claude-opus",
@@ -233129,10 +241803,10 @@
    "claude-opus-4-6@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.495,
-     "cache_write": 6.1875,
-     "input": 4.95,
-     "output": 24.75
+     "cache_read": 0.55,
+     "cache_write": 6.875,
+     "input": 5.5,
+     "output": 27.5
     },
     "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
     "family": "claude-opus",
@@ -233179,10 +241853,10 @@
    "claude-opus-4-7": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.45,
-     "cache_write": 5.625,
-     "input": 4.5,
-     "output": 22.5
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
     },
     "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
     "family": "claude-opus",
@@ -233229,10 +241903,10 @@
    "claude-opus-4-7@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.495,
-     "cache_write": 6.1875,
-     "input": 4.95,
-     "output": 24.75
+     "cache_read": 0.55,
+     "cache_write": 6.875,
+     "input": 5.5,
+     "output": 27.5
     },
     "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
     "family": "claude-opus",
@@ -233279,10 +241953,10 @@
    "claude-opus-4-8": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.45,
-     "cache_write": 5.625,
-     "input": 4.5,
-     "output": 22.5
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
     },
     "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
     "family": "claude-opus",
@@ -233329,10 +242003,10 @@
    "claude-opus-4-8@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.495,
-     "cache_write": 6.1875,
-     "input": 4.95,
-     "output": 24.75
+     "cache_read": 0.55,
+     "cache_write": 6.875,
+     "input": 5.5,
+     "output": 27.5
     },
     "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
     "family": "claude-opus",
@@ -233379,10 +242053,10 @@
    "claude-opus-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.45,
-     "cache_write": 5.625,
-     "input": 4.5,
-     "output": 22.5
+     "cache_read": 0.5,
+     "cache_write": 6.25,
+     "input": 5,
+     "output": 25
     },
     "description": "Strongest Claude Opus model for coding, agents, and professional work",
     "family": "claude-opus",
@@ -233429,10 +242103,10 @@
    "claude-opus-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.495,
-     "cache_write": 6.1875,
-     "input": 4.95,
-     "output": 24.75
+     "cache_read": 0.55,
+     "cache_write": 6.875,
+     "input": 5.5,
+     "output": 27.5
     },
     "description": "Strongest Claude Opus model for coding, agents, and professional work",
     "family": "claude-opus",
@@ -233479,22 +242153,22 @@
    "claude-sonnet-4-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.27,
-     "cache_write": 3.375,
+     "cache_read": 0.3,
+     "cache_write": 3.75,
      "context_over_200k": {
-      "cache_read": 0.54,
-      "cache_write": 6.75,
-      "input": 5.4,
-      "output": 20.25
+      "cache_read": 0.6,
+      "cache_write": 7.5,
+      "input": 6,
+      "output": 22.5
      },
-     "input": 2.7,
-     "output": 13.5,
+     "input": 3,
+     "output": 15,
      "tiers": [
       {
-       "cache_read": 0.54,
-       "cache_write": 6.75,
-       "input": 5.4,
-       "output": 20.25,
+       "cache_read": 0.6,
+       "cache_write": 7.5,
+       "input": 6,
+       "output": 22.5,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -233547,22 +242221,22 @@
    "claude-sonnet-4-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.27,
-     "cache_write": 3.7125,
+     "cache_read": 0.3,
+     "cache_write": 4.125,
      "context_over_200k": {
-      "cache_read": 0.54,
-      "cache_write": 7.425,
-      "input": 5.94,
-      "output": 22.275
+      "cache_read": 0.6,
+      "cache_write": 8.25,
+      "input": 6.6,
+      "output": 24.75
      },
-     "input": 2.97,
-     "output": 14.85,
+     "input": 3.3,
+     "output": 16.5,
      "tiers": [
       {
-       "cache_read": 0.54,
-       "cache_write": 7.425,
-       "input": 5.94,
-       "output": 22.275,
+       "cache_read": 0.6,
+       "cache_write": 8.25,
+       "input": 6.6,
+       "output": 24.75,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -233615,10 +242289,10 @@
    "claude-sonnet-4-6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.27,
-     "cache_write": 3.375,
-     "input": 2.7,
-     "output": 13.5
+     "cache_read": 0.3,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
     },
     "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
     "family": "claude-sonnet",
@@ -233665,10 +242339,10 @@
    "claude-sonnet-4-6@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.27,
-     "cache_write": 3.7125,
-     "input": 2.97,
-     "output": 14.85
+     "cache_read": 0.3,
+     "cache_write": 4.125,
+     "input": 3.3,
+     "output": 16.5
     },
     "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
     "family": "claude-sonnet",
@@ -233715,22 +242389,22 @@
    "claude-sonnet-4@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.27,
-     "cache_write": 3.375,
+     "cache_read": 0.3,
+     "cache_write": 3.75,
      "context_over_200k": {
-      "cache_read": 0.54,
-      "cache_write": 6.75,
-      "input": 5.4,
-      "output": 20.25
+      "cache_read": 0.6,
+      "cache_write": 7.5,
+      "input": 6,
+      "output": 22.5
      },
-     "input": 2.7,
-     "output": 13.5,
+     "input": 3,
+     "output": 15,
      "tiers": [
       {
-       "cache_read": 0.54,
-       "cache_write": 6.75,
-       "input": 5.4,
-       "output": 20.25,
+       "cache_read": 0.6,
+       "cache_write": 7.5,
+       "input": 6,
+       "output": 22.5,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -233783,10 +242457,10 @@
    "claude-sonnet-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.18,
-     "cache_write": 2.25,
-     "input": 1.8,
-     "output": 9
+     "cache_read": 0.2,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 10
     },
     "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
     "family": "claude-sonnet",
@@ -233833,10 +242507,10 @@
    "claude-sonnet-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.198,
-     "cache_write": 2.475,
-     "input": 1.98,
-     "output": 9.9
+     "cache_read": 0.22,
+     "cache_write": 2.75,
+     "input": 2.2,
+     "output": 11
     },
     "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
     "family": "claude-sonnet",
@@ -233883,9 +242557,9 @@
    "deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0126,
-     "input": 0.396,
-     "output": 1.188
+     "cache_read": 0.014,
+     "input": 0.44,
+     "output": 1.32
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -233915,9 +242589,9 @@
    "deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.063,
-     "input": 0.126,
-     "output": 0.252
+     "cache_read": 0.07,
+     "input": 0.14,
+     "output": 0.28
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -233962,9 +242636,9 @@
    "deepseek-v4-flash-0731@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.063,
-     "input": 0.126,
-     "output": 0.252
+     "cache_read": 0.07,
+     "input": 0.14,
+     "output": 0.28
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -234009,9 +242683,9 @@
    "deepseek-v4-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0396,
-     "input": 1.188,
-     "output": 3.564
+     "cache_read": 0.044,
+     "input": 1.32,
+     "output": 3.96
     },
     "description": "Open MoE flagship with million-token context for coding and long agent runs",
     "family": "deepseek-thinking",
@@ -234056,9 +242730,9 @@
    "deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0396,
-     "input": 1.188,
-     "output": 3.564
+     "cache_read": 0.044,
+     "input": 1.32,
+     "output": 3.96
     },
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
@@ -234102,9 +242776,9 @@
    "deepseek-v4-pro@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.396,
-     "input": 1.575,
-     "output": 3.15
+     "cache_read": 0.44,
+     "input": 1.75,
+     "output": 3.5
     },
     "description": "Open MoE flagship with million-token context for coding and long agent runs",
     "family": "deepseek-thinking",
@@ -234149,9 +242823,9 @@
    "devstral-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.396,
-     "input": 0.396,
-     "output": 1.98
+     "cache_read": 0.44,
+     "input": 0.44,
+     "output": 2.2
     },
     "description": "An enterprise grade text model, that excels at using tools to explore codebases, editing multiple files and power software engineering agents.",
     "family": "devstral",
@@ -234179,9 +242853,9 @@
    "devstral-latest@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.396,
-     "input": 0.396,
-     "output": 1.98
+     "cache_read": 0.44,
+     "input": 0.44,
+     "output": 2.2
     },
     "description": "An enterprise grade text model, that excels at using tools to explore codebases, editing multiple files and power software engineering agents.",
     "family": "devstral",
@@ -234209,19 +242883,19 @@
    "fugu-ultra": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.45,
+     "cache_read": 0.5,
      "context_over_200k": {
-      "cache_read": 0.9,
-      "input": 9,
-      "output": 40.5
+      "cache_read": 1,
+      "input": 10,
+      "output": 45
      },
-     "input": 4.5,
-     "output": 27,
+     "input": 5,
+     "output": 30,
      "tiers": [
       {
-       "cache_read": 0.9,
-       "input": 9,
-       "output": 40.5,
+       "cache_read": 1,
+       "input": 10,
+       "output": 45,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -234257,10 +242931,10 @@
    "gemini-2.5-flash@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0675,
-     "cache_write": 0.495,
-     "input": 0.27,
-     "output": 2.25
+     "cache_read": 0.075,
+     "cache_write": 0.55,
+     "input": 0.3,
+     "output": 2.5
     },
     "description": "Fast Gemini workhorse for multimodal apps where latency and price matter",
     "family": "gemini-flash",
@@ -234309,22 +242983,22 @@
    "gemini-3-pro-image": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.18,
-     "cache_write": 4.05,
+     "cache_read": 0.2,
+     "cache_write": 4.5,
      "context_over_200k": {
-      "cache_read": 0.18,
-      "cache_write": 4.05,
-      "input": 3.6,
-      "output": 16.2
+      "cache_read": 0.2,
+      "cache_write": 4.5,
+      "input": 4,
+      "output": 18
      },
-     "input": 1.8,
-     "output": 10.8,
+     "input": 2,
+     "output": 12,
      "tiers": [
       {
-       "cache_read": 0.18,
-       "cache_write": 4.05,
-       "input": 3.6,
-       "output": 16.2,
+       "cache_read": 0.2,
+       "cache_write": 4.5,
+       "input": 4,
+       "output": 18,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -234378,15 +243052,15 @@
     "attachment": true,
     "cost": {
      "context_over_200k": {
-      "input": 0.45,
-      "output": 1.8
+      "input": 0.5,
+      "output": 2
      },
-     "input": 0.45,
-     "output": 1.8,
+     "input": 0.5,
+     "output": 2,
      "tiers": [
       {
-       "input": 0.45,
-       "output": 1.8,
+       "input": 0.5,
+       "output": 2,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -234441,22 +243115,22 @@
    "gemini-3.1-flash-lite": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0225,
-     "cache_write": 0.074997,
+     "cache_read": 0.025,
+     "cache_write": 0.08333,
      "context_over_200k": {
-      "cache_read": 0.0225,
-      "cache_write": 0.074997,
-      "input": 0.45,
-      "output": 2.025
+      "cache_read": 0.025,
+      "cache_write": 0.08333,
+      "input": 0.5,
+      "output": 2.25
      },
-     "input": 0.225,
-     "output": 1.35,
+     "input": 0.25,
+     "output": 1.5,
      "tiers": [
       {
-       "cache_read": 0.0225,
-       "cache_write": 0.074997,
-       "input": 0.45,
-       "output": 2.025,
+       "cache_read": 0.025,
+       "cache_write": 0.08333,
+       "input": 0.5,
+       "output": 2.25,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -234511,22 +243185,22 @@
    "gemini-3.1-flash-lite@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.02475,
-     "cache_write": 0.082497,
+     "cache_read": 0.0275,
+     "cache_write": 0.091663,
      "context_over_200k": {
-      "cache_read": 0.02475,
-      "cache_write": 0.082497,
-      "input": 0.495,
-      "output": 2.2275
+      "cache_read": 0.0275,
+      "cache_write": 0.091663,
+      "input": 0.55,
+      "output": 2.475
      },
-     "input": 0.2475,
-     "output": 1.485,
+     "input": 0.275,
+     "output": 1.65,
      "tiers": [
       {
-       "cache_read": 0.02475,
-       "cache_write": 0.082497,
-       "input": 0.495,
-       "output": 2.2275,
+       "cache_read": 0.0275,
+       "cache_write": 0.091663,
+       "input": 0.55,
+       "output": 2.475,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -234581,22 +243255,22 @@
    "gemini-3.1-pro-preview": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.18,
-     "cache_write": 4.05,
+     "cache_read": 0.2,
+     "cache_write": 4.5,
      "context_over_200k": {
-      "cache_read": 0.18,
-      "cache_write": 4.05,
-      "input": 3.6,
-      "output": 16.2
+      "cache_read": 0.2,
+      "cache_write": 4.5,
+      "input": 4,
+      "output": 18
      },
-     "input": 1.8,
-     "output": 10.8,
+     "input": 2,
+     "output": 12,
      "tiers": [
       {
-       "cache_read": 0.18,
-       "cache_write": 4.05,
-       "input": 3.6,
-       "output": 16.2,
+       "cache_read": 0.2,
+       "cache_write": 4.5,
+       "input": 4,
+       "output": 18,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -234651,10 +243325,10 @@
    "gemini-3.5-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.135,
-     "cache_write": 1.4247,
-     "input": 1.35,
-     "output": 8.1
+     "cache_read": 0.15,
+     "cache_write": 1.583,
+     "input": 1.5,
+     "output": 9
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -234703,9 +243377,9 @@
    "gemini-3.5-flash-lite": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.027,
-     "input": 0.27,
-     "output": 2.25
+     "cache_read": 0.03,
+     "input": 0.3,
+     "output": 2.5
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash-lite",
@@ -234754,9 +243428,9 @@
    "gemini-3.5-flash-lite@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0297,
-     "input": 0.297,
-     "output": 2.475
+     "cache_read": 0.033,
+     "input": 0.33,
+     "output": 2.75
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash-lite",
@@ -234805,10 +243479,10 @@
    "gemini-3.5-flash@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1485,
-     "cache_write": 1.56717,
-     "input": 1.485,
-     "output": 8.91
+     "cache_read": 0.165,
+     "cache_write": 1.7413,
+     "input": 1.65,
+     "output": 9.9
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -234857,9 +243531,9 @@
    "gemini-3.6-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.135,
-     "input": 1.35,
-     "output": 6.3
+     "cache_read": 0.15,
+     "input": 1.5,
+     "output": 7
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -234908,9 +243582,9 @@
    "gemini-3.7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.06,
-     "input": 0.6,
-     "output": 3
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 3.75
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -234959,9 +243633,9 @@
    "gemini-3.7-flash@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.066,
-     "input": 0.66,
-     "output": 3.3
+     "cache_read": 0.0825,
+     "input": 0.825,
+     "output": 4.125
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -235010,9 +243684,9 @@
    "gemma-4-26b-a4b-it": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.063,
-     "input": 0.063,
-     "output": 0.306
+     "cache_read": 0.07,
+     "input": 0.07,
+     "output": 0.34
     },
     "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
     "family": "gemma",
@@ -235103,9 +243777,9 @@
    "glm-5.1": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.234,
-     "input": 1.26,
-     "output": 3.96
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
     },
     "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
     "family": "glm",
@@ -235149,9 +243823,9 @@
    "glm-5.1@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 1.26,
-     "input": 1.26,
-     "output": 3.96
+     "cache_read": 1.4,
+     "input": 1.4,
+     "output": 4.4
     },
     "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
     "family": "glm",
@@ -235195,9 +243869,9 @@
    "glm-5.2": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.234,
-     "input": 1.08,
-     "output": 3.78
+     "cache_read": 0.26,
+     "input": 1.2,
+     "output": 4.2
     },
     "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
     "family": "glm",
@@ -235241,9 +243915,9 @@
    "glm-5.2-fast": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.189,
-     "input": 1.89,
-     "output": 5.94
+     "cache_read": 0.21,
+     "input": 2.1,
+     "output": 6.6
     },
     "description": "GLM-5.2 introduces a robust 1M-token context and advanced, multi-effort coding capabilities to significantly enhance performance on long-horizon tasks. Its new IndexShare architecture and improved MTP layer simultaneously boost efficiency by reducing per-token FLOPs and increasing speculative decoding lengths. A 743B-parameter model in Zhipu AI's GLM series, designed to plan, execute, and iterate autonomously on extended, engineering-grade tasks.",
     "family": "glm",
@@ -235286,9 +243960,9 @@
    "glm-5.2@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.234,
-     "input": 1.08,
-     "output": 3.78
+     "cache_read": 0.26,
+     "input": 1.2,
+     "output": 4.2
     },
     "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
     "family": "glm",
@@ -235332,9 +244006,9 @@
    "glm-5.3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.234,
-     "input": 1.26,
-     "output": 3.96
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
     },
     "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
     "family": "glm",
@@ -235353,7 +244027,102 @@
      ]
     },
     "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
     "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3@eu": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.44,
+     "input": 1.75,
+     "output": 4.5
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3@eu",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 (EU)",
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -235378,9 +244147,9 @@
    "gpt-4.1-mini@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.099,
-     "input": 0.396,
-     "output": 1.584
+     "cache_read": 0.11,
+     "input": 0.44,
+     "output": 1.76
     },
     "description": "Affordable GPT-4.1 lane for fast coding help and structured extraction",
     "family": "gpt-mini",
@@ -235412,9 +244181,9 @@
    "gpt-4.1-nano@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.02475,
-     "input": 0.099,
-     "output": 0.396
+     "cache_read": 0.0275,
+     "input": 0.11,
+     "output": 0.44
     },
     "description": "Tiny GPT-4.1 option for classification, routing, and very high-volume tasks",
     "family": "gpt-nano",
@@ -235445,9 +244214,9 @@
    "gpt-4.1@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.495,
-     "input": 1.98,
-     "output": 7.92
+     "cache_read": 0.55,
+     "input": 2.2,
+     "output": 8.8
     },
     "description": "Long-lived GPT workhorse for coding, instruction following, and production apps",
     "family": "gpt",
@@ -235479,9 +244248,9 @@
    "gpt-4o-mini@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.07425,
-     "input": 0.1485,
-     "output": 0.594
+     "cache_read": 0.0825,
+     "input": 0.165,
+     "output": 0.66
     },
     "description": "Small omni GPT for cheap multimodal assistance and production-scale traffic",
     "family": "gpt-mini",
@@ -235513,9 +244282,9 @@
    "gpt-5-mini@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.02475,
-     "input": 0.2475,
-     "output": 1.98
+     "cache_read": 0.0275,
+     "input": 0.275,
+     "output": 2.2
     },
     "description": "Small GPT-5 for responsive agents, coding help, and everyday automation",
     "family": "gpt-mini",
@@ -235561,9 +244330,9 @@
    "gpt-5-nano@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.00495,
-     "input": 0.0495,
-     "output": 0.396
+     "cache_read": 0.0055,
+     "input": 0.055,
+     "output": 0.44
     },
     "description": "Tiny GPT-5 lane for routing, extraction, classification, and bulk jobs",
     "family": "gpt-nano",
@@ -235609,9 +244378,9 @@
    "gpt-5.1@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.12375,
-     "input": 1.2375,
-     "output": 9.9
+     "cache_read": 0.1375,
+     "input": 1.375,
+     "output": 11
     },
     "description": "Sharper GPT-5 generation for coding, product work, and tool-assisted tasks",
     "family": "gpt",
@@ -235652,61 +244421,15 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "gpt-5.3-chat": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.1575,
-     "input": 1.575,
-     "output": 12.6
-    },
-    "description": "GPT-5.3 Chat is an update to ChatGPT's most-used model that makes everyday conversations smoother, more useful, and more directly helpful. It delivers more accurate answers with better contextualization and significantly reduces unnecessary refusals, caveats, and overly cautious phrasing that can interrupt conversational flow.",
-    "family": "gpt",
-    "id": "gpt-5.3-chat",
-    "last_updated": "2026-03-18",
-    "limit": {
-     "context": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "gpt-5.3-chat",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "max"
-      ]
-     },
-     {
-      "type": "budget_tokens"
-     }
-    ],
-    "release_date": "2026-03-18",
-    "structured_output": true,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.3-codex": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1575,
-     "input": 1.575,
-     "output": 12.6
+     "cache_read": 0.175,
+     "input": 1.75,
+     "output": 14
     },
     "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
     "family": "gpt-codex",
@@ -235748,15 +244471,15 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2475,
-     "input": 2.475,
-     "output": 14.85
+     "cache_read": 0.275,
+     "input": 2.75,
+     "output": 16.5
     },
     "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
     "family": "gpt",
@@ -235798,15 +244521,15 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0675,
-     "input": 0.675,
-     "output": 4.05
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 4.5
     },
     "description": "Strong small GPT for coding subagents, quick tool use, and high-volume work",
     "family": "gpt-mini",
@@ -235847,15 +244570,15 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-nano": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.018,
-     "input": 0.18,
-     "output": 1.125
+     "cache_read": 0.02,
+     "input": 0.2,
+     "output": 1.25
     },
     "description": "Cheapest GPT-5.4 lane for simple routing, extraction, and bulk automation",
     "family": "gpt-nano",
@@ -235896,15 +244619,15 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-pro": {
     "attachment": true,
     "cost": {
-     "cache_read": 27,
-     "input": 27,
-     "output": 162
+     "cache_read": 30,
+     "input": 30,
+     "output": 180
     },
     "description": "More exact GPT-5.4 tier for demanding professional reasoning and agent tasks",
     "family": "gpt-pro",
@@ -235951,19 +244674,19 @@
    "gpt-5.4@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.225,
+     "cache_read": 0.25,
      "context_over_200k": {
-      "cache_read": 0.45,
-      "input": 4.5,
-      "output": 20.25
+      "cache_read": 0.5,
+      "input": 5,
+      "output": 22.5
      },
-     "input": 2.25,
-     "output": 13.5,
+     "input": 2.5,
+     "output": 15,
      "tiers": [
       {
-       "cache_read": 0.45,
-       "input": 4.5,
-       "output": 20.25,
+       "cache_read": 0.5,
+       "input": 5,
+       "output": 22.5,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -236011,15 +244734,15 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.495,
-     "input": 4.95,
-     "output": 29.7
+     "cache_read": 0.55,
+     "input": 5.5,
+     "output": 33
     },
     "description": "Default frontier GPT for coding, computer use, research, and knowledge work",
     "family": "gpt",
@@ -236067,8 +244790,8 @@
    "gpt-5.5-pro": {
     "attachment": true,
     "cost": {
-     "input": 27,
-     "output": 162
+     "input": 30,
+     "output": 180
     },
     "description": "Highest-accuracy GPT-5.5 tier for slower, precision-heavy reasoning and coding",
     "family": "gpt-pro",
@@ -236116,19 +244839,19 @@
    "gpt-5.5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.45,
+     "cache_read": 0.5,
      "context_over_200k": {
-      "cache_read": 0.9,
-      "input": 9,
-      "output": 40.5
+      "cache_read": 1,
+      "input": 10,
+      "output": 45
      },
-     "input": 4.5,
-     "output": 27,
+     "input": 5,
+     "output": 30,
      "tiers": [
       {
-       "cache_read": 0.9,
-       "input": 9,
-       "output": 40.5,
+       "cache_read": 1,
+       "input": 10,
+       "output": 45,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -236182,19 +244905,19 @@
    "gpt-5.6-luna": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.018,
+     "cache_read": 0.02,
      "context_over_200k": {
-      "cache_read": 0.036,
-      "input": 0.36,
-      "output": 1.62
+      "cache_read": 0.04,
+      "input": 0.4,
+      "output": 1.8
      },
-     "input": 0.18,
-     "output": 1.08,
+     "input": 0.2,
+     "output": 1.2,
      "tiers": [
       {
-       "cache_read": 0.036,
-       "input": 0.36,
-       "output": 1.62,
+       "cache_read": 0.04,
+       "input": 0.4,
+       "output": 1.8,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -236248,9 +244971,9 @@
    "gpt-5.6-luna@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0198,
-     "input": 0.198,
-     "output": 1.188
+     "cache_read": 0.022,
+     "input": 0.22,
+     "output": 1.32
     },
     "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
     "family": "gpt-luna",
@@ -236298,19 +245021,22 @@
    "gpt-5.6-sol": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.45,
+     "cache_read": 0.4,
+     "cache_write": 5,
      "context_over_200k": {
-      "cache_read": 0.9,
-      "input": 9,
-      "output": 40.5
+      "cache_read": 0.8,
+      "cache_write": 10,
+      "input": 8,
+      "output": 30
      },
-     "input": 4.5,
-     "output": 27,
+     "input": 4,
+     "output": 20,
      "tiers": [
       {
-       "cache_read": 0.9,
-       "input": 9,
-       "output": 40.5,
+       "cache_read": 0.8,
+       "cache_write": 10,
+       "input": 8,
+       "output": 30,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -236364,9 +245090,9 @@
    "gpt-5.6-sol@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.495,
-     "input": 4.95,
-     "output": 29.7
+     "cache_read": 0.55,
+     "input": 5.5,
+     "output": 33
     },
     "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
     "family": "gpt-sol",
@@ -236414,19 +245140,19 @@
    "gpt-5.6-terra": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.18,
+     "cache_read": 0.2,
      "context_over_200k": {
-      "cache_read": 0.36,
-      "input": 3.6,
-      "output": 16.2
+      "cache_read": 0.4,
+      "input": 4,
+      "output": 18
      },
-     "input": 1.8,
-     "output": 10.8,
+     "input": 2,
+     "output": 12,
      "tiers": [
       {
-       "cache_read": 0.36,
-       "input": 3.6,
-       "output": 16.2,
+       "cache_read": 0.4,
+       "input": 4,
+       "output": 18,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -236480,9 +245206,9 @@
    "gpt-5.6-terra@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.198,
-     "input": 1.98,
-     "output": 11.88
+     "cache_read": 0.22,
+     "input": 2.2,
+     "output": 13.2
     },
     "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
     "family": "gpt-terra",
@@ -236530,9 +245256,9 @@
    "gpt-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.12375,
-     "input": 1.2375,
-     "output": 9.9
+     "cache_read": 0.1375,
+     "input": 1.375,
+     "output": 11
     },
     "description": "Original GPT-5 workhorse for reasoning, coding, writing, and tool workflows",
     "family": "gpt",
@@ -236579,22 +245305,22 @@
    "grok-4.2-beta": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.18,
-     "cache_write": 1.8,
+     "cache_read": 0.2,
+     "cache_write": 2,
      "context_over_200k": {
-      "cache_read": 0.36,
-      "cache_write": 3.6,
-      "input": 3.6,
-      "output": 10.8
+      "cache_read": 0.4,
+      "cache_write": 4,
+      "input": 4,
+      "output": 12
      },
-     "input": 1.8,
-     "output": 5.4,
+     "input": 2,
+     "output": 6,
      "tiers": [
       {
-       "cache_read": 0.36,
-       "cache_write": 3.6,
-       "input": 3.6,
-       "output": 10.8,
+       "cache_read": 0.4,
+       "cache_write": 4,
+       "input": 4,
+       "output": 12,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -236644,22 +245370,22 @@
    "grok-4.3": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.18,
-     "cache_write": 1.125,
+     "cache_read": 0.2,
+     "cache_write": 1.25,
      "context_over_200k": {
-      "cache_read": 0.36,
-      "cache_write": 2.25,
-      "input": 2.25,
-      "output": 4.5
+      "cache_read": 0.4,
+      "cache_write": 2.5,
+      "input": 2.5,
+      "output": 5
      },
-     "input": 1.125,
-     "output": 2.25,
+     "input": 1.25,
+     "output": 2.5,
      "tiers": [
       {
-       "cache_read": 0.36,
-       "cache_write": 2.25,
-       "input": 2.25,
-       "output": 4.5,
+       "cache_read": 0.4,
+       "cache_write": 2.5,
+       "input": 2.5,
+       "output": 5,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -236711,22 +245437,22 @@
    "grok-4.5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.45,
-     "cache_write": 1.8,
+     "cache_read": 0.5,
+     "cache_write": 2,
      "context_over_200k": {
-      "cache_read": 0.9,
-      "cache_write": 3.6,
-      "input": 3.6,
-      "output": 10.8
+      "cache_read": 1,
+      "cache_write": 4,
+      "input": 4,
+      "output": 12
      },
-     "input": 1.8,
-     "output": 5.4,
+     "input": 2,
+     "output": 6,
      "tiers": [
       {
-       "cache_read": 0.9,
-       "cache_write": 3.6,
-       "input": 3.6,
-       "output": 10.8,
+       "cache_read": 1,
+       "cache_write": 4,
+       "input": 4,
+       "output": 12,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -236777,22 +245503,22 @@
    "grok-4.6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.45,
-     "cache_write": 1.8,
+     "cache_read": 0.5,
+     "cache_write": 2,
      "context_over_200k": {
-      "cache_read": 0.9,
-      "cache_write": 3.6,
-      "input": 3.6,
-      "output": 10.8
+      "cache_read": 1,
+      "cache_write": 4,
+      "input": 4,
+      "output": 12
      },
-     "input": 1.8,
-     "output": 5.4,
+     "input": 2,
+     "output": 6,
      "tiers": [
       {
-       "cache_read": 0.9,
-       "cache_write": 3.6,
-       "input": 3.6,
-       "output": 10.8,
+       "cache_read": 1,
+       "cache_write": 4,
+       "input": 4,
+       "output": 12,
        "tier": {
         "size": 200000,
         "type": "context"
@@ -236844,9 +245570,9 @@
    "grok-build-0.1": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.09,
-     "input": 0.9,
-     "output": 1.8
+     "cache_read": 0.1,
+     "input": 1,
+     "output": 2
     },
     "description": "Fast Grok coding model tuned for agentic engineering and iterative edits",
     "family": "grok-build",
@@ -236877,9 +245603,9 @@
    "hy3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.0315,
-     "input": 0.126,
-     "output": 0.522
+     "cache_read": 0.035,
+     "input": 0.14,
+     "output": 0.58
     },
     "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
     "family": "Hy",
@@ -236923,9 +245649,9 @@
    "inkling": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.3366,
-     "input": 1.683,
-     "output": 4.212
+     "cache_read": 0.374,
+     "input": 1.87,
+     "output": 4.68
     },
     "description": "Multimodal MoE reasoning model (975B total, 41B active) for text, image, and audio",
     "family": "ling",
@@ -236971,9 +245697,9 @@
    "inkling-256k": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2992,
-     "input": 1.496,
-     "output": 3.744
+     "cache_read": 0.374,
+     "input": 1.87,
+     "output": 4.68
     },
     "description": "Inkling 256K is the extended context variant of Inkling, a large MoE hybrid reasoning model from Thinking Machines with audio and vision input support and a 256K context window.",
     "id": "inkling-256k",
@@ -237016,8 +245742,8 @@
    "kat-coder-pro": {
     "attachment": false,
     "cost": {
-     "input": 0.27,
-     "output": 1.08
+     "input": 0.3,
+     "output": 1.2
     },
     "description": "KAT-Coder-Pro V2 by KwaiKAT is a non-reasoning model optimized for agentic coding. It delivers strong performance on reasoning-style tasks while requiring significantly fewer output tokens than peer models. With the 1210 release, it achieved a score of 64 on the Artificial Analysis Intelligence Index, placing it in the global Top 10 and ranking first among all non-reasoning models.",
     "family": "kat-coder",
@@ -237045,9 +245771,9 @@
    "kimi-k2.6": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.144,
-     "input": 0.855,
-     "output": 3.6
+     "cache_read": 0.16,
+     "input": 0.95,
+     "output": 4
     },
     "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
     "family": "kimi-k2",
@@ -237094,9 +245820,9 @@
    "kimi-k2.6@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.855,
-     "input": 0.855,
-     "output": 3.6
+     "cache_read": 0.95,
+     "input": 0.95,
+     "output": 4
     },
     "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
     "family": "kimi-k2",
@@ -237143,9 +245869,9 @@
    "kimi-k2.7-code": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.171,
-     "input": 0.855,
-     "output": 3.6
+     "cache_read": 0.19,
+     "input": 0.95,
+     "output": 4
     },
     "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
     "family": "kimi-k2",
@@ -237192,9 +245918,9 @@
    "kimi-k2.7-code@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.279,
-     "input": 1.125,
-     "output": 4.05
+     "cache_read": 0.31,
+     "input": 1.25,
+     "output": 4.5
     },
     "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
     "family": "kimi-k2",
@@ -237241,9 +245967,9 @@
    "kimi-k3": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2025,
-     "input": 2.025,
-     "output": 10.125
+     "cache_read": 0.225,
+     "input": 2.25,
+     "output": 11.25
     },
     "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
     "family": "kimi-k3",
@@ -237289,9 +246015,9 @@
    "kimi-k3@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2025,
-     "input": 2.025,
-     "output": 10.125
+     "cache_read": 0.225,
+     "input": 2.25,
+     "output": 11.25
     },
     "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
     "family": "kimi-k3",
@@ -237483,8 +246209,8 @@
    "ling-2.6-1t": {
     "attachment": false,
     "cost": {
-     "input": 0.27,
-     "output": 2.25
+     "input": 0.3,
+     "output": 2.5
     },
     "description": "Inclusion AI ling-2.6-1t",
     "family": "ling",
@@ -237512,8 +246238,8 @@
    "ling-2.6-flash": {
     "attachment": false,
     "cost": {
-     "input": 0.09,
-     "output": 0.27
+     "input": 0.1,
+     "output": 0.3
     },
     "description": "Inclusion AI ling-2.6-flash",
     "family": "ling",
@@ -237585,9 +246311,9 @@
    "mimo-v2.5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.00252,
-     "input": 0.126,
-     "output": 0.252
+     "cache_read": 0.0028,
+     "input": 0.14,
+     "output": 0.28
     },
     "description": "Open MiMo model for multimodal coding agents and long-context automation",
     "family": "mimo",
@@ -237620,9 +246346,9 @@
    "mimo-v2.5-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.00324,
-     "input": 0.3915,
-     "output": 0.783
+     "cache_read": 0.0036,
+     "input": 0.435,
+     "output": 0.87
     },
     "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
     "family": "mimo",
@@ -237652,10 +246378,10 @@
    "minimax-m2.7": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.054,
-     "cache_write": 1.08,
-     "input": 0.27,
-     "output": 1.08
+     "cache_read": 0.06,
+     "cache_write": 1.2,
+     "input": 0.3,
+     "output": 1.2
     },
     "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
     "family": "minimax",
@@ -237699,10 +246425,10 @@
    "minimax-m2.7-highspeed": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.054,
-     "cache_write": 1.08,
-     "input": 0.54,
-     "output": 2.16
+     "cache_read": 0.06,
+     "cache_write": 1.2,
+     "input": 0.6,
+     "output": 2.4
     },
     "description": "Low-latency M2.7 variant for interactive coding plans and agent loops",
     "family": "minimax",
@@ -237746,9 +246472,9 @@
    "minimax-m3": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.048,
-     "input": 0.24,
-     "output": 0.96
+     "cache_read": 0.06,
+     "input": 0.3,
+     "output": 1.2
     },
     "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
     "family": "minimax",
@@ -237794,9 +246520,9 @@
    "minimax-m3@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.09,
-     "input": 0.36,
-     "output": 1.8
+     "cache_read": 0.1,
+     "input": 0.4,
+     "output": 2
     },
     "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
     "family": "minimax",
@@ -237842,9 +246568,9 @@
    "mistral-medium-3-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 1.485,
-     "input": 1.485,
-     "output": 7.425
+     "cache_read": 1.65,
+     "input": 1.65,
+     "output": 8.25
     },
     "description": "Mistral Medium 3.5 is a dense 128B instruction following model from Mistral AI. It supports text and image inputs with text output, and is designed for agentic workflows, coding, and complex multi step reasoning. It is particularly strong at reliable multi tool calling and long horizon tasks, with a 256K context window, configurable reasoning effort per request, and a custom vision encoder that handles variable image sizes and aspect ratios. Self hostable on as few as four GPUs and available under open weights.",
     "family": "mistral-medium",
@@ -237888,9 +246614,9 @@
    "mistral-medium-3-5@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 1.485,
-     "input": 1.485,
-     "output": 7.425
+     "cache_read": 1.65,
+     "input": 1.65,
+     "output": 8.25
     },
     "description": "Mistral Medium 3.5 is a dense 128B instruction following model from Mistral AI. It supports text and image inputs with text output, and is designed for agentic workflows, coding, and complex multi step reasoning. It is particularly strong at reliable multi tool calling and long horizon tasks, with a 256K context window, configurable reasoning effort per request, and a custom vision encoder that handles variable image sizes and aspect ratios. Self hostable on as few as four GPUs and available under open weights.",
     "family": "mistral-medium",
@@ -237934,9 +246660,9 @@
    "mistral-medium-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.396,
-     "input": 0.396,
-     "output": 1.98
+     "cache_read": 0.44,
+     "input": 0.44,
+     "output": 2.2
     },
     "description": "Balanced Mistral model for enterprise assistants, multilingual work, and tools",
     "family": "mistral-medium",
@@ -237966,9 +246692,9 @@
    "mistral-medium-latest@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.396,
-     "input": 0.396,
-     "output": 1.98
+     "cache_read": 0.44,
+     "input": 0.44,
+     "output": 2.2
     },
     "description": "Balanced Mistral model for enterprise assistants, multilingual work, and tools",
     "family": "mistral-medium",
@@ -237998,9 +246724,9 @@
    "mistral-small-2603": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1485,
-     "input": 0.1485,
-     "output": 0.594
+     "cache_read": 0.165,
+     "input": 0.165,
+     "output": 0.66
     },
     "description": "Fast Mistral production model for chat, extraction, and cost-sensitive agents",
     "family": "mistral-small",
@@ -238046,9 +246772,9 @@
    "mistral-small-2603@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1485,
-     "input": 0.1485,
-     "output": 0.594
+     "cache_read": 0.165,
+     "input": 0.165,
+     "output": 0.66
     },
     "description": "Fast Mistral production model for chat, extraction, and cost-sensitive agents",
     "family": "mistral-small",
@@ -238141,9 +246867,9 @@
    "nemotron-3-nano-omni": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.054,
-     "input": 0.054,
-     "output": 0.216
+     "cache_read": 0.06,
+     "input": 0.06,
+     "output": 0.24
     },
     "description": "The most open, efficient, and accurate omni modal reasoning model for agentic AI.",
     "family": "nemotron",
@@ -238234,9 +246960,9 @@
    "nemotron-3-nano-omni@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.054,
-     "input": 0.054,
-     "output": 0.216
+     "cache_read": 0.06,
+     "input": 0.06,
+     "output": 0.24
     },
     "description": "The most open, efficient, and accurate omni modal reasoning model for agentic AI.",
     "family": "nemotron",
@@ -238369,9 +247095,9 @@
    "nemotron-3-ultra-nvfp4": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.108,
-     "input": 0.54,
-     "output": 2.16
+     "cache_read": 0.12,
+     "input": 0.6,
+     "output": 2.4
     },
     "description": "Nemotron-3-Ultra-550B-A55B-NVFP4 is a frontier-scale large language model (LLM) trained by NVIDIA, designed to deliver strong agentic, reasoning, and conversational capabilities. It is optimized for the most demanding workloads, including complex multi-step agents, long-context analysis, and high-accuracy reasoning over code, math, and science. The model employs a hybrid Latent Mixture-of-Experts (LatentMoE) architecture, utilizing interleaved Mamba-2 and MoE layers, along with select Attention layers. Like the Super model, the Ultra model incorporates Multi-Token Prediction (MTP) layers for faster text generation and improved quality, and it is trained using an NVFP4 pre-training recipe to maximize compute efficiency. The model has 55B active parameters and 550B parameters in total.",
     "family": "nemotron",
@@ -238504,9 +247230,9 @@
    "nemotron-lightning-3.5-30b-a3b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.009,
-     "input": 0.045,
-     "output": 0.18
+     "cache_read": 0.01,
+     "input": 0.05,
+     "output": 0.2
     },
     "description": "Nemotron-Lightning-3.5-30B-A3B is a 30B-parameter Mixture-of-Experts language model (3B active) from NVIDIA's Nemotron-H family, built on a hybrid Mamba-Transformer architecture for efficient long-context inference. Like other models in the family, it responds to queries by first generating a reasoning trace and then concluding with a final response, with reasoning behavior configurable through a flag in the chat template. It includes a multi-token prediction (MTP) speculative decoding head for low-latency serving.",
     "family": "nemotron",
@@ -238549,8 +247275,8 @@
    "nvidia-nemotron-3-super-120b-a12b": {
     "attachment": false,
     "cost": {
-     "input": 0.09,
-     "output": 0.45
+     "input": 0.1,
+     "output": 0.5
     },
     "description": "NVIDIA Nemotron 3 Super is a hybrid Mixture-of-Experts (MoE) model engineered for highest compute efficiency and accuracy in multi-agent applications and specialized agentic systems. It is optimized to run many collaborating agents per application on a single GPU, delivering high accuracy for reasoning, tool use, and instruction following.",
     "family": "nemotron",
@@ -238593,8 +247319,8 @@
    "nvidia-nemotron-3-ultra": {
     "attachment": false,
     "cost": {
-     "input": 0.45,
-     "output": 2.25
+     "input": 0.5,
+     "output": 2.5
     },
     "description": "NVIDIA Nemotron 3 Ultra is NVIDIA's strongest open-weights reasoning model, positioned near GPT-5.4 Mini (xhigh) and ahead of DeepSeek V4-Flash and Qwen3.5-397B-A17B.",
     "family": "nemotron",
@@ -238637,9 +247363,9 @@
    "o4-mini@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.27225,
-     "input": 1.089,
-     "output": 4.356
+     "cache_read": 0.3025,
+     "input": 1.21,
+     "output": 4.84
     },
     "description": "Fast o-series model for compact reasoning, coding, and tool use",
     "family": "o-mini",
@@ -238685,8 +247411,8 @@
    "qwen3.5-27b": {
     "attachment": true,
     "cost": {
-     "input": 0.234,
-     "output": 2.34
+     "input": 0.26,
+     "output": 2.6
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -238733,8 +247459,8 @@
    "qwen3.5-2b": {
     "attachment": true,
     "cost": {
-     "input": 0.018,
-     "output": 0.09
+     "input": 0.02,
+     "output": 0.1
     },
     "description": "Qwen3.5-2B is a compact yet capable model from Alibaba's Qwen3.5 series. It features a 262K token context window, support for 201 languages, thinking/reasoning mode, and tool calling for agentic workflows. A strong choice for prototyping, fine-tuning, and efficient multilingual deployments.",
     "family": "qwen3.5",
@@ -238778,9 +247504,9 @@
    "qwen3.5-35b-a3b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.045,
-     "input": 0.126,
-     "output": 0.9
+     "cache_read": 0.05,
+     "input": 0.14,
+     "output": 1
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -238827,10 +247553,10 @@
    "qwen3.6-plus": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.045,
-     "cache_write": 0.5625,
-     "input": 0.45,
-     "output": 2.7
+     "cache_read": 0.05,
+     "cache_write": 0.625,
+     "input": 0.5,
+     "output": 3
     },
     "description": "Earlier Qwen multimodal workhorse for million-token agent and document tasks",
     "family": "qwen",
@@ -238877,10 +247603,10 @@
    "qwen3.7-max": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.225,
-     "cache_write": 2.8125,
-     "input": 2.25,
-     "output": 6.75
+     "cache_read": 0.25,
+     "cache_write": 3.125,
+     "input": 2.5,
+     "output": 7.5
     },
     "description": "Qwen frontier model tuned for agent frameworks, coding assistants, and long tasks",
     "family": "qwen",
@@ -238924,10 +247650,10 @@
    "qwen3.7-plus": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.028,
-     "cache_write": 0.35,
-     "input": 0.28,
-     "output": 1.12
+     "cache_read": 0.032,
+     "cache_write": 0.4,
+     "input": 0.32,
+     "output": 1.28
     },
     "description": "Multimodal Qwen workhorse for long-context agents, visual inputs, and coding",
     "family": "qwen",
@@ -238974,9 +247700,9 @@
    "qwen3.8-2.4T-A95B": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.18,
-     "input": 1.8,
-     "output": 5.4
+     "cache_read": 0.2,
+     "input": 2,
+     "output": 6
     },
     "description": "Open-weight sparse MoE (2.4T total, 95B active), the open-weight twin of Qwen3.8 Max for coding, research, complex reasoning, and agentic workflows",
     "family": "qwen",
@@ -239020,10 +247746,10 @@
    "qwen3.8-max": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.225,
-     "cache_write": 2.25,
-     "input": 1.8,
-     "output": 5.4
+     "cache_read": 0.25,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 6
     },
     "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
     "family": "qwen",
@@ -239070,8 +247796,8 @@
    "ring-2.6-1t": {
     "attachment": false,
     "cost": {
-     "input": 0.27,
-     "output": 2.25
+     "input": 0.3,
+     "output": 2.5
     },
     "description": "Inclusion AI ring-2.6-1t",
     "family": "ring",
@@ -239114,9 +247840,9 @@
    "seed-1.8": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.045,
-     "input": 0.225,
-     "output": 1.8
+     "cache_read": 0.05,
+     "input": 0.25,
+     "output": 2
     },
     "description": "Optimized specifically for multimodal agent scenarios. It features enhanced agent capabilities, upgraded multimodal comprehension, and more flexible context management.",
     "family": "seed",
@@ -239160,9 +247886,9 @@
    "seed-2.0-code": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.09,
-     "input": 0.45,
-     "output": 2.7
+     "cache_read": 0.1,
+     "input": 0.5,
+     "output": 3
     },
     "description": "ByteDance Seed coding model for multimodal software engineering and long-running agents",
     "family": "seed",
@@ -239208,9 +247934,9 @@
    "seed-2.0-mini": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.018,
-     "input": 0.09,
-     "output": 0.36
+     "cache_read": 0.02,
+     "input": 0.1,
+     "output": 0.4
     },
     "description": "Lightweight ByteDance Seed 2.0 model for low-latency multimodal reasoning and high-volume tasks",
     "family": "seed",
@@ -239256,9 +247982,9 @@
    "seed-2.0-pro": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.09,
-     "input": 0.45,
-     "output": 2.7
+     "cache_read": 0.1,
+     "input": 0.5,
+     "output": 3
     },
     "description": "Flagship ByteDance Seed 2.0 model for complex multimodal reasoning and long-horizon agent workflows",
     "family": "seed",
@@ -239304,9 +248030,9 @@
    "step-3.7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.036,
-     "input": 0.18,
-     "output": 1.035
+     "cache_read": 0.04,
+     "input": 0.2,
+     "output": 1.15
     },
     "description": "Newer StepFun flash model for faster agents, coding, and multimodal prompts",
     "id": "step-3.7-flash",
@@ -239352,9 +248078,9 @@
    "thinkingcap-qwen3.6-27b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.234,
-     "input": 0.36,
-     "output": 2.7
+     "cache_read": 0.26,
+     "input": 0.4,
+     "output": 3
     },
     "description": "ThinkingCap-Qwen3.6-27B is a reasoning tuned model from BottlecapAI built on Qwen3.6 27B. It supports extended thinking with tool calling and a 256K context window. Served via Sference.",
     "family": "qwen3.6",
@@ -239397,9 +248123,9 @@
    "thinkingcap-qwen3.6-27b@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.234,
-     "input": 0.36,
-     "output": 2.7
+     "cache_read": 0.26,
+     "input": 0.4,
+     "output": 3
     },
     "description": "ThinkingCap-Qwen3.6-27B is a reasoning tuned model from BottlecapAI built on Qwen3.6 27B. It supports extended thinking with tool calling and a 256K context window. Served via Sference.",
     "family": "qwen3.6",
@@ -240046,7 +248772,7 @@
     "tool_call": true
    },
    "Qwen/Qwen3.8-27B": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.01,
      "input": 0.1,
@@ -240062,7 +248788,8 @@
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
@@ -240168,6 +248895,7 @@
    "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16": {
     "attachment": false,
     "cost": {
+     "cache_read": 0.01,
      "input": 0.05,
      "output": 0.15
     },
@@ -240196,6 +248924,89 @@
      }
     ],
     "release_date": "2026-08-11",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "ornith-ai/Ornith-1.5-35B-A3B": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Mixture-of-experts coding-reasoning model for agentic software tasks, tool use, and image understanding",
+    "family": "ornith",
+    "id": "ornith-ai/Ornith-1.5-35B-A3B",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-23",
+    "limit": {
+     "context": 262144,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ornith 1.5 35B A3B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-18",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai-org/GLM-5.3-Flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3-Flash",
+    "interleaved": true,
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -241796,7 +250607,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4": {
@@ -241843,7 +250654,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
@@ -243238,6 +252049,52 @@
     "temperature": true,
     "tool_call": true
    },
+   "DeepSeek-V4-Pro-0813": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "DeepSeek-V4-Pro-0813",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "GLM-5": {
     "attachment": false,
     "cost": {
@@ -243605,8 +252462,8 @@
     },
     "last_updated": "2026-06-01",
     "limit": {
-     "context": 512000,
-     "output": 128000
+     "context": 1048576,
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -243857,6 +252714,147 @@
    }
   },
   "name": "SCX.ai",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "sensenova": {
+  "api": "https://token.sensenova.cn/v1",
+  "doc": "https://platform.sensenova.cn/docs",
+  "env": [
+   "SENSENOVA_API_KEY"
+  ],
+  "id": "sensenova",
+  "models": {
+   "deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "glm-5.2",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "sensenova-6.8-flash-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "SenseNova lightweight multimodal agent model for real-world complex tasks, data analysis, and complex information presentation",
+    "id": "sensenova-6.8-flash-lite",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "SenseNova 6.8 Flash Lite",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-11",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "SenseNova (China)",
   "npm": "@ai-sdk/openai-compatible"
  },
  "siliconflow": {
@@ -247788,7 +256786,7 @@
     ],
     "release_date": "2025-11-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai-gpt-5.2": {
@@ -247829,7 +256827,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai-gpt-5.4": {
@@ -247888,7 +256886,7 @@
     "release_date": "2026-03-05",
     "status": "beta",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai-gpt-5.5": {
@@ -248357,6 +257355,57 @@
    }
   },
   "name": "STACKIT",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "standardcompute": {
+  "api": "https://api.stdcmpt.com/v1",
+  "doc": "https://standardcompute.com/models",
+  "env": [
+   "STANDARDCOMPUTE_API_KEY"
+  ],
+  "id": "standardcompute",
+  "models": {
+   "standardcompute": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Flat-rate smart-routing gateway: one model id, each request routed across a curated catalog of 1M-context models (DeepSeek, GLM, MiniMax, Qwen, GPT-5.6, Claude 5, Gemini 2.5, Kimi) or pinned to a user-selected model",
+    "family": "auto",
+    "id": "standardcompute",
+    "interleaved": {
+     "field": "reasoning_details"
+    },
+    "last_updated": "2026-08-24",
+    "limit": {
+     "context": 1000000,
+     "output": 24576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Standard Compute",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-03-01",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "Standard Compute",
   "npm": "@ai-sdk/openai-compatible"
  },
  "stepfun": {
@@ -249928,6 +258977,51 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
+   },
+   "hf:zai-org/GLM-5.3-Flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.04,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "hf:zai-org/GLM-5.3-Flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 524288,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "Synthetic",
@@ -250266,13 +259360,54 @@
      {
       "type": "effort",
       "values": [
-       "low",
-       "medium",
+       "none",
        "high"
       ]
      }
     ],
     "release_date": "2026-07-06",
+    "temperature": true,
+    "tool_call": true
+   },
+   "hy4-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.042,
+     "input": 0.834,
+     "output": 2.501
+    },
+    "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+    "family": "Hy",
+    "id": "hy4-preview",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 1024000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy4 preview",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-28",
     "temperature": true,
     "tool_call": true
    }
@@ -250322,8 +259457,7 @@
      {
       "type": "effort",
       "values": [
-       "low",
-       "medium",
+       "none",
        "high"
       ]
      }
@@ -250373,6 +259507,48 @@
      }
     ],
     "release_date": "2026-04-20",
+    "temperature": true,
+    "tool_call": true
+   },
+   "hy4-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.042,
+     "input": 0.834,
+     "output": 2.501
+    },
+    "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+    "family": "Hy",
+    "id": "hy4-preview",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 1024000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy4 preview",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-28",
     "temperature": true,
     "tool_call": true
    }
@@ -251980,8 +261156,12 @@
      {
       "type": "effort",
       "values": [
+       "none",
+       "minimal",
        "low",
+       "medium",
        "high",
+       "xhigh",
        "max"
       ]
      }
@@ -252195,12 +261375,8 @@
      {
       "type": "effort",
       "values": [
-       "none",
-       "minimal",
        "low",
-       "medium",
        "high",
-       "xhigh",
        "max"
       ]
      }
@@ -253561,10 +262737,678 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
+   },
+   "zai-org/GLM-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1048576,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai-org/GLM-5.3-Flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3-Flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048575,
+     "output": 400000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "Together AI",
   "npm": "@ai-sdk/togetherai"
+ },
+ "tokengo": {
+  "api": "https://api.tokengo.com/v1",
+  "doc": "https://www.tokengo.com/docs",
+  "env": [
+   "TOKENGO_API_KEY"
+  ],
+  "id": "tokengo",
+  "models": {
+   "deepseek/deepseek-v3.1": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.19,
+     "output": 0.71
+    },
+    "description": "Hybrid-reasoning DeepSeek model with thinking and non-thinking modes",
+    "family": "deepseek",
+    "id": "deepseek/deepseek-v3.1",
+    "last_updated": "2025-08-21",
+    "limit": {
+     "context": 131072,
+     "output": 8192
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek-V3.1",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-08-21",
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v3.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.06,
+     "input": 0.2174,
+     "output": 0.326
+    },
+    "description": "Hybrid-reasoning DeepSeek model with thinking and non-thinking modes, sparse attention, and tool-use",
+    "family": "deepseek",
+    "id": "deepseek/deepseek-v3.2",
+    "knowledge": "2024-07",
+    "last_updated": "2025-12-01",
+    "limit": {
+     "context": 128000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V3.2",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-12-01",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.028,
+     "input": 0.098,
+     "output": 0.196
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash",
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek/deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "input": 0.435,
+     "output": 0.87
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "deepseek/deepseek-v4-pro",
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m2.5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.3,
+     "output": 1.2
+    },
+    "description": "Prior MiniMax coding model for agent workflows, office edits, and automation",
+    "family": "minimax",
+    "id": "minimax/minimax-m2.5",
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 204800,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax-M2.5",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-02-12",
+    "temperature": true,
+    "tool_call": true
+   },
+   "moonshotai/kimi-k2.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.16,
+     "input": 0.95,
+     "output": 4
+    },
+    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
+    "family": "kimi-k2",
+    "id": "moonshotai/kimi-k2.6",
+    "knowledge": "2025-01",
+    "last_updated": "2026-04-21",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.6",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-04-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "moonshotai/kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "input": 3,
+     "output": 15
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "moonshotai/kimi-k3",
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "qwen/qwen3.5-397b-a17b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 0.4,
+     "output": 2.65
+    },
+    "description": "Large open Qwen multimodal MoE for visual agents and long technical tasks",
+    "family": "qwen",
+    "id": "qwen/qwen3.5-397b-a17b",
+    "last_updated": "2026-02-15",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.5 397B-A17B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-02-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2226,
+     "input": 0.89,
+     "output": 3.2647
+    },
+    "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
+    "family": "glm",
+    "id": "z-ai/glm-5",
+    "last_updated": "2026-02-12",
+    "limit": {
+     "context": 204800,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-02-12",
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.1": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
+    "family": "glm",
+    "id": "z-ai/glm-5.1",
+    "last_updated": "2026-04-07",
+    "limit": {
+     "context": 200000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.1",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-04-07",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "z-ai/glm-5.2",
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "z-ai/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "input": 0.075,
+     "output": 0.025
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "z-ai/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "TokenGo",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "tokenrouter": {
+  "api": "https://api.tokenrouter.com/v1",
+  "doc": "https://www.tokenrouter.com/docs/tokenrouter-feature-guide/",
+  "env": [
+   "TOKENROUTER_API_KEY"
+  ],
+  "id": "tokenrouter",
+  "models": {
+   "z-ai/glm-5.3-free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "z-ai/glm-5.3-free",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 (free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "TokenRouter",
+  "npm": "@ai-sdk/openai-compatible"
  },
  "trustedrouter": {
   "api": "https://api.trustedrouter.com/v1",
@@ -253574,10 +263418,10 @@
   ],
   "id": "trustedrouter",
   "models": {
-   "auto": {
+   "trustedrouter/auto": {
     "attachment": true,
     "description": "TrustedRouter automatic routing alias that chooses a healthy supported model endpoint for the request.",
-    "id": "auto",
+    "id": "trustedrouter/auto",
     "last_updated": "2026-06-27",
     "limit": {
      "context": 1000000,
@@ -253612,10 +263456,10 @@
     "temperature": true,
     "tool_call": true
    },
-   "cheap": {
+   "trustedrouter/cheap": {
     "attachment": true,
     "description": "TrustedRouter low-cost routing alias that prefers inexpensive healthy model endpoints.",
-    "id": "cheap",
+    "id": "trustedrouter/cheap",
     "last_updated": "2026-06-27",
     "limit": {
      "context": 1000000,
@@ -253650,10 +263494,10 @@
     "temperature": true,
     "tool_call": true
    },
-   "e2e": {
+   "trustedrouter/e2e": {
     "attachment": true,
     "description": "TrustedRouter privacy routing alias for end-to-end encrypted provider routes where available.",
-    "id": "e2e",
+    "id": "trustedrouter/e2e",
     "last_updated": "2026-06-27",
     "limit": {
      "context": 1000000,
@@ -253688,10 +263532,10 @@
     "temperature": true,
     "tool_call": true
    },
-   "fast": {
+   "trustedrouter/fast": {
     "attachment": true,
     "description": "TrustedRouter speed routing alias that prefers low-latency healthy model endpoints.",
-    "id": "fast",
+    "id": "trustedrouter/fast",
     "last_updated": "2026-06-27",
     "limit": {
      "context": 1000000,
@@ -253726,10 +263570,10 @@
     "temperature": true,
     "tool_call": true
    },
-   "synth": {
+   "trustedrouter/synth": {
     "attachment": true,
     "description": "TrustedRouter synthesis orchestration alias that combines multiple model responses into one answer.",
-    "id": "synth",
+    "id": "trustedrouter/synth",
     "last_updated": "2026-06-27",
     "limit": {
      "context": 1000000,
@@ -253764,10 +263608,10 @@
     "temperature": true,
     "tool_call": true
    },
-   "synth-code": {
+   "trustedrouter/synth-code": {
     "attachment": true,
     "description": "TrustedRouter code synthesis orchestration alias that combines multiple model responses into one answer.",
-    "id": "synth-code",
+    "id": "trustedrouter/synth-code",
     "last_updated": "2026-06-27",
     "limit": {
      "context": 1000000,
@@ -253802,10 +263646,10 @@
     "temperature": true,
     "tool_call": true
    },
-   "zdr": {
+   "trustedrouter/zdr": {
     "attachment": true,
     "description": "TrustedRouter privacy routing alias that prefers zero data retention model endpoints.",
-    "id": "zdr",
+    "id": "trustedrouter/zdr",
     "last_updated": "2026-06-27",
     "limit": {
      "context": 1000000,
@@ -254975,7 +264819,7 @@
     "reasoning_options": [],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4": {
@@ -255010,7 +264854,7 @@
     "reasoning_options": [],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4:free": {
@@ -255045,7 +264889,7 @@
     "reasoning_options": [],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
@@ -255584,6 +265428,385 @@
   "name": "v0",
   "npm": "@ai-sdk/vercel"
  },
+ "vancine": {
+  "api": "https://vancine.com/v1",
+  "doc": "https://vancine.com/docs",
+  "env": [
+   "VANCINE_API_KEY"
+  ],
+  "id": "vancine",
+  "models": {
+   "MiniMax-M3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.048,
+     "input": 0.24,
+     "output": 0.96
+    },
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "family": "minimax",
+    "id": "MiniMax-M3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 1048576,
+     "output": 512000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax-M3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-01",
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.022,
+     "input": 0.66,
+     "output": 1.98
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.208,
+     "input": 1.12,
+     "output": 3.52
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.012,
+     "input": 0.06,
+     "output": 0.2
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "kimi-k3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.24,
+     "input": 2.4,
+     "output": 12
+    },
+    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
+    "family": "kimi-k3",
+    "id": "kimi-k3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-07-16",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-16",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.013,
+     "input": 0.12,
+     "output": 0.38
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen3.8-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "max": 262144,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "qwen3.8-max": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1.6,
+     "output": 4.8
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "qwen3.8-max",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     },
+     {
+      "max": 262144,
+      "min": 0,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-03",
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "Vancine",
+  "npm": "@ai-sdk/openai-compatible"
+ },
  "venice": {
   "doc": "https://docs.venice.ai",
   "env": [
@@ -256033,10 +266256,10 @@
    "claude-sonnet-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.3,
-     "cache_write": 3.75,
-     "input": 3,
-     "output": 15
+     "cache_read": 0.2,
+     "cache_write": 2.5000000000000004,
+     "input": 2,
+     "output": 10.000000000000002
     },
     "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
     "family": "claude-sonnet",
@@ -256447,9 +266670,9 @@
    "gemini-3-6-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1875,
-     "input": 1.875,
-     "output": 9.375
+     "cache_read": 0.09375,
+     "input": 0.9375,
+     "output": 4.6875
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -256483,9 +266706,9 @@
    "gemini-3-7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1875,
-     "input": 1.875,
-     "output": 9.375
+     "cache_read": 0.09375,
+     "input": 0.9375,
+     "output": 4.6875
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -257262,7 +267485,17 @@
     "name": "Kimi K3",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-07-16",
     "structured_output": true,
     "temperature": false,
@@ -257295,7 +267528,17 @@
     "name": "Kimi K3 Fast",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-08-03",
     "structured_output": true,
     "temperature": false,
@@ -257806,7 +268049,7 @@
     ],
     "release_date": "2025-12-13",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai-gpt-52-codex": {
@@ -257898,7 +268141,7 @@
     ],
     "release_date": "2026-02-24",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai-gpt-54": {
@@ -257944,7 +268187,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai-gpt-54-mini": {
@@ -257990,7 +268233,7 @@
     ],
     "release_date": "2026-03-27",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai-gpt-54-pro": {
@@ -259184,49 +269427,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "stealth-ox-alpha": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0,
-     "input": 0,
-     "output": 0
-    },
-    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
-    "family": "alpha",
-    "id": "stealth-ox-alpha",
-    "last_updated": "2026-08-21",
-    "limit": {
-     "context": 1048576,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ox Alpha",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-08-21",
-    "structured_output": true,
-    "tool_call": true
-   },
    "venice-uncensored-1-2": {
     "attachment": true,
     "cost": {
@@ -259359,17 +269559,52 @@
     "name": "GLM 5.3",
     "open_weights": false,
     "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-18",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "z-ai-glm-5-3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "id": "z-ai-glm-5-3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Flash",
+    "open_weights": true,
+    "reasoning": true,
     "reasoning_options": [
      {
       "type": "effort",
       "values": [
+       "none",
        "low",
-       "high",
-       "max"
+       "medium",
+       "high"
       ]
      }
     ],
-    "release_date": "2026-08-18",
+    "release_date": "2026-08-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -260721,7 +270956,7 @@
    "alibaba/qwen3.8-2.4t-a95b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.2,
+     "cache_read": 0.25,
      "input": 2,
      "output": 6
     },
@@ -260731,7 +270966,7 @@
     "last_updated": "2026-08-12",
     "limit": {
      "context": 262144,
-     "output": 131072
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -260763,9 +270998,10 @@
    "alibaba/qwen3.8-27b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.11,
-     "input": 0.55,
-     "output": 3.3
+     "cache_read": 0.1,
+     "cache_write": 0.625,
+     "input": 0.5,
+     "output": 3
     },
     "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
     "family": "qwen",
@@ -260802,6 +271038,47 @@
     "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.16,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "alibaba/qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 991000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "tool_call": true
    },
    "alibaba/qwen3.8-max": {
@@ -261049,6 +271326,56 @@
     "reasoning": false,
     "release_date": "2026-04-07",
     "temperature": true,
+    "tool_call": false
+   },
+   "alibaba/wan-v3.0-video": {
+    "attachment": true,
+    "description": "Video model for prompt-guided generation, editing, and motion workflows",
+    "family": "o",
+    "id": "alibaba/wan-v3.0-video",
+    "last_updated": "2026-08-23",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "video"
+     ]
+    },
+    "name": "Wan v3.0 Video",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-23",
+    "tool_call": false
+   },
+   "alibaba/wan-v3.0-video-prime": {
+    "attachment": true,
+    "description": "Video model for prompt-guided generation, editing, and motion workflows",
+    "family": "o",
+    "id": "alibaba/wan-v3.0-video-prime",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "video"
+     ]
+    },
+    "name": "Wan v3.0 Video Prime",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-28",
     "tool_call": false
    },
    "amazon/nova-2-lite": {
@@ -261935,36 +272262,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "arcee-ai/trinity-mini": {
-    "attachment": false,
-    "cost": {
-     "input": 0.045,
-     "output": 0.15
-    },
-    "description": "Reasoning-tuned 26B MoE model with 3B active parameters for agents, tools, and multi-step workloads",
-    "family": "trinity",
-    "id": "arcee-ai/trinity-mini",
-    "knowledge": "2024-10",
-    "last_updated": "2025-12",
-    "limit": {
-     "context": 131072,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Trinity Mini",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-12-01",
-    "temperature": true,
-    "tool_call": false
-   },
    "bfl/flux-2-flex": {
     "attachment": false,
     "description": "Image model for prompt-driven generation, editing, and visual design workflows",
@@ -262372,6 +272669,31 @@
     "reasoning": false,
     "release_date": "2026-04-14",
     "temperature": true,
+    "tool_call": false
+   },
+   "bytedance/seedance-2.0-mini": {
+    "attachment": true,
+    "description": "Video model for prompt-guided generation, editing, and motion workflows",
+    "family": "seed",
+    "id": "bytedance/seedance-2.0-mini",
+    "last_updated": "2026-06-22",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "video"
+     ]
+    },
+    "name": "Seedance 2.0 Mini",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-06-22",
     "tool_call": false
    },
    "bytedance/seedance-2.5": {
@@ -263023,9 +273345,9 @@
    "deepseek/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.14,
-     "input": 1.74,
-     "output": 3.48
+     "cache_read": 0.022,
+     "input": 0.66,
+     "output": 1.98
     },
     "description": "Open MoE flagship with million-token context for coding and long agent runs",
     "family": "deepseek-thinking",
@@ -263033,8 +273355,8 @@
     "knowledge": "2025-05",
     "last_updated": "2026-04-24",
     "limit": {
-     "context": 1048600,
-     "output": 1048600
+     "context": 1000000,
+     "output": 384000
     },
     "modalities": {
      "input": [
@@ -263067,9 +273389,9 @@
    "deepseek/deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.132,
-     "input": 1.32,
-     "output": 3.96
+     "cache_read": 0.066,
+     "input": 0.66,
+     "output": 1.98
     },
     "description": "Flagship DeepSeek model for coding, reasoning, and agentic work",
     "family": "deepseek-thinking",
@@ -263857,6 +274179,58 @@
     "temperature": true,
     "tool_call": true
    },
+   "google/gemini-3.5-transcribe": {
+    "attachment": false,
+    "cost": {
+     "input": 2,
+     "output": 12
+    },
+    "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
+    "family": "gemini",
+    "id": "google/gemini-3.5-transcribe",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Transcribe",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-26",
+    "tool_call": false
+   },
+   "google/gemini-3.5-transcribe-live": {
+    "attachment": false,
+    "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
+    "family": "gemini",
+    "id": "google/gemini-3.5-transcribe-live",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.5 Transcribe Live",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-26",
+    "tool_call": false
+   },
    "google/gemini-3.6-flash": {
     "attachment": true,
     "cost": {
@@ -264367,6 +274741,72 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-08-06",
+    "tool_call": true
+   },
+   "inclusionai/ling-3.0-flash-fin": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Finance-enhanced model for financial research, multi-step investment workflows, and long-horizon planning and execution",
+    "family": "ling",
+    "id": "inclusionai/ling-3.0-flash-fin",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 256000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ling 3.0 Flash Fin",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-27",
+    "tool_call": true
+   },
+   "inclusionai/ling-3.0-flash-fin-free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Finance-enhanced model for financial research, multi-step investment workflows, and long-horizon planning and execution",
+    "family": "ling",
+    "id": "inclusionai/ling-3.0-flash-fin-free",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 256000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ling 3.0 Flash Fin (Free)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-27",
     "tool_call": true
    },
    "interfaze/interfaze-beta": {
@@ -264932,6 +275372,31 @@
     "temperature": true,
     "tool_call": true
    },
+   "meta/muse-image-1.0": {
+    "attachment": true,
+    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+    "family": "muse",
+    "id": "meta/muse-image-1.0",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "image"
+     ]
+    },
+    "name": "Muse Image 1.0",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-26",
+    "tool_call": false
+   },
    "meta/muse-spark-1.1": {
     "attachment": false,
     "cost": {
@@ -265066,6 +275531,31 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2026-07-30",
+    "tool_call": false
+   },
+   "minimax/minimax-h3-max": {
+    "attachment": true,
+    "description": "Video model for prompt-guided generation, editing, and motion workflows",
+    "family": "minimax",
+    "id": "minimax/minimax-h3-max",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 0,
+     "output": 0
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "video"
+     ]
+    },
+    "name": "MiniMax H3 Max",
+    "open_weights": false,
+    "reasoning": false,
+    "release_date": "2026-08-27",
     "tool_call": false
    },
    "minimax/minimax-m2": {
@@ -265264,6 +275754,36 @@
     "temperature": true,
     "tool_call": true
    },
+   "minimax/minimax-m2.7-free": {
+    "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+    "family": "minimax",
+    "id": "minimax/minimax-m2.7-free",
+    "last_updated": "2026-03-18",
+    "limit": {
+     "context": 196608,
+     "output": 196608
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Minimax M2.7 (Free)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-03-18",
+    "temperature": true,
+    "tool_call": true
+   },
    "minimax/minimax-m2.7-highspeed": {
     "attachment": true,
     "cost": {
@@ -265308,8 +275828,8 @@
     "id": "minimax/minimax-m3",
     "last_updated": "2026-06-01",
     "limit": {
-     "context": 1000000,
-     "output": 1000000
+     "context": 512000,
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -265322,6 +275842,42 @@
      ]
     },
     "name": "MiniMax M3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-01",
+    "temperature": true,
+    "tool_call": true
+   },
+   "minimax/minimax-m3-free": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "family": "minimax",
+    "id": "minimax/minimax-m3-free",
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax M3 (Free)",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -265446,68 +276002,6 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2025-12-09",
-    "temperature": true,
-    "tool_call": true
-   },
-   "mistral/magistral-medium": {
-    "attachment": false,
-    "cost": {
-     "input": 2,
-     "output": 5
-    },
-    "description": "Mistral reasoning model for transparent analysis, math, and complex decisions",
-    "family": "magistral-medium",
-    "id": "mistral/magistral-medium",
-    "knowledge": "2025-06",
-    "last_updated": "2025-03-20",
-    "limit": {
-     "context": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Magistral Medium (latest)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-03-17",
-    "temperature": true,
-    "tool_call": true
-   },
-   "mistral/magistral-small": {
-    "attachment": false,
-    "cost": {
-     "input": 0.5,
-     "output": 1.5
-    },
-    "description": "Mistral reasoning model for transparent analysis, math, and complex decisions",
-    "family": "magistral-small",
-    "id": "mistral/magistral-small",
-    "knowledge": "2025-06",
-    "last_updated": "2025-03-17",
-    "limit": {
-     "context": 128000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Magistral Small",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-03-17",
     "temperature": true,
     "tool_call": true
    },
@@ -265964,7 +276458,7 @@
    "moonshotai/kimi-k2.7-code": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.19,
+     "cache_read": 0.16,
      "input": 0.95,
      "output": 4
     },
@@ -266272,16 +276766,17 @@
    "nvidia/nemotron-3.5-lightning": {
     "attachment": false,
     "cost": {
-     "input": 0,
-     "output": 0
+     "cache_read": 0.01,
+     "input": 0.05,
+     "output": 0.2
     },
     "description": "Nemotron model for efficient reasoning, coding, and specialized AI agents",
     "family": "nemotron",
     "id": "nvidia/nemotron-3.5-lightning",
     "last_updated": "2026-08-11",
     "limit": {
-     "context": 1000000,
-     "output": 32768
+     "context": 262144,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -266292,46 +276787,6 @@
      ]
     },
     "name": "Nemotron 3.5 Lightning 30B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "max": 32768,
-      "min": 1,
-      "type": "budget_tokens"
-     }
-    ],
-    "release_date": "2026-08-11",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nvidia/nemotron-3.5-lightning-free": {
-    "attachment": false,
-    "cost": {
-     "input": 0,
-     "output": 0
-    },
-    "description": "Fast NVIDIA Nemotron MoE for reliable agentic tasks across enterprise workloads",
-    "family": "nemotron",
-    "id": "nvidia/nemotron-3.5-lightning-free",
-    "last_updated": "2026-08-11",
-    "limit": {
-     "context": 1000000,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3.5 Lightning 30B (Free)",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -266828,38 +277283,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "openai/gpt-4o-mini-search-preview": {
-    "attachment": false,
-    "cost": {
-     "input": 0.15,
-     "output": 0.6
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "gpt-mini",
-    "id": "openai/gpt-4o-mini-search-preview",
-    "knowledge": "2023-09",
-    "last_updated": "2025-01",
-    "limit": {
-     "context": 128000,
-     "input": 111616,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT 4o Mini Search Preview",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-03-12",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
    "openai/gpt-4o-mini-transcribe": {
     "attachment": false,
     "cost": {
@@ -266993,7 +277416,16 @@
     "name": "GPT-5-Codex",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2025-09-15",
     "structured_output": true,
     "temperature": false,
@@ -267575,7 +278007,7 @@
     ],
     "release_date": "2025-12-11",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.2-pro": {
@@ -267711,7 +278143,7 @@
     ],
     "release_date": "2026-02-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4": {
@@ -267805,7 +278237,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-mini": {
@@ -267899,7 +278331,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "openai/gpt-5.4-nano": {
@@ -268628,12 +279060,52 @@
     "temperature": true,
     "tool_call": true
    },
+   "openai/gpt-oss-safeguard-120b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.15,
+     "output": 0.6
+    },
+    "description": "Safety model for policy screening, moderation, and risk-aware routing workflows",
+    "family": "gpt-oss",
+    "id": "openai/gpt-oss-safeguard-120b",
+    "last_updated": "2025-10-29",
+    "limit": {
+     "context": 128000,
+     "input": 112000,
+     "output": 16000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS Safeguard 120B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-10-29",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "openai/gpt-oss-safeguard-20b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.037,
-     "input": 0.075,
-     "output": 0.3
+     "input": 0.07,
+     "output": 0.2
     },
     "description": "Safety model for policy screening, moderation, and risk-aware routing workflows",
     "family": "gpt-oss",
@@ -268641,9 +279113,9 @@
     "knowledge": "2024-10",
     "last_updated": "2024-12-01",
     "limit": {
-     "context": 131072,
-     "input": 65536,
-     "output": 65536
+     "context": 128000,
+     "input": 112000,
+     "output": 16000
     },
     "modalities": {
      "input": [
@@ -268925,48 +279397,6 @@
     "release_date": "2025-04-16",
     "structured_output": true,
     "temperature": false,
-    "tool_call": true
-   },
-   "openai/o3-deep-research": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 2.5,
-     "input": 10,
-     "output": 40
-    },
-    "description": "Research model for long-horizon investigation, synthesis, and analytical reports",
-    "family": "o",
-    "id": "openai/o3-deep-research",
-    "knowledge": "2024-05",
-    "last_updated": "2024-06-26",
-    "limit": {
-     "context": 200000,
-     "input": 100000,
-     "output": 100000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "o3-deep-research",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "medium"
-      ]
-     }
-    ],
-    "release_date": "2024-06-26",
-    "temperature": true,
     "tool_call": true
    },
    "openai/o3-fast": {
@@ -270130,7 +280560,7 @@
     "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
     "family": "grok",
     "id": "spacexai/grok-4.3",
-    "last_updated": "2026-04-30",
+    "last_updated": "2026-04-17",
     "limit": {
      "context": 1000000,
      "output": 1000000
@@ -270148,8 +280578,19 @@
     "name": "Grok 4.3",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-04-30",
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-04-17",
+    "structured_output": true,
+    "temperature": true,
     "tool_call": true
    },
    "spacexai/grok-4.5": {
@@ -270180,8 +280621,19 @@
     "name": "Grok 4.5",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2026-07-08",
+    "structured_output": true,
+    "temperature": true,
     "tool_call": true
    },
    "spacexai/grok-4.6": {
@@ -270194,6 +280646,7 @@
     "description": "Grok model for agentic tool use, reasoning, coding, and live assistance",
     "family": "grok",
     "id": "spacexai/grok-4.6",
+    "knowledge": "2026-02-01",
     "last_updated": "2026-08-12",
     "limit": {
      "context": 500000,
@@ -270211,8 +280664,19 @@
     "name": "Grok 4.6",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
     "tool_call": true
    },
    "spacexai/grok-build-0.1": {
@@ -270225,7 +280689,7 @@
     "description": "Grok coding model for agentic engineering, edits, and codebase workflows",
     "family": "grok-build",
     "id": "spacexai/grok-build-0.1",
-    "last_updated": "2026-05-20",
+    "last_updated": "2026-04-16",
     "limit": {
      "context": 256000,
      "output": 256000
@@ -270243,7 +280707,9 @@
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [],
-    "release_date": "2026-05-20",
+    "release_date": "2026-04-16",
+    "structured_output": true,
+    "temperature": true,
     "tool_call": true
    },
    "spacexai/grok-imagine-image": {
@@ -270292,6 +280758,7 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2026-08-07",
+    "temperature": false,
     "tool_call": false
    },
    "spacexai/grok-imagine-video": {
@@ -270323,7 +280790,7 @@
     "description": "Image model for prompt-driven generation, editing, and visual design workflows",
     "family": "grok",
     "id": "spacexai/grok-imagine-video-1.5",
-    "last_updated": "2026-06-22",
+    "last_updated": "2026-05-30",
     "limit": {
      "context": 0,
      "output": 0
@@ -270339,7 +280806,8 @@
     "name": "Grok Imagine Video 1.5",
     "open_weights": false,
     "reasoning": false,
-    "release_date": "2026-06-22",
+    "release_date": "2026-05-30",
+    "temperature": false,
     "tool_call": false
    },
    "spacexai/grok-imagine-video-1.5-preview": {
@@ -270636,17 +281104,17 @@
    "tencent/hy3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.033,
-     "input": 0.132,
-     "output": 0.528
+     "cache_read": 0.035,
+     "input": 0.14,
+     "output": 0.58
     },
     "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
     "family": "Hy",
     "id": "tencent/hy3",
     "last_updated": "2026-07-06",
     "limit": {
-     "context": 256000,
-     "output": 128000
+     "context": 262144,
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -270670,6 +281138,45 @@
      }
     ],
     "release_date": "2026-07-06",
+    "temperature": true,
+    "tool_call": true
+   },
+   "tencent/hy4-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.042,
+     "input": 0.834,
+     "output": 2.501
+    },
+    "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+    "family": "Hy",
+    "id": "tencent/hy4-preview",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 1024000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Tencent Hy4 Preview",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-28",
     "temperature": true,
     "tool_call": true
    },
@@ -271589,7 +282096,7 @@
    "zai/glm-5.3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
+     "cache_read": 0.14,
      "input": 1.4,
      "output": 4.4
     },
@@ -271599,7 +282106,7 @@
     "last_updated": "2026-08-14",
     "limit": {
      "context": 1000000,
-     "output": 12800
+     "output": 1000000
     },
     "modalities": {
      "input": [
@@ -271610,7 +282117,7 @@
      ]
     },
     "name": "GLM 5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -271623,6 +282130,48 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "zai/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -271935,6 +282484,55 @@
     "temperature": true,
     "tool_call": true
    },
+   "gemini-3.7-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
+    "family": "gemini-flash",
+    "id": "gemini-3.7-flash",
+    "knowledge": "2026-03",
+    "last_updated": "2026-08-13",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.7 Flash",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai-compatible"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "glm-5.2": {
     "attachment": false,
     "cost": {
@@ -272005,7 +282603,7 @@
      ]
     },
     "name": "GLM-5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -272018,6 +282616,53 @@
      }
     ],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.04,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -272600,6 +283245,1262 @@
   "name": "Vivgrid",
   "npm": "@ai-sdk/openai"
  },
+ "volcengine": {
+  "api": "https://ark.cn-beijing.volces.com/api/v3",
+  "doc": "https://www.volcengine.com/docs/82379/1330310",
+  "env": [
+   "ARK_API_KEY"
+  ],
+  "id": "volcengine",
+  "models": {
+   "deepseek-v4-flash-ga-260731": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.01484,
+     "input": 0.4453,
+     "output": 1.3359
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash-ga-260731",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-pro-ga-260813": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.04453,
+     "input": 1.3359,
+     "output": 4.00771
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "deepseek-v4-pro-ga-260813",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-1-6-251015": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.02375,
+     "input": 0.11875,
+     "output": 1.18747,
+     "tiers": [
+      {
+       "cache_read": 0.02375,
+       "input": 0.17812,
+       "output": 2.37494,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "cache_read": 0.02375,
+       "input": 0.35624,
+       "output": 3.56241,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "ByteDance Seed model for long-context reasoning, instruction following, and tool-assisted tasks",
+    "family": "seed",
+    "id": "doubao-seed-1-6-251015",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2025-10-15",
+    "limit": {
+     "context": 256000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 1.6",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-10-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-1-6-flash-250828": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.00445,
+     "input": 0.02227,
+     "output": 0.22265,
+     "tiers": [
+      {
+       "cache_read": 0.00445,
+       "input": 0.04453,
+       "output": 0.4453,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "cache_read": 0.00445,
+       "input": 0.08906,
+       "output": 0.8906,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Low-latency ByteDance Seed model for high-throughput chat, extraction, and lightweight tool use",
+    "family": "seed",
+    "id": "doubao-seed-1-6-flash-250828",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2025-08-28",
+    "limit": {
+     "context": 256000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 1.6 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-08-28",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-1-6-vision-250815": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02375,
+     "input": 0.11875,
+     "output": 1.18747,
+     "tiers": [
+      {
+       "cache_read": 0.02375,
+       "input": 0.17812,
+       "output": 2.37494,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "cache_read": 0.02375,
+       "input": 0.35624,
+       "output": 3.56241,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "ByteDance Seed multimodal model for image understanding, visual reasoning, and tool-assisted tasks",
+    "family": "seed",
+    "id": "doubao-seed-1-6-vision-250815",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2025-08-15",
+    "limit": {
+     "context": 256000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 1.6 Vision",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2025-08-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-1-8-251228": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02375,
+     "input": 0.11875,
+     "output": 1.18747,
+     "tiers": [
+      {
+       "cache_read": 0.02375,
+       "input": 0.17812,
+       "output": 2.37494,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "cache_read": 0.02375,
+       "input": 0.35624,
+       "output": 3.56241,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "ByteDance Seed model for multimodal reasoning, long-context analysis, and agent workflows",
+    "family": "seed",
+    "id": "doubao-seed-1-8-251228",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2025-12-28",
+    "limit": {
+     "context": 256000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 1.8",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2025-12-28",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-2-0-code-preview-260215": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.095,
+     "input": 0.47499,
+     "output": 2.37494,
+     "tiers": [
+      {
+       "cache_read": 0.1425,
+       "input": 0.71248,
+       "output": 3.56241,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "cache_read": 0.28499,
+       "input": 1.42496,
+       "output": 7.12482,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "ByteDance Seed coding model for multimodal software engineering and long-running agents",
+    "family": "seed",
+    "id": "doubao-seed-2-0-code-preview-260215",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-14",
+    "limit": {
+     "context": 262144,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 2.0 Code",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-2-0-lite-260428": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01781,
+     "input": 0.08906,
+     "output": 0.53436,
+     "tiers": [
+      {
+       "cache_read": 0.02672,
+       "input": 0.13359,
+       "output": 0.80154,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "cache_read": 0.05344,
+       "input": 0.26718,
+       "output": 1.60308,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Cost-efficient ByteDance Seed 2.0 model for production chat, analysis, and structured generation",
+    "family": "seed",
+    "id": "doubao-seed-2-0-lite-260428",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-14",
+    "limit": {
+     "context": 256000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 2.0 Lite",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-2-0-mini-260428": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.00594,
+     "input": 0.02969,
+     "output": 0.29687,
+     "tiers": [
+      {
+       "cache_read": 0.01187,
+       "input": 0.05937,
+       "output": 0.59374,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "cache_read": 0.02375,
+       "input": 0.11875,
+       "output": 1.18747,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Lightweight ByteDance Seed 2.0 model for low-latency multimodal reasoning and high-volume tasks",
+    "family": "seed",
+    "id": "doubao-seed-2-0-mini-260428",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-14",
+    "limit": {
+     "context": 256000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 2.0 Mini",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-2-0-pro-260215": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.095,
+     "input": 0.47499,
+     "output": 2.37494,
+     "tiers": [
+      {
+       "cache_read": 0.1425,
+       "input": 0.71248,
+       "output": 3.56241,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      },
+      {
+       "cache_read": 0.28499,
+       "input": 1.42496,
+       "output": 7.12482,
+       "tier": {
+        "size": 128000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "Flagship ByteDance Seed 2.0 model for complex multimodal reasoning and long-horizon agent workflows",
+    "family": "seed",
+    "id": "doubao-seed-2-0-pro-260215",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-14",
+    "limit": {
+     "context": 256000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 2.0 Pro",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-02-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-2-1-pro-260628": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.17812,
+     "input": 0.8906,
+     "output": 4.45301
+    },
+    "description": "Flagship ByteDance Seed 2.1 model for complex multimodal reasoning, coding, and agents",
+    "family": "seed",
+    "id": "doubao-seed-2-1-pro-260628",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-23",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 2.1 Pro",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-23",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-2-1-turbo-260628": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.08906,
+     "input": 0.4453,
+     "output": 2.22651
+    },
+    "description": "Faster ByteDance Seed 2.1 model for multimodal reasoning and latency-sensitive agent workflows",
+    "family": "seed",
+    "id": "doubao-seed-2-1-turbo-260628",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-23",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 2.1 Turbo",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-23",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-character-260628": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02375,
+     "input": 0.11875,
+     "output": 0.29687,
+     "tiers": [
+      {
+       "cache_read": 0.02375,
+       "input": 0.17812,
+       "output": 0.8906,
+       "tier": {
+        "size": 32000,
+        "type": "context"
+       }
+      }
+     ]
+    },
+    "description": "ByteDance Seed model optimized for character-driven dialogue and consistent conversational behavior",
+    "family": "seed",
+    "id": "doubao-seed-character-260628",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-23",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed Character",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-23",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-evolving": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.17812,
+     "input": 0.8906,
+     "output": 4.45301
+    },
+    "description": "Rolling ByteDance Seed model for rapidly updated reasoning, coding, and agent capabilities",
+    "family": "seed",
+    "id": "doubao-seed-evolving",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-23",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed Evolving",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-06-23",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5-2-260617": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.29687,
+     "input": 1.18747,
+     "output": 4.15615
+    },
+    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "family": "glm",
+    "id": "glm-5-2-260617",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-13",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.2",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "Volcengine Ark",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "volcengine-coding-plan": {
+  "api": "https://ark.cn-beijing.volces.com/api/coding/v3",
+  "doc": "https://www.volcengine.com/docs/82379/1928261",
+  "env": [
+   "ARK_CODING_PLAN_API_KEY"
+  ],
+  "id": "volcengine-coding-plan",
+  "models": {
+   "deepseek-v4-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-pro": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Open MoE flagship with million-token context for coding and long agent runs",
+    "family": "deepseek-thinking",
+    "id": "deepseek-v4-pro",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-04-24",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-04-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-2.0-lite": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Cost-efficient ByteDance Seed 2.0 model for production chat, analysis, and structured generation",
+    "family": "seed",
+    "id": "doubao-seed-2.0-lite",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-02-14",
+    "limit": {
+     "context": 256000,
+     "output": 32000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 2.0 Lite",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-02-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-2.1-turbo": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Faster ByteDance Seed 2.1 model for multimodal reasoning and latency-sensitive agent workflows",
+    "family": "seed",
+    "id": "doubao-seed-2.1-turbo",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-23",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed 2.1 Turbo",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-23",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "doubao-seed-evolving": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Rolling ByteDance Seed model for rapidly updated reasoning, coding, and agent capabilities",
+    "family": "seed",
+    "id": "doubao-seed-evolving",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-23",
+    "limit": {
+     "context": 256000,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Seed Evolving",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-23",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "kimi-k2.7-code": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+    "family": "kimi-k2",
+    "id": "kimi-k2.7-code",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-06-12",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "minimax-m3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "family": "minimax",
+    "id": "minimax-m3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-06-01",
+    "limit": {
+     "context": 1048576,
+     "output": 512000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiniMax-M3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-01",
+    "temperature": true,
+    "tool_call": true
+   }
+  },
+  "name": "Volcengine Ark Coding Plan",
+  "npm": "@ai-sdk/openai-compatible"
+ },
  "vultr": {
   "api": "https://api.vultrinference.com/v1",
   "doc": "https://api.vultrinference.com/",
@@ -273104,7 +285005,7 @@
     "last_updated": "2026-06-01",
     "limit": {
      "context": 1048576,
-     "output": 128000
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -273230,38 +285131,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "MiniMaxAI/MiniMax-M2.5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.3,
-     "input": 0.3,
-     "output": 1.2
-    },
-    "description": "MoE model with a highly sparse architecture designed for high-throughput and low latency with strong coding capabilities.",
-    "family": "minimax-m2.5",
-    "id": "MiniMaxAI/MiniMax-M2.5",
-    "last_updated": "2026-02-12",
-    "limit": {
-     "context": 196608,
-     "output": 196608
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "MiniMax M2.5",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-02-12",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "MiniMaxAI/MiniMax-M3": {
     "attachment": true,
     "cost": {
@@ -273353,38 +285222,6 @@
     "open_weights": true,
     "reasoning": false,
     "release_date": "2025-07-29",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 1,
-     "input": 1,
-     "output": 1.5
-    },
-    "description": "Mixture-of-Experts model optimized for agentic coding tasks such as function calling, tool use, and long-context reasoning.",
-    "family": "qwen",
-    "id": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
-    "knowledge": "2025-04",
-    "last_updated": "2025-07-22",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3 Coder 480B A35B",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-07-22",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -273679,6 +285516,42 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek-ai/DeepSeek-V4-Pro-0813": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.044,
+     "input": 1.31,
+     "output": 3.96
+    },
+    "description": "DeepSeek V4-Pro-0813 is a 1.6T-parameter MoE model excelling at advanced reasoning, coding, and complex agentic workloads.",
+    "family": "deepseek",
+    "id": "deepseek-ai/DeepSeek-V4-Pro-0813",
+    "last_updated": "2026-08-13",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "google/gemma-4-31B-it": {
     "attachment": true,
     "cost": {
@@ -273747,6 +285620,42 @@
     "temperature": true,
     "tool_call": true
    },
+   "ibm-granite/granite-4.2-8b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.15
+    },
+    "description": "Granite 4.2 8B is an instruct model capable of enhanced tool calling, instruction following, and chat capabilities.",
+    "family": "granite",
+    "id": "ibm-granite/granite-4.2-8b",
+    "last_updated": "2026-08-24",
+    "limit": {
+     "context": 131072,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Granite 4.2 8B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-24",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "meta-llama/Llama-3.1-70B-Instruct": {
     "attachment": false,
     "cost": {
@@ -273759,8 +285668,8 @@
     "id": "meta-llama/Llama-3.1-70B-Instruct",
     "last_updated": "2024-07-23",
     "limit": {
-     "context": 128000,
-     "output": 128000
+     "context": 131072,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -273791,8 +285700,8 @@
     "knowledge": "2023-12",
     "last_updated": "2024-07-23",
     "limit": {
-     "context": 128000,
-     "output": 128000
+     "context": 131072,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -273906,75 +285815,6 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-06-12",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "moonshotai/Kimi-K3": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.3,
-     "input": 3,
-     "output": 15
-    },
-    "description": "Kimi K3 is a 2.8T-parameter multimodal MoE model with 104B active parameters built for long-horizon coding and agentic workflows.",
-    "family": "kimi-k3",
-    "id": "moonshotai/Kimi-K3",
-    "last_updated": "2026-07-16",
-    "limit": {
-     "context": 1048576,
-     "output": 1048576
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K3",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-07-16",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.2,
-     "input": 0.2,
-     "output": 0.8
-    },
-    "description": "Nemotron 3 is a LatentMoE model designed to deliver strong agentic, reasoning, and conversational capabilities.",
-    "family": "nemotron",
-    "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
-    "last_updated": "2026-03-11",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Super",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-03-11",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -274115,42 +285955,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "zai-org/GLM-5.1": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
-    },
-    "description": "Powerful MoE model for long-horizon agentic engineering and advanced reasoning.",
-    "family": "glm",
-    "id": "zai-org/GLM-5.1",
-    "last_updated": "2026-04-07",
-    "limit": {
-     "context": 202752,
-     "output": 202752
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 5.1",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-04-07",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "zai-org/GLM-5.2": {
     "attachment": false,
     "cost": {
@@ -274163,8 +285967,8 @@
     "id": "zai-org/GLM-5.2",
     "last_updated": "2026-06-16",
     "limit": {
-     "context": 262144,
-     "output": 262144
+     "context": 1048576,
+     "output": 1048576
     },
     "modalities": {
      "input": [
@@ -276193,7 +287997,7 @@
     ],
     "release_date": "2026-03-05",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.4-mini": {
@@ -276242,7 +288046,7 @@
     ],
     "release_date": "2026-03-17",
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "tool_call": true
    },
    "gpt-5.5": {
@@ -277046,6 +288850,99 @@
     "temperature": true,
     "tool_call": true
    },
+   "glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "cache_write": 0,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "cache_write": 0,
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "glm-5v-turbo": {
     "attachment": true,
     "cost": {
@@ -277296,7 +289193,100 @@
      ]
     },
     "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "cache_write": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
     "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-highspeed": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "cache_write": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3-highspeed",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 Highspeed",
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -279021,8 +291011,8 @@
     "id": "minimax/minimax-m3",
     "last_updated": "2026-06-01",
     "limit": {
-     "context": 512000,
-     "output": 128000
+     "context": 1048576,
+     "output": 512000
     },
     "modalities": {
      "input": [
@@ -282783,6 +294773,99 @@
     "temperature": true,
     "tool_call": true
    },
+   "glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.26,
+     "cache_write": 0,
+     "input": 1.4,
+     "output": 4.4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "cache_write": 0,
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "glm-5v-turbo": {
     "attachment": true,
     "cost": {
@@ -283110,7 +295193,100 @@
      ]
     },
     "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "cache_write": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
     "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-highspeed": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0,
+     "cache_write": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3-highspeed",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 Highspeed",
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {

--- a/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.meta.json
+++ b/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.meta.json
@@ -1,8 +1,8 @@
 {
   "source": "https://models.dev/api.json",
-  "fetchedUtc": "2026-08-23T02:09:32Z",
-  "providers": 193,
-  "providersWithApiUrl": 167,
-  "sha256": "1565e15952a89aef53f6d47c659c57122b59061491ec3ded24295349e60a22ed",
+  "fetchedUtc": "2026-08-31T17:57:03Z",
+  "providers": 212,
+  "providersWithApiUrl": 186,
+  "sha256": "829023c0010120a2f814ce121316439e95f77edcbb8fe3d5b644faa57ea045fa",
   "license": "MIT (models.dev)"
 }


### PR DESCRIPTION
Pre-release checklist item from `RELEASE_PROCESS.md`: run `refresh-models-snapshot.sh`, **then read the diff** — which is the stated reason this file is committed rather than fetched at build time.

## The diff

**193 → 212 providers**, 167 → 186 with an `api` URL. **19 added, 0 removed** — nothing a reader had today is taken away.

`above`, `agentrouter`, `agnes`, `aixy`, `bothub`, `iteracompute`, `klokintegration`, `llmtech`, `neosmith`, `openreason`, `opper`, `pendra`, `sensenova`, `standardcompute`, `tokengo`, `tokenrouter`, `vancine`, `volcengine`, `volcengine-coding-plan`

All 19 pass `AiPresetSource`'s rejection rules (slug id, absolute http(s) base URL, no `${...}` templating, not in `DeniedIds`), so **what the app offers from the catalogue goes 159 → 178**.

## Checks that mattered

- **SDK-backed providers untouched.** `anthropic`, `groq`, `openai`, `google` all still carry `api=null` and keep their model counts (13 / 15 / 47 / 39) — they are served from the hand-kept table, so a catalogue refresh cannot disturb them.
- **Ollama absent from both snapshots** — by design, not a regression. models.dev catalogues hosted providers and will never list it (`AiProviderPresets.cs:41`); it ships as a local preset.
- `openrouter` churned as usual: +7 models, −14.
- Catalogue / preset / models.dev tests: **171 passed, 0 failed**.

## Follow-up for the release notes

The draft says *"Around 166 are offered from the models.dev catalogue"*. That tracked the old snapshot (167 with an api URL). Post-refresh the equivalent figure is **186** by that basis, or **178** counting what actually survives the preset filter. Worth updating before publishing — I have not touched the draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)