### PR TITLE
Open the Beta 8 cycle: bump Bucket A to 5.0.0-beta.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Agent guide for CST Reader
 
-CST Reader (**CST = Chaṭṭha Saṅgāyana Tipiṭaka**) is a cross-platform Pāli text reader — .NET 10 + Avalonia UI, a ground-up rewrite of the WinForms CST4. Texts are provided by the Vipassana Research Institute (VRI). Currently **Beta 7 in development** (Beta 6 released 2026-09); development is on **macOS**, with Windows now shipping too (x64 + arm64) and tested on dedicated machines (Linux remains designed-in but untested).
+CST Reader (**CST = Chaṭṭha Saṅgāyana Tipiṭaka**) is a cross-platform Pāli text reader — .NET 10 + Avalonia UI, a ground-up rewrite of the WinForms CST4. Texts are provided by the Vipassana Research Institute (VRI). Currently **Beta 8 in development** (Beta 7 released 2026-09); development is on **macOS**, with Windows now shipping too (x64 + arm64) and tested on dedicated machines (Linux remains designed-in but untested).
 
 - **Feature overview:** see [README.md](README.md) (front page).
 - **Roadmap / planned work:** [GitHub issues](https://github.com/fsnow/cst/issues) (`feature`/`enhancement` labels) + specs in [docs/features/planned/](docs/features/planned/). Issues are the canonical tracker.

--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -2,18 +2,18 @@
 
 This document describes the complete process for releasing a new version of CST Reader.
 
-**Last Updated:** September 2, 2026
-**Current Version:** 5.0.0-beta.7 (in development; Beta 6 released 2026-09)
+**Last Updated:** September 3, 2026
+**Current Version:** 5.0.0-beta.8 (in development; Beta 7 released 2026-09)
 
-> **Clean-start status for Beta 7: not yet determined.** The cycle has just opened and nothing on disk
-> has changed, so as of today a Beta 6 user would upgrade in place. That is a statement about right now,
+> **Clean-start status for Beta 8: not yet determined.** The cycle has just opened and nothing on disk
+> has changed, so as of today a Beta 7 user would upgrade in place. That is a statement about right now,
 > not a promise about the release — **re-derive it before publishing** rather than carrying this line
 > forward. A tokenizer or index-format change is what flips it to a mandatory clean start, because no
 > migration can absorb that one.
 >
 > Users coming from **Beta 5 or earlier** are a separate question, to be answered at the same time. Beta 6
-> required a wipe from Beta 4 and earlier (the Beta 5 index-offset change, #53); whether Beta 7 extends
-> that line to Beta 5 depends on what this cycle changes.
+> and Beta 7 both required a wipe from Beta 4 and earlier (the Beta 5 index-offset change, #53) and neither
+> extended that line to Beta 5; whether Beta 8 does depends on what this cycle changes.
 >
 > **What to verify before publishing** is not "did anything change" but "does the upgrade path still
 > work": launch the new build on a real data directory from the previous release and confirm settings,

--- a/src/CST.Avalonia/CST.Avalonia.csproj
+++ b/src/CST.Avalonia/CST.Avalonia.csproj
@@ -10,15 +10,15 @@
     <CFBundleName>CST Reader</CFBundleName>
     <CFBundleDisplayName>CST Reader</CFBundleDisplayName>
     <CFBundleIdentifier>com.cst.avalonia</CFBundleIdentifier>
-    <CFBundleVersion>5.0.0-beta.7</CFBundleVersion>
-    <CFBundleShortVersionString>5.0.0-beta.7</CFBundleShortVersionString>
+    <CFBundleVersion>5.0.0-beta.8</CFBundleVersion>
+    <CFBundleShortVersionString>5.0.0-beta.8</CFBundleShortVersionString>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- .NET Assembly Version Properties -->
-    <Version>5.0.0-beta.7</Version>
-    <AssemblyVersion>5.0.0.7</AssemblyVersion>
-    <FileVersion>5.0.0.7</FileVersion>
-    <InformationalVersion>5.0.0-beta.7</InformationalVersion>
+    <Version>5.0.0-beta.8</Version>
+    <AssemblyVersion>5.0.0.8</AssemblyVersion>
+    <FileVersion>5.0.0.8</FileVersion>
+    <InformationalVersion>5.0.0-beta.8</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">

--- a/src/CST.Avalonia/Info.plist
+++ b/src/CST.Avalonia/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.cst.avalonia</string>
     <key>CFBundleVersion</key>
-    <string>5.0.0-beta.7</string>
+    <string>5.0.0-beta.8</string>
     <key>CFBundleShortVersionString</key>
-    <string>5.0.0-beta.7</string>
+    <string>5.0.0-beta.8</string>
     <key>CFBundleExecutable</key>
     <string>CST.Avalonia</string>
     <key>CFBundleIconFile</key>

--- a/src/CST.Avalonia/Resources/welcome-content.html
+++ b/src/CST.Avalonia/Resources/welcome-content.html
@@ -339,7 +339,7 @@
         <div class="logo"><img src="buddha-transparent.png" alt="Buddha"></div>
         <h1>CST Reader</h1>
         <p class="subtitle">A Pāli Text Reader for the Chaṭṭha Saṅgāyana Tipiṭaka</p>
-        <p class="version">Version 5.0.0-beta.7 &bull; September 2026</p>
+        <p class="version">Version 5.0.0-beta.8 &bull; September 2026</p>
     </div>
 
     <div class="beta-notice">
@@ -465,7 +465,7 @@
 
     <div class="update-note">
         <p>This welcome page updates automatically with new releases.</p>
-        <p>CST Reader 5.0.0-beta.7 • September 2026</p>
+        <p>CST Reader 5.0.0-beta.8 • September 2026</p>
     </div>
 </body>
 </html>

--- a/src/CST.Avalonia/Services/WelcomeUpdateService.cs
+++ b/src/CST.Avalonia/Services/WelcomeUpdateService.cs
@@ -35,7 +35,7 @@ namespace CST.Avalonia.Services
         private static readonly HttpClient SharedHttpClient = new() { Timeout = HttpTimeout };
 
         // Current app version - will be injected from App.axaml.cs
-        public string CurrentAppVersion { get; set; } = "5.0.0-beta.7";
+        public string CurrentAppVersion { get; set; } = "5.0.0-beta.8";
 
         public WelcomeUpdateService(HttpClient? httpClient = null)
         {

--- a/src/CST.Avalonia/ViewModels/WelcomeViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/WelcomeViewModel.cs
@@ -103,7 +103,7 @@ namespace CST.Avalonia.ViewModels
             var assembly = Assembly.GetExecutingAssembly();
             var rawVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
                           ?? assembly.GetName().Version?.ToString()
-                          ?? "5.0.0-beta.7";
+                          ?? "5.0.0-beta.8";
 
             // Strip SemVer build metadata (the git hash after '+') for display + comparison. (#71)
             _updateService.CurrentAppVersion = VersionComparer.StripBuildMetadata(rawVersion);

--- a/src/CST.Avalonia/package-macos.sh
+++ b/src/CST.Avalonia/package-macos.sh
@@ -139,9 +139,9 @@ HELPER_EOF
     <key>CFBundleDisplayName</key>
     <string>$HELPER_NAME</string>
     <key>CFBundleVersion</key>
-    <string>5.0.0-beta.7</string>
+    <string>5.0.0-beta.8</string>
     <key>CFBundleShortVersionString</key>
-    <string>5.0.0-beta.7</string>
+    <string>5.0.0-beta.8</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSBackgroundOnly</key>


### PR DESCRIPTION
Every string that says what is being **built**. The strings that say what has been **released** — `welcome-updates.json` and `README.md` — stay at Beta 7 and move only after Beta 8 publishes.

| File | Changed |
|---|---|
| `CST.Avalonia.csproj` | `Version`, `InformationalVersion`, `CFBundleVersion`, `CFBundleShortVersionString`, `AssemblyVersion`, `FileVersion` |
| `Info.plist` | `CFBundleVersion`, `CFBundleShortVersionString` |
| `package-macos.sh` | helper-bundle version pair |
| `Resources/welcome-content.html` | header + footer version number |
| `WelcomeUpdateService.cs` | `CurrentAppVersion` default |
| `WelcomeViewModel.cs` | version fallback |
| `CLAUDE.md` | status line |
| `RELEASE_PROCESS.md` | `Current Version`, `Last Updated`, clean-start banner |

`AssemblyVersion`/`FileVersion` take **5.0.0.8** — 4-part numerics cannot hold `-beta.N`, and the fourth field carries the beta number.

### The welcome page's date does not move

Its version number does; the date still reads **September 2026**, per the rule adopted in #975 — a date only ever moves forward, to the month of the release it is stamped for. Reverting it to a placeholder each cycle is what nearly shipped "in development" on the front of Beta 7.

Left alone deliberately: the date rule's own illustration further down `RELEASE_PROCESS.md` still quotes `"5.0.0-beta.7 • September 2026"`. That is now a real shipped example rather than a stale one.

### The clean-start banner is re-derived, not renumbered

Nothing on disk has changed yet, so a Beta 7 user would upgrade in place **today** — a statement about now, not a promise about the release. The Beta 5 line is restated as fact: Beta 6 and Beta 7 both required a wipe from Beta 4 and earlier, and neither extended it to Beta 5.

Not touched (the doc's "do not bulk-replace" list): `VersionComparer.cs` and its tests, `WelcomeViewModelTests`, `AboutViewModelTests`, `AboutViewModel.cs`'s example comment, `LEMMA_EXPANSION.md`'s historical statements.

Build: 0 warnings, 0 errors. Tests: **2825 passed, 0 failed, 18 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)