### PR TITLE
Stop refusing a logo over a doctype or a comment

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiLogoImagesTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiLogoImagesTests.cs
@@ -79,6 +79,65 @@ public class AiLogoImagesTests : IDisposable
         Assert.Equal("references a remote resource", AiLogoImages.Screen(Write("remote.svg", svg)));
     }
 
+    /// <summary>The SVG 1.1 doctype names a w3.org DTD. The renderer does not resolve it, and refusing over
+    /// it cost <c>hpc-ai.svg</c> its mark — one of only two refusals across the whole 173-logo cache, both
+    /// of them wrong (#930).</summary>
+    [Fact]
+    public void A_standard_doctype_is_not_a_remote_reference()
+    {
+        var path = Write("hpc-ai.svg", """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path d="M0,0H1"/></svg>
+            """);
+
+        Assert.Null(AiLogoImages.Screen(path));
+    }
+
+    /// <summary>Inkscape stamps its home page into a comment. That is the whole reason
+    /// <c>regolo-ai.svg</c> was refused (#930); a comment is not drawn and cannot cause a fetch.</summary>
+    [Fact]
+    public void A_generator_comment_is_not_a_remote_reference()
+    {
+        var path = Write("regolo-ai.svg", """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+            <!-- Created with Inkscape (http://www.inkscape.org/) -->
+            <path d="M0,0H1"/></svg>
+            """);
+
+        Assert.Null(AiLogoImages.Screen(path));
+    }
+
+    /// <summary>The point of the guard survives the two exemptions: a real fetch is still refused even when
+    /// the file also carries a doctype and a comment, which is what a fix that merely stopped looking would
+    /// break.</summary>
+    [Fact]
+    public void A_real_remote_image_is_still_refused_alongside_a_doctype_and_a_comment()
+    {
+        var path = Write("hostile.svg", """
+            <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+            <!-- Created with Inkscape (http://www.inkscape.org/) -->
+            <image href="https://example.com/tracker.png"/></svg>
+            """);
+
+        Assert.Equal("references a remote resource", AiLogoImages.Screen(path));
+    }
+
+    /// <summary>An entity bomb hides in the doctype's internal subset, which this change strips. It must
+    /// still be caught — the &lt;!ENTITY test reads the RAW text and runs first, and this pins that
+    /// ordering (#930).</summary>
+    [Fact]
+    public void An_entity_in_the_internal_subset_is_still_caught_though_the_doctype_is_stripped()
+    {
+        var path = Write("bomb.svg", """
+            <!DOCTYPE svg [ <!ENTITY lol "lol"> <!ENTITY lol2 "&lol;&lol;&lol;"> ]>
+            <svg xmlns="http://www.w3.org/2000/svg"><text>&lol2;</text></svg>
+            """);
+
+        Assert.Equal("declares XML entities", AiLogoImages.Screen(path));
+    }
+
     /// <summary>A fragment reference is internal and ordinary — one logo in the set uses one for a clip
     /// path.</summary>
     [Fact]

--- a/src/CST.Avalonia/Services/Ai/AiLogoImages.cs
+++ b/src/CST.Avalonia/Services/Ai/AiLogoImages.cs
@@ -50,13 +50,34 @@ namespace CST.Avalonia.Services.Ai
         internal const int MaxBytes = 256 * 1024;
 
         /// <summary>
