### PR TITLE
Open Go To on the numbering you last used, and put the caret back (#844)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/GoToDialogViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/GoToDialogViewModelTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using CST;
 using CST.Avalonia.ViewModels;
 using Xunit;
 
@@ -84,4 +86,42 @@ public class GoToDialogViewModelTests
     [InlineData("1645", "P1.1645")]
     public void BuildPageAnchor_PadsPageToFourDigits(string input, string expected)
         => Assert.Equal(expected, GoToDialogViewModel.BuildPageAnchor("P", input, "1.2"));
+
+    // ---- The preference actually reaches the dialog (#844) --------------------------------------------
+
+    /// <summary>
+    /// <see cref="PageNumbering.Resolve"/> is covered thoroughly in <c>PageNumberingTests</c>, and all of
+    /// that passes whether or not the dialog ever CALLS it. These two cover the one line that wires the
+    /// feature in — replacing <c>Resolve(preferred, editions)</c> with <c>Resolve(null, editions)</c> is a
+    /// mutation the pure-function tests cannot see.
+    ///
+    /// <para>A freshly constructed <see cref="BookDisplayViewModel"/> has not built its markers, so
+    /// <c>Editions</c> is null. That is not a limitation of the test — it is the state #457 was about, and
+    /// the two paths give visibly different answers in it: <c>DefaultType(null)</c> is Paragraph, while a
+    /// preference is honoured because <c>Has(null, …)</c> answers "available". So Paragraph here means the
+    /// preference was dropped.</para>
+    /// </summary>
+    private static BookDisplayViewModel AnyBook()
+    {
+        ReactiveUiTestInit.Ensure();
+        var book = Books.Inst?.FirstOrDefault();
+        Assert.NotNull(book);
+        return new BookDisplayViewModel(book!);
+    }
+
+    [Fact]
+    public void Opens_On_The_Remembered_System()
+    {
+        var dialog = new GoToDialogViewModel(AnyBook(), NavigationType.PtsPage);
+
+        Assert.Equal(NavigationType.PtsPage, dialog.SelectedType);
+    }
+
+    [Fact]
+    public void Opens_On_The_Books_Default_When_Nothing_Is_Remembered()
+    {
+        var dialog = new GoToDialogViewModel(AnyBook());
+
+        Assert.Equal(NavigationType.Paragraph, dialog.SelectedType);
+    }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/PageNumberingTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/PageNumberingTests.cs
@@ -197,4 +197,74 @@ public class PageNumberingTests
     {
         Assert.Equal("Thai: 3.0210", PageNumbering.ComposeStatus(Eds(PageEdition.Thai), Page));
     }
+
+    // ---- Offers / Resolve (#844) ----------------------------------------------------------------------
+
+    [Fact]
+    public void Offers_Paragraph_ForEveryBook_IncludingOneWithNoPagination()
+    {
+        // Paragraph is the fallback precisely because it is the one address every book has.
+        Assert.True(PageNumbering.Offers(Eds(), NavigationType.Paragraph));
+        Assert.True(PageNumbering.Offers(Eds(PageEdition.Thai), NavigationType.Paragraph));
+        Assert.True(PageNumbering.Offers(null, NavigationType.Paragraph));
+    }
+
+    [Fact]
+    public void Offers_APageSystem_OnlyWhenTheBookCarriesIt()
+    {
+        var editions = Eds(PageEdition.Vri, PageEdition.Myanmar);
+
+        Assert.True(PageNumbering.Offers(editions, NavigationType.VriPage));
+        Assert.True(PageNumbering.Offers(editions, NavigationType.MyanmarPage));
+        Assert.False(PageNumbering.Offers(editions, NavigationType.PtsPage));
+        Assert.False(PageNumbering.Offers(editions, NavigationType.ThaiPage));
+        Assert.False(PageNumbering.Offers(editions, NavigationType.OtherPage));
+    }
+
+    [Fact]
+    public void Offers_TreatsUnbuiltMarkersAsAvailable_LikeHas()
+    {
+        // null is "not built yet", not "none" — see Has. Withholding a system the book has leaves the
+        // reader no route in; offering one it lacks costs a failed lookup.
+        Assert.True(PageNumbering.Offers(null, NavigationType.PtsPage));
+    }
+
+    [Fact]
+    public void Resolve_KeepsTheReadersSystem_WhenTheBookHasIt()
+    {
+        var editions = Eds(PageEdition.Vri, PageEdition.Pts);
+
+        // VRI wins the DefaultType precedence, so a PTS answer here can only come from the preference.
+        Assert.Equal(NavigationType.VriPage, PageNumbering.DefaultType(editions));
+        Assert.Equal(NavigationType.PtsPage, PageNumbering.Resolve(NavigationType.PtsPage, editions));
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToTheBooksDefault_WhenTheBookLacksIt()
+    {
+        // The PTS reader opens a Myanmar-only text. The dialog has to be usable; the preference itself is
+        // the caller's to keep, and Resolve cannot touch it because it never sees it.
+        var editions = Eds(PageEdition.Myanmar);
+
+        Assert.Equal(NavigationType.MyanmarPage, PageNumbering.Resolve(NavigationType.PtsPage, editions));
+    }
+
+    [Fact]
+    public void Resolve_WithNoPreference_BehavesExactlyAsBefore()
+    {
+        // A first run, or a state file written before #844 existed.
+        foreach (var editions in new[] { Eds(), Eds(PageEdition.Thai), Eds(PageEdition.Vri, PageEdition.Pts) })
+            Assert.Equal(PageNumbering.DefaultType(editions), PageNumbering.Resolve(null, editions));
+    }
+
+    [Fact]
+    public void Resolve_HonoursAPreferenceForParagraph_OverAPaginatedBook()
+    {
+        // The one case where the preference must beat a "better" address: a reader who works in paragraph
+        // numbers has chosen that, and DefaultType would override them on every book with pagination.
+        var editions = Eds(PageEdition.Vri, PageEdition.Pts);
+
+        Assert.Equal(NavigationType.VriPage, PageNumbering.DefaultType(editions));
+        Assert.Equal(NavigationType.Paragraph, PageNumbering.Resolve(NavigationType.Paragraph, editions));
+    }
 }

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -54,9 +54,12 @@ public class ApplicationState
     /// have never chosen. (#844)
     ///
     /// <para>Written when the reader presses OK with a well-formed number - never when the dialog merely
-    /// opens on a fallback, and never on cancel. Not every book carries every system, so a PTS reader
-    /// opening a Myanmar-only text must not come back to find themselves converted.
-    /// <see cref="ViewModels.PageNumbering.Resolve"/> holds the other half of that rule.</para>
+    /// opens, and never on cancel. That includes a system the dialog fell back to because this book lacks
+    /// the reader's: pressing OK means a page number was typed in that system, which is a use.
+    /// <b>[fsnow]:</b> <i>"'the dialog opened on something and you pressed OK'. That's not a thing. You
+    /// wouldn't use a numbering system just because it opened to it."</i>
+    /// <see cref="ViewModels.PageNumbering.Resolve"/> holds the other half - it picks what to show, and
+    /// cannot write anything.</para>
     ///
     /// <para><b>Not "when navigation succeeds"</b>, though an earlier comment here said so: navigation is
     /// an event that runs JS which swallows a missing anchor, so success is not observable from C# at all.

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -49,6 +49,20 @@ public class ApplicationState
     /// first set; empty restores the default (Select a Book). (#91)</summary>
     public string ActiveLeftToolId { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The numbering system the reader last used in Go To — a <c>NavigationType</c> name, or empty if they
+    /// have never chosen. (#844)
+    ///
+    /// <para>Written only when a navigation actually succeeds, never when the dialog merely opens on a
+    /// fallback: not every book carries every system, so a PTS reader opening a Myanmar-only text must not
+    /// come back to find themselves converted. <see cref="ViewModels.PageNumbering.Resolve"/> holds the
+    /// other half of that rule.</para>
+    ///
+    /// <para>The name rather than the enum's number, because the number is positional and this file
+    /// outlives builds; an inserted enum member would silently re-point every saved preference.</para>
+    /// </summary>
+    public string PreferredGoToNumbering { get; set; } = string.Empty;
+
     // Open Book Dialog State  
     public OpenBookDialogState OpenBookDialog { get; set; } = new();
 

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -53,10 +53,14 @@ public class ApplicationState
     /// The numbering system the reader last used in Go To — a <c>NavigationType</c> name, or empty if they
     /// have never chosen. (#844)
     ///
-    /// <para>Written only when a navigation actually succeeds, never when the dialog merely opens on a
-    /// fallback: not every book carries every system, so a PTS reader opening a Myanmar-only text must not
-    /// come back to find themselves converted. <see cref="ViewModels.PageNumbering.Resolve"/> holds the
-    /// other half of that rule.</para>
+    /// <para>Written when the reader presses OK with a well-formed number - never when the dialog merely
+    /// opens on a fallback, and never on cancel. Not every book carries every system, so a PTS reader
+    /// opening a Myanmar-only text must not come back to find themselves converted.
+    /// <see cref="ViewModels.PageNumbering.Resolve"/> holds the other half of that rule.</para>
+    ///
+    /// <para><b>Not "when navigation succeeds"</b>, though an earlier comment here said so: navigation is
+    /// an event that runs JS which swallows a missing anchor, so success is not observable from C# at all.
+    /// The gate is the reader's intent, which is the honest thing to record anyway.</para>
     ///
     /// <para>The name rather than the enum's number, because the number is positional and this file
     /// outlives builds; an inserted enum member would silently re-point every saved preference.</para>

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -881,6 +881,51 @@ namespace CST.Avalonia.Services
             }
         }
 
