### PR TITLE
Send a selection's daṇḍas to the model as periods

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/SelectionPipelineTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/SelectionPipelineTests.cs
@@ -47,6 +47,46 @@ public class SelectionPipelineTests
         Assert.Null(SelectionPipeline.Normalize(raw, Script.Latin));
     }
 
+    /// <summary>
+    /// A selection must not carry Devanāgarī punctuation into otherwise-Latin text. (#942)
+    ///
+    /// <para><b>[fsnow]</b>, running the Beta 6 runbook: <i>"I opened Apadanapali-1 and selected the third
+    /// verse. I see in the context the single danda and double danda in the Latin-script Pali, not semicolon
+    /// and period."</i></para>
+    ///
+    /// <para>Both marks flatten to a period. That loses the gāthā distinction the passage window keeps — a
+    /// single daṇḍa reads ";" there, because it ends a pada — and that is a deliberate call:
+    /// <i>"I am fine with both single and double danda being converted to period in this case. I don't think
+    /// it will materially affect the LLMs ability to understand the text."</i></para></summary>
+    [Theory]
+    [InlineData("gacchati\u0964", "gacchati.")]
+    [InlineData("gacchati\u0965", "gacchati.")]
+    [InlineData("eka\u0964 dve\u0965", "eka. dve.")]
+    public void A_danda_reaches_the_model_as_a_period(string raw, string expected)
+    {
+        Assert.Equal(expected, SelectionPipeline.Normalize(raw, Script.Latin));
+    }
+
+    /// <summary>
+    /// The reported path: reading in a non-Latin script, where the selection arrives as source text and only
+    /// its LETTERS were being converted.
+    ///
+    /// <para>This is why the check passes in Latin and fails everywhere else — a Latin reader's selection is
+    /// copied from what the reader itself rendered, through <c>ConvertBook</c>, which applies the
+    /// markup-driven daṇḍa rules.</para></summary>
+    [Fact]
+    public void A_selection_read_in_Devanagari_carries_no_Devanagari_punctuation()
+    {
+        // गच्छति। — "gacchati" followed by a single daṇḍa.
+        const string deva = "\u0917\u091A\u094D\u091B\u0924\u093F\u0964";
+
+        var normalized = SelectionPipeline.Normalize(deva, Script.Devanagari)!;
+
+        Assert.DoesNotContain('\u0964', normalized);
+        Assert.DoesNotContain('\u0965', normalized);
+        Assert.EndsWith(".", normalized);
+    }
+
     [Fact]
     public void Normalizing_is_idempotent()
     {

--- a/src/CST.Avalonia/Services/Ai/SelectionPipeline.cs
+++ b/src/CST.Avalonia/Services/Ai/SelectionPipeline.cs
@@ -43,6 +43,23 @@ public static class SelectionPipeline
 
         var latin = sourceScript == Script.Latin ? raw : ScriptConverter.Convert(raw, sourceScript, Script.Latin);
 
+        // Latin letters with Devanāgarī punctuation is not a script. (#942)
+        //
+        // ScriptConverter.Convert converts LETTERS; the daṇḍa rules are written against <p rend> and need
+        // markup a selection does not have. So a reader in Devanāgarī sent "।" and "॥" to the model inside
+        // otherwise-Latin text. This is the same fallback TeiText.Convert applies to passage text that has
+        // lost its tags, now shared rather than copied.
+        //
+        // ONLY reachable for a non-Latin reading script. A Latin reader's selection is copied from what the
+        // reader itself rendered, through ConvertBook, which does run the markup rules - so their gāthā
+        // already reads ";" and passes through here untouched.
+        //
+        // Both marks flatten to a period, which loses the gāthā distinction the window keeps. [fsnow] made
+        // that call: "I am fine with both single and double danda being converted to period in this case. I
+        // don't think it will materially affect the LLMs ability to understand the text. It's better than
+        // non-Latin punctuation coming through, which could potentially confuse."
+        latin = ScriptConverter.LatinizeDandas(latin);
+
         // Compose BEFORE collapsing whitespace: a combining mark is not whitespace, but normalizing after a
         // regex pass means the regex ran over a different string than the one that ships.
         latin = latin.Normalize(NormalizationForm.FormC);

--- a/src/CST.Core/Conversion/ScriptConverter.cs
+++ b/src/CST.Core/Conversion/ScriptConverter.cs
@@ -137,6 +137,23 @@ namespace CST.Conversion
             return str;
         }
 