-        /// Any absolute URL, once the namespace declarations that legitimately contain one are removed.
+        /// Any absolute URL, once the parts of the file that can hold URL-shaped text WITHOUT causing a fetch
+        /// are removed.
         /// </summary>
         private static readonly Regex ExternalReference =
             new(@"\b(?:https?|ftp|file)://", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex NamespaceDeclaration =
             new(@"xmlns(:[\w-]+)?\s*=\s*""[^""]*""", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// An XML comment. Generators write their own home page into one - Inkscape does, which is how
+        /// <c>regolo-ai.svg</c> came to be refused (#930). A comment is not drawn and cannot cause a fetch.
+        /// </summary>
+        private static readonly Regex Comment =
+            new(@"<!--.*?-->", RegexOptions.Compiled | RegexOptions.Singleline);
+
+        /// <summary>
+        /// A doctype declaration. Its system identifier is a w3.org URL in every SVG 1.1 file that carries
+        /// one - <c>hpc-ai.svg</c> is the live case (#930). The renderer does not resolve it.
+        ///
+        /// <para>The optional internal subset is matched so that a <c>]&gt;</c> inside it cannot end the match
+        /// early and leave the tail behind. Stripping it loses nothing: <see cref="Screen"/> tests for
+        /// <c>&lt;!ENTITY</c> against the RAW text first, precisely because that is where an entity bomb
+        /// lives.</para>
+        /// </summary>
+        private static readonly Regex Doctype =
+            new(@"<!DOCTYPE[^\[>]*(\[[\s\S]*?\])?[^>]*>",
+                RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Keyed by file AND colour: the same mark is a different image in light and dark, and a reader can
@@ -151,8 +172,23 @@ namespace CST.Avalonia.Services.Ai
             if (text.Contains("<!ENTITY", StringComparison.OrdinalIgnoreCase))
                 return "declares XML entities";
 
-            // The SVG namespace is itself an http URL, so those have to come out before asking the question.
-            if (ExternalReference.IsMatch(NamespaceDeclaration.Replace(text, string.Empty)))
+            // Three kinds of URL-shaped text are not references to anything the renderer will fetch, and all
+            // three have to come out before asking the question: the SVG namespace is itself an http URL, a
+            // doctype's system identifier is a w3.org URL, and a generator stamps its home page into a
+            // comment. Measured over the 173-logo cache, the last two were the ONLY refusals, and both were
+            // wrong (#930).
+            //
+            // Order matters: this runs after the <!ENTITY test above, which reads the raw text.
+            var content = Doctype.Replace(text, string.Empty);
+            content = Comment.Replace(content, string.Empty);
+            content = NamespaceDeclaration.Replace(content, string.Empty);
+
+            // Still a bare scheme search over what is left, deliberately. The narrower rule - a remote scheme
+            // inside an href/xlink:href/src value - was the other way to fix this, and it is the wrong trade
+            // HERE: a false positive costs a monogram, which is what a missing logo has always shown, while a
+            // false negative is a synchronous network fetch on the UI thread. Over-refusing is the cheap
+            // failure, so only text that provably cannot cause a fetch is removed.
+            if (ExternalReference.IsMatch(content))
                 return "references a remote resource";
 
             return null;


### PR DESCRIPTION
Fixes #930.

## The defect

`AiLogoImages.Screen` searches the whole file for a URL scheme, removing only `xmlns` declarations first. URL-shaped text that is not a reference therefore matches. Across the 173-logo cache the rule had **two refusals and no true positives, and both refusals were wrong**:

| file | what tripped it | what it is |
|---|---|---|
| `hpc-ai.svg` | `<!DOCTYPE svg PUBLIC … "http://www.w3.org/…/svg11.dtd">` | the standard SVG 1.1 doctype; its only image is an embedded `data:` URI |
| `regolo-ai.svg` | `<!-- Created with Inkscape (http://www.inkscape.org/) -->` | a generator comment |

## The fix

Strip the doctype and XML comments alongside `xmlns` before the search.

**I kept the bare scheme search, against the issue's own preferred direction** (matching a remote scheme inside `href`/`xlink:href`/`src`). That rule is narrower and harder to re-break, but it is the wrong trade for this particular guard:

- a **false positive** costs a monogram — which is what a missing logo has always shown;
- a **false negative** is a synchronous network fetch on the UI thread, i.e. a frozen window.

Over-refusal is the cheap failure here, so the change removes only text that provably cannot cause a fetch rather than narrowing where we look. Enumerating every fetch-causing position (`<use href>`, `@font-face src`, `url()` in a `<style>` block, single-quoted attributes…) is exactly the kind of list that acquires a gap.

Happy to switch to the narrower rule if you'd rather — it was a close call, and the issue argued the other way.

## Ordering, which the change depends on

The doctype pattern matches the optional internal subset, so a `]>` inside it cannot end the match early and leave the tail unstripped. Stripping the subset loses nothing **because the `<!ENTITY` test reads the raw text and runs first** — that ordering is now pinned by a test, since both rules touch the same string.

## Tests — four, and what each is for

- the two real files as fixtures
- **a hostile file carrying a doctype *and* a comment *and* a real remote `<image>`** — the case a fix that merely stopped looking would break
- the entity bomb inside an internal subset, pinning the ordering above

**Mutation-tested:** reverting the source change fails exactly the two false-positive tests (15 passed / 2 failed). The other two pass either way by design — they guard preserved behaviour, not the fix.

## Not verified

This machine has no logo cache, so I could not run `Screen` against the real `hpc-ai.svg` and `regolo-ai.svg`. The fixtures reproduce the exact strings quoted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)