### PR TITLE
Clear the August review's unresolved findings

### DIFF
--- a/src/CST.Avalonia.Tests/Models/PresetIdDerivationTests.cs
+++ b/src/CST.Avalonia.Tests/Models/PresetIdDerivationTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using CST.Avalonia.Models.Ai;
+using CST.Avalonia.Services.Ai;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Models;
+
+/// <summary>
+/// Which catalogue preset a connection belongs to. (R5-6, #766)
+///
+/// <para>#766 stopped the connections row guessing this from the connection id, because a reader's own slug
+/// can collide with a provider a later catalogue adds — the preset table then answers about a provider the
+/// connection has nothing to do with. Four sibling lookups kept guessing: two doc links, the models group's
+/// logo, and the model picker's usability verdict, which turns a wrong answer into a <b>disabled row</b> for
+/// a keyless endpoint that works.</para>
+/// </summary>
+public class PresetIdDerivationTests
+{
+    private static AiConnection With(string id, string? presetId) =>
+        new(id, id, ChatProviderKind.OpenAiCompatible, "https://example.invalid/v1",
+            new List<AiModelEntry>(), Array.Empty<AiHeader>(), new Dictionary<string, string>(),
+            PresetId: presetId);
+
+    /// <summary>Added from the provider list: the recorded preset, so a connection the reader renamed keeps
+    /// its identity.</summary>
+    [Fact]
+    public void A_recorded_preset_is_used()
+    {
+        Assert.Equal("groq", With("my-groq", "groq").PresetIdOrLegacyId);
+    }
+
+    /// <summary>
+    /// The case with teeth. Recorded as custom — empty, not null — means we KNOW there is no provider
+    /// behind it, so no lookup may be attempted even though the slug would match one.
+    /// </summary>
+    [Fact]
+    public void A_custom_endpoint_resolves_to_no_preset_even_when_its_slug_would_match()
+    {
+        Assert.Null(With("groq", "").PresetIdOrLegacyId);
+    }
+
+    /// <summary>A settings file older than the field records nothing, and the id is the same answer it
+    /// always was — right for every connection such a file can hold.</summary>
+    [Fact]
+    public void A_file_older_than_the_field_falls_back_to_the_id()
+    {
+        Assert.Equal("openai", With("openai", null).PresetIdOrLegacyId);
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/AnswerMarkupTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AnswerMarkupTests.cs
@@ -219,6 +219,50 @@ public class AnswerMarkupTests
         Assert.Empty(table.Rows);
     }
 
+    /// <summary>
+    /// Model output is untrusted input, and the renderer is on the UI thread. (R6-3)
+    ///
+    /// <para><c>AnswerTableView.Apply</c> builds rows×columns controls and rebuilds the whole grid on every
+    /// 100 ms streaming flush, so a malfunctioning model emitting a few-hundred-column row freezes the panel
+    /// and the app rather than degrading.</para></summary>
+    [Fact]
+    public void A_runaway_row_is_clamped_rather_than_rendered()
+    {
+        var wide = "|" + string.Join("|", Enumerable.Repeat("x", 400)) + "|";
+        var source = wide + "\n|" + string.Join("|", Enumerable.Repeat("---", 400)) + "|\n" + wide;
+
+        var table = Assert.IsType<AnswerTable>(Assert.Single(AnswerMarkup.Parse(source)));
+
+        Assert.Equal(AnswerMarkup.MaxColumns, table.Header.Count);
+        Assert.Equal(AnswerMarkup.MaxColumns, Assert.Single(table.Rows).Count);
+    }
+
+    /// <summary>Height is capped the same way, and the overflow rows are still CONSUMED — left unread they
+    /// would come back as a wall of pipe characters rendered as prose.</summary>
+    [Fact]
+    public void A_runaway_row_count_is_clamped_and_not_re_read_as_prose()
+    {
+        var row = "| a | b |";
+        var source = "| h1 | h2 |\n| --- | --- |\n" +
+                     string.Join("\n", Enumerable.Repeat(row, AnswerMarkup.MaxRows + 50));
+
+        var blocks = AnswerMarkup.Parse(source);
+        var table = Assert.IsType<AnswerTable>(Assert.Single(blocks));
+
+        Assert.Equal(AnswerMarkup.MaxRows, table.Rows.Count);
+    }
+
+    /// <summary>An ordinary table is untouched — the caps are far above anything a reader would want, and a
+    /// word-by-word gloss is the real shape.</summary>
+    [Fact]
+    public void An_ordinary_table_is_not_clamped()
+    {
+        var table = Assert.IsType<AnswerTable>(Assert.Single(AnswerMarkup.Parse(WordTable)));
+
+        Assert.True(table.Header.Count < AnswerMarkup.MaxColumns);
+        Assert.True(table.Rows.Count < AnswerMarkup.MaxRows);
+    }
+
     [Fact]
     public void A_line_of_dashes_that_is_not_a_table_is_left_alone()
     {

--- a/src/CST.Avalonia.Tests/Services/Ai/ModelsDevCatalogTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ModelsDevCatalogTests.cs
@@ -56,8 +56,45 @@ public class ModelsDevCatalogTests : IDisposable
     private static HttpResponseMessage Ok(string body) =>
         new(HttpStatusCode.OK) { Content = new StringContent(body) };
 
-    private ModelsDevCatalog Make(HttpClient? http = null) =>
-        new(http ?? new HttpClient(new Stub(() => Ok(TwoProviders))), CachePath, "https://example.invalid/api.json");
+    // minimumProviders: 1 so the fixtures can stay two providers wide and readable. The floor's own
+    // behaviour is tested by passing a real one — see the cache-floor tests below. (R4-5)
+    private ModelsDevCatalog Make(HttpClient? http = null, int minimumProviders = 1) =>
+        new(http ?? new HttpClient(new Stub(() => Ok(TwoProviders))), CachePath,
+            "https://example.invalid/api.json", minimumProviders);
+
+    /// <summary>
+    /// The plausibility floor guarded only the network path; a sub-floor file on disk was served as the
+    /// catalogue. (R4-5)
+    ///
+    /// <para>A hand-edited or externally truncated <c>models-dev.json</c> then became the provider list with
+    /// no problem reported — <c>AiPresetSource</c>'s collapse guard fires only at zero hosted providers, and
+    /// one is enough to clear it. Permanent while offline, self-healing only after a successful refetch.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_cache_with_implausibly_few_providers_is_not_served()
+    {
+        File.WriteAllText(CachePath, TwoProviders);
+
+        // Offline, so the cache is the only thing that could answer.
+        var offline = new HttpClient(new Stub(() => throw new HttpRequestException("offline")));
+        var result = await Make(offline, minimumProviders: 50).GetAsync();
+
+        Assert.NotEqual(CatalogSource.Cache, result.Source);
+        Assert.False(File.Exists(CachePath));   // discarded, so a later refetch can heal it
+    }
+
+    /// <summary>And a cache that clears the floor is still preferred — the rule is a floor, not a
+    /// rejection of caches.</summary>
+    [Fact]
+    public async Task A_cache_that_clears_the_floor_is_still_served()
+    {
+        File.WriteAllText(CachePath, TwoProviders);
+
+        var offline = new HttpClient(new Stub(() => throw new HttpRequestException("offline")));
+        var result = await Make(offline, minimumProviders: 2).GetAsync();
+
+        Assert.Equal(CatalogSource.Cache, result.Source);
+    }
 
     // ---- the floor ------------------------------------------------------------------------------------
 
@@ -201,7 +238,11 @@ public class ModelsDevCatalogTests : IDisposable
     public async Task An_error_body_that_is_valid_json_does_not_replace_the_cache()
     {
         File.WriteAllText(CachePath, TwoProviders);
-        var catalog = Make(Client(() => Ok("""{"error":{"id":"rate_limited","message":"slow down"}}"""), out _));
+
+        // An explicit floor, because this test IS the floor: the error body parses to one record, so it
+        // clears the harness default of 1 and would be accepted. (R4-5)
+        var catalog = Make(Client(() => Ok("""{"error":{"id":"rate_limited","message":"slow down"}}"""), out _),
+                           minimumProviders: 2);
 
         await catalog.RefreshAsync(force: true);
         var result = await catalog.GetAsync();

--- a/src/CST.Avalonia.Tests/Services/Ai/ShellEnvironmentTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/ShellEnvironmentTests.cs
@@ -325,6 +325,48 @@ public sealed class ShellEnvParserTests
         Assert.Empty(parsed);
     }
 
+    /// <summary>
+    /// A stream cut off mid-value must not yield a truncated key. (R3-4)
+    ///
+    /// <para><c>env -0</c> terminates every entry, the last one included, so a complete stream ends in NUL.
+    /// Without one, the final entry was cut off — and "ANTHROPIC_API_KEY=sk-ant-parti" has a valid name and
+    /// a plausible value, so every other check passes it. The symptom is a 401 from a key the reader knows
+    /// is right, which is the hardest kind of wrong to diagnose from the outside.</para>
+    ///
+    /// <para><c>ShellEnvironment.WellFormed</c> makes the same test but is consulted only where the exit was
+    /// never observed; a shell that exits 0 having written a truncated payload arrives here already judged
+    /// a success.</para></summary>
+    [Fact]
+    public void A_value_cut_off_mid_write_is_discarded_rather_than_used()
+    {
+        var truncated = Parse("HOME=/Users/x\0ANTHROPIC_API_KEY=sk-ant-parti", "HOME", "ANTHROPIC_API_KEY");
+
+        Assert.Equal("/Users/x", truncated["HOME"]);
+        Assert.False(truncated.ContainsKey("ANTHROPIC_API_KEY"));
+    }
+
+    /// <summary>The same value, terminated, is kept — the rule is about the missing NUL, not about the last
+    /// entry being suspicious.</summary>
+    [Fact]
+    public void A_terminated_final_value_is_kept()
+    {
+        var complete = Parse("HOME=/Users/x\0ANTHROPIC_API_KEY=sk-ant-whole\0", "HOME", "ANTHROPIC_API_KEY");
+
+        Assert.Equal("sk-ant-whole", complete["ANTHROPIC_API_KEY"]);
+    }
+
+    /// <summary>A profile that prints its epilogue AFTER env leaves trailing chatter rather than a truncated
+    /// entry. Dropping the last chunk costs nothing there — the chatter would fail the name-shape check
+    /// anyway — and every complete variable before it survives, which is why this drops a chunk rather than
+    /// rejecting the whole payload.</summary>
+    [Fact]
+    public void Trailing_chatter_does_not_cost_the_variables_before_it()
+    {
+        var withEpilogue = Parse("OPENAI_API_KEY=sk-real\0Goodbye from .zlogout", "OPENAI_API_KEY");
+
+        Assert.Equal("sk-real", withEpilogue["OPENAI_API_KEY"]);
+    }
+
     [Fact]
     public void Nothing_is_kept_from_an_empty_stream()
     {

--- a/src/CST.Avalonia.Tests/ViewModels/HighlightOffsetGuardTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/HighlightOffsetGuardTests.cs
@@ -1,0 +1,66 @@
+using CST.Avalonia.ViewModels;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// Whether a search-highlight offset may be spliced at. (R8-6)
+///
+/// <para>Highlighting runs off Lucene offsets, which were computed against the XML as it was when the book
+/// was last indexed. If the corpus is updated after that pass, the offsets still fall inside the file's
+/// range but no longer point at the same characters — and an <c>&lt;hi&gt;</c> spliced into the middle of
+/// <c>&lt;p n="331"&gt;</c> makes the whole document malformed, so <c>LoadXml</c> throws and the reader gets
+/// "Error loading book" for a book that opens fine without a search.</para>
+/// </summary>
+public class HighlightOffsetGuardTests
+{
+    private const string Xml = """<p n="331">gacchati bhikkhu</p>""";
+
+    [Fact]
+    public void An_offset_in_text_is_spliceable()
+    {
+        // "gacchati" starts right after the closing '>' of the <p> tag.
+        int inText = Xml.IndexOf("gacchati");
+
+        Assert.False(BookDisplayViewModel.IsInsideTag(Xml, inText));
+    }
+
+    /// <summary>The case that produces the malformed document: an offset that has drifted into an attribute
+    /// value.</summary>
+    [Fact]
+    public void An_offset_inside_a_tag_is_refused()
+    {
+        int insideAttribute = Xml.IndexOf("331");
+
+        Assert.True(BookDisplayViewModel.IsInsideTag(Xml, insideAttribute));
+    }
+
+    /// <summary>A closing tag is markup too — a drifted end offset lands here just as easily.</summary>
+    [Fact]
+    public void An_offset_inside_a_closing_tag_is_refused()
+    {
+        int insideClose = Xml.IndexOf("</p>") + 2;   // between '/' and 'p'
+
+        Assert.True(BookDisplayViewModel.IsInsideTag(Xml, insideClose));
+    }
+
+    /// <summary>A highlight legitimately SPANS whole tags — the &lt;hi&gt;-crossing cases downstream exist
+    /// for exactly that — so the guard tests the endpoints, never the span. Text on both sides of a tag is
+    /// spliceable at both ends.</summary>
+    [Fact]
+    public void Text_either_side_of_a_tag_is_spliceable()
+    {
+        const string spanning = """<p>eka <hi rend="bold">dve</hi> tini</p>""";
+
+        Assert.False(BookDisplayViewModel.IsInsideTag(spanning, spanning.IndexOf("eka")));
+        Assert.False(BookDisplayViewModel.IsInsideTag(spanning, spanning.IndexOf("tini")));
+    }
+
+    [Fact]
+    public void Degenerate_positions_are_not_treated_as_markup()
+    {
+        Assert.False(BookDisplayViewModel.IsInsideTag(Xml, 0));
+        Assert.False(BookDisplayViewModel.IsInsideTag("", 0));
+        Assert.False(BookDisplayViewModel.IsInsideTag(Xml, Xml.Length + 10));
+    }
+}

--- a/src/CST.Avalonia/Models/Ai/AiConnection.cs
+++ b/src/CST.Avalonia/Models/Ai/AiConnection.cs
@@ -209,6 +209,30 @@ namespace CST.Avalonia.Models.Ai
         /// </summary>
         public bool IsSecretInput(string key) =>
             SecretInputs is { } keys && keys.Contains(key, System.StringComparer.Ordinal);
+
+        /// <summary>
+        /// Which catalogue preset this connection came from, or null when it did not come from one. (#766)
+        ///
+        /// <para><b>Never guessed from <see cref="Id"/> where the answer is recorded.</b> A reader's own slug
+        /// can collide with a provider a later catalogue adds, and asking the preset table for it then
+        /// answers about a provider this connection has nothing to do with — wrong logo, wrong docs, and in
+        /// the model picker a "no API key stored" verdict that DISABLES a keyless endpoint that works.</para>
+        ///
+        /// <list type="bullet">
+        /// <item>A recorded preset id: that preset. The mark follows the provider, so a renamed connection
+        /// keeps it.</item>
+        /// <item>Recorded as custom (empty): null, and no lookup attempted — we KNOW there is no provider
+        /// behind it.</item>
+        /// <item>Nothing recorded: the id, which is the same answer for every connection a settings file
+        /// older than the field can hold.</item>
+        /// </list>
+        /// </summary>
+        public string? PresetIdOrLegacyId => PresetId switch
+        {
+            { Length: > 0 } preset => preset,
+            { } => null,
+            null => Id,
+        };
     }
 
     /// <summary>

--- a/src/CST.Avalonia/Services/Ai/AnswerMarkup.cs
+++ b/src/CST.Avalonia/Services/Ai/AnswerMarkup.cs
@@ -91,8 +91,8 @@ public static class AnswerMarkup
                 var row = i + 2;
                 while (row < lines.Length && IsPipeRow(lines[row]))
                 {
-                    rows.Add(Cells(lines[row], aligns));
-                    row++;
+                    if (rows.Count < MaxRows) rows.Add(Cells(lines[row], aligns));
+                    row++;   // keep consuming, so the overflow is not re-read as prose
                 }
 
                 blocks.Add(new AnswerTable(header, rows));
@@ -274,12 +274,29 @@ public static class AnswerMarkup
             })
             .ToList();
 
