### PR TITLE
Fold ḷ/l in the class DPPN is actually read through

### DIFF
--- a/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
+++ b/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
@@ -41,6 +41,78 @@ namespace CST.Avalonia.Tests.Lexicon
             return LexiconReader.Open(path);
         }
 
+        // ---- ḷ/l folding on a miss (#933) ----
+
+        /// <summary>
+        /// The reported case, through the class DPPN is actually read with.
+        ///
+        /// <para>DPPN follows Malalasekera's PTS spelling (plain l); the corpus spells the same name with ḷ
+        /// in 102 of its 126 occurrences, so four clicks in five missed. The query is the INFLECTED
+        /// <c>nāḷandaṃ</c>, which has no entry — it can only be reached through the near-neighbour guess,
+        /// and the decoys are the real neighbours: <c>nāḷandaṃ</c> shares "nāḷ" with Nāḷika but "nāland"
+        /// with Nālandā once folded.</para>
+        ///
+        /// <para>This test exists because the first fix for #933 was applied to <c>DictionaryIndex</c>,
+        /// which serves only the flat-file dictionaries. It passed its own tests and left DPPN — the
+        /// dictionary in the report — exactly as broken as before.</para>
+        /// </summary>
+        [Fact]
+        public void An_inflected_query_crosses_the_l_spelling_difference()
+        {
+            var lex = Build(
+                new RawEntry("N\u0101\u1E37ika", "<p>A measure.</p>"),
+                new RawEntry("N\u0101\u1E37ikera", "<p>A coconut.</p>"),
+                new RawEntry("N\u0101land\u0101 1", "<p>A town.</p>"),
+                new RawEntry("N\u0101land\u0101sutta 1", "<p>A discourse.</p>"));
+
+            var hits = lex.Lookup("n\u0101\u1E37anda\u1E43");
+
+            Assert.Equal(
+                new[] { "N\u0101land\u0101 1", "N\u0101land\u0101sutta 1" },
+                hits.Select(h => h.Headword).ToArray());
+        }
+
+        /// <summary>An exact spelling wins every tie, so a word genuinely spelled with ḷ finds itself rather
+        /// than being dragged to a plain-l neighbour. Folding can only lengthen a common prefix, never
+        /// shorten one, which is why "strictly further" is the right test.</summary>
+        [Fact]
+        public void A_word_really_spelled_with_retroflex_l_still_finds_itself()
+        {
+            var lex = Build(
+                new RawEntry("N\u0101\u1E37ika", "<p>A measure.</p>"),
+                new RawEntry("N\u0101land\u0101 1", "<p>A town.</p>"));
+
+            Assert.Equal(new[] { "N\u0101\u1E37ika" },
+                lex.Lookup("n\u0101\u1E37ika").Select(h => h.Headword).ToArray());
+        }
+
+        /// <summary>
+        /// The fold must be decided before <paramref name="max"/> truncates anything.
+        ///
+        /// <para>Both near-neighbour arms return as soon as the bound is reached, so a fold applied after
+        /// them is skipped for exactly the queries whose unfolded guess is already crowded. Found by probing
+        /// the real dictionary at max=6, where <c>upāḷinā</c> filled the bound with unrelated
+        /// <c>upādāna…</c> entries and never reached the fold.</para>
+        /// </summary>
+        [Fact]
+        public void The_bound_does_not_suppress_the_fold()
+        {
+            var lex = Build(
+                new RawEntry("Up\u0101d\u0101nasutta 1", "<p>A discourse.</p>"),
+                new RawEntry("Up\u0101d\u0101nasutta 2", "<p>A discourse.</p>"),
+                new RawEntry("Up\u0101li 1", "<p>An elder.</p>"),
+                new RawEntry("Up\u0101lig\u0101th\u0101", "<p>Verses.</p>"));
+
+            // Unfolded, the two upādāna entries tie at "upā" and would fill a bound of 2 on their own. Both
+            // Upāli entries tie at "upāli" once folded, so the bound admits exactly those two - the point
+            // being that the fold decided the run at all, not which of its members survived the bound.
+            var hits = lex.Lookup("up\u0101\u1E37in\u0101", max: 2);
+
+            Assert.Equal(
+                new[] { "Up\u0101li 1", "Up\u0101lig\u0101th\u0101" },
+                hits.Select(h => h.Headword).ToArray());
+        }
+
         // ---- key derivation ----
 
         [Fact]

--- a/src/CST.Avalonia/Services/DictionaryIndex.cs
+++ b/src/CST.Avalonia/Services/DictionaryIndex.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using CST.Avalonia.Models;
+using CST.Lexicon;
 
 namespace CST.Avalonia.Services;
 
