### PR TITLE
Refresh the models.dev snapshot for Beta 7

### DIFF
--- a/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.json
+++ b/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.json
@@ -7051,6 +7051,47 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
+   },
+   "abliterated-model-large-v2": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 5,
+     "output": 5
+    },
+    "description": "GLM-5.3 model abliterated and finetuned for cyber, ML red teaming, and agent testing",
+    "id": "abliterated-model-large-v2",
+    "last_updated": "2026-08-31",
+    "limit": {
+     "context": 1000000,
+     "input": 1000000,
+     "output": 999990
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Abliterated Model Large V2",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-29",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
    }
   },
   "name": "abliteration.ai",
@@ -9647,6 +9688,100 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek-v4-flash-0731": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0284,
+     "input": 0.142,
+     "output": 0.284
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash-0731",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-pro-0813": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.023058,
+     "input": 0.6918,
+     "output": 2.0754
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "deepseek-v4-pro-0813",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "doubao-seed-2-0-code-preview": {
     "attachment": true,
     "cost": {
@@ -10416,6 +10551,96 @@
      }
     ],
     "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2817,
+     "input": 1.1268,
+     "output": 3.9438
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "glm-5.3",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.02817,
+     "input": 0.11268,
+     "output": 0.39438
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -11198,6 +11423,50 @@
     "temperature": true,
     "tool_call": true
    },
+   "grok-4.6": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "grok-4.6",
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 500000,
+     "output": 500000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "grok-build-0.1": {
     "attachment": true,
     "cost": {
@@ -11700,6 +11969,51 @@
     "temperature": true,
     "tool_call": true
    },
+   "qwen3.7-flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.00564,
+     "cache_write": 0.03525,
+     "input": 0.0282,
+     "output": 0.1128
+    },
+    "description": "Lightweight multimodal Qwen model for high-throughput text, image, and video tasks",
+    "family": "qwen",
+    "id": "qwen3.7-flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-07-15",
+    "limit": {
+     "context": 991000,
+     "input": 991000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.7 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "max": 262144,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-07-15",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "qwen3.7-max": {
     "attachment": false,
     "cost": {
@@ -11785,6 +12099,51 @@
      }
     ],
     "release_date": "2026-06-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-2.4t-a95b": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "Open-weight sparse MoE (2.4T total, 95B active), the open-weight twin of Qwen3.8 Max for coding, research, complex reasoning, and agentic workflows",
+    "family": "qwen",
+    "id": "qwen3.8-2.4t-a95b",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 262000,
+     "output": 262000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 2.4T A95B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -20926,6 +21285,52 @@
     "temperature": false,
     "tool_call": true
    },
+   "anthropic.claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "anthropic.claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "temperature": false,
+    "tool_call": true
+   },
    "anthropic.claude-haiku-4-5-20251001-v1:0": {
     "attachment": true,
     "cost": {
@@ -22313,6 +22718,52 @@
      }
     ],
     "release_date": "2026-06-09",
+    "temperature": false,
+    "tool_call": true
+   },
+   "global.anthropic.claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "global.anthropic.claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1 (Global)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
     "temperature": false,
     "tool_call": true
    },
@@ -24870,6 +25321,52 @@
     "temperature": false,
     "tool_call": true
    },
+   "us.anthropic.claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.275,
+     "cache_write": 13.75,
+     "input": 11,
+     "output": 55
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "us.anthropic.claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1 (US)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "temperature": false,
+    "tool_call": true
+   },
    "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
     "attachment": true,
     "cost": {
@@ -26253,6 +26750,53 @@
      }
     ],
     "release_date": "2026-06-07",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -29248,6 +29792,57 @@
     "temperature": false,
     "tool_call": true
    },
+   "claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "provider": {
+     "api": "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/anthropic/v1",
+     "npm": "@ai-sdk/anthropic"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
    "claude-haiku-4-5": {
     "attachment": true,
     "cost": {
@@ -31408,8 +32003,8 @@
       "input": 10,
       "output": 45
      },
-     "input": 5,
-     "output": 30,
+     "input": 4,
+     "output": 20,
      "tiers": [
       {
        "cache_read": 1,
@@ -31799,6 +32394,46 @@
     "reasoning_options": [],
     "release_date": "2026-04-08",
     "status": "beta",
+    "temperature": true,
+    "tool_call": true
+   },
+   "grok-4.6": {
+    "attachment": true,
+    "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+    "family": "grok",
+    "id": "grok-4.6",
+    "knowledge": "2026-02-01",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 200000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Grok 4.6",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "status": "beta",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -32643,6 +33278,57 @@
     ],
     "release_date": "2026-06-09",
     "status": "beta",
+    "temperature": false,
+    "tool_call": true
+   },
+   "claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "provider": {
+     "api": "https://${AZURE_COGNITIVE_SERVICES_RESOURCE_NAME}.services.ai.azure.com/anthropic/v1",
+     "npm": "@ai-sdk/anthropic"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "structured_output": true,
     "temperature": false,
     "tool_call": true
    },
