### PR TITLE
Restore which headword the Dictionary had selected

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/DictionarySelectionRestoreTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/DictionarySelectionRestoreTests.cs
@@ -77,6 +77,43 @@ public class DictionarySelectionRestoreTests
         Assert.Equal("n\u0101land\u0101", Word(DictionaryViewModel.ChooseSelection(deva, words)));
     }
 
+    /// <summary>
+    /// The case #935 was actually filed about, across a script change. (fable review)
+    ///
+    /// <para>DPPN distinguishes its homographs by NUMBER — "Nālandā 1", "Nālandāsutta 1". The display
+    /// pipeline converts those digits into the reading script, and IPE carries a Devanāgarī digit through
+    /// unchanged while a Latin one stays ASCII, so the keys differ in 11 of the 14 scripts. The earlier
+    /// script-change test passed only because its headword had no number — the feature's own motivating
+    /// data was the case it did not cover.</para>
+    ///
+    /// <para>The miss was not transient either: the fallback selection is written straight back to state,
+    /// so a failed match replaced the reader's remembered one permanently.</para></summary>
+    [Fact]
+    public void A_numbered_headword_still_matches_after_the_reading_script_changed()
+    {
+        // "N\u0101land\u0101sutta 1" as shown in Devan\u0101gar\u012B, digit included (\u0967 = 1).
+        const string devaNumbered =
+            "\u0928\u093E\u0932\u0928\u094D\u0926\u093E\u0938\u0941\u0924\u094D\u0924 \u0967";
+
+        // Wanted entry deliberately not first, so the auto-select cannot produce the answer by accident.
+        var words = Words("n\u0101land\u0101 1", "n\u0101land\u0101sutta 1");
+
+        Assert.Equal("n\u0101land\u0101sutta 1",
+            Word(DictionaryViewModel.ChooseSelection(devaNumbered, words)));
+    }
+
+    /// <summary>Numbers still distinguish, which is the point of keeping them: folding digits to ASCII must
+    /// not collapse "Nālandā 1" and "Nālandā 2" into the same key, or the reader who picked the second of
+    /// four would land on the first.</summary>
+    [Fact]
+    public void Folding_digits_does_not_merge_different_homographs()
+    {
+        var words = Words("n\u0101land\u0101 1", "n\u0101land\u0101 2");
+
+        Assert.Equal("n\u0101land\u0101 2",
+            Word(DictionaryViewModel.ChooseSelection("n\u0101land\u0101 2", words)));
+    }
+
     /// <summary>An empty result list selects nothing rather than throwing — a lookup that matched nothing is
     /// ordinary.</summary>
     [Fact]