@@ -35,7 +36,14 @@ public sealed class DictionaryIndex
         _words.Sort(DictionaryWordComparer.Instance);
 
         _lFolded = _words.Select(w => (Key: FoldL(w.Word), Word: w)).ToList();
-        _lFolded.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
+        // Tiebreak on the UNFOLDED headword: List.Sort is unstable, and real folding pairs exist (Koḷa/Kola,
+        // Nāḷika/Nālika), so without this the order of a mixed run - and therefore which entry the pane
+        // auto-selects - would depend on build order. (fable review)
+        _lFolded.Sort((a, b) =>
+        {
+            int byKey = string.CompareOrdinal(a.Key, b.Key);
+            return byKey != 0 ? byKey : string.CompareOrdinal(a.Word.Word, b.Word.Word);
+        });
     }
 
     /// <summary>
@@ -50,7 +58,7 @@ public sealed class DictionaryIndex
     /// <para>Applied to the query and to the index key alike, so it works in both directions: a query
     /// spelled with <c>ḷ</c> reaches an <c>l</c> headword and the reverse.</para>
     /// </summary>
-    internal static string FoldL(string ipe) => ipe.Replace('\u00E9', '\u00E5');
+    internal static string FoldL(string ipe) => LexiconKey.FoldRetroflexL(ipe);
 
     public int Count => _words.Count;
 

--- a/src/CST.Lexicon/LexiconKey.cs
+++ b/src/CST.Lexicon/LexiconKey.cs
@@ -73,5 +73,21 @@ namespace CST.Lexicon
             string.IsNullOrEmpty(query)
                 ? string.Empty
                 : Any2Ipe.Convert(StripJoiners(query).ToLowerInvariant().Normalize(NormalizationForm.FormC));
+
+        /// <summary>
+        /// IPE <c>ḷ</c> (U+00E9) read as <c>l</c> (U+00E5), for MATCHING ONLY. (#933)
+        ///
+        /// <para><b>Not a claim that they are the same letter.</b> They are distinct phonemes in Pāli. What
+        /// this reconciles is two editorial traditions: DPPN follows Malalasekera's PTS spelling while the
+        /// corpus and DPD follow the Burmese/CST one, and the corpus itself disagrees - नाळन्द… occurs 102
+        /// times against नालन्द…'s 24. Applied to a query and to a key alike, so it works in both
+        /// directions.</para>
+        ///
+        /// <para>Lives here, beside <see cref="DeriveKey"/>, because two lookups need it - this library's
+        /// <c>LexiconReader</c> and the flat-file <c>DictionaryIndex</c> - and a rule about WHICH codepoints
+        /// fold is exactly the kind that drifts once it is written down twice. There is no combined ḷh
+        /// codepoint in IPE, so a single-character replacement covers ḷh as well.</para>
+        /// </summary>
+        public static string FoldRetroflexL(string ipe) => ipe.Replace('\u00E9', '\u00E5');
     }
 }

--- a/src/CST.Lexicon/LexiconReader.cs
+++ b/src/CST.Lexicon/LexiconReader.cs
@@ -115,6 +115,24 @@ namespace CST.Lexicon
             int commonBehind = lo - 1 >= 0 ? CommonPrefix(queryKey, _entries[lo - 1].IpeKey) : 0;
             int commonAhead = lo < _entries.Length ? CommonPrefix(queryKey, _entries[lo].IpeKey) : 0;
 