@@ -36587,6 +37273,51 @@
   ],
   "id": "berget",
   "models": {
+   "Qwen/Qwen3.8-27B-FP8": {
+    "attachment": true,
+    "cost": {
+     "input": 0.46,
+     "output": 3.48
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "Qwen/Qwen3.8-27B-FP8",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "google/gemma-4-31B-it": {
     "attachment": true,
     "cost": {
@@ -36622,79 +37353,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "meta-llama/Llama-3.3-70B-Instruct": {
-    "attachment": false,
-    "cost": {
-     "input": 0.99,
-     "output": 0.99
-    },
-    "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
-    "family": "llama",
-    "id": "meta-llama/Llama-3.3-70B-Instruct",
-    "knowledge": "2023-12",
-    "last_updated": "2025-04-27",
-    "limit": {
-     "context": 128000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama 3.3 70B Instruct",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-04-27",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "mistralai/Mistral-Medium-3.5-128B": {
-    "attachment": true,
-    "cost": {
-     "input": 1.65,
-     "output": 5.5
-    },
-    "description": "Mistral model for multilingual chat, reasoning, and tool-assisted workflows",
-    "family": "mistral-medium",
-    "id": "mistralai/Mistral-Medium-3.5-128B",
-    "knowledge": "2026-04",
-    "last_updated": "2026-04-29",
-    "limit": {
-     "context": 262144,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "image",
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Mistral Medium 3.5 128B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-04-29",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "mistralai/Mistral-Small-3.2-24B-Instruct-2506": {
     "attachment": false,
     "cost": {
@@ -36723,48 +37381,6 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2025-10-01",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "moonshotai/Kimi-K2.6": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.16,
-     "input": 0.83,
-     "output": 3.85
-    },
-    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
-    "family": "kimi-k2",
-    "id": "moonshotai/Kimi-K2.6",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-07",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.6",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-05-07",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -36813,79 +37429,6 @@
     "temperature": false,
     "tool_call": true
    },
-   "openai/gpt-oss-120b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.22,
-     "output": 0.83
-    },
-    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
-    "family": "gpt-oss",
-    "id": "openai/gpt-oss-120b",
-    "knowledge": "2025-08",
-    "last_updated": "2025-08-05",
-    "limit": {
-     "context": 128000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-OSS-120B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-08-05",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/GLM-4.7": {
-    "attachment": false,
-    "cost": {
-     "input": 0.77,
-     "output": 2.75
-    },
-    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
-    "family": "glm",
-    "id": "zai-org/GLM-4.7",
-    "knowledge": "2025-12",
-    "last_updated": "2026-01-19",
-    "limit": {
-     "context": 128000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.7",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-01-19",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "zai-org/GLM-5.2": {
     "attachment": false,
     "cost": {
@@ -36925,49 +37468,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "zai-org/GLM-5.3": {
-    "attachment": false,
-    "cost": {
-     "input": 1.75,
-     "output": 5.82
-    },
-    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
-    "family": "glm",
-    "id": "zai-org/GLM-5.3",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-08-29",
-    "limit": {
-     "context": 327680,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-5.3",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "high",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-08-14",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "zai-org/GLM-5.3-Flash": {
     "attachment": true,
     "cost": {
@@ -36980,9 +37480,9 @@
     "interleaved": {
      "field": "reasoning_content"
     },
-    "last_updated": "2026-08-29",
+    "last_updated": "2026-09-01",
     "limit": {
-     "context": 327680,
+     "context": 524288,
      "output": 16384
     },
     "modalities": {
@@ -37459,9 +37959,9 @@
    "Qwen/Qwen3.8-27B-TEE": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.03499999999999999,
-     "input": 0.35,
-     "output": 2.75
+     "cache_read": 0.031999999999999994,
+     "input": 0.32,
+     "output": 2.5
     },
     "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
     "family": "qwen",
@@ -42481,18 +42981,18 @@
   ],
   "id": "coralbricks",
   "models": {
-   "glm-5.2-fp4": {
+   "glm-5.3-fp4": {
     "attachment": false,
     "cost": {
      "cache_read": 0,
      "input": 1.12,
      "output": 4.4
     },
-    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
     "family": "glm",
-    "id": "glm-5.2-fp4",
+    "id": "glm-5.3-fp4",
     "interleaved": true,
-    "last_updated": "2026-06-13",
+    "last_updated": "2026-08-14",
     "limit": {
      "context": 1048576,
      "output": 131072
@@ -42505,24 +43005,20 @@
       "text"
      ]
     },
-    "name": "GLM 5.2 FP4",
+    "name": "GLM 5.3 FP4",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
-       "minimal",
        "low",
-       "medium",
-       "high"
+       "high",
+       "max"
       ]
      }
     ],
-    "release_date": "2026-06-13",
+    "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -42645,7 +43141,7 @@
     "last_updated": "2025-09-02",
     "limit": {
      "context": 65536,
-     "output": 65536
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -42679,7 +43175,7 @@
     "last_updated": "2025-09-29",
     "limit": {
      "context": 200000,
-     "output": 200000
+     "output": 64000
     },
     "modalities": {
      "input": [
@@ -42728,7 +43224,7 @@
     "last_updated": "2026-03-13",
     "limit": {
      "context": 1000000,
-     "output": 1000000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -42777,7 +43273,7 @@
     "last_updated": "2025-10-15",
     "limit": {
      "context": 200000,
-     "output": 200000
+     "output": 64000
     },
     "modalities": {
      "input": [
@@ -42826,7 +43322,7 @@
     "last_updated": "2026-07-24",
     "limit": {
      "context": 1000000,
-     "output": 1000000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -42875,7 +43371,7 @@
     "last_updated": "2025-11-24",
     "limit": {
      "context": 200000,
-     "output": 200000
+     "output": 64000
     },
     "modalities": {
      "input": [
@@ -42924,7 +43420,7 @@
     "last_updated": "2026-03-13",
     "limit": {
      "context": 1000000,
-     "output": 1000000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -42973,7 +43469,7 @@
     "last_updated": "2026-04-16",
     "limit": {
      "context": 1000000,
-     "output": 1000000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -43022,7 +43518,7 @@
     "last_updated": "2026-05-28",
     "limit": {
      "context": 1000000,
-     "output": 1000000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -43071,7 +43567,7 @@
     "last_updated": "2025-05-22",
     "limit": {
      "context": 200000,
-     "output": 200000
+     "output": 65000
     },
     "modalities": {
      "input": [
@@ -43120,7 +43616,7 @@
     "last_updated": "2026-06-30",
     "limit": {
      "context": 1000000,
-     "output": 1000000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -43388,12 +43884,53 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek-v4-pro-0813": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.5,
+     "input": 2,
+     "output": 3.999
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "deepseek-v4-pro-0813",
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1048576,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "devstral-2512": {
     "attachment": false,
     "cost": {
      "cache_read": 0.045,
-     "input": 0.446,
-     "output": 2.228
+     "input": 0.478,
+     "output": 2.392
     },
     "description": "Mistral coding agent model for repository tasks and software engineering workflows",
     "family": "devstral",
@@ -43401,8 +43938,8 @@
     "knowledge": "2025-12",
     "last_updated": "2025-12-09",
     "limit": {
-     "context": 262000,
-     "output": 262000
+     "context": 256000,
+     "output": 256000
     },
     "modalities": {
      "input": [
@@ -43435,7 +43972,7 @@
     "last_updated": "2025-06-17",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 65535
     },
     "modalities": {
      "input": [
@@ -43508,7 +44045,7 @@
     "last_updated": "2026-05-07",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 65535
     },
     "modalities": {
      "input": [
@@ -43545,7 +44082,7 @@
     "last_updated": "2026-05-19",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 65535
     },
     "modalities": {
      "input": [
@@ -43589,7 +44126,7 @@
     "last_updated": "2026-07-21",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 65535
     },
     "modalities": {
      "input": [
@@ -43636,7 +44173,7 @@
     "last_updated": "2026-07-21",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 65535
     },
     "modalities": {
      "input": [
@@ -43681,7 +44218,7 @@
     "last_updated": "2026-08-13",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 65535
     },
     "modalities": {
      "input": [
@@ -43723,7 +44260,7 @@
     "last_updated": "2025-03-12",
     "limit": {
      "context": 131000,
-     "output": 131000
+     "output": 110000
     },
     "modalities": {
      "input": [
@@ -43755,7 +44292,7 @@
     "last_updated": "2026-04-02",
     "limit": {
      "context": 262000,
-     "output": 262000
+     "output": 81920
     },
     "modalities": {
      "input": [
@@ -43823,7 +44360,7 @@
     "last_updated": "2025-12-22",
     "limit": {
      "context": 202752,
-     "output": 198000
+     "output": 202752
     },
     "modalities": {
      "input": [
@@ -43996,7 +44533,7 @@
     "last_updated": "2026-06-13",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 1000000
     },
     "modalities": {
      "input": [
@@ -44026,9 +44563,9 @@
    "glm-5.3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.438,
-     "input": 1.75,
-     "output": 4.499
+     "cache_read": 0.26,
+     "input": 1.4,
+     "output": 4.399
     },
     "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
     "family": "glm",
@@ -44077,7 +44614,7 @@
     "last_updated": "2026-08-26",
     "limit": {
      "context": 1048576,
-     "output": 64000
+     "output": 1048576
     },
     "modalities": {
      "input": [
@@ -44154,7 +44691,7 @@
     "last_updated": "2025-04-14",
     "limit": {
      "context": 1047576,
-     "output": 1047576
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -44188,7 +44725,7 @@
     "last_updated": "2025-04-14",
     "limit": {
      "context": 1047576,
-     "output": 1047576
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -44222,7 +44759,7 @@
     "last_updated": "2025-04-14",
     "limit": {
      "context": 1047576,
-     "output": 1047576
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -44256,7 +44793,7 @@
     "last_updated": "2024-08-06",
     "limit": {
      "context": 128000,
-     "output": 128000
+     "output": 16000
     },
     "modalities": {
      "input": [
@@ -44290,7 +44827,7 @@
     "last_updated": "2024-07-18",
     "limit": {
      "context": 128000,
-     "output": 128000
+     "output": 16000
     },
     "modalities": {
      "input": [
@@ -44325,7 +44862,7 @@
     "limit": {
      "context": 400000,
      "input": 272000,
-     "output": 400000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -44369,7 +44906,7 @@
     "limit": {
      "context": 400000,
      "input": 272000,
-     "output": 400000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -44413,7 +44950,7 @@
     "limit": {
      "context": 400000,
      "input": 272000,
-     "output": 400000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -44457,7 +44994,7 @@
     "limit": {
      "context": 400000,
      "input": 272000,
-     "output": 400000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -44501,7 +45038,7 @@
     "last_updated": "2026-03-05",
     "limit": {
      "context": 1050000,
-     "output": 1050000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -44547,7 +45084,7 @@
     "limit": {
      "context": 1050000,
      "input": 922000,
-     "output": 1050000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -44593,7 +45130,7 @@
     "limit": {
      "context": 1050000,
      "input": 922000,
-     "output": 1050000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -44639,7 +45176,7 @@
     "limit": {
      "context": 1050000,
      "input": 922000,
-     "output": 1050000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -44682,7 +45219,7 @@
     "last_updated": "2025-08-05",
     "limit": {
      "context": 131000,
-     "output": 128000
+     "output": 131000
     },
     "modalities": {
      "input": [
@@ -44866,7 +45403,7 @@
     "last_updated": "2026-01",
     "limit": {
      "context": 262144,
-     "output": 256000
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -44907,7 +45444,7 @@
     "last_updated": "2026-04-21",
     "limit": {
      "context": 262144,
-     "output": 256000
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -44999,7 +45536,16 @@
     "name": "Kimi K3",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-07-16",
     "structured_output": true,
     "temperature": false,
@@ -45174,7 +45720,7 @@
     "last_updated": "2025-10-27",
     "limit": {
      "context": 400000,
-     "output": 400000
+     "output": 196000
     },
     "modalities": {
      "input": [
@@ -45242,8 +45788,8 @@
     },
     "last_updated": "2026-02-12",
     "limit": {
-     "context": 196680,
-     "output": 196608
+     "context": 196000,
+     "output": 196000
     },
     "modalities": {
      "input": [
@@ -45274,7 +45820,7 @@
     "last_updated": "2026-03-18",
     "limit": {
      "context": 196608,
-     "output": 196072
+     "output": 196608
     },
     "modalities": {
      "input": [
@@ -45430,7 +45976,7 @@
     "last_updated": "2025-05-26",
     "limit": {
      "context": 32000,
-     "output": 32000
+     "output": 8192
     },
     "modalities": {
      "input": [
@@ -45489,7 +46035,7 @@
     "last_updated": "2025-05-26",
     "limit": {
      "context": 32000,
-     "output": 32000
+     "output": 8192
     },
     "modalities": {
      "input": [
@@ -45542,38 +46088,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "mistral-medium-2508": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.045,
-     "input": 0.446,
-     "output": 2.228
-    },
-    "description": "Mistral Medium 2508 is a frontier-class multimodal LLM with a 128,000 token context window, optimized for reasoning, coding, and multimodal tasks.",
-    "id": "mistral-medium-2508",
-    "last_updated": "2024-08-07",
-    "limit": {
-     "context": 128000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "mistral-medium-2508",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2024-08-07",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
    "mistral-medium-3.5": {
     "attachment": true,
     "cost": {
@@ -45618,7 +46132,7 @@
     "last_updated": "2024-08-07",
     "limit": {
      "context": 128000,
-     "output": 131072
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -45680,7 +46194,7 @@
     "last_updated": "2026-03-16",
     "limit": {
      "context": 262144,
-     "output": 262144
+     "output": 256000
     },
     "modalities": {
      "input": [
@@ -45742,7 +46256,7 @@
     "last_updated": "2023-12-11",
     "limit": {
      "context": 32000,
-     "output": 32000
+     "output": 4096
     },
     "modalities": {
      "input": [
@@ -45804,7 +46318,7 @@
     "last_updated": "2025-12-04",
     "limit": {
      "context": 1000000,
-     "output": 1000000
+     "output": 65535
     },
     "modalities": {
      "input": [
@@ -45836,7 +46350,7 @@
     "last_updated": "2025-04-14",
     "limit": {
      "context": 300000,
-     "output": 300000
+     "output": 10000
     },
     "modalities": {
      "input": [
@@ -45868,7 +46382,7 @@
     "last_updated": "2025-04-14",
     "limit": {
      "context": 128000,
-     "output": 128000
+     "output": 10000
     },
     "modalities": {
      "input": [
@@ -45901,7 +46415,7 @@
     "last_updated": "2024-12-03",
     "limit": {
      "context": 300000,
-     "output": 5000
+     "output": 10000
     },
     "modalities": {
      "input": [
@@ -45963,7 +46477,7 @@
     "last_updated": "2026-04-29",
     "limit": {
      "context": 300000,
-     "output": 300000
+     "output": 65536
     },
     "modalities": {
      "input": [
@@ -45993,7 +46507,7 @@
     "last_updated": "2024-11-09",
     "limit": {
      "context": 128000,
-     "output": 128000
+     "output": 4096
     },
     "modalities": {
      "input": [
@@ -46089,7 +46603,7 @@
     "last_updated": "2025-07-21",
     "limit": {
      "context": 262000,
-     "output": 131000
+     "output": 262000
     },
     "modalities": {
      "input": [
@@ -46183,7 +46697,7 @@
     "last_updated": "2025-04",
     "limit": {
      "context": 262144,
-     "output": 262000
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -46339,7 +46853,7 @@
     "last_updated": "2026-02-15",
     "limit": {
      "context": 262000,
-     "output": 250000
+     "output": 262000
     },
     "modalities": {
      "input": [
@@ -46433,7 +46947,7 @@
     "last_updated": "2026-04-17",
     "limit": {
      "context": 262000,
-     "output": 262000
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -47775,6 +48289,51 @@
     ],
     "release_date": "2026-06-09",
     "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
     "temperature": false,
     "tool_call": true
    },
@@ -49830,6 +50389,7 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 262144,
+     "input": 192000,
      "output": 131072
     },
     "modalities": {
@@ -54709,7 +55269,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 262144,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -55042,7 +55603,7 @@
    "zai-org/GLM-5.3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.24,
+     "cache_read": 0.12,
      "input": 1.2,
      "output": 4
     },
@@ -55803,6 +56364,51 @@
      }
     ],
     "release_date": "2026-06-09",
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic-claude-fable-5.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "anthropic-claude-fable-5.1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Anthropic Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
     "temperature": false,
     "tool_call": true
    },
@@ -59767,19 +60373,19 @@
     "temperature": false,
     "tool_call": true
    },
-   "anthropic/claude-fable-latest": {
+   "anthropic/claude-fable-5-1": {
     "attachment": true,
     "cost": {
-     "cache_read": 1,
+     "cache_read": 0.25,
      "cache_write": 12.5,
      "input": 10,
      "output": 50
     },
-    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
     "family": "claude-fable",
-    "id": "anthropic/claude-fable-latest",
-    "knowledge": "2026-01-31",
-    "last_updated": "2026-06-09",
+    "id": "anthropic/claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
     "limit": {
      "context": 1000000,
      "output": 128000
@@ -59794,7 +60400,7 @@
       "text"
      ]
     },
-    "name": "Claude Fable 5",
+    "name": "Claude Fable 5.1",
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
@@ -59809,7 +60415,54 @@
       ]
      }
     ],
-    "release_date": "2026-06-09",
+    "release_date": "2026-09-01",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-fable-latest": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-latest",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -60912,10 +61565,97 @@
     "temperature": true,
     "tool_call": true
    },
+   "databricks/databricks-deepseek-v4-flash-0731": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.028,
+     "cache_write": 0.14,
+     "input": 0.14,
+     "output": 0.28
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "databricks/databricks-deepseek-v4-flash-0731",
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-07-31",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
+   "databricks/databricks-deepseek-v4-pro-0813": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.13202,
+     "cache_write": 1.31999,
+     "input": 1.31999,
+     "output": 3.95997
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "databricks/databricks-deepseek-v4-pro-0813",
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "databricks/databricks-gpt-oss-120b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.15001,
+     "cache_read": 0.015001,
      "cache_write": 0.15001,
      "input": 0.15001,
      "output": 0.59997
@@ -60957,7 +61697,7 @@
    "databricks/databricks-gpt-oss-120b@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.15001,
+     "cache_read": 0.015001,
      "cache_write": 0.15001,
      "input": 0.15001,
      "output": 0.59997
@@ -60999,7 +61739,7 @@
    "databricks/databricks-gpt-oss-20b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.07,
+     "cache_read": 0.007,
      "cache_write": 0.07,
      "input": 0.07,
      "output": 0.30002
@@ -61041,7 +61781,7 @@
    "databricks/databricks-gpt-oss-20b@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.07,
+     "cache_read": 0.007,
      "cache_write": 0.07,
      "input": 0.07,
      "output": 0.30002
@@ -61796,7 +62536,7 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 262144,
-     "output": 64000
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -62403,11 +63143,52 @@
     "temperature": true,
     "tool_call": false
    },
+   "flexai/Step-3.7-Flash": {
+    "attachment": true,
+    "cost": {
+     "input": 0.2,
+     "output": 1.15
+    },
+    "description": "Newer StepFun flash model for faster agents, coding, and multimodal prompts",
+    "id": "flexai/Step-3.7-Flash",
+    "knowledge": "2026-03-01",
+    "last_updated": "2026-05-29",
+    "limit": {
+     "context": 262144,
+     "output": 256000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Step 3.7 Flash",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-05-29",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
    "flexai/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "input": 0.08,
-     "output": 0.18
+     "input": 0.03,
+     "output": 0.1
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -63208,12 +63989,12 @@
    "google/gemini-3.7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 0.083333,
-     "input": 1.5,
-     "input_audio": 1.5,
-     "output": 7.5,
-     "reasoning": 7.5
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -63257,12 +64038,12 @@
    "google/gemini-flash-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 0.083333,
-     "input": 1.5,
-     "input_audio": 1.5,
-     "output": 7.5,
-     "reasoning": 7.5
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -63453,8 +64234,8 @@
    "ionos/meta-llama/Llama-3.3-70B-Instruct": {
     "attachment": false,
     "cost": {
-     "input": 0.75374,
-     "output": 0.75374
+     "input": 0.75257,
+     "output": 0.75257
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
     "family": "llama",
@@ -63484,8 +64265,8 @@
    "ionos/openai/gpt-oss-120b": {
     "attachment": false,
     "cost": {
-     "input": 0.17394,
-     "output": 0.75374
+     "input": 0.17367,
+     "output": 0.75257
     },
     "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
     "family": "gpt-oss",
@@ -64175,6 +64956,39 @@
     "structured_output": true,
     "temperature": false,
     "tool_call": true
+   },
+   "moonshot/kimi-k2.7-code-highspeed": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.38,
+     "input": 1.9,
+     "output": 8
+    },
+    "description": "Lower-latency Kimi Code variant for interactive edits and coding-agent loops",
+    "family": "kimi-k2",
+    "id": "moonshot/kimi-k2.7-code-highspeed",
+    "knowledge": "2025-01",
+    "last_updated": "2026-06-12",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2.7 Code Highspeed",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-06-12",
+    "structured_output": false,
+    "temperature": false,
+    "tool_call": false
    },
    "moonshot/kimi-k3": {
     "attachment": true,
@@ -67134,8 +67948,8 @@
    "scaleway/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "input": 0.46384,
-     "output": 0.92768
+     "input": 0.46312,
+     "output": 0.92624
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -67176,8 +67990,8 @@
    "scaleway/gpt-oss-120b": {
     "attachment": false,
     "cost": {
-     "input": 0.17394,
-     "output": 0.69576
+     "input": 0.17367,
+     "output": 0.69468
     },
     "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
     "family": "gpt-oss",
@@ -67216,8 +68030,8 @@
    "scaleway/llama-3.3-70b-instruct": {
     "attachment": false,
     "cost": {
-     "input": 1.04364,
-     "output": 1.04364
+     "input": 1.04202,
+     "output": 1.04202
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
     "family": "llama",
@@ -68552,12 +69366,12 @@
    "vertex/gemini-3.7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 0.083333,
-     "input": 1.5,
-     "input_audio": 1.5,
-     "output": 7.5,
-     "reasoning": 7.5
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -68601,12 +69415,12 @@
    "vertex/gemini-3.7-flash@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 0.083333,
-     "input": 1.5,
-     "input_audio": 1.5,
-     "output": 7.5,
-     "reasoning": 7.5
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -68650,12 +69464,12 @@
    "vertex/gemini-3.7-flash@us": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 0.083333,
-     "input": 1.5,
-     "input_audio": 1.5,
-     "output": 7.5,
-     "reasoning": 7.5
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -68699,12 +69513,12 @@
    "vertex/gemini-flash-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 0.083333,
-     "input": 1.5,
-     "input_audio": 1.5,
-     "output": 7.5,
-     "reasoning": 7.5
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -71845,6 +72659,56 @@
     "temperature": true,
     "tool_call": true
    },
+   "qwen3-8-max-0902": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 2,
+     "input": 2,
+     "output": 6
+    },
+    "description": "2.4-trillion-parameter MoE flagship for coding, professional work, multimodal understanding, and long-horizon agentic workflows",
+    "family": "qwen",
+    "id": "qwen3-8-max-0902",
+    "last_updated": "2026-08-03",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max 0902",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "max": 262144,
+      "min": 1,
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-03",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "qwen3-max": {
     "attachment": false,
     "cost": {
@@ -74525,9 +75389,9 @@
    "accounts/fireworks/models/deepseek-v4-flash-0731": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.028,
-     "input": 0.14,
-     "output": 0.28
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
     },
     "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
@@ -74566,6 +75430,54 @@
      }
     ],
     "release_date": "2026-07-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "accounts/fireworks/models/deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "accounts/fireworks/models/deepseek-v4-flash-vision-exp",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -74707,7 +75619,7 @@
    "accounts/fireworks/models/glm-5p3-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.029,
+     "cache_read": 0.03,
      "input": 0.15,
      "output": 0.5
     },
@@ -78778,6 +79690,52 @@
     "temperature": false,
     "tool_call": true
    },
+   "duo-chat-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "cache_write": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "duo-chat-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Agentic Chat (Claude Fable 5.1)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "temperature": false,
+    "tool_call": true
+   },
    "duo-chat-gpt-5-1": {
     "attachment": true,
     "cost": {
@@ -81372,6 +82330,52 @@
     "temperature": true,
     "tool_call": true
    },
+   "gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75
+    },
+    "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+    "family": "gemini-flash",
+    "id": "gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "gemini-embedding-001": {
     "attachment": false,
     "cost": {
@@ -81562,50 +82566,6 @@
     "release_date": "2026-06-30",
     "temperature": true,
     "tool_call": false
-   },
-   "gemini-robotics-er-1.6-preview": {
-    "attachment": true,
-    "cost": {
-     "input": 1,
-     "input_audio": 2,
-     "output": 5
-    },
-    "description": "Vision-language model for embodied reasoning: spatial understanding, task planning, and physical-world agentic robotics",
-    "family": "gemini",
-    "id": "gemini-robotics-er-1.6-preview",
-    "knowledge": "2025-01",
-    "last_updated": "2026-04-14",
-    "limit": {
-     "context": 131072,
-     "output": 65536
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video",
-      "audio"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Gemini Robotics-ER 1.6 Preview",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "min": 0,
-      "type": "budget_tokens"
-     }
-    ],
-    "release_date": "2026-04-14",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
    },
    "gemma-4-26b-a4b-it": {
     "attachment": true,
@@ -81828,6 +82788,56 @@
   ],
   "id": "google-vertex",
   "models": {
+   "claude-fable-5-1@default": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "claude-fable-5-1@default",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/google-vertex/anthropic"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
    "claude-fable-5@default": {
     "attachment": true,
     "cost": {
@@ -83376,6 +84386,52 @@
     "temperature": true,
     "tool_call": true
    },
+   "gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "input_audio": 0.75,
+     "output": 3.75
+    },
+    "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+    "family": "gemini-flash",
+    "id": "gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "gemini-embedding-001": {
     "attachment": false,
     "cost": {
@@ -83832,6 +84888,53 @@
   ],
   "id": "google-vertex-anthropic",
   "models": {
+   "claude-fable-5-1@default": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "claude-fable-5-1@default",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
    "claude-fable-5@default": {
     "attachment": true,
     "cost": {
@@ -86330,6 +87433,49 @@
      }
     ],
     "release_date": "2026-04-22",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen/qwen3.8-27b": {
+    "attachment": true,
+    "cost": {
+     "input": 0.8,
+     "output": 4
+    },
+    "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen/qwen3.8-27b",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 131042,
+     "output": 16384
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "default",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -91818,7 +92964,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 262144,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -92509,9 +93656,9 @@
    "gemma-4-26b-a4b-it": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.06,
-     "input": 0.12,
-     "output": 0.42
+     "cache_write": 0.058,
+     "input": 0.116,
+     "output": 0.38
     },
     "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
     "family": "gemma",
@@ -92541,9 +93688,9 @@
    "glm-5": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.455,
-     "input": 0.91,
-     "output": 2.934
+     "cache_write": 0.425,
+     "input": 0.85,
+     "output": 2.774
     },
     "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
     "family": "glm",
@@ -92572,9 +93719,9 @@
    "glm-5.1": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.666,
-     "input": 1.332,
-     "output": 4.312
+     "cache_write": 0.645,
+     "input": 1.29,
+     "output": 4.22
     },
     "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
     "family": "glm",
@@ -92769,12 +93916,44 @@
     "temperature": true,
     "tool_call": true
    },
+   "kimi-k2-thinking": {
+    "attachment": false,
+    "cost": {
+     "cache_write": 0.3,
+     "input": 0.6,
+     "output": 2.5
+    },
+    "description": "Thinking Kimi model for slower research passes, planning, and hard technical questions",
+    "family": "kimi-thinking",
+    "id": "kimi-k2-thinking",
+    "knowledge": "2024-08",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 262144,
+     "output": 26214
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Kimi K2 Thinking",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-09-02",
+    "temperature": true,
+    "tool_call": true
+   },
    "kimi-k2.5": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.2722,
-     "input": 0.5444,
-     "output": 2.855
+     "cache_write": 0.2642,
+     "input": 0.5284,
+     "output": 2.785
     },
     "description": "Earlier Kimi frontier model for long-context agents, coding, and multimodal work",
     "family": "kimi-k2",
@@ -92986,9 +94165,9 @@
    "minimax-m2.7": {
     "attachment": false,
     "cost": {
-     "cache_write": 0.212,
-     "input": 0.424,
-     "output": 1.612
+     "cache_write": 0.213,
+     "input": 0.426,
+     "output": 1.62
     },
     "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
     "family": "minimax",
@@ -99099,26 +100278,64 @@
   ],
   "id": "iteracompute",
   "models": {
+   "iteracompute/ornith-1.5-35b-a3b": {
+    "attachment": false,
+    "cost": {
+     "input": 0.3,
+     "output": 3
+    },
+    "description": "Mixture-of-experts coding-reasoning model for agentic software tasks, tool use, and image understanding",
+    "family": "ornith",
+    "id": "iteracompute/ornith-1.5-35b-a3b",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-23",
+    "limit": {
+     "context": 327680,
+     "input": 262144,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Ornith 1.5 35B A3B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-08-18",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "iteracompute/qwen3.8-27b": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
-     "input": 0.35,
-     "output": 3
+     "input": 0.3,
+     "output": 2.5
     },
     "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
     "family": "qwen",
     "id": "iteracompute/qwen3.8-27b",
     "last_updated": "2026-08-14",
     "limit": {
-     "context": 262144,
-     "output": 32768
+     "context": 327680,
+     "input": 262144,
+     "output": 65536
     },
     "modalities": {
      "input": [
       "text",
-      "image",
-      "video"
+      "image"
      ],
      "output": [
       "text"
@@ -99324,7 +100541,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 202752,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -103281,7 +104499,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 256000,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -103320,7 +104539,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 256000,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -104445,7 +105665,7 @@
    "anthracite-org/magnum-v4-72b": {
     "attachment": false,
     "cost": {
-     "input": 3,
+     "input": 2.5,
      "output": 5
     },
     "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
@@ -104548,6 +105768,53 @@
      }
     ],
     "release_date": "2026-06-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-fable-5.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude Fable 5.1 improves on Claude Fable 5 across the board, with the biggest gains in agentic coding, long-running agentic workflows, and knowledge work: long code refactors, front-end and visual...",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-5.1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -104822,54 +106089,6 @@
     "temperature": false,
     "tool_call": true
    },
-   "anthropic/claude-opus-4.7-fast": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 3,
-     "cache_write": 37.5,
-     "input": 30,
-     "output": 150
-    },
-    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-    "family": "claude-opus",
-    "id": "anthropic/claude-opus-4.7-fast",
-    "knowledge": "2026-01-31",
-    "last_updated": "2026-04-16",
-    "limit": {
-     "context": 1000000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude Opus 4.7",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-04-16",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
    "anthropic/claude-opus-4.8": {
     "attachment": true,
     "cost": {
@@ -104918,54 +106137,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "anthropic/claude-opus-4.8-fast": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1,
-     "cache_write": 12.5,
-     "input": 10,
-     "output": 50
-    },
-    "description": "Fast-mode variant of [Opus 4.8](/anthropic/claude-opus-4.8) - identical capabilities with higher output speed at 2x pricing relative to regular Opus 4.8. Learn more in Anthropic's docs: https://platform.claude.com/docs/en/build-with-claude/fast-mode",
-    "family": "claude-opus",
-    "id": "anthropic/claude-opus-4.8-fast",
-    "knowledge": "2026-01",
-    "last_updated": "2026-05-28",
-    "limit": {
-     "context": 1000000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude Opus 4.8",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-05-28",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
    "anthropic/claude-opus-5": {
     "attachment": true,
     "cost": {
@@ -105012,54 +106183,6 @@
     "release_date": "2026-07-24",
     "structured_output": true,
     "temperature": true,
-    "tool_call": true
-   },
-   "anthropic/claude-opus-5-fast": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1,
-     "cache_write": 12.5,
-     "input": 10,
-     "output": 50
-    },
-    "description": "Fast-mode variant of [Opus 5](/anthropic/claude-opus-5) - identical capabilities with higher output speed at 2x pricing relative to regular Opus 5. Learn more in Anthropic's docs: https://platform.claude.com/docs/en/build-with-claude/fast-mode",
-    "family": "claude-opus",
-    "id": "anthropic/claude-opus-5-fast",
-    "knowledge": "2026-05",
-    "last_updated": "2026-07-24",
-    "limit": {
-     "context": 1000000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude Opus 5",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-07-24",
-    "structured_output": true,
-    "temperature": false,
     "tool_call": true
    },
    "anthropic/claude-sonnet-4": {
@@ -105248,8 +106371,8 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.06,
-     "input": 0.22,
-     "output": 0.85
+     "input": 0.25,
+     "output": 0.8
     },
     "description": "Reasoning-optimized 398B MoE agent model with extended thinking for long-horizon and multi-turn tool use",
     "family": "trinity",
@@ -105279,7 +106402,7 @@
      }
     ],
     "release_date": "2026-04-01",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -105873,8 +106996,8 @@
     "id": "deepseek/deepseek-chat-v3.1",
     "last_updated": "2025-08-21",
     "limit": {
-     "context": 161000,
-     "output": 144900
+     "context": 163840,
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -106262,7 +107385,7 @@
      }
     ],
     "release_date": "2026-08-21",
-    "structured_output": false,
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -106320,7 +107443,7 @@
     "id": "deepseek/deepseek-v4-pro-0813",
     "last_updated": "2026-08-22",
     "limit": {
-     "context": 1048576,
+     "context": 1024000,
      "output": 384000
     },
     "modalities": {
@@ -106439,10 +107562,10 @@
    "google/gemini-2.5-flash-image": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.03,
-     "cache_write": 0.083333,
-     "input": 0.3,
-     "output": 2.5
+     "cache_read": 0.015,
+     "cache_write": 0.041667,
+     "input": 0.15,
+     "output": 1.25
     },
     "description": "Image model for prompt-driven generation, editing, and visual design workflows",
     "family": "gemini-flash",
@@ -106657,11 +107780,11 @@
    "google/gemini-3-flash-preview": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.05,
-     "cache_write": 0.083333,
-     "input": 0.5,
-     "output": 3,
-     "reasoning": 3
+     "cache_read": 0.025,
+     "cache_write": 0.041667,
+     "input": 0.25,
+     "output": 1.5,
+     "reasoning": 1.5
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -106719,7 +107842,7 @@
     "knowledge": "2025-01",
     "last_updated": "2026-05-28",
     "limit": {
-     "context": 131072,
+     "context": 65536,
      "output": 32768
     },
     "modalities": {
@@ -106752,11 +107875,11 @@
    "google/gemini-3-pro-image-preview": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
-     "cache_write": 0.375,
-     "input": 2,
-     "output": 12,
-     "reasoning": 12
+     "cache_read": 0.1,
+     "cache_write": 0.1875,
+     "input": 1,
+     "output": 6,
+     "reasoning": 6
     },
     "description": "Image model for prompt-driven generation, editing, and visual design workflows",
     "family": "gemini-pro",
@@ -106885,11 +108008,11 @@
    "google/gemini-3.1-flash-lite": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.025,
-     "cache_write": 0.083333,
-     "input": 0.25,
-     "output": 1.5,
-     "reasoning": 1.5
+     "cache_read": 0.0125,
+     "cache_write": 0.041667,
+     "input": 0.125,
+     "output": 0.75,
+     "reasoning": 0.75
     },
     "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
     "family": "gemini-flash-lite",
@@ -106979,11 +108102,11 @@
    "google/gemini-3.1-flash-lite-preview": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.025,
-     "cache_write": 0.083333,
-     "input": 0.25,
-     "output": 1.5,
-     "reasoning": 1.5
+     "cache_read": 0.0125,
+     "cache_write": 0.041667,
+     "input": 0.125,
+     "output": 0.75,
+     "reasoning": 0.75
     },
     "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
     "family": "gemini-flash-lite",
@@ -107029,11 +108152,11 @@
    "google/gemini-3.1-pro-preview": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
-     "cache_write": 0.375,
-     "input": 2,
-     "output": 12,
-     "reasoning": 12
+     "cache_read": 0.1,
+     "cache_write": 0.1875,
+     "input": 1,
+     "output": 6,
+     "reasoning": 6
     },
     "description": "Advanced Gemini model for complex reasoning, coding, and multimodal analysis",
     "family": "gemini-pro",
@@ -107125,11 +108248,11 @@
    "google/gemini-3.5-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 0.083333,
-     "input": 1.5,
-     "output": 9,
-     "reasoning": 9
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "output": 4.5,
+     "reasoning": 4.5
     },
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash",
@@ -107174,11 +108297,11 @@
    "google/gemini-3.5-flash-lite": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.03,
-     "cache_write": 0.083333,
-     "input": 0.3,
-     "output": 2.5,
-     "reasoning": 2.5
+     "cache_read": 0.015,
+     "cache_write": 0.041667,
+     "input": 0.15,
+     "output": 1.25,
+     "reasoning": 1.25
     },
     "description": "Gemini 3.5 Flash Lite is a high-efficiency model from Google with upgraded agentic capabilities. It is suited for subagents that execute focused tasks within complex, multi-agent workflows.",
     "family": "gemini-flash-lite",
@@ -107223,11 +108346,11 @@
    "google/gemini-3.6-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.075,
-     "cache_write": 0.041667,
-     "input": 0.75,
-     "output": 3.75,
-     "reasoning": 3.75
+     "cache_read": 0.0375,
+     "cache_write": 0.020833,
+     "input": 0.375,
+     "output": 1.875,
+     "reasoning": 1.875
     },
     "description": "Gemini 3.6 Flash is a high-efficiency model from Google for coding, agentic workflows, and web and app development. It is designed to produce polished outputs with fewer unnecessary edits and...",
     "family": "gemini-flash",
@@ -107272,11 +108395,11 @@
    "google/gemini-3.7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.15,
-     "cache_write": 0.083333,
-     "input": 1.5,
-     "output": 7.5,
-     "reasoning": 7.5
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
     },
     "description": "Gemini 3.7 Flash is a multimodal model from Google for fast agentic workflows, coding, and complex multi-step reasoning. It is designed for tasks that require responsive performance and reliable multi-step...",
     "family": "gemini-flash",
@@ -107313,6 +108436,53 @@
      }
     ],
     "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google/gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
+    },
+    "description": "Gemini 3.8 Flash is Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows.",
+    "family": "gemini-flash",
+    "id": "google/gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -107677,6 +108847,47 @@
     "temperature": true,
     "tool_call": true
    },
+   "ibm-granite/granite-4.2-8b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.15
+    },
+    "description": "Granite 4.2 8B is a dense reasoning model from IBM. It is suited for mathematics, code generation, multilingual dialogue, and agentic workflows that need multi-step reasoning. It supports full, low-effort,...",
+    "family": "granite",
+    "id": "ibm-granite/granite-4.2-8b",
+    "last_updated": "2026-08-31",
+    "limit": {
+     "context": 131072,
+     "output": 117964
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "IBM: Granite 4.2 8B",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "inception/mercury-2": {
     "attachment": false,
     "cost": {
@@ -107715,6 +108926,48 @@
      }
     ],
     "release_date": "2026-03-04",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "inception/mercury-2.5-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.02,
+     "input": 0.2,
+     "output": 0.75
+    },
+    "description": "Mercury 2.5 is the fastest reasoning LLM, and the latest diffusion LLM (dLLM) from Inception. Instead of generating tokens sequentially, Mercury 2.5 produces and refines multiple tokens in parallel, achieving...",
+    "family": "mercury",
+    "id": "inception/mercury-2.5-preview",
+    "last_updated": "2026-08-31",
+    "limit": {
+     "context": 260000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Inception: Mercury 2.5 Preview",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-31",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -108075,7 +109328,7 @@
    "mancer/weaver": {
     "attachment": false,
     "cost": {
-     "input": 0.5,
+     "input": 0.4,
      "output": 0.75
     },
     "description": "An attempt to recreate Claude-style verbosity, but don't expect the same level of coherence or memory. Meant for use in roleplay/narrative situations.",
@@ -108138,47 +109391,6 @@
      }
     ],
     "release_date": "2026-07-20",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "meituan/longcat-2.0-free": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0,
-     "input": 0,
-     "output": 0,
-     "reasoning": 0
-    },
-    "description": "LongCat 2.0 is a sparse mixture-of-experts language model from Meituan, with 48B active parameters out of 1.6T total. It is suited for coding, repository-level changes, long-horizon problem solving, and agentic workflows. Available free in Kilo for a limited time.",
-    "family": "longcat",
-    "id": "meituan/longcat-2.0-free",
-    "last_updated": "2025-08-26",
-    "limit": {
-     "context": 1048756,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Meituan: LongCat 2.0 (free)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-08-26",
     "structured_output": false,
     "temperature": true,
     "tool_call": true
@@ -108316,8 +109528,8 @@
     "knowledge": "2023-12",
     "last_updated": "2024-12-06",
     "limit": {
-     "context": 128000,
-     "output": 115200
+     "context": 131072,
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -108377,8 +109589,8 @@
     "id": "meta-llama/llama-4-scout",
     "last_updated": "2025-04-05",
     "limit": {
-     "context": 131072,
-     "output": 8192
+     "context": 327680,
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -108442,7 +109654,7 @@
     "last_updated": "2026-08-10",
     "limit": {
      "context": 131072,
-     "output": 16384
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -108610,6 +109822,100 @@
      }
     ],
     "release_date": "2026-08-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.25,
+     "output": 4.25
+    },
+    "description": "Muse Spark 1.3 is a multimodal reasoning model from Meta for long-running agentic, multi-agent, and coding workflows. It is designed to keep track of information across extended tasks, work through...",
+    "family": "muse",
+    "id": "meta/muse-spark-1.3",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 943718
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Meta: Muse Spark 1.3",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.3-contributor": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.002,
+     "input": 0.1,
+     "output": 0.2
+    },
+    "description": "Muse Spark 1.3 Contributor is the cost-efficient contributor tier of Meta’s multimodal reasoning model for experimentation, learning, and early-stage agentic, multi-agent, and coding workflows. It is designed to track information...",
+    "family": "muse",
+    "id": "meta/muse-spark-1.3-contributor",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 943718
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Meta: Muse Spark 1.3 Contributor",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -108932,10 +110238,8 @@
    "minimax/minimax-m2.7:free": {
     "attachment": false,
     "cost": {
-     "cache_read": 0,
      "input": 0,
-     "output": 0,
-     "reasoning": 0
+     "output": 0
     },
     "description": "MiniMax-M2.7 is a next-generation large language model designed for autonomous, real-world productivity and continuous improvement. Built to actively participate in its own evolution, M2.7 integrates advanced agentic capabilities through multi-agent...",
     "family": "minimax",
@@ -108943,7 +110247,7 @@
     "last_updated": "2026-03-18",
     "limit": {
      "context": 196608,
-     "output": 196608
+     "output": 176947
     },
     "modalities": {
      "input": [
@@ -109014,10 +110318,8 @@
    "minimax/minimax-m3:free": {
     "attachment": true,
     "cost": {
-     "cache_read": 0,
      "input": 0,
-     "output": 0,
-     "reasoning": 0
+     "output": 0
     },
     "description": "MiniMax-M3 is a multimodal foundation model from MiniMax. It supports text, image, and video inputs with text output, a 1M-token context window, and is suited for long-horizon agentic work, coding,...",
     "family": "minimax",
@@ -109025,12 +110327,13 @@
     "last_updated": "2026-06-01",
     "limit": {
      "context": 1048576,
-     "output": 1048576
+     "output": 943718
     },
     "modalities": {
      "input": [
       "text",
-      "image"
+      "image",
+      "video"
      ],
      "output": [
       "text"
@@ -110033,7 +111336,7 @@
       "text"
      ]
     },
-    "name": "Nex AGI: Nex-N2-Mini",
+    "name": "Nex AGI: Nex-N2-Mini (retires Sep 8)",
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
@@ -110074,7 +111377,7 @@
       "text"
      ]
     },
-    "name": "Nex AGI: Nex-N2-Pro",
+    "name": "Nex AGI: Nex-N2-Pro (retires Sep 8)",
     "open_weights": false,
     "reasoning": true,
     "reasoning_options": [
@@ -110232,7 +111535,7 @@
    "nvidia/nemotron-3-nano-30b-a3b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.025,
+     "cache_read": 0.03,
      "input": 0.05,
      "output": 0.2
     },
@@ -110242,7 +111545,7 @@
     "last_updated": "2025-12-15",
     "limit": {
      "context": 262144,
-     "output": 228000
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -110403,8 +111706,8 @@
     "id": "nvidia/nemotron-3-ultra-550b-a55b",
     "last_updated": "2026-06-04",
     "limit": {
-     "context": 262144,
-     "output": 16384
+     "context": 202800,
+     "output": 182520
     },
     "modalities": {
      "input": [
@@ -113694,8 +114997,8 @@
     "id": "qwen/qwen3-14b",
     "last_updated": "2025-04-28",
     "limit": {
-     "context": 40960,
-     "output": 16384
+     "context": 131072,
+     "output": 8192
     },
     "modalities": {
      "input": [
@@ -114259,7 +115562,7 @@
     "last_updated": "2025-09",
     "limit": {
      "context": 262144,
-     "output": 16384
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -114694,7 +115997,7 @@
     "last_updated": "2026-02-15",
     "limit": {
      "context": 262144,
-     "output": 65536
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -115238,8 +116541,8 @@
     "id": "qwen/qwen3.8-2.4t-a95b",
     "last_updated": "2026-08-12",
     "limit": {
-     "context": 262144,
-     "output": 131072
+     "context": 1000000,
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -116198,9 +117501,9 @@
    "tencent/hy3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.020625,
-     "input": 0.0825,
-     "output": 0.33
+     "cache_read": 0.035,
+     "input": 0.14,
+     "output": 0.58
     },
     "description": "Hy3 is a 295B-parameter Mixture-of-Experts model from Tencent (21B active, 192 experts with top-8 routing) built for reasoning, agentic workflows, and real-world production use. It supports a configurable reasoning effort:...",
     "family": "Hy",
@@ -116208,6 +117511,7 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 262144,
+     "input": 192000,
      "output": 128000
     },
     "modalities": {
@@ -116592,7 +117896,7 @@
    "undi95/remm-slerp-l2-13b": {
     "attachment": false,
     "cost": {
-     "input": 0.45,
+     "input": 0.35,
      "output": 0.65
     },
     "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
@@ -117237,9 +118541,9 @@
    "z-ai/glm-4.6": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.08,
-     "input": 0.43,
-     "output": 1.75
+     "cache_read": 0.11,
+     "input": 0.55,
+     "output": 2.2
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
@@ -117247,8 +118551,8 @@
     "knowledge": "2025-04",
     "last_updated": "2025-09-30",
     "limit": {
-     "context": 198000,
-     "output": 16384
+     "context": 204800,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -117533,7 +118837,7 @@
     "last_updated": "2026-06-13",
     "limit": {
      "context": 1048576,
-     "output": 262144
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -117690,7 +118994,7 @@
    "~anthropic/claude-fable-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 1,
+     "cache_read": 0.25,
      "cache_write": 12.5,
      "input": 10,
      "output": 50
@@ -117875,7 +119179,7 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.013,
-     "input": 0.03,
+     "input": 0.05,
      "output": 0.16
     },
     "description": "This model always redirects to the latest model in the DeepSeek V4 Flash family.",
@@ -118187,20 +119491,63 @@
     "temperature": true,
     "tool_call": true
    },
+   "~z-ai/glm-flash-latest": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "This model always redirects to the latest model in the GLM Flash family.",
+    "family": "glm-flash",
+    "id": "~z-ai/glm-flash-latest",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 1048576,
+     "output": 943718
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Z.ai: GLM Flash Latest",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-27",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "~z-ai/glm-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.247,
-     "input": 1.1875,
-     "output": 4.18
+     "cache_read": 0.1794,
+     "input": 1.092,
+     "output": 3.432
     },
     "description": "This model always redirects to the latest GLM model from Z.ai.",
     "family": "glm",
     "id": "~z-ai/glm-latest",
     "last_updated": "2026-08-19",
     "limit": {
-     "context": 262144,
-     "output": 131072
+     "context": 1048576,
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -118234,7 +119581,7 @@
  },
  "kimi-for-coding": {
   "api": "https://api.kimi.com/coding/v1",
-  "doc": "https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html",
+  "doc": "https://www.kimi.com/code/docs/en/kimi-code/models.html",
   "env": [
    "KIMI_API_KEY"
   ],
@@ -119105,6 +120452,52 @@
     "temperature": false,
     "tool_call": true
    },
+   "claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "temperature": false,
+    "tool_call": true
+   },
    "claude-haiku-4-5": {
     "attachment": true,
     "cost": {
@@ -119711,41 +121104,6 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": false
-   },
-   "cosmos3-super-reasoner": {
-    "attachment": true,
-    "cost": {
-     "input": 0.1,
-     "output": 0.3
-    },
-    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
-    "id": "cosmos3-super-reasoner",
-    "last_updated": "2026-06-01",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Cosmos 3 Super Reasoner",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-06-01",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
    },
    "custom": {
     "attachment": true,
@@ -120565,6 +121923,51 @@
     "temperature": true,
     "tool_call": true
    },
+   "gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "cache_write": 0.08333,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini",
+    "id": "gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "gemini-pro-latest": {
     "attachment": true,
     "cost": {
@@ -120604,37 +122007,6 @@
     ],
     "release_date": "2026-02-27",
     "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "gemma-3-27b": {
-    "attachment": true,
-    "cost": {
-     "input": 0.1,
-     "output": 0.3
-    },
-    "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
-    "family": "gemma",
-    "id": "gemma-3-27b",
-    "last_updated": "2025-03-12",
-    "limit": {
-     "context": 110000,
-     "output": 110000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Gemma 3 27B",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-03-12",
-    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -121325,8 +122697,8 @@
    "glm-5.3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.25,
-     "input": 1.3,
+     "cache_read": 0.2,
+     "input": 1.2,
      "output": 4
     },
     "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
@@ -121396,8 +122768,12 @@
      {
       "type": "effort",
       "values": [
+       "none",
+       "minimal",
        "low",
+       "medium",
        "high",
+       "xhigh",
        "max"
       ]
      }
@@ -122719,8 +124095,9 @@
    "gpt-oss-20b": {
     "attachment": false,
     "cost": {
-     "input": 0.05,
-     "output": 0.2
+     "cache_read": 0.01,
+     "input": 0.04,
+     "output": 0.19
     },
     "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
     "family": "gpt-oss",
@@ -123284,76 +124661,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "hermes-4-405b": {
-    "attachment": false,
-    "cost": {
-     "input": 1,
-     "output": 3
-    },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "hermes",
-    "id": "hermes-4-405b",
-    "last_updated": "2025-08-26",
-    "limit": {
-     "context": 131072,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Hermes 4 405B",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-08-26",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "hermes-4-70b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.13,
-     "output": 0.4
-    },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "hermes",
-    "id": "hermes-4-70b",
-    "last_updated": "2025-08-26",
-    "limit": {
-     "context": 131072,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Hermes 4 70B",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-08-26",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
    "hy3": {
     "attachment": false,
     "cost": {
@@ -123367,7 +124674,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 262144,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -123855,36 +125163,6 @@
     "temperature": true,
     "tool_call": false
    },
-   "llama-3.1-nemotron-ultra-253b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.6,
-     "output": 1.8
-    },
-    "description": "Flagship Nemotron model for high-throughput reasoning and complex agents",
-    "family": "nemotron",
-    "id": "llama-3.1-nemotron-ultra-253b",
-    "last_updated": "2025-04-07",
-    "limit": {
-     "context": 128000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama 3.1 Nemotron Ultra 253B",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-04-07",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
    "llama-3.2-11b-instruct": {
     "attachment": false,
     "cost": {
@@ -123948,7 +125226,7 @@
    "llama-3.3-70b-instruct": {
     "attachment": true,
     "cost": {
-     "input": 0.13,
+     "input": 0.135,
      "output": 0.4
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
@@ -124165,36 +125443,6 @@
      }
     ],
     "release_date": "2026-04-22",
-    "temperature": true,
-    "tool_call": true
-   },
-   "minicpm-v-4.5": {
-    "attachment": true,
-    "cost": {
-     "input": 0.658,
-     "output": 1.11
-    },
-    "description": "Multimodal model for analyzing text, images, documents, and rich media",
-    "id": "minicpm-v-4.5",
-    "last_updated": "2025-08-26",
-    "limit": {
-     "context": 32000,
-     "output": 32000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "MiniCPM-V 4.5",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-08-26",
-    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -124851,112 +126099,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "nemotron-3-nano-30b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.06,
-     "output": 0.24
-    },
-    "description": "Compact Nemotron model for efficient reasoning and deployable AI agents",
-    "family": "nemotron",
-    "id": "nemotron-3-nano-30b",
-    "last_updated": "2025-12-15",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Nano 30B",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-12-15",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nemotron-3-nano-omni": {
-    "attachment": true,
-    "cost": {
-     "input": 0.06,
-     "output": 0.24
-    },
-    "description": "Omni-modal model for text, vision, audio, and multimodal agent tasks",
-    "family": "nemotron",
-    "id": "nemotron-3-nano-omni",
-    "last_updated": "2026-04-28",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Nano Omni",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-04-28",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nemotron-3-super-120b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.3,
-     "output": 0.9
-    },
-    "description": "Nemotron model for efficient reasoning, coding, and specialized AI agents",
-    "family": "nemotron",
-    "id": "nemotron-3-super-120b",
-    "last_updated": "2026-03-11",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Super 120B",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-03-11",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
    "nemotron-3-ultra-550b": {
     "attachment": false,
     "cost": {
@@ -125341,37 +126483,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "qwen2-5-vl-72b-instruct": {
-    "attachment": false,
-    "cost": {
-     "input": 0.25,
-     "output": 0.75
-    },
-    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
-    "family": "qwen",
-    "id": "qwen2-5-vl-72b-instruct",
-    "knowledge": "2024-04",
-    "last_updated": "2024-09",
-    "limit": {
-     "context": 32000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen2.5-VL 72B Instruct",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-09",
-    "temperature": true,
-    "tool_call": true
-   },
    "qwen3-235b-a22b-fp8": {
     "attachment": false,
     "cost": {
@@ -125468,41 +126579,11 @@
     "temperature": true,
     "tool_call": true
    },
-   "qwen3-30b-a3b-instruct-2507": {
-    "attachment": false,
-    "cost": {
-     "input": 0.1,
-     "output": 0.3
-    },
-    "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
-    "family": "qwen",
-    "id": "qwen3-30b-a3b-instruct-2507",
-    "last_updated": "2025-07-08",
-    "limit": {
-     "context": 262000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3 30B A3B Instruct (2507)",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-07-08",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "qwen3-32b": {
     "attachment": false,
     "cost": {
-     "input": 0.1,
-     "output": 0.3,
+     "input": 0.36,
+     "output": 0.87,
      "reasoning": 8.4
     },
     "description": "Dense open Qwen model for self-hosted chat, reasoning, and coding",
@@ -127905,6 +128986,53 @@
      }
     ],
     "release_date": "2026-06-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1 (Anthropic)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -132342,6 +133470,47 @@
     "temperature": true,
     "tool_call": true
    },
+   "consensusprotocol/gpt-oss-20b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.04,
+     "output": 0.19
+    },
+    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+    "family": "gpt-oss",
+    "id": "consensusprotocol/gpt-oss-20b",
+    "last_updated": "2025-08-05",
+    "limit": {
+     "context": 65536,
+     "output": 32768
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GPT OSS 20B (Consensus Protocol)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2025-08-05",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepinfra/deepseek-v3.2": {
     "attachment": false,
     "cost": {
@@ -132601,6 +133770,7 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 262144,
+     "input": 192000,
      "output": 131072
     },
     "modalities": {
@@ -134821,6 +135991,51 @@
     "temperature": true,
     "tool_call": true
    },
+   "google-vertex/gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "cache_write": 0.08333,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini",
+    "id": "google-vertex/gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash (Google Vertex AI)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "groq/gpt-oss-120b": {
     "attachment": false,
     "cost": {
@@ -135893,950 +137108,6 @@
     "temperature": false,
     "tool_call": true
    },
-   "nebius/cosmos3-super-reasoner": {
-    "attachment": true,
-    "cost": {
-     "input": 0.1,
-     "output": 0.3
-    },
-    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
-    "id": "nebius/cosmos3-super-reasoner",
-    "last_updated": "2026-06-01",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Cosmos 3 Super Reasoner (Nebius AI)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-06-01",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/deepseek-v4-pro": {
-    "attachment": false,
-    "cost": {
-     "input": 1.75,
-     "output": 3.5
-    },
-    "description": "Open MoE flagship with million-token context for coding and long agent runs",
-    "family": "deepseek-thinking",
-    "id": "nebius/deepseek-v4-pro",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-05",
-    "last_updated": "2026-04-24",
-    "limit": {
-     "context": 1048576,
-     "output": 384000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek V4 Pro (Nebius AI)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "minimal",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-04-24",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/gemma-3-27b": {
-    "attachment": true,
-    "cost": {
-     "input": 0.1,
-     "output": 0.3
-    },
-    "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
-    "family": "gemma",
-    "id": "nebius/gemma-3-27b",
-    "last_updated": "2025-03-12",
-    "limit": {
-     "context": 110000,
-     "output": 110000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Gemma 3 27B (Nebius AI)",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-03-12",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "nebius/glm-5.1": {
-    "attachment": false,
-    "cost": {
-     "input": 1.4,
-     "output": 4.4
-    },
-    "description": "Strong GLM coding model for agentic engineering, terminals, and repository generation",
-    "family": "glm",
-    "id": "nebius/glm-5.1",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-04-07",
-    "limit": {
-     "context": 202752,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-5.1 (Nebius AI)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "minimal",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-04-07",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/glm-5.2": {
-    "attachment": false,
-    "cost": {
-     "input": 1.4,
-     "output": 4.4
-    },
-    "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
-    "family": "glm",
-    "id": "nebius/glm-5.2",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "last_updated": "2026-06-13",
-    "limit": {
-     "context": 1048576,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-5.2 (Nebius AI)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "minimal",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-06-13",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/gpt-oss-120b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.15,
-     "output": 0.6
-    },
-    "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
-    "family": "gpt-oss",
-    "id": "nebius/gpt-oss-120b",
-    "last_updated": "2025-08-05",
-    "limit": {
-     "context": 131072,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT OSS 120B (Nebius AI)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-08-05",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/hermes-4-405b": {
-    "attachment": false,
-    "cost": {
-     "input": 1,
-     "output": 3
-    },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "hermes",
-    "id": "nebius/hermes-4-405b",
-    "last_updated": "2025-08-26",
-    "limit": {
-     "context": 131072,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Hermes 4 405B (Nebius AI)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-08-26",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/hermes-4-70b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.13,
-     "output": 0.4
-    },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "family": "hermes",
-    "id": "nebius/hermes-4-70b",
-    "last_updated": "2025-08-26",
-    "limit": {
-     "context": 131072,
-     "output": 131072
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Hermes 4 70B (Nebius AI)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-08-26",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/kimi-k2.6": {
-    "attachment": true,
-    "cost": {
-     "input": 0.95,
-     "output": 4
-    },
-    "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
-    "family": "kimi-k2",
-    "id": "nebius/kimi-k2.6",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-01",
-    "last_updated": "2026-04-21",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.6 (Nebius AI)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "minimal",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-04-21",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/kimi-k2.7-code": {
-    "attachment": false,
-    "cost": {
-     "input": 0.95,
-     "output": 4
-    },
-    "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
-    "family": "kimi-k2",
-    "id": "nebius/kimi-k2.7-code",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-01",
-    "last_updated": "2026-06-12",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K2.7 Code (Nebius AI)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-06-12",
-    "structured_output": false,
-    "temperature": false,
-    "tool_call": true
-   },
-   "nebius/kimi-k3": {
-    "attachment": true,
-    "cost": {
-     "input": 3,
-     "output": 15
-    },
-    "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
-    "family": "kimi-k3",
-    "id": "nebius/kimi-k3",
-    "last_updated": "2026-07-16",
-    "limit": {
-     "context": 1048576,
-     "output": 1048576
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "video"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi K3 (Nebius AI)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "minimal",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-07-16",
-    "structured_output": false,
-    "temperature": false,
-    "tool_call": true
-   },
-   "nebius/llama-3.1-nemotron-ultra-253b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.6,
-     "output": 1.8
-    },
-    "description": "Flagship Nemotron model for high-throughput reasoning and complex agents",
-    "family": "nemotron",
-    "id": "nebius/llama-3.1-nemotron-ultra-253b",
-    "last_updated": "2025-04-07",
-    "limit": {
-     "context": 128000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama 3.1 Nemotron Ultra 253B (Nebius AI)",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-04-07",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "nebius/llama-3.3-70b-instruct": {
-    "attachment": false,
-    "cost": {
-     "input": 0.13,
-     "output": 0.4
-    },
-    "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
-    "family": "llama",
-    "id": "nebius/llama-3.3-70b-instruct",
-    "knowledge": "2023-12",
-    "last_updated": "2024-12-06",
-    "limit": {
-     "context": 128000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama 3.3 70B Instruct (Nebius AI)",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-12-06",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/minicpm-v-4.5": {
-    "attachment": true,
-    "cost": {
-     "input": 0.658,
-     "output": 1.11
-    },
-    "description": "Multimodal model for analyzing text, images, documents, and rich media",
-    "id": "nebius/minicpm-v-4.5",
-    "last_updated": "2025-08-26",
-    "limit": {
-     "context": 32000,
-     "output": 32000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "MiniCPM-V 4.5 (Nebius AI)",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-08-26",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "nebius/minimax-m2.5": {
-    "attachment": false,
-    "cost": {
-     "input": 0.3,
-     "output": 1.2
-    },
-    "description": "Prior MiniMax coding model for agent workflows, office edits, and automation",
-    "family": "minimax",
-    "id": "nebius/minimax-m2.5",
-    "last_updated": "2026-02-12",
-    "limit": {
-     "context": 196608,
-     "output": 131100
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "MiniMax M2.5 (Nebius AI)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-02-12",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/minimax-m3": {
-    "attachment": false,
-    "cost": {
-     "input": 0.3,
-     "output": 1.2
-    },
-    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
-    "family": "minimax",
-    "id": "nebius/minimax-m3",
-    "last_updated": "2026-06-01",
-    "limit": {
-     "context": 1048576,
-     "output": 512000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "MiniMax M3 (Nebius AI)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "none",
-       "minimal",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-06-01",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/nemotron-3-nano-30b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.06,
-     "output": 0.24
-    },
-    "description": "Compact Nemotron model for efficient reasoning and deployable AI agents",
-    "family": "nemotron",
-    "id": "nebius/nemotron-3-nano-30b",
-    "last_updated": "2025-12-15",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Nano 30B (Nebius AI)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-12-15",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/nemotron-3-nano-omni": {
-    "attachment": true,
-    "cost": {
-     "input": 0.06,
-     "output": 0.24
-    },
-    "description": "Omni-modal model for text, vision, audio, and multimodal agent tasks",
-    "family": "nemotron",
-    "id": "nebius/nemotron-3-nano-omni",
-    "last_updated": "2026-04-28",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Nano Omni (Nebius AI)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-04-28",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/nemotron-3-super-120b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.3,
-     "output": 0.9
-    },
-    "description": "Nemotron model for efficient reasoning, coding, and specialized AI agents",
-    "family": "nemotron",
-    "id": "nebius/nemotron-3-super-120b",
-    "last_updated": "2026-03-11",
-    "limit": {
-     "context": 262144,
-     "output": 262144
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Super 120B (Nebius AI)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-03-11",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/nemotron-3-ultra-550b": {
-    "attachment": false,
-    "cost": {
-     "input": 1,
-     "output": 3
-    },
-    "description": "Flagship Nemotron model for high-throughput reasoning and complex agents",
-    "family": "nemotron",
-    "id": "nebius/nemotron-3-ultra-550b",
-    "last_updated": "2026-06-01",
-    "limit": {
-     "context": 1048576,
-     "output": 1048576
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron 3 Ultra 550B (Nebius AI)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-06-01",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/qwen2-5-vl-72b-instruct": {
-    "attachment": true,
-    "cost": {
-     "input": 0.25,
-     "output": 0.75
-    },
-    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
-    "family": "qwen",
-    "id": "nebius/qwen2-5-vl-72b-instruct",
-    "knowledge": "2024-04",
-    "last_updated": "2024-09",
-    "limit": {
-     "context": 32000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen2.5 VL 72B Instruct (Nebius AI)",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-09",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "nebius/qwen3-235b-a22b-instruct-2507": {
-    "attachment": false,
-    "cost": {
-     "input": 0.2,
-     "output": 0.6
-    },
-    "description": "Updated large open Qwen3 MoE instruct model for multilingual chat, coding, and tool use",
-    "family": "qwen",
-    "id": "nebius/qwen3-235b-a22b-instruct-2507",
-    "last_updated": "2025-07-21",
-    "limit": {
-     "context": 262000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3 235B A22B Instruct 2507 (Nebius AI)",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-07-21",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/qwen3-30b-a3b-instruct-2507": {
-    "attachment": false,
-    "cost": {
-     "input": 0.1,
-     "output": 0.3
-    },
-    "description": "Tool-capable chat model for instruction following and agentic application workflows",
-    "id": "nebius/qwen3-30b-a3b-instruct-2507",
-    "last_updated": "2025-07-30",
-    "limit": {
-     "context": 262000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3 30B A3B Instruct 2507 (Nebius AI)",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-07-30",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/qwen3-32b": {
-    "attachment": false,
-    "cost": {
-     "input": 0.1,
-     "output": 0.3
-    },
-    "description": "Dense open Qwen model for self-hosted chat, reasoning, and coding",
-    "family": "qwen",
-    "id": "nebius/qwen3-32b",
-    "knowledge": "2025-04",
-    "last_updated": "2025-04",
-    "limit": {
-     "context": 40960,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3 32B (Nebius AI)",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-04",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nebius/qwen3-next-80b-a3b-thinking": {
-    "attachment": false,
-    "cost": {
-     "input": 0.15,
-     "output": 1.2
-    },
-    "description": "Efficient Qwen thinking model for local reasoning, math, and coding agents",
-    "family": "qwen",
-    "id": "nebius/qwen3-next-80b-a3b-thinking",
-    "knowledge": "2025-04",
-    "last_updated": "2025-09",
-    "limit": {
-     "context": 131072,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3 Next 80B A3B Thinking (Nebius AI)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "minimal",
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2025-09",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
    "novita/deepseek-v3.2": {
     "attachment": false,
     "cost": {
@@ -137368,6 +137639,7 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 262144,
+     "input": 192000,
      "output": 262144
     },
     "modalities": {
@@ -140263,6 +140535,95 @@
     "temperature": true,
     "tool_call": true
    },
+   "runware/glm-5.3": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.2,
+     "input": 1.2,
+     "output": 4
+    },
+    "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+    "family": "glm",
+    "id": "runware/glm-5.3",
+    "last_updated": "2026-08-14",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 (Runware)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "runware/glm-5.3-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.03,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "runware/glm-5.3-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3 Flash (Runware)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "runware/gpt-oss-120b": {
     "attachment": false,
     "cost": {
@@ -140519,7 +140880,7 @@
     "tool_call": true
    },
    "scx-ai-gp/glm-5.3-flash": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.024,
      "input": 0.13,
@@ -140535,7 +140896,10 @@
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image",
+      "video",
+      "pdf"
      ],
      "output": [
       "text"
@@ -143034,7 +143398,7 @@
     "tool_call": true
    },
    "zai/glm-5.3-flash": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.03,
      "input": 0.15,
@@ -143050,7 +143414,10 @@
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image",
+      "video",
+      "pdf"
      ],
      "output": [
       "text"
@@ -143087,7 +143454,7 @@
   "id": "llmtech",
   "models": {
    "unsloth/Qwen3.8-27B-NVFP4": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.04,
      "input": 0.25,
@@ -143103,7 +143470,8 @@
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
@@ -145366,6 +145734,53 @@
     "temperature": false,
     "tool_call": true
    },
+   "anthropic/claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
    "anthropic/claude-haiku-4-5-20251001": {
     "attachment": true,
     "cost": {
@@ -146474,6 +146889,39 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek/deepseek-v4-flash-0731-fast": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.07,
+     "input": 0.28,
+     "output": 0.56
+    },
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+    "family": "deepseek-flash",
+    "id": "deepseek/deepseek-v4-flash-0731-fast",
+    "knowledge": "2025-05",
+    "last_updated": "2026-07-31",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash 0731",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-07-31",
+    "structured_output": false,
+    "temperature": true,
+    "tool_call": false
+   },
    "deepseek/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
@@ -147379,6 +147827,42 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google/gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+    "family": "gemini-flash",
+    "id": "google/gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-09-02",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -148545,8 +149029,8 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.3,
-     "input": 3,
-     "output": 15
+     "input": 2.9,
+     "output": 14
     },
     "description": "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work",
     "family": "kimi-k3",
@@ -150665,7 +151149,7 @@
     "tool_call": true
    },
    "qwen/qwen3.5-122b-a10b": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.023,
      "input": 0.115,
@@ -150676,12 +151160,13 @@
     "id": "qwen/qwen3.5-122b-a10b",
     "last_updated": "2026-02-23",
     "limit": {
-     "context": 131072,
-     "output": 32768
+     "context": 256000,
+     "output": 64000
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
@@ -150701,7 +151186,7 @@
     "tool_call": true
    },
    "qwen/qwen3.5-27b": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.0172,
      "input": 0.086,
@@ -150712,12 +151197,13 @@
     "id": "qwen/qwen3.5-27b",
     "last_updated": "2026-02-23",
     "limit": {
-     "context": 131072,
-     "output": 32768
+     "context": 256000,
+     "output": 64000
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
@@ -150773,7 +151259,7 @@
     "tool_call": true
    },
    "qwen/qwen3.5-397b-a17b": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.0344,
      "input": 0.172,
@@ -150784,12 +151270,13 @@
     "id": "qwen/qwen3.5-397b-a17b",
     "last_updated": "2026-02-15",
     "limit": {
-     "context": 131072,
-     "output": 32768
+     "context": 256000,
+     "output": 64000
     },
     "modalities": {
      "input": [
-      "text"
+      "text",
+      "image"
      ],
      "output": [
       "text"
@@ -152171,7 +152658,7 @@
     "id": "muse-spark-1.1",
     "last_updated": "2026-07-09",
     "limit": {
-     "context": 1000000,
+     "context": 1048576,
      "output": 32000
     },
     "modalities": {
@@ -156226,7 +156713,7 @@
     "tool_call": true
    },
    "kimi-k2.5": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.1,
      "input": 0.6,
@@ -156610,7 +157097,7 @@
     "tool_call": true
    },
    "kimi-k2.5": {
-    "attachment": false,
+    "attachment": true,
     "cost": {
      "cache_read": 0.1,
      "input": 0.6,
@@ -156929,68 +157416,6 @@
   ],
   "id": "nano-gpt",
   "models": {
-   "Baichuan4-Air": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.0785,
-     "input": 0.157,
-     "output": 0.157
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "baichuan",
-    "id": "Baichuan4-Air",
-    "last_updated": "2025-08-19",
-    "limit": {
-     "context": 32768,
-     "input": 32768,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Baichuan 4 Air",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-08-19",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "Baichuan4-Turbo": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 1.21,
-     "input": 2.42,
-     "output": 2.42
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "baichuan",
-    "id": "Baichuan4-Turbo",
-    "last_updated": "2025-08-19",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Baichuan 4 Turbo",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-08-19",
-    "structured_output": false,
-    "tool_call": false
-   },
    "Doctor-Shotgun/MS3.2-24B-Magnum-Diamond": {
     "attachment": false,
     "cost": {
@@ -158675,39 +159100,6 @@
     "structured_output": true,
     "tool_call": true
    },
-   "TEE/glm-4.7": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.425,
-     "input": 0.85,
-     "output": 3.3
-    },
-    "description": "Mature GLM model for dependable coding, reasoning, and structured agent tasks",
-    "family": "glm",
-    "id": "TEE/glm-4.7",
-    "knowledge": "2025-04",
-    "last_updated": "2025-12-22",
-    "limit": {
-     "context": 131000,
-     "input": 131000,
-     "output": 65535
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.7 TEE",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-12-22",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
    "TEE/glm-5.1": {
     "attachment": false,
     "cost": {
@@ -159841,37 +160233,6 @@
     "structured_output": false,
     "tool_call": false
    },
-   "Tongyi-Zhiwen/QwenLong-L1-32B": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.07,
-     "input": 0.14,
-     "output": 0.6
-    },
-    "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
-    "family": "qwen",
-    "id": "Tongyi-Zhiwen/QwenLong-L1-32B",
-    "last_updated": "2025-01-25",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 40960
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "QwenLong L1 32B",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
    "VongolaChouko/Starcannon-Unleashed-12B-v1.0": {
     "attachment": false,
     "cost": {
@@ -160339,6 +160700,50 @@
     "structured_output": true,
     "tool_call": true
    },
+   "alibaba/qwen3.8-max-0902": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.17,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "Qwen3.8 Max 0902 is Alibaba's September 2 checkpoint of its flagship Qwen3.8 Max model for coding, knowledge work, data analysis, and long-running agent workflows. It supports text, image, video, PDF input, selectable thinking, tool calling, structured output, and a near-million-token context window.",
+    "family": "qwen3.8-max",
+    "id": "alibaba/qwen3.8-max-0902",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 991808,
+     "input": 991808,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max 0902",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "tool_call": true
+   },
    "amazon/nova-2-lite-v1": {
     "attachment": false,
     "cost": {
@@ -160539,6 +160944,54 @@
      }
     ],
     "release_date": "2026-06-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-fable-5.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-5.1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "input": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -163063,84 +163516,6 @@
     "temperature": true,
     "tool_call": false
    },
-   "cohere/north-mini-code": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1,
-     "input": 0.2,
-     "output": 0.8
-    },
-    "description": "Cohere coding model for practical software engineering and agentic edits",
-    "family": "north",
-    "id": "cohere/north-mini-code",
-    "knowledge": "2025-09-23",
-    "last_updated": "2026-06-09",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 64000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Cohere North Mini Code 1.0",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-06-09",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": false
-   },
-   "command-a-plus-05-2026": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1.25,
-     "input": 2.5,
-     "output": 10
-    },
-    "description": "Cohere's stronger command model for multilingual agents and enterprise workflows",
-    "family": "command-a",
-    "id": "command-a-plus-05-2026",
-    "knowledge": "2025-04-01",
-    "last_updated": "2026-06-09",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 64000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Cohere Command A+ (05/2026)",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-05-20",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": false
-   },
    "command-a-reasoning-08-2025": {
     "attachment": false,
     "cost": {
@@ -163785,37 +164160,6 @@
     "structured_output": true,
     "tool_call": true
    },
-   "deepseek/deepseek-prover-v2-671b": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.5,
-     "input": 1,
-     "output": 2.5
-    },
-    "description": "Flagship DeepSeek model for coding, reasoning, and agentic work",
-    "family": "deepseek",
-    "id": "deepseek/deepseek-prover-v2-671b",
-    "last_updated": "2025-04-30",
-    "limit": {
-     "context": 160000,
-     "input": 160000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek Prover v2 671B",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-11-15",
-    "structured_output": false,
-    "tool_call": false
-   },
    "deepseek/deepseek-v3.2": {
     "attachment": true,
     "cost": {
@@ -164061,9 +164405,9 @@
    "deepseek/deepseek-v4-flash-vision-exp": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.007,
-     "input": 0.22,
-     "output": 0.66
+     "cache_read": 0.014,
+     "input": 0.44,
+     "output": 1.32
     },
     "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
     "family": "deepseek-flash",
@@ -167088,10 +167432,10 @@
    "google/gemini-3.7-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0375,
-     "cache_write": 0.020833,
-     "input": 0.375,
-     "output": 1.875
+     "cache_read": 0.075,
+     "cache_write": 0.075,
+     "input": 0.75,
+     "output": 3.75
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -167134,13 +167478,61 @@
     "temperature": true,
     "tool_call": true
    },
+   "google/gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "cache_write": 0.075,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+    "family": "gemini-flash",
+    "id": "google/gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "google/gemini-flash-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.0375,
-     "cache_write": 0.020833,
-     "input": 0.375,
-     "output": 1.875
+     "cache_read": 0.075,
+     "cache_write": 0.075,
+     "input": 0.75,
+     "output": 3.75
     },
     "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
@@ -167769,6 +168161,89 @@
     "structured_output": true,
     "tool_call": true
    },
+   "ibm-granite/granite-4.2-8b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.15
+    },
+    "description": "IBM Granite 4.2 8B is an Apache 2.0-licensed dense model with native step-by-step reasoning and specialized training for agentic work. It can plan before acting, sequence tools, navigate codebases, work in terminals, and verify results across coding, search, mathematics, science, and complex instruction-following tasks.",
+    "family": "granite",
+    "id": "ibm-granite/granite-4.2-8b",
+    "last_updated": "2026-08-31",
+    "limit": {
+     "context": 131072,
+     "input": 131072,
+     "output": 117964
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Granite 4.2 8B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-31",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "inception/mercury-2.5-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.004,
+     "input": 0.04,
+     "output": 0.15
+    },
+    "description": "Mercury 2.5 Preview is Inception's latest and most intelligent diffusion language model. Instead of generating tokens strictly one at a time, it produces and refines multiple tokens in parallel, reaching up to 1,107 tokens per second on standard GPUs. It delivers a 10+ point intelligence gain over Mercury 2, with tunable reasoning, parallel tool calls, schema-aligned JSON output, and a 260K context window. It is built for latency-sensitive production work such as search agents, voice pipelines, customer support, rapid coding iteration, and coding subagents.",
+    "family": "mercury",
+    "id": "inception/mercury-2.5-preview",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 260000,
+     "input": 260000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Mercury 2.5 Preview",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "structured_output": true,
+    "tool_call": true
+   },
    "inclusionai/ling-3.0-flash": {
     "attachment": false,
     "cost": {
@@ -167905,99 +168380,6 @@
     "reasoning": false,
     "release_date": "2025-12-15",
     "structured_output": false,
-    "tool_call": true
-   },
-   "kwaipilot/kat-coder-air-v2.5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.03,
-     "input": 0.15,
-     "output": 0.6
-    },
-    "description": "Fast, cost-efficient KAT Coder model for code generation, editing, debugging, and agentic software-development workflows.",
-    "family": "kat-coder",
-    "id": "kwaipilot/kat-coder-air-v2.5",
-    "last_updated": "2026-07-14",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 80000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "KAT Coder Air V2.5",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-07-14",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "kwaipilot/kat-coder-pro-v2": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.15,
-     "input": 0.3,
-     "output": 1.2
-    },
-    "description": "Coding model for repository understanding, refactors, and agentic engineering tasks",
-    "family": "kat-coder",
-    "id": "kwaipilot/kat-coder-pro-v2",
-    "last_updated": "2026-03-28",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 80000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "KAT Coder Pro V2",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-03-28",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "kwaipilot/kat-coder-pro-v2.5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.15,
-     "input": 0.74,
-     "output": 2.96
-    },
-    "description": "Higher-capability KAT Coder model for complex code generation, repository-scale editing, debugging, and agentic software-development workflows.",
-    "family": "kat-coder",
-    "id": "kwaipilot/kat-coder-pro-v2.5",
-    "last_updated": "2026-07-14",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 80000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "KAT Coder Pro V2.5",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-07-14",
-    "structured_output": true,
     "tool_call": true
    },
    "liquid/lfm-2.5-2.6b": {
@@ -168609,6 +168991,100 @@
      }
     ],
     "release_date": "2026-08-05",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.25,
+     "output": 4.25
+    },
+    "description": "Meta's Muse Spark 1.3 is a frontier multimodal reasoning model for long-horizon coding and agentic workflows, with strong gains in computer use, browsing, professional tool use, codebase understanding, instruction following, and million-token retrieval. It accepts text, images, audio, video, and files, supports tool calling and structured output, and always reasons before answering.",
+    "family": "muse",
+    "id": "meta/muse-spark-1.3",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 943718
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.3",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.3-contributor": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.002,
+     "input": 0.1,
+     "output": 0.2
+    },
+    "description": "Meta's Muse Spark 1.3 Contributor is a frontier multimodal reasoning model for long-horizon coding and agentic workflows, with strong gains in computer use, browsing, professional tool use, codebase understanding, and million-token retrieval. It accepts text, images, audio, video, and files, supports tool calling and structured output, and always reasons before answering. Prompts and outputs may be used by Meta for training and to improve its products.",
+    "family": "muse",
+    "id": "meta/muse-spark-1.3-contributor",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "input": 1048576,
+     "output": 943718
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.3 Contributor",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
     "structured_output": true,
     "tool_call": true
    },
@@ -170806,36 +171282,6 @@
     "temperature": true,
     "tool_call": false
    },
-   "openai/gpt-4-turbo-preview": {
-    "attachment": false,
-    "cost": {
-     "input": 10,
-     "output": 30
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "gpt",
-    "id": "openai/gpt-4-turbo-preview",
-    "last_updated": "2024-01-01",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-4 Turbo Preview",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
    "openai/gpt-4.1": {
     "attachment": true,
     "cost": {
@@ -171076,69 +171522,6 @@
     "temperature": true,
     "tool_call": false
    },
-   "openai/gpt-4o-mini-search-preview": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.075,
-     "input": 0.15,
-     "output": 0.6
-    },
-    "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-    "family": "gpt-mini",
-    "id": "openai/gpt-4o-mini-search-preview",
-    "last_updated": "2024-07-18",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-4o mini Search Preview",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-03-10",
-    "structured_output": false,
-    "tool_call": false
-   },
-   "openai/gpt-4o-search-preview": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1.25,
-     "input": 2.5,
-     "output": 10
-    },
-    "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
-    "family": "gpt",
-    "id": "openai/gpt-4o-search-preview",
-    "last_updated": "2024-05-13",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-4o Search Preview",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2026-03-10",
-    "structured_output": false,
-    "tool_call": false
-   },
    "openai/gpt-5": {
     "attachment": true,
     "cost": {
@@ -171181,40 +171564,6 @@
      }
     ],
     "release_date": "2025-08-07",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
-   "openai/gpt-5-codex": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.125,
-     "input": 1.25,
-     "output": 10
-    },
-    "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
-    "family": "gpt-codex",
-    "id": "openai/gpt-5-codex",
-    "knowledge": "2024-09-30",
-    "last_updated": "2025-09-15",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GPT-5 Codex",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-09-15",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -172455,47 +172804,6 @@
     "temperature": false,
     "tool_call": false
    },
-   "openai/o1-preview": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 7.5,
-     "input": 15,
-     "output": 60
-    },
-    "description": "O-series reasoning model for hard analysis, math, coding, and planning",
-    "family": "o",
-    "id": "openai/o1-preview",
-    "last_updated": "2024-09-12",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "OpenAI o1-preview",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2024-01-01",
-    "structured_output": false,
-    "tool_call": false
-   },
    "openai/o1-pro": {
     "attachment": true,
     "cost": {
@@ -172570,47 +172878,6 @@
      }
     ],
     "release_date": "2025-04-16",
-    "structured_output": false,
-    "temperature": false,
-    "tool_call": false
-   },
-   "openai/o3-deep-research": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 5.5,
-     "input": 11,
-     "output": 44
-    },
-    "description": "Research model for long-horizon investigation, synthesis, and analytical reports",
-    "family": "o",
-    "id": "openai/o3-deep-research",
-    "knowledge": "2024-05",
-    "last_updated": "2024-06-26",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 100000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "OpenAI o3 Deep Research",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "medium"
-      ]
-     }
-    ],
-    "release_date": "2024-06-26",
     "structured_output": false,
     "temperature": false,
     "tool_call": false
@@ -172824,47 +173091,6 @@
     "temperature": false,
     "tool_call": true
    },
-   "openai/o4-mini-deep-research": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 1.1,
-     "input": 2.2,
-     "output": 8.8
-    },
-    "description": "Research model for long-horizon investigation, synthesis, and analytical reports",
-    "family": "o-mini",
-    "id": "openai/o4-mini-deep-research",
-    "knowledge": "2024-05",
-    "last_updated": "2024-06-26",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 100000
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "OpenAI o4-mini Deep Research",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "medium"
-      ]
-     }
-    ],
-    "release_date": "2024-06-26",
-    "structured_output": false,
-    "temperature": false,
-    "tool_call": false
-   },
    "openai/o4-mini-high": {
     "attachment": false,
     "cost": {
@@ -172965,72 +173191,6 @@
      ]
     },
     "name": "Ornith 1.5 35B Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-07-29",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "ornith-ai/ornith-1.5-9b": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.05,
-     "input": 0.1,
-     "output": 0.2
-    },
-    "description": "Ornith 1.5 9B is an FP8 dense open-weight reasoning model built for agentic coding, tool use, visual understanding, and efficient long-context work.",
-    "family": "ornith",
-    "id": "ornith-ai/ornith-1.5-9b",
-    "last_updated": "2026-08-23",
-    "limit": {
-     "context": 262144,
-     "input": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ornith 1.5 9B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-07-29",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "ornith-ai/ornith-1.5-9b:thinking": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.05,
-     "input": 0.1,
-     "output": 0.2
-    },
-    "description": "Ornith 1.5 9B with thinking enabled for more deliberate agentic coding, tool use, visual understanding, and long-context work.",
-    "family": "ornith",
-    "id": "ornith-ai/ornith-1.5-9b:thinking",
-    "last_updated": "2026-08-24",
-    "limit": {
-     "context": 262144,
-     "input": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Ornith 1.5 9B Thinking",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [],
@@ -174314,72 +174474,6 @@
     "structured_output": false,
     "temperature": true,
     "tool_call": false
-   },
-   "qwen/qwen3.6-35b-a3b-uncensored": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.075,
-     "input": 0.15,
-     "output": 0.95
-    },
-    "description": "Qwen 3.6 35B A3B Uncensored is an FP8 open-weight mixture-of-experts model tuned for fewer refusals across chat, coding, tool use, and multimodal tasks.",
-    "family": "qwen3.6",
-    "id": "qwen/qwen3.6-35b-a3b-uncensored",
-    "last_updated": "2026-08-21",
-    "limit": {
-     "context": 262144,
-     "input": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen 3.6 35B A3B Uncensored",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-07-29",
-    "structured_output": true,
-    "tool_call": true
-   },
-   "qwen/qwen3.6-35b-a3b-uncensored:thinking": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.075,
-     "input": 0.15,
-     "output": 0.95
-    },
-    "description": "Qwen 3.6 35B A3B Uncensored with thinking enabled for more deliberate coding, multimodal analysis, tool use, and complex chat tasks.",
-    "family": "qwen3.6",
-    "id": "qwen/qwen3.6-35b-a3b-uncensored:thinking",
-    "last_updated": "2026-08-24",
-    "limit": {
-     "context": 262144,
-     "input": 262144,
-     "output": 32768
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen 3.6 35B A3B Uncensored Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-07-29",
-    "structured_output": true,
-    "tool_call": true
    },
    "qwen/qwen3.8-2.4t-a95b": {
     "attachment": true,
@@ -175812,48 +175906,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "sarvam-30b": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.017,
-     "input": 0.028,
-     "output": 0.111
-    },
-    "description": "Efficient Indian-language reasoning model for chat, coding, and multilingual work",
-    "family": "sarvam",
-    "id": "sarvam-30b",
-    "last_updated": "2026-02-18",
-    "limit": {
-     "context": 65536,
-     "input": 65536,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Sarvam 30B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2026-02-18",
-    "structured_output": false,
-    "temperature": true,
-    "tool_call": true
-   },
    "shisa-ai/shisa-v2-llama3.3-70b": {
     "attachment": false,
     "cost": {
@@ -176270,37 +176322,6 @@
     "structured_output": true,
     "temperature": true,
     "tool_call": true
-   },
-   "tencent/Hunyuan-MT-7B": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 5,
-     "input": 10,
-     "output": 20
-    },
-    "description": "Translation model for multilingual conversion, localization, and cross-language workflows",
-    "family": "hunyuan",
-    "id": "tencent/Hunyuan-MT-7B",
-    "last_updated": "2025-09-18",
-    "limit": {
-     "context": 8192,
-     "input": 8192,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Hunyuan MT 7B",
-    "open_weights": false,
-    "reasoning": false,
-    "release_date": "2025-08-15",
-    "structured_output": false,
-    "tool_call": false
    },
    "tencent/hy3": {
     "attachment": false,
@@ -177887,38 +177908,6 @@
     "temperature": true,
     "tool_call": false
    },
-   "z-ai/glm-4.6v-flash-original": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.05,
-     "input": 0.1,
-     "output": 0.4
-    },
-    "description": "GLM-4.6V-Flash (9B), a lightweight model optimized for local deployment and low-latency applications. Scales context window to 128k tokens and achieves SoTA performance in visual understanding among similar-scale models.",
-    "family": "glm",
-    "id": "z-ai/glm-4.6v-flash-original",
-    "last_updated": "2025-12-08",
-    "limit": {
-     "context": 128000,
-     "input": 128000,
-     "output": 24000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM 4.6V Flash",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-12-08",
-    "structured_output": false,
-    "tool_call": false
-   },
    "z-ai/glm-4.6v-original": {
     "attachment": true,
     "cost": {
@@ -178607,8 +178596,8 @@
     "id": "z-ai/glm-5.3-flash-uncensored",
     "last_updated": "2026-08-27",
     "limit": {
-     "context": 262144,
-     "input": 262144,
+     "context": 1048576,
+     "input": 1048576,
      "output": 32768
     },
     "modalities": {
@@ -178780,9 +178769,9 @@
    "z-ai/glm-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.078,
-     "input": 0.42,
-     "output": 1.32
+     "cache_read": 0.2,
+     "input": 1,
+     "output": 3.2
     },
     "description": "Compatibility alias that routes to the newest thinking GLM model. Currently routes to GLM 5.2 Thinking.",
     "family": "glm",
@@ -180323,75 +180312,6 @@
   ],
   "id": "nebius",
   "models": {
-   "MiniMaxAI/MiniMax-M2.5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.03,
-     "cache_write": 0.375,
-     "input": 0.3,
-     "output": 1.2
-    },
-    "description": "MiniMax model for chat, coding, office work, and agentic tasks",
-    "id": "MiniMaxAI/MiniMax-M2.5",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-07",
-    "limit": {
-     "context": 196608,
-     "input": 190000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "MiniMax-M2.5",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-01-20",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "MiniMaxAI/MiniMax-M2.5-fast": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.03,
-     "cache_write": 0.375,
-     "input": 0.3,
-     "output": 1.2
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "id": "MiniMaxAI/MiniMax-M2.5-fast",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-07",
-    "limit": {
-     "context": 8000,
-     "input": 7000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "MiniMax-M2.5-fast",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-01-20",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "MiniMaxAI/MiniMax-M3": {
     "attachment": false,
     "cost": {
@@ -180439,7 +180359,7 @@
     "knowledge": "2025-11",
     "last_updated": "2026-02-04",
     "limit": {
-     "context": 128000,
+     "context": 131072,
      "input": 120000,
      "output": 8192
     },
@@ -180456,112 +180376,6 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-01-30",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "NousResearch/Hermes-4-70B": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.013,
-     "cache_write": 0.16,
-     "input": 0.13,
-     "output": 0.4,
-     "reasoning": 0.4
-    },
-    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-    "id": "NousResearch/Hermes-4-70B",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-11",
-    "last_updated": "2026-02-04",
-    "limit": {
-     "context": 128000,
-     "input": 120000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Hermes-4-70B",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-01-30",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "PrimeIntellect/INTELLECT-3": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.02,
-     "cache_write": 0.25,
-     "input": 0.2,
-     "output": 1.1
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "id": "PrimeIntellect/INTELLECT-3",
-    "knowledge": "2025-10",
-    "last_updated": "2026-02-04",
-    "limit": {
-     "context": 128000,
-     "input": 120000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "INTELLECT-3",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2026-01-25",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "Qwen/Qwen2.5-VL-72B-Instruct": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.025,
-     "cache_write": 0.31,
-     "input": 0.25,
-     "output": 0.75
-    },
-    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
-    "id": "Qwen/Qwen2.5-VL-72B-Instruct",
-    "knowledge": "2024-12",
-    "last_updated": "2026-02-04",
-    "limit": {
-     "context": 128000,
-     "input": 120000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen2.5-VL-72B-Instruct",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-01-20",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -180596,41 +180410,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "Qwen/Qwen3-235B-A22B-Thinking-2507-fast": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.05,
-     "cache_write": 0.625,
-     "input": 0.5,
-     "output": 2
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "id": "Qwen/Qwen3-235B-A22B-Thinking-2507-fast",
-    "knowledge": "2025-07",
-    "last_updated": "2026-05-07",
-    "limit": {
-     "context": 8000,
-     "input": 7000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3-235B-A22B-Thinking-2507-fast",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-07-25",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "Qwen/Qwen3-30B-A3B-Instruct-2507": {
     "attachment": false,
     "cost": {
@@ -180644,8 +180423,8 @@
     "knowledge": "2025-12",
     "last_updated": "2026-02-04",
     "limit": {
-     "context": 128000,
-     "input": 120000,
+     "context": 262144,
+     "input": 262144,
      "output": 8192
     },
     "modalities": {
@@ -180657,39 +180436,6 @@
      ]
     },
     "name": "Qwen3-30B-A3B-Instruct-2507",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2026-01-28",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "Qwen/Qwen3-32B": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.01,
-     "cache_write": 0.125,
-     "input": 0.1,
-     "output": 0.3
-    },
-    "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
-    "id": "Qwen/Qwen3-32B",
-    "knowledge": "2025-12",
-    "last_updated": "2026-02-04",
-    "limit": {
-     "context": 128000,
-     "input": 120000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3-32B",
     "open_weights": true,
     "reasoning": false,
     "release_date": "2026-01-28",
@@ -180709,8 +180455,8 @@
     "knowledge": "2025-10",
     "last_updated": "2026-02-04",
     "limit": {
-     "context": 32768,
-     "input": 32768,
+     "context": 40960,
+     "input": 40960,
      "output": 0
     },
     "modalities": {
@@ -180728,79 +180474,6 @@
     "structured_output": false,
     "temperature": false,
     "tool_call": false
-   },
-   "Qwen/Qwen3-Next-80B-A3B-Thinking": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.015,
-     "cache_write": 0.18,
-     "input": 0.15,
-     "output": 1.2,
-     "reasoning": 1.2
-    },
-    "description": "Qwen reasoning model for deliberate problem solving, math, and coding",
-    "id": "Qwen/Qwen3-Next-80B-A3B-Thinking",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-12",
-    "last_updated": "2026-02-04",
-    "limit": {
-     "context": 128000,
-     "input": 120000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3-Next-80B-A3B-Thinking",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2026-01-28",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "Qwen/Qwen3-Next-80B-A3B-Thinking-fast": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.015,
-     "cache_write": 0.1875,
-     "input": 0.15,
-     "output": 1.2
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "id": "Qwen/Qwen3-Next-80B-A3B-Thinking-fast",
-    "knowledge": "2025-07",
-    "last_updated": "2026-05-07",
-    "limit": {
-     "context": 8000,
-     "input": 7000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3-Next-80B-A3B-Thinking-fast",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-07-25",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
    },
    "Qwen/Qwen3.5-397B-A17B": {
     "attachment": false,
@@ -180840,145 +180513,24 @@
     "temperature": true,
     "tool_call": true
    },
-   "Qwen/Qwen3.5-397B-A17B-fast": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.06,
-     "cache_write": 0.75,
-     "input": 0.6,
-     "output": 3.6
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "id": "Qwen/Qwen3.5-397B-A17B-fast",
-    "knowledge": "2025-07",
-    "last_updated": "2026-05-07",
-    "limit": {
-     "context": 8000,
-     "input": 7000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Qwen3.5-397B-A17B-fast",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-07-15",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "deepseek-ai/DeepSeek-V3.2": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.03,
-     "cache_write": 0.375,
-     "input": 0.3,
-     "output": 0.45,
-     "reasoning": 0.45
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "id": "deepseek-ai/DeepSeek-V3.2",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-11",
-    "last_updated": "2026-02-04",
-    "limit": {
-     "context": 163000,
-     "input": 160000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek-V3.2",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-01-20",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "deepseek-ai/DeepSeek-V3.2-fast": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.04,
-     "cache_write": 0.5,
-     "input": 0.4,
-     "output": 2
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "id": "deepseek-ai/DeepSeek-V3.2-fast",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-07",
-    "limit": {
-     "context": 8000,
-     "input": 7000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek-V3.2-fast",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-01-27",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "deepseek-ai/DeepSeek-V4-Flash": {
+   "deepseek-ai/DeepSeek-V4-Flash-0731": {
     "attachment": false,
     "cost": {
      "cache_read": 0.14,
      "input": 0.14,
      "output": 0.28
     },
-    "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+    "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
     "family": "deepseek-flash",
-    "id": "deepseek-ai/DeepSeek-V4-Flash",
+    "id": "deepseek-ai/DeepSeek-V4-Flash-0731",
     "interleaved": {
      "field": "reasoning_content"
     },
     "knowledge": "2025-05",
-    "last_updated": "2026-04-24",
+    "last_updated": "2026-07-31",
     "limit": {
-     "context": 131072,
-     "output": 131072
+     "context": 1024000,
+     "output": 1024000
     },
     "modalities": {
      "input": [
@@ -180988,7 +180540,7 @@
       "text"
      ]
     },
-    "name": "DeepSeek V4 Flash",
+    "name": "DeepSeek V4 Flash 0731",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -181002,7 +180554,7 @@
       ]
      }
     ],
-    "release_date": "2026-04-24",
+    "release_date": "2026-07-31",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -181023,8 +180575,8 @@
     "knowledge": "2025-05",
     "last_updated": "2026-04-24",
     "limit": {
-     "context": 1000000,
-     "output": 384000
+     "context": 1048576,
+     "output": 1048576
     },
     "modalities": {
      "input": [
@@ -181039,14 +180591,12 @@
     "reasoning": true,
     "reasoning_options": [
      {
-      "type": "toggle"
-     },
-     {
       "type": "effort",
       "values": [
+       "none",
        "low",
-       "medium",
-       "high"
+       "high",
+       "max"
       ]
      }
     ],
@@ -181085,128 +180635,6 @@
     "open_weights": true,
     "reasoning": false,
     "release_date": "2026-01-20",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "meta-llama/Llama-3.3-70B-Instruct": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.013,
-     "cache_write": 0.16,
-     "input": 0.13,
-     "output": 0.4
-    },
-    "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
-    "id": "meta-llama/Llama-3.3-70B-Instruct",
-    "knowledge": "2025-08",
-    "last_updated": "2026-02-04",
-    "limit": {
-     "context": 128000,
-     "input": 120000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama-3.3-70B-Instruct",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-12-05",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "moonshotai/Kimi-K2.5": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.05,
-     "cache_write": 0.625,
-     "input": 0.5,
-     "output": 2.5,
-     "reasoning": 2.5
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "family": "kimi-k2",
-    "id": "moonshotai/Kimi-K2.5",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-06",
-    "last_updated": "2026-02-04",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi-K2.5",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-12-15",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "moonshotai/Kimi-K2.5-fast": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 0.05,
-     "cache_write": 0.625,
-     "input": 0.5,
-     "output": 2.5
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "family": "kimi-k2",
-    "id": "moonshotai/Kimi-K2.5-fast",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2025-06",
-    "last_updated": "2026-02-04",
-    "limit": {
-     "context": 256000,
-     "input": 256000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Kimi-K2.5-fast",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2025-12-15",
-    "status": "deprecated",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -181292,57 +180720,59 @@
     "temperature": false,
     "tool_call": true
    },
-   "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1": {
+   "nvidia/Nemotron-3-Ultra-550b-a55b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 1,
+     "input": 1,
+     "output": 3
+    },
+    "description": "Largest Nemotron 3 model for maximum open-weight reasoning and agent accuracy",
+    "family": "nemotron",
+    "id": "nvidia/Nemotron-3-Ultra-550b-a55b",
+    "last_updated": "2026-06-04",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Nemotron 3 Ultra 550B A55B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-06-04",
+    "temperature": true,
+    "tool_call": true
+   },
+   "nvidia/Nemotron-3_5-Lightning": {
     "attachment": false,
     "cost": {
      "cache_read": 0.06,
-     "cache_write": 0.75,
-     "input": 0.6,
-     "output": 1.8
-    },
-    "description": "Flagship Nemotron model for high-throughput reasoning and complex agents",
-    "family": "nemotron",
-    "id": "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
-    "knowledge": "2024-12",
-    "last_updated": "2026-02-04",
-    "limit": {
-     "context": 128000,
-     "input": 120000,
-     "output": 4096
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Llama-3.1-Nemotron-Ultra-253B-v1",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-01-15",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.006,
-     "cache_write": 0.075,
      "input": 0.06,
      "output": 0.24
     },
-    "description": "Small Nemotron 3 MoE for efficient coding, math, and long-context agents",
+    "description": "Fast NVIDIA Nemotron MoE for reliable agentic tasks across enterprise workloads",
     "family": "nemotron",
-    "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
-    "knowledge": "2025-05",
-    "last_updated": "2026-02-04",
+    "id": "nvidia/Nemotron-3_5-Lightning",
+    "last_updated": "2026-08-11",
     "limit": {
-     "context": 32000,
-     "input": 30000,
-     "output": 4096
+     "context": 1048576,
+     "output": 1048576
     },
     "modalities": {
      "input": [
@@ -181352,45 +180782,19 @@
       "text"
      ]
     },
-    "name": "Nemotron-3-Nano-30B-A3B",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2025-08-10",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "nvidia/Nemotron-3-Nano-Omni": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.006,
-     "cache_write": 0.075,
-     "input": 0.06,
-     "output": 0.24
-    },
-    "description": "Open Nemotron omni model combining reasoning with text, vision, and audio",
-    "family": "nemotron",
-    "id": "nvidia/Nemotron-3-Nano-Omni",
-    "knowledge": "2025-01",
-    "last_updated": "2026-05-07",
-    "limit": {
-     "context": 65536,
-     "input": 60000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Nemotron-3-Nano-Omni",
+    "name": "Nemotron 3.5 Lightning 30B A3B",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
-    "release_date": "2025-01-20",
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-11",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -181407,8 +180811,8 @@
     "knowledge": "2026-02",
     "last_updated": "2026-03-12",
     "limit": {
-     "context": 256000,
-     "input": 256000,
+     "context": 262144,
+     "input": 262144,
      "output": 32768
     },
     "modalities": {
@@ -181445,7 +180849,7 @@
     "knowledge": "2025-09",
     "last_updated": "2026-02-04",
     "limit": {
-     "context": 128000,
+     "context": 131072,
      "input": 124000,
      "output": 8192
     },
@@ -181475,92 +180879,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "openai/gpt-oss-120b-fast": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.01,
-     "cache_write": 0.125,
-     "input": 0.1,
-     "output": 0.5
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "id": "openai/gpt-oss-120b-fast",
-    "knowledge": "2025-06",
-    "last_updated": "2026-05-07",
-    "limit": {
-     "context": 8000,
-     "input": 7000,
-     "output": 8192
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "gpt-oss-120b-fast",
-    "open_weights": true,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high"
-      ]
-     }
-    ],
-    "release_date": "2025-06-10",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
-   "zai-org/GLM-5": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.1,
-     "cache_write": 1,
-     "input": 1,
-     "output": 3.2
-    },
-    "description": "Legacy model retained for compatibility with older integrations",
-    "id": "zai-org/GLM-5",
-    "interleaved": {
-     "field": "reasoning_content"
-    },
-    "knowledge": "2026-01",
-    "last_updated": "2026-03-10",
-    "limit": {
-     "context": 200000,
-     "input": 200000,
-     "output": 16384
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "GLM-5",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     }
-    ],
-    "release_date": "2026-03-01",
-    "status": "deprecated",
-    "structured_output": true,
-    "temperature": true,
-    "tool_call": true
-   },
    "zai-org/GLM-5.2": {
     "attachment": false,
     "cost": {
@@ -181575,8 +180893,8 @@
     },
     "last_updated": "2026-06-13",
     "limit": {
-     "context": 432000,
-     "output": 432000
+     "context": 1048576,
+     "output": 1048576
     },
     "modalities": {
      "input": [
@@ -181600,6 +180918,50 @@
      }
     ],
     "release_date": "2026-06-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "zai-org/GLM-5.3-Flash": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 0.15,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "zai-org/GLM-5.3-Flash",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1024000,
+     "output": 1024000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -183028,19 +182390,22 @@
    "gpt-5-6-luna": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.1,
+     "cache_read": 0.02,
+     "cache_write": 0.25,
      "context_over_200k": {
-      "cache_read": 0.2,
-      "input": 2,
-      "output": 9
+      "cache_read": 0.04,
+      "cache_write": 0.5,
+      "input": 0.4,
+      "output": 1.8
      },
-     "input": 1,
-     "output": 6,
+     "input": 0.2,
+     "output": 1.2,
      "tiers": [
       {
-       "cache_read": 0.2,
-       "input": 2,
-       "output": 9,
+       "cache_read": 0.04,
+       "cache_write": 0.5,
+       "input": 0.4,
+       "output": 1.8,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -183099,8 +182464,10 @@
     "attachment": true,
     "cost": {
      "cache_read": 0.5,
+     "cache_write": 6.25,
      "context_over_200k": {
       "cache_read": 1,
+      "cache_write": 12.5,
       "input": 10,
       "output": 45
      },
@@ -183109,6 +182476,7 @@
      "tiers": [
       {
        "cache_read": 1,
+       "cache_write": 12.5,
        "input": 10,
        "output": 45,
        "tier": {
@@ -183168,19 +182536,22 @@
    "gpt-5-6-terra": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.25,
+     "cache_read": 0.2,
+     "cache_write": 2.5,
      "context_over_200k": {
-      "cache_read": 0.5,
-      "input": 5,
-      "output": 22.5
+      "cache_read": 0.4,
+      "cache_write": 5,
+      "input": 4,
+      "output": 18
      },
-     "input": 2.5,
-     "output": 15,
+     "input": 2,
+     "output": 12,
      "tiers": [
       {
-       "cache_read": 0.5,
-       "input": 5,
-       "output": 22.5,
+       "cache_read": 0.4,
+       "cache_write": 5,
+       "input": 4,
+       "output": 18,
        "tier": {
         "size": 272000,
         "type": "context"
@@ -183340,8 +182711,8 @@
    "gpt-oss-120b": {
     "attachment": false,
     "cost": {
-     "input": 0.072,
-     "output": 0.28
+     "input": 0.15,
+     "output": 0.6
     },
     "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
     "family": "gpt-oss",
@@ -183380,8 +182751,8 @@
    "gpt-oss-20b": {
     "attachment": false,
     "cost": {
-     "input": 0.05,
-     "output": 0.2
+     "input": 0.07,
+     "output": 0.3
     },
     "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
     "family": "gpt-oss",
@@ -183419,6 +182790,11 @@
    },
    "inkling": {
     "attachment": true,
+    "cost": {
+     "cache_read": 0.17,
+     "input": 1,
+     "output": 4.05
+    },
     "description": "Multimodal MoE reasoning model (975B total, 41B active) for text, image, and audio",
     "family": "ling",
     "id": "inkling",
@@ -197864,6 +197240,7 @@
      }
     ],
     "release_date": "2025-12-11",
+    "status": "deprecated",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -197940,6 +197317,7 @@
     "open_weights": false,
     "reasoning": false,
     "release_date": "2026-03-03",
+    "status": "deprecated",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -199445,6 +198823,55 @@
     "temperature": false,
     "tool_call": true
    },
+   "claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/anthropic"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
+    "temperature": false,
+    "tool_call": true
+   },
    "claude-haiku-4-5": {
     "attachment": true,
     "cost": {
@@ -200526,6 +199953,55 @@
      }
     ],
     "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.5,
+     "input_audio": 1.5,
+     "output": 7.5
+    },
+    "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+    "family": "gemini-flash",
+    "id": "gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/google"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -202036,7 +201512,7 @@
     "tool_call": true
    },
    "grok-code": {
-    "attachment": true,
+    "attachment": false,
     "cost": {
      "cache_read": 0,
      "cache_write": 0,
@@ -202084,6 +201560,7 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 190000,
+     "input": 192000,
      "output": 64000
     },
     "modalities": {
@@ -203150,6 +202627,56 @@
     "temperature": true,
     "tool_call": true
    },
+   "muse-spark-1.3-contributor-free": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0,
+     "input": 0,
+     "output": 0
+    },
+    "description": "Muse Spark 1.3 is a multimodal reasoning model from Meta for coding and agentic workflows.",
+    "family": "muse-free",
+    "id": "muse-spark-1.3-contributor-free",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.3 Free",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "nemotron-3-super-free": {
     "attachment": false,
     "cost": {
@@ -204143,7 +203670,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 256000,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -204742,6 +204270,56 @@
      }
     ],
     "release_date": "2026-08-05",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "muse-spark-1.3-contributor": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.002,
+     "input": 0.1,
+     "output": 0.2
+    },
+    "description": "Muse Spark 1.3 is a multimodal reasoning model from Meta for coding and agentic workflows.",
+    "family": "muse",
+    "id": "muse-spark-1.3-contributor",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.3 Contributor",
+    "open_weights": false,
+    "provider": {
+     "npm": "@ai-sdk/openai"
+    },
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -205548,7 +205126,7 @@
    "anthracite-org/magnum-v4-72b": {
     "attachment": false,
     "cost": {
-     "input": 3,
+     "input": 2.5,
      "output": 5
     },
     "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
@@ -205652,6 +205230,53 @@
      }
     ],
     "release_date": "2026-06-09",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-fable-5.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-5.1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
     "structured_output": true,
     "temperature": false,
     "tool_call": true
@@ -205954,56 +205579,6 @@
     "temperature": false,
     "tool_call": true
    },
-   "anthropic/claude-opus-4.7-fast": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 3,
-     "cache_write": 37.5,
-     "input": 30,
-     "output": 150
-    },
-    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-    "family": "claude-opus",
-    "id": "anthropic/claude-opus-4.7-fast",
-    "knowledge": "2026-01-31",
-    "last_updated": "2026-04-16",
-    "limit": {
-     "context": 1000000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude Opus 4.7 (Fast)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-04-16",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
    "anthropic/claude-opus-4.8": {
     "attachment": true,
     "cost": {
@@ -206054,56 +205629,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "anthropic/claude-opus-4.8-fast": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1,
-     "cache_write": 12.5,
-     "input": 10,
-     "output": 50
-    },
-    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-    "family": "claude-opus",
-    "id": "anthropic/claude-opus-4.8-fast",
-    "knowledge": "2026-01",
-    "last_updated": "2026-05-28",
-    "limit": {
-     "context": 1000000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude Opus 4.8 (Fast)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-05-28",
-    "structured_output": true,
-    "temperature": false,
-    "tool_call": true
-   },
    "anthropic/claude-opus-5": {
     "attachment": true,
     "cost": {
@@ -206152,56 +205677,6 @@
     "release_date": "2026-07-24",
     "structured_output": true,
     "temperature": true,
-    "tool_call": true
-   },
-   "anthropic/claude-opus-5-fast": {
-    "attachment": true,
-    "cost": {
-     "cache_read": 1,
-     "cache_write": 12.5,
-     "input": 10,
-     "output": 50
-    },
-    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-    "family": "claude-opus",
-    "id": "anthropic/claude-opus-5-fast",
-    "knowledge": "2026-05",
-    "last_updated": "2026-07-24",
-    "limit": {
-     "context": 1000000,
-     "output": 128000
-    },
-    "modalities": {
-     "input": [
-      "text",
-      "image",
-      "pdf"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "Claude Opus 5 (Fast)",
-    "open_weights": false,
-    "reasoning": true,
-    "reasoning_options": [
-     {
-      "type": "toggle"
-     },
-     {
-      "type": "effort",
-      "values": [
-       "low",
-       "medium",
-       "high",
-       "xhigh",
-       "max"
-      ]
-     }
-    ],
-    "release_date": "2026-07-24",
-    "structured_output": true,
-    "temperature": false,
     "tool_call": true
    },
    "anthropic/claude-sonnet-4": {
@@ -206465,7 +205940,7 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-04-01",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -207091,9 +206566,9 @@
    "deepseek/deepseek-chat-v3.1": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.55,
-     "input": 0.55,
-     "output": 1.65
+     "cache_read": 0.13,
+     "input": 0.25,
+     "output": 0.95
     },
     "description": "DeepSeek chat model for instruction following, coding, and analysis",
     "family": "deepseek",
@@ -207102,7 +206577,7 @@
     "last_updated": "2025-08-21",
     "limit": {
      "context": 163840,
-     "output": 144900
+     "output": 32768
     },
     "modalities": {
      "input": [
@@ -207339,9 +206814,9 @@
    "deepseek/deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.016492,
-     "input": 0.08246,
-     "output": 0.16492
+     "cache_read": 0.017721,
+     "input": 0.088606,
+     "output": 0.177212
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -207431,9 +206906,9 @@
    "deepseek/deepseek-v4-flash-vision-exp": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.007,
-     "input": 0.22,
-     "output": 0.66
+     "cache_read": 0.014,
+     "input": 0.44,
+     "output": 1.32
     },
     "description": "Fast DeepSeek model for efficient chat, coding help, and agent loops",
     "family": "deepseek-flash",
@@ -207469,16 +206944,16 @@
      }
     ],
     "release_date": "2026-08-21",
-    "structured_output": false,
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
    "deepseek/deepseek-v4-pro": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.086188,
-     "input": 1.034256,
-     "output": 2.068512
+     "cache_read": 0.086855,
+     "input": 1.04226,
+     "output": 2.08452
     },
     "description": "Open MoE flagship with million-token context for coding and long agent runs",
     "family": "deepseek-thinking",
@@ -207523,9 +206998,9 @@
    "deepseek/deepseek-v4-pro-0813": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.022,
-     "input": 0.66,
-     "output": 1.98
+     "cache_read": 0.03718,
+     "input": 1.1154,
+     "output": 3.3462
     },
     "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
     "family": "deepseek-thinking",
@@ -208599,6 +208074,53 @@
     "temperature": true,
     "tool_call": true
    },
+   "google/gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "cache_write": 0.041667,
+     "input": 0.75,
+     "output": 3.75,
+     "reasoning": 3.75
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "google/gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "google/gemma-2-27b-it": {
     "attachment": false,
     "cost": {
@@ -209031,6 +208553,47 @@
     "temperature": true,
     "tool_call": true
    },
+   "ibm-granite/granite-4.2-8b": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.1,
+     "output": 0.15
+    },
+    "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
+    "family": "granite",
+    "id": "ibm-granite/granite-4.2-8b",
+    "last_updated": "2026-08-31",
+    "limit": {
+     "context": 131072,
+     "output": 117964
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Granite 4.2 8B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-31",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "inception/mercury-2": {
     "attachment": false,
     "cost": {
@@ -209069,6 +208632,48 @@
      }
     ],
     "release_date": "2026-03-04",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "inception/mercury-2.5-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.004,
+     "input": 0.04,
+     "output": 0.15
+    },
+    "description": "Preview model for early access evaluation, prototyping, and compatibility testing",
+    "family": "mercury",
+    "id": "inception/mercury-2.5-preview",
+    "last_updated": "2026-08-31",
+    "limit": {
+     "context": 260000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Mercury 2.5 Preview",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-31",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -209240,7 +208845,7 @@
    "mancer/weaver": {
     "attachment": false,
     "cost": {
-     "input": 0.5,
+     "input": 0.4,
      "output": 0.75
     },
     "description": "General-purpose chat model for instruction following, writing, and analysis",
@@ -209435,9 +209040,8 @@
    "meta-llama/llama-3.3-70b-instruct": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.71,
-     "input": 0.71,
-     "output": 0.71
+     "input": 0.1,
+     "output": 0.32
     },
     "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
     "family": "llama",
@@ -209446,7 +209050,7 @@
     "last_updated": "2024-12-06",
     "limit": {
      "context": 131072,
-     "output": 115200
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -209499,9 +209103,8 @@
    "meta-llama/llama-4-scout": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.055,
-     "input": 0.11,
-     "output": 0.34
+     "input": 0.1,
+     "output": 0.3
     },
     "description": "Open multimodal Llama model for long-context analysis and efficient agents",
     "family": "llama",
@@ -209510,7 +209113,7 @@
     "last_updated": "2025-04-05",
     "limit": {
      "context": 1310720,
-     "output": 8192
+     "output": 16384
     },
     "modalities": {
      "input": [
@@ -209566,7 +209169,7 @@
     "cost": {
      "cache_read": 0.04,
      "input": 0.3,
-     "output": 1.2
+     "output": 1.1
     },
     "description": "Muse Glimmer is a 30-billion-parameter open-weight multimodal model from Meta Superintelligence Labs, distilled from Muse Spark for always-on local agents, tool use, coding, and image understanding.",
     "family": "muse",
@@ -209575,7 +209178,7 @@
     "last_updated": "2026-08-10",
     "limit": {
      "context": 131072,
-     "output": 16384
+     "output": 117964
     },
     "modalities": {
      "input": [
@@ -209742,6 +209345,100 @@
      }
     ],
     "release_date": "2026-08-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.25,
+     "output": 4.25
+    },
+    "description": "Open Llama multimodal model for image understanding and text reasoning",
+    "family": "muse",
+    "id": "meta/muse-spark-1.3",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 943718
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.3",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "meta/muse-spark-1.3-contributor": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.002,
+     "input": 0.1,
+     "output": 0.2
+    },
+    "description": "Open Llama multimodal model for image understanding and text reasoning",
+    "family": "muse",
+    "id": "meta/muse-spark-1.3-contributor",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 943718
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf",
+      "audio"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.3 Contributor",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "minimal",
+       "low",
+       "medium",
+       "high",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -211317,7 +211014,7 @@
    "nvidia/nemotron-3-nano-30b-a3b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.025,
+     "cache_read": 0.03,
      "input": 0.05,
      "output": 0.2
     },
@@ -211327,7 +211024,7 @@
     "last_updated": "2025-12-15",
     "limit": {
      "context": 262144,
-     "output": 228000
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -211484,9 +211181,9 @@
    "nvidia/nemotron-3-ultra-550b-a55b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.1,
-     "input": 0.5,
-     "output": 2.2
+     "cache_read": 0.12,
+     "input": 0.6,
+     "output": 2.4
     },
     "description": "Largest Nemotron 3 model for maximum open-weight reasoning and agent accuracy",
     "family": "nemotron",
@@ -211494,7 +211191,7 @@
     "last_updated": "2026-06-04",
     "limit": {
      "context": 262144,
-     "output": 16384
+     "output": 182520
     },
     "modalities": {
      "input": [
@@ -214876,8 +214573,8 @@
    "qwen/qwen3-14b": {
     "attachment": false,
     "cost": {
-     "input": 0.12,
-     "output": 0.24
+     "input": 0.2275,
+     "output": 0.91
     },
     "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
     "family": "qwen",
@@ -214886,7 +214583,7 @@
     "last_updated": "2025-04-28",
     "limit": {
      "context": 131072,
-     "output": 16384
+     "output": 8192
     },
     "modalities": {
      "input": [
@@ -215495,7 +215192,8 @@
    "qwen/qwen3-next-80b-a3b-instruct": {
     "attachment": false,
     "cost": {
-     "input": 0.09,
+     "cache_read": 0.07,
+     "input": 0.1,
      "output": 1.1
     },
     "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
@@ -215505,7 +215203,7 @@
     "last_updated": "2025-09",
     "limit": {
      "context": 262144,
-     "output": 16384
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -215895,8 +215593,9 @@
    "qwen/qwen3.5-397b-a17b": {
     "attachment": true,
     "cost": {
-     "input": 0.39,
-     "output": 2.34
+     "cache_read": 0.225,
+     "input": 0.55,
+     "output": 3.5
     },
     "description": "Large open Qwen multimodal MoE for visual agents and long technical tasks",
     "family": "qwen",
@@ -215904,7 +215603,7 @@
     "last_updated": "2026-02-15",
     "limit": {
      "context": 262144,
-     "output": 65536
+     "output": 235929
     },
     "modalities": {
      "input": [
@@ -216504,7 +216203,7 @@
    "qwen/qwen3.8-2.4t-a95b": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.2,
+     "cache_read": 0.25,
      "input": 2,
      "output": 6
     },
@@ -216514,7 +216213,7 @@
     "last_updated": "2026-08-12",
     "limit": {
      "context": 1048576,
-     "output": 131072
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -217196,9 +216895,9 @@
    "tencent/hy3": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.020625,
-     "input": 0.0825,
-     "output": 0.33
+     "cache_read": 0.033,
+     "input": 0.132,
+     "output": 0.528
     },
     "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
     "family": "Hy",
@@ -217206,6 +216905,7 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 262144,
+     "input": 192000,
      "output": 128000
     },
     "modalities": {
@@ -218266,9 +217966,9 @@
    "z-ai/glm-4.6": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.08,
-     "input": 0.43,
-     "output": 1.75
+     "cache_read": 0.11,
+     "input": 0.55,
+     "output": 2.2
     },
     "description": "Late GLM-4 workhorse for coding agents, reasoning, and structured tasks",
     "family": "glm",
@@ -218277,7 +217977,7 @@
     "last_updated": "2025-09-30",
     "limit": {
      "context": 204800,
-     "output": 16384
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -218539,9 +218239,9 @@
    "z-ai/glm-5.2": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.221,
-     "input": 1.19,
-     "output": 3.74
+     "cache_read": 0.1932,
+     "input": 0.966,
+     "output": 3.036
     },
     "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
     "family": "glm",
@@ -218552,7 +218252,7 @@
     "last_updated": "2026-06-13",
     "limit": {
      "context": 1048576,
-     "output": 262144
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -218749,7 +218449,7 @@
    "~anthropic/claude-fable-latest": {
     "attachment": true,
     "cost": {
-     "cache_read": 1,
+     "cache_read": 0.25,
      "cache_write": 12.5,
      "input": 10,
      "output": 50
@@ -218934,7 +218634,7 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.013,
-     "input": 0.03,
+     "input": 0.05,
      "output": 0.16
     },
     "description": "Fast DeepSeek model for efficient chat, coding help, and agent loops",
@@ -219304,12 +219004,55 @@
     "temperature": true,
     "tool_call": true
    },
+   "~z-ai/glm-flash-latest": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.015,
+     "input": 0.075,
+     "output": 0.25
+    },
+    "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm-flash",
+    "id": "~z-ai/glm-flash-latest",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 1310720,
+     "output": 943718
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM Flash Latest",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-27",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "~z-ai/glm-latest": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.247,
-     "input": 1.1875,
-     "output": 4.18
+     "cache_read": 0.1794,
+     "input": 1.092,
+     "output": 3.432
     },
     "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
     "family": "glm",
@@ -219317,7 +219060,7 @@
     "last_updated": "2026-08-19",
     "limit": {
      "context": 1310720,
-     "output": 131072
+     "output": 943718
     },
     "modalities": {
      "input": [
@@ -225989,7 +225732,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 256000,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -226028,7 +225772,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 256000,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -226840,8 +226585,55 @@
     "temperature": true,
     "tool_call": true
    },
+   "qwen3.8-27b": {
+    "attachment": true,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
+    "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+    "family": "qwen",
+    "id": "qwen3.8-27b",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8-27B",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "minimal",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "qwen3guard-gen-0.6b": {
     "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
     "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
     "id": "qwen3guard-gen-0.6b",
     "last_updated": "2026-01-22",
@@ -226866,6 +226658,10 @@
    },
    "qwen3guard-gen-8b": {
     "attachment": false,
+    "cost": {
+     "input": 0,
+     "output": 0
+    },
     "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
     "id": "qwen3guard-gen-8b",
     "last_updated": "2026-01-22",
@@ -241450,6 +241246,106 @@
     "temperature": false,
     "tool_call": true
    },
+   "claude-fable-5.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "claude-fable-5.1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-09-01",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
+   "claude-fable-5.1@eu": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.275,
+     "cache_write": 13.75,
+     "input": 11,
+     "output": 55
+    },
+    "description": "Claude model for demanding reasoning and long-horizon agentic work",
+    "family": "claude-fable",
+    "id": "claude-fable-5.1@eu",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1 (EU)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-09-01",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
    "claude-fable-5@eu": {
     "attachment": true,
     "cost": {
@@ -242557,9 +242453,9 @@
    "deepseek-v4-flash": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.014,
-     "input": 0.44,
-     "output": 1.32
+     "cache_read": 0.07,
+     "input": 0.14,
+     "output": 0.28
     },
     "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
     "family": "deepseek-flash",
@@ -242567,8 +242463,8 @@
     "knowledge": "2025-05",
     "last_updated": "2026-04-24",
     "limit": {
-     "context": 1000000,
-     "output": 384000
+     "context": 1048576,
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -242580,9 +242476,24 @@
     },
     "name": "DeepSeek V4 Flash",
     "open_weights": true,
-    "reasoning": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-04-24",
-    "structured_output": false,
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
@@ -242694,7 +242605,7 @@
     "last_updated": "2026-04-24",
     "limit": {
      "context": 1000000,
-     "output": 384000
+     "output": 131072
     },
     "modalities": {
      "input": [
@@ -242751,6 +242662,52 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "deepseek-v4-pro-0813@eu": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.44,
+     "input": 1.75,
+     "output": 3.5
+    },
+    "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "id": "deepseek-v4-pro-0813@eu",
+    "last_updated": "2026-08-22",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Pro 0813 (EU)",
     "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
@@ -242922,10 +242879,77 @@
     },
     "name": "Fugu Ultra",
     "open_weights": false,
-    "reasoning": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-06-15",
     "structured_output": false,
     "temperature": false,
+    "tool_call": true
+   },
+   "gemini-2.5-flash-lite@eu": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01,
+     "cache_write": 0.18333,
+     "input": 0.1,
+     "output": 0.4
+    },
+    "description": "Lean Gemini 2.5 lane for cheap multimodal traffic and quick agents",
+    "family": "gemini-flash-lite",
+    "id": "gemini-2.5-flash-lite@eu",
+    "knowledge": "2025-01",
+    "last_updated": "2025-06-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 2.5 Flash-Lite (EU)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2025-06-17",
+    "structured_output": true,
+    "temperature": true,
     "tool_call": true
    },
    "gemini-2.5-flash@eu": {
@@ -242980,31 +243004,83 @@
     "temperature": true,
     "tool_call": true
    },
-   "gemini-3-pro-image": {
+   "gemini-2.5-pro@eu": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
-     "cache_write": 4.5,
+     "cache_read": 0.31,
+     "cache_write": 2.375,
      "context_over_200k": {
-      "cache_read": 0.2,
-      "cache_write": 4.5,
-      "input": 4,
-      "output": 18
+      "cache_read": 0.62,
+      "cache_write": 4.75,
+      "input": 2.5,
+      "output": 15
      },
-     "input": 2,
-     "output": 12,
+     "input": 1.25,
+     "output": 10,
      "tiers": [
       {
-       "cache_read": 0.2,
-       "cache_write": 4.5,
-       "input": 4,
-       "output": 18,
+       "cache_read": 0.62,
+       "cache_write": 4.75,
+       "input": 2.5,
+       "output": 15,
        "tier": {
         "size": 200000,
         "type": "context"
        }
       }
      ]
+    },
+    "description": "Google's proven reasoning model for coding, math, and multimodal analysis",
+    "family": "gemini-pro",
+    "id": "gemini-2.5-pro@eu",
+    "knowledge": "2025-01",
+    "last_updated": "2025-06-17",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 2.5 Pro (EU)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2025-06-17",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gemini-3-pro-image": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.2,
+     "cache_write": 4.5,
+     "input": 2,
+     "output": 12
     },
     "description": "Nano Banana Pro for higher-fidelity image generation and design-heavy edits",
     "family": "gemini-pro",
@@ -243051,22 +243127,8 @@
    "gemini-3.1-flash-image": {
     "attachment": true,
     "cost": {
-     "context_over_200k": {
-      "input": 0.5,
-      "output": 2
-     },
      "input": 0.5,
-     "output": 2,
-     "tiers": [
-      {
-       "input": 0.5,
-       "output": 2,
-       "tier": {
-        "size": 200000,
-        "type": "context"
-       }
-      }
-     ]
+     "output": 2
     },
     "description": "Image model for prompt-driven generation, editing, and visual design workflows",
     "family": "gemini-flash",
@@ -243117,26 +243179,8 @@
     "cost": {
      "cache_read": 0.025,
      "cache_write": 0.08333,
-     "context_over_200k": {
-      "cache_read": 0.025,
-      "cache_write": 0.08333,
-      "input": 0.5,
-      "output": 2.25
-     },
      "input": 0.25,
-     "output": 1.5,
-     "tiers": [
-      {
-       "cache_read": 0.025,
-       "cache_write": 0.08333,
-       "input": 0.5,
-       "output": 2.25,
-       "tier": {
-        "size": 200000,
-        "type": "context"
-       }
-      }
-     ]
+     "output": 1.5
     },
     "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
     "family": "gemini-flash-lite",
@@ -243187,26 +243231,8 @@
     "cost": {
      "cache_read": 0.0275,
      "cache_write": 0.091663,
-     "context_over_200k": {
-      "cache_read": 0.0275,
-      "cache_write": 0.091663,
-      "input": 0.55,
-      "output": 2.475
-     },
      "input": 0.275,
-     "output": 1.65,
-     "tiers": [
-      {
-       "cache_read": 0.0275,
-       "cache_write": 0.091663,
-       "input": 0.55,
-       "output": 2.475,
-       "tier": {
-        "size": 200000,
-        "type": "context"
-       }
-      }
-     ]
+     "output": 1.65
     },
     "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
     "family": "gemini-flash-lite",
@@ -243258,8 +243284,8 @@
      "cache_read": 0.2,
      "cache_write": 4.5,
      "context_over_200k": {
-      "cache_read": 0.2,
-      "cache_write": 4.5,
+      "cache_read": 0.4,
+      "cache_write": 9,
       "input": 4,
       "output": 18
      },
@@ -243267,8 +243293,8 @@
      "output": 12,
      "tiers": [
       {
-       "cache_read": 0.2,
-       "cache_write": 4.5,
+       "cache_read": 0.4,
+       "cache_write": 9,
        "input": 4,
        "output": 18,
        "tier": {
@@ -243681,6 +243707,106 @@
     "temperature": true,
     "tool_call": true
    },
+   "gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+    "family": "gemini-flash",
+    "id": "gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gemini-3.8-flash@eu": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.0825,
+     "input": 0.825,
+     "output": 4.125
+    },
+    "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+    "family": "gemini-flash",
+    "id": "gemini-3.8-flash@eu",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 65535
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "audio",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash (EU)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-09-02",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "gemma-4-26b-a4b-it": {
     "attachment": true,
     "cost": {
@@ -243869,9 +243995,9 @@
    "glm-5.2": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.26,
-     "input": 1.2,
-     "output": 4.2
+     "cache_read": 0.16,
+     "input": 0.8,
+     "output": 2.55
     },
     "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
     "family": "glm",
@@ -244007,16 +244133,16 @@
     "attachment": false,
     "cost": {
      "cache_read": 0.26,
-     "input": 1.4,
-     "output": 4.4
+     "input": 1.2,
+     "output": 4.2
     },
     "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
     "family": "glm",
     "id": "glm-5.3",
     "last_updated": "2026-08-14",
     "limit": {
-     "context": 1000000,
-     "output": 128000
+     "context": 1048576,
+     "output": 1048576
     },
     "modalities": {
      "input": [
@@ -244045,15 +244171,15 @@
      }
     ],
     "release_date": "2026-08-14",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
    "glm-5.3-flash": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.03,
-     "input": 0.15,
+     "cache_read": 0.07,
+     "input": 0.2,
      "output": 0.5
     },
     "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
@@ -244062,7 +244188,7 @@
     "last_updated": "2026-08-26",
     "limit": {
      "context": 1000000,
-     "output": 128000
+     "output": 262144
     },
     "modalities": {
      "input": [
@@ -244094,16 +244220,65 @@
      }
     ],
     "release_date": "2026-08-26",
-    "structured_output": false,
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "glm-5.3-flash@eu": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.07,
+     "input": 0.2,
+     "output": 0.5
+    },
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "id": "glm-5.3-flash@eu",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1000000,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM-5.3-Flash (EU)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
     "temperature": true,
     "tool_call": true
    },
    "glm-5.3@eu": {
     "attachment": false,
     "cost": {
-     "cache_read": 0.44,
-     "input": 1.75,
-     "output": 4.5
+     "cache_read": 0.26,
+     "input": 1.2,
+     "output": 4.2
     },
     "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
     "family": "glm",
@@ -244140,7 +244315,7 @@
      }
     ],
     "release_date": "2026-08-14",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": true,
     "tool_call": true
    },
@@ -245911,7 +246086,7 @@
      }
     ],
     "release_date": "2026-06-12",
-    "structured_output": true,
+    "structured_output": false,
     "temperature": false,
     "tool_call": true
    },
@@ -246337,7 +246512,22 @@
     },
     "name": "MiMo-V2.5",
     "open_weights": true,
-    "reasoning": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-04-22",
     "structured_output": false,
     "temperature": true,
@@ -246369,7 +246559,22 @@
     },
     "name": "MiMo-V2.5-Pro",
     "open_weights": true,
-    "reasoning": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
     "release_date": "2026-04-22",
     "structured_output": false,
     "temperature": true,
@@ -247739,6 +247944,196 @@
      }
     ],
     "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-2.4T-A95B@eu": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.63,
+     "input": 2.5,
+     "output": 6
+    },
+    "description": "Open-weight sparse MoE (2.4T total, 95B active), the open-weight twin of Qwen3.8 Max for coding, research, complex reasoning, and agentic workflows",
+    "family": "qwen",
+    "id": "qwen3.8-2.4T-A95B@eu",
+    "last_updated": "2026-08-12",
+    "limit": {
+     "context": 1000000,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 2.4T A95B (EU)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-12",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.016,
+     "cache_write": 0.2,
+     "input": 0.16,
+     "output": 0.47
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "id": "qwen3.8-flash",
+    "last_updated": "2026-08-26",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-26",
+    "structured_output": true,
+    "tool_call": true
+   },
+   "qwen3.8-flash-next": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.2,
+     "output": 0.5
+    },
+    "description": "Open-weight experimental preview of the Qwen4 architecture: hybrid-attention MoE (125B total, 6B active) with vision encoder for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen3.8-flash-next",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash Next",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-27",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "qwen3.8-flash-next@eu": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.05,
+     "input": 0.2,
+     "output": 0.5
+    },
+    "description": "Open-weight experimental preview of the Qwen4 architecture: hybrid-attention MoE (125B total, 6B active) with vision encoder for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "qwen3.8-flash-next@eu",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 262144,
+     "output": 262144
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Flash Next (EU)",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     },
+     {
+      "type": "budget_tokens"
+     }
+    ],
+    "release_date": "2026-08-27",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -259340,7 +259735,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 256000,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -259437,7 +259833,8 @@
     "last_updated": "2026-07-06",
     "limit": {
      "context": 256000,
-     "output": 64000
+     "input": 192000,
+     "output": 128000
     },
     "modalities": {
      "input": [
@@ -265524,6 +265921,54 @@
     "temperature": true,
     "tool_call": true
    },
+   "deepseek-v4-flash-vision-exp": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.007,
+     "input": 0.22,
+     "output": 0.66
+    },
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "id": "deepseek-v4-flash-vision-exp",
+    "interleaved": {
+     "field": "reasoning_content"
+    },
+    "last_updated": "2026-08-21",
+    "limit": {
+     "context": 1000000,
+     "output": 384000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     },
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "high",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-21",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "deepseek-v4-pro": {
     "attachment": false,
     "cost": {
@@ -265653,6 +266098,45 @@
     ],
     "release_date": "2026-08-26",
     "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "hy4-preview": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.034,
+     "input": 0.67,
+     "output": 2
+    },
+    "description": "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities.",
+    "family": "Hy",
+    "id": "hy4-preview",
+    "last_updated": "2026-08-28",
+    "limit": {
+     "context": 1024000,
+     "output": 64000
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Hy4 preview",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "high"
+      ]
+     }
+    ],
+    "release_date": "2026-08-28",
     "temperature": true,
     "tool_call": true
    },
@@ -265938,6 +266422,52 @@
     "temperature": false,
     "tool_call": true
    },
+   "claude-fable-5-1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.3,
+     "cache_write": 15,
+     "input": 12,
+     "output": 60
+    },
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "id": "claude-fable-5-1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-08-29",
+    "structured_output": true,
+    "temperature": false,
+    "tool_call": true
+   },
    "claude-opus-4-5": {
     "attachment": true,
     "cost": {
@@ -266002,7 +266532,17 @@
     "name": "Claude Opus 4.6",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-02-05",
     "structured_output": true,
     "temperature": true,
@@ -266037,7 +266577,18 @@
     "name": "Claude Opus 4.7",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-04-16",
     "structured_output": true,
     "temperature": false,
@@ -266072,7 +266623,18 @@
     "name": "Claude Opus 4.8",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-05-28",
     "structured_output": true,
     "temperature": false,
@@ -266107,7 +266669,18 @@
     "name": "Claude Opus 4.8 Fast",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-05-28",
     "structured_output": true,
     "temperature": false,
@@ -266142,7 +266715,18 @@
     "name": "Claude Opus 5",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-07-23",
     "structured_output": true,
     "temperature": false,
@@ -266177,7 +266761,18 @@
     "name": "Claude Opus 5 Fast",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-07-23",
     "structured_output": true,
     "temperature": false,
@@ -266247,7 +266842,17 @@
     "name": "Claude Sonnet 4.6",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-02-17",
     "structured_output": true,
     "temperature": true,
@@ -266256,10 +266861,10 @@
    "claude-sonnet-5": {
     "attachment": true,
     "cost": {
-     "cache_read": 0.2,
-     "cache_write": 2.5000000000000004,
-     "input": 2,
-     "output": 10.000000000000002
+     "cache_read": 0.3,
+     "cache_write": 3.75,
+     "input": 3,
+     "output": 15
     },
     "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
     "family": "claude-sonnet",
@@ -266282,7 +266887,18 @@
     "name": "Claude Sonnet 5",
     "open_weights": false,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
     "release_date": "2026-06-29",
     "structured_output": true,
     "temperature": false,
@@ -266361,7 +266977,17 @@
     "name": "DeepSeek V4 Flash 0423",
     "open_weights": true,
     "reasoning": true,
-    "reasoning_options": [],
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "none",
+       "low",
+       "medium",
+       "high"
+      ]
+     }
+    ],
     "release_date": "2026-04-24",
     "structured_output": true,
     "temperature": true,
@@ -266513,7 +267139,7 @@
      ]
     },
     "name": "DeepSeek V4 Pro 0813",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-08-14",
@@ -266735,6 +267361,41 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-08-14",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "gemini-3-8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.09375,
+     "input": 0.9375,
+     "output": 4.6875
+    },
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "family": "gemini-flash",
+    "id": "gemini-3-8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-09-02",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -267360,7 +268021,7 @@
      ]
     },
     "name": "Kimi K2.5",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-01-27",
@@ -269254,7 +269915,7 @@
      ]
     },
     "name": "Qwen 3.6 27B",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [
      {
@@ -269557,7 +270218,7 @@
      ]
     },
     "name": "GLM 5.3",
-    "open_weights": false,
+    "open_weights": true,
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-08-18",
@@ -271081,6 +271742,48 @@
     "structured_output": true,
     "tool_call": true
    },
+   "alibaba/qwen3.8-flash-next": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.01,
+     "input": 0.12,
+     "output": 0.4
+    },
+    "description": "Open-weight experimental preview of the Qwen4 architecture: hybrid-attention MoE (125B total, 6B active) with vision encoder for coding, agent tasks, and image and video understanding",
+    "family": "qwen",
+    "id": "alibaba/qwen3.8-flash-next",
+    "last_updated": "2026-08-27",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen 3.8 Flash Next",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "xhigh"
+      ]
+     }
+    ],
+    "release_date": "2026-08-27",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
    "alibaba/qwen3.8-max": {
     "attachment": true,
     "cost": {
@@ -271126,6 +271829,39 @@
     ],
     "release_date": "2026-07-19",
     "temperature": true,
+    "tool_call": true
+   },
+   "alibaba/qwen3.8-max-0902": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 2.5,
+     "input": 2,
+     "output": 6
+    },
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen3.8-max",
+    "id": "alibaba/qwen3.8-max-0902",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 991000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Qwen3.8 Max 0902",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-09-01",
     "tool_call": true
    },
    "alibaba/wan-v2.5-t2v-preview": {
@@ -271624,6 +272360,52 @@
      }
     ],
     "release_date": "2026-06-09",
+    "temperature": false,
+    "tool_call": true
+   },
+   "anthropic/claude-fable-5.1": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.25,
+     "cache_write": 12.5,
+     "input": 10,
+     "output": 50
+    },
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "id": "anthropic/claude-fable-5.1",
+    "knowledge": "2026-06",
+    "last_updated": "2026-09-01",
+    "limit": {
+     "context": 1000000,
+     "output": 128000
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Claude Fable 5.1",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "effort",
+      "values": [
+       "low",
+       "medium",
+       "high",
+       "xhigh",
+       "max"
+      ]
+     }
+    ],
+    "release_date": "2026-09-01",
     "temperature": false,
     "tool_call": true
    },
@@ -273056,36 +273838,6 @@
     "temperature": true,
     "tool_call": true
    },
-   "deepseek/deepseek-v3": {
-    "attachment": false,
-    "cost": {
-     "cache_read": 0.135,
-     "input": 0.27,
-     "output": 1.12
-    },
-    "description": "DeepSeek chat model for instruction following, coding, and analysis",
-    "family": "deepseek",
-    "id": "deepseek/deepseek-v3",
-    "last_updated": "2024-12-26",
-    "limit": {
-     "context": 163840,
-     "output": 163840
-    },
-    "modalities": {
-     "input": [
-      "text"
-     ],
-     "output": [
-      "text"
-     ]
-    },
-    "name": "DeepSeek V3 0324",
-    "open_weights": true,
-    "reasoning": false,
-    "release_date": "2024-12-26",
-    "temperature": true,
-    "tool_call": true
-   },
    "deepseek/deepseek-v3.1": {
     "attachment": false,
     "cost": {
@@ -273310,8 +274062,8 @@
     "id": "deepseek/deepseek-v4-flash-vision-exp",
     "last_updated": "2026-08-21",
     "limit": {
-     "context": 1000000,
-     "output": 384000
+     "context": 1048576,
+     "output": 1048576
     },
     "modalities": {
      "input": [
@@ -274316,6 +275068,40 @@
      }
     ],
     "release_date": "2026-08-13",
+    "structured_output": true,
+    "temperature": true,
+    "tool_call": true
+   },
+   "google/gemini-3.8-flash": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.075,
+     "input": 0.75,
+     "output": 3.75
+    },
+    "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+    "family": "gemini-flash",
+    "id": "google/gemini-3.8-flash",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1000000,
+     "output": 65536
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Gemini 3.8 Flash",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-09-02",
     "structured_output": true,
     "temperature": true,
     "tool_call": true
@@ -275506,6 +276292,70 @@
     "reasoning": true,
     "reasoning_options": [],
     "release_date": "2026-08-05",
+    "tool_call": true
+   },
+   "meta/muse-spark-1.3": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.15,
+     "input": 1.25,
+     "output": 4.25
+    },
+    "description": "Open Llama multimodal model for image understanding and text reasoning",
+    "family": "muse",
+    "id": "meta/muse-spark-1.3",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.3",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-09-02",
+    "tool_call": true
+   },
+   "meta/muse-spark-1.3-contributor": {
+    "attachment": true,
+    "cost": {
+     "cache_read": 0.002,
+     "input": 0.1,
+     "output": 0.2
+    },
+    "description": "Open Llama multimodal model for image understanding and text reasoning",
+    "family": "muse",
+    "id": "meta/muse-spark-1.3-contributor",
+    "last_updated": "2026-09-02",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text",
+      "image",
+      "pdf"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "Muse Spark 1.3 Contributor",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-09-02",
     "tool_call": true
    },
    "minimax/minimax-h3": {
@@ -281645,6 +282495,42 @@
     "temperature": true,
     "tool_call": true
    },
+   "xiaomi/mimo-v2.5-pro-ultraspeed": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.0108,
+     "input": 1.305,
+     "output": 2.61
+    },
+    "description": "MiMo pro model for strong multimodal reasoning and agent execution",
+    "family": "mimo",
+    "id": "xiaomi/mimo-v2.5-pro-ultraspeed",
+    "knowledge": "2024-12",
+    "last_updated": "2026-06-09",
+    "limit": {
+     "context": 1048576,
+     "output": 131072
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "MiMo V2.5 Pro UltraSpeed",
+    "open_weights": true,
+    "reasoning": true,
+    "reasoning_options": [
+     {
+      "type": "toggle"
+     }
+    ],
+    "release_date": "2026-06-08",
+    "temperature": true,
+    "tool_call": true
+   },
    "zai/glm-4.5": {
     "attachment": false,
     "cost": {
@@ -282174,6 +283060,36 @@
     "release_date": "2026-08-26",
     "structured_output": true,
     "temperature": true,
+    "tool_call": true
+   },
+   "zai/glm-5.3-promo-50": {
+    "attachment": false,
+    "cost": {
+     "cache_read": 0.13,
+     "input": 0.7,
+     "output": 2.2
+    },
+    "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+    "family": "glm",
+    "id": "zai/glm-5.3-promo-50",
+    "last_updated": "2026-08-18",
+    "limit": {
+     "context": 1048576,
+     "output": 1048576
+    },
+    "modalities": {
+     "input": [
+      "text"
+     ],
+     "output": [
+      "text"
+     ]
+    },
+    "name": "GLM 5.3 (50% off)",
+    "open_weights": false,
+    "reasoning": true,
+    "reasoning_options": [],
+    "release_date": "2026-08-18",
     "tool_call": true
    },
    "zai/glm-5v-turbo": {

--- a/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.meta.json
+++ b/src/CST.Avalonia/Resources/Ai/models-dev-snapshot.meta.json
@@ -1,8 +1,8 @@
 {
   "source": "https://models.dev/api.json",
-  "fetchedUtc": "2026-08-31T17:57:03Z",
+  "fetchedUtc": "2026-09-03T02:03:37Z",
   "providers": 212,
   "providersWithApiUrl": 186,
-  "sha256": "829023c0010120a2f814ce121316439e95f77edcbb8fe3d5b644faa57ea045fa",
+  "sha256": "6efc927ed4b50de2930eb2dcb12ca238e682bbb8c5acad03bd11257fb655fe02",
   "license": "MIT (models.dev)"
 }


### PR DESCRIPTION
Pre-release checklist item. `./src/CST.Avalonia/refresh-models-snapshot.sh`, fetched 2026-09-03.

**212 providers, 186 with an API URL — both unchanged** from the 2026-08-31 snapshot. No provider appeared or disappeared. What moved is the model lists inside them.

### The review that matters

The app parses **six fields** per provider — `CatalogProvider` carries `id`, `name`, `api`, `npm`, `doc`, `env`. `models` is not one of them; model lists are fetched from the provider at runtime by `AiModelCatalog`. So the entire model-list churn below is inert, and the diff worth reading is the other six.

Of those, **exactly one changed**: `kimi-for-coding`'s `doc` URL moved from the third-party-tools page to a models page. No `api`, `name`, `env` or `npm` field changed on any provider — those are what would alter how a connection is made or which environment variable is offered.

`ModelsDev` tests: 16 passed.

### For the record — the model churn

**Claude Fable 5.1**, released two days ago, is now listed by sixteen providers: `anthropic` itself, the cloud resellers (`amazon-bedrock`, `azure`, `google-vertex` and their `-anthropic` variants), and the gateways (`openrouter`, `vercel`, `requesty`, `nano-gpt`, `kilo`, `llmgateway`, `merge-gateway`, `crossmodel`, `edenai`, `digitalocean`, `venice`, `opencode`, `gitlab`). **Gemini 3.8 Flash** arrived at about a dozen of the same.

The removals are almost all one story: `nebius` pruned 21 models, and its two gateway mirrors dropped the same ones (`llmgateway-providers` 25, `llmgateway` 11). `nano-gpt` pruned 24 of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)