### PR TITLE
Open the Beta 7 cycle: bump Bucket A to 5.0.0-beta.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Agent guide for CST Reader
 
-CST Reader (**CST = Chaṭṭha Saṅgāyana Tipiṭaka**) is a cross-platform Pāli text reader — .NET 10 + Avalonia UI, a ground-up rewrite of the WinForms CST4. Texts are provided by the Vipassana Research Institute (VRI). Currently **Beta 6 in development** (Beta 5 released 2026-07); development is on **macOS**, with Windows now shipping too (x64 + arm64) and tested on dedicated machines (Linux remains designed-in but untested).
+CST Reader (**CST = Chaṭṭha Saṅgāyana Tipiṭaka**) is a cross-platform Pāli text reader — .NET 10 + Avalonia UI, a ground-up rewrite of the WinForms CST4. Texts are provided by the Vipassana Research Institute (VRI). Currently **Beta 7 in development** (Beta 6 released 2026-09); development is on **macOS**, with Windows now shipping too (x64 + arm64) and tested on dedicated machines (Linux remains designed-in but untested).
 
 - **Feature overview:** see [README.md](README.md) (front page).
 - **Roadmap / planned work:** [GitHub issues](https://github.com/fsnow/cst/issues) (`feature`/`enhancement` labels) + specs in [docs/features/planned/](docs/features/planned/). Issues are the canonical tracker.

--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -2,34 +2,22 @@
 
 This document describes the complete process for releasing a new version of CST Reader.
 
-**Last Updated:** August 22, 2026
-**Current Version:** 5.0.0-beta.6 (in development; Beta 5 released 2026-07)
+**Last Updated:** September 2, 2026
+**Current Version:** 5.0.0-beta.7 (in development; Beta 6 released 2026-09)
 
-> **Clean-start status for Beta 6: NOT required from Beta 5.** Beta 5 users upgrade in place —
-> **not because nothing on disk changed**, which is false, but because Beta 6 was built to absorb what
-> did. `settings.json` gained the whole AI connections surface, and the shape of a connection's headers
-> changed (#771); Beta 6 reads either shape (#784) rather than discarding the file. Two data-directory
-> migrations run on first launch: the superseded en/hi dictionary directories (#569) and the user XSL
-> directory (#616). And loading itself became recoverable — a backup is consulted when the file will not
-> parse (#785), a single bad property no longer costs the rest of it (#803), and a test asserts this build
-> reads what earlier builds wrote (#787).
+> **Clean-start status for Beta 7: not yet determined.** The cycle has just opened and nothing on disk
+> has changed, so as of today a Beta 6 user would upgrade in place. That is a statement about right now,
+> not a promise about the release — **re-derive it before publishing** rather than carrying this line
+> forward. A tokenizer or index-format change is what flips it to a mandatory clean start, because no
+> migration can absorb that one.
 >
-> Only users coming from **Beta 4 or earlier** must delete the data directory
-> (`~/Library/Application Support/CSTReader/` on macOS, `%APPDATA%\CSTReader\` on Windows) — the Beta 5
-> index-offset change (#53) is what they are crossing.
+> Users coming from **Beta 5 or earlier** are a separate question, to be answered at the same time. Beta 6
+> required a wipe from Beta 4 and earlier (the Beta 5 index-offset change, #53); whether Beta 7 extends
+> that line to Beta 5 depends on what this cycle changes.
 >
-> **What to verify before publishing** is therefore not "did anything change" but "does the upgrade path
-> still work": launch the new build on a real Beta 5 data directory and confirm settings, layout and open
-> books survive. Section 3 of the validation runbook covers it. A tokenizer or index-format change is
-> still the thing that flips this to a mandatory clean start, because no migration can absorb that one.
->
-> **Going backwards is the direction that bites.** Beta 6 writes state a Beta 5 install did not expect,
-> and Beta 5 lacks the tolerant loading that Beta 6 added. #616's migration is marked `Recurring`
-> precisely because a still-installed Beta 5 recreates the directory it removes.
->
-> General rule: whenever the tokenizer or index format changes, the clean-start instruction goes FIRST
-> in the release notes — not buried in "Upgrade Notes." When it is *not* required, say so explicitly,
-> because the beta line has trained users to wipe.
+> **What to verify before publishing** is not "did anything change" but "does the upgrade path still
+> work": launch the new build on a real data directory from the previous release and confirm settings,
+> layout and open books survive. Section 3 of the validation runbook covers it.
 
 ---
 
@@ -229,8 +217,12 @@ These contain the version text but must be left alone; a blind find-and-replace 
 
 - `Services/VersionComparer.cs` and `Tests/Services/VersionComparerTests.cs` — SemVer parsing **fixtures**
   (e.g. `"5.0.0-beta.5+abc1234"` testing build-metadata stripping). Version-agnostic by design.
-- `Tests/ViewModels/WelcomeViewModelTests.cs` — constructed test data, not an assertion about the app's
-  own version.
+- `Tests/ViewModels/WelcomeViewModelTests.cs` and `Tests/ViewModels/AboutViewModelTests.cs` —
+  constructed test data, not assertions about the app's own version. `AboutViewModelTests` alone holds
+  eleven occurrences, all of them inputs testing how a version string is PARSED (build-metadata
+  stripping, short-SHA extraction); renumbering them changes nothing and breaks the expected values.
+- `ViewModels/AboutViewModel.cs` — one doc comment carrying an example version (`e.g. "5.0.0-beta.6"`).
+  An illustration, not a string the app emits.
 - `docs/architecture/LEMMA_EXPANSION.md` and similar — **historical statements** ("implemented in Beta 5")
   that stay true.
 

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -10,15 +10,15 @@
     <CFBundleName>CST Reader</CFBundleName>
     <CFBundleDisplayName>CST Reader</CFBundleDisplayName>
     <CFBundleIdentifier>com.cst.avalonia</CFBundleIdentifier>
-    <CFBundleVersion>5.0.0-beta.6</CFBundleVersion>
-    <CFBundleShortVersionString>5.0.0-beta.6</CFBundleShortVersionString>
+    <CFBundleVersion>5.0.0-beta.7</CFBundleVersion>
+    <CFBundleShortVersionString>5.0.0-beta.7</CFBundleShortVersionString>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- .NET Assembly Version Properties -->
-    <Version>5.0.0-beta.6</Version>
-    <AssemblyVersion>5.0.0.6</AssemblyVersion>
-    <FileVersion>5.0.0.6</FileVersion>
-    <InformationalVersion>5.0.0-beta.6</InformationalVersion>
+    <Version>5.0.0-beta.7</Version>
+    <AssemblyVersion>5.0.0.7</AssemblyVersion>
+    <FileVersion>5.0.0.7</FileVersion>
+    <InformationalVersion>5.0.0-beta.7</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">

--- a/src/CST.Avalonia/Info.plist
+++ b/src/CST.Avalonia/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.cst.avalonia</string>
     <key>CFBundleVersion</key>
-    <string>5.0.0-beta.6</string>
+    <string>5.0.0-beta.7</string>
     <key>CFBundleShortVersionString</key>
-    <string>5.0.0-beta.6</string>
+    <string>5.0.0-beta.7</string>
     <key>CFBundleExecutable</key>
     <string>CST.Avalonia</string>
     <key>CFBundleIconFile</key>

--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -339,7 +339,7 @@
         <div class="logo"><img src="buddha-transparent.png" alt="Buddha"></div>
         <h1>CST Reader</h1>
         <p class="subtitle">A Pāli Text Reader for the Chaṭṭha Saṅgāyana Tipiṭaka</p>
-        <p class="version">Version 5.0.0-beta.6 &bull; September 2026</p>
+        <p class="version">Version 5.0.0-beta.7 &bull; in development</p>
     </div>
 
     <div class="beta-notice">
@@ -465,7 +465,7 @@
 
     <div class="update-note">
         <p>This welcome page updates automatically with new releases.</p>
-        <p>CST Reader 5.0.0-beta.6 • September 2026</p>
+        <p>CST Reader 5.0.0-beta.7 • in development</p>
     </div>
 </body>
 </html>

--- a/src/CST.Avalonia/Services/WelcomeUpdateService.cs
+++ b/src/CST.Avalonia/Services/WelcomeUpdateService.cs
@@ -35,7 +35,7 @@ namespace CST.Avalonia.Services
         private static readonly HttpClient SharedHttpClient = new() { Timeout = HttpTimeout };
 
         // Current app version - will be injected from App.axaml.cs
-        public string CurrentAppVersion { get; set; } = "5.0.0-beta.6";
+        public string CurrentAppVersion { get; set; } = "5.0.0-beta.7";
 
         public WelcomeUpdateService(HttpClient? httpClient = null)
         {

--- a/src/CST.Avalonia/ViewModels/WelcomeViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/WelcomeViewModel.cs
@@ -103,7 +103,7 @@ namespace CST.Avalonia.ViewModels
             var assembly = Assembly.GetExecutingAssembly();
             var rawVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
                           ?? assembly.GetName().Version?.ToString()
-                          ?? "5.0.0-beta.6";
+                          ?? "5.0.0-beta.7";
 
             // Strip SemVer build metadata (the git hash after '+') for display + comparison. (#71)
             _updateService.CurrentAppVersion = VersionComparer.StripBuildMetadata(rawVersion);

--- a/src/CST.Avalonia/package-macos.sh
+++ b/src/CST.Avalonia/package-macos.sh
@@ -139,9 +139,9 @@ HELPER_EOF
     <key>CFBundleDisplayName</key>
     <string>$HELPER_NAME</string>
     <key>CFBundleVersion</key>
-    <string>5.0.0-beta.6</string>
+    <string>5.0.0-beta.7</string>
     <key>CFBundleShortVersionString</key>
-    <string>5.0.0-beta.6</string>
+    <string>5.0.0-beta.7</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSBackgroundOnly</key>


### PR DESCRIPTION
The post-release step `RELEASE_PROCESS.md` records as historically skipped. Until it lands, every dev build and every bug report between now and the next release is labelled `beta.6`.

## Bucket A — all eight places

`CST.Avalonia.csproj` (six properties; `AssemblyVersion`/`FileVersion` → `5.0.0.7`, since the fourth field carries the beta number) · `Info.plist` · `package-macos.sh` · `welcome-content.html` header + footer · `WelcomeUpdateService.CurrentAppVersion` · `WelcomeViewModel` fallback · `CLAUDE.md` status line · this doc's `Current Version` / `Last Updated` / clean-start banner.

Two judgment calls worth review:

- **The welcome page's date is now "in development"**, not a guessed month. The release month is not knowable at cycle open, and a dev build made in December claiming "September 2026" is worse than one saying it is unreleased. It needs setting close to release, alongside the Focus Areas prose.
- **The clean-start banner is rewritten, not renumbered.** Beta 6's answer was specific to what Beta 6 was built to absorb; carrying it forward would assert a compatibility nobody has established. It now says what is true today, and to re-derive it before publishing.

## The doc's exclusion list was incomplete

You asked whether the doc lists everywhere. **The Bucket A table does** — after this change, no file in the app still says `beta.6`, and I verified that by grep rather than by trusting the table.

But **"Not version strings — do not bulk-replace" had a gap**, and it is the dangerous direction: a blind find-and-replace would have silently corrupted tests.

- `Tests/ViewModels/AboutViewModelTests.cs` — **eleven** occurrences, every one a parser *input* (build-metadata stripping, short-SHA extraction) paired with an expected value. Renumbering them changes nothing about what is tested and breaks the assertions.
- `ViewModels/AboutViewModel.cs:66` — an example version in a doc comment.

The About box shipped in Beta 6, so its tests postdate the list. Both are now named.

## Deliberately unchanged

`README.md` and `welcome-updates.json` name the newest **published** version and correctly stay on beta 6 (Bucket B). `welcome-content.html`'s release-specific prose — the upgrade notice, Focus Areas, "brand new in this release" blurbs — is rewritten as content close to release, per the doc's own guidance.

## Verification

- `dotnet build src/CST.Avalonia` — succeeded, 0 errors
- About / Welcome / VersionComparer tests: **96 passed, 0 failed** — the suite most likely to break on a version change

## Unrelated, but noticed

The build emits one warning, `CS8602` at `Services/Ai/ReaderState.cs:254`, in the code path changed by the #938 floated-book fix. Not touched here.

**Correction (kestrel-cst-2):** I first described this as *pre-existing on `main`*. That is wrong, and I had not tested it. #939 introduced it — the line responsible, `chosen.Book?.FileName`, is an addition in `1f3d749` and does not exist at its parent `ccfa051`, which builds with 0 warnings. Beta 6 shipping with it is still accurate.

It is not a null risk: the `?.` is applied to a non-nullable member, which poisons the compiler's flow state for `.Book` and makes every later `document.Book.…` read as possibly-null. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