--- a/src/CST.Avalonia.Tests/ViewModels/DictionarySelectionRestoreTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/DictionarySelectionRestoreTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using CST.Avalonia.ViewModels;
+using CST.Tools;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// Which headword a completed lookup selects. (#935)
+///
+/// <para>The Dictionary pane restored its search text and its source but not WHICH of several matching
+/// headwords was chosen, so a reader who had selected the third of four came back to the first. This covers
+/// the decision; the one-shot bookkeeping that limits it to a restore lives in the view model, which needs a
+/// dock layout and a live lookup and so is not reachable from a unit test.</para>
+/// </summary>
+public class DictionarySelectionRestoreTests
+{
+    private static IReadOnlyList<DictionaryEntryViewModel> Words(params string[] headwords)
+    {
+        var list = new List<DictionaryEntryViewModel>();
+        foreach (var h in headwords)
+            list.Add(new DictionaryEntryViewModel(new DictionaryEntry(h, "<p>def</p>", "dppn")));
+        return list;
+    }
+
+    private static string Word(DictionaryEntryViewModel? vm) => vm?.DisplayWord ?? "(none)";
+
+    /// <summary>The reported case: nālanda matches four headwords in DPPN and the reader had picked the
+    /// third.</summary>
+    [Fact]
+    public void A_remembered_headword_is_selected_rather_than_the_first_match()
+    {
+        var words = Words("N\u0101land\u0101 1", "N\u0101land\u0101 2",
+                          "N\u0101land\u0101sutta 1", "N\u0101land\u0101sutta 2");
+
+        Assert.Equal("N\u0101land\u0101sutta 1",
+            Word(DictionaryViewModel.ChooseSelection("N\u0101land\u0101sutta 1", words)));
+    }
+
+    /// <summary>No remembered selection — a fresh lookup — keeps the auto-select that shows a definition
+    /// immediately, which is CST4's behaviour and the reason the auto-select exists.</summary>
+    [Fact]
+    public void An_ordinary_lookup_still_auto_selects_the_first_match()
+    {
+        var words = Words("N\u0101land\u0101 1", "N\u0101land\u0101 2");
+
+        Assert.Equal("N\u0101land\u0101 1", Word(DictionaryViewModel.ChooseSelection(null, words)));
+        Assert.Equal("N\u0101land\u0101 1", Word(DictionaryViewModel.ChooseSelection("", words)));
+    }
+
+    /// <summary>A remembered headword the dictionary no longer offers falls back to the first match. Sources
+    /// are updated between sessions, and #933 changed what a lookup returns — so this is a normal outcome,
+    /// not an error, and the fallback is what the pane did before any of this existed.</summary>
+    [Fact]
+    public void A_headword_that_is_no_longer_in_the_results_falls_back_to_the_first()
+    {
+        var words = Words("N\u0101land\u0101 1", "N\u0101land\u0101 2");
+
+        Assert.Equal("N\u0101land\u0101 1",
+            Word(DictionaryViewModel.ChooseSelection("Nobody\u0101 3", words)));
+    }
+
+    /// <summary>A headword is rendered in whichever script was current when it was saved. Comparing through
+    /// IPE is what lets a reader who switched script between sessions still match their own selection —
+    /// here the same word saved in Devanāgarī and looked up in Latin.</summary>
+    [Fact]
+    public void A_remembered_headword_still_matches_after_the_reading_script_changed()
+    {
+        // "n\u0101land\u0101" in Devanāgarī: na + aa + la + nna + virama + da + aa
+        const string deva = "\u0928\u093E\u0932\u0928\u094D\u0926\u093E";
+
+        // The wanted entry is deliberately NOT first: if it were, the auto-select would produce the same
+        // answer and the test would pass without any matching happening at all.
+        var words = Words("n\u0101land\u0101sutta", "n\u0101land\u0101");
+
+        Assert.Equal("n\u0101land\u0101", Word(DictionaryViewModel.ChooseSelection(deva, words)));
+    }
+
+    /// <summary>An empty result list selects nothing rather than throwing — a lookup that matched nothing is
+    /// ordinary.</summary>
+    [Fact]
+    public void No_results_selects_nothing()
+    {
+        Assert.Null(DictionaryViewModel.ChooseSelection("anything", Words()));
+        Assert.Null(DictionaryViewModel.ChooseSelection(null, Words()));
+    }
+}

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -176,7 +176,12 @@ public class DictionaryDialogState
     public double? Y { get; set; }
 
     public string UserText { get; set; } = string.Empty;
-    public int SelectedWordIndex { get; set; }
+
+    /// <summary>Which of the matching headwords was selected, remembered across sessions (#935). Stored as
+    /// the headword rather than its position: the list is recomputed by a lookup at restore, against a
+    /// dictionary that can be updated between sessions and a matcher that #933 has already changed, so a
+    /// position is only correct while the list happens to be identical. Empty until first set.</summary>
+    public string SelectedHeadword { get; set; } = string.Empty;
     /// <summary>Preferred dictionary SOURCE id ("vri-childers"/"vri-hindi"/"dpd"/"dppn"), remembered across
     /// sessions (#466). A source identity, never a language code. Empty until first set.</summary>
     public string SourceId { get; set; } = string.Empty;

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
@@ -64,6 +65,20 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
     /// restore - so a later lookup the reader actually asks for is never hijacked.</para>
     /// </summary>
     private string? _pendingSelectedHeadword;