+    /// <summary>
+    /// The widest and tallest table that will be rendered as a table. (R6-3)
+    ///
+    /// <para>Both are far beyond any table a reader would want — the assistant's real tables are a handful
+    /// of columns of word-by-word glosses — and low enough that a malfunctioning model cannot cost the UI
+    /// thread. <c>AnswerTableView.Apply</c> builds rows×columns <c>Border</c> + <c>SelectableTextBlock</c>
+    /// controls and rebuilds the WHOLE grid on every 100 ms streaming flush, so a few-hundred-column row
+    /// freezes the panel and the app rather than degrading.</para>
+    ///
+    /// <para>Overflow is not dropped: a row too wide keeps its first <see cref="MaxColumns"/> cells, and a
+    /// table too tall keeps its first <see cref="MaxRows"/>, so the answer stays readable rather than
+    /// vanishing. Model output is untrusted input like any other.</para>
+    /// </summary>
+    internal const int MaxColumns = 64;
+    internal const int MaxRows = 500;
+
     /// <summary>Split a pipe row into cells, dropping the leading and trailing pipes.</summary>
     private static IReadOnlyList<string> SplitRow(string line)
     {
         var trimmed = line.Trim();
         var inner = trimmed[1..^1];
-        return inner.Split('|');
+        var cells = inner.Split('|');
+        return cells.Length <= MaxColumns ? cells : cells[..MaxColumns];
     }
 
     // ---- Inline emphasis -----------------------------------------------------------------------------

