### PR TITLE
Stamp the welcome page with the release month, not "in development"

### DIFF
--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -141,11 +141,17 @@ the build succeeds, the tests pass, and the mistake ships. Both were missed in B
 
 - [ ] **In-app welcome page rewritten for this release** — `src/CST.Avalonia/Resources/welcome-content.html`.
       This is BUNDLED INTO THE BUILD, so it must be correct before anything is packaged; it is not the same
-      file as `welcome-updates.json`, which is live-fetched and updated post-publish in Step 5. Three parts go
+      file as `welcome-updates.json`, which is live-fetched and updated post-publish in Step 5. Four parts go
       stale every cycle and none of them fail a test:
+      - the **date beside the version**, in the header and the footer alike. Bucket A bumps the version
+        number at the start of the cycle and sets the date to "in development", because the release month
+        is not known yet. Flipping it to the actual month — "5.0.0-beta.7 • September 2026" — is the last
+        thing that happens, and it is easy to miss precisely because the version number beside it is right;
       - the **upgrade notice** — whether a clean start is required, and from which version. Beta 5's said
         "delete your data directory", which would have been wrong advice for every Beta 5 upgrader;
-      - the **focus areas** — they should name what is new *in this release*, not the last one;
+      - the **focus areas** — they should name what is new *in this release*, not the last one. When a
+        release follows close on the last one, the previous cycle's focus areas may still be the newest
+        thing the reader has seen; check whether they were installed before rewriting;
       - the **known limitations** — delete the ones that were fixed. Beta 6 still listed book fonts as
         not customizable, which #42 had shipped.
 - [ ] **Version strings updated and consistent** (bucket A) — see **Version strings: two timing buckets**

--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -143,10 +143,11 @@ the build succeeds, the tests pass, and the mistake ships. Both were missed in B
       This is BUNDLED INTO THE BUILD, so it must be correct before anything is packaged; it is not the same
       file as `welcome-updates.json`, which is live-fetched and updated post-publish in Step 5. Four parts go
       stale every cycle and none of them fail a test:
-      - the **date beside the version**, in the header and the footer alike. Bucket A bumps the version
-        number at the start of the cycle and sets the date to "in development", because the release month
-        is not known yet. Flipping it to the actual month — "5.0.0-beta.7 • September 2026" — is the last
-        thing that happens, and it is easy to miss precisely because the version number beside it is right;
+      - the **date beside the version**, in the header and the footer alike. It is **only ever moved
+        forward** to the release month — "5.0.0-beta.7 • September 2026" — and **never set back** to a
+        placeholder, so a dev build carries the previous release's month until this step. It is easy to
+        miss precisely because the version number beside it is right: Bucket A bumps the number at the
+        start of the cycle, when the release month is not yet known, and leaves the date alone;
       - the **upgrade notice** — whether a clean start is required, and from which version. Beta 5's said
         "delete your data directory", which would have been wrong advice for every Beta 5 upgrader;
       - the **focus areas** — they should name what is new *in this release*, not the last one. When a
@@ -189,7 +190,7 @@ point every dev build self-identifies as the new version, which is what makes bu
 | `CST.Avalonia.csproj` | `Version`, `InformationalVersion`, `CFBundleVersion`, `CFBundleShortVersionString`, `AssemblyVersion`, `FileVersion` — **canonical source** |
 | `Info.plist` | `CFBundleVersion` + `CFBundleShortVersionString` |
 | `package-macos.sh` | helper-bundle `CFBundleVersion` / `CFBundleShortVersionString` |
-| `Resources/welcome-content.html` | header version + footer version/date |
+| `Resources/welcome-content.html` | header + footer **version number only** — leave the date, which is stamped with the release month at release time (checklist item 1) |
 | `Services/WelcomeUpdateService.cs` | `CurrentAppVersion` default |
 | `ViewModels/WelcomeViewModel.cs` | version fallback string |
 | `CLAUDE.md` | status line ("Beta N in development") |

--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -339,7 +339,7 @@
         <div class="logo"><img src="buddha-transparent.png" alt="Buddha"></div>
         <h1>CST Reader</h1>
         <p class="subtitle">A Pāli Text Reader for the Chaṭṭha Saṅgāyana Tipiṭaka</p>
-        <p class="version">Version 5.0.0-beta.7 &bull; in development</p>
+        <p class="version">Version 5.0.0-beta.7 &bull; September 2026</p>
     </div>
 
     <div class="beta-notice">
@@ -465,7 +465,7 @@
 
     <div class="update-note">
         <p>This welcome page updates automatically with new releases.</p>
-        <p>CST Reader 5.0.0-beta.7 • in development</p>
+        <p>CST Reader 5.0.0-beta.7 • September 2026</p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
The bundled welcome page's header and footer both read `5.0.0-beta.7 • in development`. Correct for a dev build, wrong for a release — Beta 6 shipped as `5.0.0-beta.6 • September 2026`, and Beta 7 should match.

Two lines: 342 (header) and 468 (footer).

### The date moves forward only

**[fsnow]:** *"let's not change it *from* a date again"*

Opening the Beta 7 cycle set this string to "in development" alongside the version bump, and it stayed that way until it was caught on the eve of the release. Reverting a real date to a placeholder every cycle only creates the chance to ship the placeholder; a dev build carrying the previous release's month is harmless by comparison, and the version number beside it already says `beta.7` if anyone wonders.

So Bucket A now bumps the **number only** and leaves the date alone. The date is written once, at release time, and only ever forward.

### Checklist

The pre-release checklist named three stale parts of this file and not this one; it names four now. The date is easy to miss precisely because the version number beside it is right — Bucket A sets that at cycle start, so the date is the one half that cannot be set until the end, and the line reads as correct at a glance.

The focus-areas bullet also gains the case this cycle presented: Beta 7 follows Beta 6 by two days, so the previous cycle's focus areas are still the newest thing a reader has seen. "Name what is new *in this release*" is right for a normal cycle and wrong for a fast follow where nobody installed the release being superseded.

Two string edits and a doc change. No code, no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)