### PR TITLE
Draw the book tree's icons instead of borrowing them from a font (#932)

### DIFF
--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml
@@ -95,29 +95,58 @@
                                 <Style Selector="TreeViewItem:selected /template/ ContentPresenter#PART_HeaderPresenter">
                                     <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}"/>
                                 </Style>
+                                <!-- The icons need a rule of their own; the inheritance above does NOT reach
+                                     them. Fluent's ControlTheme for PathIcon sets Foreground to
+                                     TextControlForeground, and a Style setter outranks an Inherited value - so a
+                                     PathIcon with no local Foreground is not transparent to the rule above the
+                                     way the label is. It keeps the theme's ordinary text colour and sits black
+                                     on the accent fill. Measured, not reasoned: with this rule removed, a
+                                     selected row renders label White and icon Black in light mode. Dark mode
+                                     hides it, because TextControlForeground is white there too - which is why
+                                     it would have survived a dark-only look.
+
+                                     ">" and not a descendant combinator, for the reason given above: ">"
+                                     matches a LOGICAL child, and the header content's logical parent is the
+                                     TreeViewItem, so a child book's icon is out of reach. The descendant form
+                                     was measured doing exactly the damage that comment predicts - selecting a
+                                     category turned every book under it white on a black row.
+
+                                     Do not move this onto the PathIcons as a local Foreground instead:
+                                     LocalValue outranks StyleTrigger in Avalonia, so a local brush would beat
+                                     this rule and put the bug back. -->
+                                <Style Selector="TreeViewItem:selected &gt; StackPanel &gt; PathIcon">
+                                    <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}"/>
+                                </Style>
                             </TreeView.Styles>
                             <TreeView.DataTemplates>
                                 <TreeDataTemplate DataType="vm:BookTreeNode" ItemsSource="{Binding Children}">
                                     <StackPanel Orientation="Horizontal" Margin="2">
                                         <!-- Tintable vector icons, not emoji (#932). These three glyphs were
-                                             U+1F4C4 / U+1F4C1 / U+1F4C2 in a TextBlock with no FontFamily, so
-                                             the shape was chosen by each platform's font fallback rather than
-                                             by us: colour on one Windows machine, black silhouette on the
-                                             next, grey on macOS - the same build disagreeing with itself. A
-                                             geometry takes the fallback chain out of the picture.
+                                             U+1F4C4 / U+1F4C1 / U+1F4C2 in a TextBlock with no FontFamily.
+                                             [fsnow], testing the Beta 6 builds: on macOS "they are always
+                                             grey"; on Windows "sometimes rendering in color, yellow folders
+                                             and light grey documents, and sometimes in black sillhouette".
 
-                                             Foreground is deliberately UNSET, so it inherits exactly as the
-                                             DisplayName label below does. That is what carries the selected
-                                             row's accent foreground down from ContentPresenter#PART_Header-
-                                             Presenter (see the TreeView.Styles comment above), and what makes
-                                             the icons follow light and dark. A colour emoji could do neither,
-                                             because it ignores Foreground - being tintable is the reason this
-                                             is a path and not merely a better-chosen font.
+                                             The diagnosis is font fallback, and it is an INFERENCE, not a
+                                             measurement: no FontFamily was set and none inherited, so the
+                                             shape came from whatever each platform resolved for a codepoint
+                                             the UI font does not carry. Nobody established which font drew
+                                             which rendering. A geometry is the right answer either way -
+                                             it removes the font from the question rather than choosing a
+                                             better one.
 
-                                             14x14 matches the PathIcon sizing in SearchPanel.axaml. Much
-                                             below that the open and closed folders stop being tellable apart.
-                                             The data is Material Design Icons (book, folder, folder-open) on
-                                             a 24x24 viewBox, which PathIcon scales to fit. -->
+                                             A colour emoji also ignores Foreground, so it can follow neither
+                                             the selected row nor the theme; being tintable is the second
+                                             reason this is a path. How the tint actually arrives is the
+                                             TreeViewItem:selected rule above - a style, not inheritance.
+
+                                             14x14 matches the PathIcons in SearchPanel.axaml. Much below
+                                             that the open and closed folders stop being tellable apart. The
+                                             data is Material Design Icons - book-outline, folder,
+                                             folder-open. PathIcon fits each path to the bounds of its OWN
+                                             geometry, not to a shared 24x24 frame, so the three land at
+                                             slightly different scales (0.70 / 0.70 / 0.66). Nothing is
+                                             clipped, because a bounds fit cannot clip. -->
                                         <!-- Book -->
                                         <PathIcon Data="M18,2A2,2 0 0,1 20,4V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V4A2,2 0 0,1 6,2H18M18,4H13V12L10.5,9.75L8,12V4H6V20H18V4Z"
                                                   Width="14" Height="14"

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml
@@ -99,34 +99,55 @@
                             <TreeView.DataTemplates>
                                 <TreeDataTemplate DataType="vm:BookTreeNode" ItemsSource="{Binding Children}">
                                     <StackPanel Orientation="Horizontal" Margin="2">
-                                        <!-- Icons using Unicode symbols for now (Mac-style icons coming later) -->
-                                        <!-- Book icon -->
-                                        <TextBlock Text="📄" FontSize="12" 
-                                               Margin="0,0,4,0" 
-                                               VerticalAlignment="Center"
-                                               IsVisible="{Binding IsBook}"/>
-                                        <!-- Closed folder icon -->
-                                        <TextBlock Text="📁" FontSize="12"
-                                               Margin="0,0,4,0" 
-                                               VerticalAlignment="Center">
-                                            <TextBlock.IsVisible>
+                                        <!-- Tintable vector icons, not emoji (#932). These three glyphs were
+                                             U+1F4C4 / U+1F4C1 / U+1F4C2 in a TextBlock with no FontFamily, so
+                                             the shape was chosen by each platform's font fallback rather than
+                                             by us: colour on one Windows machine, black silhouette on the
+                                             next, grey on macOS - the same build disagreeing with itself. A
+                                             geometry takes the fallback chain out of the picture.
+
+                                             Foreground is deliberately UNSET, so it inherits exactly as the
+                                             DisplayName label below does. That is what carries the selected
+                                             row's accent foreground down from ContentPresenter#PART_Header-
+                                             Presenter (see the TreeView.Styles comment above), and what makes
+                                             the icons follow light and dark. A colour emoji could do neither,
+                                             because it ignores Foreground - being tintable is the reason this
+                                             is a path and not merely a better-chosen font.
+
+                                             14x14 matches the PathIcon sizing in SearchPanel.axaml. Much
+                                             below that the open and closed folders stop being tellable apart.
+                                             The data is Material Design Icons (book, folder, folder-open) on
+                                             a 24x24 viewBox, which PathIcon scales to fit. -->
+                                        <!-- Book -->
+                                        <PathIcon Data="M18,2A2,2 0 0,1 20,4V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V4A2,2 0 0,1 6,2H18M18,4H13V12L10.5,9.75L8,12V4H6V20H18V4Z"
+                                                  Width="14" Height="14"
+                                                  Margin="0,0,4,0"
+                                                  VerticalAlignment="Center"
+                                                  IsVisible="{Binding IsBook}"/>
+                                        <!-- Closed category -->
+                                        <PathIcon Data="M10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6H12L10,4Z"
+                                                  Width="14" Height="14"
+                                                  Margin="0,0,4,0"
+                                                  VerticalAlignment="Center">
+                                            <PathIcon.IsVisible>
                                                 <MultiBinding Converter="{x:Static converters:CategoryIconConverter.Instance}" ConverterParameter="closed">
                                                     <Binding Path="IsCategory"/>
                                                     <Binding Path="IsExpanded"/>
                                                 </MultiBinding>
-                                            </TextBlock.IsVisible>
-                                        </TextBlock>
-                                        <!-- Open folder icon -->
-                                        <TextBlock Text="📂" FontSize="12"
-                                               Margin="0,0,4,0" 
-                                               VerticalAlignment="Center">
-                                            <TextBlock.IsVisible>
+                                            </PathIcon.IsVisible>
+                                        </PathIcon>
+                                        <!-- Open category -->
+                                        <PathIcon Data="M19,20H4C2.89,20 2,19.1 2,18V6C2,4.89 2.89,4 4,4H10L12,6H19A2,2 0 0,1 21,8H21L4,8V18L6.14,10H23.21L20.93,18.5C20.7,19.37 19.92,20 19,20Z"
+                                                  Width="14" Height="14"
+                                                  Margin="0,0,4,0"
+                                                  VerticalAlignment="Center">
+                                            <PathIcon.IsVisible>
                                                 <MultiBinding Converter="{x:Static converters:CategoryIconConverter.Instance}" ConverterParameter="open">
                                                     <Binding Path="IsCategory"/>
                                                     <Binding Path="IsExpanded"/>
                                                 </MultiBinding>
-                                            </TextBlock.IsVisible>
-                                        </TextBlock>
+                                            </PathIcon.IsVisible>
+                                        </PathIcon>
                                         <!-- Text -->
                                         <TextBlock Text="{Binding DisplayName}" 
                                                    VerticalAlignment="Center"


### PR DESCRIPTION
Closes #932.

## What was wrong

The folder and book glyphs in **Open a Book** were emoji in a `TextBlock` with no `FontFamily` — U+1F4C4, U+1F4C1, U+1F4C2 — so the shape was chosen by each platform's font fallback rather than by us. macOS always drew them grey; Windows drew them in colour on one run and as black silhouettes on another.

The same build disagreeing with itself is what identifies the cause. Nothing in the app was choosing between the two, because nothing in the app was choosing at all. All three codepoints default to emoji presentation, so no variation selector is deciding it either — the fallback chain is, and that chain is neither a setting we control nor obliged to be stable.

## What this does

Three `PathIcon`s with Material Design geometry, 14×14, matching the `PathIcon` sizing already in `SearchPanel.axaml`. The `IsVisible` bindings and `CategoryIconConverter` are untouched. No new assets, no new dependency, one file.

**How the icons get their colour** — corrected after review, see below. In the default state they take Fluent's `PathIcon` theme brush, which is theme-aware. On a selected row, a style in `TreeView.Styles` tints them with the accent foreground, scoped with `>` so it reaches the selected item's own icon and not the icons of books nested under a selected category.

A colour emoji can follow neither — it ignores `Foreground`. Being tintable is the reason this is a path and not merely a better-chosen font.

## CST4's assets were examined first, and rejected on evidence

The issue said to look at them before drawing anything. I did — and three of my four original grounds were wrong or misapplied, corrected here after review:

- **Decisive, and I had not stated it:** they carry **no alpha**, so the white background is part of the image. On a dark theme they would render as white 16-pixel squares, and on a Retina display they would be upscaled. That alone rules them out.
- **Confirmed:** 16×16, and `book_hardcvr_with_A.psd` — the Photoshop master — is *also* 16×16. There is no scalable source in the CST4 tree.
- **Confirmed:** colour, which reintroduces the tinting problem this change exists to fix.
- ~~8-bit palette~~ — **wrong.** The PNGs are 8-bit-per-channel truecolour and the BMP is 24-bit. Neither is paletted.
- ~~WinForms did transparency with a key colour~~ — **unfounded.** `cst4-final:src/Cst4/FormSelectBook.cs` builds the `ImageList` at `Depth24Bit` and sets no `TransparentColor`. The tree background was white, so nothing needed keying.
- ~~Visual Studio 2005 Image Library provenance~~ — **misapplied.** The `*HS.bmp` files are indeed that library, but the tree never used them: `FormSelectBook` uses `FolderClosed`, `FolderOpen` and `BookHardCvr`, none of which is HS-named. The licensing argument was about assets that are not in question.

The shape still follows CST4's vocabulary: a closed book, not the document page the emoji was drawing.

## One correction to the issue

Its `[observed]` line claimed these were the only emoji used as UI icons anywhere in the app. That was wrong, and it was mine. `CstDockFactory.SearchTitlePrefix` prefixes a search-opened book's tab title with U+1F50D, which is an emoji doing an icon's job under the same fallback lottery. Out of scope here — a Dock tab title is a plain string with nowhere to hang a geometry — but the issue body now records it.

## Verification

- `dotnet build src/CST.Avalonia` — **0 errors, 0 warnings**. Avalonia compiles XAML at build time, so the elements and properties are validated by the build.
- `dotnet test src/CST.Avalonia.Tests` — **2770 passed, 0 failed, 18 skipped**.
- **Not verified in the running app.** It is a visual change and still wants an eye on it.

## Review — Fable, on `68c906f`

It found the first commit's central claim false, and I reproduced it before believing it. `d0af14c` is the fix.

`Foreground` was left unset on the assumption it would inherit like the label beside it. **It does not.** Fluent's `ControlTheme` for `PathIcon` sets `Foreground` to `TextControlForeground`, and a Style setter outranks an Inherited value. I had verified that the *property* inherits and stopped there; a theme setter is always present and always wins.

Measured in a headless Avalonia 11.3.6 + FluentTheme harness loading this file's own `TreeView.Styles` and template, with a book selected:

```
before   label.Foreground=White (Inherited)   icon.Foreground=Black (Style)
after    label.Foreground=White (Inherited)   icon.Foreground=White (StyleTrigger)
```

**Light mode only — dark mode masks it completely**, because `TextControlForeground` is white there too. Manual test 3 below would have failed and test 4 would have passed.

Also corrected, all of them mine: the comment paraphrased the maintainer's "sometimes … sometimes" as "on one machine … on the next" (and this PR body as "on one run … on another") — two embellishments of one observation in a single change; the font-fallback diagnosis was asserted as fact when it is an inference; the geometry is `book-outline`, not `book`; and "a 24×24 viewBox, which PathIcon scales to fit" names the wrong mechanism — `Stretch=Uniform` fits each path's own bounds, so the three land at 0.70 / 0.70 / 0.66.

**Cost per node — the thing I asked to have attacked, and a non-issue.** 280 realised nodes: emoji 263/272/250/283 ms against PathIcon 281/272/285/227 ms for show+layout. Hidden `PathIcon`s are never templated at all (`Layoutable.MeasureCore` returns before `ApplyTemplate` when `IsVisible` is false), so one `Path` is built per node, not three.

## Manual test list

1. Categories show a folder, books show a book — no emoji anywhere in the tree.
2. Expand a category: the icon changes to the open folder.
3. Click a row: the icon turns white with the label on the blue selection. *(This is the inheritance question above.)*
4. Light ↔ dark: icons follow the text colour.
5. Same on Windows — the point of the fix is that it now looks identical there.
