### PR TITLE
Stop a defensive ?. from teaching the compiler that Book is nullable

### DIFF
--- a/src/CST.Avalonia/Services/Ai/ReaderState.cs
+++ b/src/CST.Avalonia/Services/Ai/ReaderState.cs
@@ -239,7 +239,7 @@ public sealed class ReaderStateService : IReaderStateService
         {
             _logger.LogDebug(
                 "Reader state: {Count} active book windows, resolved to the last one focused ({Book})",
-                candidates.Count, chosen.Book?.FileName);
+                candidates.Count, chosen.Book.FileName);
             document = chosen;
         }
         else


### PR DESCRIPTION
`CS8602` at `ReaderState.cs:254`, the only warning in the build. **Introduced by #939**, not pre-existing — see the provenance note below.

## It is not a null risk

The warning names `document.Book` at the Multi-volume check, four lines from the cause, which makes it read like a null hazard in the book lookup. It is not:

`BookDisplayViewModel.Book` is `public Book Book => _book;` — non-nullable, over a `readonly` field assigned from a non-nullable constructor parameter, in a `<Nullable>enable</Nullable>` project. Every construction passes a real `Book`; the sole call site is `CstDockFactory.cs:603`, with no `null` or `null!` anywhere.

## The actual cause

```csharp
candidates.Count, chosen.Book?.FileName);   // :242
```

The `?.` is applied to that non-nullable member. Roslyn treats the null-conditional as evidence and sets the **member** flow state for `.Book` to maybe-null; `document = chosen;` on the next line carries the state forward, so the first `document.Book.…` below absorbs the warning for the three that follow.

Dropping the `?.` clears it — **0 warnings, 0 errors**. No other edit needed.

Deliberately **not** `!` and **not** a null check: both would encode a null case that cannot occur and would outlive the memory of why.

## How it was pinned

Suppression bisect rather than reasoning: `document!` left the warning standing, `document.Book!` cleared it, and a probe assignment `CST.Book __probe = document.Book;` produced `CS8600` — isolating the maybe-null state to `.Book`, not to `document`. **kestrel-cst-2** reached the same place independently by splitting the expression, and confirmed `document.ToString()` warns not at all.

## Provenance correction

PR #945's body described this warning as *pre-existing on `main`*. That was wrong and untested on my part. **kestrel-cst-2** built `ccfa051`, the commit before #939, in a throwaway worktree: **0 warnings**. I confirmed it from the diff independently — `chosen.Book?.FileName` is an addition in `1f3d749` and does not exist at `ccfa051`. #945's body has been corrected. Beta 6 shipping with the warning remains accurate.

## Verification

- `dotnet build src/CST.Avalonia` — 0 warnings, 0 errors
- ReaderState + AiAssistant tests: **51 passed, 0 failed**

## Left alone

`?.` on `.Book` also appears at `SimpleTabbedWindow.cs:1106` and `BookDisplayView.axaml.cs` ×4, but those sit on genuinely nullable receivers (`_viewModel?.Book?.FileName`) and are a different case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)