### PR TITLE
Define the seventeen theme brushes the app names but nothing supplied (#955)

### DIFF
--- a/src/CST.Avalonia.Tests/Views/ThemeDictionaryParityTests.cs
+++ b/src/CST.Avalonia.Tests/Views/ThemeDictionaryParityTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Views;
+
+/// <summary>
+/// Every <c>{DynamicResource}</c> key the app names has to exist somewhere. (#955)
+///
+/// <para>A DynamicResource that resolves to nothing does not throw, log, or fail a build. It sets the
+/// property to nothing, and the control keeps its default: an unset <c>Background</c> is transparent, an
+/// unset <c>BorderBrush</c> draws no edge, and an unset <c>Foreground</c> is <b>black</b>. On a light ground
+/// black is what secondary text nearly looks like anyway, so eleven WinUI brush names that no loaded theme
+/// defines went unnoticed for a year and surfaced only as "the small text is invisible in dark mode".</para>
+///
+/// <para>Two rules, and the first is the one that made #955 a dark-mode bug rather than an everywhere bug:
+/// #102 added six of these keys to the <c>Light</c> dictionary and left <c>Dark</c> empty, so the same
+/// markup resolved in one theme and not the other. A key defined for one theme only is always a defect -
+/// either it is needed, and the other theme is missing it, or it is not, and it should go.</para>
+///
+/// <para>Parsed rather than resolved on purpose. Resolving would need a live Avalonia application with the
+/// themes loaded, which this project has no support for (#655); parsing catches the same class of mistake
+/// with no framework at all, and runs in milliseconds.</para>
+/// </summary>
+public class ThemeDictionaryParityTests
+{
+    private static readonly XNamespace X = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    /// <summary>
+    /// Keys a loaded theme really does provide, so we must NOT define them - shadowing a live theme brush
+    /// is how you get an app that ignores its own theme.
+    ///
+    /// <para>The first five were measured resolving in a headless <c>FluentTheme</c> +
+    /// <c>DockFluentTheme</c> harness. The four <c>SystemAccentColor*</c> entries were NOT: the platform
+    /// supplies those at runtime and a headless process has no platform, so the harness cannot tell
+    /// "absent" from "absent here". They are trusted rather than verified, and that is the one hole in
+    /// this test.</para>
+    /// </summary>
+    private static readonly HashSet<string> ProvidedByALoadedTheme = new(StringComparer.Ordinal)
+    {
+        "DockApplicationAccentBrushHigh",
+        "DockApplicationAccentBrushLow",
+        "DockApplicationAccentBrushMed",
+        "DockApplicationAccentForegroundBrush",
+        "SystemControlBackgroundChromeMediumBrush",
+
+        "SystemAccentColor",
+        "SystemAccentColorDark1",
+        "SystemAccentColorLight2",
+        "SystemAccentColorLight3",
+    };
+
+    /// <summary>Our own, declared in App.axaml outside the theme dictionaries.</summary>
+    private static readonly HashSet<string> OurNonThemedResources = new(StringComparer.Ordinal)
+    {
+        "ControlRecyclingKey",
+    };
+
+    [Fact]
+    public void The_light_and_dark_theme_dictionaries_define_the_same_keys()
+    {
+        var (light, dark) = ThemeDictionaries();
+
+        Assert.NotEmpty(light);
+        Assert.Equal(light.OrderBy(k => k, StringComparer.Ordinal),
+                     dark.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Every_dynamic_resource_key_the_markup_names_is_defined_somewhere()
+    {
+        var (light, _) = ThemeDictionaries();
+        var known = new HashSet<string>(light, StringComparer.Ordinal);
+        known.UnionWith(ProvidedByALoadedTheme);
+        known.UnionWith(OurNonThemedResources);
+
+        var unresolved = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var file in Directory.EnumerateFiles(
+                     Path.Combine(RepoRoot(), "src", "CST.Avalonia"), "*.axaml", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}") ||
+                file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+                continue;
+
+            foreach (Match m in Regex.Matches(File.ReadAllText(file), @"\{DynamicResource\s+([A-Za-z0-9_]+)\s*\}"))
+            {
+                var key = m.Groups[1].Value;
+                if (known.Contains(key)) continue;
+                if (!unresolved.TryGetValue(key, out var files)) unresolved[key] = files = new List<string>();
+                var name = Path.GetFileName(file);
+                if (!files.Contains(name)) files.Add(name);
+            }
+        }
+
+        Assert.True(unresolved.Count == 0,
+            "These DynamicResource keys are defined by no loaded theme and by no dictionary of ours, so they " +
+            "silently set nothing:\n  " +
+            string.Join("\n  ", unresolved.Select(kv => $"{kv.Key} — {string.Join(", ", kv.Value)}")));
+    }
+
+    private static (List<string> Light, List<string> Dark) ThemeDictionaries()
+    {
+        var path = Path.Combine(RepoRoot(), "src", "CST.Avalonia", "App.axaml");
+        Assert.True(File.Exists(path), path);
+
+        var themed = XDocument.Load(path).Descendants()
+            .First(e => e.Name.LocalName == "ResourceDictionary.ThemeDictionaries");
+
+        List<string> KeysOf(string variant) => themed.Elements()
+            .Single(e => (string?)e.Attribute(X + "Key") == variant)
+            .Elements()
+            .Select(e => (string?)e.Attribute(X + "Key"))
+            .Where(k => k is not null)
+            .Select(k => k!)
+            .ToList();
+
+        return (KeysOf("Light"), KeysOf("Dark"));
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/src/CST.Avalonia.Tests/Views/ThemeDictionaryParityTests.cs
+++ b/src/CST.Avalonia.Tests/Views/ThemeDictionaryParityTests.cs
@@ -11,11 +11,16 @@ namespace CST.Avalonia.Tests.Views;
 /// <summary>
 /// Every <c>{DynamicResource}</c> key the app names has to exist somewhere. (#955)
 ///
-/// <para>A DynamicResource that resolves to nothing does not throw, log, or fail a build. It sets the
-/// property to nothing, and the control keeps its default: an unset <c>Background</c> is transparent, an
-/// unset <c>BorderBrush</c> draws no edge, and an unset <c>Foreground</c> is <b>black</b>. On a light ground
-/// black is what secondary text nearly looks like anyway, so eleven WinUI brush names that no loaded theme
-/// defines went unnoticed for a year and surfaced only as "the small text is invisible in dark mode".</para>
+/// <para>A DynamicResource that resolves to nothing does not throw, log, or fail a build - and what it does
+/// instead depends on where it is written. <b>Inside a DataTemplate</b> it binds at
+/// <c>BindingPriority.Template</c>, where the miss yields the property's DEFAULT: an unset
+/// <c>Foreground</c> is then <b>black</b>. <b>Outside</b> one it publishes <c>UnsetValue</c> at
+/// <c>LocalValue</c>, and the property falls through to INHERITED - which usually looks right.</para>
+///
+/// <para>That split is why #955 read as one panel misbehaving. The Assistant's turn template went black on
+/// a dark ground while visually identical text a few lines above it, outside any template, inherited white
+/// and looked fine. On a light ground neither is noticeable, because black is what secondary text nearly
+/// looks like anyway - so the phantom keys went unremarked for a year.</para>
 ///
 /// <para>Two rules, and the first is the one that made #955 a dark-mode bug rather than an everywhere bug:
 /// #102 added six of these keys to the <c>Light</c> dictionary and left <c>Dark</c> empty, so the same
@@ -34,11 +39,15 @@ public class ThemeDictionaryParityTests
     /// Keys a loaded theme really does provide, so we must NOT define them - shadowing a live theme brush
     /// is how you get an app that ignores its own theme.
     ///
-    /// <para>The first five were measured resolving in a headless <c>FluentTheme</c> +
-    /// <c>DockFluentTheme</c> harness. The four <c>SystemAccentColor*</c> entries were NOT: the platform
-    /// supplies those at runtime and a headless process has no platform, so the harness cannot tell
-    /// "absent" from "absent here". They are trusted rather than verified, and that is the one hole in
-    /// this test.</para>
+    /// <para>The <c>SystemAccentColor*</c> keys are NOT platform-supplied, though an earlier version of this
+    /// comment said so. <c>FluentTheme</c> answers them itself through its <c>SystemAccentColors</c>
+    /// resource provider, falling back to a hard-coded <c>#0078D7</c> when there is no
+    /// <c>IPlatformSettings</c> - so they resolve in a headless process too. Defining them here would
+    /// shadow the user's real accent colour.</para>
+    ///
+    /// <para><c>ContentControlThemeFontFamily</c> is Fluent's own, from <c>Accents/BaseResources.xaml</c>.
+    /// It is listed because a probe that bound a <c>FontFamily</c> to an <c>IBrush</c> property once
+    /// reported it missing, and a working attribute was removed on the strength of that.</para>
     /// </summary>
     private static readonly HashSet<string> ProvidedByALoadedTheme = new(StringComparer.Ordinal)
     {
@@ -52,6 +61,8 @@ public class ThemeDictionaryParityTests
         "SystemAccentColorDark1",
         "SystemAccentColorLight2",
         "SystemAccentColorLight3",
+
+        "ContentControlThemeFontFamily",
     };
 
     /// <summary>Our own, declared in App.axaml outside the theme dictionaries.</summary>
@@ -70,8 +81,39 @@ public class ThemeDictionaryParityTests
                      dark.OrderBy(k => k, StringComparer.Ordinal));
     }
 
+    /// <summary>
+    /// A key repeated inside ONE dictionary is a startup crash, and comparing the two key sets does not
+    /// catch it: duplicate the same <c>x:Key</c> in both and the sets still match. The build stays clean
+    /// too - the XAML compiler emits the populate method without complaint, and
+    /// <c>ArgumentException: An item with the same key has already been added</c> is thrown when
+    /// <c>App.Initialize</c> runs it, which no test in this project reaches.
+    /// </summary>
     [Fact]
-    public void Every_dynamic_resource_key_the_markup_names_is_defined_somewhere()
+    public void Neither_theme_dictionary_defines_a_key_twice()
+    {
+        var (light, dark) = ThemeDictionaries();
+
+        foreach (var (variant, keys) in new[] { ("Light", light), ("Dark", dark) })
+        {
+            var repeated = keys.GroupBy(k => k, StringComparer.Ordinal)
+                               .Where(g => g.Count() > 1)
+                               .Select(g => $"{g.Key} ×{g.Count()}")
+                               .ToList();
+
+            Assert.True(repeated.Count == 0,
+                $"The {variant} dictionary defines a key more than once, which throws inside " +
+                $"App.Initialize before any window opens:\n  " + string.Join("\n  ", repeated));
+        }
+    }
+
+    /// <summary>
+    /// Markup and code both, because they fail identically and only one of them is obvious. A key renamed
+    /// everywhere except <c>ProviderLogoConverter</c>'s <c>TryGetResource</c> call would leave that lookup
+    /// returning false forever, and its fallback is good enough that nobody would notice - which is exactly
+    /// how the original defect hid for a year.
+    /// </summary>
+    [Fact]
+    public void Every_resource_key_the_app_names_is_defined_somewhere()
     {
         var (light, _) = ThemeDictionaries();
         var known = new HashSet<string>(light, StringComparer.Ordinal);
@@ -79,14 +121,10 @@ public class ThemeDictionaryParityTests
         known.UnionWith(OurNonThemedResources);
 
         var unresolved = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
-        foreach (var file in Directory.EnumerateFiles(
-                     Path.Combine(RepoRoot(), "src", "CST.Avalonia"), "*.axaml", SearchOption.AllDirectories))
-        {
-            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}") ||
-                file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
-                continue;
 
-            foreach (Match m in Regex.Matches(File.ReadAllText(file), @"\{DynamicResource\s+([A-Za-z0-9_]+)\s*\}"))
+        void Collect(string file, string pattern)
+        {
+            foreach (Match m in Regex.Matches(File.ReadAllText(file), pattern))
             {
                 var key = m.Groups[1].Value;
                 if (known.Contains(key)) continue;
@@ -96,8 +134,21 @@ public class ThemeDictionaryParityTests
             }
         }
 
+        foreach (var file in Directory.EnumerateFiles(
+                     Path.Combine(RepoRoot(), "src", "CST.Avalonia"), "*.*", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}") ||
+                file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+                continue;
+
+            if (file.EndsWith(".axaml", StringComparison.Ordinal))
+                Collect(file, @"\{(?:Dynamic|Static)Resource\s+([A-Za-z0-9_]+)\s*\}");
+            else if (file.EndsWith(".cs", StringComparison.Ordinal))
+                Collect(file, @"(?:TryGetResource|TryFindResource|FindResource|GetResourceObservable)\(\s*""([A-Za-z0-9_]+)""");
+        }
+
         Assert.True(unresolved.Count == 0,
-            "These DynamicResource keys are defined by no loaded theme and by no dictionary of ours, so they " +
+            "These resource keys are defined by no loaded theme and by no dictionary of ours, so they " +
             "silently set nothing:\n  " +
             string.Join("\n  ", unresolved.Select(kv => $"{kv.Key} — {string.Join(", ", kv.Value)}")));
     }

--- a/src/CST.Avalonia/App.axaml
+++ b/src/CST.Avalonia/App.axaml
@@ -52,14 +52,34 @@
 
     <Application.Resources>
         <ResourceDictionary>
+            <!-- These are OUR brushes, not Avalonia's. Every key below is a WinUI name that the call
+                 sites were written against and that neither Avalonia 11.3.6's FluentTheme nor
+                 Dock.Avalonia.Themes.Fluent actually defines (#955). An unresolved DynamicResource sets
+                 nothing, so a Foreground fell back to TextBlock's default black - invisible on a dark
+                 ground, and indistinguishable from ordinary text on a light one, which is why it survived
+                 a year. Measured in a headless FluentTheme + DockFluentTheme harness, not read from
+                 documentation.
+
+                 Both dictionaries must define the SAME KEYS. The Dark one used to be empty, which is
+                 what made this a dark-mode bug rather than an everywhere bug: #102 supplied six of these
+                 for Light only, so Light resolved and Dark did not.
+                 ThemeDictionaryParityTests holds that line.
+
+                 Values marked "Fluent" are the measured colour of the Avalonia brush named beside them,
+                 so this palette rides the theme's own ladder instead of a second opinion about it. The
+                 chrome values in Light are #102's and are deliberately NOT replaced. The three semantic
+                 colours at the end have no Fluent equivalent and are chosen. -->
             <ResourceDictionary.ThemeDictionaries>
-                <!-- Light-mode surface hierarchy (#102): a SUBTLE grey "chrome" tone (toolbars,
-                     left tool dock, tree, gutters) against white "content" surfaces (reading pane,
-                     cards) - matching the gentle VS Code "Light 2026" aesthetic, not a high-contrast
-                     ladder. Chrome #F6F6F9 vs content #FFFFFF ~= a 9-level step. Dark mode unchanged
-                     (empty Dark dict below). -->
                 <ResourceDictionary x:Key="Light">
-                    <!-- Chrome: window/page bg, dock gutters, book tree, toolbars, status bars, nav -->
+                    <!-- Text. Fluent: ForegroundBaseHigh / BaseMedium / BaseMediumLow. -->
+                    <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="#FF000000"/>
+                    <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="#99000000"/>
+                    <SolidColorBrush x:Key="TextFillColorTertiaryBrush" Color="#66000000"/>
+
+                    <!-- Chrome: window/page bg, dock gutters, book tree, toolbars, status bars, nav.
+                         A SUBTLE grey against white content surfaces - the gentle VS Code "Light 2026"
+                         aesthetic, not a high-contrast ladder. Chrome #F6F6F9 vs content #FFFFFF is
+                         about a 9-level step. (#102) -->
                     <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="#F6F6F9"/>
                     <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="#F6F6F9"/>
                     <SolidColorBrush x:Key="CardBackgroundFillColorSecondaryBrush" Color="#F6F6F9"/>
@@ -68,9 +88,54 @@
                     <SolidColorBrush x:Key="CardBackgroundFillColorDefaultBrush" Color="#FFFFFF"/>
                     <!-- Subtle border so inset content edges read against the grey -->
                     <SolidColorBrush x:Key="CardStrokeColorDefaultBrush" Color="#E6E6EC"/>
+
+                    <!-- Controls. Fluent: ChromeMediumLow for the filled ones. -->
+                    <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="#FFFFFFFF"/>
+                    <SolidColorBrush x:Key="TextControlBackgroundBrush" Color="#FFFFFFFF"/>
+                    <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="#FFFFFFFF"/>
+                    <!-- Fluent: BackgroundListLow. The old value was invisible rather than faint - the
+                         key did not exist, so a selected row got no fill at all. -->
+                    <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#19000000"/>
+                    <SolidColorBrush x:Key="SubtleFillColorTransparentBrush" Color="Transparent"/>
+
+                    <!-- Semantic. No Fluent equivalent; chosen to stay legible on this ground. -->
+                    <SolidColorBrush x:Key="SystemFillColorCautionBrush" Color="#FF9D5D00"/>
+                    <SolidColorBrush x:Key="SystemFillColorCautionBackgroundBrush" Color="#FFFFF4CE"/>
+                    <SolidColorBrush x:Key="SystemFillColorCriticalBrush" Color="#FFC42B1C"/>
                 </ResourceDictionary>
-                <!-- Dark mode unchanged: inherit Fluent dark defaults -->
-                <ResourceDictionary x:Key="Dark"/>
+
+                <ResourceDictionary x:Key="Dark">
+                    <!-- Text. Fluent: ForegroundBaseHigh / BaseMedium / BaseMediumLow. The reported
+                         defect (#955) is this block having been absent. -->
+                    <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="#FFFFFFFF"/>
+                    <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="#99FFFFFF"/>
+                    <SolidColorBrush x:Key="TextFillColorTertiaryBrush" Color="#66FFFFFF"/>
+
+                    <!-- Chrome, mirroring Light's step but inverted. Fluent: ChromeMedium for the
+                         recessed tone, ChromeMediumLow for content surfaces. -->
+                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="#FF1F1F1F"/>
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="#FF1F1F1F"/>
+                    <SolidColorBrush x:Key="CardBackgroundFillColorSecondaryBrush" Color="#FF1F1F1F"/>
+                    <SolidColorBrush x:Key="LayerFillColorDefaultBrush" Color="#FF2B2B2B"/>
+                    <SolidColorBrush x:Key="CardBackgroundFillColorDefaultBrush" Color="#FF2B2B2B"/>
+                    <!-- Fluent: ForegroundBaseLow. Translucent white, so it reads as an edge on either
+                         of the two chrome tones above rather than only on one of them. -->
+                    <SolidColorBrush x:Key="CardStrokeColorDefaultBrush" Color="#33FFFFFF"/>
+
+                    <!-- Controls. Fluent: ChromeMediumLow / BackgroundAltHigh. -->
+                    <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="#FF2B2B2B"/>
+                    <SolidColorBrush x:Key="TextControlBackgroundBrush" Color="#FF2B2B2B"/>
+                    <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="#FF000000"/>
+                    <!-- Fluent: BackgroundListLow. -->
+                    <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#19FFFFFF"/>
+                    <SolidColorBrush x:Key="SubtleFillColorTransparentBrush" Color="Transparent"/>
+
+                    <!-- Semantic. Lightened for a dark ground: the Light amber and red are unreadable
+                         on it, which is the whole reason these are per-theme. -->
+                    <SolidColorBrush x:Key="SystemFillColorCautionBrush" Color="#FFFCE100"/>
+                    <SolidColorBrush x:Key="SystemFillColorCautionBackgroundBrush" Color="#FF433519"/>
+                    <SolidColorBrush x:Key="SystemFillColorCriticalBrush" Color="#FFFF99A4"/>
+                </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 
             <!-- ControlRecycling for view caching - preserves scroll position and state when switching tabs -->

--- a/src/CST.Avalonia/App.axaml
+++ b/src/CST.Avalonia/App.axaml
@@ -80,7 +80,13 @@
                     <!-- Text. Fluent: ForegroundBaseHigh / BaseMedium / BaseMediumLow. -->
                     <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="#FF000000"/>
                     <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="#99000000"/>
-                    <SolidColorBrush x:Key="TextFillColorTertiaryBrush" Color="#66000000"/>
+                    <!-- Tertiary is DARKER than Fluent's own ladder would put it, on purpose. At
+                         BaseMediumLow (#66000000) it renders #999999 on white - 2.85:1, below WCAG AA's
+                         4.5:1 for text this size, and [fsnow] called it "a little light" on sight in the
+                         search panel's "217 of 217 books". #89000000 is #767676, 4.54:1, and still a clear
+                         step below Secondary's 5.74:1 so the three-level ladder survives. WinUI's own
+                         tertiary is 3.7:1, so matching the source palette exactly could not fix this. -->
+                    <SolidColorBrush x:Key="TextFillColorTertiaryBrush" Color="#89000000"/>
 
                     <!-- Chrome: window/page bg, dock gutters, book tree, toolbars, status bars, nav.
                          A SUBTLE grey against white content surfaces - the gentle VS Code "Light 2026"
@@ -117,7 +123,10 @@
                          defect (#955) is this block having been absent. -->
                     <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="#99FFFFFF"/>
-                    <SolidColorBrush x:Key="TextFillColorTertiaryBrush" Color="#66FFFFFF"/>
+                    <!-- Same correction as Light. #66FFFFFF is 3.79:1 on the #1F1F1F chrome and 3.66:1 on
+                         the Assistant's pure-black pane; #80FFFFFF is 5.10:1 and 5.32:1, against
+                         Secondary's 6.69:1. -->
+                    <SolidColorBrush x:Key="TextFillColorTertiaryBrush" Color="#80FFFFFF"/>
 
                     <!-- Chrome, mirroring Light's step but inverted. Fluent: ChromeMedium for the
                          recessed tone, ChromeMediumLow for content surfaces. -->

--- a/src/CST.Avalonia/App.axaml
+++ b/src/CST.Avalonia/App.axaml
@@ -54,10 +54,16 @@
         <ResourceDictionary>
             <!-- These are OUR brushes, not Avalonia's. Every key below is a WinUI name that the call
                  sites were written against and that neither Avalonia 11.3.6's FluentTheme nor
-                 Dock.Avalonia.Themes.Fluent actually defines (#955). An unresolved DynamicResource sets
-                 nothing, so a Foreground fell back to TextBlock's default black - invisible on a dark
-                 ground, and indistinguishable from ordinary text on a light one, which is why it survived
-                 a year. Measured in a headless FluentTheme + DockFluentTheme harness, not read from
+                 Dock.Avalonia.Themes.Fluent actually defines (#955).
+
+                 What an unresolved DynamicResource does depends on WHERE it is written, which is why this
+                 presented as one panel misbehaving rather than as the whole app. Outside a template it
+                 publishes UnsetValue at LocalValue priority and the property falls through to INHERITED -
+                 so the composer's own labels stayed white in dark and looked fine. Inside a DataTemplate
+                 it binds at Template priority, where the miss yields the property DEFAULT - and
+                 TextBlock.Foreground defaults to black. The reported text was invisible because it lives
+                 in the Assistant's turn template; the visually identical text above it did not, and did
+                 not. Measured in a headless FluentTheme + DockFluentTheme harness, not read from
                  documentation.
 
                  Both dictionaries must define the SAME KEYS. The Dark one used to be empty, which is
@@ -89,7 +95,9 @@
                     <!-- Subtle border so inset content edges read against the grey -->
                     <SolidColorBrush x:Key="CardStrokeColorDefaultBrush" Color="#E6E6EC"/>
 
-                    <!-- Controls. Fluent: ChromeMediumLow for the filled ones. -->
+                    <!-- Controls. White rather than Fluent's ChromeMediumLow (#F2F2F2): these sit inside
+                         cards that are already #FFFFFF, and the #102 ladder puts content surfaces above
+                         chrome, not below. The Dark block below does use ChromeMediumLow. -->
                     <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="TextControlBackgroundBrush" Color="#FFFFFFFF"/>
                     <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="#FFFFFFFF"/>

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml
@@ -211,10 +211,7 @@
 
                                     <TextBlock Grid.Row="0" Grid.Column="0" Classes="label" Text="XML file"/>
                                     <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
-                                        <!-- No FontFamily: this used to name ContentControlThemeFontFamily, a key no loaded
-                                             theme defines (#955), so it always fell through to the default UI font -
-                                             which is what a file name wants anyway. -->
-                                        <SelectableTextBlock Text="{Binding XmlFileName}"/>
+                                        <SelectableTextBlock Text="{Binding XmlFileName}" FontFamily="{DynamicResource ContentControlThemeFontFamily}"/>
                                         <Button x:Name="copyXmlFileNameButton"
                                                 Margin="10,0,0,0" Padding="6,1" MinWidth="0"
                                                 ToolTip.Tip="Copy the file name">

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml
@@ -211,7 +211,10 @@
 
                                     <TextBlock Grid.Row="0" Grid.Column="0" Classes="label" Text="XML file"/>
                                     <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
-                                        <SelectableTextBlock Text="{Binding XmlFileName}" FontFamily="{DynamicResource ContentControlThemeFontFamily}"/>
+                                        <!-- No FontFamily: this used to name ContentControlThemeFontFamily, a key no loaded
+                                             theme defines (#955), so it always fell through to the default UI font -
+                                             which is what a file name wants anyway. -->
+                                        <SelectableTextBlock Text="{Binding XmlFileName}"/>
                                         <Button x:Name="copyXmlFileNameButton"
                                                 Margin="10,0,0,0" Padding="6,1" MinWidth="0"
                                                 ToolTip.Tip="Copy the file name">

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml
@@ -60,8 +60,9 @@
                                      Colours follow the convention #270 established: Dock's FIXED VS-Code
                                      blue, not the OS accent, so "selected" reads the same here as on the
                                      book/tool tabs and in the Settings category list whatever accent the OS
-                                     is set to. (The Settings list also records that
-                                     SubtleFillColorSecondaryBrush was too faint to see in light mode.)
+                                     is set to. (The Settings list reached the same convention from the
+                                     other end: SubtleFillColorSecondaryBrush painted nothing there, because
+                                     until #955 that key existed in no loaded theme.)
 
                                      Fluent paints TreeViewItem selection on Border#PART_LayoutRoot and
                                      colours the text through ContentPresenter#PART_HeaderPresenter. What

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -93,9 +93,10 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                     <ListBox.Styles>
-                        <!-- The selected category used SubtleFillColorSecondaryBrush, which is faint enough
-                             to be invisible in light mode - the panel gave no indication of which category
-                             was showing. Re-pointed at the SAME fixed Dock accent the book/tool tabs and the
+                        <!-- The selected category used SubtleFillColorSecondaryBrush and showed nothing at
+                             all - the panel gave no indication of which category was showing. Recorded here
+                             as "faint enough to be invisible"; it was not faint, it was ABSENT. That key did
+                             not exist in any loaded theme until #955 defined it, so the setter set nothing. Re-pointed at the SAME fixed Dock accent the book/tool tabs and the
                              Highlight/Footnotes toggles use, so "selected" reads identically everywhere
                              whatever the OS accent colour is. (#270 established this convention.) -->
                         <Style Selector="ListBoxItem:selected /template/ ContentPresenter">


### PR DESCRIPTION
Closes #955.

## The reported line was one of forty

`TextFillColorSecondaryBrush` **does not exist**. Neither Avalonia 11.3.6's `FluentTheme` nor `Dock.Avalonia.Themes.Fluent` defines it, so the `DynamicResource` resolved to nothing, `Foreground` was never set, and the `TextBlock` kept its default `Brushes.Black`. **Seventeen of the keys the app names are defined by no loaded theme.**

Measured in a headless `FluentTheme` + `DockFluentTheme` harness, binding each key onto a property whose default is `null` so "missing" could not be confused with "resolved to something dark". Two keys that *do* exist were resolved through the identical path in the same run:

```
                                        Light     Dark
TextFillColorSecondaryBrush             MISSING   MISSING
TextControlForeground                   Black     White     <- resolves
SystemControlForegroundBaseHighBrush    Black     White     <- resolves
```

## Why it survived a year — and why it read as one panel

**What an unresolved `DynamicResource` does depends on where it is written**, and that split is the whole shape of the bug. Measured on the real Assistant panel, pre-fix, in dark:

```
"Answers are generated by a model…"   Foreground=White  prio=Inherited   VISIBLE
"evaṃ me sutaṃ – ekaṃ samayaṃ…"       Foreground=Black  prio=Template    INVISIBLE
"Dīgha Nikāya · Brahmajālasutta"       Foreground=Black  prio=Template    INVISIBLE
```

- **Outside a template** the miss publishes `UnsetValue` at `LocalValue`, and the property falls through to **inherited** — which usually looks right.
- **Inside a `DataTemplate`** it binds at `Template` priority, where the miss yields the property **default**, and `TextBlock.Foreground` defaults to black.

So the invisible text is the Subject, Citation and Status in the Assistant's *turn* template, and visually identical text a few lines above it was always fine. On a light ground neither is noticeable, because black is roughly what secondary text looks like anyway.

**#102 added six of these keys to the `Light` dictionary and left `Dark` empty**, which is why it presented as dark-only. And missing `Background`/`BorderBrush` are silent — unset is transparent, not wrong-coloured.

## What this does

Both theme dictionaries now define the same seventeen keys. Values marked `Fluent` in the file are the **measured** colour of the Avalonia brush named beside them, so the palette rides the theme's own ladder rather than a second opinion about it. #102's light chrome values are kept exactly as they were. Three semantic colours — caution, caution background, critical — have no Fluent equivalent and are chosen.

Verified by loading this `App.axaml`'s actual resource dictionary back into the harness — every key the app names now resolves in both variants:

```
                                        Light        Dark
TextFillColorPrimaryBrush               Black        White
TextFillColorSecondaryBrush             #99000000    #99ffffff
TextFillColorTertiaryBrush              #66000000    #66ffffff
CardBackgroundFillColorDefaultBrush     White        #ff2b2b2b
CardBackgroundFillColorSecondaryBrush   #fff6f6f9    #ff1f1f1f
CardStrokeColorDefaultBrush             #ffe6e6ec    #33ffffff
SystemFillColorCautionBrush             #ff9d5d00    #fffce100
SystemFillColorCriticalBrush            #ffc42b1c    #ffff99a4
        …seventeen in all, both variants
```

**The four `SystemAccentColor*` keys are deliberately not defined**, and the reason in the first draft was wrong. They are not platform-supplied: `FluentTheme` answers them through its own `SystemAccentColors` provider with a hard-coded `#0078D7` fallback, so they resolve headlessly too. Defining them would shadow the user's real accent colour. Same for `ContentControlThemeFontFamily`, which Fluent defines in `Accents/BaseResources.xaml` — an earlier commit removed a working attribute that named it, on the strength of a probe that bound a `FontFamily` to an `IBrush` property. Restored.

## Two comments were wrong about this

- `SettingsWindow.axaml` recorded `SubtleFillColorSecondaryBrush` as *"faint enough to be invisible in light mode"*. It was not faint — it was **absent**, and the setter still claimed the slot, shadowing Fluent's own selection highlight. Confirmed by replicating the pre-#270 style against the pre-fix dictionary.
- `OpenBookPanel.axaml` repeated that claim second-hand.

## A second bug this explains

`ProviderLogoConverter.Foreground()` reads `TextFillColorPrimaryBrush` and falls back to `#808080`, with a doc comment saying the fallback exists because black *"disappears in dark mode"*. Since the key never resolved, **the fallback was the only path ever taken** — provider logos have never matched the theme's text colour, in either theme. They will now.

## The test

`ThemeDictionaryParityTests` holds both halves:

1. The two dictionaries define **the same keys** — a key defined for one theme only is always a defect.
2. Every `{DynamicResource}` key in any `.axaml` is defined by us, or is one of the five measured as coming from a loaded theme.

**Three mutants killed, each by the test meant for it:**

| mutation | caught by | message |
|---|---|---|
| drop a key from `Dark` | parity | names the two differing sets |
| a made-up key in `AboutWindow.axaml` | coverage | `TotallyMadeUpBrush — AboutWindow.axaml` |
| the same key twice in **both** dictionaries | duplicate guard | `TextFillColorTertiaryBrush ×2` |
| rename the key in `ProviderLogoConverter.cs` | coverage | `TextFillColorPrimaryBrushX — ProviderLogoConverter.cs` |

The duplicate-key case is the one the first draft missed, and it is the worst of them: the sets still match, the build is clean, and `ArgumentException: An item with the same key has already been added` is thrown inside `App.Initialize` before any window opens.

Parsed rather than resolved, because resolving needs a live Avalonia app this project cannot yet start (#655).

## Verification

- `dotnet build src/CST.Avalonia` — 0 errors, 0 warnings
- `dotnet test src/CST.Avalonia.Tests` — **2799 passed, 0 failed, 18 skipped**; and **2814 passed** on a trial merge with current `main` after #969
- **Not verified in the running app.** Twenty brushes across every surface changes how the whole app looks in dark.

## What to look at

1. **The Assistant, in dark** — the reported line, and the 17 other uses in that one panel.
2. **The dark chrome step**: `#1F1F1F` recessed against `#2B2B2B` content, mirroring #102's light ladder inverted. This is the judgement call. In particular the Assistant's Subject card uses the recessed tone, so check it still reads as a card against the panel behind it.
3. **Provider logos in Settings** — they should now take the theme's text colour instead of the grey they have always been.
4. **Caution and critical text** — the amber and red are per-theme for the first time.


## Answered in the app, not left open

`TextFillColorTertiaryBrush` was `#66000000` — **2.85:1 on white**, below WCAG AA. **[fsnow]**, reading the search panel: *"The '217 of 217 books'? That's a little light."* Raised in both themes:

```
Light   #66000000 -> #999999  2.85:1        #89000000 -> #767676  4.54:1
Dark    #66FFFFFF  3.79:1 on #1F1F1F        #80FFFFFF  5.10:1
                   3.66:1 on black                     5.32:1
```

Secondary stays at 5.74:1 / 6.69:1, so the ladder still reads as three levels. **This deliberately departs from the palette the other values track** — WinUI's own tertiary is 3.7:1, so copying the source ladder faithfully could not fix it. Both sites carry a comment saying so, since a reader comparing against WinUI would otherwise "correct" it back.

Two things found in passing, neither this PR's business: `SearchPanel.axaml`'s `ListBoxItem:selected` block has been dead since it was written (Fluent's own theme sets foreground on the presenter at `StyleTrigger` and wins), and `ApplicationPageBackgroundThemeBrush` is referenced by no view at all — dead since #102.

---

## Verified in the running app — [fsnow], both themes

Checked on a build merging this PR and #970 onto current main:

- **The reported defect is gone.** The turn's selected-text card, citation and status are legible in dark.
- Caution and critical text read correctly in dark — the first time those have been per-theme.
- Light mode passed, including the surfaces that had no background at all before (search input container, Settings font-preview box, list hovers).
- The tertiary label is *"more readable now in light mode"* after the AA correction above.

One defect found while looking, **pre-existing and filed separately as #971**: three provider logos declare `fill="black"` and so vanish on a dark pane. This PR is what makes them conspicuous — before it every logo fell back to grey — but it does not cause them.
