### PR TITLE
Date the welcome page's prose to Beta 7

### DIFF
--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -343,7 +343,7 @@
     </div>
 
     <div class="beta-notice">
-        <strong>Upgrading from Beta 5? Nothing to do.</strong>
+        <strong>Upgrading from Beta 5 or Beta 6? Nothing to do.</strong>
         <p>Install over the top. Your settings, layout, open books and downloaded dictionaries carry across.</p>
         <p style="margin-top: 8px;"><strong>Coming from Beta 4 or earlier:</strong> delete your CST Reader data directory first &mdash; the search index changed in Beta 5 and an older one will not be read correctly.</p>
         <p style="margin-top: 8px;"><strong>macOS:</strong> <code>~/Library/Application Support/CSTReader/</code> &nbsp;&bull;&nbsp; <strong>Windows:</strong> <code>%APPDATA%\CSTReader\</code></p>
@@ -354,7 +354,7 @@
         <p>Thank you for testing CST Reader! Your feedback will help shape the final release.</p>
 
         <h3 style="margin-top: 24px; margin-bottom: 16px;">Focus Areas</h3>
-        <p>Beta 5 reached feature parity with CST4. Beta 6 adds a great deal on top of it, and these areas are the newest &mdash; feedback on them is especially valuable:</p>
+        <p>Beta 5 reached feature parity with CST4. Beta 6 and Beta 7 add a great deal on top of it, and these areas are the newest &mdash; feedback on them is especially valuable:</p>
 
         <div class="focus-item">
             <strong>The AI Assistant &mdash; brand new</strong>


### PR DESCRIPTION
The bundled welcome page still described itself as Beta 6. Version strings were bumped when the cycle opened (#945); the prose around them was not.

Two phrases carried the date:

- **The upgrade notice** said "Upgrading from Beta 5? Nothing to do." A Beta 6 user reading it is told nothing about their own case → now "Beta 5 or Beta 6".
- **The Focus Areas intro** said "Beta 6 adds a great deal on top of it", which reads as a claim about the build in front of the reader → now "Beta 6 and Beta 7 add".

Everything below stays. Beta 7 follows Beta 6 by two days and adds nothing a tester would go looking for, so the focus items still name the newest work — and a reader who never installed Beta 6 is seeing all of it for the first time. The macOS idle-CPU limitation still says "Beta 6 reduces how often that timer fires"; that is a historical statement and stays true.

This file is compiled into the build, so it has to be right before packaging rather than after — it leads the pre-release checklist because it was missed in the Beta 6 run and caught by hand.

Two lines, no code. Not covered by tests; verified by reading the rendered section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)