+            // The same guess with ḷ and l read alike, taken only when it reaches STRICTLY further into the
+            // word. (#933)
+            //
+            // This is the arm that matters: the query that fails is an inflected form with no entry at all.
+            // nāḷandaṃ shares "nāḷ" (3) with Nāḷika but "nāland" (6) with Nālandā once folded, so DPPN sent
+            // the reader to Nāḷika. An earlier attempt folded only the EXACT arm, and in DictionaryIndex -
+            // which is not the class DPPN is read through - so it changed nothing here.
+            //
+            // Decided BEFORE the runs are collected: both arms below return early once `max` is reached, so
+            // a fold placed after them is skipped for exactly the queries whose unfolded guess is already
+            // crowded. Found by probing the real dictionary at max=6, where upāḷinā filled the bound with
+            // unrelated upādāna… entries and never reached the fold.
+            //
+            // Strictly greater, so an exact spelling wins every tie: folding can only lengthen a common
+            // prefix, so nothing that resolves today is diverted.
+            var folded = FoldedGuess(queryKey, Math.Max(commonBehind, commonAhead), max);
+            if (folded is not null) return folded;
+
             if (commonBehind >= commonAhead && commonBehind > 0)
             {
                 var stack = new Stack<LexiconEntry>();
@@ -141,6 +159,44 @@ namespace CST.Lexicon
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// The best ḷ/l-folded run, or null when folding gets no closer than <paramref name="unfoldedBest"/>.
+        /// (#933)
+        ///
+        /// <para>Scans rather than binary-searches: the question is how far into the word the closest entry
+        /// agrees, which an insertion point does not answer, and the folded order is not the stored order.
+        /// Runs only after an exact lookup has already missed.</para>
+        ///
+        /// <para>Ties break on the unfolded key, so a run mixing both spellings is ordered predictably - the
+        /// caller shows the first entry, and DPPN really does hold folding pairs (Koḷa/Kola,
+        /// Nāḷika/Nālika).</para>
+        /// </summary>
+        private IReadOnlyList<LexiconEntry>? FoldedGuess(string queryKey, int unfoldedBest, int max)
+        {
+            var key = LexiconKey.FoldRetroflexL(queryKey);
+
+            int best = 0;
+            for (int i = 0; i < _entries.Length; i++)
+            {
+                int common = CommonPrefix(key, LexiconKey.FoldRetroflexL(_entries[i].IpeKey));
+                if (common > best) best = common;
+            }
+
+            if (best <= unfoldedBest) return null;
+
+            var hits = new List<LexiconEntry>();
+            for (int i = 0; i < _entries.Length; i++)
+            {
+                if (CommonPrefix(key, LexiconKey.FoldRetroflexL(_entries[i].IpeKey)) == best)
+                    hits.Add(_entries[i]);
+            }
+
+            hits.Sort((a, b) => string.CompareOrdinal(a.IpeKey, b.IpeKey));
+
+            if (max > 0 && hits.Count > max) hits.RemoveRange(max, hits.Count - max);
+            return hits;
         }
 
         private static bool Reached(List<LexiconEntry> r, int max) => max > 0 && r.Count >= max;


### PR DESCRIPTION
Follow-up to #948, which fixed #933 in the wrong class. **The reported bug is still live on `main`.**

## What #948 missed

`dppn` is a **reserved id** owned by `SqliteDictionarySource` (`DictionarySourceFactory.cs:17-18, 33`), which reads through `LexiconReader.LookupByKey` — a separate copy of the same near-neighbour guess, its own comment reading *"Ported from DictionaryIndex"*. `DictionaryIndex`, where #948 put the fold, serves only the flat-file dictionaries (vri-childers, vri-hindi).

So the merged fix does real work — vri-childers has 175 `ḷ` headwords — but not for the dictionary in the report.

**Found by a Fable review.** My own before/after measurement did not catch it because the probe loaded `dppn.db`'s rows into a `DictionaryIndex` by hand: the wrong harness, wrong in the same direction as the fix, so it agreed with itself. That is the second time on this issue that a green measurement was measuring the wrong thing.

## Verified through the real path this time

`LexiconReader.Open(dppn.db).Lookup(…)` against the installed dictionary:

| query | before | after |
|---|---|---|
| `nāḷandaṃ` | `Nāḷika \| Nāḷikīra \| Nāḷikera \| Nāḷisobbha` | **`Nālandā 1 \| Nālandā 2 \| Nālandāsutta 1 \| Nālandāsutta 2`** |
| `upāḷinā` | `Upāgatabhāsaniya \| Upādāna…` | **`Upāli 1 \| … \| Upāligāthā`** |
| `nāḷika` | `Nāḷika` | unchanged — exact spelling wins |
| `nālandā` | `Nālandā 1 \| 2 \| …` | unchanged |

## A bug my own probe caught, that the review did not

The fold decision now happens **before** the runs are collected. Both arms here `return` as soon as `max` is reached, so a fold placed after them is skipped for exactly the queries whose unfolded guess is already crowded. Probing at `max: 6` found it — `upāḷinā` filled the bound with unrelated `upādāna…` entries and never reached the fold. `DictionaryIndex` has no `max`, so its version never had to think about this.

## Also from the review

- **`FoldRetroflexL` moves to `LexiconKey`**, beside `DeriveKey`, and `DictionaryIndex` calls it. Which codepoints fold is precisely the rule that drifts once two lookups each own a copy — which is how this bug happened.
- **`_lFolded`'s sort gets a real tiebreaker** on the unfolded headword. `List.Sort` is unstable and DPPN holds genuine folding pairs (`Koḷa`/`Kola`, `Nāḷika`/`Nālika`), so which entry the pane auto-selected from a mixed run depended on build order.

## Tests

Three at the lexicon layer — the inflected query with the real decoys, the exact-spelling guard, and the `max` case. **Reverting `LexiconReader` fails exactly two of them.** Full suite: **2780 passed, 0 failed, 18 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)