### PR TITLE
Ask the parsed logo, not its text, whether it fetches

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiLogoImagesTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiLogoImagesTests.cs
@@ -71,12 +71,79 @@ public class AiLogoImagesTests : IDisposable
     /// icon has no business reaching the network at draw time.</summary>
     [Theory]
     [InlineData("""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><image href="https://evil.example/x.png"/></svg>""")]
-    [InlineData("""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><image xlink:href="http://evil.example/x.png"/></svg>""")]
+    // Declares xmlns:xlink, as every real file using the prefix does. Without the declaration this is not
+    // well-formed XML at all, and is refused for that reason instead — covered separately below.
+    [InlineData("""<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 10 10"><image xlink:href="http://evil.example/x.png"/></svg>""")]
     [InlineData("""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><image href="file:///etc/passwd"/></svg>""")]
     [InlineData("""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path fill="url(https://evil.example/g)" d="M0,0H1"/></svg>""")]
     public void A_document_reaching_off_the_machine_is_refused(string svg)
     {
         Assert.Equal("references a remote resource", AiLogoImages.Screen(Write("remote.svg", svg)));
+    }
+
+    /// <summary>The bypass that shipped in c1fbb7a. (#930, fable review)
+    ///
+    /// <para>A <c>&lt;!--</c> inside one CDATA section and a <c>--&gt;</c> inside another let the
+    /// comment-stripping regex delete everything between them — including a live remote
+    /// <c>&lt;image&gt;</c> — so the file was ACCEPTED. The XML parser reads CDATA as literal text, so the
+    /// element is real and the renderer fetches it, synchronously, on the UI thread. Confirmed with a
+    /// loopback listener before this was fixed.</para></summary>
+    [Fact]
+    public void A_remote_image_hidden_between_two_CDATA_sections_is_still_refused()
+    {
+        var path = Write("cdata.svg", """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><desc><![CDATA[<!--]]></desc><image href="https://evil.example/x.png" width="10" height="10"/><desc><![CDATA[-->]]></desc></svg>
+            """);
+
+        Assert.Equal("references a remote resource", AiLogoImages.Screen(path));
+    }
+
+    /// <summary>A character reference spells the same URL without the letters being contiguous anywhere in
+    /// the file. No raw-text search can see it; the parser resolves it before we look. (#930)</summary>
+    [Fact]
+    public void A_remote_url_written_as_character_references_is_still_refused()
+    {
+        var path = Write("charref.svg", """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><image href="&#104;ttp://evil.example/x.png" width="10" height="10"/></svg>
+            """);
+
+        Assert.Equal("references a remote resource", AiLogoImages.Screen(path));
+    }
+
+    /// <summary>CSS inside &lt;style&gt; fetches like any other reference, and it is text rather than an
+    /// attribute.</summary>
+    [Fact]
+    public void A_remote_url_in_a_style_block_is_refused()
+    {
+        var path = Write("style.svg", """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><style>.a { fill: url(https://evil.example/g); }</style><path class="a" d="M0,0H1"/></svg>
+            """);
+
+        Assert.Equal("references a remote resource", AiLogoImages.Screen(path));
+    }
+
+    /// <summary>Text that is NOT style must stay readable — a description mentioning a project's home page
+    /// is the false-positive class this whole issue was about.</summary>
+    [Fact]
+    public void A_web_address_in_a_description_is_not_a_remote_reference()
+    {
+        var path = Write("desc.svg", """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><desc>See https://example.com/about</desc><path d="M0,0H1"/></svg>
+            """);
+
+        Assert.Null(AiLogoImages.Screen(path));
+    }
+
+    /// <summary>A file the parser cannot read is refused rather than guessed at: its fetches cannot be
+    /// enumerated, and a logo is decoration — the monogram is the honest answer.</summary>
+    [Fact]
+    public void A_file_that_is_not_well_formed_is_refused()
+    {
+        var path = Write("broken.svg", """
+            <svg xmlns="http://www.w3.org/2000/svg"><image xlink:href="http://evil.example/x.png"/></svg>
+            """);
+
+        Assert.Equal("is not well-formed XML", AiLogoImages.Screen(path));
     }
 
     /// <summary>The SVG 1.1 doctype names a w3.org DTD. The renderer does not resolve it, and refusing over

--- a/src/CST.Avalonia/Services/Ai/AiLogoImages.cs
+++ b/src/CST.Avalonia/Services/Ai/AiLogoImages.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Xml;
 using Avalonia.Media;
 using Avalonia.Svg.Skia;
 using Avalonia.Threading;
@@ -50,34 +52,10 @@ namespace CST.Avalonia.Services.Ai
         internal const int MaxBytes = 256 * 1024;
 
         /// <summary>
