### PR TITLE
Answer about the last book you were in (#938)

### DIFF
--- a/src/CST.Avalonia.Tests/Integration/AppCompositionTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/AppCompositionTests.cs
@@ -30,6 +30,8 @@ namespace CST.Avalonia.Tests.Integration
         private sealed class HeadlessReaderState : CST.Avalonia.Services.Ai.IReaderStateService
         {
             public Task<CST.Avalonia.Services.Ai.ReaderStateResult> GetCurrentAsync(
+                CST.Avalonia.Services.Ai.ReaderFocusSignal focus =
+                    CST.Avalonia.Services.Ai.ReaderFocusSignal.None,
                 CancellationToken ct = default) =>
                 Task.FromResult(CST.Avalonia.Services.Ai.ReaderStateResult.Fail(
                     CST.Avalonia.Services.Ai.ReaderStateProblem.NoBookOpen));

--- a/src/CST.Avalonia.Tests/Integration/ContextPreviewEndpointTests.cs
+++ b/src/CST.Avalonia.Tests/Integration/ContextPreviewEndpointTests.cs
@@ -26,7 +26,14 @@ public class ContextPreviewEndpointTests
 
         internal FakeReaderState(ReaderStateResult result) => _result = result;
 
-        public Task<ReaderStateResult> GetCurrentAsync(CancellationToken ct = default) => Task.FromResult(_result);
+        internal ReaderFocusSignal? AskedWith { get; private set; }
+
+        public Task<ReaderStateResult> GetCurrentAsync(
+            ReaderFocusSignal focus = ReaderFocusSignal.None, CancellationToken ct = default)
+        {
+            AskedWith = focus;
+            return Task.FromResult(_result);
+        }
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -52,7 +52,16 @@ public class AiAssistantViewModelTests
         internal ReaderStateResult Result { get; set; } =
             ReaderStateResult.Ok(new ReaderState("s0101m.mul.xml", 12, null));
 
-        public Task<ReaderStateResult> GetCurrentAsync(CancellationToken ct = default) => Task.FromResult(Result);
+        /// <summary>What the caller said it knew about focus. The point of #938 is that the panel says
+        /// it can resolve, so this is asserted rather than ignored.</summary>
+        internal ReaderFocusSignal? AskedWith { get; private set; }
+
+        public Task<ReaderStateResult> GetCurrentAsync(
+            ReaderFocusSignal focus = ReaderFocusSignal.None, CancellationToken ct = default)
+        {
+            AskedWith = focus;
+            return Task.FromResult(Result);
+        }
     }
 
     private sealed class StubResolver : IChatProviderResolver
@@ -82,6 +91,31 @@ public class AiAssistantViewModelTests
             Array.Empty<string>(), false, sent);
 
     // ---- Not configured, and other ordinary refusals ---------------------------------------------
+
+    /// <summary>
+    /// The panel tells the reader-state service that it CAN say which book the reader means. (#938)
+    ///
+    /// <para><b>The whole defect in one assertion.</b> The service refuses when several book windows are
+    /// active, which is right for an HTTP or MCP caller — an outside agent has no click to remember. The
+    /// panel is not that caller: a person is here, clicking, and the app knows which book they were last in.
+    /// Inheriting the blind caller's rule made every question fail with "More than one book window is open"
+    /// the moment a book was floated beside a docked one, and the advice it offered — "click into the book
+    /// you mean" — was something this path could not act on, because it never consulted focus at all.</para>
+    ///
+    /// <para>Asserted on what the panel ASKS rather than on the answer: the resolution itself needs a live
+    /// dock layout and real focus history, which no unit test has. What a test can pin is that the panel
+    /// stops claiming to be blind.</para>
+    /// </summary>
+    [Fact]
+    public async Task The_panel_asks_as_a_caller_that_knows_which_book_was_last_focused()
+    {
+        var reader = new StubReaderState();
+        var vm = new AiAssistantViewModel(new StubOrchestrator(), reader, null, null);
+
+        await vm.AskAsync(AiTask.Explain);
+
+        Assert.Equal(ReaderFocusSignal.LastFocusedBook, reader.AskedWith);
+    }
 
     [Fact]
     public async Task An_unconfigured_assistant_says_what_to_set_and_never_calls_the_model()

