### PR TITLE
Move the Beta 6 release date to September 2026

### DIFF
--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -339,7 +339,7 @@
         <div class="logo"><img src="buddha-transparent.png" alt="Buddha"></div>
         <h1>CST Reader</h1>
         <p class="subtitle">A Pāli Text Reader for the Chaṭṭha Saṅgāyana Tipiṭaka</p>
-        <p class="version">Version 5.0.0-beta.6 &bull; August 2026</p>
+        <p class="version">Version 5.0.0-beta.6 &bull; September 2026</p>
     </div>
 
     <div class="beta-notice">
@@ -465,7 +465,7 @@
 
     <div class="update-note">
         <p>This welcome page updates automatically with new releases.</p>
-        <p>CST Reader 5.0.0-beta.6 • August 2026</p>
+        <p>CST Reader 5.0.0-beta.6 • September 2026</p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
Testing will not finish in August, so the welcome page's release month moves with it.

## Changed — the two release-date strings

Both in `src/CST.Avalonia/Resources/welcome-content.html`:

- `:342` header — `Version 5.0.0-beta.6 • September 2026`
- `:468` footer — `CST Reader 5.0.0-beta.6 • September 2026`

## Deliberately not changed

`RELEASE_PROCESS.md` warns against bulk-replacing version and date text, so I checked every other match rather than sweeping. These four are **historical statements** about the CST4 sources leaving `main`, and stay true:

- `CLAUDE.md:9`
- `README.md:154`
- `docs/README.md:107`
- `docs/features/planned/LOCALIZATION_STRATEGY.md:5`

Also left alone:

- `RELEASE_PROCESS.md:5` `**Last Updated:** August 22, 2026` — the document's own date, not the release's.
- `welcome-updates.json` — still names Beta 5 throughout, which is correct: it is a bucket B file, rewritten *after* the release is published.
- `models-dev-snapshot.json` — catalogue data.

The draft release notes carry no month string; their only date is the MCP spec version (`2026-07-28`), which is not a release date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)