### PR TITLE
The five books with no page markers are expected, not a gap

### DIFF
--- a/docs/reference/PAGE_NUMBERING_BY_BOOK.md
+++ b/docs/reference/PAGE_NUMBERING_BY_BOOK.md
@@ -55,7 +55,9 @@ Paragraph for these, and a passage in them has no page reference to cite.**
 | `e0608n.nrf.xml` | Añña/Buddha-Vandanā Gantha-Saṅgaho/Buddhaguṇagāthāvalī |
 | `e0701n.nrf.xml` | Añña/Vaṃsa-Gantha-Saṅgaho/Cūḷaganthavaṃsa |
 
-Worth confirming this is a property of the printed sources rather than a gap in the XML.
+**Expected, not a gap in the XML.** These are `e*` texts, and the VRI printed set does not
+extend to them — so there is no printed pagination for them to carry, in any edition. The same
+reason accounts for the thin coverage across Añña generally. **[fsnow]**
 
 ## By commentary level
 

--- a/docs/reference/page_numbering_by_book.py
+++ b/docs/reference/page_numbering_by_book.py
@@ -220,7 +220,9 @@ if none_at_all:
     for fn in none_at_all:
         w(f"| `{fn}` | {books.get(fn, {}).get('latin', '—')} |")
     w("")
-    w("Worth confirming this is a property of the printed sources rather than a gap in the XML.")
+    w("**Expected, not a gap in the XML.** These are `e*` texts, and the VRI printed set does not")
+    w("extend to them \u2014 so there is no printed pagination for them to carry, in any edition. The same")
+    w("reason accounts for the thin coverage across A\u00f1\u00f1a generally. **[fsnow]**")
 else:
     w("Every book carries at least one page-numbering system.")
 w("")


### PR DESCRIPTION
Follow-up to #980. **[fsnow]**, on whether the absence needed confirming: *"not our concern"*.

The table I just merged closed with an open question: *"Worth confirming this is a property of the printed sources rather than a gap in the XML."* That was not an open question, and I should not have written it as one.

The five books are `e*` texts. The VRI printed set does not extend to them, so there is no printed pagination for them to carry — in any edition. It is the same reason Añña coverage is thin generally: 5% VRI, 70% Myanmar, no PTS or Thai at all.

Leaving the question in the doc invites the next reader to go hunting for something that was never missing. That is the more expensive mistake here: the corpus is VRI's, and an agent chasing a phantom data gap in it is the kind of investigation that reaches the wrong people.

One paragraph in the generator, regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)