-        /// Any absolute URL, once the parts of the file that can hold URL-shaped text WITHOUT causing a fetch
-        /// are removed.
+        /// An absolute URL in a scheme the renderer would go to the network for.
         /// </summary>
         private static readonly Regex ExternalReference =
             new(@"\b(?:https?|ftp|file)://", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-        private static readonly Regex NamespaceDeclaration =
-            new(@"xmlns(:[\w-]+)?\s*=\s*""[^""]*""", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-        /// <summary>
-        /// An XML comment. Generators write their own home page into one - Inkscape does, which is how
-        /// <c>regolo-ai.svg</c> came to be refused (#930). A comment is not drawn and cannot cause a fetch.
-        /// </summary>
-        private static readonly Regex Comment =
-            new(@"<!--.*?-->", RegexOptions.Compiled | RegexOptions.Singleline);
-
-        /// <summary>
-        /// A doctype declaration. Its system identifier is a w3.org URL in every SVG 1.1 file that carries
-        /// one - <c>hpc-ai.svg</c> is the live case (#930). The renderer does not resolve it.
-        ///
-        /// <para>The optional internal subset is matched so that a <c>]&gt;</c> inside it cannot end the match
-        /// early and leave the tail behind. Stripping it loses nothing: <see cref="Screen"/> tests for
-        /// <c>&lt;!ENTITY</c> against the RAW text first, precisely because that is where an entity bomb
-        /// lives.</para>
-        /// </summary>
-        private static readonly Regex Doctype =
-            new(@"<!DOCTYPE[^\[>]*(\[[\s\S]*?\])?[^>]*>",
-                RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Keyed by file AND colour: the same mark is a different image in light and dark, and a reader can
@@ -169,27 +147,84 @@ namespace CST.Avalonia.Services.Ai
 
             var text = File.ReadAllText(path);
 
+            // Raw-text pre-filter, and the only one. An entity bomb has to be refused before anything tries
+            // to read the document, and XML's <!ENTITY is a lexical token that cannot be split or encoded.
             if (text.Contains("<!ENTITY", StringComparison.OrdinalIgnoreCase))
                 return "declares XML entities";
 
-            // Three kinds of URL-shaped text are not references to anything the renderer will fetch, and all
-            // three have to come out before asking the question: the SVG namespace is itself an http URL, a
-            // doctype's system identifier is a w3.org URL, and a generator stamps its home page into a
-            // comment. Measured over the 173-logo cache, the last two were the ONLY refusals, and both were
-            // wrong (#930).
+            // Everything else is asked of the PARSED document, not of the text. (#930, fable review)
             //
-            // Order matters: this runs after the <!ENTITY test above, which reads the raw text.
-            var content = Doctype.Replace(text, string.Empty);
-            content = Comment.Replace(content, string.Empty);
-            content = NamespaceDeclaration.Replace(content, string.Empty);
+            // Reading the text was the original mistake and it survived one fix. A search over raw text sees
+            // a different document than the renderer does, and every place the two disagree is a hole. The
+            // one that shipped: a <!-- inside one CDATA section and a --> inside another let the
+            // comment-stripping regex delete a live <image href="https://…"> between them, so the file was
+            // ACCEPTED and the renderer - which reads CDATA as literal text, leaving the element real -
+            // fetched it synchronously on the UI thread. Verified with a loopback listener.
+            //
+            // Parsing also closes a hole neither text approach could: the reader resolves character
+            // references, so href="&#104;ttp://…" is seen as the URL it is.
+            //
+            // Still no render backend, so this remains directly testable.
+            try
+            {
+                var settings = new XmlReaderSettings
+                {
+                    // Ignore, not Prohibit: a standard SVG 1.1 doctype is ordinary and must still parse -
+                    // refusing it is the bug this whole thread is about. Ignoring skips the DTD without
+                    // expanding anything, and the resolver is null so no system identifier is ever fetched.
+                    DtdProcessing = DtdProcessing.Ignore,
+                    XmlResolver = null,
+                    IgnoreComments = true,
+                    IgnoreWhitespace = true,
+                    IgnoreProcessingInstructions = true,
+                };
 
-            // Still a bare scheme search over what is left, deliberately. The narrower rule - a remote scheme
-            // inside an href/xlink:href/src value - was the other way to fix this, and it is the wrong trade
-            // HERE: a false positive costs a monogram, which is what a missing logo has always shown, while a
-            // false negative is a synchronous network fetch on the UI thread. Over-refusing is the cheap
-            // failure, so only text that provably cannot cause a fetch is removed.
-            if (ExternalReference.IsMatch(content))
-                return "references a remote resource";
+                using var reader = XmlReader.Create(new StringReader(text), settings);
+                var inStyle = false;
+                while (reader.Read())
+                {
+                    // <style> is the one place TEXT can fetch: CSS url() resolves like any other reference.
+                    // Other text - a <desc> that happens to mention a web page - cannot, and reading it
+                    // would put back a false positive of exactly the kind this issue was about.
+                    if (reader.NodeType == XmlNodeType.Element &&
+                        string.Equals(reader.LocalName, "style", StringComparison.OrdinalIgnoreCase))
+                        inStyle = !reader.IsEmptyElement;
+                    else if (reader.NodeType == XmlNodeType.EndElement &&
+                             string.Equals(reader.LocalName, "style", StringComparison.OrdinalIgnoreCase))
+                        inStyle = false;
+                    else if (inStyle &&
+                             reader.NodeType is XmlNodeType.Text or XmlNodeType.CDATA &&
+                             ExternalReference.IsMatch(reader.Value))
+                        return "references a remote resource";
+
+                    if (reader.NodeType != XmlNodeType.Element || !reader.HasAttributes) continue;
+
+                    while (reader.MoveToNextAttribute())
+                    {
+                        // A namespace declaration legitimately holds an http URL - the SVG namespace IS one -
+                        // and the renderer never fetches it. The ONLY exemption.
+                        if (string.Equals(reader.Prefix, "xmlns", StringComparison.Ordinal) ||
+                            string.Equals(reader.Name, "xmlns", StringComparison.Ordinal))
+                            continue;
+
+                        // Every other attribute value, rather than a list of the ones that fetch. href and
+                        // src are the obvious pair, but fill, stroke, filter, mask and clip-path all take
+                        // url(), and style takes CSS that can too. A list is a thing to be short by one -
+                        // and being short by one here is a network fetch on the UI thread, where being
+                        // over-broad is a monogram.
+                        if (ExternalReference.IsMatch(reader.Value))
+                            return "references a remote resource";
+                    }
+
+                    reader.MoveToElement();
+                }
+            }
+            catch (XmlException)
+            {
+                // Refuse what we cannot read. A file this cannot parse is one whose fetches cannot be
+                // enumerated, and a logo is decoration - the monogram is the honest answer.
+                return "is not well-formed XML";
+            }
 
             return null;
         }


### PR DESCRIPTION
Fixes a remote-fetch bypass **introduced by c1fbb7a** (the merged #930 fix), plus an older one it inherited.

## The regression I shipped

A `<!--` inside one CDATA section and a `-->` inside another let my comment-stripping regex delete everything between them — including a live `<image href="https://…">`. `Screen()` then **accepted** the file. The XML parser reads CDATA as literal text, so the element is real, and the renderer fetches it **synchronously on the UI thread** — the frozen window the guard exists to prevent.

Found by a Fable review, which confirmed an actual TCP connection with a loopback listener (its first probe hung, demonstrating the freeze). I reproduced it against the merged regexes before changing anything.

## The root cause is older than that commit

`Screen()` read **raw text** while the renderer reads a **parsed document**. Every place the two disagree is a hole. Stripping made this one exploitable, but no amount of stripping closes the class — the same review got through the *pre-c1fbb7a* code with `href="&#104;ttp://evil.example/x.png"`, which no text search can see.

## So the question is now asked of the document

`XmlReader` with `DtdProcessing.Ignore` and a null resolver — **Ignore, not Prohibit**, because a standard SVG 1.1 doctype is ordinary and must still parse, which is what #930 was about in the first place.

Comments, doctypes and CDATA stop being special cases: they are simply not attribute values. Character references resolve before we look.

**Every non-`xmlns` attribute value is tested**, not a list of the ones that fetch — `href` and `src` are the obvious pair, but `fill`, `stroke`, `filter`, `mask` and `clip-path` all take `url()`, and a list is a thing to be short by one. Short by one here is a network fetch on the UI thread; over-broad is a monogram. Plus text inside `<style>`, the one place text can fetch.

## On my reasoning in the merged commit

I argued a broad raw-text search was the conservative choice — false positive costs a monogram, false negative freezes the UI. **The conclusion was wrong**: the stripping that broad search required is exactly what produced a false negative. The review was right that the narrower rule dominated. Parsing gets both, and keeps the conservatism where it belongs.

## One fixture had to change, and why that is not moving the goalposts

The `xlink:href` `InlineData` never declared `xmlns:xlink`, so it is **not well-formed XML**. It is still refused — now as `"is not well-formed XML"` — and that rule now has its own test. Real files using the prefix declare it, so the fixture now does too.

## Tests

Six new: the CDATA bypass, the character-reference bypass, a `<style>` block, a `<desc>` mentioning a web page (**a false positive the raw search also had**), and the malformed case. **Reverting `Screen` fails four of them.**

Full suite: **2782 passed, 0 failed, 18 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)