### PR TITLE
Let a dictionary lookup cross the ḷ/l spelling difference

### DIFF
--- a/src/CST.Avalonia.Tests/Services/DictionaryIndexTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryIndexTests.cs
@@ -79,6 +79,108 @@ public class DictionaryIndexTests
         Assert.Empty(Index("abm", "abp").Lookup("zzz"));
     }
 
+    // ---- ḷ/l folding on a miss (#933) ----
+    //
+    // These use the real IPE codepoints rather than ASCII stand-ins, because the fold is defined on them:
+    // Latn2Ipe maps l -> U+00E5 and ḷ -> U+00E9. Written as escapes, per CLAUDE.md.
+    private const string IpeL = "\u00E5";    // l
+    private const string IpeLDot = "\u00E9"; // ḷ
+
+    /// <summary>The reported case. DPPN carries Nālandā with a plain l; the corpus spells the same name
+    /// with ḷ four times in five, so most clicks missed the entry entirely (#933).</summary>
+    [Fact]
+    public void A_query_spelled_with_retroflex_l_reaches_a_plain_l_headword()
+    {
+        // The decoy is load-bearing. It shares THREE leading characters with the query where the real
+        // target shares two, so the old near-neighbour guess prefers it — without folding this returns the
+        // decoy, which is the shape of the reported miss. A two-entry index would pass either way.
+        var r = Index("na" + IpeL + "anda", "na" + IpeLDot + "bbb", "zzz")
+            .Lookup("na" + IpeLDot + "anda");
+
+        Assert.Equal(new[] { "na" + IpeL + "anda" }, Words(r));
+    }
+
+    /// <summary>And the reverse — the corpus contains both spellings, so the fold has to work in both
+    /// directions rather than privileging one tradition.</summary>
+    [Fact]
+    public void A_query_spelled_with_plain_l_reaches_a_retroflex_l_headword()
+    {
+        var r = Index("na" + IpeLDot + "anda", "na" + IpeL + "bbb", "zzz")
+            .Lookup("na" + IpeL + "anda");
+
+        Assert.Equal(new[] { "na" + IpeLDot + "anda" }, Words(r));
+    }
+
+    /// <summary>The homograph run still follows, so a folded hit behaves like an exact one rather than
+    /// returning a lone entry — Nālandā 1, Nālandā 2, Nālandāsutta 1 … all reachable.</summary>
+    [Fact]
+    public void A_folded_hit_still_returns_the_prefix_run()
+    {
+        var r = Index("na" + IpeL + "anda", "na" + IpeL + "andasutta", "na" + IpeLDot + "bbb", "zzz")
+            .Lookup("na" + IpeLDot + "anda");
+
+        Assert.Equal(new[] { "na" + IpeL + "anda", "na" + IpeL + "andasutta" }, Words(r));
+    }
+
+    /// <summary>An exact spelling always wins. Both spellings exist as separate entries here, and the query
+    /// must reach its OWN — folding must never divert a lookup that already resolves, and must never merge
+    /// two entries that Pāli keeps apart.</summary>
+    [Fact]
+    public void An_exact_spelling_is_never_diverted_by_folding()
+    {
+        var index = Index("na" + IpeL + "anda", "na" + IpeLDot + "anda");
+
+        Assert.Equal(new[] { "na" + IpeL + "anda" }, Words(index.Lookup("na" + IpeL + "anda")));
+        Assert.Equal(new[] { "na" + IpeLDot + "anda" }, Words(index.Lookup("na" + IpeLDot + "anda")));
+    }
+
+    /// <summary>The reported case, in the shape the real dictionary has it. (#933)
+    ///
+    /// <para>This is the test the first attempt at this fix did not have, and it is why that attempt did not
+    /// work. The query is the INFLECTED <c>nāḷandaṃ</c>, which has no entry at all — so the fix has to reach
+    /// it through the near-neighbour guess, not through an exact match. DPPN really does hold
+    /// <c>Nāḷika</c>, <c>Nāḷikera</c>, <c>Nāḷikīra</c> and <c>Nāḷisobbha</c>, and those share <c>nāḷ</c>
+    /// with the query, so a fix that folds only the exact arm leaves the reader on them — which is what a
+    /// lookup already did.</para></summary>
+    [Fact]
+    public void An_inflected_form_reaches_the_headword_across_the_spelling_difference()
+    {
+        // n ā ḷ a n d a ṃ  — no entry; the headword is nālandā, and nāḷika… is the wrong near neighbour.
+        var index = Index(
+            "n\u0101" + IpeLDot + "ika",        // nāḷika    — shares "nāḷ" (3) unfolded
+            "n\u0101" + IpeLDot + "ikera",      // nāḷikera
+            "n\u0101" + IpeL + "and\u0101",    // nālandā   — shares "nāland" (6) once folded
+            "n\u0101" + IpeL + "and\u0101sutta");
+
+        var r = index.Lookup("n\u0101" + IpeLDot + "anda\u1E43");
+
+        Assert.Equal(
+            new[] { "n\u0101" + IpeL + "and\u0101", "n\u0101" + IpeL + "and\u0101sutta" },
+            Words(r));
+    }
+
+    /// <summary>The other side of the same index: a word genuinely spelled with ḷ must still find itself,
+    /// not be dragged to a plain-l neighbour by folding.</summary>
+    [Fact]
+    public void A_word_that_really_is_spelled_with_retroflex_l_still_finds_itself()
+    {
+        var index = Index(
+            "n\u0101" + IpeLDot + "ika",
+            "n\u0101" + IpeL + "and\u0101");
+
+        Assert.Equal(new[] { "n\u0101" + IpeLDot + "ika" },
+            Words(index.Lookup("n\u0101" + IpeLDot + "ika")));
+    }
+
+    /// <summary>Folding is tried before the near-neighbour guess but must not replace it: a query with no
+    /// folded counterpart still gets the old best-guess run.</summary>
+    [Fact]
+    public void A_word_with_no_folded_counterpart_still_gets_the_near_neighbour_guess()
+    {
+        var r = Index("apple", "apply", "banana").Lookup("appl");
+        Assert.Equal(new[] { "apple", "apply" }, Words(r));
+    }
+
     [Fact]
     public void CountReflectsEntries()
     {

--- a/src/CST.Avalonia/Services/DictionaryIndex.cs
+++ b/src/CST.Avalonia/Services/DictionaryIndex.cs
@@ -19,11 +19,38 @@ public sealed class DictionaryIndex
     // Sorted ascending by IPE headword (ordinal). Headwords are unique (the loader merges duplicates).
     private readonly List<DictionaryWord> _words;
 
+    /// <summary>
+    /// The same entries keyed by their l-folded headword and sorted on that key, consulted only when an
+    /// exact lookup misses. (#933)
+    ///
+    /// <para>A SECOND ordering rather than a changed one: <see cref="_words"/> keeps IPE's collation, every
+    /// entry keeps its own headword, and nothing here reaches display. Two entries that fold together stay
+    /// two entries.</para>
+    /// </summary>
+    private readonly List<(string Key, DictionaryWord Word)> _lFolded;
+
     public DictionaryIndex(IEnumerable<DictionaryWord> words)
     {
         _words = words.ToList();
         _words.Sort(DictionaryWordComparer.Instance);
+
+        _lFolded = _words.Select(w => (Key: FoldL(w.Word), Word: w)).ToList();
+        _lFolded.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
     }
+
+    /// <summary>
+    /// IPE <c>ḷ</c> (U+00E9) read as <c>l</c> (U+00E5), for MATCHING ONLY. (#933)
+    ///
+    /// <para><b>This is not a claim that they are the same letter.</b> They are distinct phonemes in Pāli.
+    /// What it reconciles is two editorial traditions: DPPN follows Malalasekera's PTS spelling, while the
+    /// corpus and DPD follow the Burmese/CST one, and the corpus itself disagrees — नाळन्द… occurs 102 times
+    /// and नालन्द… 24 times across the 217 files, so four clicks in five on that word landed on the spelling
+    /// DPPN does not carry.</para>
+    ///
+    /// <para>Applied to the query and to the index key alike, so it works in both directions: a query
+    /// spelled with <c>ḷ</c> reaches an <c>l</c> headword and the reverse.</para>
+    /// </summary>
+    internal static string FoldL(string ipe) => ipe.Replace('\u00E9', '\u00E5');
 
     public int Count => _words.Count;
 
@@ -100,6 +127,50 @@ public sealed class DictionaryIndex
                 else
                     break;
             }