--- a/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
+++ b/src/CST.Avalonia/Services/Ai/Credentials/ShellEnvironment.cs
@@ -793,8 +793,28 @@ internal static class ShellEnvParser
         if (stdout is null || stdout.Length == 0 || keep is null || keep.Count == 0) return result;
 
         var text = Encoding.UTF8.GetString(stdout);
-        foreach (var chunk in text.Split('\0'))
+        var chunks = text.Split('\0');
+
+        // A COMPLETE STREAM ENDS IN NUL, so the final split chunk of one is "". Where it is not, the last
+        // entry was cut off mid-write and must not be kept: "ANTHROPIC_API_KEY=sk-ant-parti" has a perfectly
+        // valid name and a plausible value, so every check below passes it, and the reader gets a 401 from a
+        // key they know is right. (R3-4)
+        //
+        // Dropping the chunk rather than rejecting the payload, because a well-formedness gate on the whole
+        // stream cannot tell truncation from a profile that prints its epilogue AFTER env - which would end
+        // the payload with chatter and cost the reader every variable. A trailing chunk is discardable
+        // either way: chatter fails the name-shape check, and a truncated entry is the case this exists for.
+        //
+        // ShellEnvironment.WellFormed makes the same test, but only where the exit was never observed
+        // (Decide returns on the exit code alone when it has one). A shell that exits 0 having written a
+        // truncated payload - the cap hit with the remainder still in the pipe, or the buffer snapshotted at
+        // DrainGrace - reaches here with its verdict already "success".
+        int last = chunks.Length - 1;
+        if (chunks[last].Length > 0) last--;
+
+        for (int i = 0; i <= last; i++)
         {
+            var chunk = chunks[i];
             var split = chunk.IndexOf('=');
             if (split <= 0) continue;
 

--- a/src/CST.Avalonia/Services/Ai/ModelsDevCatalog.cs
+++ b/src/CST.Avalonia/Services/Ai/ModelsDevCatalog.cs
@@ -110,12 +110,21 @@ namespace CST.Avalonia.Services.Ai
 
         private CatalogResult? _current;
 
-        public ModelsDevCatalog(HttpClient? http = null, string? cachePath = null, string? source = null)
+        /// <param name="minimumProviders">
+        /// The plausibility floor, injectable so the cache-read rule can be tested with small fixtures
+        /// rather than a fifty-provider one. Production always uses
+        /// <see cref="MinimumPlausibleProviders"/>. (R4-5)
+        /// </param>
+        public ModelsDevCatalog(HttpClient? http = null, string? cachePath = null, string? source = null,
+                                int minimumProviders = MinimumPlausibleProviders)
         {
             _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
             _cachePath = cachePath ?? Path.Combine(AppConstants.DataDirectory, "models-dev.json");
             _source = source ?? DefaultSource;
+            _minimumProviders = minimumProviders;
         }
+
+        private readonly int _minimumProviders;
 
         public async Task<CatalogResult> GetAsync(CancellationToken ct = default)
         {
@@ -162,7 +171,7 @@ namespace CST.Avalonia.Services.Ai
                     return;
                 }
 
-                if (Parse(text) is not { } parsed || parsed.Count < MinimumPlausibleProviders)
+                if (Parse(text) is not { } parsed || parsed.Count < _minimumProviders)
                 {
                     // A 200 carrying an error page is the realistic failure, not a 404 - so validate the
                     // shape rather than trusting the status code.
@@ -212,12 +221,19 @@ namespace CST.Avalonia.Services.Ai
                 if (!File.Exists(_cachePath)) return null;
 
                 var parsed = Parse(File.ReadAllText(_cachePath));
-                if (parsed is { Count: > 0 }) return parsed;
+                if (parsed is not null && parsed.Count >= _minimumProviders) return parsed;
 
+                // THE SAME FLOOR THE NETWORK PATH APPLIES (:165). It guarded only the fetch, so a sub-floor
+                // file on disk - hand-edited, truncated by an outside tool, or written by a build older than
+                // the floor - was served as the catalogue with no Problem reported: AiPresetSource's collapse
+                // guard fires only at zero hosted providers, and one is enough to clear it. The result is a
+                // quietly tiny provider list, permanent while offline. (R4-5)
+                //
                 // Unparseable rather than unreadable: Parse returns null instead of throwing, so this case
                 // never reaches the catch below. Discard it either way - a cache that cannot be read will
                 // fail identically on every subsequent start until something removes it.
-                Log.Warning("Provider catalogue cache did not parse; discarding it (#736)");
+                Log.Warning("Provider catalogue cache did not parse, or held implausibly few providers; " +
+                            "discarding it (#736)");
                 try { File.Delete(_cachePath); } catch { /* best effort */ }
                 return null;
             }

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -117,6 +117,32 @@ public class AiAssistantViewModel : ReactiveTool
         CopyCommand = ReactiveCommand.CreateFromTask<AiTurnViewModel>(CopyAsync);
         ClearCommand = ReactiveCommand.Create(Clear);
 
+        // An unhandled exception in a ReactiveCommand goes to RxApp.DefaultExceptionHandler, which
+        // TERMINATES THE APP. Everything these commands call catches internally today, so no failing case is
+        // currently constructible - which is exactly what makes this worth wiring: the trap is armed for the
+        // first future edit that lets something throw, and it springs as a crash in a reading app rather
+        // than a message in a panel. SearchViewModel already does this for its own command. (R6-2)
+        //
+        // The pre-turn path is the live risk: _environmentKeys.Ready, _resolver.Resolve and GetCurrentAsync
+        // all run OUTSIDE RunAsync's try, as does CopyAsync's clipboard call.
+        foreach (var command in new IHandleObservableErrors[]
+                 {
+                     ExplainCommand, TranslateCommand, GrammarCommand, WordByWordCommand, AskQuestionCommand,
+                     StopCommand, RefreshReadinessCommand, RetryCommand, CopyCommand, ClearCommand,
+                 })
+        {
+            command.ThrownExceptions.Subscribe(ex =>
+            {
+                _logger.Error(ex, "AI Assistant command failed");
+                if (_current is { } turn)
+                {
+                    turn.Status = "Something went wrong. See the log for details.";
+                    turn.Failed = true;
+                }
+                IsBusy = false;
+            });
+        }
+
         // Asked once at construction so the panel can say it is not configured before anything is pressed.
         RefreshReadiness();
 
@@ -476,11 +502,23 @@ public class AiAssistantViewModel : ReactiveTool
         }
     }
 