--- a/src/CST.Avalonia/Services/Ai/ReaderState.cs
+++ b/src/CST.Avalonia/Services/Ai/ReaderState.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
+using CST.Avalonia.Services;
 using CST.Avalonia.ViewModels;
 using CST.Conversion;
 using Microsoft.Extensions.Logging;
@@ -57,6 +59,34 @@ public sealed record ReaderState(
     bool SelectionUnavailable = false,
     int? SelectionParagraph = null);
 
+/// <summary>
+/// Whether the caller can say which book window the reader means. (#938)
+///
+/// <para><b>The two consumers differ, and only one of them is blind.</b> The Assistant panel is driven by a
+/// person clicking in this app, so the app knows which book they were last in. An HTTP or MCP caller is an
+/// outside agent with no such history — for it, several open book windows genuinely are ambiguous.</para>
+///
+/// <para>Applying the blind caller's rule to the sighted one is #938: with a book floated beside a docked
+/// one, the Assistant refused every question, having never asked the question it could have answered.</para>
+/// </summary>
+public enum ReaderFocusSignal
+{
+    /// <summary>
+    /// The caller is the reader, in this app. Resolve to <b>the last book they were in</b> — [fsnow]'s rule.
+    ///
+    /// <para>The last <i>book</i>, not the last window: reaching the Assistant means clicking into the main
+    /// window, so "last window focused" would answer with the main window's book while the reader meant the
+    /// floated one they had just selected in.</para>
+    /// </summary>
+    LastFocusedBook,
+
+    /// <summary>
+    /// The caller is outside the app and carries no focus history. More than one active book window is an
+    /// honest <see cref="ReaderStateProblem.AmbiguousBookWindow"/>.
+    /// </summary>
+    None,
+}
+
 /// <summary>Success or a named refusal. Never a partial answer.</summary>
 public readonly record struct ReaderStateResult(ReaderState? State, ReaderStateProblem? Problem)
 {
@@ -75,7 +105,14 @@ public interface IReaderStateService
     /// while the app does). In a headless process nothing pumps it and the call would simply not complete, so
     /// tests should substitute this interface rather than exercise the live implementation.</para>
     /// </summary>
-    Task<ReaderStateResult> GetCurrentAsync(CancellationToken ct = default);
+    /// <param name="focus">
+    /// What the caller knows about which window the reader means (#938). Defaulted to
+    /// <see cref="ReaderFocusSignal.None"/> so a caller has to SAY it can resolve — the failure being fixed
+    /// was an interactive caller silently inheriting an external agent's blindness, and a default that
+    /// resolves would hide the same mistake in the other direction.
+    /// </param>
+    Task<ReaderStateResult> GetCurrentAsync(
+        ReaderFocusSignal focus = ReaderFocusSignal.None, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -107,12 +144,13 @@ public sealed class ReaderStateService : IReaderStateService
 
     public ReaderStateService(ILogger<ReaderStateService> logger) => _logger = logger;
 
-    public async Task<ReaderStateResult> GetCurrentAsync(CancellationToken ct = default)
+    public async Task<ReaderStateResult> GetCurrentAsync(
+        ReaderFocusSignal focus = ReaderFocusSignal.None, CancellationToken ct = default)
     {
         // ONE resolution of the active document. An earlier version read the book and then re-resolved it to
         // fetch the selection, which let a tab switch during the selection round-trip (up to 700 ms) attribute
         // one book's selection to another book's paragraph.
-        var (result, document) = await Dispatcher.UIThread.InvokeAsync(ReadActiveBook);
+        var (result, document) = await Dispatcher.UIThread.InvokeAsync(() => ReadActiveBook(focus));
         if (result.State is null || document is null) return result;
 
         ct.ThrowIfCancellationRequested();
@@ -138,7 +176,41 @@ public sealed class ReaderStateService : IReaderStateService
             });
     }
 