+        /// <summary>
+        /// The numbering system the reader last navigated with, or null if they never have. (#844)
+        ///
+        /// <para>Stored as the enum's NAME, so an unrecognised value - a state file written by a build that
+        /// knew a system this one does not - is simply "no preference" rather than a wrong one.</para>
+        /// </summary>
+        private static NavigationType? ReadPreferredGoToNumbering()
+        {
+            try
+            {
+                var stored = App.ServiceProvider?.GetService<IApplicationStateService>()?
+                    .Current.PreferredGoToNumbering;
+
+                return string.IsNullOrEmpty(stored) ? null
+                    : Enum.TryParse<NavigationType>(stored, out var type) ? type
+                    : null;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "Could not read the preferred Go To numbering; opening on the book's default");
+                return null;
+            }
+        }
+
+        /// <summary>Records the system a successful Go To used, for the next one. (#844)</summary>
+        private static void WritePreferredGoToNumbering(NavigationType type)
+        {
+            try
+            {
+                var stateService = App.ServiceProvider?.GetService<IApplicationStateService>();
+                if (stateService is null) return;
+
+                if (stateService.Current.PreferredGoToNumbering == type.ToString()) return;
+
+                stateService.Current.PreferredGoToNumbering = type.ToString();
+                _ = stateService.SaveStateAsync();
+                Log.Information("Remembered Go To numbering: {Type}", type);
+            }
+            catch (Exception ex)
+            {
+                // A preference that fails to save costs the reader one re-selection. Never the navigation.
+                Log.Warning(ex, "Could not remember the Go To numbering {Type}", type);
+            }
+        }
+
         private void UpdateBookScriptInState(string windowId, Script newScript)
         {
             try
@@ -3613,8 +3658,8 @@ namespace CST.Avalonia.Services
             {
                 _logger.Information("Showing Go To dialog for book: {BookFile}", bookViewModel.Book.FileName);
 
-                // Create dialog ViewModel
-                var dialogViewModel = new GoToDialogViewModel(bookViewModel);
+                // Create dialog ViewModel, opening on whatever the reader last navigated with (#844).
+                var dialogViewModel = new GoToDialogViewModel(bookViewModel, ReadPreferredGoToNumbering());
 
                 // Create and show dialog
                 var dialog = new GoToDialog(dialogViewModel);
@@ -3641,6 +3686,11 @@ namespace CST.Avalonia.Services
                 if (result && !string.IsNullOrEmpty(dialogViewModel.ConstructedAnchor))
                 {
                     _logger.Information("Go To navigation requested: {Anchor}", dialogViewModel.ConstructedAnchor);
+
+                    // Remember the system only on a navigation that actually happened. Not on open, and not
+                    // on cancel: the dialog may have opened on a FALLBACK because this book lacks the
+                    // reader's system, and writing that back would convert them to it permanently. (#844)
+                    WritePreferredGoToNumbering(dialogViewModel.SelectedType);
 
                     // Trigger navigation via internal invoke method
                     bookViewModel.InvokeNavigateToChapter(dialogViewModel.ConstructedAnchor);

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -884,8 +884,11 @@ namespace CST.Avalonia.Services
         /// <summary>
         /// The numbering system the reader last navigated with, or null if they never have. (#844)
         ///
-        /// <para>Stored as the enum's NAME, so an unrecognised value - a state file written by a build that
-        /// knew a system this one does not - is simply "no preference" rather than a wrong one.</para>
+        /// <para>Stored as the enum's NAME, so a value this build does not know - a state file written by
+        /// one that knew a system this one does not - comes back as "no preference" rather than as a wrong
+        /// one. TryParse is case-SENSITIVE for names, and only this code writes the file, so the only way
+        /// to reach the odd corners (a bare number, a comma-separated pair) is to hand-edit it; those parse
+        /// to an undefined enum value that Offers rejects every time, which lands in the same place.</para>
         /// </summary>
         private static NavigationType? ReadPreferredGoToNumbering()
         {
@@ -3687,9 +3690,13 @@ namespace CST.Avalonia.Services
                 {
                     _logger.Information("Go To navigation requested: {Anchor}", dialogViewModel.ConstructedAnchor);
 
-                    // Remember the system only on a navigation that actually happened. Not on open, and not
-                    // on cancel: the dialog may have opened on a FALLBACK because this book lacks the
-                    // reader's system, and writing that back would convert them to it permanently. (#844)
+                    // Remember the system the reader pressed OK with. Not on open, and not on cancel: the
+                    // dialog may have OPENED on a fallback because this book lacks the reader's system, and
+                    // writing that back merely for having been shown would convert them to it. (#844)
+                    //
+                    // Deliberately not gated on the navigation working: InvokeNavigateToChapter raises an
+                    // event whose consumer runs JS that swallows a missing anchor, so "it succeeded" is not
+                    // a fact this side can learn. What is recorded is what the reader chose.
                     WritePreferredGoToNumbering(dialogViewModel.SelectedType);
 
                     // Trigger navigation via internal invoke method

--- a/src/CST.Avalonia/ViewModels/GoToDialogViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/GoToDialogViewModel.cs
@@ -29,7 +29,12 @@ namespace CST.Avalonia.ViewModels
         private bool _isThaiPageAvailable;
         private bool _isOtherPageAvailable;
 
-        public GoToDialogViewModel(BookDisplayViewModel bookViewModel)
+        /// <param name="preferred">
+        /// The numbering system the reader last navigated with, or null if they never have. Honoured when
+        /// this book carries it and ignored when it does not — see <see cref="PageNumbering.Resolve"/>. The
+        /// dialog does not persist it; the caller does, and only on a successful navigation. (#844)
+        /// </param>
+        public GoToDialogViewModel(BookDisplayViewModel bookViewModel, NavigationType? preferred = null)
         {
             _logger = Log.ForContext<GoToDialogViewModel>();
             _book = bookViewModel.Book;
@@ -53,9 +58,10 @@ namespace CST.Avalonia.ViewModels
             IsThaiPageAvailable = PageNumbering.Has(editions, PageEdition.Thai);
             IsOtherPageAvailable = PageNumbering.Has(editions, PageEdition.Other);
 
-            // Open on a system the book actually has. Paragraph was hardcoded, and it is the weakest address
-            // available - ambiguous in 102 of 217 books because numbering restarts per sub-book (#447, #596).
-            SelectedType = PageNumbering.DefaultType(editions);
+            // Open on what the reader last used, when this book has it; otherwise on a system the book
+            // actually has. Paragraph was hardcoded, and it is the weakest address available - ambiguous in
+            // 102 of 217 books because numbering restarts per sub-book (#447, #596). (#844)
+            SelectedType = PageNumbering.Resolve(preferred, editions);
 
             _logger.Information("GoToDialog initialized for book: {Book}, Available pages: V={V}, M={M}, P={P}, T={T}, O={O}, default={Default}",
                 _book.FileName, IsVriPageAvailable, IsMyanmarPageAvailable, IsPtsPageAvailable, IsThaiPageAvailable, IsOtherPageAvailable, SelectedType);

--- a/src/CST.Avalonia/ViewModels/GoToDialogViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/GoToDialogViewModel.cs
@@ -32,7 +32,7 @@ namespace CST.Avalonia.ViewModels
         /// <param name="preferred">
         /// The numbering system the reader last navigated with, or null if they never have. Honoured when
         /// this book carries it and ignored when it does not — see <see cref="PageNumbering.Resolve"/>. The
-        /// dialog does not persist it; the caller does, and only on a successful navigation. (#844)
+        /// dialog does not persist it; the caller does, and only when the reader presses OK. (#844)
         /// </param>
         public GoToDialogViewModel(BookDisplayViewModel bookViewModel, NavigationType? preferred = null)
         {

--- a/src/CST.Avalonia/ViewModels/PageNumbering.cs
+++ b/src/CST.Avalonia/ViewModels/PageNumbering.cs
@@ -102,12 +102,18 @@ namespace CST.Avalonia.ViewModels
         /// <summary>
         /// The type Go To should open on, given what the reader last chose. (#844)
         ///
-        /// <para><b>The remembered choice and the choice in effect are different things, and only the first
-        /// persists.</b> A reader who works in PTS opens a book with no PTS pagination; this returns the
-        /// book's own default so the dialog is usable, and the caller must NOT write that back as the
-        /// preference — one visit to a Myanmar-only text would otherwise silently convert a PTS reader to
-        /// Myanmar for good. That is the whole reason this is a pure function of the two inputs: it cannot
-        /// mutate the preference, because it cannot see it.</para>
+        /// <para><b>Choosing is not remembering.</b> A reader who works in PTS opens a book with no PTS
+        /// pagination, and this returns the book's own default so the dialog is usable — but merely being
+        /// shown a system is not evidence of anything, so this cannot be what updates the preference. It is
+        /// a pure function of its two inputs and cannot mutate the preference, because it cannot see it.
+        /// The caller decides what to record, after the reader has done something.</para>
+        ///
+        /// <para><b>[fsnow] settled what counts as "done something", and it is simpler than the guard an
+        /// earlier version of this comment described:</b> <i>"'the dialog opened on something and you
+        /// pressed OK'. That's not a thing. You wouldn't use a numbering system just because it opened to
+        /// it."</i> Pressing OK means a page number was typed <i>in</i> that system, which is a use. So a
+        /// fallback the reader actually navigates with is recorded, and rightly — what is not recorded is a
+        /// fallback merely displayed.</para>
         ///
         /// <para><paramref name="preferred"/> null means the reader has never chosen — a first run, or a
         /// state file from before this existed — and falls through to <see cref="DefaultType"/>, which is

--- a/src/CST.Avalonia/ViewModels/PageNumbering.cs
+++ b/src/CST.Avalonia/ViewModels/PageNumbering.cs
@@ -77,6 +77,45 @@ namespace CST.Avalonia.ViewModels
             return NavigationType.Paragraph;
         }
 
+        /// <summary>
+        /// Whether Go To can offer <paramref name="type"/> for a book carrying <paramref name="editions"/>.
+        ///
+        /// <para>Paragraph is always offered: every book has paragraphs, which is why it is the fallback
+        /// even though it is the weakest address. For the page systems this defers to <see cref="Has"/>,
+        /// including its deliberate "unknown answers true" for a book whose markers are not built yet.</para>
+        ///
+        /// <para>Walks <see cref="Order"/> rather than carrying an inverse of
+        /// <see cref="ToNavigationType"/>: a second switch would be a second thing to keep in step, and this
+        /// one cannot drift from the table the rest of the class already uses.</para>
+        /// </summary>
+        public static bool Offers(IReadOnlyList<PageEdition>? editions, NavigationType type)
+        {
+            if (type == NavigationType.Paragraph) return true;
+
+            foreach (var (edition, _) in Order)
+                if (ToNavigationType(edition) == type)
+                    return Has(editions, edition);
+
+            return false;
+        }
+
+        /// <summary>
+        /// The type Go To should open on, given what the reader last chose. (#844)
+        ///
+        /// <para><b>The remembered choice and the choice in effect are different things, and only the first
+        /// persists.</b> A reader who works in PTS opens a book with no PTS pagination; this returns the
+        /// book's own default so the dialog is usable, and the caller must NOT write that back as the
+        /// preference — one visit to a Myanmar-only text would otherwise silently convert a PTS reader to
+        /// Myanmar for good. That is the whole reason this is a pure function of the two inputs: it cannot
+        /// mutate the preference, because it cannot see it.</para>
+        ///
+        /// <para><paramref name="preferred"/> null means the reader has never chosen — a first run, or a
+        /// state file from before this existed — and falls through to <see cref="DefaultType"/>, which is
+        /// exactly the behaviour that shipped before.</para>
+        /// </summary>
+        public static NavigationType Resolve(NavigationType? preferred, IReadOnlyList<PageEdition>? editions)
+            => preferred is { } want && Offers(editions, want) ? want : DefaultType(editions);
+
         /// <summary>Maps an edition to the Go To navigation type that addresses it.</summary>
         public static NavigationType ToNavigationType(PageEdition edition) => edition switch
         {

--- a/src/CST.Avalonia/ViewModels/PageNumbering.cs
+++ b/src/CST.Avalonia/ViewModels/PageNumbering.cs
@@ -112,6 +112,16 @@ namespace CST.Avalonia.ViewModels
         /// <para><paramref name="preferred"/> null means the reader has never chosen — a first run, or a
         /// state file from before this existed — and falls through to <see cref="DefaultType"/>, which is
         /// exactly the behaviour that shipped before.</para>
+        ///
+        /// <para><b>The two functions disagree about a null <paramref name="editions"/>, on purpose.</b>
+        /// <see cref="DefaultType"/> reads it pessimistically and answers Paragraph — with nothing known,
+        /// pick the address every book has. <see cref="Offers"/> reads it optimistically and answers
+        /// available — see <see cref="Has"/> for why. So during the brief window before a book's markers
+        /// are built, this honours the preference rather than falling back, and the reader can get an
+        /// anchor for a system the book turns out to lack. That costs one failed lookup, which is the same
+        /// trade <see cref="Has"/> already makes deliberately, and it is preferable to overriding a
+        /// standing choice on a technicality of load order. Recorded because the asymmetry is real and
+        /// neither function used to mention the other.</para>
         /// </summary>
         public static NavigationType Resolve(NavigationType? preferred, IReadOnlyList<PageEdition>? editions)
             => preferred is { } want && Offers(editions, want) ? want : DefaultType(editions);

--- a/src/CST.Avalonia/Views/GoToDialog.axaml
+++ b/src/CST.Avalonia/Views/GoToDialog.axaml
@@ -23,35 +23,46 @@
         <StackPanel Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" Spacing="10" Margin="0,0,30,0">
             <TextBlock Text="Go To What:" FontSize="14" Margin="0,0,0,5"/>
 
+            <!-- Click, not the bound SelectedType, sends focus back to the number box (#844). A handler on
+                 the property would also fire while ARROWING between the radios, yanking focus out of the
+                 group mid-traversal and making it unusable from the keyboard. Click is raised by a pointer
+                 press and by Space - both deliberate choices - and not by focus merely moving. -->
+
             <RadioButton Content="Paragraph"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=Paragraph}"
                          IsEnabled="{Binding IsParagraphAvailable}"
-                         GroupName="NavType"/>
+                         GroupName="NavType"
+                         Click="OnNavTypeClick"/>
 
             <RadioButton Content="VRI Page"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=VriPage}"
                          IsEnabled="{Binding IsVriPageAvailable}"
-                         GroupName="NavType"/>
+                         GroupName="NavType"
+                         Click="OnNavTypeClick"/>
 
             <RadioButton Content="Myanmar Page"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=MyanmarPage}"
                          IsEnabled="{Binding IsMyanmarPageAvailable}"
-                         GroupName="NavType"/>
+                         GroupName="NavType"
+                         Click="OnNavTypeClick"/>
 
             <RadioButton Content="PTS Page"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=PtsPage}"
                          IsEnabled="{Binding IsPtsPageAvailable}"
-                         GroupName="NavType"/>
+                         GroupName="NavType"
+                         Click="OnNavTypeClick"/>
 
             <RadioButton Content="Thai Page"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=ThaiPage}"
                          IsEnabled="{Binding IsThaiPageAvailable}"
-                         GroupName="NavType"/>
+                         GroupName="NavType"
+                         Click="OnNavTypeClick"/>
 
             <RadioButton Content="Other Page"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=OtherPage}"
                          IsEnabled="{Binding IsOtherPageAvailable}"
-                         GroupName="NavType"/>
+                         GroupName="NavType"
+                         Click="OnNavTypeClick"/>
         </StackPanel>
 
         <!-- Right Column: Number input and buttons -->

--- a/src/CST.Avalonia/Views/GoToDialog.axaml
+++ b/src/CST.Avalonia/Views/GoToDialog.axaml
@@ -23,10 +23,19 @@
         <StackPanel Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" Spacing="10" Margin="0,0,30,0">
             <TextBlock Text="Go To What:" FontSize="14" Margin="0,0,0,5"/>
 
-            <!-- Click, not the bound SelectedType, sends focus back to the number box (#844). A handler on
-                 the property would also fire while ARROWING between the radios, yanking focus out of the
-                 group mid-traversal and making it unusable from the keyboard. Click is raised by a pointer
-                 press and by Space - both deliberate choices - and not by focus merely moving. -->
+            <!-- Click, not the bound SelectedType, sends focus back to the number box (#844). Click is
+                 raised only by a deliberate activation - pointer release, Space, or Enter - so focus moves
+                 when the reader CHOOSES a system, never as a side effect of the selection changing for
+                 some other reason (the letter-shortcut path in the code-behind sets SelectedType itself,
+                 and refocuses on its own terms).
+
+                 An earlier version of this comment justified it by saying a property handler would fire
+                 while ARROWING between the radios and drag focus out of the group. That is WPF's
+                 behaviour, and it is false here twice over: Avalonia 11.3.6 leaves XYFocus.NavigationModes
+                 at Gamepad|Remote, so arrow keys do nothing in this dialog at all - traversal is Tab, one
+                 stop per radio - and Avalonia's RadioButton has no key handling and no focus-triggered
+                 check, so moving focus cannot change IsChecked in the first place. Measured in a headless
+                 harness, not reasoned. Tab does not check; Space and Enter do. -->
 
             <RadioButton Content="Paragraph"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=Paragraph}"

--- a/src/CST.Avalonia/Views/GoToDialog.axaml.cs
+++ b/src/CST.Avalonia/Views/GoToDialog.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
 using CST.Avalonia.ViewModels;
@@ -61,6 +62,26 @@ namespace CST.Avalonia.Views
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+        }
+
+        /// <summary>
+        /// Choosing a numbering system puts the caret back in the number box. (#844)
+        ///
+        /// <para>Without it, "open, pick a system, type a number" needs a second click: focus stays on the
+        /// radio, so the digits go nowhere. The letter-shortcut path at
+        /// <see cref="OnNumberTextBoxChanged"/> already re-focuses for the same reason after it rewrites
+        /// the text; this is the other way in.</para>
+        ///
+        /// <para><c>SelectAll</c> to match what <c>Opened</c> does, so a number already typed is replaced
+        /// by the next keystroke rather than appended to.</para>
+        /// </summary>
+        private void OnNavTypeClick(object? sender, RoutedEventArgs e)
+        {
+            var textBox = this.FindControl<TextBox>("NumberTextBox");
+            if (textBox is null) return;
+
+            textBox.Focus();
+            textBox.SelectAll();
         }
 
         private void OnNumberTextBoxChanged(object? sender, EventArgs e)


### PR DESCRIPTION
Closes #844. Two independent annoyances in one dialog, one visit.

## 1. It never remembered the numbering system

`SelectedType` was assigned `PageNumbering.DefaultType(editions)` on every open — a property of the **book**, never of what the reader picked. Someone who works in PTS re-selected PTS every single time.

**The remembered choice and the choice in effect are different things, and only the first persists.** That's the part the issue flagged as easiest to get wrong: not every book carries every system, so a PTS reader opening a Myanmar-only text needs a usable dialog *without* being quietly converted to Myanmar for good.

So the decision is a pure function that **cannot see the preference and therefore cannot corrupt it**:

```csharp
Resolve(preferred, editions) => preferred is available ? preferred : DefaultType(editions)
```

and the caller writes the preference back **only when the reader presses OK with a well-formed number** — not on open, not on cancel.

Three details worth review:

- **`Offers()` walks the same `Order` table** the rest of the class already uses, rather than carrying an inverse of `ToNavigationType`. A second mapping would be a second thing to keep in step. It also inherits `Has()`'s deliberate *"unknown answers true"* for a book whose markers aren't built yet.
- **Paragraph is always offered**, which makes it a preference someone can actually hold. A reader who works in paragraph numbers now keeps them, instead of being overridden by `DefaultType` on every paginated book.
- **Stored as the enum's name, not its number.** The number is positional and this file outlives builds; an inserted member would silently re-point every saved preference. An unrecognised name reads as "no preference" rather than as a wrong one.

## 2. Focus did not come back to the number box

"Open, pick a system, type a number" needed a second click — focus stayed on the radio and the digits went nowhere.

Wired to **`Click`, not to the bound `SelectedType`**, so focus moves when the reader *chooses* a system rather than as a side effect of the selection changing for another reason — the letter-shortcut path sets `SelectedType` itself and refocuses on its own terms.

**The first draft justified this by protecting arrow-key traversal, and that was WPF's behaviour, not Avalonia's.** Measured in a headless harness: 11.3.6 leaves `XYFocus.NavigationModes` at `Gamepad|Remote` and this app sets no `XYFocus`/`KeyboardNavigation` property anywhere, so **arrow keys do nothing in this dialog** — traversal is Tab, one stop per radio. And Avalonia's `RadioButton` has no key handling and no focus-triggered check, so moving focus cannot change `IsChecked` at all. Enter raises `Click` too, which the old comment denied.

## Verification

- `dotnet build src/CST.Avalonia` — 0 errors, 0 warnings
- `dotnet test src/CST.Avalonia.Tests` — **2823 passed, 0 failed, 18 skipped**
- **Four mutants killed.** Three inside `PageNumbering`: ignoring the preference fails two tests, honouring it when the book lacks the system fails one, dropping Paragraph's always-available rule fails two.
- **The fourth is the one the first draft missed.** All three of those live below the line that wires the feature in: mutating the ViewModel to `Resolve(null, editions)` passed all 58 tests, because nothing constructed a `GoToDialogViewModel` with a preference. Two tests now do, and it dies.
- **Not verified in the running app.**

## What to look at

1. Pick PTS in a book that has it, navigate, then open Go To in another book that also has PTS — it should open on PTS.
2. Then open Go To in a book **without** PTS: it should fall back to that book's default, and going back to a PTS book should still give you PTS. That is the case the design exists for.
3. Pick a system by clicking a radio and type digits immediately — no second click.
4. **Tab** through the radio group (not arrow keys — they do nothing here) and press **Space** or **Enter** on one: the caret should land in the number box.

## Review — Fable, on `e239263`

It could not break the persistence rule: every exit path traced, only `NavigateCommand` yields `true`, and `Offers` agrees with `ToNavigationType` for all six enum members. `b0a1e26` fixes what it did find — the false arrow-key rationale, the untested wiring line, and a "written only when navigation succeeds" claim repeated in three comments that the architecture cannot support, since the navigation runs JS which swallows a missing anchor.

## Settled by the maintainer

**Does navigating from a fallback-opened dialog overwrite the preference? Yes, and the question was malformed.** I had worried about a PTS reader being "converted" by one detour into a Myanmar-only book. **[fsnow]:**

> *"'the dialog opened on something and you pressed OK'. That's not a thing. You wouldn't use a numbering system just because it opened to it."*

> *"you still have to type a number"*

OK is not reachable without a well-formed number typed **in** the selected system — `NavigateCommand`'s `canExecute` is `IsValidInput(InputNumber, SelectedType)`. So there is no accidental OK to guard against: a fallback the reader navigates with has been *used*, and recording it is right. What is never recorded is a fallback merely displayed, which `Resolve` being a pure function of its inputs already guarantees.

He also considered and rejected an MRU list of systems (`b0a1e26`'s successor discussion): *"Let's keep it simple: store the last numbering system. Pick a sensible default if the last one stored is not present."* That is what this PR does.

No behaviour change followed — only two comments that argued for the rule he rejected, corrected in the final commit with his words quoted rather than paraphrased.
