### PR TITLE
Close Settings on Escape, like Go To and About

### DIFF
--- a/src/CST.Avalonia/Views/AiProvidersView.axaml.cs
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml.cs
@@ -1,5 +1,9 @@
+using System;
 using System.ComponentModel;
+using System.Reactive;
+using System.Reactive.Linq;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.VisualTree;
@@ -22,6 +26,40 @@ namespace CST.Avalonia.Views
         }
 
         private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+        /// <summary>
+        /// Escape cancels the connection sheet, and only then is allowed to reach the Settings window.
+        /// (#943, fable review)
+        ///
+        /// <para><b>The sheet is the one place in Settings that is NOT applied as you type.</b> Everything
+        /// else pushes straight through to the settings service; this is a draft, committed only by
+        /// <c>Save</c> - which is where <c>StoreKey</c> files the API key
+        /// (<c>AiConnectionEditorViewModel.Save</c>). The key box is focused the moment the sheet opens,
+        /// because pasting a key is the only reason it is open, so "focus in a TextBox with uncommitted
+        /// work" is the NORMAL state here rather than an edge case. Escape closing the whole window from
+        /// there would discard the pasted key silently.</para>
+        ///
+        /// <para><b>Why here rather than on the window, and why not <c>IsCancel</c>.</b> A bubbling key
+        /// event reaches this view before the window, so handling it here settles the innermost context
+        /// first - Escape cancels the sheet, a second Escape closes Settings, which is what the reader who
+        /// asked for this expects from VS Code. <c>IsCancel="True"</c> on the sheet's Cancel button would
+        /// NOT work: Avalonia runs class handlers before instance handlers at each element, and
+        /// <c>IsCancel</c> is an instance handler on the window root, so the window's own
+        /// <c>OnKeyDown</c> would close Settings first.</para>
+        /// </summary>
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            base.OnKeyDown(e);
+
+            if (e.Handled || e.Key != Key.Escape) return;
+            if (DataContext is not AiConnectionsViewModel { IsEditing: true } vm) return;
+
+            var cancel = vm.Editor?.CancelCommand;
+            if (cancel is null) return;
+
+            e.Handled = true;
+            cancel.Execute().Subscribe();
+        }
 
         private void OnDataContextChanged(object? sender, System.EventArgs e)
         {

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml.cs
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using CST.Avalonia.Models;
@@ -21,6 +22,39 @@ namespace CST.Avalonia.Views
         public SettingsWindow()
         {
             InitializeComponent();
+        }
+
+        /// <summary>
+        /// Escape closes Settings, the way it already closes Go To and About. (#943)
+        ///
+        /// <para><b>Close, not cancel.</b> The other two windows get this from <c>IsCancel="True"</c> on a
+        /// button, which in Avalonia means only "Escape triggers this". That is honest for them - they are
+        /// confirm-or-cancel dialogs. Settings applies every change as it is made and has nothing to revert,
+        /// so a hidden cancel button here would read as an abandon-changes affordance that does not exist.
+        /// An explicit handler says what actually happens.</para>
+        ///
+        /// <para><b>Why nothing checks for an open dropdown.</b> Escape reaches this only if no child took
+        /// it: a routed event stops bubbling once it is handled, and a ComboBox with its list open handles
+        /// Escape to close the list. So the "do not close while a control is using Escape" requirement is
+        /// satisfied by the routing rather than by a test here, and a control that starts handling Escape
+        /// later is covered automatically.</para>
+        ///
+        /// <para><b>A TextBox is the open question.</b> Avalonia's TextBox is not expected to handle Escape,
+        /// so Escape while editing one should close the window - which is defensible here, because the edit
+        /// is already applied and this window has no commit step. NOT VERIFIED in the running app: Avalonia
+        /// does not publish its windows through the macOS Accessibility API, so the keystroke could not be
+        /// driven into the window from a script. Worth a human trying it in a text field and with a
+        /// dropdown open.</para>
+        /// </summary>
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            base.OnKeyDown(e);
+
+            if (!e.Handled && e.Key == Key.Escape)
+            {
+                e.Handled = true;
+                Close();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #943.

**[fsnow]** — *"Escape key to close Settings. I tested VS Code and it does this."*

Settings was the one window without it, and the one a reader spends longest in. It has no Close button of its own either, so the window control was the only way out.

## Close, not cancel

Go To and About get this from `IsCancel="True"` on a button, which in Avalonia means only *"Escape triggers this"*. That is honest for them — they are confirm-or-cancel dialogs. **Settings applies every change as it is made and has nothing to revert**, so a hidden cancel button here would advertise an abandon-changes affordance that does not exist. An explicit `OnKeyDown` override says what actually happens.

## Nothing checks for an open dropdown, deliberately

A routed event stops bubbling once handled, and a `ComboBox` with its list open handles Escape to close the list. So `OnKeyDown` is reached only when no child wanted the key — the "don't close while a control is using Escape" requirement is satisfied by the routing rather than by a list of special cases here, and a control that starts handling Escape later is covered automatically.

## ⚠️ Not verified in the running app

I tried. Avalonia does not publish its windows through the macOS Accessibility API — `System Events` reports **zero windows** for a running instance — so the keystroke could not be driven into the window from a script, and the app has no other automation seam.

**The TextBox case is reasoned, not observed.** Avalonia's `TextBox` is not expected to handle Escape, so Escape while editing one should close the window; that is defensible here because the edit is already applied and this window has no commit step. But the issue explicitly asked for that case to be checked, and I could not check it.

**Worth thirty seconds by hand before merging:** Escape with a dropdown open (should close the dropdown, not the window), and Escape while editing a text field (expected to close the window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)