### PR TITLE
Redirect an explicit black fill to currentColor (#971)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiLogoImagesTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiLogoImagesTests.cs
@@ -248,7 +248,8 @@ public class AiLogoImagesTests : IDisposable
     }
 
     /// <summary>A logo naming its own colours must not be mistaken for something reaching off the machine.
-    /// Four of the set do — 302ai, evroc, novita-ai, zenmux — and they are the ones that will not theme.</summary>
+    /// Nine of the 195 do (measured 2026-09-06), and they are the ones that will not theme from the
+    /// stylesheet alone — four of those because the colour they name is black. (#971)</summary>
     [Fact]
     public void A_logo_with_literal_colours_passes()
     {
@@ -259,6 +260,93 @@ public class AiLogoImagesTests : IDisposable
 
         Assert.Null(AiLogoImages.Screen(path));
     }
+
+    // ---- #971: an explicit black fill is the SVG default written out, not a brand colour ----------------
+
+    /// <summary>Both places a fill can be written. The style attribute is the one that matters: the renderer
+    /// resolves it after the presentation attribute, so no author stylesheet can reach it — measured, with
+    /// and without <c>!important</c>. zenmux carries both on the same element.</summary>
+    [Theory]
+    [InlineData("""<path d="M0,0H1" fill="black"/>""", """<path d="M0,0H1" fill="currentColor"/>""")]
+    [InlineData("""<path d="M0,0H1" fill="#000"/>""", """<path d="M0,0H1" fill="currentColor"/>""")]
+    [InlineData("""<path d="M0,0H1" fill="#000000"/>""", """<path d="M0,0H1" fill="currentColor"/>""")]
+    [InlineData("""<path d="M0,0H1" fill="rgb(0, 0, 0)"/>""", """<path d="M0,0H1" fill="currentColor"/>""")]
+    [InlineData("""<path d="M0,0H1" fill="BLACK"/>""", """<path d="M0,0H1" fill="currentColor"/>""")]
+    [InlineData("""<path d="M0,0H1" style="fill:black;fill-opacity:1;"/>""",
+                """<path d="M0,0H1" style="fill:currentColor;fill-opacity:1;"/>""")]
+    [InlineData("""<path d="M0,0H1" style="fill:#000000;stroke-width:0.287356"/>""",
+                """<path d="M0,0H1" style="fill:currentColor;stroke-width:0.287356"/>""")]
+    [InlineData("""<style>.a{fill:black}</style><path class="a" d="M0,0H1"/>""",
+                """<style>.a{fill:currentColor}</style><path class="a" d="M0,0H1"/>""")]
+    public void An_explicit_black_fill_becomes_currentColor(string body, string expected)
+    {
+        Assert.Equal(Svg(expected), AiLogoImages.RedirectExplicitBlack(Svg(body)));
+    }
+
+    /// <summary>zenmux, the measured case: the presentation attribute and the style declaration are both
+    /// black on one element, and both have to move or the style wins and the mark stays black.</summary>
+    [Fact]
+    public void Both_spellings_on_one_element_are_redirected()
+    {
+        var svg = Svg("""<path d="M0,0H1" fill="black" style="fill:black;fill-opacity:1;"/>""");
+
+        Assert.Equal(
+            Svg("""<path d="M0,0H1" fill="currentColor" style="fill:currentColor;fill-opacity:1;"/>"""),
+            AiLogoImages.RedirectExplicitBlack(svg));
+    }
+
+    /// <summary>The 186 that already draw in currentColor render correctly on both grounds today, and the
+    /// same instance comes back so they keep loading straight from disk. A black detail beside a currentColor
+    /// mark is a deliberate contrast; there is no reading of it that makes repainting safe.</summary>
+    [Fact]
+    public void A_document_already_using_currentColor_is_untouched()
+    {
+        var svg = Svg("""<path d="M0,0H1" fill="currentColor"/><path d="M1,1H2" fill="black"/>""");
+
+        Assert.Same(svg, AiLogoImages.RedirectExplicitBlack(svg));
+    }
+
+    /// <summary>A mark drawn in a brand's palette keeps it — that is the whole reason the stylesheet redirects
+    /// currentColor and nothing else. 302ai's greys are the case in the set.</summary>
+    [Theory]
+    [InlineData("""<path d="M0,0H1" fill="#F5F5F5"/>""")]
+    [InlineData("""<path d="M0,0H1" fill="rgb(156,155,155)"/>""")]
+    [InlineData("""<path d="M0,0H1" fill="none"/>""")]
+    [InlineData("""<path d="M0,0H1" fill="white"/>""")]
+    // Not black: the lookahead is what keeps the substitution off a longer keyword that starts the same way.
+    [InlineData("""<path d="M0,0H1" fill="blackcurrant"/>""")]
+    [InlineData("""<path d="M0,0H1" fill="#0000FF"/>""")]
+    // stroke defaults to none, so an explicit black stroke really was a choice. fill defaults to black.
+    [InlineData("""<path d="M0,0H1" stroke="black" fill="none"/>""")]
+    [InlineData("""<path d="M0,0H1" style="fill-opacity:1;stroke:black"/>""")]
+    public void A_colour_that_is_not_an_explicit_black_fill_is_left_alone(string body)
+    {
+        var svg = Svg(body);
+
+        Assert.Same(svg, AiLogoImages.RedirectExplicitBlack(svg));
+    }
+
+    /// <summary>The substitution rewrites one token and nothing around it: the document handed to the renderer
+    /// differs from the file by exactly that, so it can add no element, attribute or reference.</summary>
+    [Fact]
+    public void Nothing_but_the_colour_token_changes()
+    {
+        var svg = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+            <g clip-path="url(#c)"><path d="M0,0H1" fill="black"/></g>
+            <defs><clipPath id="c"><rect width="24" height="24" fill="white"/></clipPath></defs></svg>
+            """;
+
+        // The white in the clipPath and the fill="none" on the root are the two that a coarser rule would
+        // take with it; novita-ai carries both.
+        Assert.Equal(
+            svg.Replace(""" fill="black"/""", """ fill="currentColor"/"""),
+            AiLogoImages.RedirectExplicitBlack(svg));
+    }
+
+    private static string Svg(string body) =>
+        $"""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">{body}</svg>""";
 
     [Fact]
     public void No_path_means_no_image()

--- a/src/CST.Avalonia/Services/Ai/AiLogoImages.cs
+++ b/src/CST.Avalonia/Services/Ai/AiLogoImages.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using Avalonia.Media;
@@ -22,10 +23,16 @@ namespace CST.Avalonia.Services.Ai
     /// with no release of ours in between and nothing to say it happened.</para>
     ///
     /// <para><b>Theming, measured in the running app.</b> Every logo renders <c>#000000</c> by default —
-    /// including the 101 of 105 drawn in <c>currentColor</c>, which would be invisible on a dark ground. The
-    /// renderer takes a stylesheet, and <c>* { color: … }</c> repaints exactly those, leaving a logo's own
-    /// brand colours alone. <c>svg { color: … }</c> does <b>not</b> work — the declaration does not inherit —
-    /// and <c>* { fill: … }</c> is worse than useless: it fills the outline-drawn logos solid.</para>
+    /// including the 186 of 195 drawn in <c>currentColor</c> (measured 2026-09-06), which would be invisible
+    /// on a dark ground. The renderer takes a stylesheet, and <c>* { color: … }</c> repaints exactly those,
+    /// leaving a logo's own brand colours alone. <c>svg { color: … }</c> does <b>not</b> work — the
+    /// declaration does not inherit — and <c>* { fill: … }</c> is worse than useless: it fills the
+    /// outline-drawn logos solid.</para>
+    ///
+    /// <para><b>An explicit black is not a brand colour</b> (#971). Four of the nine that name their own fills
+    /// name <em>black</em> — the SVG default written out rather than a decision — and those are the ones that
+    /// vanish on the dark pane. <see cref="RedirectExplicitBlack"/> turns them into <c>currentColor</c> before
+    /// the document reaches the renderer, so the same stylesheet reaches them too.</para>
     /// </summary>
     public interface IAiLogoImages
     {
@@ -56,6 +63,19 @@ namespace CST.Avalonia.Services.Ai
         /// </summary>
         private static readonly Regex ExternalReference =
             new(@"\b(?:https?|ftp|file)://", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// A fill of black, in either place it can be written and in any of the spellings CSS allows for the
+        /// same value. Only <c>black</c> occurs in today's set; the rest are here because the logos arrive
+        /// over the network, so what they contain is not ours to fix at build time. (#971)
+        ///
+        /// <para><c>lead</c> is put back verbatim, which is what keeps the two forms — <c>fill="…"</c> and
+        /// <c>fill:…</c> — in one expression. The lookahead is what stops <c>fill="blackcurrant"</c>, and it
+        /// consumes nothing, so trailing space inside the quotes survives.</para>
+        /// </summary>
+        private static readonly Regex ExplicitBlackFill = new(
+            """(?<lead>\bfill\s*(?::|=\s*")\s*)(?:black|#000(?:000)?|rgb\(\s*0\s*,\s*0\s*,\s*0\s*\))(?=\s*(?:["';}]|$))""",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Keyed by file AND colour: the same mark is a different image in light and dark, and a reader can
@@ -102,13 +122,14 @@ namespace CST.Avalonia.Services.Ai
                     return null;
                 }
 
-                // Only currentColor is redirected. A logo that names its own colours keeps them - four of the
-                // set do, and repainting a brand mark would be a worse answer than leaving it.
+                // Only currentColor is redirected. A logo that names its own colours keeps them - five of the
+                // set do, and repainting a brand mark would be a worse answer than leaving it. Black is the
+                // exception, and RedirectExplicitBlack has already dealt with it. (#971)
                 var css = string.Create(
                     CultureInfo.InvariantCulture,
                     $"* {{ color: #{foreground.R:X2}{foreground.G:X2}{foreground.B:X2}; }}");
 
-                var source = SvgSource.Load(path, null, new Svg.Model.SvgParameters(null, css));
+                var source = Load(path, new Svg.Model.SvgParameters(null, css));
                 if (source is null) return null;
 
                 var image = new SvgImage { Source = source };
@@ -124,6 +145,60 @@ namespace CST.Avalonia.Services.Ai
                 Log.Debug(ex, "Could not render the logo at {Path}; falling back to the monogram (#748)", path);
                 return null;
             }
+        }
+
+        /// <summary>
+        /// The screened document at <paramref name="path"/>, ready to draw.
+        ///
+        /// <para>A file that names no black paint is loaded from disk exactly as it was before (#971): the
+        /// 186 that draw in <c>currentColor</c> already theme correctly, and the path they take should not
+        /// change to fix four that do not.</para>
+        ///
+        /// <para>Latin-1 is a lossless byte-to-char map in both directions, so the document the renderer
+        /// parses is byte-identical to the file apart from the substitution — including whatever encoding it
+        /// declares for itself, which stays true rather than being re-encoded behind its own back.</para>
+        /// </summary>
+        private static SvgSource? Load(string path, Svg.Model.SvgParameters parameters)
+        {
+            var text = Encoding.Latin1.GetString(File.ReadAllBytes(path));
+            var redirected = RedirectExplicitBlack(text);
+            if (ReferenceEquals(redirected, text))
+                return SvgSource.Load(path, null, parameters);
+
+            using var stream = new MemoryStream(Encoding.Latin1.GetBytes(redirected));
+            return SvgSource.LoadFromStream(stream, parameters);
+        }
+
+        /// <summary>
+        /// <paramref name="svg"/> with an explicit black fill rewritten to <c>currentColor</c>, or the same
+        /// instance when there is nothing to do. (#971)
+        ///
+        /// <para><b>Why black and nothing else.</b> A mark drawn in a brand's palette must keep it — that is
+        /// why the stylesheet redirects only <c>currentColor</c>. But black is the value SVG paints with when
+        /// no one chose anything, so a logo "naming" it has generally named the default rather than decided,
+        /// and it is the one value guaranteed to fail on a dark ground. Stroke is left alone: <c>stroke</c>
+        /// defaults to <c>none</c>, so an explicit black stroke really was a choice.</para>
+        ///
+        /// <para><b>Why a document already using currentColor is skipped.</b> Those render correctly today,
+        /// on both grounds. A black detail beside a currentColor mark would be a deliberate contrast, and
+        /// there is no reading of it that makes repainting safe.</para>
+        ///
+        /// <para><b>Why the text and not the parsed document</b>, against the rule <see cref="Screen"/> sets
+        /// out for itself: the two are held to different standards because they answer different questions.
+        /// Screening decides whether a document may run at all, so it must see what the renderer sees. This
+        /// substitutes one colour token for another and can add no element, attribute or reference — a
+        /// disagreement with the renderer costs a mark that stays black, not a fetch that gets through. Both
+        /// spellings have to be reached anyway: <c>fill="black"</c> as a presentation attribute, and
+        /// <c>fill:black</c> in a style attribute, which the renderer resolves in that order — an author
+        /// stylesheet cannot override the latter, with or without <c>!important</c>. Measured: zenmux carries
+        /// both, and a <c>[fill="black"]</c> rule leaves it black.</para>
+        /// </summary>
+        internal static string RedirectExplicitBlack(string svg)
+        {
+            if (svg.Contains("currentColor", StringComparison.OrdinalIgnoreCase)) return svg;
+            if (!ExplicitBlackFill.IsMatch(svg)) return svg;
+
+            return ExplicitBlackFill.Replace(svg, "${lead}currentColor");
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #971.

## What was wrong

`AiLogoImages` hands the renderer `* { color: … }`, which redirects `currentColor` and nothing else — right for a mark drawn in a brand's palette, wrong when the colour a logo "names" is literally black. Black is what SVG paints with when no one chose anything, so it is the default written out rather than a decision, and it is the one value guaranteed to fail on the dark pane.

`RedirectExplicitBlack` rewrites that token to `currentColor` before the document reaches the renderer. A document already drawing in `currentColor` comes back as the same instance and still loads straight from disk — those 186 render correctly today and their path should not change to fix four that do not.

## Both spellings have to move

The renderer resolves a `style` attribute after the presentation attribute, so an author stylesheet cannot reach `fill:black` — measured, with and without `!important`. `zenmux` carries both on one element, and a `[fill="black"] { fill: currentColor }` rule leaves it black. That is what rules out the tidier CSS-only approach the issue floated.

## Measured

All 195 logos models.dev serves today (2026-09-06, after discarding the 17 that hash to the known placeholder), rasterised on both grounds through the shipped method. Four rewritten, 191 untouched.

| | before, on dark | after |
|---|---|---|
| `novita-ai` | black on black | legible |
| `zeldoc` | black on black | legible |
| `zenmux` | black on black | legible |
| `regolo-ai` | black on black | legible |

`regolo-ai` is a fourth case the issue's survey missed: it writes `style="fill:#000000"` rather than the attribute form, so it was filed under "carries its own art".

The three counts in the doc comments (`101 of 105`, `four of the set`, and the same figure in the test) were true when written; they are re-derived here from today's set.

## Found while measuring, deliberately not changed

- **`zenmux`'s near-white ground never renders.** Its `style="fill:#F5F5F5;fill:color(display-p3 …)"` is discarded whole — the renderer cannot parse `color()`. So it is not "half-invisible on either ground" as the issue predicted; it is entirely black. Restoring the disc would put a `currentColor` mark on a near-white ground and be invisible in dark mode, so the fix is right without it.
- **`wafer.ai`** (new since the issue was filed) is a dark raster embedded as a data URI. No stylesheet reaches a bitmap.

## Tests

18 new cases on `RedirectExplicitBlack`, in the same style as the screening tests: both spellings, the four ways of writing black, the both-on-one-element case, and the colours that must survive — `302ai`'s greys, `fill="none"`, a `white` clip rect, `blackcurrant`, and an explicit black *stroke* (`stroke` defaults to `none`, so that one really was a choice).

Full suite: 2844 passed, 0 failed, 18 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)