### PR TITLE
Fix three faults in the About box, one of them a trap worth naming (#937)

### DIFF
--- a/src/CST.Avalonia.Tests/Views/ScrollViewerInsetTests.cs
+++ b/src/CST.Avalonia.Tests/Views/ScrollViewerInsetTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Views;
+
+/// <summary>
+/// A <c>ScrollViewer</c> must not carry its own <c>Padding</c>. (#937)
+///
+/// <para><b>Padding on a ScrollViewer shortens the scrollable extent instead of lengthening it.</b> Measured
+/// in a headless Avalonia 11.3.6 harness, 300px of content in a 150px-tall viewer:</para>
+///
+/// <code>
+/// Padding="20,18" on the viewer     extent 264  max offset 114  last item ends 54px BELOW the viewport
+/// Margin="20,18"  on the content    extent 336  max offset 186  last item fully visible
+/// </code>
+///
+/// <para>So with padding the content is arranged 36px shorter than its own children need, the scrollbar
+/// reaches its end while the tail is still underneath, and the symptom is a last row that looks clipped by
+/// whatever sits below the viewer. In the About box that was the final credit disappearing under the actions
+/// bar; <c>AiAssistantPanel.axaml</c> hit the same trap on the horizontal axis, where the right-hand inset
+/// scrolled away instead of reserving width and long lines lost their last characters.</para>
+///
+/// <para>Two panels, two axes, one cause, and in both cases it presented as a mysterious layout bug rather
+/// than as anything pointing at the property responsible. Hence a rule rather than two comments: put the
+/// inset on the scrolled content as a <c>Margin</c>, where it is added to the extent.</para>
+/// </summary>
+public class ScrollViewerInsetTests
+{
+    [Fact]
+    public void No_scroll_viewer_sets_its_own_padding()
+    {
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(
+                     Path.Combine(RepoRoot(), "src", "CST.Avalonia"), "*.axaml", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}") ||
+                file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+                continue;
+
+            foreach (var e in XDocument.Load(file).Descendants()
+                         .Where(e => e.Name.LocalName == "ScrollViewer"))
+            {
+                var padding = (string?)e.Attribute("Padding");
+                if (padding is not null)
+                    offenders.Add($"{Path.GetFileName(file)} — Padding=\"{padding}\"");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "A ScrollViewer's Padding shortens its scrollable extent, so the end of the content cannot be " +
+            "scrolled into view. Put the inset on the scrolled content as a Margin instead:\n  " +
+            string.Join("\n  ", offenders));
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/src/CST.Avalonia.Tests/Views/ScrollViewerInsetTests.cs
+++ b/src/CST.Avalonia.Tests/Views/ScrollViewerInsetTests.cs
@@ -8,25 +8,38 @@ using Xunit;
 namespace CST.Avalonia.Tests.Views;
 
 /// <summary>
-/// A <c>ScrollViewer</c> must not carry its own <c>Padding</c>. (#937)
+/// A <c>ScrollViewer</c> must not carry its own <c>Padding</c> — <b>while we are on Avalonia 11.3.x or 12.0</b>. (#937)
 ///
-/// <para><b>Padding on a ScrollViewer shortens the scrollable extent instead of lengthening it.</b> Measured
-/// in a headless Avalonia 11.3.6 harness, 300px of content in a 150px-tall viewer:</para>
+/// <para><b>The mechanism.</b> <c>ScrollContentPresenter</c> applies <c>Padding</c> in Arrange but not in
+/// Measure: the child is measured against the full constraint and then arranged into less, and
+/// <c>ComputeExtent</c> reports the arranged child, so the padding is <i>subtracted</i> from the scrollable
+/// extent. A <c>Margin</c> on the content is added to it instead. Measured, 300px of content in a 150px
+/// viewer:</para>
 ///
 /// <code>
 /// Padding="20,18" on the viewer     extent 264  max offset 114  last item ends 54px BELOW the viewport
 /// Margin="20,18"  on the content    extent 336  max offset 186  last item fully visible
 /// </code>
 ///
-/// <para>So with padding the content is arranged 36px shorter than its own children need, the scrollbar
-/// reaches its end while the tail is still underneath, and the symptom is a last row that looks clipped by
-/// whatever sits below the viewer. In the About box that was the final credit disappearing under the actions
-/// bar; <c>AiAssistantPanel.axaml</c> hit the same trap on the horizontal axis, where the right-hand inset
-/// scrolled away instead of reserving width and long lines lost their last characters.</para>
+/// <para>So the scrollbar reaches its end while the tail is still underneath, and the symptom is a last row
+/// that looks clipped by whatever sits below the viewer. In the About box that was the final credit under
+/// the actions bar. <c>AiAssistantPanel.axaml</c> met the same root from the other direction: there nothing
+/// scrolled horizontally at all (that viewer disables it), but a wrapped line kept the width it was
+/// measured at and ran under the overlay scrollbar.</para>
 ///
-/// <para>Two panels, two axes, one cause, and in both cases it presented as a mysterious layout bug rather
-/// than as anything pointing at the property responsible. Hence a rule rather than two comments: put the
-/// inset on the scrolled content as a <c>Margin</c>, where it is added to the extent.</para>
+/// <para><b>This rule has an expiry date.</b> It is Avalonia's defect, not <c>ScrollViewer</c>'s nature —
+/// <see href="https://github.com/AvaloniaUI/Avalonia/issues/17158">AvaloniaUI/Avalonia#17158</see>, fixed by
+/// PR #21872 and shipping in <b>12.1</b>, which moves the padding inside the scrolling area to match WinUI.
+/// 11.3.6 and 12.0 both still have it. <b>When #49 lands the Avalonia 12 upgrade, revisit this test</b>:
+/// past 12.1 it forbids a construct that works.</para>
+///
+/// <para><b>Known limits of the scan.</b> It reads the <c>Padding</c> attribute on <c>ScrollViewer</c>
+/// elements only, so a <c>Style</c>/<c>ControlTheme</c> setter, a <c>&lt;ScrollViewer.Padding&gt;</c>
+/// property element, or code-behind would slip past — the first two are checked for as well, the third
+/// cannot be. And it would wrongly block a legitimate case: a <c>ScrollViewer</c> driving a logically
+/// scrolling child (a re-templated <c>ListBox</c>) takes the plain <c>ContentPresenter</c> path, where
+/// Padding behaves correctly. Neither exists in this app today; if one appears, exempt it here by name
+/// rather than deleting the rule.</para>
 /// </summary>
 public class ScrollViewerInsetTests
 {
@@ -42,18 +55,37 @@ public class ScrollViewerInsetTests
                 file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
                 continue;
 
-            foreach (var e in XDocument.Load(file).Descendants()
-                         .Where(e => e.Name.LocalName == "ScrollViewer"))
+            var doc = XDocument.Load(file);
+
+            foreach (var e in doc.Descendants().Where(e => e.Name.LocalName == "ScrollViewer"))
             {
-                var padding = (string?)e.Attribute("Padding");
+                // The attribute form, and the property-element form that an attribute scan would miss.
+                var padding = (string?)e.Attribute("Padding")
+                              ?? e.Elements().FirstOrDefault(c => c.Name.LocalName == "ScrollViewer.Padding")?.Value;
                 if (padding is not null)
-                    offenders.Add($"{Path.GetFileName(file)} — Padding=\"{padding}\"");
+                    offenders.Add($"{Path.GetFileName(file)} — Padding=\"{padding.Trim()}\"");
+            }
+
+            // And a Style or ControlTheme that sets it on every ScrollViewer at once, which no element
+            // in the markup would show.
+            foreach (var style in doc.Descendants()
+                         .Where(e => e.Name.LocalName is "Style" or "ControlTheme"))
+            {
+                var target = (string?)style.Attribute("Selector") ?? (string?)style.Attribute("TargetType");
+                if (target is null || !target.Contains("ScrollViewer", StringComparison.Ordinal)) continue;
+
+                foreach (var setter in style.Descendants().Where(e => e.Name.LocalName == "Setter"))
+                {
+                    if ((string?)setter.Attribute("Property") != "Padding") continue;
+                    offenders.Add($"{Path.GetFileName(file)} — a setter puts Padding on \"{target}\"");
+                }
             }
         }
 
         Assert.True(offenders.Count == 0,
-            "A ScrollViewer's Padding shortens its scrollable extent, so the end of the content cannot be " +
-            "scrolled into view. Put the inset on the scrolled content as a Margin instead:\n  " +
+            "On Avalonia 11.3.x and 12.0 a ScrollViewer's Padding shortens its scrollable extent, so the " +
+            "end of the content cannot be scrolled into view (AvaloniaUI/Avalonia#17158, fixed in 12.1). " +
+            "Put the inset on the scrolled content as a Margin instead:\n  " +
             string.Join("\n  ", offenders));
     }
 

--- a/src/CST.Avalonia/ViewModels/AboutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AboutViewModel.cs
@@ -145,10 +145,15 @@ namespace CST.Avalonia.ViewModels
             // Every other line here says what the library does FOR US. This one used to say "Desktop
             // integration on Linux", which is true of the library and misleading about the app: we do no
             // desktop integration, the direct PackageReference exists only as a security version pin
-            // (CST.Avalonia.csproj, GHSA-xrw6-gwf8-vvr9), and we do not ship Linux. It stays in the list
-            // because it really does ship - dropping a shipped dependency from an attribution list would
-            // be the worse error - but it now describes the relationship rather than the package. (#937)
-            new("Tmds.DBus.Protocol", "Avalonia's Linux desktop plumbing. Shipped with the app; unused on macOS and Windows.",
+            // (CST.Avalonia.csproj, GHSA-xrw6-gwf8-vvr9), and we do not ship Linux.
+            //
+            // It stays for two reasons, and only the first is a judgement: dropping a shipped dependency
+            // from an attribution list would be the worse error, and AboutInventoryTests fails on a direct
+            // PackageReference with no line here. Verified shipped: Tmds.DBus.Protocol.dll is in the
+            // osx-arm64 publish output and in the installed .app, and Avalonia.FreeDesktop is the only
+            // shipped assembly that references it - nothing in Avalonia.Native or Avalonia.Win32 does.
+            // The wording now describes our relationship to it rather than the package. (#937)
+            new("Tmds.DBus.Protocol", "The D-Bus library Avalonia's Linux backend uses. Shipped with the app; unused on macOS and Windows.",
                 ["Tmds.DBus.Protocol"]),
             new("System.Security.Cryptography.ProtectedData", "Protecting stored API keys on Windows.",
                 ["System.Security.Cryptography.ProtectedData"]),

--- a/src/CST.Avalonia/ViewModels/AboutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AboutViewModel.cs
@@ -142,7 +142,14 @@ namespace CST.Avalonia.ViewModels
                 ["Microsoft.Data.Sqlite", "SQLitePCLRaw.bundle_e_sqlite3"]),
             new("Azure.Identity and Microsoft.Graph", "Reaching the source PDFs held on SharePoint.",
                 ["Azure.Identity", "Microsoft.Graph"]),
-            new("Tmds.DBus.Protocol", "Desktop integration on Linux.", ["Tmds.DBus.Protocol"]),
+            // Every other line here says what the library does FOR US. This one used to say "Desktop
+            // integration on Linux", which is true of the library and misleading about the app: we do no
+            // desktop integration, the direct PackageReference exists only as a security version pin
+            // (CST.Avalonia.csproj, GHSA-xrw6-gwf8-vvr9), and we do not ship Linux. It stays in the list
+            // because it really does ship - dropping a shipped dependency from an attribution list would
+            // be the worse error - but it now describes the relationship rather than the package. (#937)
+            new("Tmds.DBus.Protocol", "Avalonia's Linux desktop plumbing. Shipped with the app; unused on macOS and Windows.",
+                ["Tmds.DBus.Protocol"]),
             new("System.Security.Cryptography.ProtectedData", "Protecting stored API keys on Windows.",
                 ["System.Security.Cryptography.ProtectedData"]),
         ];

--- a/src/CST.Avalonia/ViewModels/AboutViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AboutViewModel.cs
@@ -122,7 +122,7 @@ namespace CST.Avalonia.ViewModels
             new("Avalonia", "The cross-platform UI framework, its Fluent theme, and the Inter typeface.",
                 ["Avalonia", "Avalonia.Desktop", "Avalonia.Themes.Fluent", "Avalonia.Fonts.Inter",
                  "Avalonia.Diagnostics"]),
-            new("Avalonia.Svg.Skia", "SVG rendering, which is how the provider logos are drawn.",
+            new("Avalonia.Svg.Skia", "SVG rendering, which is how the AI provider logos are drawn.",
                 ["Avalonia.Svg.Skia"]),
             new("Dock.Avalonia", "The docking layout — panels, tabs, and floating windows.",
                 ["Dock.Avalonia", "Dock.Avalonia.Themes.Fluent", "Dock.Controls.Recycling", "Dock.Model",

--- a/src/CST.Avalonia/Views/AboutWindow.axaml
+++ b/src/CST.Avalonia/Views/AboutWindow.axaml
@@ -70,8 +70,15 @@
         </Border>
 
         <!-- ACKNOWLEDGEMENTS -->
-        <ScrollViewer Grid.Row="1" Padding="20,18" HorizontalScrollBarVisibility="Disabled">
-            <StackPanel Spacing="18">
+        <!-- The inset is a MARGIN on the content, not Padding on the ScrollViewer, and the difference is
+             the whole of the clipped-last-credit bug (#937). Measured: with Padding="20,18" the extent comes
+             out 36px SHORTER than the content rather than 36px longer, so the maximum scroll offset stops
+             short and the tail of the list can never be scrolled clear of the actions bar - the last credit
+             sat 54px below the viewport with the scrollbar already at the end. A margin on the content is
+             added to the extent, which is what you want. AiAssistantPanel.axaml reached the same conclusion
+             from its own symptom; this is the same trap on the other axis. -->
+        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Spacing="18" Margin="20,18">
 
                 <StackPanel Spacing="10">
                     <TextBlock Text="Texts and data" Classes="Heading"/>
@@ -122,8 +129,15 @@
                                VerticalAlignment="Center" IsVisible="False"/>
                 </StackPanel>
 
+                <!-- No MinWidth, so it sizes to "Close" exactly as the Copy button beside it sizes to its
+                     own label. MinWidth="88" caused both reported faults at once (#937): the button was
+                     wider than it needed, and Fluent leaves HorizontalContentAlignment at Stretch, so the
+                     content presenter filled the 88px and the glyphs sat at its left edge. Measured at 88px
+                     the text began 9px in and was stretched to 70px wide; unconstrained the button is 54px
+                     with 9px either side, which is what the Copy button does (145px, 9px either side).
+                     Fluent sets no MinWidth of its own, so nothing puts the width back. -->
                 <Button Grid.Column="2" Content="Close" IsDefault="True" IsCancel="True"
-                        MinWidth="88" Click="OnClose"/>
+                        Click="OnClose"/>
             </Grid>
         </Border>
     </Grid>

--- a/src/CST.Avalonia/Views/AboutWindow.axaml
+++ b/src/CST.Avalonia/Views/AboutWindow.axaml
@@ -71,12 +71,21 @@
 
         <!-- ACKNOWLEDGEMENTS -->
         <!-- The inset is a MARGIN on the content, not Padding on the ScrollViewer, and the difference is
-             the whole of the clipped-last-credit bug (#937). Measured: with Padding="20,18" the extent comes
-             out 36px SHORTER than the content rather than 36px longer, so the maximum scroll offset stops
-             short and the tail of the list can never be scrolled clear of the actions bar - the last credit
-             sat 54px below the viewport with the scrollbar already at the end. A margin on the content is
-             added to the extent, which is what you want. AiAssistantPanel.axaml reached the same conclusion
-             from its own symptom; this is the same trap on the other axis. -->
+             the whole of the clipped-last-credit bug (#937). Measured on this window: with Padding="20,18"
+             the extent comes out 36px SHORTER than the content rather than 36px longer, so the maximum
+             scroll offset stops short and the tail of the list can never be scrolled clear of the actions
+             bar - the last credit sat 54px below the viewport with the scrollbar already at the end. A
+             margin on the content is added to the extent instead, which is what you want.
+
+             The root is that ScrollContentPresenter applies Padding in Arrange but not in Measure, so the
+             child is measured against the full width and then arranged into less. AiAssistantPanel.axaml
+             met the same root from the other direction, where a wrapped line kept the width it wrapped at
+             and ran under the overlay scrollbar.
+
+             This is Avalonia's bug, not ScrollViewer's nature: AvaloniaUI/Avalonia#17158, fixed by PR
+             #21872 and shipping in 12.1, which moves the padding inside the scrolling area to match WinUI.
+             11.3.6 and 12.0 both still have it. When #49 lands the Avalonia 12 upgrade, this workaround and
+             ScrollViewerInsetTests should both be revisited. -->
         <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">
             <StackPanel Spacing="18" Margin="20,18">
 

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -345,11 +345,18 @@
         </Border>
 
         <!-- ============ The transcript, scrolling ============ -->
-        <!-- The inset is a MARGIN on the content, not Padding on the ScrollViewer. ScrollViewer.Padding sits
-             inside the scrollable extent: the left half lands at the scroll origin and looks right, while the
-             right half scrolls off the end instead of reserving width, so the longest lines ran under the
-             edge and lost their last characters. The extra on the right clears the overlay scrollbar, which
-             Fluent draws on top of the content rather than beside it. -->
+        <!-- The inset is a MARGIN on the content, not Padding on the ScrollViewer. ScrollContentPresenter
+             applies Padding in Arrange but not in Measure, so the child is measured against the full width
+             and then arranged into less: a wrapped line keeps the width it wrapped at and runs under the
+             edge, losing its last characters. Nothing "scrolls off" here - this viewer leaves
+             HorizontalScrollBarVisibility at Disabled, so there is no horizontal extent to scroll; an
+             earlier version of this comment said otherwise and was wrong (measured, #937). The extra on the
+             right clears the overlay scrollbar, which Fluent draws on top of the content rather than beside
+             it.
+
+             Same root as the About box's clipped last credit, where it cost vertical extent instead:
+             AvaloniaUI/Avalonia#17158, fixed in Avalonia 12.1. ScrollViewerInsetTests holds the line until
+             #49 upgrades us. -->
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="14" Margin="8,8,16,8">
 


### PR DESCRIPTION
Closes #937. Three faults in one dialog, one visit.

## 1. "Desktop integration on Linux"

True of the library, misleading about the app. We do no desktop integration, the direct `PackageReference` exists **only** as a security version pin (GHSA-xrw6-gwf8-vvr9), and we do not ship Linux. Every other line in that list says what the library does *for us*; this was the one that could not.

The entry **stays** — dropping a shipped dependency from an attribution list would be the worse error — and now reads:

> The D-Bus library Avalonia's Linux backend uses. Shipped with the app; unused on macOS and Windows.

**Verified rather than assumed:** `Tmds.DBus.Protocol.dll` is in the `osx-arm64` publish output and in the installed `.app`, and `Avalonia.FreeDesktop` is the only shipped assembly that references it — nothing in `Avalonia.Native` or `Avalonia.Win32` does. The code comment also now gives *both* reasons the entry stays, only one of which is a judgement: dropping a shipped dependency would be the worse error, **and** `AboutInventoryTests` fails on a direct `PackageReference` with no line here.

## 2. The clipped last credit — and the mechanism is backwards from the guess

`ScrollViewer.Padding` **shortens** the scrollable extent instead of lengthening it. Measured in a headless Avalonia 11.3.6 harness, 300px of content in a 150px-tall viewer:

```
Padding="20,18" on the viewer     extent 264   max offset 114   last item ends 54px BELOW the viewport
Margin="20,18"  on the content    extent 336   max offset 186   last item fully visible
```

The content is arranged 36px shorter than its own children need, so the scrollbar reaches its end while the tail is still underneath. That reads as "clipped by the bar below it" and points nowhere near the property responsible — which is exactly how it survived.

The inset moves onto the scrolled content as a `Margin`.

**This is Avalonia's defect, not `ScrollViewer`'s nature** — and that matters, because the rule I wrote has an expiry date. [AvaloniaUI/Avalonia#17158](https://github.com/AvaloniaUI/Avalonia/issues/17158), fixed by PR #21872, ships in **12.1** and moves the padding inside the scrolling area to match WinUI. 11.3.6 and 12.0 both still have it. The test, its assert message and the comment all name that boundary and point at **#49** (the Avalonia 12 upgrade), where the rule should be revisited rather than silently forbidding a construct that works.

The root is that `ScrollContentPresenter` applies `Padding` in Arrange but **not** in Measure: the child is measured against the full constraint, arranged into less, and `ComputeExtent` reports the arranged child.

**`AiAssistantPanel.axaml` met the same root from the other direction** — but not, as an earlier draft of this PR and the panel's own comment both claimed, by anything "scrolling off". That viewer leaves `HorizontalScrollBarVisibility` at `Disabled`, so there is no horizontal extent at all (measured `CanHorizontallyScroll=False`, extent 284 against a 300 viewport). What happens is that a wrapped line keeps the width it was *measured* at and runs under the overlay scrollbar. I inherited that sentence and repeated it without checking; both comments are now corrected.

**`ScrollViewerInsetTests`** fails any `.axaml` whose `ScrollViewer` gets `Padding` — as an attribute, as a `<ScrollViewer.Padding>` property element, or through a `Style`/`ControlTheme` setter. Three mutants, three deaths, each naming the file and the form:

```
AboutWindow.axaml — Padding="20,18"
AboutWindow.axaml — a setter puts Padding on "ScrollViewer"
```

It documents its own blind spot too: a `ScrollViewer` driving a logically scrolling child (a re-templated `ListBox`) takes the plain `ContentPresenter` path where `Padding` behaves correctly, and would be wrongly blocked. None exists in the app today; the doc says to exempt such a case by name rather than delete the rule.

## 3. The Close button — one attribute, both faults

`MinWidth="88"` caused the width *and* the left-justification. Measured:

| | button width | label x | label width |
|---|---|---|---|
| `Close`, as shipped (`MinWidth="88"`) | 88 | 9 | **70** (stretched) |
| `Close`, unconstrained | 54 | 9 | 36 |
| `Copy version details` (the contrast case) | 145 | 9 | 127 |

Fluent leaves `HorizontalContentAlignment` at `Stretch`, so the presenter filled the 88px and the glyphs sat at its left edge. At natural width that is invisible; the `MinWidth` is what made it show. Unconstrained, Close gets 9px either side — exactly what the Copy button beside it does.

Fluent sets **no** `MinWidth` of its own (measured: effective `MinWidth` 0), so removing ours is sufficient and no alignment override is needed.

## Verification

- `dotnet build src/CST.Avalonia` — 0 errors, 0 warnings
- `dotnet test src/CST.Avalonia.Tests` — **2797 passed, 0 failed, 18 skipped**; verified against current `main` after #969 (no conflicts, guard tests green)
- `AboutInventoryTests` checks package *names* against the csproj files, not purpose strings, so the reworded line is not asserted anywhere — the wording is a judgement call and yours to overrule.
- **Not verified in the running app.** All three are visual.

## Note on ordering

Branched off `main`, not off #956. `AboutWindow.axaml` uses one of the phantom brushes that PR defines, so what this dialog *looks* like will change again when #956 lands — but the two changes touch different files and different properties, and neither conflicts.

## What to look at

1. The last credit in the list is fully clear of the actions bar.
2. Close is snug and its label centred, matching Copy version details.
3. The Tmds line reads as a statement about the app rather than about D-Bus.


## Confirmed in the app

**[fsnow]**: *"The About box button widths are fine"* — so the unconstrained Close button reads correctly beside the 145px Copy button, and no `MinWidth` needs to come back. He also asked for one wording change while there, now in `b0bff05`: the Skia credit says "the **AI provider** logos", since next to Lucene, PdfPig and SharePoint an unqualified "provider" reads as though it meant the text providers.

---

## Verified in the running app — [fsnow]

- The last credit is fully clear of the actions bar.
- The button widths are right, so no `MinWidth` returns.
- The About box otherwise *"looks fine in dark mode"*, checked on a build that also carries #956 — which matters, because this dialog's card backgrounds and borders only resolve with that PR.