-    /// <summary>Stops the turn in flight. What the visible stop control calls.</summary>
+    /// <summary>
+    /// Stops the turn in flight. What the visible stop control calls.
+    ///
+    /// <para><b>The caller's token first, and the order is the whole point.</b> The orchestrator ends a turn
+    /// quietly when the cancellation was not the caller's — <c>catch (OperationCanceledException) when
+    /// (!callerToken.IsCancellationRequested)</c> — because being superseded is not a failure. Cancelling
+    /// its internal source first opens a gap: if the stream's exception reaches that filter before the
+    /// caller token is cancelled, the filter matches, the turn ends by the superseded path, and the reader
+    /// gets a partial answer with no "Stopped." line, indistinguishable from a finished one.</para>
+    ///
+    /// <para>Cancelling the caller's token first makes the filter fail deterministically, so a stop the
+    /// reader asked for always reports itself as one. (R6-4)</para>
+    /// </summary>
     private void Stop()
     {
-        _orchestrator?.Stop();
         _turnCancellation?.Cancel();
+        _orchestrator?.Stop();
     }
 
     private AiTurnViewModel StartTurn(AiTask task, string? question, string? selection, bool clearBox)

--- a/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiConnectionsViewModel.cs
@@ -884,7 +884,10 @@ namespace CST.Avalonia.ViewModels
         /// provider. Null for a custom endpoint, which has no provider identity, and for the local runners,
         /// which the catalogue does not carry.</para>
         /// </summary>