+
+    /// <summary>
+    /// The query <see cref="_pendingSelectedHeadword"/> belongs to. (#935, fable review)
+    ///
+    /// <para>Without it the pending selection could steer a lookup the reader asked for, which is exactly
+    /// what its own comment promises will never happen. The restore lookup can be discarded by the
+    /// stale-completion guard - a cold SQLite open at startup easily outlives 300ms - and that guard returns
+    /// BEFORE the pending value is consumed, leaving it armed for whatever the reader types next.</para>
+    ///
+    /// <para>Not simply "clear it on a stale completion": the construction-time empty-query lookup can
+    /// complete AFTER ApplyState, and the guard discarding that one is what protects the restore. Matching
+    /// on the query distinguishes the two.</para>
+    /// </summary>
+    private string? _pendingSelectedFor;
 
     private bool _canGoBack;
     private bool _canGoForward;
@@ -242,16 +257,19 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         if (restored != null)
             SelectedSource = restored;
 
-        // Armed BEFORE SearchText, because assigning that is what schedules the lookup whose completion
-        // consumes it. (#935)
-        var savedWord = _stateService.Current.DictionaryDialog.SelectedHeadword;
-        _pendingSelectedHeadword = string.IsNullOrEmpty(savedWord) ? null : savedWord;
-
         // #91: restore the last looked-up word too (the parallel to the Search pane's #87 term restore).
         // Setting SearchText triggers the throttled lookup, so the last definition reappears on launch.
         var savedText = _stateService.Current.DictionaryDialog.UserText;
-        if (!string.IsNullOrEmpty(savedText))
-            SearchText = savedText;
+        if (string.IsNullOrEmpty(savedText)) return;
+
+        // Armed BEFORE SearchText, because assigning that is what schedules the lookup whose completion
+        // consumes it - and armed only alongside a query, so a saved selection with no saved text cannot sit
+        // waiting for the reader's first lookup. (#935)
+        var savedWord = _stateService.Current.DictionaryDialog.SelectedHeadword;
+        _pendingSelectedHeadword = string.IsNullOrEmpty(savedWord) ? null : savedWord;
+        _pendingSelectedFor = savedText;
+
+        SearchText = savedText;
     }
 
     /// <summary>The enabled dictionary sources for the picker (shown by <c>DisplayName</c>), in the user's
@@ -375,10 +393,14 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
                     Words.Add(new DictionaryEntryViewModel(e));
 
                 // Auto-select the best (first) match so the definition shows immediately, like CST4 - unless
-                // a restore asked for a particular one (#935). Consumed either way, so only the first lookup
-                // after ApplyState can be steered.
-                var wanted = _pendingSelectedHeadword;
+                // a restore asked for a particular one (#935). Honoured only for the query it was armed
+                // with, and consumed either way, so it can neither be spent on a different lookup nor
+                // outlive the one it belongs to.
+                var wanted = string.Equals(query, _pendingSelectedFor, StringComparison.Ordinal)
+                    ? _pendingSelectedHeadword
+                    : null;
                 _pendingSelectedHeadword = null;
+                _pendingSelectedFor = null;
 
                 SelectedWord = ChooseSelection(wanted, Words);
             });
@@ -410,11 +432,40 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         if (words.Count == 0) return null;
         if (string.IsNullOrEmpty(wantedHeadword)) return words[0];
 
-        var wanted = Any2Ipe.Convert(wantedHeadword.ToLowerInvariant());
+        var wanted = MatchKey(wantedHeadword);
         return words.FirstOrDefault(
-                   w => string.Equals(
-                       Any2Ipe.Convert(w.DisplayWord.ToLowerInvariant()), wanted, StringComparison.Ordinal))
+                   w => string.Equals(MatchKey(w.DisplayWord), wanted, StringComparison.Ordinal))
                ?? words[0];
