### PR TITLE
Repaint provider logos when the theme changes (#971)

### DIFF
--- a/src/CST.Avalonia.Tests/Converters/ProviderLogoConverterTests.cs
+++ b/src/CST.Avalonia.Tests/Converters/ProviderLogoConverterTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Media;
+using Avalonia.Styling;
+using CST.Avalonia.Converters;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Converters;
+
+/// <summary>
+/// #971: the multi-value overload, which exists so a theme switch redraws the marks.
+///
+/// <para><b>What is not covered here.</b> That the switch actually re-runs the binding is a property of the
+/// binding, not of this class, and asserting it needs a headless Avalonia application the test project does
+/// not have. It was verified instead by loading the exact XAML written into the two views —
+/// <c>&lt;Binding Path="ActualThemeVariant" RelativeSource="{RelativeSource Self}"/&gt;</c> as the second
+/// value — into a headless app and switching <c>RequestedThemeVariant</c>: the converter ran again, with
+/// <c>Dark</c>. See the PR.</para>
+///
+/// <para>Rendering is likewise out of reach: it needs a service in the container and the UI thread. What is
+/// left is the contract between the binding and the converter, which is where a mis-written binding would
+/// land, so that is what these cover.</para>
+/// </summary>
+public class ProviderLogoConverterTests
+{
+    private static object? Convert(params object?[] values) =>
+        ProviderLogoConverter.Instance.Convert(
+            new List<object?>(values), typeof(IImage), null, CultureInfo.InvariantCulture);
+
+    /// <summary>Null means draw the monogram, and the row already has one behind the image. A binding that
+    /// has not resolved yet — the first evaluation of every row — arrives here as UnsetValue.</summary>
+    [Fact]
+    public void A_path_that_is_not_there_yet_draws_nothing()
+    {
+        Assert.Null(Convert(null, ThemeVariant.Dark));
+        Assert.Null(Convert("", ThemeVariant.Dark));
+        Assert.Null(Convert(global::Avalonia.AvaloniaProperty.UnsetValue, ThemeVariant.Dark));
+    }
+
+    /// <summary>A short list is a mis-written binding, and the honest answer to one is the monogram rather
+    /// than an exception thrown inside the binding machinery, where it would surface as a blank tile with a
+    /// log line nobody reads.</summary>
+    [Fact]
+    public void A_binding_missing_its_values_draws_nothing()
+    {
+        Assert.Null(Convert());
+        Assert.Null(Convert(new object?[] { null }));
+    }
+
+    /// <summary>The variant is a dependency, not an input: it is never read, so the answer cannot turn on
+    /// which one arrives — only on the fact that a change brings the converter back.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void The_variant_itself_is_not_read(string? variant)
+    {
+        object? v = variant switch
+        {
+            "Light" => ThemeVariant.Light,
+            "Dark" => ThemeVariant.Dark,
+            _ => null,
+        };
+
+        Assert.Null(Convert(null, v));
+    }
+
+    [Fact]
+    public void Converting_back_is_not_supported()
+    {
+        Assert.Throws<NotSupportedException>(() => ProviderLogoConverter.Instance.ConvertBack(
+            null, typeof(string), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/src/CST.Avalonia/Converters/ProviderLogoConverter.cs
+++ b/src/CST.Avalonia/Converters/ProviderLogoConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using Avalonia;
 using Avalonia.Data.Converters;
@@ -15,12 +16,17 @@ namespace CST.Avalonia.Converters
     /// a placeholder: the row already has a tile behind it, and the binding simply never replaces it.</para>
     ///
     /// <para><b>The colour is read from the theme at conversion time</b>, because a mark drawn in
-    /// <c>currentColor</c> is invisible against its own background in one of the two themes. A row built
-    /// before a theme switch keeps the colour it was built with until the list is rebuilt — acceptable
-    /// because the settings window is short-lived and a theme change is rare, and worth stating so nobody
-    /// reads it as a bug.</para>
+    /// <c>currentColor</c> is invisible against its own background in one of the two themes.</para>
+    ///
+    /// <para><b>Bind it as a MultiBinding, with the control's <c>ActualThemeVariant</c> second</b> (#971).
+    /// Nothing re-runs a converter when the theme changes, so a single binding would leave every mark on the
+    /// colour it was first drawn in — every logo in the pane black at once, if the switch was to dark. The
+    /// second value is never read; it is there so the variant is a binding source and a switch invalidates
+    /// the row. Measured: <b>[fsnow]</b>, on the build that fixed the black fills — <i>"when I open the
+    /// program in dark mode all the logos show correctly as light"</i>, but switching with the pane open did
+    /// not repaint them.</para>
     /// </summary>
-    public class ProviderLogoConverter : IValueConverter
+    public class ProviderLogoConverter : IValueConverter, IMultiValueConverter
     {
         public static readonly ProviderLogoConverter Instance = new();
 
@@ -31,6 +37,11 @@ namespace CST.Avalonia.Converters
 
             return images.Get(path, Foreground());
         }
+
+        /// <param name="values">The logo path, then the theme variant that exists only to be depended on.
+        /// Tolerates a short list so a mis-written binding draws the monogram rather than throwing.</param>
+        public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
+            Convert(values.Count > 0 ? values[0] : null, targetType, parameter, culture);
 
         /// <summary>The theme's own primary text colour, so a monochrome mark reads like the name beside
         /// it. Falls back to a mid grey that is legible on either ground rather than to black, which

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -105,9 +105,16 @@
                                         </Border>
                                         <Image IsVisible="{Binding LogoPath,
                                                    Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}}"
-                                               Source="{Binding LogoPath,
-                                                   Converter={x:Static conv:ProviderLogoConverter.Instance}}"
-                                               Stretch="Uniform" Margin="1"/>
+                                               Stretch="Uniform" Margin="1">
+                                            <!-- ActualThemeVariant is not read: it is here so a theme switch invalidates the
+                                                 binding and the mark is redrawn in the new colour. (#971) -->
+                                            <Image.Source>
+                                                <MultiBinding Converter="{x:Static conv:ProviderLogoConverter.Instance}">
+                                                    <Binding Path="LogoPath"/>
+                                                    <Binding Path="ActualThemeVariant" RelativeSource="{RelativeSource Self}"/>
+                                                </MultiBinding>
+                                            </Image.Source>
+                                        </Image>
                                     </Panel>
 
                                     <TextBlock Grid.Column="2" Text="{Binding DisplayName}"

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -113,9 +113,16 @@
                                             <TextBlock Text="{Binding Monogram}"/>
                                         </Border>
                                         <Image IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}}"
-                                               Source="{Binding LogoPath,
-                                                   Converter={x:Static conv:ProviderLogoConverter.Instance}}"
-                                               Stretch="Uniform" Margin="2"/>
+                                               Stretch="Uniform" Margin="2">
+                                            <!-- ActualThemeVariant is not read: it is here so a theme switch invalidates the
+                                                 binding and the mark is redrawn in the new colour. (#971) -->
+                                            <Image.Source>
+                                                <MultiBinding Converter="{x:Static conv:ProviderLogoConverter.Instance}">
+                                                    <Binding Path="LogoPath"/>
+                                                    <Binding Path="ActualThemeVariant" RelativeSource="{RelativeSource Self}"/>
+                                                </MultiBinding>
+                                            </Image.Source>
+                                        </Image>
                                     </Panel>
 
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -234,9 +241,16 @@
                                                 <TextBlock Text="{Binding Monogram}"/>
                                             </Border>
                                             <Image IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}}"