-        public string? DocUrl => AiProviderPresets.ById(_connection.Id)?.Doc;
+        // The recorded preset, matching ProviderId above rather than guessing from the id. (R5-6)
+        public string? DocUrl => _connection.PresetIdOrLegacyId is { } presetId
+            ? AiProviderPresets.ById(presetId)?.Doc
+            : null;
 
         public bool HasDoc => !string.IsNullOrEmpty(DocUrl);
 

--- a/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelPickerViewModel.cs
@@ -346,7 +346,13 @@ namespace CST.Avalonia.ViewModels
             if (connection.KeySource == CredentialSource.Unreadable)
                 return "its API key could not be read";
 
-            var preset = AiProviderPresets.ById(connection.Id);
+            // The RECORDED preset, not a guess from the id. Asking the preset table for a reader's own slug
+            // that a later catalogue has since claimed answers about a different provider - and here that
+            // wrong answer disables the row (IsEnabled binds IsUsable) for a keyless endpoint that works.
+            // (R5-6, the fix #766 made for the logo)
+            var preset = connection.PresetIdOrLegacyId is { } presetId
+                ? AiProviderPresets.ById(presetId)
+                : null;
             if (preset is { RequiresKey: true } && connection.KeySource == CredentialSource.None)
                 return "no API key stored";
 