+    }
+
+    /// <summary>
+    /// The comparison key for a displayed headword. (#935, fable review)
+    ///
+    /// <para><b>Digits are folded to ASCII, and that is the whole reason this is not a bare
+    /// <c>Any2Ipe.Convert</c>.</b> DPPN distinguishes its homographs by NUMBER - "Nālandā 1", "Nālandā 2",
+    /// "Nālandāsutta 1" - which is exactly the case #935 was filed about. The display pipeline converts
+    /// those digits into the reading script, and IPE carries a Devanāgarī digit through unchanged while a
+    /// Latin one stays ASCII. Measured: the key differs in 11 of the 14 scripts, so a reader who selected
+    /// "Nālandāsutta 1" in Devanāgarī and reopened in Latin silently got the first match instead.</para>
+    ///
+    /// <para>And the miss was not merely transient: the new selection is written straight back to state, so
+    /// a failed match REPLACED the remembered one for good.</para>
+    ///
+    /// <para>Folding by numeric value rather than by codepoint range, so this holds for any script whose
+    /// digits the converters learn to emit later.</para>
+    /// </summary>
+    private static string MatchKey(string headword)
+    {
+        var folded = string.Create(headword.Length, headword, static (span, source) =>
+        {
+            for (int i = 0; i < source.Length; i++)
+            {
+                int digit = CharUnicodeInfo.GetDecimalDigitValue(source[i]);
+                span[i] = digit >= 0 ? (char)('0' + digit) : source[i];
+            }
+        });
+
+        return Any2Ipe.Convert(folded.ToLowerInvariant());
     }
 
     private void UpdateMeaning()

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -53,6 +53,18 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
     private DictionaryEntryViewModel? _selectedWord;
     private string _meaningDocumentHtml = "";
     private string _attribution = "";
+    /// <summary>
+    /// A headword the next completed lookup should select instead of auto-selecting the first match, then
+    /// forget. (#935)
+    ///
+    /// <para>One-shot because the restore has to BEAT the auto-select, not race it: <c>ApplyState</c> sets
+    /// <see cref="SearchText"/>, which schedules a throttled lookup, and that lookup's completion is what
+    /// assigns <see cref="SelectedWord"/>. Assigning it from <c>ApplyState</c> would simply be overwritten.
+    /// Consumed by the operation that would otherwise clobber it - the same shape as #919's tool-tab
+    /// restore - so a later lookup the reader actually asks for is never hijacked.</para>
+    /// </summary>
+    private string? _pendingSelectedHeadword;
+
     private bool _canGoBack;
     private bool _canGoForward;
 
@@ -107,6 +119,17 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         // Rebuild the meaning display whenever the selected headword changes.
         this.WhenAnyValue(x => x.SelectedWord)
             .Subscribe(_ => UpdateMeaning())
+            .DisposeWith(_disposables);
+
+        // Remember WHICH match was selected, not just the search text (#935). Skip(1) ignores the
+        // construction-time null; MarkDirty defers the write to the timer/shutdown save (STATE-2).
+        this.WhenAnyValue(x => x.SelectedWord)
+            .Skip(1)
+            .Subscribe(word =>
+            {
+                _stateService.Current.DictionaryDialog.SelectedHeadword = word?.DisplayWord ?? string.Empty;
+                _stateService.MarkDirty();
+            })
             .DisposeWith(_disposables);
 
         // Per-source attribution line, refreshed when the source changes (initial value included — no Skip).
@@ -218,6 +241,11 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
             ?? Sources.FirstOrDefault();
         if (restored != null)
             SelectedSource = restored;
+
+        // Armed BEFORE SearchText, because assigning that is what schedules the lookup whose completion
+        // consumes it. (#935)
+        var savedWord = _stateService.Current.DictionaryDialog.SelectedHeadword;
+        _pendingSelectedHeadword = string.IsNullOrEmpty(savedWord) ? null : savedWord;
 
         // #91: restore the last looked-up word too (the parallel to the Search pane's #87 term restore).
         // Setting SearchText triggers the throttled lookup, so the last definition reappears on launch.
@@ -346,14 +374,47 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
                 foreach (var e in results)
                     Words.Add(new DictionaryEntryViewModel(e));
 