+        }
+
+        // The guess again with ḷ and l read alike, taken only when it reaches STRICTLY further into the
+        // word. (#933)
+        //
+        // This has to happen on the GUESS, not on the exact search, because the guess is what bridges an
+        // inflected form to a headword - and that is where the spelling difference bites. Real case:
+        // nāḷandaṃ has no exact entry, shares "nāḷ" (3) with Nāḷika, and shares "nāland" (6) with Nālandā
+        // once folded. Folding only the exact arm left the reader on Nāḷika, which is what a lookup already
+        // did.
+        //
+        // Strictly greater, so an exact spelling still wins every tie: folding can only lengthen a common
+        // prefix, never shorten one, so anything resolving today keeps the answer it has.
+        var folded = FoldGuess(ipeWord, Math.Max(commonBehind, commonAhead));
+        return folded ?? results;
+    }
+
+    /// <summary>
+    /// The best l-folded run, or null when folding gets no closer to the query than
+    /// <paramref name="unfoldedBest"/> already did. (#933)
+    ///
+    /// <para>Scans the folded ordering rather than binary-searching it, because the question is "how far
+    /// into the word does the closest entry agree", which is not answered by an insertion point. The set is
+    /// one dictionary - 13,548 headwords for DPPN - and this runs only when an exact lookup has already
+    /// missed.</para>
+    /// </summary>
+    private IReadOnlyList<DictionaryWord>? FoldGuess(string ipeWord, int unfoldedBest)
+    {
+        var key = FoldL(ipeWord);
+
+        int best = 0;
+        for (int i = 0; i < _lFolded.Count; i++)
+        {
+            int common = CountCommonStartLetters(key, _lFolded[i].Key);
+            if (common > best) best = common;
+        }
+
+        if (best <= unfoldedBest) return null;
+
+        var results = new List<DictionaryWord>();
+        for (int i = 0; i < _lFolded.Count; i++)
+        {
+            if (CountCommonStartLetters(key, _lFolded[i].Key) == best)
+                results.Add(_lFolded[i].Word);
         }
 
         return results;


### PR DESCRIPTION
Fixes #933.

## Measured on the installed `dppn.db` — all 13,548 headwords

| query | before (`main`) | after |
|---|---|---|
| `nāḷandaṃ` | `nāḷika, nāḷikīra, nāḷikera, nāḷisobbha` | **`nālandā 1, nālandā 2, nālandāsutta 1, nālandāsutta 2`** |
| `nāḷandā` | `nāḷika, nāḷikīra, nāḷikera, nāḷisobbha` | **`nālandā 1, nālandā 2, nālandāsutta 1, nālandāsutta 2`** |
| `nālandā` | `nālandā 1, 2, …` | unchanged |
| `nāḷika` | `nāḷika` | unchanged |

DPPN lists **Nālandā** with a plain `l`; the corpus spells it with `ḷ` in **102 of 126** occurrences, so four clicks in five missed — while the identical click in DPD, which carries both spellings as lemmas, succeeded. 2,889 of DPPN's headwords contain `l` or `ḷ` and 2,885 have no counterpart spelling. DPPN follows Malalasekera's PTS orthography; the corpus and DPD follow the Burmese/CST one. The variation is systematic.

## An earlier version of this PR did not work, and why

I first folded only the **exact** arm of the lookup. **[fsnow]** caught it from the running app — *"there are some results for the l-retroflex variant, just not the right ones"* — and he was right: the `before` row above was unchanged by that version.

The reported query is the **inflected** `nāḷandaṃ`, which has no entry at all. It can only be reached through the **near-neighbour guess**, and that is precisely where the spelling difference bites: `nāḷandaṃ` shares `nāḷ` (3 chars) with `Nāḷika`, but `nāland` (6) with `Nālandā` once folded. Folding the exact arm never ran.

So the fold now applies to the guess.

## The safety property

The folded run is taken **only when it reaches strictly further** into the word. Folding can only lengthen a common prefix, never shorten one, so an exact spelling wins every tie and nothing that resolves today can be diverted — verified on the same real data (`nālandā` and `nāḷika` rows above).

`ḷ` and `l` are **distinct phonemes in Pāli**, not typographic variants. Nothing here merges entries, rewrites a headword, or changes what is displayed: `_words` keeps IPE's collation and every entry keeps its own headword.

## Scope — `ḷ`/`l` only, deliberately

The issue notes other pairs likely differ between the traditions and asks for "the general shape rather than special-casing this one letter." **That is an editorial judgment about Pāli orthography and yours to make**, so this fixes only the pair with a measured failure and a reported symptom.

## Cost, measured rather than assumed

The folded pass scans, so I timed it against the real dictionary: **0.357 ms** on a miss, **0.000 ms** on an exact hit (which never scans), 29 ms to build the index. Lookups are throttled at 300 ms.

## Tests

Seven. The positive ones carry **decoy entries** that share more leading characters with the query than the real target — without a decoy the existing fallback returns the right word by luck and the test passes unfixed, which mutation testing caught in an earlier draft. The key one, `An_inflected_form_reaches_the_headword_across_the_spelling_difference`, reproduces the real data's shape (`Nāḷika`/`Nāḷikera` competing with `Nālandā`) and is the test the first attempt lacked.

**Mutation-tested:** reverting the source fails four tests, including that one. **Full suite: 2777 passed, 0 failed, 18 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)