--- a/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiModelsViewModel.cs
@@ -262,10 +262,9 @@ namespace CST.Avalonia.ViewModels
 
         public override int MonogramTone => AiMonogram.ToneFor(Id);
 
-        /// <summary>The connection id, which is the models.dev provider id for anything added from the
-        /// catalogue. A custom endpoint's own slug matches nothing, and falls back to the generic mark like
-        /// everywhere else.</summary>
-        protected override string? ProviderId => Id;
+        /// <summary>The RECORDED preset, not the connection id. A custom endpoint whose slug a later
+        /// catalogue claims would otherwise borrow that provider's mark. (R5-6, #766)</summary>
+        protected override string? ProviderId => _connection.PresetIdOrLegacyId;
 
         /// <summary>Every row this group could show, filtered and ordered.</summary>
         public List<AiCatalogRowViewModel> Visible { get; } = new();
@@ -347,7 +346,9 @@ namespace CST.Avalonia.ViewModels
         /// failed, leaves a reader needing a model id from somewhere. This is the somewhere. Hidden once the
         /// group has models, where it would be a link to information already on screen.</para>
         /// </summary>
-        public string? DocUrl => AiProviderPresets.ById(Id)?.Doc;
+        public string? DocUrl => _connection.PresetIdOrLegacyId is { } presetId
+            ? AiProviderPresets.ById(presetId)?.Doc
+            : null;
 
         /// <summary>
         /// Offered only once we have asked and come back with nothing.

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -117,6 +117,18 @@ namespace CST.Avalonia.ViewModels
         private WebViewLifecycleOperation _webViewLifecycleOperation = WebViewLifecycleOperation.None;
         private WebViewState? _savedWebViewState = null; // Saved state during float/unfloat
         private readonly CstDockFactory? _dockFactory; // Factory for float/unfloat operations
+        /// <summary>
+        /// Guards the three restoration-intent fields below. (R8-5)
+        ///
+        /// <para><c>UpdateLastCapturedAnchor</c> runs on the CEF thread (via <c>OnTitleChanged</c>) while the
+        /// <c>TakePending*</c> consumers run on the UI thread. Reference assignment is atomic and the current
+        /// UI-post orderings make a lost restore unlikely — the pending intent is consumed before any
+        /// changed-anchor report can clear it — but nothing ENFORCED that, so BOOK-7's take-vs-clear race was
+        /// prevented by timing rather than by construction. The critical sections are field reads and writes
+        /// only, so this cannot change single-threaded behaviour.</para>
+        /// </summary>
+        private readonly object _anchorGate = new();
+
         private string? _lastCapturedAnchor = null; // Cached anchor for scroll position restoration (persists across float/unfloat)
         private string? _pendingAnchorNavigation = null; // Anchor to navigate to when View becomes available
         private ReadingPositionToken? _pendingPositionToken = null; // #434 reading-position token to restore when the View becomes available (preferred over the coarse string anchor)
@@ -307,7 +319,7 @@ namespace CST.Avalonia.ViewModels
                         // of a 1000ms delay-then-hope timer racing the load. (BOOK-7)
                         if (savedToken != null)
                         {
-                            _pendingPositionToken = savedToken;
+                            lock (_anchorGate) _pendingPositionToken = savedToken;
                             _logger.Debug("Queued reading-position token restore");
                         }
                         await LoadBookContentAsync();
@@ -568,7 +580,7 @@ namespace CST.Avalonia.ViewModels
         /// Gets the last captured anchor for scroll position restoration.
         /// Updated every 200ms by the scroll timer, persists across float/unfloat.
         /// </summary>
-        public string? LastCapturedAnchor => _lastCapturedAnchor;
+        public string? LastCapturedAnchor { get { lock (_anchorGate) return _lastCapturedAnchor; } }
 
         // Latest rolling reading-position token, pushed from the View's status tick; persisted on shutdown for
         // cross-run restore (#434). Preferred over LastCapturedAnchor when present.