-                // Auto-select the best (first) match so the definition shows immediately, like CST4.
-                SelectedWord = Words.FirstOrDefault();
+                // Auto-select the best (first) match so the definition shows immediately, like CST4 - unless
+                // a restore asked for a particular one (#935). Consumed either way, so only the first lookup
+                // after ApplyState can be steered.
+                var wanted = _pendingSelectedHeadword;
+                _pendingSelectedHeadword = null;
+
+                SelectedWord = ChooseSelection(wanted, Words);
             });
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Dictionary lookup failed for '{Query}' ({Source})", query, source?.Id);
         }
+    }
+
+    /// <summary>
+    /// Which entry a completed lookup should select: the remembered headword when the results still contain
+    /// it, otherwise the first match. (#935)
+    ///
+    /// <para>The fallback is not a failure mode - it is exactly what a lookup did before this existed, and
+    /// it is reached whenever a source has been updated between sessions or the matcher has changed (#933
+    /// changed it once already).</para>
+    ///
+    /// <para>Compared through IPE rather than as text, because a headword is rendered in whichever script
+    /// was current when it was saved. A reader who switches script between sessions would otherwise never
+    /// match their own selection.</para>
+    ///
+    /// <para>Static and free of view-model state so the decision is testable; the caller owns the one-shot
+    /// bookkeeping that makes it apply to a restore only.</para>
+    /// </summary>
+    internal static DictionaryEntryViewModel? ChooseSelection(
+        string? wantedHeadword, IReadOnlyList<DictionaryEntryViewModel> words)
+    {
+        if (words.Count == 0) return null;
+        if (string.IsNullOrEmpty(wantedHeadword)) return words[0];
+
+        var wanted = Any2Ipe.Convert(wantedHeadword.ToLowerInvariant());
+        return words.FirstOrDefault(
+                   w => string.Equals(
+                       Any2Ipe.Convert(w.DisplayWord.ToLowerInvariant()), wanted, StringComparison.Ordinal))
+               ?? words[0];
     }
 
     private void UpdateMeaning()


### PR DESCRIPTION
Fixes #935.

The pane restored its search text and its source but not **which** of several matching headwords was chosen, so a reader who had picked the third of four came back to the first. `nālanda` in DPPN matches four.

## The field existed and was wired to nothing

`DictionaryDialogState.SelectedWordIndex` declared the intent — never written, never read, serialized as `0` since it was added. **Replaced rather than connected**, per the issue's own reasoning: the list is recomputed by a lookup at restore, against a dictionary that can be updated between sessions and a matcher that **#933 changed two commits ago**. A position is only correct while the list happens to be identical; a headword survives both.

## The restore has to beat the auto-select, not race it

`ApplyState` assigns `SearchText`, which schedules the throttled lookup, and *that lookup's completion* is what assigns `SelectedWord`. Assigning it from `ApplyState` would simply be overwritten.

So a one-shot field is armed **before** `SearchText` and consumed by the operation that would otherwise clobber it — the same shape as #919's tool-tab restore. Consumed either way, so only the first lookup after a restore can be steered and a later lookup the reader actually asks for is never hijacked.

## Compared through IPE

A headword is rendered in whichever script was current when it was saved. A reader who switches script between sessions would otherwise never match their own selection.

## Tests, and what is honestly not covered

The decision is extracted as a static taking the wanted headword and the results, so it is testable. **The one-shot bookkeeping around it is not** — it needs a dock layout and a live throttled lookup, which no unit test has. Five tests cover the decision.

Both positive tests deliberately place the wanted entry **away from first**: with it first, the auto-select produces the same answer and the test passes without any matching happening at all. Mutation testing caught exactly that in a draft — the script-change test passed under a mutation that ignored the remembered headword entirely, because its expected answer was also `words[0]`.

**Mutation-tested:** replacing the body with the old auto-select fails both positive tests and neither of the guards.

Falling back to the first match when the headword is gone is not a failure mode — it is what the pane did before any of this existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)