-    private (ReaderStateResult Result, BookDisplayViewModel? Document) ReadActiveBook()
+    /// <summary>
+    /// The last book the reader was in, from the app's own interaction history. (#938)
+    ///
+    /// <para><b>The last BOOK, not the last window.</b> Reaching the Assistant means clicking into the main
+    /// window, so a window-level answer would name the main window's book while the reader meant the floated
+    /// one they had just selected in. Walking a history of dockables and keeping only the books skips the
+    /// panel they clicked to ask the question.</para>
+    ///
+    /// <para><b>Selecting text is what puts a book at the head of this list.</b> Selecting requires clicking
+    /// into the book's WebView, which raises the CEF focus callback that feeds the tracker
+    /// (<c>BookDisplayView.OnBrowserGotFocus</c>) — the feed that exists because Avalonia focus goes blind
+    /// inside CEF (#621). So the book whose selection the reader means is already at the front, which is why
+    /// this resolves the reported case without consulting selections at all. Selections carry no timestamp
+    /// and cannot be compared; the act of making one can be.</para>
+    ///
+    /// <para><b>Only among the candidates.</b> The history is app-wide and outlives tabs, so an entry may be
+    /// a book that is no longer any window's active document. Intersecting with the live set keeps this from
+    /// resurrecting one.</para>
+    /// </summary>
+    private static BookDisplayViewModel? LastFocusedBook(IReadOnlyList<BookDisplayViewModel> candidates)
+    {
+        var recent = App.TryGetService<ActiveDocumentTracker>()?.Recent;
+        if (recent is null) return null;
+
+        foreach (var dockable in recent)
+        {
+            if (dockable is BookDisplayViewModel book && candidates.Contains(book))
+                return book;
+        }
+
+        return null;
+    }
+
+    private (ReaderStateResult Result, BookDisplayViewModel? Document) ReadActiveBook(
+        ReaderFocusSignal focus)
     {
         // The dock factory is not in DI — it belongs to the main window's layout, the same lookup the
         // presentation service and the search panel use.
@@ -152,15 +224,32 @@ public sealed class ReaderStateService : IReaderStateService
         if (candidates.Count == 0)
             return (ReaderStateResult.Fail(ReaderStateProblem.NoBookOpen), null);
 
-        // An API caller carries no focus signal, so with a docked book AND a floated one both active there is
-        // no honest way to say which the user is reading. Refuse rather than pick.
-        if (candidates.Count > 1)
+        // Several active book windows - a docked book and a floated one. Whether that is ambiguous depends
+        // entirely on who is asking (#938).
+        //
+        // Resolved here rather than returned early on purpose: the chosen book still has to pass the Multi
+        // volume and position checks below. Answering about a floated book with an unknown paragraph would
+        // trade one wrong answer for another.
+        BookDisplayViewModel document;
+        if (candidates.Count == 1)
         {
+            document = candidates[0];
+        }
+        else if (focus == ReaderFocusSignal.LastFocusedBook && LastFocusedBook(candidates) is { } chosen)
+        {
+            _logger.LogDebug(
+                "Reader state: {Count} active book windows, resolved to the last one focused ({Book})",
+                candidates.Count, chosen.Book?.FileName);
+            document = chosen;
+        }
+        else
+        {
+            // No history to go on, or a caller that never had any. Refuse rather than pick: an outside agent
+            // has no click to remember, and the charter here is that a preview must never describe a passage
+            // the user is not looking at.
             _logger.LogDebug("Reader state is ambiguous: {Count} active book windows", candidates.Count);
             return (ReaderStateResult.Fail(ReaderStateProblem.AmbiguousBookWindow), null);
         }
-
-        var document = candidates[0];
 
         if (document.Book.BookType == BookType.Multi)
         {

--- a/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
+++ b/src/CST.Avalonia/Services/LocalApi/LocalApiServer.cs
@@ -700,7 +700,11 @@ namespace CST.Avalonia.Services.LocalApi
                 app.MapPost(v + "/ai/context-preview",
                     async (ContextPreviewRequest req, CancellationToken ct) =>
                 {
-                    var state = await readerState.GetCurrentAsync(ct);
+                    // No focus signal, and stated rather than defaulted (#938). An HTTP or MCP caller is
+                    // an outside agent: it has no click to remember, so several open book windows genuinely
+                    // are ambiguous and AmbiguousBookWindow below is the right answer for it.
+                    var state = await readerState.GetCurrentAsync(
+                        Services.Ai.ReaderFocusSignal.None, ct);
                     if (state.State is not { } reader)
                     {
                         // Refusals, never fallbacks: an unknown position must not read from the book start, or

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -326,7 +326,11 @@ public class AiAssistantViewModel : ReactiveTool
             }
         }
 
-        var reader = await _readerState.GetCurrentAsync();
+        // The reader is here, clicking, so the app knows which book they were last in — resolve rather
+        // than refuse (#938). Without this the panel inherited the external agent's blindness: a book
+        // floated beside a docked one made every question ambiguous, and "click into the book you mean" was
+        // advice this path could not act on, since it never consulted focus at all.
+        var reader = await _readerState.GetCurrentAsync(ReaderFocusSignal.LastFocusedBook);
         if (reader.State is not { } state)
         {
             Status = Describe(reader.Problem);


### PR DESCRIPTION
Closes #938. **Not verified in the running app** — the reported case needs a floated book and a real selection, so this wants your pass before it merges.

## The defect

With a book floated beside a docked one, the Assistant refused every question:

> More than one book window is open and none is clearly the one in use. Click into the book you mean, then ask again.

Clicking into the book didn't help, because that path never consulted focus. **Two headline Beta 6 features were mutually exclusive** — dragging a book out (#39) and the Assistant.

## Why

`ReaderStateService` refuses when several book windows are active, and `ActiveBookDocuments` returns them all deliberately. Its comment says why:

> an API caller carries no focus signal, so deciding which window wins belongs to the caller, which can refuse.

Correct — for the caller it describes. `IReaderStateService` has two, and only one is blind:

| caller | has a focus signal | refusing is |
|---|---|---|
| `LocalApiServer` — HTTP/MCP, an outside agent | no | right, and unchanged |
| `AiAssistantViewModel` — a person clicking here | yes | the bug |

## The rule **[fsnow]**

> *"last one that had focus?"*

**The Assistant answers about the last book you were in.** The last *book*, not the last window — reaching the Assistant means clicking into the main window, so a window-level answer names the main window's book while you meant the floated one you'd just selected in.

**Why no selection comparison is needed**, which is the part worth keeping: selecting text requires clicking into that book's WebView, raising the CEF focus callback that feeds `ActiveDocumentTracker` — the feed that exists because Avalonia focus goes blind inside CEF (#621). So the book whose selection you mean is already at the head of the history. Selections carry no timestamp and can't be compared; the act of making one can be.

## Two directions tried and discarded

Both on your objections, both recorded on the issue:

- **Reuse `DocumentTargetResolver`, like the five shortcuts do.** It's scoped to one layout by design — *"the first entry this layout CONTAINS wins"* — so asked from the Assistant's own window it skips the floated book and answers with the main window's. Wrong, and without a refusal.
- **Resolve by "the window holding a selection".** Fails when a stale selection sits in the main window, which is the case you raised next.

## Shape of the change

Callers now state what they know (`ReaderFocusSignal.LastFocusedBook` / `.None`), **defaulted to `None`** so saying nothing means blind — a default that resolved would hide the same mistake in the other direction. The API's refusal is untouched.

Resolution happens *before* the Multi-volume and position checks rather than returning early past them: answering about a floated book whose paragraph is unknown would trade one wrong answer for another.

## Testing

`The_panel_asks_as_a_caller_that_knows_which_book_was_last_focused` asserts what the panel **asks** rather than what it gets — the resolution itself needs a live dock layout and real focus history, which no unit test has. Putting the panel back on the default kills it.

**Suite: 2766 passed, 0 failed, 18 skipped.**

## What to check when you get to it

1. Float a book, select a passage in it, click into the main window, press Translate → the answer is about the floated book, and the citation line names it.
2. With a selection in **both** the docked and the floated book, the floated one wins if it's where you selected last.
3. Raise the main window by clicking **its book's text**, then ask → that book answers. Correct by the rule, and the citation shows it — the honest residue rather than a bug.
4. The local API still refuses: `/v1/ai/context-preview` with two book windows open should return `ambiguous-book-window`.
