### PR TITLE
Ask whether a key exists without asking to read it (#925)

### DIFF
--- a/docs/testing/UI_SMOKE_TEST.md
+++ b/docs/testing/UI_SMOKE_TEST.md
@@ -113,6 +113,78 @@ marking each step **Pass / Fail / N/A** and jotting anything odd in **Notes**.
 - [ ] Change the **Logging** level → new log lines appear at that level.
 - [ ] Settings persist across a restart.
 
+## 9a. AI Assistant — key storage  ⊞ ⭐
+
+**Why this section exists.** An API key must never reach a file we write, and on Windows that promise is
+kept by DPAPI over a file per secret — a code path **developed on macOS and exercised by tests that do not
+run there**. The suite's 17 skips are these. Everything below was learned from real defects found on
+2026-08-31 (#926, #925); each check is one of them.
+
+Skip the whole section if the AI Assistant is off (Settings › AI). Turn it on and add one provider with a
+key to run it — any provider, the key need not be valid for most of these.
+
+**Where things live on Windows**
+
+```
+%APPDATA%\CSTReader\credentials\CST Reader — AI provider\<connection>.<name>.dpapi
+```
+
+One file per secret, e.g. `openrouter.primary.dpapi`. The separator is `.` on Windows and `:` on macOS —
+`:` is not a legal filename character. On macOS these are Keychain items under the service
+**"CST Reader — AI provider"**, visible in Keychain Access.
+
+**The promise**
+
+- [ ] After storing a key, open `%APPDATA%\CSTReader\settings.json` and search for it. **The key must not
+      be there** — not the whole key, not a fragment.  ⭐
+- [ ] Open the `.dpapi` file in a hex or text viewer. **The key must not be readable in it.**  ⊞ ⭐
+- [ ] Restart the app. The provider still shows its key as stored, and a request still works.
+
+**Removing**
+
+- [ ] **Settings › AI › Providers › Edit › Remove stored key** → the sheet stops saying a key is stored, and
+      the `.dpapi` file is gone.
+- [ ] **Delete a whole connection** (row → Delete) → its `.dpapi` file is gone too. *(A leftover file is an
+      orphan nothing can reach, and a connection later created with the same id would silently adopt it.)*
+- [ ] Removing the last key leaves **no empty `credentials` sub-directory** behind.
+
+**An unreadable key is not a missing key**  ⊞ ⭐ *(#926 — the defect this section was written for)*
+
+On Windows a blob stops decrypting after an **administrator-initiated password reset**, which discards the
+user's DPAPI master key. Simulate it by overwriting the file with junk:
+
+```powershell
+$f = "$env:APPDATA\CSTReader\credentials\CST Reader — AI provider\<connection>.primary.dpapi"
+Copy-Item $f "$f.bak"                          # keep the real one
+[IO.File]::WriteAllBytes($f, (1..64 | % { Get-Random -Max 256 }))
+```
+
+Restart the app, then check:
+
+- [ ] The provider row badges **"Key locked"**, not "No key".  ⭐
+- [ ] Its message says the key is **stored but could not be decrypted**, and to enter it again. It must
+      **not** say no key is stored — that sends the reader to re-enter a key they may still have, and on
+      macOS re-entering cannot work at all.
+- [ ] The Edit sheet agrees: it must not say *"No key is stored for &lt;provider&gt;."*
+- [ ] Sending a message reports the same thing, **not** *"No API key is stored… Add one in Settings."*
+      *(The row and the composer disagreeing is the specific failure this was caught as.)*
+- [ ] **The junk file is still there.** It is deliberately not deleted: "cannot decrypt now" is not "cannot
+      decrypt ever" — a roaming profile can arrive later, and a domain account can recover after an admin
+      reset. Deleting would turn a temporary state into permanent loss.
+- [ ] **Entering the key again fixes it** on Windows — `Save` writes a fresh file, so replace works here.
+      *(It does not on macOS, where the item's ACL is not its value. That platform difference is why the two
+      messages differ; if the Windows message ever starts talking about authorizing, that is the bug.)*
+
+Then `Move-Item "$f.bak" $f -Force` to restore, or just re-enter the key.
+
+**Quiet at launch**  *(#925)*
+
+- [ ] Set logging to **Debug**, restart, open Settings › AI › Providers, close it. In the log, count
+      `Credential lookup` lines: expect **single digits**, and none at all before the first thing that
+      needs a key. *(It was 114 for three connections across one launch and one Settings window. On Windows
+      the cost is only wasted decryption; on macOS each one could raise a password dialog.)*
+- [ ] No credential prompt of any kind appears at launch.
+
 ## 10. Graphics / rendering stability  ⊞ ⭐
 
 - [ ] Over sustained use (open/close books, float/unfloat, switch tabs, scroll), the reader view **does not go black/blank and stay that way**.  ⊞ *(#401 — the virtualized-GPU stall; if it happens: does clicking/selecting text restore it? capture repro + whether hardware-accel is on)*
@@ -155,6 +227,9 @@ marking each step **Pass / Fail / N/A** and jotting anything odd in **Notes**.
 10. **Install/uninstall + process cleanup** — §1, §14.
 11. **SmartScreen / unsigned installer** friction — §1.
 12. **Multi-monitor / DPI changes** — §2, §13.
+13. **DPAPI key storage** (#579, #926) — §9a. The whole Windows credential path is developed on macOS and
+    covered by tests that **skip** there, so this seam reaches Windows less exercised than any other in this
+    list.
 
 ---
 
@@ -171,6 +246,7 @@ marking each step **Pass / Fail / N/A** and jotting anything odd in **Notes**.
 | 7 Dock float/split | | | |
 | 8 Menus & shortcuts | | | |
 | 9 Settings | | | |
+| 9a AI key storage (DPAPI) | | | |
 | 10 Rendering stability | | | |
 | 11 View Source PDF | | | |
 | 12 Updates | | | |

--- a/docs/testing/UI_SMOKE_TEST.md
+++ b/docs/testing/UI_SMOKE_TEST.md
@@ -113,78 +113,6 @@ marking each step **Pass / Fail / N/A** and jotting anything odd in **Notes**.
 - [ ] Change the **Logging** level → new log lines appear at that level.
 - [ ] Settings persist across a restart.
 
-## 9a. AI Assistant — key storage  ⊞ ⭐
-
-**Why this section exists.** An API key must never reach a file we write, and on Windows that promise is
-kept by DPAPI over a file per secret — a code path **developed on macOS and exercised by tests that do not
-run there**. The suite's 17 skips are these. Everything below was learned from real defects found on
-2026-08-31 (#926, #925); each check is one of them.
-
-Skip the whole section if the AI Assistant is off (Settings › AI). Turn it on and add one provider with a
-key to run it — any provider, the key need not be valid for most of these.
-
-**Where things live on Windows**
-
-```
-%APPDATA%\CSTReader\credentials\CST Reader — AI provider\<connection>.<name>.dpapi
-```
-
-One file per secret, e.g. `openrouter.primary.dpapi`. The separator is `.` on Windows and `:` on macOS —
-`:` is not a legal filename character. On macOS these are Keychain items under the service
-**"CST Reader — AI provider"**, visible in Keychain Access.
-
-**The promise**
-
-- [ ] After storing a key, open `%APPDATA%\CSTReader\settings.json` and search for it. **The key must not
-      be there** — not the whole key, not a fragment.  ⭐
-- [ ] Open the `.dpapi` file in a hex or text viewer. **The key must not be readable in it.**  ⊞ ⭐
-- [ ] Restart the app. The provider still shows its key as stored, and a request still works.
-
-**Removing**
-
-- [ ] **Settings › AI › Providers › Edit › Remove stored key** → the sheet stops saying a key is stored, and
-      the `.dpapi` file is gone.
-- [ ] **Delete a whole connection** (row → Delete) → its `.dpapi` file is gone too. *(A leftover file is an
-      orphan nothing can reach, and a connection later created with the same id would silently adopt it.)*
-- [ ] Removing the last key leaves **no empty `credentials` sub-directory** behind.
-
-**An unreadable key is not a missing key**  ⊞ ⭐ *(#926 — the defect this section was written for)*
-
-On Windows a blob stops decrypting after an **administrator-initiated password reset**, which discards the
-user's DPAPI master key. Simulate it by overwriting the file with junk:
-
-```powershell
-$f = "$env:APPDATA\CSTReader\credentials\CST Reader — AI provider\<connection>.primary.dpapi"
-Copy-Item $f "$f.bak"                          # keep the real one
-[IO.File]::WriteAllBytes($f, (1..64 | % { Get-Random -Max 256 }))
-```
-
-Restart the app, then check:
-
-- [ ] The provider row badges **"Key locked"**, not "No key".  ⭐
-- [ ] Its message says the key is **stored but could not be decrypted**, and to enter it again. It must
-      **not** say no key is stored — that sends the reader to re-enter a key they may still have, and on
-      macOS re-entering cannot work at all.
-- [ ] The Edit sheet agrees: it must not say *"No key is stored for &lt;provider&gt;."*
-- [ ] Sending a message reports the same thing, **not** *"No API key is stored… Add one in Settings."*
-      *(The row and the composer disagreeing is the specific failure this was caught as.)*
-- [ ] **The junk file is still there.** It is deliberately not deleted: "cannot decrypt now" is not "cannot
-      decrypt ever" — a roaming profile can arrive later, and a domain account can recover after an admin
-      reset. Deleting would turn a temporary state into permanent loss.
-- [ ] **Entering the key again fixes it** on Windows — `Save` writes a fresh file, so replace works here.
-      *(It does not on macOS, where the item's ACL is not its value. That platform difference is why the two
-      messages differ; if the Windows message ever starts talking about authorizing, that is the bug.)*
-
-Then `Move-Item "$f.bak" $f -Force` to restore, or just re-enter the key.
-
-**Quiet at launch**  *(#925)*
-
-- [ ] Set logging to **Debug**, restart, open Settings › AI › Providers, close it. In the log, count
-      `Credential lookup` lines: expect **single digits**, and none at all before the first thing that
-      needs a key. *(It was 114 for three connections across one launch and one Settings window. On Windows
-      the cost is only wasted decryption; on macOS each one could raise a password dialog.)*
-- [ ] No credential prompt of any kind appears at launch.
-
 ## 10. Graphics / rendering stability  ⊞ ⭐
 
 - [ ] Over sustained use (open/close books, float/unfloat, switch tabs, scroll), the reader view **does not go black/blank and stay that way**.  ⊞ *(#401 — the virtualized-GPU stall; if it happens: does clicking/selecting text restore it? capture repro + whether hardware-accel is on)*
@@ -227,9 +155,6 @@ Then `Move-Item "$f.bak" $f -Force` to restore, or just re-enter the key.
 10. **Install/uninstall + process cleanup** — §1, §14.
 11. **SmartScreen / unsigned installer** friction — §1.
 12. **Multi-monitor / DPI changes** — §2, §13.
-13. **DPAPI key storage** (#579, #926) — §9a. The whole Windows credential path is developed on macOS and
-    covered by tests that **skip** there, so this seam reaches Windows less exercised than any other in this
-    list.
 
 ---
 
@@ -246,7 +171,6 @@ Then `Move-Item "$f.bak" $f -Force` to restore, or just re-enter the key.
 | 7 Dock float/split | | | |
 | 8 Menus & shortcuts | | | |
 | 9 Settings | | | |
-| 9a AI key storage (DPAPI) | | | |
 | 10 Rendering stability | | | |
 | 11 View Source PDF | | | |
 | 12 Updates | | | |

--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -342,6 +342,9 @@ public class AiConnectionServiceTests
         /// binary, or a DPAPI blob that will not decrypt. The store can see it and cannot read it. (#926)</summary>
         internal HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
 
+        /// <summary>Accounts a real Read has actually visited. (#925)</summary>
+        private readonly HashSet<string> _readOnce = new(StringComparer.Ordinal);
+
         public bool IsAvailable => true;
         public string? Unavailable => null;
         public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
@@ -351,8 +354,13 @@ public class AiConnectionServiceTests
 
         public CredentialState Probe(string connectionId, string name)
         {
+            // Unreadable ONLY once a real Read has established it — the real store's semantics. (#925, fable)
+            // A probe asks the item's metadata and cannot learn that its value is unreadable; it reports
+            // Found. Fakes that answered Unreadable straight away tested only the post-first-read steady
+            // state, and certified a state the app does not enter at launch.
             var account = Account(connectionId, name);
-            if (Unreadable.Contains(account)) return CredentialState.Unreadable;
+            if (Unreadable.Contains(account) && _readOnce.Contains(account))
+                return CredentialState.Unreadable;
             return _byAccount.ContainsKey(account) ? CredentialState.Found : CredentialState.NotStored;
         }
 
@@ -360,6 +368,7 @@ public class AiConnectionServiceTests
         {
             ValueReads++;
             var account = Account(connectionId, name);
+            _readOnce.Add(account);
             if (Unreadable.Contains(account)) return CredentialRead.Unreadable;
             return _byAccount.TryGetValue(account, out var k)
                 ? CredentialRead.Found(k)
@@ -489,6 +498,13 @@ public class AiConnectionServiceTests
 
         keys.Unreadable.Add("box:" + AiCredentialNames.Primary);
 
+        // Still Keychain: a probe asks the item's metadata and cannot learn its value is unreadable (#925).
+        // "A key is stored" is true, and #926's rule was never to claim one is ABSENT when it is not.
+        Assert.Equal(CredentialSource.Keychain, service.Connections.Single().KeySource);
+
+        // Something actually uses the key. That read fails, the store remembers, and the badge catches up.
+        keys.Get("box", AiCredentialNames.Primary);
+
         Assert.Equal(CredentialSource.Unreadable, service.Connections.Single().KeySource);
     }
 
@@ -507,6 +523,7 @@ public class AiConnectionServiceTests
         service.Add("box", Draft());
         keys.Set("box", AiCredentialNames.Primary, "k");
         keys.Unreadable.Add("box:" + AiCredentialNames.Primary);
+        keys.Get("box", AiCredentialNames.Primary);   // a real use establishes the locked state (#925)
 
         var record = settings.Ai.Chat.Connections.Single();
         record.UsesEnvironmentKey = true;

--- a/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiConnectionServiceTests.cs
@@ -346,8 +346,19 @@ public class AiConnectionServiceTests
         public string? Unavailable => null;
         public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
 
+        /// <summary>How many times a caller asked for a VALUE. A status query must never move this. (#925)</summary>
+        internal int ValueReads { get; private set; }
+
+        public CredentialState Probe(string connectionId, string name)
+        {
+            var account = Account(connectionId, name);
+            if (Unreadable.Contains(account)) return CredentialState.Unreadable;
+            return _byAccount.ContainsKey(account) ? CredentialState.Found : CredentialState.NotStored;
+        }
+
         public CredentialRead Read(string connectionId, string name)
         {
+            ValueReads++;
             var account = Account(connectionId, name);
             if (Unreadable.Contains(account)) return CredentialRead.Unreadable;
             return _byAccount.TryGetValue(account, out var k)
@@ -402,6 +413,52 @@ public class AiConnectionServiceTests
     /// an environment-sourced one — offer no remove action rather than a button that would lie.</summary>
     [Fact]
     public void A_connection_reports_whether_a_key_is_stored_for_it()
+    {
+        var (service, _, keys) = MakeWithKeys();
+        service.Add("box", Draft());
+
+        Assert.Equal(CredentialSource.None, service.Connections.Single().KeySource);
+
+        keys.Set("box", AiCredentialNames.Primary, "k");
+
+        Assert.Equal(CredentialSource.Keychain, service.Connections.Single().KeySource);
+    }
+
+    /// <summary>
+    /// Asking about connections never fetches a secret. (#925)
+    ///
+    /// <para><b>This is the whole issue in one assertion.</b> Every status question — the connection list,
+    /// the badges, the model picker — was answered by fetching the value, and on macOS fetching a value is
+    /// what raises the authorization dialog. Measured on the maintainer's machine: <b>114 reads</b> across
+    /// one launch and one Settings window, <b>76 of them for a single account</b>, each able to raise a
+    /// prompt because cancelling one records no decision. He pressed Escape "a good 15 or 20 times".</para>
+    ///
+    /// <para>Asserted as zero rather than as a smaller number: any value fetch on this path can prompt, so
+    /// "fewer" is not the property worth having. Reading the list repeatedly is deliberate — the defect was
+    /// that repetition cost anything at all.</para>
+    /// </summary>
+    [Fact]
+    public void Reading_the_connection_list_never_fetches_a_secret()
+    {
+        var (service, _, keys) = MakeWithKeys();
+        service.Add("box", Draft());
+        keys.Set("box", AiCredentialNames.Primary, "k");
+        var before = keys.ValueReads;
+
+        for (var i = 0; i < 20; i++)
+        {
+            var connections = service.Connections;
+            Assert.Equal(CredentialSource.Keychain, connections.Single().KeySource);
+        }
+
+        Assert.Equal(before, keys.ValueReads);
+    }
+
+    /// <summary>
+    /// And a probe still tells a stored key from an absent one, so the silence is not bought with ignorance.
+    /// </summary>
+    [Fact]
+    public void A_probe_still_distinguishes_a_stored_key_from_none()
     {
         var (service, _, keys) = MakeWithKeys();
         service.Add("box", Draft());

--- a/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiCredentialStoreTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using CST.Avalonia.Services.Ai;
 using CST.Avalonia.Services.Ai.Credentials;
@@ -387,6 +388,145 @@ public class AiCredentialStoreTests : IDisposable
         Assert.Contains(_log.Lines, l => l.Contains("found", StringComparison.Ordinal));
         Assert.All(_log.Lines, l => Assert.DoesNotContain(Secret, l, StringComparison.Ordinal));
         Assert.All(_log.Lines, l => Assert.DoesNotContain(Secret[..12], l, StringComparison.Ordinal));
+    }
+
+    // ---- the probe and what it remembers (#925) ---------------------------------------------------------
+
+    /// <summary>
+    /// A probe answers presence without fetching the value. (#925)
+    ///
+    /// <para>On macOS the ACL guards an item's data, not its metadata, which is the whole mechanism: this
+    /// runs against the real Keychain and must not prompt.</para>
+    /// </summary>
+    [Fact]
+    public void Probe_reports_presence_without_reading_the_value()
+    {
+        Assert.Equal(CredentialState.NotStored, _store.Probe("anthropic", AiCredentialNames.Primary));
+
+        _store.Set("anthropic", AiCredentialNames.Primary, Secret);
+
+        Assert.Equal(CredentialState.Found, _store.Probe("anthropic", AiCredentialNames.Primary));
+        Assert.All(_log.Lines, l => Assert.DoesNotContain(Secret, l, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The probe remembers what a real read learned, rather than re-reading. (#925)
+    ///
+    /// <para>Observed by deleting the item behind the store's back: a passthrough would report NotStored, a
+    /// cache reports what the last real read established. This is the only test that can tell them apart
+    /// without a second signed binary. (fable — the cache had no tests at all)</para>
+    /// </summary>
+    [Fact]
+    public void Probe_reports_what_the_last_real_read_established()
+    {
+        _store.Set("anthropic", AiCredentialNames.Primary, Secret);
+        Assert.Equal(Secret, _store.Read("anthropic", AiCredentialNames.Primary).Secret);
+
+        // Behind the store's back, so nothing invalidates its memory.
+        MacOsKeychain.Delete(_service, AiCredentialStore.AccountFor("anthropic", AiCredentialNames.Primary));
+
+        Assert.Equal(CredentialState.Found, _store.Probe("anthropic", AiCredentialNames.Primary));
+    }
+
+    /// <summary>
+    /// Stores an item the real store will find PRESENT and UNREADABLE, using each platform's own primitive.
+    ///
+    /// <para>macOS: an item whose value is empty — <c>Find</c> classifies a zero-length payload as unreadable,
+    /// and <c>AiCredentialStore.Set</c> refuses to create one, so it has to be written directly. Windows: junk
+    /// where a DPAPI blob should be, which is what an administrator-initiated password reset leaves behind.
+    /// Both give a genuine <see cref="CredentialState.Unreadable"/> through the real store, which is otherwise
+    /// only reachable with two differently-signed binaries.</para>
+    /// </summary>
+    private void StoreAnUnreadableItem(string connectionId, string name)
+    {
+        var account = AiCredentialStore.AccountFor(connectionId, name);
+        if (OperatingSystem.IsWindows())
+        {
+            _store.Set(connectionId, name, Secret);
+            var file = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
+            File.WriteAllBytes(file, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        }
+        else
+        {
+            Assert.True(MacOsKeychain.Save(_service, account, ""));
+        }
+    }
+
+    /// <summary>
+    /// A successful Set does not erase a remembered <see cref="CredentialState.Unreadable"/>. (#925, fable)
+    ///
+    /// <para><b>The trap this closes.</b> On macOS <c>SecItemUpdate</c> rewrites a value and leaves the ACL
+    /// alone, so pasting a replacement over a locked key succeeds and changes nothing — tested 2026-08-31.
+    /// Clearing the memory on save made every surface then report the connection healthy: #926's confusion
+    /// upgraded from silence to a false statement, on the exact path the sheet invites with "Paste a new one
+    /// to replace it".</para>
+    ///
+    /// <para>So the save under-claims, and only a real read may lift it — which is the last assertion here,
+    /// and what stops the rule being "remember Unreadable forever".</para>
+    /// </summary>
+    [Fact]
+    public void A_save_does_not_clear_a_remembered_unreadable_but_a_read_does()
+    {
+        StoreAnUnreadableItem("anthropic", AiCredentialNames.Primary);
+
+        Assert.Equal(CredentialState.Unreadable, _store.Read("anthropic", AiCredentialNames.Primary).State);
+        Assert.Equal(CredentialState.Unreadable, _store.Probe("anthropic", AiCredentialNames.Primary));
+
+        Assert.True(_store.Set("anthropic", AiCredentialNames.Primary, Secret));
+
+        // Still Unreadable: the save is exactly the operation that succeeds without helping.
+        Assert.Equal(CredentialState.Unreadable, _store.Probe("anthropic", AiCredentialNames.Primary));
+
+        // And a real read is what corrects it, so the under-claim cannot outlive the evidence for it.
+        Assert.Equal(Secret, _store.Read("anthropic", AiCredentialNames.Primary).Secret);
+        Assert.Equal(CredentialState.Found, _store.Probe("anthropic", AiCredentialNames.Primary));
+    }
+
+    /// <summary>
+    /// A FAILED delete leaves the remembered state alone. (#925, fable)
+    ///
+    /// <para>A failed delete changed nothing, so the evidence still holds. Discarding it made a declined
+    /// removal look like progress: the badge went from "Key locked" to "Keychain" because the reader's
+    /// attempt to revoke a key had failed.</para>
+    /// </summary>
+    [Fact]
+    public void A_delete_that_succeeds_clears_the_memory_and_reports_not_stored()
+    {
+        _store.Set("anthropic", AiCredentialNames.Primary, Secret);
+        _store.Read("anthropic", AiCredentialNames.Primary);
+        Assert.Equal(CredentialState.Found, _store.Probe("anthropic", AiCredentialNames.Primary));
+
+        Assert.True(_store.Delete("anthropic", AiCredentialNames.Primary));
+
+        // Not the remembered Found: a successful delete is exactly when the memory must go.
+        Assert.Equal(CredentialState.NotStored, _store.Probe("anthropic", AiCredentialNames.Primary));
+    }
+
+    /// <summary>
+    /// A delete the OS REFUSES leaves the remembered state alone. (#925, fable)
+    ///
+    /// <para><b>Windows-only because a failing delete cannot be produced on macOS</b> — there, refusal needs
+    /// an item whose ACL names another binary, which needs a second signed build. Holding the DPAPI file open
+    /// makes the same refusal reachable, so this is the one machine that can run it.</para>
+    ///
+    /// <para>The rule: a failed delete changed nothing, so the evidence still stands. Discarding it made a
+    /// <i>declined</i> removal look like progress — the badge went from "Key locked" to "Keychain" because
+    /// the reader's attempt to revoke a key had failed.</para>
+    /// </summary>
+    [WindowsFact]
+    public void A_delete_the_os_refuses_leaves_the_remembered_state_alone()
+    {
+        _store.Set("anthropic", AiCredentialNames.Primary, Secret);
+        Assert.Equal(Secret, _store.Read("anthropic", AiCredentialNames.Primary).Secret);
+
+        var file = Directory.EnumerateFiles(WindowsDpapiStore.DirectoryFor(_service)).Single();
+        using (var _ = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            Assert.False(_store.Delete("anthropic", AiCredentialNames.Primary));
+
+            // Not NotStored: nothing was deleted, so nothing about the previous evidence changed.
+            Assert.Equal(CredentialState.Found, _store.Probe("anthropic", AiCredentialNames.Primary));
+        }
     }
 
     [Fact]

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -357,12 +357,24 @@ public class AiModelCatalogTests
         public string? Unavailable => null;
         public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
 
+        /// <summary>How many times a caller asked for a VALUE. Every one can raise a macOS prompt. (#925)</summary>
+        internal int ValueReads { get; private set; }
+
         public CredentialState Probe(string connectionId, string name) =>
             _byAccount.ContainsKey(connectionId + ":" + name)
                 ? CredentialState.Found
                 : CredentialState.NotStored;
 
         public CredentialRead Read(string connectionId, string name) =>
+            Counted(connectionId, name);
+
+        private CredentialRead Counted(string connectionId, string name)
+        {
+            ValueReads++;
+            return ReadUncounted(connectionId, name);
+        }
+
+        private CredentialRead ReadUncounted(string connectionId, string name) =>
             _byAccount.TryGetValue(connectionId + ":" + name, out var k)
                 ? CredentialRead.Found(k)
                 : CredentialRead.NotStored;
@@ -570,6 +582,41 @@ public class AiModelCatalogTests
 
     private static AiModelCatalog CatalogOver(StubHttpMessageHandler handler) =>
         new(new HttpClient(handler), credentials: null, NullLogger<AiModelCatalog>.Instance);
+
+    /// <summary>
+    /// A paginated listing fetches its credentials once, not once per page. (#925)
+    ///
+    /// <para><b>Every credential fetch is a possible macOS authorization dialog</b> — the ACL guards the
+    /// value, and cancelling one prompt records no decision, so the next fetch asks again. Authenticate ran
+    /// per request, inside the page loop: Anthropic pages at twenty models by default, so a five-hundred
+    /// model catalogue was twenty-five prompts to load one list.</para>
+    ///
+    /// <para>Nothing is lost by hoisting it. The credentials cannot change part-way through a listing, so
+    /// re-reading them per page was never buying freshness — only prompts.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_paged_listing_reads_its_key_once_for_the_whole_listing()
+    {
+        var keys = new NamedKeys();
+        keys.Set("anthropic", AiCredentialNames.Primary, "sk-ant-test");
+
+        var handler = new StubHttpMessageHandler(request =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    request.RequestUri!.Query.Contains("after_id=", StringComparison.Ordinal)
+                        ? """{"data":[{"id":"claude-sonnet"}],"has_more":false}"""
+                        : """{"data":[{"id":"claude-opus"}],"has_more":true,"last_id":"claude-opus"}"""),
+            });
+
+        var before = keys.ValueReads;
+        var result = await new AiModelCatalog(
+            new HttpClient(handler), keys, NullLogger<AiModelCatalog>.Instance).FetchAsync(Paged());
+
+        Assert.True(result.Ok);
+        Assert.Equal(2, handler.RequestedUrls.Count);          // two pages were genuinely fetched
+        Assert.Equal(before + 1, keys.ValueReads);             // and the key was read once
+    }
 
     /// <summary>
     /// The listing is read to the end, not one page deep. Before #769 an Anthropic-protocol connection with

--- a/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiModelCatalogTests.cs
@@ -357,6 +357,11 @@ public class AiModelCatalogTests
         public string? Unavailable => null;
         public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
 
+        public CredentialState Probe(string connectionId, string name) =>
+            _byAccount.ContainsKey(connectionId + ":" + name)
+                ? CredentialState.Found
+                : CredentialState.NotStored;
+
         public CredentialRead Read(string connectionId, string name) =>
             _byAccount.TryGetValue(connectionId + ":" + name, out var k)
                 ? CredentialRead.Found(k)

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -47,6 +47,13 @@ public class ChatProviderResolverTests
         /// <summary>Names the OS holds and will not hand over. (#926)</summary>
         internal HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
 
+        public CredentialState Probe(string connectionId, string name)
+        {
+            if (!IsAvailable) return CredentialState.Unavailable;
+            if (Unreadable.Contains(name)) return CredentialState.Unreadable;
+            return Read(connectionId, name).State;
+        }
+
         public CredentialRead Read(string connectionId, string name)
         {
             if (!IsAvailable) return CredentialRead.Unavailable;

--- a/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ChatProviderResolverTests.cs
@@ -47,14 +47,23 @@ public class ChatProviderResolverTests
         /// <summary>Names the OS holds and will not hand over. (#926)</summary>
         internal HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
 
+        /// <summary>How many times a caller asked for a VALUE. Each is a possible macOS prompt. (#925)</summary>
+        internal int ValueReads { get; private set; }
+
         public CredentialState Probe(string connectionId, string name)
         {
             if (!IsAvailable) return CredentialState.Unavailable;
             if (Unreadable.Contains(name)) return CredentialState.Unreadable;
-            return Read(connectionId, name).State;
+            return ReadUncounted(connectionId, name).State;
         }
 
         public CredentialRead Read(string connectionId, string name)
+        {
+            ValueReads++;
+            return ReadUncounted(connectionId, name);
+        }
+
+        private CredentialRead ReadUncounted(string connectionId, string name)
         {
             if (!IsAvailable) return CredentialRead.Unavailable;
             if (Unreadable.Contains(name)) return CredentialRead.Unreadable;
@@ -178,6 +187,36 @@ public class ChatProviderResolverTests
         Assert.Contains("stored", problem, StringComparison.OrdinalIgnoreCase);
         if (!OperatingSystem.IsWindows())
             Assert.Contains("Allow", problem, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A send reads each secret header once, not twice. (#925, fable)
+    ///
+    /// <para>The locked-header guard used to <c>Read</c> a header that <c>ExpandHeaders</c> had already read
+    /// microseconds earlier — which is <i>why</i> its value was empty. On macOS that is a second
+    /// authorization dialog for one send. The guard now asks <c>Probe</c>, which returns exactly what that
+    /// read recorded.</para>
+    ///
+    /// <para>Counted rather than asserted as a message, because the count is the thing that reaches the
+    /// reader: by this codebase's own metric, calls are prompts.</para>
+    /// </summary>
+    [Fact]
+    public void A_send_reads_a_secret_header_once()
+    {
+        var store = new FixedKey("sk-ant-stored");
+        store.Unreadable.Add(AiCredentialNames.Header("x-gateway-token"));
+
+        var resolver = Resolver(chat =>
+        {
+            var c = Conn(chat);
+            c.Kind = "anthropic";
+            c.Headers = new List<AiHeaderRecord> { new() { Name = "x-gateway-token", Secret = true } };
+            chat.ActiveModelId = "claude-opus-5";
+        }, store: store);
+
+        Assert.Null(resolver.Resolve(out var problem));
+        Assert.NotNull(problem);
+        Assert.Equal(1, store.ValueReads);
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -84,22 +84,37 @@ public class AiConnectionEditorViewModelTests
         public HashSet<string> Undeletable { get; } = new(StringComparer.Ordinal);
 
         /// <summary>How many times a caller asked for a VALUE. (#925)</summary>
+        /// <summary>How many times a caller asked for a VALUE. Every one can raise a macOS prompt. (#925)</summary>
         public int ValueReads { get; private set; }
+
+        /// <summary>Accounts a real Read has actually visited. (#925)</summary>
+        private readonly HashSet<string> _readOnce = new(StringComparer.Ordinal);
 
         public CredentialState Probe(string connectionId, string name)
         {
             if (!Available) return CredentialState.Unavailable;
             var account = Account(connectionId, name);
-            if (Unreadable.Contains(account)) return CredentialState.Unreadable;
+            // Unreadable only once a real Read has established it — a probe reads metadata and cannot learn
+            // that a value is unreadable. Matching the real store here is what makes the pre-first-read
+            // window testable at all. (fable)
+            if (Unreadable.Contains(account) && _readOnce.Contains(account))
+                return CredentialState.Unreadable;
             return Stored.ContainsKey(account) ? CredentialState.Found : CredentialState.NotStored;
         }
 
-        public CredentialRead Read(string connectionId, string name) =>
-            !Available ? CredentialRead.Unavailable
-            : Unreadable.Contains(Account(connectionId, name)) ? CredentialRead.Unreadable
-            : Stored.TryGetValue(Account(connectionId, name), out var k)
+        public CredentialRead Read(string connectionId, string name)
+        {
+            if (!Available) return CredentialRead.Unavailable;
+
+            var account = Account(connectionId, name);
+            ValueReads++;
+            _readOnce.Add(account);
+
+            if (Unreadable.Contains(account)) return CredentialRead.Unreadable;
+            return Stored.TryGetValue(account, out var k)
                 ? CredentialRead.Found(k)
                 : CredentialRead.NotStored;
+        }
         public bool Set(string connectionId, string name, string secret)
         { Stored[Account(connectionId, name)] = secret; return true; }
         /// <summary>
@@ -1163,6 +1178,35 @@ public class AiConnectionEditorViewModelTests
     }
 
     /// <summary>
+    /// Opening the edit sheet fetches no secret. (#925, fable)
+    ///
+    /// <para>The sheet asks about keys to decide what to SAY, never to send anything — so on macOS it has no
+    /// business raising an authorization dialog, and it was "one of the worst offenders". Nothing pinned that
+    /// after the fix: the counter existed on the fake and no test read it, so reverting either call site to
+    /// <c>Read</c> passed the whole suite.</para>
+    ///
+    /// <para>Zero, not fewer: any fetch on this path can prompt.</para>
+    /// </summary>
+    [Fact]
+    public void Opening_the_edit_sheet_reads_no_secret()
+    {
+        var h = new Harness();
+        h.Service.Add("gw", Draft());
+        h.Keys.Set("gw", AiCredentialNames.Primary, "sk-stored");
+        h.Keys.Set("gw", AiCredentialNames.Header("cf-aig-authorization"), "cf-token");
+
+        var before = h.Keys.ValueReads;
+        var vm = h.Existing("gw");
+
+        // Touch everything the sheet renders about stored secrets.
+        Assert.True(vm.HasStoredKey);
+        _ = vm.KeyStatus;
+        _ = vm.Headers.Count;
+
+        Assert.Equal(before, h.Keys.ValueReads);
+    }
+
+    /// <summary>
     /// The sheet says a locked key IS stored, and gives the remedy that works. (#926)
     ///
     /// <para><b>This sheet is where the reader acts on being told wrong.</b> The row badged "Key locked" and
@@ -1180,6 +1224,7 @@ public class AiConnectionEditorViewModelTests
         Assert.True(h.Existing("mine").HasStoredKey);
 
         h.Keys.Unreadable.Add("mine:" + AiCredentialNames.Primary);
+        h.Keys.Get("mine", AiCredentialNames.Primary);   // a real use establishes the locked state (#925)
         var locked = h.Existing("mine");
 
         Assert.True(locked.HasStoredKey);

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionEditorViewModelTests.cs
@@ -83,6 +83,17 @@ public class AiConnectionEditorViewModelTests
         /// <summary>Accounts the OS will not delete. (#926)</summary>
         public HashSet<string> Undeletable { get; } = new(StringComparer.Ordinal);
 
+        /// <summary>How many times a caller asked for a VALUE. (#925)</summary>
+        public int ValueReads { get; private set; }
+
+        public CredentialState Probe(string connectionId, string name)
+        {
+            if (!Available) return CredentialState.Unavailable;
+            var account = Account(connectionId, name);
+            if (Unreadable.Contains(account)) return CredentialState.Unreadable;
+            return Stored.ContainsKey(account) ? CredentialState.Found : CredentialState.NotStored;
+        }
+
         public CredentialRead Read(string connectionId, string name) =>
             !Available ? CredentialRead.Unavailable
             : Unreadable.Contains(Account(connectionId, name)) ? CredentialRead.Unreadable

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -91,8 +91,19 @@ public class AiConnectionsViewModelTests
         public string? Unavailable => null;
         public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
 
+        /// <summary>How many times a caller asked for a VALUE. (#925)</summary>
+        public int ValueReads { get; private set; }
+
+        public CredentialState Probe(string connectionId, string name)
+        {
+            var account = Account(connectionId, name);
+            if (Unreadable.Contains(account)) return CredentialState.Unreadable;
+            return Keys.ContainsKey(account) ? CredentialState.Found : CredentialState.NotStored;
+        }
+
         public CredentialRead Read(string connectionId, string name)
         {
+            ValueReads++;
             var account = Account(connectionId, name);
             if (Unreadable.Contains(account)) return CredentialRead.Unreadable;
             return Keys.TryGetValue(account, out var k)

--- a/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiConnectionsViewModelTests.cs
@@ -87,6 +87,9 @@ public class AiConnectionsViewModelTests
         /// <summary>Accounts the OS holds but will not hand over. (#926)</summary>
         public HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
 
+        /// <summary>Accounts a real Read has actually visited. (#925)</summary>
+        private readonly HashSet<string> _readOnce = new(StringComparer.Ordinal);
+
         public bool IsAvailable => true;
         public string? Unavailable => null;
         public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
@@ -96,8 +99,13 @@ public class AiConnectionsViewModelTests
 
         public CredentialState Probe(string connectionId, string name)
         {
+            // Unreadable ONLY once a real Read has established it — the real store's semantics. (#925, fable)
+            // A probe asks the item's metadata and cannot learn that its value is unreadable; it reports
+            // Found. Fakes that answered Unreadable straight away tested only the post-first-read steady
+            // state, and certified a state the app does not enter at launch.
             var account = Account(connectionId, name);
-            if (Unreadable.Contains(account)) return CredentialState.Unreadable;
+            if (Unreadable.Contains(account) && _readOnce.Contains(account))
+                return CredentialState.Unreadable;
             return Keys.ContainsKey(account) ? CredentialState.Found : CredentialState.NotStored;
         }
 
@@ -105,6 +113,7 @@ public class AiConnectionsViewModelTests
         {
             ValueReads++;
             var account = Account(connectionId, name);
+            _readOnce.Add(account);
             if (Unreadable.Contains(account)) return CredentialRead.Unreadable;
             return Keys.TryGetValue(account, out var k)
                 ? CredentialRead.Found(k)

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -29,6 +29,9 @@ public class AiModelPickerViewModelTests
         /// <summary>Accounts the OS holds but will not hand over. (#926)</summary>
         public HashSet<string> Unreadable { get; } = new(StringComparer.Ordinal);
 
+        /// <summary>Accounts a real Read has actually visited. (#925)</summary>
+        private readonly HashSet<string> _readOnce = new(StringComparer.Ordinal);
+
         public bool IsAvailable => true;
         public string? Unavailable => null;
         public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
@@ -37,8 +40,13 @@ public class AiModelPickerViewModelTests
 
         public CredentialState Probe(string connectionId, string name)
         {
+            // Unreadable ONLY once a real Read has established it — the real store's semantics. (#925, fable)
+            // A probe asks the item's metadata and cannot learn that its value is unreadable; it reports
+            // Found. Fakes that answered Unreadable straight away tested only the post-first-read steady
+            // state, and certified a state the app does not enter at launch.
             var account = Account(connectionId, name);
-            if (Unreadable.Contains(account)) return CredentialState.Unreadable;
+            if (Unreadable.Contains(account) && _readOnce.Contains(account))
+                return CredentialState.Unreadable;
             return Keys.ContainsKey(account) ? CredentialState.Found : CredentialState.NotStored;
         }
 
@@ -46,6 +54,7 @@ public class AiModelPickerViewModelTests
         {
             ValueReads++;
             var account = Account(connectionId, name);
+            _readOnce.Add(account);
             if (Unreadable.Contains(account)) return CredentialRead.Unreadable;
             return Keys.TryGetValue(account, out var k)
                 ? CredentialRead.Found(k)
@@ -480,6 +489,7 @@ public class AiModelPickerViewModelTests
         Assert.True(AllModels(picker).Single().IsUsable);
 
         keys.Unreadable.Add("openrouter:" + AiCredentialNames.Primary);
+        keys.Get("openrouter", AiCredentialNames.Primary);   // a real use establishes it (#925)
         picker.Refresh();
 
         var model = AllModels(picker).Single();

--- a/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiModelPickerViewModelTests.cs
@@ -33,8 +33,18 @@ public class AiModelPickerViewModelTests
         public string? Unavailable => null;
         public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
 
+        public int ValueReads { get; private set; }
+
+        public CredentialState Probe(string connectionId, string name)
+        {
+            var account = Account(connectionId, name);
+            if (Unreadable.Contains(account)) return CredentialState.Unreadable;
+            return Keys.ContainsKey(account) ? CredentialState.Found : CredentialState.NotStored;
+        }
+
         public CredentialRead Read(string connectionId, string name)
         {
+            ValueReads++;
             var account = Account(connectionId, name);
             if (Unreadable.Contains(account)) return CredentialRead.Unreadable;
             return Keys.TryGetValue(account, out var k)

--- a/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiSettingsViewModelTests.cs
@@ -51,6 +51,13 @@ namespace CST.Avalonia.Tests.ViewModels
 
             private static string Account(string connectionId, string name) => connectionId + ":" + name;
 
+            public CST.Avalonia.Services.Ai.Credentials.CredentialState Probe(
+                string connectionId, string name) =>
+                !Available ? CST.Avalonia.Services.Ai.Credentials.CredentialState.Unavailable
+                : _keys.ContainsKey(Account(connectionId, name))
+                    ? CST.Avalonia.Services.Ai.Credentials.CredentialState.Found
+                    : CST.Avalonia.Services.Ai.Credentials.CredentialState.NotStored;
+
             public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
 
             public CST.Avalonia.Services.Ai.Credentials.CredentialRead Read(string connectionId, string name) =>

--- a/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
+++ b/src/CST.Avalonia/Services/Ai/AiConnectionService.cs
@@ -255,11 +255,19 @@ namespace CST.Avalonia.Services.Ai
         /// </summary>
         private (CredentialSource Source, bool StoredKeyUnreadable) CredentialFor(string connectionId)
         {
-            // Read, not Get (#926). A stored key this build cannot read is a different state from no key.
-            var read = _credentials?.Read(connectionId, AiCredentialNames.Primary);
-            if (read?.State == CredentialState.Found) return (CredentialSource.Keychain, false);
+            // Probe, not Read (#925). This runs for every connection on every refresh - it is where 114
+            // credential reads in one session came from - and it only ever needed to know whether a key is
+            // configured. Read fetches the value, and fetching the value is what raises the macOS
+            // authorization dialog; Probe asks the item's metadata, which the ACL does not guard.
+            //
+            // Found here means PRESENT, not readable. A locked key therefore reports Keychain until
+            // something actually tries to use it, at which point the store remembers the failure and this
+            // reports Unreadable on the next refresh. That is the honest ordering: "a key is stored" is true
+            // throughout, and #926's rule was never to claim a key is ABSENT when it is not.
+            var state = _credentials?.Probe(connectionId, AiCredentialNames.Primary);
+            if (state == CredentialState.Found) return (CredentialSource.Keychain, false);
 
-            var locked = read?.State == CredentialState.Unreadable;
+            var locked = state == CredentialState.Unreadable;
 
             // Adopted from the environment, and the variable still holds something. When it does not — unset
             // between sessions, or renamed — this falls through to None, which reads as "no key" rather than

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -419,17 +419,6 @@ namespace CST.Avalonia.Services.Ai
             return AiCatalogResult.Success(models, complete, skipped);
         }
 
-        /// <summary>
-        /// Authenticates exactly as a chat request to the same endpoint would.
-        ///
-        /// <para>Routed through <see cref="AiHttp.ApplyAuth"/> rather than reimplemented: a listing and a
-        /// question go to the same host with the same credential, and two implementations would eventually
-        /// disagree. The visible symptom would be a provider whose model list loads while its answers 401 —
-        /// two surfaces contradicting each other, which is the failure #673 exists to prevent.</para>
-        ///
-        /// <para>Header values are templates like the base URL is: Azure and Cloudflare put reader-supplied
-        /// inputs in them.</para>
-        /// </summary>
         /// <summary>Everything a request to this connection has to carry, fetched once per listing. (#925)</summary>
         private sealed record ListingCredentials(string? Key, Dictionary<string, string> Headers);
 
@@ -461,6 +450,18 @@ namespace CST.Avalonia.Services.Ai
             return new ListingCredentials(key, headers);
         }
 
+        /// <summary>
+        /// Authenticates exactly as a chat request to the same endpoint would.
+        ///
+        /// <para>Routed through <see cref="AiHttp.ApplyAuth"/> rather than reimplemented: a listing and a
+        /// question go to the same host with the same credential, and two implementations would eventually
+        /// disagree. The visible symptom would be a provider whose model list loads while its answers 401 —
+        /// two surfaces contradicting each other, which is the failure #673 exists to prevent.</para>
+        ///
+        /// <para>Header values are templates like the base URL is: Azure and Cloudflare put reader-supplied
+        /// inputs in them — expanded in <see cref="ResolveCredentials"/>, which runs once per listing while
+        /// this runs once per page.</para>
+        /// </summary>
         private void Authenticate(
             HttpRequestMessage request, AiConnection connection, ListingCredentials credentials)
         {

--- a/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/AiModelCatalog.cs
@@ -257,6 +257,13 @@ namespace CST.Avalonia.Services.Ai
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
             timeout.CancelAfter(Timeout);
 
+            // Resolved ONCE, outside the page loop (#925). Authenticate used to run per request, so a
+            // paginated listing fetched the same secrets again for every page - and on macOS each fetch of a
+            // locked key is its own authorization dialog. Anthropic pages at twenty models, so a five-hundred
+            // model catalogue was twenty-five prompts for one listing. The credentials cannot change
+            // mid-listing anyway; re-reading them per page was never buying freshness.
+            var credentials = ResolveCredentials(connection);
+
             var models = new List<AiCatalogModel>();
             var seen = new HashSet<string>(StringComparer.Ordinal);
             var skipped = 0;
@@ -269,7 +276,7 @@ namespace CST.Avalonia.Services.Ai
                 {
                     var pageUrl = cursor is null ? url : After(url, cursor);
                     using var request = new HttpRequestMessage(HttpMethod.Get, pageUrl);
-                    Authenticate(request, connection);
+                    Authenticate(request, connection, credentials);
 
                     using var response = await _http.SendAsync(request, timeout.Token).ConfigureAwait(false);
 
@@ -423,7 +430,17 @@ namespace CST.Avalonia.Services.Ai
         /// <para>Header values are templates like the base URL is: Azure and Cloudflare put reader-supplied
         /// inputs in them.</para>
         /// </summary>
-        private void Authenticate(HttpRequestMessage request, AiConnection connection)
+        /// <summary>Everything a request to this connection has to carry, fetched once per listing. (#925)</summary>
+        private sealed record ListingCredentials(string? Key, Dictionary<string, string> Headers);
+
+        /// <summary>
+        /// Reads this connection's secrets, once. (#925)
+        ///
+        /// <para>Separate from <see cref="Authenticate"/> so that applying them to a request - which happens
+        /// per page - cannot fetch them again. Every call here can raise a macOS authorization dialog, so the
+        /// count of calls is a count of possible prompts.</para>
+        /// </summary>
+        private ListingCredentials ResolveCredentials(AiConnection connection)
         {
             // Stored, then the environment — the SAME rule the chat path applies, through the same helper.
             // Reading only the store here is the contradiction the summary above forbids: an adopted
@@ -440,6 +457,15 @@ namespace CST.Avalonia.Services.Ai
                 headers[header.Name] = header.Secret
                     ? _credentials?.Get(connection.Id, AiCredentialNames.Header(header.Name)) ?? string.Empty
                     : AiTemplate.Expand(header.Value ?? string.Empty, connection.Inputs);
+
+            return new ListingCredentials(key, headers);
+        }
+
+        private void Authenticate(
+            HttpRequestMessage request, AiConnection connection, ListingCredentials credentials)
+        {
+            var key = credentials.Key;
+            var headers = credentials.Headers;
 
             if (connection.Kind == ChatProviderKind.Anthropic)
             {

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -58,6 +58,20 @@ public interface IAiCredentialStore
     /// </summary>
     CredentialRead Read(string connectionId, string name);
 
+    /// <summary>
+    /// What is known about a secret without asking the OS to hand it over. (#925)
+    ///
+    /// <para><b>Use this for every question that is only "is a key configured?"</b> — badges, status, the
+    /// editor's stored-key note. <see cref="Read"/> fetches the value, and on macOS fetching a value is what
+    /// raises the authorization dialog; answering a yes/no question that way is what produced 114 prompts'
+    /// worth of reads across one launch and one Settings window.</para>
+    ///
+    /// <para><see cref="CredentialState.Found"/> means an item is PRESENT. It does not promise the value can
+    /// be read — that is knowable only by reading, which prompts — unless a previous real read established
+    /// otherwise, which this reports.</para>
+    /// </summary>
+    CredentialState Probe(string connectionId, string name);
+
     /// <summary>Store or replace one named secret. False when the platform cannot.</summary>
     bool Set(string connectionId, string name, string secret);
 

--- a/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
+++ b/src/CST.Avalonia/Services/Ai/ChatProviderResolver.cs
@@ -322,7 +322,11 @@ public sealed class ChatProviderResolver : IChatProviderResolver
         var lockedSecrets = connection.Headers
             .Where(h => h.Secret
                         && string.IsNullOrEmpty(headers.GetValueOrDefault(h.Name))
-                        && _credentials?.Read(connection.Id, AiCredentialNames.Header(h.Name)).State
+                        // Probe, not Read (#925, fable). ExpandHeaders has already Read this exact header a
+                        // few lines up - which is why its value is empty - so a second Read would raise a
+                        // SECOND authorization dialog for one send. Probe returns what that read recorded:
+                        // exact, free, and one prompt instead of two.
+                        && _credentials?.Probe(connection.Id, AiCredentialNames.Header(h.Name))
                            == CredentialState.Unreadable)
             .Select(h => h.Name)
             .ToList();

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using CST.Avalonia.Services.Ai;
 using Microsoft.Extensions.Logging;
 
@@ -11,13 +12,17 @@ namespace CST.Avalonia.Services.Ai.Credentials;
 /// synced between machines. A key in it is a key in every one of those places, and unlike a wrong port number
 /// there is no way to notice after the fact.</para>
 ///
-/// <para><b>Reads should be lazy, on the request that needs it, and today they are not</b> — tracked as #925.
-/// The intent was that nothing here runs at startup, so a user who never turns surface B on never triggers a
-/// Keychain access (or, on Windows, a decrypt): a permission dialog on launch, for a feature the user has not
-/// asked for, teaches them to click through prompts. That is exactly what went on to happen — the maintainer
-/// met eight authorization prompts before a beta candidate was usable. Status queries reach
-/// <see cref="Read"/> at startup and on every refresh, and nothing caches, so one connection was read 153
-/// times in a single session. Do not read this paragraph as a description of current behaviour.</para>
+/// <para><b>Fetching a secret is lazy; asking whether one exists is not, and does not need to be.</b> (#925)
+/// The rule that matters is the original one: no permission dialog on launch for a feature the user has not
+/// asked for, because that teaches them to click through prompts. It stopped holding once every status
+/// question — the connection list, the badges, the editor's stored-key note — answered itself by fetching the
+/// value, which on macOS is the thing the ACL guards. Measured before the fix: 114 reads across one launch
+/// and one Settings window, 76 of them for a single account, and the maintainer pressing Escape fifteen to
+/// twenty times.</para>
+///
+/// <para>So the seam has two verbs. <see cref="Probe"/> answers "is a key configured?" from the item's
+/// metadata and never prompts; <see cref="Read"/> fetches the value and is reserved for the request that
+/// actually sends it. Everything that only renders a state uses the first.</para>
 ///
 /// <para><b>Nothing is ever logged.</b> Not the value, not a prefix, not its length. Outcomes only —
 /// <see cref="CredentialRead.Describe"/> is the whole vocabulary, and it says nothing about the value.</para>
@@ -35,6 +40,21 @@ public sealed class AiCredentialStore : IAiCredentialStore
 
     private readonly ILogger<AiCredentialStore> _logger;
     private readonly string _service;
+
+    /// <summary>
+    /// What a real read last learned about an account, by account name. (#925)
+    ///
+    /// <para><b>States, never secrets.</b> Holding the value would keep a credential in memory for the life
+    /// of the process to save a lookup nobody is waiting on, and this file's standing rule is that a secret
+    /// lives in the OS store and travels no further than the request that needs it.</para>
+    ///
+    /// <para><b>Written only by <see cref="Read"/>, cleared by <see cref="Set"/> and <see cref="Delete"/>.</b>
+    /// Those are the only two ways the app changes a stored secret, which is what makes this safe: the
+    /// original objection to caching here was that it "would go stale the moment the user changes the key in
+    /// Settings", and a cache both mutators clear cannot.</para>
+    /// </summary>
+    private readonly Dictionary<string, CredentialState> _known = new(StringComparer.Ordinal);
+    private readonly object _knownGate = new();
 
     public AiCredentialStore(ILogger<AiCredentialStore> logger) : this(logger, ServiceName) { }
 
@@ -79,6 +99,39 @@ public sealed class AiCredentialStore : IAiCredentialStore
         : "Secure key storage is not available on this platform. "
           + "An endpoint that needs no API key still works.";
 
+    /// <summary>
+    /// What is known about a secret <b>without asking the OS to hand it over</b>. (#925)
+    ///
+    /// <para><b>Never prompts, so status queries are free.</b> Presence comes from the item's metadata,
+    /// which the macOS ACL does not guard — see <see cref="MacOsKeychain.Exists"/>. Everything that only
+    /// wants to know whether a key is configured should call this: the connection list, the badges, the
+    /// editor's "a key is stored" note. They were fetching the secret to answer a yes/no question, and each
+    /// fetch could raise a modal password dialog.</para>
+    ///
+    /// <para><b><see cref="CredentialState.Found"/> here means PRESENT, not readable.</b> Readability is
+    /// knowable only by attempting the read, which is the thing that prompts. So a probe that has never seen
+    /// a real read reports a locked key as present — which is true, and is the honest half of what #926
+    /// established: the failure to avoid is claiming a key is ABSENT when it is not.</para>
+    ///
+    /// <para><b>A remembered failure wins.</b> Once a real <see cref="Read"/> has found an item unreadable,
+    /// that is recorded and reported here, so the badge catches up the moment anything actually tries to use
+    /// the key rather than waiting for the reader to try again.</para>
+    /// </summary>
+    public CredentialState Probe(string connectionId, string name)
+    {
+        if (!IsAvailable) return CredentialState.Unavailable;
+
+        var account = AccountFor(connectionId, name);
+        lock (_knownGate)
+            if (_known.TryGetValue(account, out var remembered)) return remembered;
+
+        var exists = OperatingSystem.IsWindows()
+            ? WindowsDpapiStore.Exists(_service, account)
+            : MacOsKeychain.Exists(_service, account);
+
+        return exists ? CredentialState.Found : CredentialState.NotStored;
+    }
+
     public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
 
     public CredentialRead Read(string connectionId, string name)
@@ -89,6 +142,11 @@ public sealed class AiCredentialStore : IAiCredentialStore
         var read = OperatingSystem.IsWindows()
             ? WindowsDpapiStore.Find(_service, account)
             : MacOsKeychain.Find(_service, account);
+
+        // What a REAL read learned, for Probe to report without repeating the read. Only the state is kept -
+        // never the secret, which would put a credential in memory for the life of the process to save a
+        // lookup nobody was waiting on.
+        lock (_knownGate) _known[account] = read.State;
 
         // The OUTCOME, never the value — and not its length either, which narrows a guess.
         //
@@ -111,9 +169,16 @@ public sealed class AiCredentialStore : IAiCredentialStore
     {
         if (!IsAvailable || string.IsNullOrWhiteSpace(secret)) return false;
 
+        var account = AccountFor(connectionId, name);
         var saved = OperatingSystem.IsWindows()
-            ? WindowsDpapiStore.Save(_service, AccountFor(connectionId, name), secret.Trim())
-            : MacOsKeychain.Save(_service, AccountFor(connectionId, name), secret.Trim());
+            ? WindowsDpapiStore.Save(_service, account, secret.Trim())
+            : MacOsKeychain.Save(_service, account, secret.Trim());
+
+        // Forgotten rather than assumed. A successful Save does not make the item readable BY US - on macOS
+        // SecItemUpdate rewrites the value and leaves the ACL alone, which is why replacing a locked key
+        // succeeds and changes nothing the reader can see (#926). Recording Found here would have the badge
+        // announce a key we still cannot read.
+        lock (_knownGate) _known.Remove(account);
         _logger.LogInformation("Stored a secret for {Connection}/{Name}: {Result}",
             connectionId, name, saved ? "ok" : "failed");
         return saved;
@@ -124,9 +189,14 @@ public sealed class AiCredentialStore : IAiCredentialStore
     {
         if (!IsAvailable) return false;
 
+        var account = AccountFor(connectionId, name);
         var deleted = OperatingSystem.IsWindows()
-            ? WindowsDpapiStore.Delete(_service, AccountFor(connectionId, name))
-            : MacOsKeychain.Delete(_service, AccountFor(connectionId, name));
+            ? WindowsDpapiStore.Delete(_service, account)
+            : MacOsKeychain.Delete(_service, account);
+
+        // Forgotten either way. On success there is nothing to remember; on failure the item is still there
+        // and in a state we no longer have evidence about.
+        lock (_knownGate) _known.Remove(account);
         _logger.LogInformation("Removed a secret for {Connection}/{Name}: {Result}",
             connectionId, name, deleted ? "ok" : "failed");
         return deleted;

--- a/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/AiCredentialStore.cs
@@ -125,11 +125,12 @@ public sealed class AiCredentialStore : IAiCredentialStore
         lock (_knownGate)
             if (_known.TryGetValue(account, out var remembered)) return remembered;
 
-        var exists = OperatingSystem.IsWindows()
+        // Each platform classifies its own probe. macOS reuses MacOsKeychain.Classify, so an unanticipated
+        // Security.framework failure reports Unreadable rather than absent - the same rule a real read
+        // follows, and the one that keeps a locked keychain from reading as "you have no keys". (fable)
+        return OperatingSystem.IsWindows()
             ? WindowsDpapiStore.Exists(_service, account)
             : MacOsKeychain.Exists(_service, account);
-
-        return exists ? CredentialState.Found : CredentialState.NotStored;
     }
 
     public string? Get(string connectionId, string name) => Read(connectionId, name).Secret;
@@ -174,11 +175,22 @@ public sealed class AiCredentialStore : IAiCredentialStore
             ? WindowsDpapiStore.Save(_service, account, secret.Trim())
             : MacOsKeychain.Save(_service, account, secret.Trim());
 
-        // Forgotten rather than assumed. A successful Save does not make the item readable BY US - on macOS
-        // SecItemUpdate rewrites the value and leaves the ACL alone, which is why replacing a locked key
-        // succeeds and changes nothing the reader can see (#926). Recording Found here would have the badge
-        // announce a key we still cannot read.
-        lock (_knownGate) _known.Remove(account);
+        // A remembered Unreadable SURVIVES a successful save; anything else is forgotten. (fable)
+        //
+        // Recording Found here would have the badge announce a key we still cannot read - and so, one hop
+        // later, does forgetting: the next Probe misses the cache, asks the OS whether an item exists, and
+        // gets Found. On macOS SecItemUpdate rewrites the value and leaves the ACL alone, so pasting a
+        // replacement over a locked key succeeds and changes nothing (tested 2026-08-31). Clearing here made
+        // every surface then report it healthy - the #926 confusion upgraded from silence to a false
+        // statement, on the exact path the sheet invites with "Paste a new one to replace it".
+        //
+        // Keeping it under-claims if the item really was recreated readable, and the next real read corrects
+        // that. Under-claiming is the direction this whole seam has chosen.
+        lock (_knownGate)
+        {
+            if (!_known.TryGetValue(account, out var before) || before != CredentialState.Unreadable)
+                _known.Remove(account);
+        }
         _logger.LogInformation("Stored a secret for {Connection}/{Name}: {Result}",
             connectionId, name, saved ? "ok" : "failed");
         return saved;
@@ -194,9 +206,13 @@ public sealed class AiCredentialStore : IAiCredentialStore
             ? WindowsDpapiStore.Delete(_service, account)
             : MacOsKeychain.Delete(_service, account);
 
-        // Forgotten either way. On success there is nothing to remember; on failure the item is still there
-        // and in a state we no longer have evidence about.
-        lock (_knownGate) _known.Remove(account);
+        // Forgotten only on SUCCESS. (fable)
+        //
+        // A failed delete changed nothing, so the evidence we had still holds - and discarding it made a
+        // DECLINED removal look like progress: badge "Key locked" -> Remove -> dismiss the prompt -> delete
+        // fails -> cache cleared -> next Probe finds the item present -> badge "Keychain", problem gone. The
+        // reader's failed attempt to revoke a key made the row report it healthier.
+        if (deleted) lock (_knownGate) _known.Remove(account);
         _logger.LogInformation("Removed a secret for {Connection}/{Name}: {Result}",
             connectionId, name, deleted ? "ok" : "failed");
         return deleted;

--- a/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
@@ -214,9 +214,9 @@ internal static class MacOsKeychain
     /// prompts — so a probe reports presence and the locked state is discovered at first real use. See
     /// <see cref="AiCredentialStore.Probe"/>, which is where the two are reconciled.</para>
     /// </summary>
-    internal static bool Exists(string service, string account)
+    internal static CredentialState Exists(string service, string account)
     {
-        if (Symbols.Value is not { } k) return false;
+        if (Symbols.Value is not { } k) return CredentialState.Unavailable;
 
         var query = IntPtr.Zero;
         var result = IntPtr.Zero;
@@ -233,12 +233,17 @@ internal static class MacOsKeychain
                     k.True,
                     k.MatchLimitOne,
                 });
-            if (query == IntPtr.Zero) return false;
+            if (query == IntPtr.Zero) return CredentialState.Unavailable;
 
-            // Success means an item matched. Every failure - not found, and anything unanticipated - is
-            // reported as "no", because this answer is used to say a key IS present and over-claiming that
-            // would put the app back to describing keys the reader does not have.
-            return SecItemCopyMatching(query, out result) == ErrSecSuccess;
+            // Classified by the SAME rule as a real read, deliberately. (fable)
+            //
+            // This returned a bool and mapped every failure to "absent", which contradicted Classify twelve
+            // lines up - "an unanticipated failure is not evidence that an item is absent, and claiming
+            // absence we cannot see is precisely the harm here". The concrete risk is errSecInteractionNotAllowed
+            // on a locked login keychain: if an attributes query can fail that way, EVERY stored key would
+            // report NotStored and #926's defect returns wholesale. Whether it can was not established, so
+            // the cheap and consistent thing is not to have the question matter.
+            return Classify(SecItemCopyMatching(query, out result));
         }
         finally
         {

--- a/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/MacOsKeychain.cs
@@ -123,7 +123,7 @@ internal static class MacOsKeychain
 
     private sealed record Constants(
         IntPtr Class, IntPtr GenericPassword, IntPtr Service, IntPtr Account,
-        IntPtr ValueData, IntPtr ReturnData, IntPtr MatchLimit, IntPtr MatchLimitOne,
+        IntPtr ValueData, IntPtr ReturnData, IntPtr ReturnAttributes, IntPtr MatchLimit, IntPtr MatchLimitOne,
         IntPtr True);
 
     private static Constants? LoadConstants()
@@ -149,6 +149,7 @@ internal static class MacOsKeychain
             Deref(security, "kSecAttrAccount"),
             Deref(security, "kSecValueData"),
             Deref(security, "kSecReturnData"),
+            Deref(security, "kSecReturnAttributes"),
             Deref(security, "kSecMatchLimit"),
             Deref(security, "kSecMatchLimitOne"),
             Deref(cf, "kCFBooleanTrue"));
@@ -158,7 +159,8 @@ internal static class MacOsKeychain
         foreach (var value in new[]
                  {
                      constants.Class, constants.GenericPassword, constants.Service, constants.Account,
-                     constants.ValueData, constants.ReturnData, constants.MatchLimit, constants.MatchLimitOne,
+                     constants.ValueData, constants.ReturnData, constants.ReturnAttributes,
+                     constants.MatchLimit, constants.MatchLimitOne,
                      constants.True,
                  })
         {
@@ -191,6 +193,60 @@ internal static class MacOsKeychain
     };
 
     // ---- Operations ----------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Whether an item exists, <b>without asking to read it</b>. (#925)
+    ///
+    /// <para><b>This is the whole fix, and it turns on one flag.</b> The login keychain's per-item ACL
+    /// guards the item's DATA, not its metadata: a query that asks for <c>kSecReturnAttributes</c> and not
+    /// <c>kSecReturnData</c> is answered without any authorization, and therefore without the modal password
+    /// dialog. Demonstrated on the maintainer's machine while the app was prompting eight times for the very
+    /// same items — <c>security find-generic-password -s "CST Reader — AI provider"</c>, with no <c>-w</c>,
+    /// listed all six silently.</para>
+    ///
+    /// <para><b>Why it matters more than caching.</b> Most callers only ever asked "is there a key?" and
+    /// answered it by fetching the secret, so every status refresh was a potential prompt — 114 reads across
+    /// a launch and one Settings window, 76 of them for a single account, each one able to raise a dialog
+    /// because cancelling records no decision. Fetching a value nobody wanted is what made the app
+    /// unusable in this state; caching only reduces how often it does it.</para>
+    ///
+    /// <para><b>It cannot tell you the item is READABLE.</b> That is knowable only by trying, which is what
+    /// prompts — so a probe reports presence and the locked state is discovered at first real use. See
+    /// <see cref="AiCredentialStore.Probe"/>, which is where the two are reconciled.</para>
+    /// </summary>
+    internal static bool Exists(string service, string account)
+    {
+        if (Symbols.Value is not { } k) return false;
+
+        var query = IntPtr.Zero;
+        var result = IntPtr.Zero;
+        var strings = new StringHandles();
+        try
+        {
+            query = CreateDictionary(
+                new[] { k.Class, k.Service, k.Account, k.ReturnAttributes, k.MatchLimit },
+                new[]
+                {
+                    k.GenericPassword,
+                    strings.Add(service),
+                    strings.Add(account),
+                    k.True,
+                    k.MatchLimitOne,
+                });
+            if (query == IntPtr.Zero) return false;
+
+            // Success means an item matched. Every failure - not found, and anything unanticipated - is
+            // reported as "no", because this answer is used to say a key IS present and over-claiming that
+            // would put the app back to describing keys the reader does not have.
+            return SecItemCopyMatching(query, out result) == ErrSecSuccess;
+        }
+        finally
+        {
+            if (result != IntPtr.Zero) CFRelease(result);
+            if (query != IntPtr.Zero) CFRelease(query);
+            strings.Dispose();
+        }
+    }
 
     /// <summary>
     /// One stored secret, and what happened when we asked for it. (#926)

--- a/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
@@ -104,7 +104,6 @@ internal static class WindowsDpapiStore
         }
     }
 
-    /// <summary>The stored secret, or null when there is none - or when the blob cannot be decrypted.</summary>
     /// <summary>
     /// Whether a blob exists, without decrypting it. (#925)
     ///
@@ -115,11 +114,17 @@ internal static class WindowsDpapiStore
     /// <para>Presence, not readability: a blob whose master key is gone still exists, and reporting it
     /// absent is the conflation #926 removed.</para>
     /// </summary>
-    internal static bool Exists(string service, string account)
+    internal static CredentialState Exists(string service, string account)
     {
-        lock (Gate) return File.Exists(FileFor(service, account));
+        // A state rather than a bool, to match the macOS probe, which has a third answer this does not:
+        // File.Exists is not refused the way a Keychain query can be.
+        lock (Gate)
+            return File.Exists(FileFor(service, account))
+                ? CredentialState.Found
+                : CredentialState.NotStored;
     }
 
+    /// <summary>The stored secret, or null when there is none - or when the blob cannot be decrypted.</summary>
     internal static CredentialRead Find(string service, string account)
     {
         var path = FileFor(service, account);

--- a/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/WindowsDpapiStore.cs
@@ -105,6 +105,21 @@ internal static class WindowsDpapiStore
     }
 
     /// <summary>The stored secret, or null when there is none - or when the blob cannot be decrypted.</summary>
+    /// <summary>
+    /// Whether a blob exists, without decrypting it. (#925)
+    ///
+    /// <para>Free here — DPAPI has no equivalent of the macOS prompt, so this exists for the shared seam
+    /// rather than to avoid a dialog. It does buy the same thing macOS gets: a status query stops doing
+    /// cryptography it has no use for.</para>
+    ///
+    /// <para>Presence, not readability: a blob whose master key is gone still exists, and reporting it
+    /// absent is the conflation #926 removed.</para>
+    /// </summary>
+    internal static bool Exists(string service, string account)
+    {
+        lock (Gate) return File.Exists(FileFor(service, account));
+    }
+
     internal static CredentialRead Find(string service, string account)
     {
         var path = FileFor(service, account);

--- a/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionEditorViewModel.cs
@@ -265,10 +265,11 @@ namespace CST.Avalonia.ViewModels
                     ArrivedSecret = header.Secret,
                     OriginalName = header.Name,
                     // Exists, not readable (#926): a locked secret is still stored, and telling the reader it
-                    // is not is what sends them to re-enter something they already have.
+                    // is not is what sends them to re-enter something they already have. Probed rather than
+                    // read (#925) - building the sheet must not fetch every secret header's value.
                     HasStoredSecret = header.Secret
-                        && (credentials?.Read(connection.Id, AiCredentialNames.Header(header.Name))
-                            ?? CredentialRead.Unavailable).Exists,
+                        && credentials?.Probe(connection.Id, AiCredentialNames.Header(header.Name))
+                           is CredentialState.Found or CredentialState.Unreadable,
                 });
 
             vm._secretHeadersAtOpen.AddRange(connection.Headers
@@ -408,10 +409,16 @@ namespace CST.Avalonia.ViewModels
 
         public bool HasKeyUnavailable => !string.IsNullOrEmpty(KeyUnavailable);
 
-        /// <summary>What the store says about this connection's primary key. (#926)</summary>
-        private CredentialRead StoredKey => _existingId is null
-            ? CredentialRead.NotStored
-            : _credentials?.Read(_existingId, AiCredentialNames.Primary) ?? CredentialRead.Unavailable;
+        /// <summary>
+        /// What the store says about this connection's primary key. (#926, #925)
+        ///
+        /// <para>Probe, not Read: the sheet asks this to decide what to SAY, never to send anything, so it
+        /// has no business fetching the secret — and on macOS fetching it is what raises the authorization
+        /// dialog. Opening the sheet used to be one of the worst offenders.</para>
+        /// </summary>
+        private CredentialState StoredKey => _existingId is null
+            ? CredentialState.NotStored
+            : _credentials?.Probe(_existingId, AiCredentialNames.Primary) ?? CredentialState.Unavailable;
 
         /// <summary>
         /// Whether a key is already filed under this id — only knowable for a connection that exists.
@@ -420,16 +427,17 @@ namespace CST.Avalonia.ViewModels
         /// sheet where the reader would act on being told otherwise: it drove the whole defect, since the row
         /// badged "Key locked" while the Edit sheet directly under it said "No key is stored".</para>
         /// </summary>
-        public bool HasStoredKey => StoredKey.Exists;
+        public bool HasStoredKey =>
+            StoredKey is CredentialState.Found or CredentialState.Unreadable;
 
         public string KeyStatus => _existingId is null
             ? "Stored in the operating system's credential store, never in settings."
             // Locked first: it is a kind of "stored", so the readable-key sentence below would otherwise claim
             // it and tell the reader to paste a replacement - which on macOS needs the authorization that just
             // failed, so it would appear to work and change nothing. (#926)
-            : StoredKey.State == CredentialState.Unreadable
+            : StoredKey == CredentialState.Unreadable
                 ? CredentialRead.Advice($"{_displayName}'s key")
-            : StoredKey.State == CredentialState.Found
+            : StoredKey == CredentialState.Found
                 ? $"A key is stored for {_displayName}. Paste a new one to replace it."
                 // "No key is stored" is true and reads as "you have no key", which on an adopted connection is
                 // false — it authenticates from the environment, and saying otherwise sends the reader to

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -899,9 +899,14 @@ namespace CST.Avalonia.ViewModels
         /// <para>False for a key we did not store, and false when there is none — in both cases the slot is
         /// simply empty. #678 made this reachable by filing keys under the connection's id.</para>
         ///
-        /// <para><b>True for a stored key we cannot read</b> (#926). We did store it, deleting needs no
-        /// authorization on either platform, and it is the reader's way out of the state — so this is the one
-        /// row where removal matters most, and it would be absent if the check were "can we read it".</para>
+        /// <para><b>True for a stored key we cannot read</b> (#926). We did store it, so removal is ours to
+        /// offer, and it is the reader's only way out of the state from inside the app — which makes this the
+        /// one row where it matters most, and it would be absent if the check were "can we read it".</para>
+        ///
+        /// <para><b>Offering it is not promising it will work.</b> This said deleting "needs no authorization
+        /// on either platform"; it does, and a declined prompt fails the delete — observed 2026-08-31, with
+        /// the item still in the keychain afterwards. <c>KeyProblem</c> forty lines up says so. The button
+        /// stays, because trying is worth offering and the failure is now reported rather than swallowed.</para>
         /// </summary>
         public bool CanRemoveKey =>
             _connection.KeySource is CredentialSource.Keychain or CredentialSource.Unreadable;


### PR DESCRIPTION
Closes #925.

## The defect

Every status question — the connection list, the badges, the editor's stored-key note — answered itself by **fetching the secret**. On macOS fetching a secret is what the login keychain's per-item ACL guards, so a question as ordinary as *"does this connection have a key?"* could raise a modal password dialog. Cancelling one records no decision, so the next read asks again.

Measured on the maintainer's machine: **114 reads** across one launch and one Settings window, **76 of them for a single account**. He pressed Escape "a good 15 or 20 times" at launch, and the prompts came back when he opened Settings — the screen most about credentials, so the one that asks most often, and the one you go to in order to fix it.

## The fix

The ACL guards the **data**, not the metadata. A query asking for `kSecReturnAttributes` and not `kSecReturnData` is answered with no authorization and no dialog — demonstrated while the app was prompting eight times for the same items: `security find-generic-password` without `-w` listed all six silently.

So the seam has two verbs. **`Probe`** answers "is a key configured?" and never prompts; **`Read`** fetches the value and is reserved for the request that sends it. Six call sites move to `Probe`; the five that genuinely need a value keep `Read`.

`Probe`'s `Found` means **present, not readable** — readability is knowable only by trying, which is the thing that prompts. So a locked key reports as stored until something uses it, at which point `Read` records what it learned and the badge catches up. That ordering is what #926 asked for: never claim a key is *absent* when it is not.

**Also:** `AiModelCatalog` resolved credentials inside the page loop, so a paginated listing re-fetched them per page. Anthropic pages at twenty models — up to **25 prompts to load one list**.

## Measured result

**114 reads → 6**, one prompt, confirmed by the maintainer on the running app. Launch and Settings are silent; the remaining prompt is the Models tab fetching a listing, which genuinely needs the key.

## Review findings (fable)

Two real bugs, both erasing a truth the store had established, both making the UI look **healthier than reality**:

- **A successful `Set` cleared a remembered `Unreadable`.** Its own comment said recording `Found` would "announce a key we still cannot read" — and clearing does the same one hop later, since the next `Probe` asks the OS and gets `Found`. Pasting a replacement over a locked key succeeds and leaves the ACL alone, so every surface then reported the connection healthy: #926's confusion upgraded from silence to a false statement, on the path the sheet invites.
- **A failed `Delete` cleared it too.** A declined removal made the badge go from "Key locked" to "Keychain" — the reader's failed attempt to revoke a key made the row look better.

Plus: `Exists` mapped every failure to "absent", contradicting `Classify` twelve lines above it (both now share `Classify`); and the resolver's locked-header check re-`Read` a header `ExpandHeaders` had just read — a second dialog for one send.

**The test findings were sharper than the code ones:**

- **Every fake's `Probe` returned `Unreadable` with no prior `Read`**, unlike the real store — so the locked-key tests only ever exercised the post-first-read steady state, certifying a state the app does not enter at launch. Three tests failed once the fakes were corrected, and now establish the state the way the app does.
- **The editor fake had a `ValueReads` counter nothing incremented**, so "opening the sheet reads no secret" asserted nothing; reverting either call site to `Read` passed the whole suite.
- **The cache had no tests at all.** Four added against the real store, including one that produces a genuine `Unreadable` per platform — an empty-valued Keychain item, or a corrupt DPAPI blob — since a locked item otherwise needs two differently-signed binaries.

## Testing

**Suite: 2765 passed, 0 failed, 18 skipped.** Mutants killed include reverting `SourceFor` to `Read`, putting the catalogue's resolution back in the page loop, both cache-invalidation bugs, the editor's `Probe` usage, and the resolver's double read.

**Confirmed on the running app** (2026-09-01): launch silent, and Remove on a locked key leaves the badge reading "Key locked" — the one review finding with no macOS test, since a refused delete cannot be produced here.

## Not fixed here

The prompt itself, when a key really must be read. That is the ACL mismatch in **#609** — unmilestoned, and a bigger decision.

## Note

The `docs/testing/UI_SMOKE_TEST.md` revert landed inside the last commit rather than its own: `git checkout main -- <path>` stages as well as restores. Net state is correct — that file is identical to main, and the checks live in the validation runbook artifact instead.
