### PR TITLE
Tell a locked key apart from a missing one (#926)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -483,7 +483,12 @@ public class AiConnectionServiceTests
 
         Assert.True(result.Ok);                       // the connection is gone
         Assert.Empty(settings.Ai.Chat.Connections);
-        Assert.NotNull(result.Problem);               // and the orphan is named
+        // Named, and FORMED. Asserting only NotNull let a `+ "…{displayName}…"` continuation ship - a
+        // plain string, so the placeholder reached the reader verbatim. Every one of these sentences is
+        // built by concatenation, so the brace check is the one that generalises. (#926)
+        Assert.NotNull(result.Problem);
+        Assert.Contains("My box", result.Problem!, StringComparison.Ordinal);
+        Assert.DoesNotContain("{", result.Problem!, StringComparison.Ordinal);
         Assert.Equal("k", keys.Get("box", AiCredentialNames.Primary));
     }
 

--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -356,8 +356,16 @@ public class AiConnectionServiceTests
         }
         public bool Set(string connectionId, string name, string secret)
         { _byAccount[Account(connectionId, name)] = secret; return true; }
+        /// <summary>Accounts the OS will not delete — authorization is needed for that too. (#926)</summary>
+        internal HashSet<string> Undeletable { get; } = new(StringComparer.Ordinal);
+
         public bool Delete(string connectionId, string name)
-        { _byAccount.Remove(Account(connectionId, name)); return true; }
+        {
+            var account = Account(connectionId, name);
+            if (Undeletable.Contains(account)) return false;
+            _byAccount.Remove(account);
+            return true;
+        }
     }
 
     private static (AiConnectionService Service, Settings Settings, Keys Keys) MakeWithKeys()
@@ -448,6 +456,50 @@ public class AiConnectionServiceTests
         record.EnvironmentVariable = "BOX_API_KEY";
 
         Assert.Equal(CredentialSource.Unreadable, service.Connections.Single().KeySource);