-                                                   Source="{Binding LogoPath,
-                                                       Converter={x:Static conv:ProviderLogoConverter.Instance}}"
-                                                   Stretch="Uniform" Margin="2"/>
+                                                   Stretch="Uniform" Margin="2">
+                                                <!-- ActualThemeVariant is not read: it is here so a theme switch invalidates the
+                                                     binding and the mark is redrawn in the new colour. (#971) -->
+                                                <Image.Source>
+                                                    <MultiBinding Converter="{x:Static conv:ProviderLogoConverter.Instance}">
+                                                        <Binding Path="LogoPath"/>
+                                                        <Binding Path="ActualThemeVariant" RelativeSource="{RelativeSource Self}"/>
+                                                    </MultiBinding>
+                                                </Image.Source>
+                                            </Image>
                                         </Panel>
 
                                         <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -301,9 +315,16 @@
                                                 <TextBlock Text="{Binding Monogram}"/>
                                             </Border>
                                             <Image IsVisible="{Binding LogoPath, Converter={x:Static conv:ProviderLogoRenderedConverter.Instance}}"
-                                                   Source="{Binding LogoPath,
-                                                       Converter={x:Static conv:ProviderLogoConverter.Instance}}"
-                                                   Stretch="Uniform" Margin="2"/>
+                                                   Stretch="Uniform" Margin="2">
+                                                <!-- ActualThemeVariant is not read: it is here so a theme switch invalidates the
+                                                     binding and the mark is redrawn in the new colour. (#971) -->
+                                                <Image.Source>
+                                                    <MultiBinding Converter="{x:Static conv:ProviderLogoConverter.Instance}">
+                                                        <Binding Path="LogoPath"/>
+                                                        <Binding Path="ActualThemeVariant" RelativeSource="{RelativeSource Self}"/>
+                                                    </MultiBinding>
+                                                </Image.Source>
+                                            </Image>
                                         </Panel>
 
                                         <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -337,9 +358,15 @@
                                         Background="{DynamicResource DockApplicationAccentBrushLow}">
                                     <TextBlock Text="+"/>
                                 </Border>
-                                <Image Source="{Binding $parent[UserControl].((vm:AiConnectionsViewModel)DataContext).GenericLogoPath,
-                                           Converter={x:Static conv:ProviderLogoConverter.Instance}}"
-                                       Stretch="Uniform" Margin="2"/>
+                                <Image Stretch="Uniform" Margin="2">
+                                    <!-- As above: the variant is a dependency, not an input. (#971) -->
+                                    <Image.Source>
+                                        <MultiBinding Converter="{x:Static conv:ProviderLogoConverter.Instance}">
+                                            <Binding Path="$parent[UserControl].((vm:AiConnectionsViewModel)DataContext).GenericLogoPath"/>
+                                            <Binding Path="ActualThemeVariant" RelativeSource="{RelativeSource Self}"/>
+                                        </MultiBinding>
+                                    </Image.Source>
+                                </Image>
                             </Panel>
                             <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
                                 <TextBlock Text="Custom endpoint" FontWeight="SemiBold"/>


### PR DESCRIPTION
Follow-up to #982, found by @fsnow testing it:

> when I open the program in dark mode all the logos show correctly as light

— but switching theme with the pane already open did not repaint them, so every logo went black at once.

## What was wrong

`ProviderLogoConverter` samples `TextFillColorPrimaryBrush` at conversion time, and nothing re-runs a converter when the theme changes. Its own doc comment predicted this exactly and called it acceptable:

> A row built before a theme switch keeps the colour it was built with until the list is rebuilt — acceptable because the settings window is short-lived and a theme change is rare, and worth stating so nobody reads it as a bug.

It was read as a bug within a day of #982 landing, and that is not a coincidence: before the black-fill fix, the three logos that named black were black in *both* themes and only the other 186 moved together. Now all 190 move together, so a stale colour blanks the entire pane instead of most of it — the same defect, but it now looks like a break.

## The fix

The five `Image.Source` bindings become `MultiBinding`s with the control's `ActualThemeVariant` as a second value:

```xml
<Image.Source>
    <MultiBinding Converter="{x:Static conv:ProviderLogoConverter.Instance}">
        <Binding Path="LogoPath"/>
        <Binding Path="ActualThemeVariant" RelativeSource="{RelativeSource Self}"/>
    </MultiBinding>
</Image.Source>
```

The variant is never read — the colour is still sampled from the theme — it is there so the variant is a *binding source* and a switch invalidates the row. `ProviderLogoConverter` gains `IMultiValueConverter` alongside `IValueConverter`, following `CategoryIconConverter`, which is the same pattern already in the tree.

The `IsVisible` bindings beside them keep their single binding on purpose: whether a mark rendered does not depend on what colour it rendered in.

## Verified

The exact XAML above, loaded into a headless Avalonia 11.3.6 application with a stub converter and a `Row` data context:

```
after show:   (unset) |  ;; /tmp/x.svg |  ;; /tmp/x.svg | Light
after switch: … ;; /tmp/x.svg | Dark
PASS: the theme switch re-ran the converter
```

That is the risky part — `RelativeSource Self` on a property that lives on `StyledElement`, inside a `MultiBinding` — and it resolves and re-fires.

## Tests

Six new cases on the binding/converter contract: an unresolved path (`UnsetValue`, which is what every row's first evaluation passes), an empty list and a one-element list from a mis-written binding, and that the variant's value is never read. The re-run itself is a property of the binding and cannot be asserted without a headless Avalonia application, which the test project does not have — that is said plainly in the test class's summary rather than left for the next reader to discover.

Full suite: 2850 passed, 0 failed, 18 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)