### PR TITLE
Announce Beta 6 to users (post-publish steps 5 and 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 CST Reader is a cross-platform application for reading and searching Pāli texts. The current main branch contains CST 5.0, built on .NET 10 and Avalonia UI — a ground-up rewrite of the Windows-only CST4.
 
-**Status: 5.0.0-beta.5.** This is the milestone release: CST 5 now matches or exceeds CST4 in features, apart from interface localization (see [Known Gaps](#known-gaps)). It is also the first release with Windows builds, alongside macOS.
+**Status: 5.0.0-beta.6.** The largest beta of this cycle. CST 5 matches or exceeds CST4 in features, apart from interface localization (see [Known Gaps](#known-gaps)), and Beta 6 adds an AI Assistant you can ask about the text you are reading, your choice of AI provider, and first-class Windows support on x64 and ARM64.
 
 CST Reader presents the Tipiṭaka **in Pāli**, rendered in 14 scripts. It does not include translations of the texts; the built-in dictionaries give the meaning of individual words.
 

--- a/welcome-updates.json
+++ b/welcome-updates.json
@@ -1,39 +1,45 @@
 {
   "schemaVersion": 1,
-  "lastUpdated": "2026-07-29T12:00:00Z",
+  "lastUpdated": "2026-09-02T02:20:00Z",
   "currentVersion": {
     "stable": "4.5.0-this-version-is-not-real",
-    "beta": "5.0.0-beta.5"
+    "beta": "5.0.0-beta.6"
   },
   "messages": {
     "5.0.0-beta.1": {
       "type": "upgrade",
-      "title": "New Beta Available - 5.0.0-beta.5",
-      "content": "CST Reader 5.0.0-beta.5 is available — the milestone release. It matches or exceeds CST4 in features (except the interface is still English only), and adds a multi-source dictionary panel with the Digital Pāḷi Dictionary, printing, and the first Windows builds.\n\nIMPORTANT: the search index format changed. Before installing, delete the contents of ~/Library/Application Support/CSTReader/ — an index built by an earlier beta will mis-match and mis-highlight your search results.",
-      "downloadUrl": "https://github.com/fsnow/cst/releases/tag/v5.0.0-beta.5"
+      "title": "New Beta Available - 5.0.0-beta.6",
+      "content": "CST Reader 5.0.0-beta.6 is available — the largest beta of this cycle, with 142 issues closed since Beta 5. It adds an AI Assistant you can ask about the text you are reading, your choice of AI provider, first-class Windows support on x64 and ARM64, Find in Page, text zoom, and a book font per script.\n\nIMPORTANT: coming from Beta 4 or earlier, delete the contents of ~/Library/Application Support/CSTReader/ (Windows: %APPDATA%\\CSTReader\\) before installing. The search index format changed in Beta 5 and an older index will not be read correctly.",
+      "downloadUrl": "https://github.com/fsnow/cst/releases/tag/v5.0.0-beta.6"
     },
     "5.0.0-beta.2": {
       "type": "upgrade",
-      "title": "New Beta Available - 5.0.0-beta.5",
-      "content": "CST Reader 5.0.0-beta.5 is available — the milestone release. It matches or exceeds CST4 in features (except the interface is still English only), and adds a multi-source dictionary panel with the Digital Pāḷi Dictionary, printing, and the first Windows builds.\n\nIMPORTANT: the search index format changed. Before installing, delete the contents of ~/Library/Application Support/CSTReader/ — an index built by an earlier beta will mis-match and mis-highlight your search results.",
-      "downloadUrl": "https://github.com/fsnow/cst/releases/tag/v5.0.0-beta.5"
+      "title": "New Beta Available - 5.0.0-beta.6",
+      "content": "CST Reader 5.0.0-beta.6 is available — the largest beta of this cycle, with 142 issues closed since Beta 5. It adds an AI Assistant you can ask about the text you are reading, your choice of AI provider, first-class Windows support on x64 and ARM64, Find in Page, text zoom, and a book font per script.\n\nIMPORTANT: coming from Beta 4 or earlier, delete the contents of ~/Library/Application Support/CSTReader/ (Windows: %APPDATA%\\CSTReader\\) before installing. The search index format changed in Beta 5 and an older index will not be read correctly.",
+      "downloadUrl": "https://github.com/fsnow/cst/releases/tag/v5.0.0-beta.6"
     },
     "5.0.0-beta.3": {
       "type": "upgrade",
-      "title": "New Beta Available - 5.0.0-beta.5",
-      "content": "CST Reader 5.0.0-beta.5 is available — the milestone release. It matches or exceeds CST4 in features (except the interface is still English only), and adds a multi-source dictionary panel with the Digital Pāḷi Dictionary, printing, and the first Windows builds.\n\nIMPORTANT: the search index format changed. Before installing, delete the contents of ~/Library/Application Support/CSTReader/ — an index built by an earlier beta will mis-match and mis-highlight your search results.",
-      "downloadUrl": "https://github.com/fsnow/cst/releases/tag/v5.0.0-beta.5"
+      "title": "New Beta Available - 5.0.0-beta.6",
+      "content": "CST Reader 5.0.0-beta.6 is available — the largest beta of this cycle, with 142 issues closed since Beta 5. It adds an AI Assistant you can ask about the text you are reading, your choice of AI provider, first-class Windows support on x64 and ARM64, Find in Page, text zoom, and a book font per script.\n\nIMPORTANT: coming from Beta 4 or earlier, delete the contents of ~/Library/Application Support/CSTReader/ (Windows: %APPDATA%\\CSTReader\\) before installing. The search index format changed in Beta 5 and an older index will not be read correctly.",
+      "downloadUrl": "https://github.com/fsnow/cst/releases/tag/v5.0.0-beta.6"
     },
     "5.0.0-beta.4": {
       "type": "upgrade",
-      "title": "New Beta Available - 5.0.0-beta.5",
-      "content": "CST Reader 5.0.0-beta.5 is available — the milestone release. It matches or exceeds CST4 in features (except the interface is still English only), and adds a multi-source dictionary panel with the Digital Pāḷi Dictionary, printing, and the first Windows builds.\n\nIMPORTANT: the search index format changed. Before installing, delete the contents of ~/Library/Application Support/CSTReader/ — an index built by an earlier beta will mis-match and mis-highlight your search results.",
-      "downloadUrl": "https://github.com/fsnow/cst/releases/tag/v5.0.0-beta.5"
+      "title": "New Beta Available - 5.0.0-beta.6",
+      "content": "CST Reader 5.0.0-beta.6 is available — the largest beta of this cycle, with 142 issues closed since Beta 5. It adds an AI Assistant you can ask about the text you are reading, your choice of AI provider, first-class Windows support on x64 and ARM64, Find in Page, text zoom, and a book font per script.\n\nIMPORTANT: coming from Beta 4 or earlier, delete the contents of ~/Library/Application Support/CSTReader/ (Windows: %APPDATA%\\CSTReader\\) before installing. The search index format changed in Beta 5 and an older index will not be read correctly.",
+      "downloadUrl": "https://github.com/fsnow/cst/releases/tag/v5.0.0-beta.6"
     },
     "5.0.0-beta.5": {
+      "type": "upgrade",
+      "title": "New Beta Available - 5.0.0-beta.6",
+      "content": "CST Reader 5.0.0-beta.6 is available — the largest beta of this cycle, with 142 issues closed since Beta 5. It adds an AI Assistant you can ask about the text you are reading, your choice of AI provider, first-class Windows support on x64 and ARM64, Find in Page, text zoom, and a book font per script.\n\nUpgrading from Beta 5: nothing to do. Install over the top — your settings, layout, open books and downloaded dictionaries carry across.",
+      "downloadUrl": "https://github.com/fsnow/cst/releases/tag/v5.0.0-beta.6"
+    },
+    "5.0.0-beta.6": {
       "type": "info",
-      "title": "You're Running Beta 5",
-      "content": "Thank you for testing CST Reader Beta 5. This is the first release at feature parity with CST4, and the first with Windows builds — reports from Windows are especially useful. Please report anything you find on GitHub."
+      "title": "You're Running Beta 6",
+      "content": "Thank you for testing CST Reader Beta 6. This release adds the AI Assistant and makes Windows a first-class target on both x64 and ARM64. The AI Assistant and the access surface for AI clients are the newest parts — reports on those are especially useful. Please report anything you find on GitHub."
     },
     "default": {
       "type": "warning",
@@ -44,16 +50,17 @@
   },
   "announcements": [
     {
-      "id": "2026-07-beta5-release",
-      "date": "2026-07-29T00:00:00Z",
-      "title": "CST Reader Beta 5 Released",
-      "content": "Beta 5 is the milestone release: feature parity with CST4, plus Windows support (x64 and ARM64), a multi-source dictionary panel, and printing. A clean start is required — see the release notes.",
-      "showUntil": "2026-10-31T00:00:00Z",
+      "id": "2026-09-beta6-release",
+      "date": "2026-09-02T00:00:00Z",
+      "title": "CST Reader Beta 6 Released",
+      "content": "Beta 6 is the largest beta of this cycle: an AI Assistant for the text you are reading, your choice of AI provider, and Windows as a first-class target on x64 and ARM64. Upgrading from Beta 5 needs nothing — install over the top. From Beta 4 or earlier, delete the data directory first; see the release notes.",
+      "showUntil": "2026-12-31T00:00:00Z",
       "targetVersions": [
         "5.0.0-beta.1",
         "5.0.0-beta.2",
         "5.0.0-beta.3",
-        "5.0.0-beta.4"
+        "5.0.0-beta.4",
+        "5.0.0-beta.5"
       ]
     }
   ],


### PR DESCRIPTION
Steps 5 and 6 from `RELEASE_PROCESS.md`. Both point users at a release that must already exist — `v5.0.0-beta.6` published 2026-09-02T02:14Z.

## Step 5 — `welcome-updates.json`

- `currentVersion.beta` → `5.0.0-beta.6`; every message and `downloadUrl` retargeted to the new tag.
- **The upgrade message is now two messages, not one.** This is the part worth reviewing: Beta 5 upgrades in place, while Beta 4 and earlier still need the data directory deleted, because the search index format changed in Beta 5.

  The old file could carry a single uniform *"delete the contents of ~/Library/Application Support/CSTReader/"* line because every supported source version needed it. Repeating that to a Beta 5 user would tell them to wipe settings, layout, open books and downloaded dictionaries that carry across fine — and it would contradict both the release notes and the welcome page.

- The Beta 5 announcement is **replaced, not annotated**, and the new one targets `beta.1` through `beta.5`.
- `currentVersion.stable` left as the existing placeholder.

## Step 6 — `README.md`

Status line to `5.0.0-beta.6`. It is the repo's front page and should name the newest **published** version — a README still advertising the previous beta is the most visible form of release drift.

## Checks

- `welcome-updates.json` parses; 7 messages, 1 announcement, schema fields match `Models/WelcomeUpdates.cs`
- No banned term; no Linux in user-facing text

## Still to come

The next-cycle bucket A bump to `5.0.0-beta.7`, which the release doc flags as the historically-skipped step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)