+    }
+
+    /// <summary>
+    /// A credential the OS refuses to delete is reported, and the connection still goes. (#926)
+    ///
+    /// <para><b>Observed.</b> Deleting a connection said it worked, the key stayed in the keychain, and
+    /// adding the provider back walked straight into the orphan — the state <see cref="Remove"/>'s own
+    /// comment exists to prevent: one "nothing can ever reach or clean up", which "would be silently
+    /// re-adopted if someone later created a connection with the same id". Deleting a Keychain item needs
+    /// authorization, so it can be refused, and the return value was discarded.</para>
+    ///
+    /// <para><b>Ok stays true.</b> Removing the connection is a settings edit that cannot fail, and it is the
+    /// reader's to delete — refusing would trap them with a connection they no longer want. What changes is
+    /// that the leftover is named instead of hidden.</para>
+    /// </summary>
+    [Fact]
+    public void A_credential_that_cannot_be_deleted_is_reported_and_the_connection_still_goes()
+    {
+        var (service, settings, keys) = MakeWithKeys();
+        service.Add("box", Draft());
+        keys.Set("box", AiCredentialNames.Primary, "k");
+        keys.Undeletable.Add("box:" + AiCredentialNames.Primary);
+
+        var result = service.Remove("box");
+
+        Assert.True(result.Ok);                       // the connection is gone
+        Assert.Empty(settings.Ai.Chat.Connections);
+        Assert.NotNull(result.Problem);               // and the orphan is named
+        Assert.Equal("k", keys.Get("box", AiCredentialNames.Primary));
+    }
+
+    /// <summary>The ordinary path stays silent, so the report above is not simply always on.</summary>
+    [Fact]
+    public void A_removal_that_clears_its_credentials_reports_nothing()
+    {
+        var (service, _, keys) = MakeWithKeys();
+        service.Add("box", Draft());
+        keys.Set("box", AiCredentialNames.Primary, "k");
+
+        var result = service.Remove("box");
+
+        Assert.True(result.Ok);
+        Assert.Null(result.Problem);
+        Assert.Null(keys.Get("box", AiCredentialNames.Primary));
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -338,10 +338,22 @@ public class AiConnectionServiceTests
         /// reads under another sees a miss rather than a hit (#759).</summary>
         private static string Account(string connectionId, string name) => connectionId + ":" + name;
 
+        /// <summary>Accounts the OS holds but will not hand over — a Keychain item whose ACL names another
+        /// binary, or a DPAPI blob that will not decrypt. The store can see it and cannot read it. (#926)</summary>
+        internal HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
+
         public bool IsAvailable => true;
         public string? Unavailable => null;
-        public string? Get(string connectionId, string name) =>
-            _byAccount.TryGetValue(Account(connectionId, name), out var k) ? k : null;
+        public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
+
+        public CredentialRead Read(string connectionId, string name)
+        {
+            var account = Account(connectionId, name);
+            if (Unreadable.Contains(account)) return CredentialRead.Unreadable;
+            return _byAccount.TryGetValue(account, out var k)
+                ? CredentialRead.Found(k)
+                : CredentialRead.NotStored;
+        }
         public bool Set(string connectionId, string name, string secret)
         { _byAccount[Account(connectionId, name)] = secret; return true; }
         public bool Delete(string connectionId, string name)
@@ -391,6 +403,51 @@ public class AiConnectionServiceTests
         keys.Set("box", AiCredentialNames.Primary, "k");
 
         Assert.Equal(CredentialSource.Keychain, service.Connections.Single().KeySource);
+    }
+
+    /// <summary>
+    /// A stored key the OS will not hand over reports its own state, not "no key". (#926)
+    ///
+    /// <para><b>The defect.</b> <c>SourceFor</c> asked <c>Get</c>, which answered null for a declined
+    /// authorization exactly as it did for an absent item — so a signed build reading keys a development
+    /// build had stored reported three configured providers as having none, and the app's advice was to type
+    /// them in again.</para>
+    /// </summary>
+    [Fact]
+    public void A_key_the_os_will_not_hand_over_is_reported_as_unreadable_not_as_absent()
+    {
+        var (service, _, keys) = MakeWithKeys();
+        service.Add("box", Draft());
+        keys.Set("box", AiCredentialNames.Primary, "k");
+
+        Assert.Equal(CredentialSource.Keychain, service.Connections.Single().KeySource);
+
+        keys.Unreadable.Add("box:" + AiCredentialNames.Primary);
+
+        Assert.Equal(CredentialSource.Unreadable, service.Connections.Single().KeySource);
+    }
+
+    /// <summary>
+    /// An unreadable stored key does not fall through to an environment variable. (#926)
+    ///
+    /// <para>"Stored wins" exists so a key the reader typed is never quietly replaced by a variable they had
+    /// forgotten was set — the maintainer was surprised by one of his own. An authorization he can still
+    /// grant does not make his stored key stop counting, and reporting Environment here would have the app
+    /// silently billing a different credential at the moment he is least able to tell.</para>
+    /// </summary>
+    [Fact]
+    public void An_unreadable_stored_key_does_not_fall_through_to_the_environment()
+    {
+        var (service, settings, keys) = MakeWithKeys();
+        service.Add("box", Draft());
+        keys.Set("box", AiCredentialNames.Primary, "k");
+        keys.Unreadable.Add("box:" + AiCredentialNames.Primary);
+
+        var record = settings.Ai.Chat.Connections.Single();
+        record.UsesEnvironmentKey = true;
+        record.EnvironmentVariable = "BOX_API_KEY";
+
+        Assert.Equal(CredentialSource.Unreadable, service.Connections.Single().KeySource);
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
@@ -320,6 +320,75 @@ public class AiCredentialStoreTests : IDisposable
     /// The_separator_cannot_occur_inside_either_part catches it, because '_' is a character Sanitize emits.
     /// (fable review)
     /// </summary>
+    // ---- the state channel, on the REAL store (#926) ---------------------------------------------------
+
+    /// <summary>
+    /// <c>Read</c> on the real store, not on a test double.
+    ///
+    /// <para><b>Why this needed writing.</b> #926 added four outcomes and seven test fakes that implement
+    /// them — so every test of the new states was testing the fakes' model of the store rather than the
+    /// store. <c>Get</c> was covered throughout this file and <c>Read</c> nowhere, which left the real
+    /// dispatch, the <c>!IsAvailable</c> branch and the log wiring exercised only in production. (fable)</para>
+    /// </summary>
+    [Fact]
+    public void Read_reports_not_stored_before_anything_is_stored_and_found_after()
+    {
+        Assert.Equal(CredentialState.NotStored, _store.Read("anthropic", AiCredentialNames.Primary).State);
+
+        Assert.True(_store.Set("anthropic", AiCredentialNames.Primary, Secret));
+
+        var read = _store.Read("anthropic", AiCredentialNames.Primary);
+        Assert.Equal(CredentialState.Found, read.State);
+        Assert.Equal(Secret, read.Secret);
+        Assert.True(read.Exists);
+    }
+
+    [Fact]
+    public void Read_reports_not_stored_again_after_a_delete()
+    {
+        _store.Set("anthropic", AiCredentialNames.Primary, Secret);
+        Assert.True(_store.Delete("anthropic", AiCredentialNames.Primary));
+
+        var read = _store.Read("anthropic", AiCredentialNames.Primary);
+        Assert.Equal(CredentialState.NotStored, read.State);
+        Assert.False(read.Exists);
+    }
+
+    /// <summary>Get is Read's value and nothing else, so the two can never disagree about the same item.</summary>
+    [Fact]
+    public void Get_agrees_with_Read_on_the_real_store()
+    {
+        Assert.Null(_store.Get("anthropic", AiCredentialNames.Primary));
+        Assert.Null(_store.Read("anthropic", AiCredentialNames.Primary).Secret);
+
+        _store.Set("anthropic", AiCredentialNames.Primary, Secret);
+
+        Assert.Equal(
+            _store.Read("anthropic", AiCredentialNames.Primary).Secret,
+            _store.Get("anthropic", AiCredentialNames.Primary));
+    }
+
+    /// <summary>
+    /// The outcome word reaches the log, and the secret still does not. (#926)
+    ///
+    /// <para>The log line is the only place three of the four states are visible at all today, so a change
+    /// that stopped <c>Read</c> calling <see cref="CredentialRead.Describe"/> would otherwise be silent.</para>
+    /// </summary>
+    [Fact]
+    public void Read_logs_the_outcome_and_never_the_secret()
+    {
+        _store.Read("anthropic", AiCredentialNames.Primary);
+        Assert.Contains(_log.Lines, l => l.Contains("none stored", StringComparison.Ordinal));
+
+        _log.Lines.Clear();
+        _store.Set("anthropic", AiCredentialNames.Primary, Secret);
+        _store.Read("anthropic", AiCredentialNames.Primary);
+
+        Assert.Contains(_log.Lines, l => l.Contains("found", StringComparison.Ordinal));
+        Assert.All(_log.Lines, l => Assert.DoesNotContain(Secret, l, StringComparison.Ordinal));
+        Assert.All(_log.Lines, l => Assert.DoesNotContain(Secret[..12], l, StringComparison.Ordinal));
+    }
+
     [Fact]
     public void The_service_name_is_stable()
     {

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
 using CST.Avalonia.Tests.TestSupport;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -354,8 +355,12 @@ public class AiModelCatalogTests
         private readonly Dictionary<string, string> _byAccount = new(StringComparer.Ordinal);
         public bool IsAvailable => true;
         public string? Unavailable => null;
-        public string? Get(string connectionId, string name) =>
-            _byAccount.GetValueOrDefault(connectionId + ":" + name);
+        public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
+
+        public CredentialRead Read(string connectionId, string name) =>
+            _byAccount.TryGetValue(connectionId + ":" + name, out var k)
+                ? CredentialRead.Found(k)
+                : CredentialRead.NotStored;
         public bool Set(string connectionId, string name, string secret)
         { _byAccount[connectionId + ":" + name] = secret; return true; }
         public bool Delete(string connectionId, string name) => _byAccount.Remove(connectionId + ":" + name);

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -42,10 +42,17 @@ public class ChatProviderResolverTests
 
         /// <summary>Named secrets take precedence, so a test can store a gateway token without also standing in
         /// for the primary key (#771).</summary>
-        public string? Get(string connectionId, string name) =>
-            _byName is not null && _byName.TryGetValue(name, out var named) ? named
-            : name == AiCredentialNames.Primary ? _key
-            : null;
+        public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
+
+        public CredentialRead Read(string connectionId, string name)
+        {
+            if (!IsAvailable) return CredentialRead.Unavailable;
+            var secret =
+                _byName is not null && _byName.TryGetValue(name, out var named) ? named
+                : name == AiCredentialNames.Primary ? _key
+                : null;
+            return secret is null ? CredentialRead.NotStored : CredentialRead.Found(secret);
+        }
         public bool Set(string connectionId, string name, string secret) => throw new NotSupportedException();
         public bool Delete(string connectionId, string name) => throw new NotSupportedException();
     }

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -44,9 +44,13 @@ public class ChatProviderResolverTests
         /// for the primary key (#771).</summary>
         public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
 
+        /// <summary>Names the OS holds and will not hand over. (#926)</summary>
+        internal HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
+
         public CredentialRead Read(string connectionId, string name)
         {
             if (!IsAvailable) return CredentialRead.Unavailable;
+            if (Unreadable.Contains(name)) return CredentialRead.Unreadable;
             var secret =
                 _byName is not null && _byName.TryGetValue(name, out var named) ? named
                 : name == AiCredentialNames.Primary ? _key
@@ -61,7 +65,7 @@ public class ChatProviderResolverTests
         Action<ChatSettings> configure, string? apiKey = null, bool aiEnabled = true,
         string? storageUnavailable = null, IReadOnlyDictionary<string, string>? secrets = null,
         IAiEnvironmentKeys? environmentKeys = null, IAiPresetSource? presets = null,
-        HttpMessageHandler? handler = null)
+        HttpMessageHandler? handler = null, FixedKey? store = null)
     {
         var settings = new Settings();
         settings.Ai.Enabled = aiEnabled;
@@ -73,9 +77,9 @@ public class ChatProviderResolverTests
 
         return new ChatProviderResolver(
             service.Object,
-            apiKey is null && storageUnavailable is null && secrets is null
+            store ?? (apiKey is null && storageUnavailable is null && secrets is null
                 ? null
-                : new FixedKey(apiKey, storageUnavailable, secrets),
+                : new FixedKey(apiKey, storageUnavailable, secrets)),
             NullLoggerFactory.Instance,
             handler is null
                 ? new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan }
@@ -139,6 +143,65 @@ public class ChatProviderResolverTests
 
     // The opt-in is the whole feature. Discovery must never authenticate on its own — that is the difference
     // between this and an app that adopts a forgotten variable and spends the reader's money.
+    /// <summary>
+    /// A stored key we could not READ, with nothing behind it, is not "you have no key". (#926)
+    ///
+    /// <para><b>The request path was the half of #926 that was missed.</b> The row badged "Key locked" while
+    /// pressing send still said "No API key is stored for Claude. Add one in Settings." — two surfaces
+    /// contradicting, which is the failure class <c>Reachability</c> exists to prevent. Worse, the advice
+    /// cannot work on macOS: the item exists, so re-entering runs SecItemAdd → duplicate → SecItemUpdate and
+    /// needs the very authorization that was just declined. (fable)</para>
+    /// </summary>
+    [Fact]
+    public void A_locked_key_is_not_reported_as_a_missing_one()
+    {
+        var store = new FixedKey("sk-ant-stored");
+        store.Unreadable.Add(AiCredentialNames.Primary);
+
+        var resolver = Resolver(chat =>
+        {
+            var c = Conn(chat);
+            c.Kind = "anthropic";
+            chat.ActiveModelId = "claude-opus-5";
+        }, store: store);
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.NotNull(problem);
+        Assert.DoesNotContain("No API key is stored", problem, StringComparison.Ordinal);
+        Assert.Contains("stored", problem, StringComparison.OrdinalIgnoreCase);
+        if (!OperatingSystem.IsWindows())
+            Assert.Contains("authorize", problem, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A locked stored key with an adopted variable still sends. (#926)
+    ///
+    /// <para>The resolver has always been <c>stored ?? environment</c>, and this asserts the fallback still
+    /// applies when the stored half is unreadable rather than absent — the behaviour Settings now reports
+    /// rather than contradicting. [fsnow: use the env var, and say so]</para>
+    /// </summary>
+    [Fact]
+    public void A_locked_key_still_falls_through_to_an_adopted_environment_variable()
+    {
+        var store = new FixedKey("sk-ant-stored");
+        store.Unreadable.Add(AiCredentialNames.Primary);
+
+        var resolver = Resolver(chat =>
+        {
+            var c = Conn(chat);
+            c.PresetId = "anthropic";
+            c.UsesEnvironmentKey = true;
+            c.EnvironmentVariable = "ANTHROPIC_API_KEY";
+            c.Kind = "anthropic";
+            chat.ActiveModelId = "claude-opus-5";
+        }, environmentKeys: Env("ANTHROPIC_API_KEY", "sk-from-env"),
+           presets: new FakePresets(EnvPreset("anthropic", "ANTHROPIC_API_KEY")),
+           store: store);
+
+        Assert.NotNull(resolver.Resolve(out var problem));
+        Assert.Null(problem);
+    }
+
     [Fact]
     public void A_connection_that_did_not_opt_in_does_not_use_the_environment_key()
     {

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -170,7 +170,7 @@ public class ChatProviderResolverTests
         Assert.DoesNotContain("No API key is stored", problem, StringComparison.Ordinal);
         Assert.Contains("stored", problem, StringComparison.OrdinalIgnoreCase);
         if (!OperatingSystem.IsWindows())
-            Assert.Contains("authorize", problem, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Allow", problem, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/Services/Ai/CredentialStateTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/CredentialStateTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Linq;
+using CST.Avalonia.Services.Ai.Credentials;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// A stored key this build cannot read is not a missing key. (#926)
+///
+/// <para><b>The defect these pin.</b> Installing a signed build over a machine that had been running
+/// development builds produced eight macOS authorization prompts, because the login keychain binds each item's
+/// ACL to the binary that created it. Dismissing them made every lookup return <c>errSecAuthFailed</c>, which
+/// the store reported as "none stored" — so three providers whose keys were present, correct and one
+/// authorization away were presented as unconfigured, and the remedy the app offered was to type them in
+/// again.</para>
+///
+/// <para><b>These cover the seam itself.</b> What the reader is then told is asserted where those helpers
+/// already live: the badge, the removal affordance and the environment fallthrough in
+/// <c>AiConnectionsViewModelTests</c>, and <c>SourceFor</c> in <c>AiConnectionServiceTests</c>.</para>
+/// </summary>
+public class CredentialStateTests
+{
+    // ---- classifying a Keychain status ---------------------------------------------------------------------
+
+    /// <summary>
+    /// The line the whole issue is about: a declined authorization is not an absent item. (#926)
+    ///
+    /// <para><b>Why this is a separate function at all.</b> It lived inside <c>Find</c>, wrapped in P/Invoke
+    /// calls no test can drive — so a mutation putting <c>errSecAuthFailed</c> back to "not stored" killed no
+    /// test, on the one line that caused the bug. Extracting the mapping is what makes it assertable.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(MacOsKeychain.ErrSecAuthFailed)]              // the item's ACL names a different binary
+    [InlineData(MacOsKeychain.ErrSecUserCanceled)]            // the reader dismissed the prompt
+    [InlineData(MacOsKeychain.ErrSecInteractionNotAllowed)]   // locked, with no UI available to ask
+    public void A_read_the_os_refused_is_unreadable_not_absent(int status)
+    {
+        Assert.Equal(CredentialState.Unreadable, MacOsKeychain.Classify(status));
+    }
+
+    /// <summary>
+    /// The status numbers themselves, against Apple's <c>SecBase.h</c>. (#926)
+    ///
+    /// <para>Nothing else can catch a wrong one. <see cref="MacOsKeychain.Classify"/> is tested through these
+    /// same constants, so the test and the code would move together and a typo would stay green — the same
+    /// hazard <c>WindowsDpapiStoreTests.The_entropy_is_stable</c> exists to cover. A wrong number fails
+    /// silently in the worst direction: the status stops matching its case, falls to the default, and a key
+    /// that genuinely is not there begins reporting itself as stored-but-unreadable.</para>
+    /// </summary>
+    [Fact]
+    public void The_keychain_status_codes_are_the_ones_apple_documents()
+    {
+        Assert.Equal(0, MacOsKeychain.ErrSecSuccess);
+        Assert.Equal(-25300, MacOsKeychain.ErrSecItemNotFound);
+        Assert.Equal(-25293, MacOsKeychain.ErrSecAuthFailed);
+        Assert.Equal(-128, MacOsKeychain.ErrSecUserCanceled);
+        Assert.Equal(-25308, MacOsKeychain.ErrSecInteractionNotAllowed);
+    }
+
+    [Fact]
+    public void Only_item_not_found_means_nothing_is_stored()
+    {
+        // The one status that should send the reader to type a key in. Everything else must not.
+        Assert.Equal(CredentialState.NotStored, MacOsKeychain.Classify(MacOsKeychain.ErrSecItemNotFound));
+        Assert.Equal(CredentialState.Found, MacOsKeychain.Classify(MacOsKeychain.ErrSecSuccess));
+    }
+
+    [Fact]
+    public void An_unrecognised_status_is_unreadable_rather_than_absent()
+    {
+        // A Security.framework failure nobody anticipated is not evidence that an item is gone. Claiming
+        // absence we cannot see is the harm being fixed, so the unknown case errs towards under-claiming.
+        Assert.Equal(CredentialState.Unreadable, MacOsKeychain.Classify(-25291));   // errSecNotAvailable
+        Assert.Equal(CredentialState.Unreadable, MacOsKeychain.Classify(-50));      // errSecParam
+        Assert.Equal(CredentialState.Unreadable, MacOsKeychain.Classify(int.MinValue));
+    }
+
+    // ---- the outcome type ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void An_unreadable_read_carries_no_secret_but_still_reports_the_item_exists()
+    {
+        var read = CredentialRead.Unreadable;
+
+        Assert.Equal(CredentialState.Unreadable, read.State);
+        Assert.Null(read.Secret);
+        Assert.True(read.Exists);
+    }
+
+    [Fact]
+    public void Nothing_stored_does_not_claim_an_item_exists()
+    {
+        // The other side of Exists, and the one that matters: if this ever returned true, every unconfigured
+        // provider would be described as holding a key it cannot read.
+        Assert.False(CredentialRead.NotStored.Exists);
+        Assert.False(CredentialRead.Unavailable.Exists);
+        Assert.True(CredentialRead.Found("sk-test").Exists);
+    }
+
+    [Fact]
+    public void The_four_outcomes_describe_themselves_differently()
+    {
+        // The log line was one word for all four. A future change that collapses any two of them again fails
+        // here rather than in a bug report six weeks later.
+        var words = new[]
+        {
+            CredentialRead.Found("sk-test").Describe(),
+            CredentialRead.NotStored.Describe(),
+            CredentialRead.Unreadable.Describe(),
+            CredentialRead.Unavailable.Describe(),
+        };
+
+        Assert.Equal(4, words.Distinct(StringComparer.Ordinal).Count());
+
+        // And none of them says anything about the value, which is the standing rule for this whole path.
+        Assert.All(words, w => Assert.DoesNotContain("sk-test", w, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Get_still_yields_null_for_every_outcome_that_has_no_secret()
+    {
+        // Callers that only want the value keep working unchanged. This is what makes the new state safe to
+        // add without auditing every call site at once.
+        Assert.Equal("sk-test", CredentialRead.Found("sk-test").Secret);
+        Assert.Null(CredentialRead.NotStored.Secret);
+        Assert.Null(CredentialRead.Unreadable.Secret);
+        Assert.Null(CredentialRead.Unavailable.Secret);
+    }
+
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/WindowsDpapiStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/WindowsDpapiStoreTests.cs
@@ -15,7 +15,8 @@ namespace CST.Avalonia.Tests.Services.Ai;
 /// replace-in-place, per-provider separation, and the acceptance test that the key never reaches a log. Those
 /// now exercise DPAPI for real when the suite runs on Windows. What is left here is what only this
 /// implementation can be asked: that the bytes on disk are actually encrypted, and that a blob this user cannot
-/// currently decrypt is treated as "no key" without being destroyed.</para>
+/// currently decrypt reports itself unreadable — distinctly from no key at all (#926) — without being
+/// destroyed.</para>
 ///
 /// <para>These are <see cref="WindowsFactAttribute"/> rather than tests that return early off Windows, so the
 /// macOS run reports skips instead of green tests that asserted nothing.</para>
@@ -88,15 +89,23 @@ public class WindowsDpapiStoreTests : IDisposable
     }
 
     [WindowsFact]
-    public void An_undecryptable_blob_reads_as_no_key_rather_than_throwing()
+    public void An_undecryptable_blob_reads_as_unreadable_rather_than_as_absent()
     {
         // The administrator-initiated password reset case: the user's DPAPI master key is discarded, so every
         // CurrentUser blob becomes unreadable. A user in that state should be asked to re-enter their key, not
         // shown a cryptography error they can do nothing about. Also covers a file copied from another machine.
+        //
+        // "Ask them to re-enter it" is the MESSAGE, and it is still right here. The STATE is Unreadable, not
+        // NotStored (#926): a blob is on disk, and reporting absence about a file we can see is what let the
+        // macOS half of this - a stored key behind a declined authorization - tell the maintainer he had no
+        // keys at all. No value escapes either way; the difference is what the app may then say and do.
         WindowsDpapiStore.Save(_service, "anthropic", Secret);
         File.WriteAllBytes(TheFile, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });   // not a DPAPI blob at all
 
-        Assert.Null(WindowsDpapiStore.Find(_service, "anthropic"));
+        var read = WindowsDpapiStore.Find(_service, "anthropic");
+        Assert.Equal(CredentialState.Unreadable, read.State);
+        Assert.Null(read.Secret);
+        Assert.True(read.Exists);   // and so the app must not offer "no key stored"
     }
 
     [WindowsFact]
@@ -117,7 +126,7 @@ public class WindowsDpapiStoreTests : IDisposable
 
         // And re-entering a key overwrites the dead blob, so nothing accumulates from keeping it.
         Assert.True(WindowsDpapiStore.Save(_service, "anthropic", "sk-ant-replacement"));
-        Assert.Equal("sk-ant-replacement", WindowsDpapiStore.Find(_service, "anthropic"));
+        Assert.Equal("sk-ant-replacement", WindowsDpapiStore.Find(_service, "anthropic").Secret);
         Assert.NotEqual(before, File.ReadAllBytes(file));
     }
 
@@ -126,17 +135,17 @@ public class WindowsDpapiStoreTests : IDisposable
     {
         // The other half of the same principle, and the distinction the implementation draws deliberately: a
         // transient IO failure - a backup tool or sync client holding the file open - must not cost the user
-        // their key. It reads as "none stored" for that moment and works again afterwards.
+        // their key. It reads as unreadable for that moment and works again afterwards.
         WindowsDpapiStore.Save(_service, "anthropic", Secret);
         var file = TheFile;
 
         using (var _ = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.None))
         {
-            Assert.Null(WindowsDpapiStore.Find(_service, "anthropic"));
+            Assert.Equal(CredentialState.Unreadable, WindowsDpapiStore.Find(_service, "anthropic").State);
             Assert.True(File.Exists(file));
         }
 
-        Assert.Equal(Secret, WindowsDpapiStore.Find(_service, "anthropic"));
+        Assert.Equal(Secret, WindowsDpapiStore.Find(_service, "anthropic").Secret);
     }
 
     [WindowsFact]
@@ -147,7 +156,7 @@ public class WindowsDpapiStoreTests : IDisposable
         var awkward = _service + " \u2014 with / \\ : * ? \" < > |";
 
         Assert.True(WindowsDpapiStore.Save(awkward, "anthropic", Secret));
-        Assert.Equal(Secret, WindowsDpapiStore.Find(awkward, "anthropic"));
+        Assert.Equal(Secret, WindowsDpapiStore.Find(awkward, "anthropic").Secret);
 
         try { Directory.Delete(WindowsDpapiStore.DirectoryFor(awkward), recursive: true); } catch { }
     }
@@ -155,7 +164,10 @@ public class WindowsDpapiStoreTests : IDisposable
     [WindowsFact]
     public void Reading_a_provider_that_was_never_stored_leaves_no_file_behind()
     {
-        Assert.Null(WindowsDpapiStore.Find(_service, "openai-compatible"));
+        // NotStored, not Unreadable: there is genuinely no file, and this is the one state that should send
+        // the reader to type a key in. If this ever reported Unreadable, every unconfigured provider would
+        // claim to be holding a key it cannot read. (#926)
+        Assert.Equal(CredentialState.NotStored, WindowsDpapiStore.Find(_service, "openai-compatible").State);
 
         var dir = WindowsDpapiStore.DirectoryFor(_service);
         Assert.True(!Directory.Exists(dir) || !Directory.EnumerateFiles(dir).Any());
@@ -168,7 +180,7 @@ public class WindowsDpapiStoreTests : IDisposable
         WindowsDpapiStore.Save(_service, "anthropic", Secret);
         Assert.True(WindowsDpapiStore.Delete(_service, "anthropic"));
         Assert.True(WindowsDpapiStore.Delete(_service, "anthropic"));   // again
-        Assert.Null(WindowsDpapiStore.Find(_service, "anthropic"));
+        Assert.Equal(CredentialState.NotStored, WindowsDpapiStore.Find(_service, "anthropic").State);
     }
 
     [WindowsFact]
@@ -198,7 +210,7 @@ public class WindowsDpapiStoreTests : IDisposable
         var files = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).ToList();
         Assert.Single(files);
         Assert.DoesNotContain(files, f => f.EndsWith(".tmp", StringComparison.Ordinal));
-        Assert.Equal("sk-ant-second", WindowsDpapiStore.Find(_service, "anthropic"));
+        Assert.Equal("sk-ant-second", WindowsDpapiStore.Find(_service, "anthropic").Secret);
     }
 
     [WindowsFact]
@@ -218,6 +230,6 @@ public class WindowsDpapiStoreTests : IDisposable
             Assert.False(WindowsDpapiStore.Save(_service, "anthropic", "sk-ant-never-lands"));
 
         Assert.False(File.Exists(temp));
-        Assert.Equal(Secret, WindowsDpapiStore.Find(_service, "anthropic"));   // the working key survived
+        Assert.Equal(Secret, WindowsDpapiStore.Find(_service, "anthropic").Secret);   // the working key survived
     }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -77,8 +77,12 @@ public class AiConnectionEditorViewModelTests
         public string? Unavailable => Available ? null : "Nowhere to store a key in this build.";
         public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
 
+        /// <summary>Accounts the OS holds but will not hand over. (#926)</summary>
+        public HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
+
         public CredentialRead Read(string connectionId, string name) =>
             !Available ? CredentialRead.Unavailable
+            : Unreadable.Contains(Account(connectionId, name)) ? CredentialRead.Unreadable
             : Stored.TryGetValue(Account(connectionId, name), out var k)
                 ? CredentialRead.Found(k)
                 : CredentialRead.NotStored;
@@ -1085,6 +1089,68 @@ public class AiConnectionEditorViewModelTests
 
         Assert.Null(h.Keys.Get("gw", AiCredentialNames.Header("cf-aig-authorization")));
         Assert.Equal("cf-token-abc", h.Keys.Get("gw", AiCredentialNames.Header("x-gateway-token")));
+    }
+
+    /// <summary>
+    /// The sheet says a locked key IS stored, and gives the remedy that works. (#926)
+    ///
+    /// <para><b>This sheet is where the reader acts on being told wrong.</b> The row badged "Key locked" and
+    /// the Edit sheet directly under it said "No key is stored for Groq." — so the reader pastes a
+    /// replacement, which on macOS runs SecItemAdd → duplicate → SecItemUpdate and needs the authorization
+    /// that just failed. It appears to work and changes nothing. (fable)</para>
+    /// </summary>
+    [Fact]
+    public void The_sheet_reports_a_locked_key_as_stored_rather_than_missing()
+    {
+        var h = new Harness();
+        h.Service.Add("mine", Draft());
+        h.Keys.Set("mine", AiCredentialNames.Primary, "sk-stored");
+
+        Assert.True(h.Existing("mine").HasStoredKey);
+
+        h.Keys.Unreadable.Add("mine:" + AiCredentialNames.Primary);
+        var locked = h.Existing("mine");
+
+        Assert.True(locked.HasStoredKey);
+        Assert.DoesNotContain("No key is stored", locked.KeyStatus, StringComparison.Ordinal);
+        // Not the replace-it sentence either: pasting is what does not work here.
+        Assert.DoesNotContain("Paste a new one", locked.KeyStatus, StringComparison.Ordinal);
+        if (!OperatingSystem.IsWindows())
+            Assert.Contains("authorize", locked.KeyStatus, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Renaming a secret header whose value is LOCKED must not destroy it. (#926)
+    ///
+    /// <para><b>This was silent, permanent data loss.</b> The carry read the old account with <c>Get</c>,
+    /// which answers null for an unreadable item exactly as it does for an absent one, so nothing was
+    /// carried — and the sweep below then deleted the old account, because no header claimed it any more.
+    /// The reader's only copy of the secret was gone, with no error and nothing to recover from. It
+    /// contradicted <see cref="CredentialState.Unreadable"/>'s own rule that the state is never a reason to
+    /// delete anything, since both platforms can recover from it. (fable)</para>
+    ///
+    /// <para>Keeping the old account is the conservative half: the reader authorizes, and their secret is
+    /// still there under the name it was stored with.</para>
+    /// </summary>
+    [Fact]
+    public void Renaming_a_secret_header_whose_value_is_locked_does_not_destroy_it()
+    {
+        var h = new Harness();
+        var add = h.Custom();
+        add.Id = "gw";
+        add.BaseUrl = "https://gateway.example/v1";
+        Header(add, "cf-aig-authorization", "cf-token-abc", secret: true);
+        Save(add);
+
+        var old = AiCredentialNames.Header("cf-aig-authorization");
+        h.Keys.Unreadable.Add("gw:" + old);
+
+        var edit = h.Existing("gw");
+        edit.Headers.Single().Name = "x-gateway-token";
+        Save(edit);
+
+        // Still there under the name it was stored with, ready for the reader to authorize.
+        Assert.Equal("cf-token-abc", h.Keys.Stored["gw:" + old]);
     }
 
     /// <summary>Renaming and rotating in one edit does both: a typed value wins over the carried one.</summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -80,6 +80,9 @@ public class AiConnectionEditorViewModelTests
         /// <summary>Accounts the OS holds but will not hand over. (#926)</summary>
         public HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
 
+        /// <summary>Accounts the OS will not delete. (#926)</summary>
+        public HashSet<string> Undeletable { get; } = new(StringComparer.Ordinal);
+
         public CredentialRead Read(string connectionId, string name) =>
             !Available ? CredentialRead.Unavailable
             : Unreadable.Contains(Account(connectionId, name)) ? CredentialRead.Unreadable
@@ -88,7 +91,20 @@ public class AiConnectionEditorViewModelTests
                 : CredentialRead.NotStored;
         public bool Set(string connectionId, string name, string secret)
         { Stored[Account(connectionId, name)] = secret; return true; }
-        public bool Delete(string connectionId, string name) => Stored.Remove(Account(connectionId, name));
+        /// <summary>
+        /// Refuses to delete an account the OS will not let go of. (#926)
+        ///
+        /// <para>Deleting a locked Keychain item needs authorization, so a reader who dismisses the prompt
+        /// cannot delete their way out — observed as <c>Removed a secret for groq/primary: failed</c> with
+        /// the item still present afterwards. A fake that always succeeds could not have caught the caller
+        /// discarding this.</para>
+        /// </summary>
+        public bool Delete(string connectionId, string name)
+        {
+            var account = Account(connectionId, name);
+            if (Undeletable.Contains(account)) return false;
+            return Stored.Remove(account);
+        }
     }
 
     private static void Save(AiConnectionEditorViewModel vm) => vm.SaveCommand.Execute().Subscribe();
@@ -1092,6 +1108,50 @@ public class AiConnectionEditorViewModelTests
     }
 
     /// <summary>
+    /// A removal the OS refuses is reported, not swallowed. (#926)
+    ///
+    /// <para><b>Observed, not theorised.</b> Pressing Remove on a locked key logged
+    /// <c>Removed a secret for groq/primary: failed</c>, the sheet cleared as though it had worked, and the
+    /// item was still in the keychain afterwards — the app reporting a revocation that had not happened.
+    /// Deleting a Keychain item needs authorization too, which this fix originally assumed it did not.</para>
+    ///
+    /// <para>Nothing is cleared on failure, because nothing changed: the key is still stored, and the sheet
+    /// must go on saying so.</para>
+    /// </summary>
+    [Fact]
+    public void A_removal_the_os_refuses_is_reported_and_changes_nothing()
+    {
+        var h = new Harness();
+        h.Service.Add("mine", Draft());
+        h.Keys.Set("mine", AiCredentialNames.Primary, "sk-stored");
+        h.Keys.Undeletable.Add("mine:" + AiCredentialNames.Primary);
+
+        var vm = h.Existing("mine");
+        vm.RemoveKeyCommand.Execute().Subscribe();
+
+        Assert.True(vm.HasProblem);
+        Assert.True(vm.HasStoredKey);                              // still stored, and still says so
+        Assert.Equal("sk-stored", h.Keys.Stored["mine:" + AiCredentialNames.Primary]);
+    }
+
+    /// <summary>A removal the OS allows still clears the sheet, so the guard above is not simply refusing
+    /// everything.</summary>
+    [Fact]
+    public void A_removal_that_succeeds_clears_the_key_and_raises_no_problem()
+    {
+        var h = new Harness();
+        h.Service.Add("mine", Draft());
+        h.Keys.Set("mine", AiCredentialNames.Primary, "sk-stored");
+
+        var vm = h.Existing("mine");
+        vm.RemoveKeyCommand.Execute().Subscribe();
+
+        Assert.False(vm.HasProblem);
+        Assert.False(vm.HasStoredKey);
+        Assert.DoesNotContain("mine:" + AiCredentialNames.Primary, h.Keys.Stored.Keys);
+    }
+
+    /// <summary>
     /// The sheet says a locked key IS stored, and gives the remedy that works. (#926)
     ///
     /// <para><b>This sheet is where the reader acts on being told wrong.</b> The row badged "Key locked" and
@@ -1116,7 +1176,14 @@ public class AiConnectionEditorViewModelTests
         // Not the replace-it sentence either: pasting is what does not work here.
         Assert.DoesNotContain("Paste a new one", locked.KeyStatus, StringComparison.Ordinal);
         if (!OperatingSystem.IsWindows())
-            Assert.Contains("authorize", locked.KeyStatus, StringComparison.OrdinalIgnoreCase);
+        {
+            // "Allow" is the button macOS actually shows.
+            Assert.Contains("Allow", locked.KeyStatus, StringComparison.Ordinal);
+            // And it must say replacing will not help. That write SUCCEEDS - tested 2026-08-31, the item was
+            // modified on disk - and leaves the reader exactly as stuck, because an item's ACL is not its
+            // value. Advice that appears to work is worse than advice that fails.
+            Assert.Contains("will not help", locked.KeyStatus, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -5,6 +5,7 @@ using CST.Avalonia.Models;
 using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services;
 using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
 using CST.Avalonia.ViewModels;
 using Moq;
 using Xunit;
@@ -74,8 +75,13 @@ public class AiConnectionEditorViewModelTests
         public bool Available { get; set; } = true;
         public bool IsAvailable => Available;
         public string? Unavailable => Available ? null : "Nowhere to store a key in this build.";
-        public string? Get(string connectionId, string name) =>
-            Stored.GetValueOrDefault(Account(connectionId, name));
+        public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
+
+        public CredentialRead Read(string connectionId, string name) =>
+            !Available ? CredentialRead.Unavailable
+            : Stored.TryGetValue(Account(connectionId, name), out var k)
+                ? CredentialRead.Found(k)
+                : CredentialRead.NotStored;
         public bool Set(string connectionId, string name, string secret)
         { Stored[Account(connectionId, name)] = secret; return true; }
         public bool Delete(string connectionId, string name) => Stored.Remove(Account(connectionId, name));

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -232,12 +232,17 @@ public class AiConnectionsViewModelTests
     private static AiConnectionRowViewModel Row(
         CredentialSource source = CredentialSource.None,
         Reachability state = Reachability.Configured,
-        string baseUrl = "http://localhost:11434/v1")
+        string baseUrl = "http://localhost:11434/v1",
+        bool storedKeyUnreadable = false,
+        string? environmentVariable = null)
     {
         var connection = new AiConnection(
             "local", "Local Ollama", ChatProviderKind.OpenAiCompatible, baseUrl,
             new List<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>(),
-            PresetId: null, KeySource: source, State: state);
+            PresetId: null, KeySource: source, State: state,
+            UsesEnvironmentKey: environmentVariable is not null,
+            EnvironmentVariable: environmentVariable,
+            StoredKeyUnreadable: storedKeyUnreadable);
         return new AiConnectionRowViewModel(new AiConnectionsViewModel(null, null), connection);
     }
 
@@ -276,6 +281,68 @@ public class AiConnectionsViewModelTests
         Assert.True(Row(CredentialSource.Keychain).CanRemoveKey);
         Assert.False(Row(CredentialSource.Environment).CanRemoveKey);
         Assert.False(Row(CredentialSource.None).CanRemoveKey);
+    }
+
+    /// <summary>
+    /// A locked key with a working variable names the variable, and does not read as broken. (#926)
+    ///
+    /// <para>Requests succeed and are billed to that variable, so the row states which credential is in use
+    /// rather than raising an alarm — and <c>KeyProblemNeedsAction</c> stays false, so it does not take the
+    /// caution colour the unusable states use. [fsnow: use the env var, and say so]</para>
+    /// </summary>
+    [Fact]
+    public void A_locked_key_with_an_environment_fallback_names_the_variable_and_is_not_an_alarm()
+    {
+        var row = Row(CredentialSource.Environment, storedKeyUnreadable: true,
+                      environmentVariable: "OPENROUTER_API_KEY");
+
+        Assert.Contains("OPENROUTER_API_KEY", row.KeySourceBadge, StringComparison.Ordinal);
+        Assert.True(row.HasKeyProblem);
+        Assert.False(row.KeyProblemNeedsAction);
+        Assert.True(row.KeyProblemIsStatement);
+        Assert.Contains("OPENROUTER_API_KEY", row.KeyProblem!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A locked key with nothing behind it IS an alarm, and the two shapes never render together. (#926)
+    ///
+    /// <para>The mutual exclusion is asserted because the row template binds both to the same text: without
+    /// it the caution case would print the sentence twice.</para>
+    /// </summary>
+    [Fact]
+    public void A_locked_key_with_no_fallback_needs_action_and_renders_one_line_only()
+    {
+        var row = Row(CredentialSource.Unreadable, storedKeyUnreadable: true);
+
+        Assert.True(row.HasKeyProblem);
+        Assert.True(row.KeyProblemNeedsAction);
+        Assert.False(row.KeyProblemIsStatement);
+        Assert.NotEqual(row.KeyProblemNeedsAction, row.KeyProblemIsStatement);
+    }
+
+    /// <summary>
+    /// The advice for an unreadable key is the one for THIS platform. (#926)
+    ///
+    /// <para>This is the only place in the app that tells a macOS reader the remedy is to <i>authorize</i>.
+    /// A mutation making the string platform-blind killed no test, and the consequence is not cosmetic: it
+    /// would hand macOS readers the DPAPI advice — delete and retype — which discards precisely the
+    /// recoverable state <see cref="CredentialState.Unreadable"/> says never to clean up. (fable)</para>
+    /// </summary>
+    [Fact]
+    public void The_locked_key_advice_matches_the_platform()
+    {
+        var text = Row(CredentialSource.Unreadable, storedKeyUnreadable: true).KeyProblem!;
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Contains("decrypt", text, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("authorize", text, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Contains("authorize", text, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("decrypt", text, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -340,7 +340,7 @@ public class AiConnectionsViewModelTests
         }
         else
         {
-            Assert.Contains("authorize", text, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Allow", text, StringComparison.Ordinal);
             Assert.DoesNotContain("decrypt", text, StringComparison.OrdinalIgnoreCase);
         }
     }

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -174,6 +174,8 @@ public class AiConnectionsViewModelTests
         vm.Delete("openrouter");
 
         Assert.True(vm.HasProblem);
+        Assert.Contains("OpenRouter", vm.Problem!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("{", vm.Problem!, StringComparison.Ordinal);
         Assert.Empty(vm.Connections);          // the connection still goes
     }
 

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -84,10 +84,21 @@ public class AiConnectionsViewModelTests
         /// <summary>Keyed by the joined account, exactly as the real store files it (#759).</summary>
         public Dictionary<string, string> Keys { get; } = new(StringComparer.Ordinal);
         private static string Account(string connectionId, string name) => connectionId + ":" + name;
+        /// <summary>Accounts the OS holds but will not hand over. (#926)</summary>
+        public HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
+
         public bool IsAvailable => true;
         public string? Unavailable => null;
-        public string? Get(string connectionId, string name) =>
-            Keys.GetValueOrDefault(Account(connectionId, name));
+        public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
+
+        public CredentialRead Read(string connectionId, string name)
+        {
+            var account = Account(connectionId, name);
+            if (Unreadable.Contains(account)) return CredentialRead.Unreadable;
+            return Keys.TryGetValue(account, out var k)
+                ? CredentialRead.Found(k)
+                : CredentialRead.NotStored;
+        }
         public bool Set(string connectionId, string name, string secret)
         { Keys[Account(connectionId, name)] = secret; return true; }
         public bool Delete(string connectionId, string name) => Keys.Remove(Account(connectionId, name));
@@ -228,6 +239,43 @@ public class AiConnectionsViewModelTests
             new List<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>(),
             PresetId: null, KeySource: source, State: state);
         return new AiConnectionRowViewModel(new AiConnectionsViewModel(null, null), connection);
+    }
+
+    /// <summary>
+    /// A key the OS holds and will not hand over is badged apart from having no key at all. (#926)
+    ///
+    /// <para><b>The defect in one assertion.</b> These two rendered as the same "No key", and the maintainer
+    /// acted on it the way anyone would — by re-entering three keys that were present and correct, one macOS
+    /// authorization away. The badge is asserted by inequality rather than by its words, so renaming it is
+    /// free and merging the two states is not.</para>
+    /// </summary>
+    [Fact]
+    public void A_key_that_cannot_be_read_is_badged_apart_from_no_key()
+    {
+        var locked = Row(CredentialSource.Unreadable);
+        var empty = Row(CredentialSource.None);
+
+        Assert.NotEqual(empty.KeySourceBadge, locked.KeySourceBadge);
+        Assert.True(locked.HasKeyProblem);
+        Assert.False(empty.HasKeyProblem);
+        Assert.False(Row(CredentialSource.Keychain).HasKeyProblem);
+    }
+
+    /// <summary>
+    /// Removal stays offered for a key we cannot read. (#926)
+    ///
+    /// <para>It is the reader's way out of the state, and it would be absent had this been written as "can we
+    /// read it" rather than "did we store it". Deleting needs no authorization on either platform, so the
+    /// button is not promising something it cannot do — the distinction that keeps an environment-sourced row
+    /// showing an empty slot instead.</para>
+    /// </summary>
+    [Fact]
+    public void Removal_is_offered_for_a_stored_key_that_cannot_be_read()
+    {
+        Assert.True(Row(CredentialSource.Unreadable).CanRemoveKey);
+        Assert.True(Row(CredentialSource.Keychain).CanRemoveKey);
+        Assert.False(Row(CredentialSource.Environment).CanRemoveKey);
+        Assert.False(Row(CredentialSource.None).CanRemoveKey);
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -101,7 +101,15 @@ public class AiConnectionsViewModelTests
         }
         public bool Set(string connectionId, string name, string secret)
         { Keys[Account(connectionId, name)] = secret; return true; }
-        public bool Delete(string connectionId, string name) => Keys.Remove(Account(connectionId, name));
+        /// <summary>Accounts the OS will not delete. (#926)</summary>
+        public HashSet<string> Undeletable { get; } = new(StringComparer.Ordinal);
+
+        public bool Delete(string connectionId, string name)
+        {
+            var account = Account(connectionId, name);
+            if (Undeletable.Contains(account)) return false;
+            return Keys.Remove(account);
+        }
     }
 
     /// <summary>Adds a preset the way a reader does — open the sheet, fill it in, save. There is no
@@ -146,6 +154,41 @@ public class AiConnectionsViewModelTests
 
         Assert.Contains(vm.Connections, c => c.Id == "openrouter");
         Assert.DoesNotContain(vm.AvailablePresets, p => p.Id == "openrouter");
+    }
+
+    /// <summary>
+    /// Deleting a connection whose key the OS will not release says so. (#926)
+    ///
+    /// <para><b>The screen is where this failed.</b> The service reported the leftover with Ok=true, and this
+    /// view model dropped it — <c>Problem = result.Ok ? null : result.Problem</c> — so the reader saw a clean
+    /// removal, and adding the provider back walked into the orphan.</para>
+    /// </summary>
+    [Fact]
+    public void Deleting_a_connection_whose_key_survives_tells_the_reader()
+    {
+        var keys = new FakeCredentialStore();
+        var (vm, _) = Make(keys);
+        AddThroughSheet(vm, "openrouter");
+        keys.Undeletable.Add("openrouter:" + AiCredentialNames.Primary);
+
+        vm.Delete("openrouter");
+
+        Assert.True(vm.HasProblem);
+        Assert.Empty(vm.Connections);          // the connection still goes
+    }
+
+    /// <summary>And an ordinary delete stays quiet, so the above is not simply always on.</summary>
+    [Fact]
+    public void Deleting_a_connection_whose_key_goes_reports_nothing()
+    {
+        var keys = new FakeCredentialStore();
+        var (vm, _) = Make(keys);
+        AddThroughSheet(vm, "openrouter");
+
+        vm.Delete("openrouter");
+
+        Assert.False(vm.HasProblem);
+        Assert.Empty(vm.Connections);
     }
 
     /// <summary>Deleting puts it back, so the reader can undo an add without knowing the URL by heart.</summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -5,6 +5,7 @@ using CST.Avalonia.Models;
 using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services;
 using CST.Avalonia.Services.Ai;
+using System.Threading.Tasks;
 using CST.Avalonia.Services.Ai.Credentials;
 using CST.Avalonia.ViewModels;
 using Moq;
@@ -45,14 +46,33 @@ public class AiModelPickerViewModelTests
         public bool Delete(string connectionId, string name) => Keys.Remove(Account(connectionId, name));
     }
 
-    private static (AiModelPickerViewModel Picker, AiConnectionService Service, FakeCredentialStore Keys) Make()
+    private static (AiModelPickerViewModel Picker, AiConnectionService Service, FakeCredentialStore Keys) Make(
+        IAiEnvironmentKeys? environment = null)
     {
         var settings = new Settings();
         var svc = new Mock<ISettingsService>();
         svc.SetupGet(s => s.Settings).Returns(settings);
         var keys = new FakeCredentialStore();
-        var service = new AiConnectionService(svc.Object, keys);
+        var service = new AiConnectionService(svc.Object, keys, null, environment);
         return (new AiModelPickerViewModel(service), service, keys);
+    }
+
+    /// <summary>An environment holding exactly one variable, for the adoption cases. (#926)</summary>
+    private sealed class OneVariable : IAiEnvironmentKeys
+    {
+        private readonly string _name;
+        private readonly string _value;
+
+        internal OneVariable(string name, string value) { _name = name; _value = value; }
+
+        public event EventHandler? Changed;
+        public string? VariableFor(AiProviderPreset preset) => _name;
+        public string? ValueFor(AiProviderPreset preset) => _value;
+        public string? Read(string variableName) =>
+            string.Equals(variableName, _name, StringComparison.Ordinal) ? _value : null;
+        public IReadOnlyList<AiEnvironmentKey> Discover(IEnumerable<AiProviderPreset> presets) =>
+            Array.Empty<AiEnvironmentKey>();
+        public Task Ready => Task.CompletedTask;
     }
 
     private static AiConnectionDraft Draft(string name, params AiModelEntry[] models) =>
@@ -426,6 +446,58 @@ public class AiModelPickerViewModelTests
         picker.Refresh();
 
         Assert.True(AllModels(picker).Single().IsUsable);
+    }
+
+    /// <summary>
+    /// A stored key the OS will not hand over disables the model, and says so in its own words. (#926)
+    ///
+    /// <para><b>This test did not exist and should have.</b> The branch it covers could be deleted with the
+    /// whole suite still green: the fake gained an <c>Unreadable</c> set that nothing used, so an unreadable
+    /// connection fell past the <c>KeySource == None</c> check and the model became silently usable — half
+    /// the fix reverted, undetected. (fable)</para>
+    ///
+    /// <para>The reason is asserted as "not the missing-key sentence" rather than by its exact words: the
+    /// wording is free to change, the distinction is not.</para>
+    /// </summary>
+    [Fact]
+    public void A_model_whose_stored_key_cannot_be_read_is_unusable_for_that_reason()
+    {
+        var (picker, service, keys) = Make();
+        service.AddFromPreset("openrouter", new Dictionary<string, string>());
+        service.EnableModel("openrouter", "x/y", "X", true);
+        keys.Set("openrouter", AiCredentialNames.Primary, "sk-or-secret");
+        picker.Refresh();
+        Assert.True(AllModels(picker).Single().IsUsable);
+
+        keys.Unreadable.Add("openrouter:" + AiCredentialNames.Primary);
+        picker.Refresh();
+
+        var model = AllModels(picker).Single();
+        Assert.False(model.IsUsable);
+        Assert.NotEqual("no API key stored", model.Unusable);
+        Assert.NotEqual("", model.Unusable);
+    }
+
+    /// <summary>
+    /// A locked stored key with a working environment variable leaves the model usable. (#926)
+    ///
+    /// <para>The request path resolves <c>stored ?? environment</c>, so it sends perfectly well. Disabling it
+    /// here would have the picker contradict the wire — the failure class <see cref="Reachability"/> exists
+    /// to prevent one layer up, arriving from the credential side instead.</para>
+    /// </summary>
+    [Fact]
+    public void A_locked_key_with_an_environment_fallback_leaves_the_model_usable()
+    {
+        var (picker, service, keys) = Make(new OneVariable("OPENROUTER_API_KEY", "sk-or-from-env"));
+        service.AddFromPreset("openrouter", new Dictionary<string, string>(), "OPENROUTER_API_KEY");
+        service.EnableModel("openrouter", "x/y", "X", true);
+        keys.Set("openrouter", AiCredentialNames.Primary, "sk-or-secret");
+        keys.Unreadable.Add("openrouter:" + AiCredentialNames.Primary);
+        picker.Refresh();
+
+        var model = AllModels(picker).Single();
+        Assert.True(model.IsUsable);
+        Assert.Equal("", model.Unusable);
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -5,6 +5,7 @@ using CST.Avalonia.Models;
 using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services;
 using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
 using CST.Avalonia.ViewModels;
 using Moq;
 using Xunit;
@@ -24,10 +25,21 @@ public class AiModelPickerViewModelTests
         /// <summary>Keyed by the joined account, exactly as the real store files it (#759).</summary>
         public Dictionary<string, string> Keys { get; } = new(StringComparer.Ordinal);
         private static string Account(string connectionId, string name) => connectionId + ":" + name;
+        /// <summary>Accounts the OS holds but will not hand over. (#926)</summary>
+        public HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
+
         public bool IsAvailable => true;
         public string? Unavailable => null;
-        public string? Get(string connectionId, string name) =>
-            Keys.GetValueOrDefault(Account(connectionId, name));
+        public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
+
+        public CredentialRead Read(string connectionId, string name)
+        {
+            var account = Account(connectionId, name);
+            if (Unreadable.Contains(account)) return CredentialRead.Unreadable;
+            return Keys.TryGetValue(account, out var k)
+                ? CredentialRead.Found(k)
+                : CredentialRead.NotStored;
+        }
         public bool Set(string connectionId, string name, string secret)
         { Keys[Account(connectionId, name)] = secret; return true; }
         public bool Delete(string connectionId, string name) => Keys.Remove(Account(connectionId, name));

--- a/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
@@ -51,8 +51,13 @@ namespace CST.Avalonia.Tests.ViewModels
 
             private static string Account(string connectionId, string name) => connectionId + ":" + name;
 
-            public string? Get(string connectionId, string name) =>
-                Available && _keys.TryGetValue(Account(connectionId, name), out var k) ? k : null;
+            public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
+
+            public CST.Avalonia.Services.Ai.Credentials.CredentialRead Read(string connectionId, string name) =>
+                !Available ? CST.Avalonia.Services.Ai.Credentials.CredentialRead.Unavailable
+                : _keys.TryGetValue(Account(connectionId, name), out var k)
+                    ? CST.Avalonia.Services.Ai.Credentials.CredentialRead.Found(k)
+                    : CST.Avalonia.Services.Ai.Credentials.CredentialRead.NotStored;
 
             public bool Set(string connectionId, string name, string secret)
             {

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -15,6 +15,20 @@ namespace CST.Avalonia.Models.Ai
         Keychain,
 
         /// <summary>
+        /// Stored by us, and this build could not read it. (#926)
+        ///
+        /// <para><b>Distinct from <see cref="None"/> because the remedy is opposite.</b> None means type a
+        /// key in; this means one is already there and something else must be settled — on macOS, authorizing
+        /// a binary the item's ACL does not name, which is the ordinary state once a development build and a
+        /// signed build have both written keys. Reported as None, it sent the maintainer to re-enter three
+        /// keys that were present and correct.</para>
+        ///
+        /// <para><b>Removal stays offered</b>, unlike <see cref="Environment"/>: the app did store this one,
+        /// deleting needs no authorization on either platform, and it is the reader's way out.</para>
+        /// </summary>
+        Unreadable,
+
+        /// <summary>
         /// Picked up from an environment variable the app did not set.
         ///
         /// <para><b>This is why the enum exists rather than a bool.</b> The app cannot delete a credential it

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -153,6 +153,16 @@ namespace CST.Avalonia.Models.Ai
     /// <param name="Inputs">The reader's answers to the preset's prompts (resource name, account id, region,
     /// project). Substituted into <paramref name="BaseUrl"/> and <paramref name="Headers"/>. Empty for the
     /// ~150 of 189 providers that are a plain base URL and a bearer token.</param>
+    /// <param name="StoredKeyUnreadable">A key IS stored for this connection and this build could not read it
+    /// — on macOS, ordinarily an item whose ACL names a different binary. (#926)
+    ///
+    /// <para><b>Separate from <paramref name="KeySource"/> because they answer different questions.</b>
+    /// KeySource says where the credential a request will actually use comes from; this says something is
+    /// wrong with the stored one. Both can be true at once: a locked stored key alongside a working
+    /// environment variable resolves to <see cref="CredentialSource.Environment"/> — requests work — while
+    /// this stays true so the row can say which credential is being used and why the other is not. Folding
+    /// them into one enum would force a choice between reporting the working credential and reporting the
+    /// broken one, and the reader needs both.</para></param>
     public sealed record AiConnection(
         string Id,
         string DisplayName,
@@ -168,8 +178,21 @@ namespace CST.Avalonia.Models.Ai
         string AuthHeaderName = "Authorization",
         string? AuthScheme = "Bearer",
         bool UsesEnvironmentKey = false,
-        string? EnvironmentVariable = null)
+        string? EnvironmentVariable = null,
+        bool StoredKeyUnreadable = false)
     {
+        /// <summary>
+        /// A key is stored for this connection and could not be read — however the source resolved. (#926)
+        ///
+        /// <para><b>Ask this, not the two fields.</b> "Locked" is expressible twice — as
+        /// <see cref="CredentialSource.Unreadable"/> when nothing else can serve, and as
+        /// <see cref="StoredKeyUnreadable"/> beside a working <see cref="CredentialSource.Environment"/>
+        /// variable — and a consumer that checks only one of them is right in one case and wrong in the
+        /// other. Deriving it here is what stops the two from being able to disagree in practice, since the
+        /// service sets them together and everything else reads this.</para>
+        /// </summary>
+        public bool KeyLocked => StoredKeyUnreadable || KeySource == CredentialSource.Unreadable;
+
         /// <summary>The base URL with <see cref="Inputs"/> substituted in — what a request actually goes to.</summary>
         public string ResolvedBaseUrl => AiTemplate.Expand(BaseUrl, Inputs);
 

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -210,14 +210,6 @@ namespace CST.Avalonia.Services.Ai
         public IReadOnlyList<AiConnection> Connections =>
             Chat.Connections.Select(ToRuntime).ToList();
 
-        /// <summary>
-        /// Where this connection's credential came from. (#678, #689)
-        ///
-        /// <para>Only <c>Keychain</c> and <c>None</c> today. <c>Environment</c> arrives with the
-        /// <c>CST_AI_*</c> discovery work, and when it does the rule is that a found credential makes a
-        /// provider <i>available</i>, never <i>connected</i> — so it will be reported here without a
-        /// connection existing until the reader acts.</para>
-        /// </summary>
         /// <summary>Reads last-known reachability under the lock; see <see cref="ReportReachability"/>.</summary>
         private Reachability ReachabilityOf(string connectionId)
         {
@@ -226,7 +218,8 @@ namespace CST.Avalonia.Services.Ai
         }
 
         /// <summary>
-        /// Where this connection's credential comes from. (#689, #714)
+        /// Where this connection's credential comes from, and whether a stored one is unreadable.
+        /// (#689, #714, #926)
         ///
         /// <para><b>Stored wins.</b> Entering a key is a deliberate act and a variable in the environment is
         /// often forgotten — the maintainer was surprised by one on his own machine — so a reader who typed a
@@ -237,16 +230,25 @@ namespace CST.Avalonia.Services.Ai
         /// <para>A discovered credential counts only for a connection that was ADOPTED from the environment.
         /// Discovery alone never makes a connection authenticated: that is the opt-in step, and this method
         /// reports state rather than creating it.</para>
+        ///
+        /// <para><b>Two facts, because they answer different questions</b> (#926). The source names the
+        /// credential a request will actually use; the flag says the stored one is there and unreadable. A
+        /// locked stored key beside a working variable is both at once, and the row needs to say so — the
+        /// alternative is a Settings page reporting a state the wire does not share, which is precisely what
+        /// <see cref="Reachability"/> exists to prevent one layer up.</para>
+        ///
+        /// <para><b>This must agree with the request path, not merely be defensible.</b>
+        /// <c>ChatProviderResolver</c> and <c>AiModelCatalog</c> both resolve <c>stored ?? environment</c>; if
+        /// this refused to fall through, Settings would disable a model that sends perfectly well, and the
+        /// reader consulting Settings to diagnose would be reading the surface that is wrong.</para>
         /// </summary>
-        private CredentialSource SourceFor(string connectionId)
+        private (CredentialSource Source, bool StoredKeyUnreadable) CredentialFor(string connectionId)
         {
-            // Read, not Get (#926). A stored key this build cannot read is a different state from no key, and
-            // it must not fall through to the environment either: the whole point of "stored wins" above is
-            // that a key the reader typed is not quietly replaced by a variable they forgot they set, and an
-            // authorization the reader can still grant does not make their key stop counting.
+            // Read, not Get (#926). A stored key this build cannot read is a different state from no key.
             var read = _credentials?.Read(connectionId, AiCredentialNames.Primary);
-            if (read?.State == CredentialState.Found) return CredentialSource.Keychain;
-            if (read?.State == CredentialState.Unreadable) return CredentialSource.Unreadable;
+            if (read?.State == CredentialState.Found) return (CredentialSource.Keychain, false);
+
+            var locked = read?.State == CredentialState.Unreadable;
 
             // Adopted from the environment, and the variable still holds something. When it does not — unset
             // between sessions, or renamed — this falls through to None, which reads as "no key" rather than
@@ -259,9 +261,18 @@ namespace CST.Avalonia.Services.Ai
             if (record is not null
                 && AiEnvironmentCredential.For(
                     record.UsesEnvironmentKey, record.EnvironmentVariable, _environmentKeys) is not null)
-                return CredentialSource.Environment;
+                // A locked stored key does NOT stop the environment variable being used, because the request
+                // path uses it: ChatProviderResolver and AiModelCatalog both resolve `stored ?? environment`,
+                // so refusing here would have Settings disable a model that sends perfectly well. Reporting
+                // Environment is what the app ACTUALLY does; the locked key travels alongside as its own fact
+                // so the row can say which credential is in use and why the other is not. "Stored wins" is
+                // intact — a readable stored key still takes precedence, above. (#926) [fsnow: use the env
+                // var, and say so]
+                return (CredentialSource.Environment, locked);
 
-            return CredentialSource.None;
+            // No usable credential at all. Not None: a key IS stored, and telling the reader otherwise is the
+            // whole of #926 — it sends them to re-enter one that is present and correct.
+            return locked ? (CredentialSource.Unreadable, true) : (CredentialSource.None, false);
         }
 
 
@@ -752,7 +763,10 @@ namespace CST.Avalonia.Services.Ai
             record.AuthScheme = draft.AuthScheme;
         }
 
-        private AiConnection ToRuntime(AiConnectionRecord r) => new(
+        private AiConnection ToRuntime(AiConnectionRecord r)
+        {
+            var credential = CredentialFor(r.Id);
+            return new AiConnection(
             r.Id,
             r.DisplayName,
             ChatProviderResolver.TryParseKind(r.Kind, out var kind) ? kind : ChatProviderKind.OpenAiCompatible,
@@ -766,12 +780,14 @@ namespace CST.Avalonia.Services.Ai
             new Dictionary<string, string>(r.Inputs),
             r.PresetId,
             r.SecretInputs?.ToList(),
-            SourceFor(r.Id),
+            credential.Source,
             ReachabilityOf(r.Id),
             r.AuthHeaderName,
             r.AuthScheme,
             r.UsesEnvironmentKey,
-            r.EnvironmentVariable);
+            r.EnvironmentVariable,
+            credential.StoredKeyUnreadable);
+        }
 
         /// <summary>
         /// Every credential name this connection could have filed a secret under. (#759)

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -240,8 +240,13 @@ namespace CST.Avalonia.Services.Ai
         /// </summary>
         private CredentialSource SourceFor(string connectionId)
         {
-            if (_credentials?.Get(connectionId, AiCredentialNames.Primary) is not null)
-                return CredentialSource.Keychain;
+            // Read, not Get (#926). A stored key this build cannot read is a different state from no key, and
+            // it must not fall through to the environment either: the whole point of "stored wins" above is
+            // that a key the reader typed is not quietly replaced by a variable they forgot they set, and an
+            // authorization the reader can still grant does not make their key stop counting.
+            var read = _credentials?.Read(connectionId, AiCredentialNames.Primary);
+            if (read?.State == CredentialState.Found) return CredentialSource.Keychain;
+            if (read?.State == CredentialState.Unreadable) return CredentialSource.Unreadable;
 
             // Adopted from the environment, and the variable still holds something. When it does not — unset
             // between sessions, or renamed — this falls through to None, which reads as "no key" rather than

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -101,9 +101,20 @@ namespace CST.Avalonia.Services.Ai
         /// <summary>Edits everything except the id, which is immutable because the credential is filed under it.</summary>
         AiConnectionResult Update(string id, AiConnectionDraft draft);
 
-        /// <summary>Removes the connection and its models. Does not touch the credential — that is a separate
-        /// action, because for a custom endpoint the hand-entered model list is real user work and destroying
-        /// it on an action meant only to stop billing would be data loss.</summary>
+        /// <summary>
+        /// Removes the connection, its models and <b>every credential it filed</b>.
+        ///
+        /// <para>This said "does not touch the credential — that is a separate action" and had not been true
+        /// for some time: leaving a secret behind orphans it in the OS store, where nothing can reach it and
+        /// a later connection taking the same id would silently adopt it. The implementation's own comment
+        /// says so. What remains true is the reasoning underneath — the hand-typed model list is real user
+        /// work — which is why "remove this key" and "delete this connection" are still two actions rather
+        /// than one.</para>
+        ///
+        /// <para><b>Can return Ok with a Problem</b> (#926). The connection is a settings edit and always
+        /// goes; deleting a credential needs authorization and can be refused, and the reader has to be told
+        /// which secrets were left behind.</para>
+        /// </summary>
         AiConnectionResult Remove(string id);
 
         /// <summary>Chooses what the next request uses. A null model clears the choice.</summary>
@@ -522,8 +533,14 @@ namespace CST.Avalonia.Services.Ai
             // EVERY name, not just the primary one (#759): a connection may file more than one secret, and an
             // orphan is invisible precisely because nothing reads it. This is the one place that has to know
             // the full set, so it is the one place to extend when a provider adds a name.
-            foreach (var name in CredentialNamesOf(record))
-                _credentials?.Delete(record.Id, name);
+            // The return values are checked, not discarded (#926). Deleting a Keychain item needs
+            // authorization, so this CAN fail - observed 2026-08-31, when removing a connection reported
+            // success and left its key behind, and adding the provider back walked into the orphan the
+            // comment above warns about. The connection still goes: that is a settings edit, it cannot fail,
+            // and it is the reader's to delete. What changes is that they are told what was left.
+            var leftBehind = CredentialNamesOf(record)
+                .Where(name => _credentials is not null && !_credentials.Delete(record.Id, name))
+                .ToList();
 
             // Do not leave the active pointer dangling at something that no longer exists - a stale id reads
             // as "configured" to anything that only checks for null.
@@ -535,7 +552,12 @@ namespace CST.Avalonia.Services.Ai
 
             _settings.RequestSave();
             RaiseChanged();
-            return new AiConnectionResult(true);
+
+            // Ok, WITH a problem: the removal happened and something about it needs saying. Callers that only
+            // check Ok are unchanged; the one screen that shows this reads Problem either way.
+            return leftBehind.Count > 0
+                ? new AiConnectionResult(true, CredentialRead.SecretsLeftBehind(record.DisplayName))
+                : new AiConnectionResult(true);
         }
 
         public AiConnectionResult SetActive(string connectionId, string? modelId)

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -214,10 +214,26 @@ namespace CST.Avalonia.Services.Ai
                 return AiCatalogResult.Fail(
                     $"This connection has two {duplicate.Key} headers. Remove one under Settings \u2192 AI.");
 
-            var missingSecrets = connection.Headers
-                .Where(h => h.Secret
-                            && string.IsNullOrEmpty(_credentials?.Get(connection.Id, AiCredentialNames.Header(h.Name))))
-                .Select(h => h.Name)
+            // Unreadable before absent, and the same sentence the chat path uses (#926). The two surfaces send
+            // the same credentials, so they must also explain a failure the same way - and "re-enter it"
+            // cannot work on macOS for a secret that is stored and merely locked.
+            var reads = connection.Headers
+                .Where(h => h.Secret)
+                .Select(h => (h.Name, Read: _credentials?.Read(connection.Id, AiCredentialNames.Header(h.Name))
+                                            ?? CredentialRead.Unavailable))
+                .ToList();
+
+            var lockedSecrets = reads
+                .Where(r => r.Read.State == CredentialState.Unreadable)
+                .Select(r => r.Name)
+                .ToList();
+            if (lockedSecrets.Count > 0)
+                return AiCatalogResult.Fail(
+                    CredentialRead.Advice($"The {string.Join(", ", lockedSecrets)} header's value"));
+
+            var missingSecrets = reads
+                .Where(r => string.IsNullOrEmpty(r.Read.Secret))
+                .Select(r => r.Name)
                 .ToList();
             if (missingSecrets.Count > 0)
                 return AiCatalogResult.Fail(

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -43,8 +43,20 @@ public interface IAiCredentialStore
     /// more than one secret — Cloudflare's gateway wants a gateway token beside the upstream key (#701),
     /// Bedrock a secret access key beside an access key id (#702). A connection with one secret simply calls
     /// it <see cref="AiCredentialNames.Primary"/>.</para>
+    ///
+    /// <para><b>Null does not mean "none stored"</b> — see <see cref="Read"/>. This overload is for callers
+    /// that need the value and have nothing useful to say about why it is missing.</para>
     /// </summary>
     string? Get(string connectionId, string name);
+
+    /// <summary>
+    /// One stored secret, and what happened when we asked for it. (#926)
+    ///
+    /// <para>Prefer this wherever the answer reaches the reader. <see cref="Get"/> cannot distinguish "you
+    /// have not stored a key" from "your key is there and the OS would not let this build read it", and the
+    /// two need opposite advice: type one in, versus authorize and keep the one you have.</para>
+    /// </summary>
+    CredentialRead Read(string connectionId, string name);
 
     /// <summary>Store or replace one named secret. False when the platform cannot.</summary>
     bool Set(string connectionId, string name, string secret);

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -300,6 +300,24 @@ public sealed class ChatProviderResolver : IChatProviderResolver
         // A header marked secret whose secret is not stored - the store was unavailable when it was saved, or
         // the reader deleted the item in Keychain Access. Sending the header empty produces a 401 that reads
         // as a bad key, so say which header is missing instead. (#771)
+        //
+        // Absent and unreadable are separated first (#926). Both leave the header empty, and the old single
+        // message told a reader whose secret was merely locked to re-enter it - which on macOS cannot work,
+        // since SecItemAdd on an existing item falls through to SecItemUpdate and needs the authorization
+        // that was just declined.
+        var lockedSecrets = connection.Headers
+            .Where(h => h.Secret
+                        && string.IsNullOrEmpty(headers.GetValueOrDefault(h.Name))
+                        && _credentials?.Read(connection.Id, AiCredentialNames.Header(h.Name)).State
+                           == CredentialState.Unreadable)
+            .Select(h => h.Name)
+            .ToList();
+        if (lockedSecrets.Count > 0)
+        {
+            problem = CredentialRead.Advice($"The {string.Join(", ", lockedSecrets)} header's value");
+            return null;
+        }
+
         var missingSecrets = connection.Headers
             .Where(h => h.Secret && string.IsNullOrEmpty(headers.GetValueOrDefault(h.Name)))
             .Select(h => h.Name)
@@ -318,9 +336,25 @@ public sealed class ChatProviderResolver : IChatProviderResolver
         // Read at the moment of use rather than cached, so a variable the reader changes or unsets takes
         // effect on the next request. Nothing is copied into the credential store — a duplicate there would
         // outlive the variable, and the row it came from offers no remove action to undo that with (#691).
-        var apiKey = _credentials?.Get(connection.Id, AiCredentialNames.Primary)
+        var storedKey = _credentials?.Read(connection.Id, AiCredentialNames.Primary)
+                        ?? CredentialRead.Unavailable;
+        var apiKey = storedKey.Secret
                      ?? AiEnvironmentCredential.For(
                          connection.UsesEnvironmentKey, connection.EnvironmentVariable, _environmentKeys);
+
+        // A stored key we could not READ, with nothing behind it. Distinct from having none (#926): telling
+        // this reader to add a key sends them to re-enter one that is present and correct, and on macOS the
+        // re-entry needs the same authorization that just failed. Placed here, ahead of the per-kind guards,
+        // because the diagnosis is the same whatever protocol the connection speaks.
+        //
+        // Only when the fallback produced nothing: a locked key beside a working variable sends perfectly
+        // well, and refusing it here would contradict what the row now says. [fsnow: use the env var, and
+        // say so]
+        if (storedKey.State == CredentialState.Unreadable && string.IsNullOrWhiteSpace(apiKey))
+        {
+            problem = CredentialRead.Advice("This connection's API key");
+            return null;
+        }
 
         switch (kind)
         {

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
@@ -11,16 +11,16 @@ namespace CST.Avalonia.Services.Ai.Credentials;
 /// synced between machines. A key in it is a key in every one of those places, and unlike a wrong port number
 /// there is no way to notice after the fact.</para>
 ///
-/// <para><b>Read lazily, on the request that needs it.</b> Nothing here runs at startup, so a user who never
-/// turns surface B on never triggers a Keychain access (or, on Windows, a decrypt). That is the same class of
-/// mistake as the Chromium Safe Storage prompt this app already works around: a permission dialog on launch,
-/// for a feature the user has not asked for, teaches them to click through prompts.</para>
+/// <para><b>Reads should be lazy, on the request that needs it, and today they are not</b> — tracked as #925.
+/// The intent was that nothing here runs at startup, so a user who never turns surface B on never triggers a
+/// Keychain access (or, on Windows, a decrypt): a permission dialog on launch, for a feature the user has not
+/// asked for, teaches them to click through prompts. That is exactly what went on to happen — the maintainer
+/// met eight authorization prompts before a beta candidate was usable. Status queries reach
+/// <see cref="Read"/> at startup and on every refresh, and nothing caches, so one connection was read 153
+/// times in a single session. Do not read this paragraph as a description of current behaviour.</para>
 ///
-/// <para><b>Nothing is cached.</b> A cache would go stale the moment the user changes the key in Settings, and
-/// the lookup costs microseconds — the wrong side of that trade is the one where the app keeps using a
-/// credential the user has already replaced.</para>
-///
-/// <para><b>Nothing is ever logged.</b> Not the value, not a prefix, not its length. Outcomes only.</para>
+/// <para><b>Nothing is ever logged.</b> Not the value, not a prefix, not its length. Outcomes only —
+/// <see cref="CredentialRead.Describe"/> is the whole vocabulary, and it says nothing about the value.</para>
 /// </summary>
 public sealed class AiCredentialStore : IAiCredentialStore
 {
@@ -79,12 +79,14 @@ public sealed class AiCredentialStore : IAiCredentialStore
         : "Secure key storage is not available on this platform. "
           + "An endpoint that needs no API key still works.";
 
-    public string? Get(string connectionId, string name)
+    public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
+
+    public CredentialRead Read(string connectionId, string name)
     {
-        if (!IsAvailable) return null;
+        if (!IsAvailable) return CredentialRead.Unavailable;
 
         var account = AccountFor(connectionId, name);
-        var secret = OperatingSystem.IsWindows()
+        var read = OperatingSystem.IsWindows()
             ? WindowsDpapiStore.Find(_service, account)
             : MacOsKeychain.Find(_service, account);
 
@@ -95,10 +97,13 @@ public sealed class AiCredentialStore : IAiCredentialStore
         // travels on every request in the clear, so it is public in a way its value never is, and "which of
         // this connection's secrets was missing" is the whole diagnosis when a two-credential provider 401s.
         // The line to hold is the value, and it is held here and at every other call. (fable review)
+        //
+        // Four outcomes, not two (#926). The line that read "none stored" for every one of them is what made
+        // eight declined authorization prompts look like three connections with no keys.
         _logger.LogDebug("Credential lookup for {Connection}/{Name}: {Result}",
-            connectionId, name, secret is null ? "none stored" : "found");
+            connectionId, name, read.Describe());
 
-        return secret;
+        return read;
     }
 
     /// <summary>Store or replace one named secret. Returns false when the platform cannot.</summary>

--- a/src/CST.Avalonia/Services/Ai/Credentials/CredentialRead.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/CredentialRead.cs
@@ -115,12 +115,14 @@ public readonly record struct CredentialRead(CredentialState State, string? Secr
     /// same id".</para>
     /// </summary>
     public static string SecretsLeftBehind(string displayName) =>
+        // Interpolated on EVERY line. A `+ "…{displayName}…"` continuation is a plain string, so the
+        // placeholder reaches the reader verbatim — which is exactly what shipped for one build.
         OperatingSystem.IsWindows()
             ? $"{displayName} was removed, but its stored key could not be deleted and is still on this "
-              + "computer."
+              + $"computer."
             : $"{displayName} was removed, but its stored key could not be deleted \u2014 macOS did not "
-              + "allow it. It is still in your keychain, and adding {displayName} again will find it. "
-              + "Delete the \u201cCST Reader \u2014 AI provider\u201d entry in Keychain Access to clear it.";
+              + $"allow it. It is still in your keychain, and adding {displayName} again will find it. "
+              + $"Delete the \u201cCST Reader \u2014 AI provider\u201d entry in Keychain Access to clear it.";
 
     /// <summary>The word for a log line. Deliberately says nothing about the value.</summary>
     public string Describe() => State switch

--- a/src/CST.Avalonia/Services/Ai/Credentials/CredentialRead.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/CredentialRead.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace CST.Avalonia.Services.Ai.Credentials;
 
 /// <summary>
@@ -57,6 +59,21 @@ public readonly record struct CredentialRead(CredentialState State, string? Secr
     /// <summary>Whether an item exists, whether or not its value could be read. False only when nothing is
     /// stored or there is nowhere to store it — so it never claims a key the reader has not provided.</summary>
     public bool Exists => State is CredentialState.Found or CredentialState.Unreadable;
+
+    /// <summary>
+    /// What to tell the reader about a named secret that is stored and unreadable. (#926)
+    ///
+    /// <para><b>One sentence, shared by every surface that reports it.</b> The resolver, the model catalogue
+    /// and the connection editor each phrased "no stored value … re-enter it" separately, which is how they
+    /// came to give advice that cannot work: on macOS the item exists, so re-entering runs
+    /// <c>SecItemAdd</c> → duplicate → <c>SecItemUpdate</c>, which needs the very authorization that was
+    /// just declined. Windows has no such problem — <c>Save</c> writes a fresh file — hence the split.</para>
+    /// </summary>
+    public static string Advice(string what) =>
+        OperatingSystem.IsWindows()
+            ? $"{what} is stored but could not be decrypted. Enter it again under Settings \u2192 AI."
+            : $"{what} is stored but CST Reader was not allowed to read it. Authorize it when macOS asks, "
+              + "or remove it under Settings \u2192 AI and enter it again.";
 
     /// <summary>The word for a log line. Deliberately says nothing about the value.</summary>
     public string Describe() => State switch

--- a/src/CST.Avalonia/Services/Ai/Credentials/CredentialRead.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/CredentialRead.cs
@@ -104,6 +104,24 @@ public readonly record struct CredentialRead(CredentialState State, string? Secr
               + "is still stored. Try again and choose Allow, or delete the \u201cCST Reader\u201d entry "
               + "in Keychain Access.";
 
+    /// <summary>
+    /// What to tell the reader when a connection was removed but its secrets could not be. (#926)
+    ///
+    /// <para><b>The removal itself is not in doubt</b> — that is a settings edit and it cannot fail. What can
+    /// fail is clearing the credential, because deleting a Keychain item needs authorization. The connection
+    /// must still go: it is the reader's to delete, and refusing would trap them. But saying nothing leaves
+    /// exactly the orphan <c>AiConnectionService.Remove</c>'s own comment warns about — one "nothing can ever
+    /// reach or clean up", which "would be silently re-adopted if someone later created a connection with the
+    /// same id".</para>
+    /// </summary>
+    public static string SecretsLeftBehind(string displayName) =>
+        OperatingSystem.IsWindows()
+            ? $"{displayName} was removed, but its stored key could not be deleted and is still on this "
+              + "computer."
+            : $"{displayName} was removed, but its stored key could not be deleted \u2014 macOS did not "
+              + "allow it. It is still in your keychain, and adding {displayName} again will find it. "
+              + "Delete the \u201cCST Reader \u2014 AI provider\u201d entry in Keychain Access to clear it.";
+
     /// <summary>The word for a log line. Deliberately says nothing about the value.</summary>
     public string Describe() => State switch
     {

--- a/src/CST.Avalonia/Services/Ai/Credentials/CredentialRead.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/CredentialRead.cs
@@ -1,0 +1,69 @@
+namespace CST.Avalonia.Services.Ai.Credentials;
+
+/// <summary>
+/// What happened when we asked the OS for one stored secret. (#926)
+///
+/// <para><b>Why this is not just <c>string?</c>.</b> It was, and the four outcomes below all arrived as
+/// <c>null</c>. A reader who declined a Keychain authorization prompt was told no key was stored, so the
+/// remedy the app offered him was to type his API key in again — over a key that was present and correct the
+/// whole time. Absence and refusal need different words because they need different remedies.</para>
+///
+/// <para><b>The distinction that matters to the reader is not "error or not" but "what do I do now".</b>
+/// <see cref="NotStored"/> means type a key in. <see cref="Unreadable"/> means the key is there and something
+/// else must be settled first — authorize the app, or unlock the keychain — and re-entering it would be
+/// wasted work. <see cref="Unavailable"/> means this machine has nowhere to keep one at all.</para>
+/// </summary>
+public enum CredentialState
+{
+    /// <summary>The secret was read.</summary>
+    Found,
+
+    /// <summary>There is no such item. The reader has not stored this secret, which is an ordinary state —
+    /// a local runner needs no key, and a connection may authenticate through headers instead.</summary>
+    NotStored,
+
+    /// <summary>
+    /// An item exists and this process could not read its value.
+    ///
+    /// <para>On macOS: the login keychain's per-item ACL named a different binary, or the reader dismissed
+    /// the authorization prompt, or the keychain is locked with no UI available to unlock it. On Windows: the
+    /// DPAPI blob is present but did not decrypt.</para>
+    ///
+    /// <para><b>Never a reason to delete anything.</b> Both platforms can recover — authorizing once on
+    /// macOS, a roaming master key arriving on Windows — so this is a state to report, not to clean up.</para>
+    /// </summary>
+    Unreadable,
+
+    /// <summary>There is no credential store on this platform, or it could not be reached at all.</summary>
+    Unavailable,
+}
+
+/// <summary>
+/// One credential lookup: what happened, and the secret when there is one.
+///
+/// <para><b>A secret is present only for <see cref="CredentialState.Found"/>.</b> Every other state carries
+/// null, so a caller that reads <see cref="Secret"/> without checking <see cref="State"/> behaves exactly as
+/// the old <c>string?</c> API did — which keeps call sites that genuinely only want the value honest, without
+/// making them all handle four cases.</para>
+/// </summary>
+public readonly record struct CredentialRead(CredentialState State, string? Secret)
+{
+    public static CredentialRead Found(string secret) => new(CredentialState.Found, secret);
+
+    public static readonly CredentialRead NotStored = new(CredentialState.NotStored, null);
+    public static readonly CredentialRead Unreadable = new(CredentialState.Unreadable, null);
+    public static readonly CredentialRead Unavailable = new(CredentialState.Unavailable, null);
+
+    /// <summary>Whether an item exists, whether or not its value could be read. False only when nothing is
+    /// stored or there is nowhere to store it — so it never claims a key the reader has not provided.</summary>
+    public bool Exists => State is CredentialState.Found or CredentialState.Unreadable;
+
+    /// <summary>The word for a log line. Deliberately says nothing about the value.</summary>
+    public string Describe() => State switch
+    {
+        CredentialState.Found => "found",
+        CredentialState.NotStored => "none stored",
+        CredentialState.Unreadable => "stored, but this build was not allowed to read it",
+        _ => "no credential store available",
+    };
+}

--- a/src/CST.Avalonia/Services/Ai/Credentials/CredentialRead.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/CredentialRead.cs
@@ -64,16 +64,45 @@ public readonly record struct CredentialRead(CredentialState State, string? Secr
     /// What to tell the reader about a named secret that is stored and unreadable. (#926)
     ///
     /// <para><b>One sentence, shared by every surface that reports it.</b> The resolver, the model catalogue
-    /// and the connection editor each phrased "no stored value … re-enter it" separately, which is how they
-    /// came to give advice that cannot work: on macOS the item exists, so re-entering runs
-    /// <c>SecItemAdd</c> → duplicate → <c>SecItemUpdate</c>, which needs the very authorization that was
-    /// just declined. Windows has no such problem — <c>Save</c> writes a fresh file — hence the split.</para>
+    /// and the connection editor each phrased "no stored value … re-enter it" separately, and drifted.</para>
+    ///
+    /// <para><b>On macOS it says AUTHORIZE, and nothing else — because nothing else works.</b> Tested
+    /// 2026-08-31 against a locked item, and both of the obvious remedies failed in different ways:</para>
+    ///
+    /// <list type="bullet">
+    /// <item>Entering a replacement key <b>succeeds and does not help.</b> The write goes through
+    /// (<c>SecItemUpdate</c>, item modified on disk) but an item's ACL is not its value, so the same binary
+    /// still cannot read what it just wrote. Advice that appears to work and changes nothing is worse than
+    /// advice that fails, because the reader stops looking.</item>
+    /// <item>Removing it <b>can fail</b>. Deleting needs authorization too, so a reader who cannot satisfy
+    /// the prompt cannot delete their way out either — see <c>AiConnectionEditorViewModel.RemoveKey</c>,
+    /// which now reports that rather than claiming success.</item>
+    /// </list>
+    ///
+    /// <para>What is left is granting the authorization, or deleting the item in Keychain Access, which is
+    /// trusted for the login keychain in a way this app is not. Windows has neither problem — <c>Save</c>
+    /// there writes a fresh file, so re-entering genuinely fixes it — hence the split.</para>
     /// </summary>
     public static string Advice(string what) =>
         OperatingSystem.IsWindows()
             ? $"{what} is stored but could not be decrypted. Enter it again under Settings \u2192 AI."
-            : $"{what} is stored but CST Reader was not allowed to read it. Authorize it when macOS asks, "
-              + "or remove it under Settings \u2192 AI and enter it again.";
+            : $"{what} is stored, and CST Reader was not allowed to read it. Choose Allow when macOS asks "
+              + "for your login keychain password. Replacing the key will not help; if you cannot allow it, "
+              + "delete the \u201cCST Reader\u201d entry in Keychain Access and add the key again.";
+
+    /// <summary>
+    /// What to tell the reader when the OS refused to delete their stored secret. (#926)
+    ///
+    /// <para>Its own sentence rather than <see cref="Advice"/>: the reader has just pressed Remove, so
+    /// "authorize it" is about a different operation than the one they are attempting, and the fallback is
+    /// the only route left.</para>
+    /// </summary>
+    public static string RemovalRefused(string displayName) =>
+        OperatingSystem.IsWindows()
+            ? $"{displayName}\u2019s stored key could not be removed. It is still stored."
+            : $"{displayName}\u2019s stored key could not be removed \u2014 macOS did not allow it, so it "
+              + "is still stored. Try again and choose Allow, or delete the \u201cCST Reader\u201d entry "
+              + "in Keychain Access.";
 
     /// <summary>The word for a log line. Deliberately says nothing about the value.</summary>
     public string Describe() => State switch

--- a/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
@@ -24,11 +24,19 @@ namespace CST.Avalonia.Services.Ai.Credentials;
 /// <para><b>This targets the FILE-BASED (login) keychain, deliberately.</b> <c>SecItem</c> routes to the
 /// data-protection keychain only when the query carries <c>kSecUseDataProtectionKeychain</c> or
 /// <c>kSecAttrSynchronizable</c>; with neither, it talks to the file-based one
-/// (Apple, TN3137 / DTS "On Mac Keychains"). That is the right target here because the data-protection keychain
-/// "is only available to code that can carry an entitlement", and its access groups are determined by code
-/// signing — so a plain <c>dotnet run</c> development build could not reach a key the signed <c>.app</c> stored,
-/// or the reverse. Apple does say the file-based implementation is on the road to deprecation; revisiting is
-/// tracked separately.</para>
+/// (Apple, TN3137 / DTS "On Mac Keychains"). The data-protection keychain "is only available to code that can
+/// carry an entitlement", and its access groups are determined by code signing, so a plain <c>dotnet run</c>
+/// build could not reach a key the signed <c>.app</c> stored. What the file-based keychain buys is that a
+/// development build can store and read <b>its own</b> keys without a signed bundle. Apple says the file-based
+/// implementation is on the road to deprecation; revisiting is #609.</para>
+///
+/// <para><b>It does NOT let a development build and a signed build share keys.</b> This doc used to say so, and
+/// it was the stated reason for the choice. The file-based keychain gates on a per-item ACL, and an ACL records
+/// the binary that created the item — <c>apphost</c>, ad-hoc signed, no team for a <c>dotnet run</c> build
+/// against <c>com.cst.avalonia</c>, Developer ID for the installed app. Each is foreign to the other. The
+/// difference from the data-protection keychain is not that sharing works; it is that the failure arrives as a
+/// modal password dialog rather than a clean denial, one per read. Installing a signed build over a machine
+/// that had been running development builds produced eight such dialogs at launch (#609, #925).</para>
 ///
 /// <para><b>Hence no <c>kSecAttrAccessible</c>.</b> Accessibility classes are the data-protection keychain's
 /// access model; the file-based keychain uses ACLs instead, and the attribute is accepted and ignored there.
@@ -43,9 +51,21 @@ internal static class MacOsKeychain
     private const string CoreFoundation =
         "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
 
-    private const int ErrSecSuccess = 0;
-    private const int ErrSecItemNotFound = -25300;
+    internal const int ErrSecSuccess = 0;
+    internal const int ErrSecItemNotFound = -25300;
     private const int ErrSecDuplicateItem = -25299;
+
+    // The three ways a READ can fail while the item is sitting right there. Distinguished because the remedy
+    // differs from "no key stored": the reader authorizes once, or unlocks, and the same key works. Collapsing
+    // them into not-found is #926 — it told the maintainer to re-enter keys he already had.
+    //
+    // internal so the tests can both name them in Classify's cases and pin their VALUES against SecBase.h.
+    // Naming them alone would not catch a wrong number - the test and the code would move together - and a
+    // wrong number here is silent: the status never matches, so the read falls to the default and a genuinely
+    // absent key starts reporting itself unreadable.
+    internal const int ErrSecAuthFailed = -25293;              // authorization declined
+    internal const int ErrSecUserCanceled = -128;              // the reader dismissed the prompt
+    internal const int ErrSecInteractionNotAllowed = -25308;   // locked, and no UI available to ask
 
     // ---- CoreFoundation ------------------------------------------------------------------------------------
 
@@ -150,12 +170,41 @@ internal static class MacOsKeychain
 
     internal static bool IsAvailable => OperatingSystem.IsMacOS() && Symbols.Value is not null;
 
+    /// <summary>
+    /// What an unsuccessful <c>SecItemCopyMatching</c> status means for the reader. (#926)
+    ///
+    /// <para><b>Separated from <see cref="Find"/> so it can be tested at all.</b> Everything around it is a
+    /// P/Invoke into Security.framework, which no unit test can drive — and this mapping is the entire defect
+    /// #926 fixes, so leaving it inside the native call would leave the one line that matters unguarded. A
+    /// mutation flipping <c>errSecAuthFailed</c> back to "not stored" killed no test until this moved out.</para>
+    ///
+    /// <para><b>Unrecognised statuses are Unreadable, not NotStored.</b> An unanticipated failure is not
+    /// evidence that an item is absent, and claiming absence we cannot see is precisely the harm here: it is
+    /// what tells a reader to re-enter a key that is present and correct. The conservative direction is to
+    /// under-claim.</para>
+    /// </summary>
+    internal static CredentialState Classify(int status) => status switch
+    {
+        ErrSecSuccess => CredentialState.Found,
+        ErrSecItemNotFound => CredentialState.NotStored,
+        _ => CredentialState.Unreadable,
+    };
+
     // ---- Operations ----------------------------------------------------------------------------------------
 
-    /// <summary>The stored secret, or null when there is no item (or the platform is unavailable).</summary>
-    internal static string? Find(string service, string account)
+    /// <summary>
+    /// One stored secret, and what happened when we asked for it. (#926)
+    ///
+    /// <para><b>Every status is classified, not just success.</b> This is the one operation of the three here
+    /// whose answer reaches the reader, and it used to be the only one that did not discriminate — while
+    /// <see cref="Save"/> acts on <c>errSecDuplicateItem</c> and <see cref="Delete"/> accepts
+    /// <c>errSecItemNotFound</c>. An item whose ACL names a different binary — the ordinary case after a
+    /// development build and a signed build have both written keys — answers <c>errSecAuthFailed</c>, which
+    /// read as "no key stored" and sent the reader off to re-enter one.</para>
+    /// </summary>
+    internal static CredentialRead Find(string service, string account)
     {
-        if (Symbols.Value is not { } k) return null;
+        if (Symbols.Value is not { } k) return CredentialRead.Unavailable;
 
         var query = IntPtr.Zero;
         var result = IntPtr.Zero;
@@ -172,17 +221,21 @@ internal static class MacOsKeychain
                     k.True,
                     k.MatchLimitOne,
                 });
-            if (query == IntPtr.Zero) return null;
+            if (query == IntPtr.Zero) return CredentialRead.Unavailable;
 
             var status = SecItemCopyMatching(query, out result);
-            if (status != ErrSecSuccess || result == IntPtr.Zero) return null;
+            if (status != ErrSecSuccess) return new CredentialRead(Classify(status), null);
+
+            // Success with nothing to copy. Not an item that is missing — one whose value we failed to
+            // receive, which is the same class of "cannot read it" as a declined authorization.
+            if (result == IntPtr.Zero) return CredentialRead.Unreadable;
 
             var length = CFDataGetLength(result);
-            if (length <= 0) return null;
+            if (length <= 0) return CredentialRead.Unreadable;
 
             var bytes = new byte[length];
             Marshal.Copy(CFDataGetBytePtr(result), bytes, 0, (int)length);
-            return Encoding.UTF8.GetString(bytes);
+            return CredentialRead.Found(Encoding.UTF8.GetString(bytes));
         }
         finally
         {

--- a/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
@@ -105,13 +105,13 @@ internal static class WindowsDpapiStore
     }
 
     /// <summary>The stored secret, or null when there is none - or when the blob cannot be decrypted.</summary>
-    internal static string? Find(string service, string account)
+    internal static CredentialRead Find(string service, string account)
     {
         var path = FileFor(service, account);
 
         lock (Gate)
         {
-            if (!File.Exists(path)) return null;
+            if (!File.Exists(path)) return CredentialRead.NotStored;
 
             try
             {
@@ -119,7 +119,7 @@ internal static class WindowsDpapiStore
                     File.ReadAllBytes(path), Entropy, DataProtectionScope.CurrentUser);
                 try
                 {
-                    return Encoding.UTF8.GetString(plaintext);
+                    return CredentialRead.Found(Encoding.UTF8.GetString(plaintext));
                 }
                 finally
                 {
@@ -135,8 +135,11 @@ internal static class WindowsDpapiStore
                 // the user performs themselves migrates it, so this is the IT-helpdesk case, not the
                 // forgot-my-password case. It also covers a file copied from another machine or account.
                 //
-                // Reported as "no key stored", never as an error: the honest thing to tell someone in that
-                // state is "please re-enter your key", not a cryptography failure they can do nothing with.
+                // Reported as Unreadable, not NotStored (#926). This used to report "no key stored", reasoning
+                // that "please re-enter your key" is more useful to someone in this state than a cryptography
+                // failure they can do nothing with. That advice survives - see below, re-entering does work
+                // here - but it belongs in the message, not in the state: saying "nothing is stored" about a
+                // blob that IS stored is what let the same collapse hide a recoverable macOS denial.
                 //
                 // The file is deliberately LEFT IN PLACE. "Undecryptable now" is not "undecryptable forever":
                 // the data directory is ROAMING AppData, and the DPAPI master keys under
@@ -145,18 +148,24 @@ internal static class WindowsDpapiStore
                 // keys to the DC and can likewise recover after an admin reset. Deleting here would convert
                 // both of those temporary states into permanent loss, to save a sub-millisecond decrypt on the
                 // next launch. Re-entering a key overwrites the blob anyway, so nothing accumulates.
-                return null;
+                //
+                // Re-entering is a REAL remedy on this platform, which is not true of the macOS case sharing
+                // this state: Save here writes a fresh file with no permission to ask for, whereas SecItemAdd
+                // on a duplicate falls through to SecItemUpdate and needs the very authorization that was
+                // just declined. Anything phrasing this state for the reader has to say something different
+                // per platform.
+                return CredentialRead.Unreadable;
             }
             catch (Exception)
             {
-                // Unreadable file, transient IO, a concurrent writer. Report "none stored" and leave the file
+                // Unreadable file, transient IO, a concurrent writer. Report Unreadable and leave the file
                 // alone - destroying it on a hiccup would be data loss.
                 //
                 // Behaviourally identical to the catch above, and kept separate only to carry the two
                 // different explanations: the cases arrive for unrelated reasons and a future change is
                 // likelier to want to treat one of them differently. No test distinguishes them, and none
                 // can - both tests below would pass with these collapsed into one.
-                return null;
+                return CredentialRead.Unreadable;
             }
         }
     }

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -766,11 +766,31 @@ namespace CST.Avalonia.ViewModels
         /// model list is real user work, and destroying it on an action meant only to stop billing would be
         /// data loss.</para>
         /// </summary>
+        /// <summary>
+        /// Forget the stored key — and say so when the OS refuses. (#926)
+        ///
+        /// <para><b>The return value used to be discarded.</b> Deleting a macOS Keychain item DOES need
+        /// authorization, contrary to what this fix originally assumed: on a locked item the reader is
+        /// prompted, and dismissing the prompt fails the delete. The row then stopped showing the key and the
+        /// sheet said nothing, so the app reported a removal that had not happened — leaving a live
+        /// credential the reader believed they had revoked, which is the one outcome a Remove button must
+        /// never produce. Observed 2026-08-31: <c>Removed a secret for groq/primary: failed</c>, with the
+        /// item still in the keychain afterwards.</para>
+        ///
+        /// <para>Only the sheet is refreshed on success. On failure nothing is cleared, because nothing
+        /// changed, and the reader is told what to do about it.</para>
+        /// </summary>
         private void RemoveKey()
         {
             if (_credentials is null || _existingId is null) return;
 
-            _credentials.Delete(_existingId, AiCredentialNames.Primary);
+            if (!_credentials.Delete(_existingId, AiCredentialNames.Primary))
+            {
+                Problem = CredentialRead.RemovalRefused(_displayName);
+                return;
+            }
+
+            Problem = null;
             ApiKeyEntry = "";
             this.RaisePropertyChanged(nameof(HasStoredKey));
             this.RaisePropertyChanged(nameof(KeyStatus));

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reactive;
 using CST.Avalonia.Models.Ai;
 using CST.Avalonia.Services.Ai;
+using CST.Avalonia.Services.Ai.Credentials;
 using ReactiveUI;
 
 namespace CST.Avalonia.ViewModels
@@ -54,6 +55,17 @@ namespace CST.Avalonia.ViewModels
         /// header that is renamed, unmarked or removed takes its stored secret with it rather than leaving an
         /// orphan nothing can reach. (#771)</summary>
         private readonly List<string> _secretHeadersAtOpen = new();
+
+        /// <summary>
+        /// Accounts a rename could not carry because the OS would not hand the secret over, and which must
+        /// therefore survive the sweep that removes accounts no header claims any more. (#926)
+        ///
+        /// <para>Without this, renaming a secret header while its item is locked deletes the only copy: the
+        /// carry reads null, writes nothing, and the sweep then removes the account the value was still in.
+        /// Keeping it is recoverable — the reader authorizes and the old name still holds their secret — and
+        /// deleting it is not.</para>
+        /// </summary>
+        private readonly HashSet<string> _secretsToKeepUnreadable = new(StringComparer.Ordinal);
 
         private string _id = "";
         private string _displayName = "";
@@ -252,8 +264,11 @@ namespace CST.Avalonia.ViewModels
                     IsSecret = header.Secret,
                     ArrivedSecret = header.Secret,
                     OriginalName = header.Name,
+                    // Exists, not readable (#926): a locked secret is still stored, and telling the reader it
+                    // is not is what sends them to re-enter something they already have.
                     HasStoredSecret = header.Secret
-                        && credentials?.Get(connection.Id, AiCredentialNames.Header(header.Name)) is not null,
+                        && (credentials?.Read(connection.Id, AiCredentialNames.Header(header.Name))
+                            ?? CredentialRead.Unavailable).Exists,
                 });
 
             vm._secretHeadersAtOpen.AddRange(connection.Headers
@@ -393,14 +408,28 @@ namespace CST.Avalonia.ViewModels
 
         public bool HasKeyUnavailable => !string.IsNullOrEmpty(KeyUnavailable);
 
-        /// <summary>Whether a key is already filed under this id — only knowable for a connection that
-        /// exists.</summary>
-        public bool HasStoredKey =>
-            _existingId is not null && _credentials?.Get(_existingId, AiCredentialNames.Primary) is not null;
+        /// <summary>What the store says about this connection's primary key. (#926)</summary>
+        private CredentialRead StoredKey => _existingId is null
+            ? CredentialRead.NotStored
+            : _credentials?.Read(_existingId, AiCredentialNames.Primary) ?? CredentialRead.Unavailable;
+
+        /// <summary>
+        /// Whether a key is already filed under this id — only knowable for a connection that exists.
+        ///
+        /// <para><b>Exists, not readable</b> (#926). A key we cannot read is still a key, and this is the
+        /// sheet where the reader would act on being told otherwise: it drove the whole defect, since the row
+        /// badged "Key locked" while the Edit sheet directly under it said "No key is stored".</para>
+        /// </summary>
+        public bool HasStoredKey => StoredKey.Exists;
 
         public string KeyStatus => _existingId is null
             ? "Stored in the operating system's credential store, never in settings."
-            : HasStoredKey
+            // Locked first: it is a kind of "stored", so the readable-key sentence below would otherwise claim
+            // it and tell the reader to paste a replacement - which on macOS needs the authorization that just
+            // failed, so it would appear to work and change nothing. (#926)
+            : StoredKey.State == CredentialState.Unreadable
+                ? CredentialRead.Advice($"{_displayName}'s key")
+            : StoredKey.State == CredentialState.Found
                 ? $"A key is stored for {_displayName}. Paste a new one to replace it."
                 // "No key is stored" is true and reads as "you have no key", which on an adopted connection is
                 // false — it authenticates from the environment, and saying otherwise sends the reader to
@@ -694,7 +723,19 @@ namespace CST.Avalonia.ViewModels
                 var to = AiCredentialNames.Header(row.Name.Trim());
                 if (string.Equals(from, to, StringComparison.Ordinal)) continue;
 
-                if (_credentials.Get(connectionId, from) is { } carried)
+                // Read, not Get (#926). A locked secret returns null from Get, so the carry was skipped and
+                // the sweep below then deleted the old account - renaming a secret header while its Keychain
+                // item was unauthorized DESTROYED the secret, permanently and silently. Recorded here as the
+                // account to leave alone: CredentialRead.Unreadable's own doc says this state is never a
+                // reason to delete anything, because both platforms can recover from it.
+                var read = _credentials.Read(connectionId, from);
+                if (read.State == CredentialState.Unreadable)
+                {
+                    _secretsToKeepUnreadable.Add(from);
+                    continue;
+                }
+
+                if (read.Secret is { } carried)
                     _credentials.Set(connectionId, to, carried);
             }
 
@@ -703,7 +744,8 @@ namespace CST.Avalonia.ViewModels
                 .Select(h => AiCredentialNames.Header(h.Name.Trim()))
                 .ToHashSet(StringComparer.Ordinal);
 
-            foreach (var gone in _secretHeadersAtOpen.Where(name => !keeping.Contains(name)))
+            foreach (var gone in _secretHeadersAtOpen.Where(
+                         name => !keeping.Contains(name) && !_secretsToKeepUnreadable.Contains(name)))
                 _credentials.Delete(connectionId, gone);
 
             // A typed value wins over anything carried above, so renaming and rotating in one edit does both.

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -850,7 +850,9 @@ namespace CST.Avalonia.ViewModels
                 ? $"The stored key could not be read, so requests are using {_connection.EnvironmentVariable}"
             : OperatingSystem.IsWindows()
                 ? "Stored, but it did not decrypt — enter it again to replace it"
-                : "Stored, but this build was not allowed to read it — authorize it, or remove and re-enter";
+                // Not "remove and re-enter": removing needs authorization too and can fail, and replacing
+                // the key succeeds without helping — an item's ACL is not its value. Both tested 2026-08-31.
+                : "Stored, but this build was not allowed to read it — choose Allow when macOS asks";
 
         /// <summary>
         /// Whether <see cref="KeyProblem"/> is a problem the reader must act on, or merely a statement.

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -816,13 +816,34 @@ namespace CST.Avalonia.ViewModels
         ///
         /// <para>"No key" is a legitimate resting state, not a warning: a local runner needs none, and a
         /// connection may authenticate entirely through its headers.</para>
+        ///
+        /// <para><b>"Key locked" is the one badge that IS a warning</b> (#926), and it has to be visibly
+        /// unlike "No key" — those two shared a badge, and the reader acted on it by re-entering keys that
+        /// were already stored and correct.</para>
         /// </summary>
         public string KeySourceBadge => _connection.KeySource switch
         {
             CredentialSource.Keychain => "Keychain",
             CredentialSource.Environment => "Environment",
+            CredentialSource.Unreadable => "Key locked",
             _ => "No key",
         };
+
+        /// <summary>
+        /// What to do about a key that is stored and unreadable, or null when there is nothing to say. (#926)
+        ///
+        /// <para>Platform-specific because the remedy is. On macOS the item's ACL names a different binary —
+        /// ordinarily a development build that stored the key before this signed one — and the way out is to
+        /// authorize once at the prompt, or to remove the key here and enter it again. On Windows the DPAPI
+        /// blob did not decrypt, which is usually an administrator-initiated password reset; entering the key
+        /// again is the whole fix, and may simply start working once a roaming profile finishes syncing.</para>
+        /// </summary>
+        public string? KeyProblem => _connection.KeySource != CredentialSource.Unreadable ? null
+            : OperatingSystem.IsWindows()
+                ? "Stored, but it did not decrypt — remove it and enter it again"
+                : "Stored, but this build was not allowed to read it — authorize it, or remove and re-enter";
+
+        public bool HasKeyProblem => KeyProblem is not null;
 
         /// <summary>
         /// The provider's own documentation, where the catalogue publishes one.
@@ -847,8 +868,13 @@ namespace CST.Avalonia.ViewModels
         ///
         /// <para>False for a key we did not store, and false when there is none — in both cases the slot is
         /// simply empty. #678 made this reachable by filing keys under the connection's id.</para>
+        ///
+        /// <para><b>True for a stored key we cannot read</b> (#926). We did store it, deleting needs no
+        /// authorization on either platform, and it is the reader's way out of the state — so this is the one
+        /// row where removal matters most, and it would be absent if the check were "can we read it".</para>
         /// </summary>
-        public bool CanRemoveKey => _connection.KeySource == CredentialSource.Keychain;
+        public bool CanRemoveKey =>
+            _connection.KeySource is CredentialSource.Keychain or CredentialSource.Unreadable;
 
         /// <summary>
         /// What we actually know about whether this works.
@@ -941,6 +967,8 @@ namespace CST.Avalonia.ViewModels
             this.RaisePropertyChanged(nameof(RowTooltip));
             this.RaisePropertyChanged(nameof(KeySourceBadge));
             this.RaisePropertyChanged(nameof(CanRemoveKey));
+            this.RaisePropertyChanged(nameof(KeyProblem));
+            this.RaisePropertyChanged(nameof(HasKeyProblem));
             this.RaisePropertyChanged(nameof(StatusText));
             this.RaisePropertyChanged(nameof(IsIncomplete));
             this.RaisePropertyChanged(nameof(IncompleteText));

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -445,7 +445,10 @@ namespace CST.Avalonia.ViewModels
         {
             if (_service is null) return;
             var result = _service.Remove(id);
-            Problem = result.Ok ? null : result.Problem;
+            // Not `result.Ok ? null : …` (#926). Remove can succeed and still have something the reader must
+            // know: the connection is gone, its key could not be deleted, and adding the provider back would
+            // find the orphan.
+            Problem = result.Problem;
         }
 
         /// <summary>
@@ -460,7 +463,9 @@ namespace CST.Avalonia.ViewModels
         internal void RemoveKey(string id)
         {
             if (_credentials is null) return;
-            _credentials.Delete(id, AiCredentialNames.Primary);
+            Problem = _credentials.Delete(id, AiCredentialNames.Primary)
+                ? null
+                : CredentialRead.RemovalRefused(id);
             Rebind();
         }
 

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -821,11 +821,15 @@ namespace CST.Avalonia.ViewModels
         /// unlike "No key" — those two shared a badge, and the reader acted on it by re-entering keys that
         /// were already stored and correct.</para>
         /// </summary>
-        public string KeySourceBadge => _connection.KeySource switch
+        public string KeySourceBadge => _connection switch
         {
-            CredentialSource.Keychain => "Keychain",
-            CredentialSource.Environment => "Environment",
-            CredentialSource.Unreadable => "Key locked",
+            // The compound case first: a locked stored key beside a working variable. Requests DO work, and
+            // they are billed to the variable, so the badge names it rather than reporting either fact alone.
+            { KeySource: CredentialSource.Environment, KeyLocked: true } c =>
+                $"Key locked — using {c.EnvironmentVariable}",
+            { KeySource: CredentialSource.Keychain } => "Keychain",
+            { KeySource: CredentialSource.Environment } => "Environment",
+            { KeySource: CredentialSource.Unreadable } => "Key locked",
             _ => "No key",
         };
 
@@ -838,10 +842,29 @@ namespace CST.Avalonia.ViewModels
         /// blob did not decrypt, which is usually an administrator-initiated password reset; entering the key
         /// again is the whole fix, and may simply start working once a roaming profile finishes syncing.</para>
         /// </summary>
-        public string? KeyProblem => _connection.KeySource != CredentialSource.Unreadable ? null
+        public string? KeyProblem =>
+            !_connection.KeyLocked ? null
+            : _connection.KeySource == CredentialSource.Environment
+                // Nothing is broken for the reader right now, so this states the situation rather than asking
+                // for action: the request path is already using the variable.
+                ? $"The stored key could not be read, so requests are using {_connection.EnvironmentVariable}"
             : OperatingSystem.IsWindows()
-                ? "Stored, but it did not decrypt — remove it and enter it again"
+                ? "Stored, but it did not decrypt — enter it again to replace it"
                 : "Stored, but this build was not allowed to read it — authorize it, or remove and re-enter";
+
+        /// <summary>
+        /// Whether <see cref="KeyProblem"/> is a problem the reader must act on, or merely a statement.
+        /// (#926)
+        ///
+        /// <para>A locked key with a working variable is not a fault: sending works. Colouring it like the
+        /// caution states would teach the reader that the warning colour means nothing much.</para>
+        /// </summary>
+        public bool KeyProblemNeedsAction =>
+            _connection.KeyLocked && _connection.KeySource != CredentialSource.Environment;
+
+        /// <summary>The complement, so the two lines in the row template are mutually exclusive rather than
+        /// both rendering the same sentence when action IS needed.</summary>
+        public bool KeyProblemIsStatement => HasKeyProblem && !KeyProblemNeedsAction;
 
         public bool HasKeyProblem => KeyProblem is not null;
 
@@ -969,6 +992,8 @@ namespace CST.Avalonia.ViewModels
             this.RaisePropertyChanged(nameof(CanRemoveKey));
             this.RaisePropertyChanged(nameof(KeyProblem));
             this.RaisePropertyChanged(nameof(HasKeyProblem));
+            this.RaisePropertyChanged(nameof(KeyProblemNeedsAction));
+            this.RaisePropertyChanged(nameof(KeyProblemIsStatement));
             this.RaisePropertyChanged(nameof(StatusText));
             this.RaisePropertyChanged(nameof(IsIncomplete));
             this.RaisePropertyChanged(nameof(IncompleteText));

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -329,10 +329,19 @@ namespace CST.Avalonia.ViewModels
         /// provider fact from the extraction rather than a guess. For a custom endpoint nothing is claimed:
         /// plenty of them need no key at all, and disabling a model on a hunch would be worse than letting
         /// the request explain itself.</para>
+        ///
+        /// <para><b>A locked key is stated separately from a missing one</b> (#926). Both leave the model
+        /// unusable this moment, but "no API key stored" sends a reader who has one to store it again; the
+        /// key is there and the reader needs to authorize it, not replace it. Unlike the two above, this one
+        /// is worth saying even for a custom endpoint: an item we can see and cannot read is a fact about
+        /// this connection, not a guess about whether it needs a key.</para>
         /// </summary>
         private static string ReasonItCannotBeUsed(AiConnection connection)
         {
             if (connection.IsIncomplete) return "not finished being set up";
+
+            if (connection.KeySource == CredentialSource.Unreadable)
+                return "its API key could not be read";
 
             var preset = AiProviderPresets.ById(connection.Id);
             if (preset is { RequiresKey: true } && connection.KeySource == CredentialSource.None)

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -340,6 +340,9 @@ namespace CST.Avalonia.ViewModels
         {
             if (connection.IsIncomplete) return "not finished being set up";
 
+            // KeySource, not StoredKeyUnreadable: a locked stored key beside a working environment variable
+            // resolves to Environment and sends perfectly well, so disabling it here would have the picker
+            // contradict the wire. Only a locked key with nothing behind it makes the model unusable. (#926)
             if (connection.KeySource == CredentialSource.Unreadable)
                 return "its API key could not be read";
 

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -128,6 +128,16 @@
                                                    IsVisible="{Binding IsIncomplete}"
                                                    Classes="Secondary"
                                                    Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
+                                        <!-- A stored key we could not read (#926). Shares the caution slot
+                                             with IncompleteText because it is the same kind of statement -
+                                             this row is not usable yet, and here is the reason - and the two
+                                             cannot both apply: a connection still carrying URL placeholders
+                                             has never reached the point of storing a key. -->
+                                        <TextBlock Text="{Binding KeyProblem}"
+                                                   IsVisible="{Binding HasKeyProblem}"
+                                                   Classes="Secondary"
+                                                   TextWrapping="Wrap"
+                                                   Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
                                     </StackPanel>
 
                                     <Border Grid.Column="2" Classes="Pill" VerticalAlignment="Center"

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -128,13 +128,18 @@
                                                    IsVisible="{Binding IsIncomplete}"
                                                    Classes="Secondary"
                                                    Foreground="{DynamicResource SystemFillColorCautionBrush}"/>
-                                        <!-- A stored key we could not read (#926). Shares the caution slot
-                                             with IncompleteText because it is the same kind of statement -
-                                             this row is not usable yet, and here is the reason - and the two
-                                             cannot both apply: a connection still carrying URL placeholders
-                                             has never reached the point of storing a key. -->
+                                        <!-- A stored key we could not read (#926). Two shapes, because two
+                                             situations: with no fallback the row cannot be used and takes the
+                                             caution colour IncompleteText uses; with a working environment
+                                             variable the request path carries on regardless, so it is a plain
+                                             secondary line. Colouring a working connection like a broken one
+                                             teaches the reader that the caution colour means nothing much. -->
                                         <TextBlock Text="{Binding KeyProblem}"
-                                                   IsVisible="{Binding HasKeyProblem}"
+                                                   IsVisible="{Binding KeyProblemIsStatement}"
+                                                   Classes="Secondary"
+                                                   TextWrapping="Wrap"/>
+                                        <TextBlock Text="{Binding KeyProblem}"
+                                                   IsVisible="{Binding KeyProblemNeedsAction}"
                                                    Classes="Secondary"
                                                    TextWrapping="Wrap"
                                                    Foreground="{DynamicResource SystemFillColorCautionBrush}"/>


### PR DESCRIPTION
Closes #926.

## The defect

A credential lookup had one word for four outcomes. `MacOsKeychain.Find` collapsed every non-success status into `null` and the store logged **"none stored"**, so `errSecAuthFailed` — an item whose ACL names a different binary, the ordinary state once a development build and a signed build have both written keys — was indistinguishable from `errSecItemNotFound`.

Installing the beta 6 candidate over a machine that had been running `dotnet run` builds produced **eight** authorization prompts. Dismissing them made all three of the maintainer's providers report no key at all, and the remedy the app offered was to type them in again — over keys that were present and correct.

## What changed

`CredentialRead` carries the state: `Found`, `NotStored`, `Unreadable`, `Unavailable`. `Get` still returns the value and `null` for the rest, so call sites that only want a secret are unchanged.

- **`MacOsKeychain.Classify`** is a pure status → state function, extracted from `Find` so the line that caused the bug is reachable by a test. It was not: a mutation putting `errSecAuthFailed` back to `NotStored` killed nothing while it sat between P/Invokes. Its status numbers are pinned against `SecBase.h`, for the same reason the DPAPI entropy is.
- **An unrecognised status is `Unreadable`, not `NotStored`.** An unanticipated failure is not evidence an item is gone.
- **`WindowsDpapiStore`** reports `Unreadable` for a blob that will not decrypt. "Ask them to re-enter it" was the right *message* and still is — unlike macOS, `Save` there writes a fresh file — but it was wrong as a *state*.

## What the second commit adds, after review

The first commit fixed two of the four layers where the answer reaches the reader. The row badged "Key locked" while pressing send still said *"No API key is stored for Claude. Add one in Settings."*

- **The request path and the editor** now carry the state. `CredentialRead.Advice` is one sentence, per platform, shared by the resolver, the catalogue and the editor — those three had each phrased it separately and drifted into advice that cannot work on macOS.
- **Data loss fixed.** Renaming a secret header whose item was locked *destroyed* the secret: the carry read the old account with `Get`, got `null`, carried nothing, and the sweep then deleted the account the only copy was in. Silent and permanent.
- **[fsnow]** on the environment question: *"use the env var, and say so"*. A locked key beside a working variable resolves to `Environment` — what the request path already did — and the row reads **"Key locked — using GROQ_API_KEY"**. Refusing would have had Settings disable a model that sends perfectly well.

That needs two facts, so `AiConnection` gains `StoredKeyUnreadable` beside `KeySource`, with `KeyLocked` derived from both.

## Docs corrected

Two paragraphs that had stopped being true, both load-bearing:

- `MacOsKeychain` claimed the file-based keychain lets a development build and a signed build share keys. It does not — it gates on a per-item ACL naming the creating binary (`apphost`/ad-hoc/no-team against `com.cst.avalonia`/Developer ID/`69M77LM9K3`). Verified independently in review.
- `AiCredentialStore` claimed nothing runs at startup, and named the harm exactly: *"a permission dialog on launch, for a feature the user has not asked for, teaches them to click through prompts."* Reads begin before the shell probe. #925 tracks the fix; the paragraph now says so.

Also removed an orphaned `SourceFor` summary stacked above `ReachabilityOf`, citing the `CST_AI_*` namespace CLAUDE.md records as an invented embellishment.

## Testing

**16 mutants applied, 15 killed** by the intended test. The survivor is `CredentialState.Unavailable`, which nothing distinguishes from `NotStored` outside one log word — the store returns it only where `IsAvailable` is false, which on this suite's platforms it never is. Recorded rather than papered over.

Review also found the real `AiCredentialStore.Read` had **zero** coverage — seven test fakes implemented it, so every test of the new states was testing the fakes' model of the store. Now covered directly.

**Suite: 2750 passed, 0 failed, 17 skipped.** The Windows DPAPI tests are among the skips and are **unverified on macOS** — worth a look on a Windows machine before release.

## Not covered by tests

The keychain prompt itself. Reproducing it needs two differently-signed binaries and a real login keychain.