+        /// <summary>
+        /// Latin text carrying no Devanāgarī sentence punctuation: both daṇḍas become a period. (#668, #942)
+        ///
+        /// <para><b>Only for text that arrives without its markup.</b> The daṇḍa rules proper are written
+        /// against <c>&lt;p rend&gt;</c> — <c>ConvertBook</c> runs them, and in a gāthā a single daṇḍa becomes
+        /// a semicolon because the distinction there is metrical. Bare text cannot know which paragraph it
+        /// came from, so this is the fallback both such callers share rather than a rule either owns.</para>
+        ///
+        /// <para><b>[fsnow]</b> settled flattening both marks rather than pursuing the alternative of cutting
+        /// the selection out of the rendered window: <i>"I am fine with both single and double danda being
+        /// converted to period in this case. I don't think it will materially affect the LLMs ability to
+        /// understand the text. It's better than non-Latin punctuation coming through, which could
+        /// potentially confuse."</i></para>
+        /// </summary>
+        public static string LatinizeDandas(string str) =>
+            str.Replace('\u0964', '.').Replace('\u0965', '.');
+
         public static string ToTitleCase(string str)
         {
             StringBuilder sb = new StringBuilder();

--- a/src/CST.Core/Search/TeiText.cs
+++ b/src/CST.Core/Search/TeiText.cs
@@ -43,7 +43,7 @@ namespace CST.Search
             // — see LatinStop. This is the fallback for the prose case and for any text that did not come
             // through Clean, so the two never disagree the way the two Latin paths once did. (#680)
             if (output == Script.Latin)
-                converted = converted.Replace("\u0964", ".").Replace("\u0965", ".");
+                converted = ScriptConverter.LatinizeDandas(converted);
 
             return converted;
         }


### PR DESCRIPTION
Fixes #942.

**[fsnow]**, running the Beta 6 runbook: *"I opened Apadanapali-1 and selected the third verse. I see in the context the single danda and double danda in the Latin-script Pali, not semicolon and period."*

## The defect

`SelectionPipeline.Normalize` was the one Latin path without #668's fix. `ScriptConverter.Convert` converts **letters**; the daṇḍa rules are written against `<p rend>` and need markup a bare selection does not have.

Only reachable for a **non-Latin reading script**, exactly as the issue predicted. A Latin reader's selection is copied from what the reader itself rendered, through `ConvertBook`, which *does* run the markup rules — so their gāthā already reads `;` and passes through untouched.

## The decision, and what it gives up

Both marks flatten to a period. That loses the gāthā distinction the passage window keeps, where a single daṇḍa reads `;` because it ends a pada — so a selected verse line and the same line in the window will punctuate differently.

**[fsnow]** made that call over the alternative:

> *"I am fine with both single and double danda being converted to period in this case. I don't think it will materially affect the LLMs ability to understand the text. It's better than non-Latin punctuation coming through, which could potentially confuse."*

So the direction the issue raised — **locating the selection in the window and taking the window's own rendering, which knows the `rend`** — is not pursued. I'll record that on the issue so it isn't re-proposed.

## One home for the rule

`ScriptConverter.LatinizeDandas`, called by both `TeiText.Convert` and `SelectionPipeline` rather than copied. This is the **fourth** place the same two-character rule has been written (#641, #668, #680, here), and #933 last night was a copied rule drifting.

## Checked, and not a hazard

I expected fixing this might break selection location, since `Latn2Deva` passes `.` and `;` through unchanged (verified: `U+002E → U+002E`), so the needle would no longer match the XML's `।`. It doesn't — `TeiPassageReader.LocateSelection` **drops punctuation entirely** and matches on letters alone, which #668 did for precisely this reason.

## Tests

Five: both marks singly, a mixed string, and the reported non-Latin path end to end. **Mutation-tested** — reverting `SelectionPipeline` fails exactly the two new tests.

Full suite: **2781 passed, 0 failed, 18 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)