@@ -586,6 +598,8 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         public void UpdateLastCapturedAnchor(string? anchor)
         {
+            lock (_anchorGate)
+            {
             var previous = _lastCapturedAnchor;
             _lastCapturedAnchor = anchor;
 
@@ -611,6 +625,7 @@ namespace CST.Avalonia.ViewModels
                     _pendingPositionToken = null;
                 }
             }
+            }
         }
 
         /// <summary>
@@ -622,9 +637,12 @@ namespace CST.Avalonia.ViewModels
         /// </summary>
         internal string? TakePendingAnchorNavigation()
         {
-            var anchor = _pendingAnchorNavigation;
-            _pendingAnchorNavigation = null;
-            return anchor;
+            lock (_anchorGate)
+            {
+                var anchor = _pendingAnchorNavigation;
+                _pendingAnchorNavigation = null;
+                return anchor;
+            }
         }
 
         // Take (and clear) the queued #434 reading-position token. Preferred over the string anchor when both
@@ -632,15 +650,21 @@ namespace CST.Avalonia.ViewModels
         // than an anchor's top edge. (#434)
         internal ReadingPositionToken? TakePendingPositionToken()
         {
-            var token = _pendingPositionToken;
-            _pendingPositionToken = null;
-            return token;
+            lock (_anchorGate)
+            {
+                var token = _pendingPositionToken;
+                _pendingPositionToken = null;
+                return token;
+            }
         }
 
         // Queue a reading-position token to restore when the View next becomes available. Used when a
         // cross-window drag rebuilds this book's View with a fresh browser (#458): the VM instance is
         // preserved, so seeding the pending token lands the fresh View where the user was reading. (#434)
-        internal void QueuePositionRestore(ReadingPositionToken token) => _pendingPositionToken = token;
+        internal void QueuePositionRestore(ReadingPositionToken token)
+        {
+            lock (_anchorGate) _pendingPositionToken = token;
+        }
 
         internal int? TakePendingHitNavigation()
         {
@@ -944,13 +968,13 @@ namespace CST.Avalonia.ViewModels
                 if (_initialPositionToken != null && !restoreSearchHit)
                 {
                     // #434 cross-run restore: prefer the exact reading-position token over the coarse anchor.
-                    _pendingPositionToken = _initialPositionToken;
+                    lock (_anchorGate) _pendingPositionToken = _initialPositionToken;
                     _logger.Debug("Queued initial reading-position token restore (above={Above}, below={Below})",
                         _initialPositionToken.Above, _initialPositionToken.Below);
                 }
                 else if (!string.IsNullOrEmpty(_initialAnchor) && !restoreSearchHit)
                 {
-                    _pendingAnchorNavigation = _initialAnchor;
+                    lock (_anchorGate) _pendingAnchorNavigation = _initialAnchor;
                     _logger.Debug("Queued initial anchor navigation: {Anchor}", _initialAnchor);
                 }
                 else if (_searchTerms?.Any() == true)
@@ -1326,6 +1350,25 @@ namespace CST.Avalonia.ViewModels
         }
 
         /// <summary>
+        /// Whether <paramref name="pos"/> sits between a &lt; and its matching &gt; — i.e. inside a tag rather
+        /// than in text. (R8-6)
+        ///
+        /// <para>Scans back to the nearest angle bracket of each kind: a "&lt;" nearer than any "&gt;" means the
+        /// last thing opened has not closed, so this position is inside markup. Bounded in practice by the
+        /// distance to the previous tag, which in TEI is short.</para>
+        /// </summary>
+        internal static bool IsInsideTag(string xml, int pos)
+        {
+            if (pos <= 0 || pos > xml.Length) return false;
+
+            int lastOpen = xml.LastIndexOf('<', Math.Min(pos, xml.Length - 1));
+            if (lastOpen < 0) return false;
+
+            int lastClose = xml.LastIndexOf('>', Math.Min(pos, xml.Length - 1));
+            return lastOpen > lastClose;
+        }
+
+        /// <summary>
         /// Apply highlighting using pre-computed TermPosition objects with IsFirstTerm flags (for phrase/proximity search)
         /// </summary>
         private string ApplyHighlightingFromPositions(string xmlContent)
@@ -1350,6 +1393,23 @@ namespace CST.Avalonia.ViewModels
                     {
                         Log.Warning("[BookDisplay] Invalid offset range: {Start}-{End} (xml length: {Length})",
                             startOffset, endOffset, xmlContent.Length);
+                        continue;
+                    }
+
+                    // In range is not the same as in TEXT. An offset from an index that is stale relative to
+                    // the file on disk - the corpus updated after the last incremental pass - lands wherever
+                    // the old byte count put it, and splicing <hi> into the middle of "<p n=331>" makes the
+                    // whole document malformed. LoadXml then throws and the reader gets "Error loading book"
+                    // for a book that opens fine without a search. Skipping the one highlight degrades
+                    // honestly instead. (R8-6)
+                    //
+                    // Testing the ENDPOINTS, not the span: a highlight legitimately contains whole tags, and
+                    // the <hi>-crossing cases below exist to handle exactly that.
+                    if (IsInsideTag(xmlContent, startOffset) || IsInsideTag(xmlContent, endOffset))
+                    {
+                        Log.Warning("[BookDisplay] Skipping a highlight whose offsets land inside markup: " +
+                                    "{Start}-{End}. The search index is likely stale for this book (R8-6)",
+                            startOffset, endOffset);
                         continue;
                     }
 

--- a/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/DictionaryViewModel.cs
@@ -408,6 +408,27 @@ public class DictionaryViewModel : ReactiveTool, IDisposable
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Dictionary lookup failed for '{Query}' ({Source})", query, source?.Id);
+
+            // Clear rather than leave the previous query's entries standing under the new SearchText, which
+            // presents the OLD query's results as if they matched the new one - a wrong answer rather than a
+            // visible failure. Narrow trigger, since sources swallow their own failures and return empty; a
+            // mid-query SqliteException is about the only way here. (R12-5)
+            //
+            // Behind the same stale-completion guard as the success path, so a failed lookup that has
+            // already been superseded cannot wipe the results the reader is now looking at.
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                if (query != SearchText || !ReferenceEquals(source, SelectedSource))
+                    return;
+
+                Words.Clear();
+                SelectedWord = null;
+
+                // The one-shot restore is consumed here too. Leaving it armed would let a failed restore
+                // lookup steer whatever the reader typed next. (#935)
+                _pendingSelectedHeadword = null;
+                _pendingSelectedFor = null;
+            });
         }
     }
 


### PR DESCRIPTION
The 2026-08 review left **eleven findings marked ❓** — raised but never verified. I read them in doc order, checked each against current source (and against the installed assets where one existed), and **all eleven were still live**. Eight are fixed here; three are filed without a fix, with the reason.

Fixes issues #957, #958, #962, #963, #964, #965, #966, #967, #968.

## Fixed

| # | What was wrong |
|---|---|
| **R3-4** | A shell probe cut off mid-value yielded a **truncated API key** and an unexplainable 401 |
| **R4-5** | A sub-floor `models-dev.json` on disk was served as the catalogue, silently, permanent while offline |
| **R8-6** | A stale search offset spliced `<hi>` into markup → malformed document → "Error loading book" |
| **R12-5** | A failed dictionary lookup left the previous query's results under the new text |
| **R6-2** | An exception in any Assistant command reached `RxApp.DefaultExceptionHandler` and **terminated the app** |
| **R6-3** | A runaway table from the model froze the UI thread |
| **R6-4** | Stop could end a turn with no "Stopped." line, indistinguishable from a finished one |
| **R5-6** | Four provider lookups still guessed from `connection.Id`, one **disabling a working keyless endpoint** |
| **R8-5** | Restore intent mutated from the CEF thread with no lock (hygiene; no known symptom) |

Three worth calling out:

**R3-4 was sharper than the finding.** `WellFormed` already tests for the trailing NUL — but `Decide` consults it *only* where the exit was never observed, so a shell exiting 0 with a truncated payload arrives already judged a success. The fix drops the un-terminated final **chunk**, not the payload: a whole-stream gate cannot tell truncation from a profile printing its epilogue after `env`, which would cost the reader every variable.

**R8-6 is scoped tighter than suggested.** The finding proposed rejecting any span containing `<`. That would break the existing `<hi>`-crossing cases, which handle spans legitimately containing whole tags. The guard tests the **endpoints** instead — the actual hazard is an offset landing *inside* a tag.

**R5-6 got one shared derivation** rather than four parallel fixes: `AiConnection.PresetIdOrLegacyId`, carrying #766's three-way rule (recorded preset wins; recorded-as-custom means no lookup at all; nothing recorded falls back to the id). Four copies of a rule is how #933 went wrong last night.

## Filed, not fixed — and why

**#959 (R8-2, MED) — live zoom leaks across scripts.** Chromium broadcasts a per-origin zoom and all books share an origin; the handler ignores the event for other scripts. The load path already compensates for the same leak, and its own comment says so. But the fix costs the untouched book **two reflows**, and this file's zoom code is built almost entirely around not disturbing the reading position across one — the burst snapshot, the `CACHE_BUILT` await, the backstop, the superseded-generation stamps. I cannot drive two books in two scripts from here (Avalonia publishes no windows to the macOS Accessibility API), and guessing at that interaction is how a MED bug becomes a subtler one. **The issue carries a four-step repro recipe.**

**#961 (R13-4, MED) — a dossier shows one homonym's family under every other.** Verified against the shipped `dpd-cst-subset.db`: `ta 1.1` (pronoun), `ta 2.1` (the letter *t*), `ta 3.1` (a suffix) each pull in all **74** lemmas with `derived_from='ta'`; `karoti` is **172**; **2,697** homonymous bases have children. Suppress vs annotate is a **lexicographic call**, and DPD's unnumbered `derived_from` makes real attribution impossible — so that one is yours.

**R15-1** was already retired with evidence in an earlier session (946 faces across macOS and Windows; no Indic-capable font omits ZWNJ).

## Verification

Every fix has tests, and each was mutation-tested — reverting the source fails exactly the intended tests and no others. One test needed an explicit floor after R4-5 made it injectable (`An_error_body_that_is_valid_json_does_not_replace_the_cache` **is** the floor test, and would otherwise have passed vacuously).

Full suite: **2812 passed, 0 failed, 18 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)