### PR TITLE
Let a PDF tab float into its own window, and delete the scaffold #39 orphaned (#419)

### DIFF
--- a/src/CST.Avalonia.Tests/ViewModels/PdfFloatFlagsTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/PdfFloatFlagsTests.cs
@@ -1,0 +1,45 @@
+using CST.Avalonia.ViewModels;
+using Xunit;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// The dock flags that decide whether a PDF tab can leave its window. (#419)
+///
+/// <para>This is all a headless test can reach. The float itself needs a real <c>HostWindow</c> and the
+/// <c>ControlRecycling</c> resource, so <c>SplitToWindow</c>, <c>PrepareCrossWindowMove</c> and
+/// <c>DisposeAndEvictRecycledView</c> cannot be exercised here (#655) — the manual list on #419 is what
+/// covers them. What this pins is the pair of flags, and the pair matters more than either alone.</para>
+///
+/// <para><b>Why <c>CanDrag</c> is asserted too.</b> It was never set, so it has always defaulted true, and
+/// Dock's <c>ValidateDocument</c> gates a drop into an existing floating window on <c>CanDrag</c>/<c>CanDrop</c>
+/// without consulting <c>CanFloat</c>. So a PDF's browser could already cross windows before #419, and the
+/// funnel already had to handle it. Setting <c>CanDrag = false</c> later — copying <c>WelcomeViewModel</c>,
+/// say — would silently disable dragging while leaving <c>CanFloat</c> true, which reads as "floating is
+/// enabled" while the tab cannot be picked up.</para>
+/// </summary>
+public class PdfFloatFlagsTests
+{
+    private static PdfDisplayViewModel Vm() =>
+        new("s0101m.mul.xml", CST.Sources.SourceType.Burmese1957, 1);
+
+    [Fact]
+    public void A_pdf_tab_can_float_into_its_own_window()
+    {
+        Assert.True(Vm().CanFloat);
+    }
+
+    [Fact]
+    public void A_pdf_tab_can_be_dragged()
+    {
+        Assert.True(Vm().CanDrag);
+    }
+
+    [Fact]
+    public void A_pdf_tab_can_still_be_closed()
+    {
+        // CloseDockable's PDF branch is what evicts the browser; a non-closable PDF would slip into the
+        // "left in the closing window" path instead.
+        Assert.True(Vm().CanClose);
+    }
+}

--- a/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/BookDisplayViewModel.cs
@@ -114,8 +114,6 @@ namespace CST.Avalonia.ViewModels
         private bool _isWebViewAvailable = true; // Start optimistically to avoid fallback flash
         private bool _updatingChapterFromScroll = false;
         private bool _isInitializing = true;
-        private WebViewLifecycleOperation _webViewLifecycleOperation = WebViewLifecycleOperation.None;
-        private WebViewState? _savedWebViewState = null; // Saved state during float/unfloat
         private readonly CstDockFactory? _dockFactory; // Factory for float/unfloat operations
         /// <summary>
         /// Guards the three restoration-intent fields below. (R8-5)
@@ -441,12 +439,6 @@ namespace CST.Avalonia.ViewModels
         {
             get => _isLoading;
             set => this.RaiseAndSetIfChanged(ref _isLoading, value);
-        }
-
-        public WebViewLifecycleOperation WebViewLifecycleOperation
-        {
-            get => _webViewLifecycleOperation;
-            set => this.RaiseAndSetIfChanged(ref _webViewLifecycleOperation, value);
         }
 
         public string PageStatusText
@@ -1788,34 +1780,6 @@ namespace CST.Avalonia.ViewModels
             OpenPdfRequested?.Invoke(_book.FileName, sourceType, pdfPage);
         }
 
-        /// <summary>
-        /// Restore WebView state after float/unfloat operation
-        /// </summary>
-        private void RestoreWebViewState()
-        {
-            if (_savedWebViewState == null)
-            {
-                _logger.Warning("No saved state to restore");
-                return;
-            }
-
-            _logger.Information("Restoring WebView state: HtmlLength={HtmlLength}, Positions={PositionCount}, Terms={TermCount}",
-                _savedWebViewState.HtmlContent?.Length ?? 0,
-                _savedWebViewState.SearchPositions?.Count ?? 0,
-                _savedWebViewState.SearchTerms?.Count ?? 0);
-
-            // Restore state (Note: _searchTerms and _searchPositions are readonly,
-            // so we can't reassign them - they stay as initialized)
-            _htmlContent = _savedWebViewState.HtmlContent ?? "";
-            CurrentHitIndex = _savedWebViewState.CurrentHitIndex;
-            TotalHits = _savedWebViewState.TotalHits;
-
-            // Update hit status text
-            UpdateHitStatusText();
-
-            // View will reload HTML and restore scroll position when it recreates WebView
-        }
-
         private void UpdateHitStatusText()
         {
             if (TotalHits > 0)
@@ -2326,49 +2290,4 @@ namespace CST.Avalonia.ViewModels
         }
     }
 
-    /// <summary>
-    /// Lifecycle signals for disposing and rebuilding a WebView around a float/unfloat.
-    ///
-    /// <para><b>DORMANT — nothing sets the four float states, and that is intentional. Do not delete them.</b>
-    /// They are scaffolding retained for #419 (float/unfloat for Source-PDF tabs). The float/unfloat buttons
-    /// that used to drive this were removed in #39 when drag-to-float shipped, taking the only writers with
-    /// them (<c>FloatDockableWithoutRecycling</c> / <c>UnfloatDockableWithoutRecycling</c>, both since
-    /// deleted). The enum, the view-model properties and both views' handlers survive; the only assignment
-    /// left in the tree is a reset to <c>None</c> inside the handler that reacts to it. Nothing misbehaves,
-    /// because these states are never entered. (#896)</para>
-    ///
-    /// <para><b>Whoever implements #419: this is probably not the mechanism you want.</b> The shipped float
-    /// path is the dispose-before-move funnel — <c>CstDockFactory.SplitToWindow</c> calling
-    /// <c>DisposeAndEvictRecycledView</c> before the move, so a fresh browser is built at the destination —
-    /// which already covers <c>PdfDisplayViewModel</c>. This enum is the older, button-era approach.</para>
-    ///
-    /// <para>The prior reference here, to <c>docs/research/BUTTON_BASED_FLOAT_APPROACH.md</c> Phase 4, is
-    /// SUPERSEDED: that document recommends <c>CanFloat = false</c> on documents, which is the opposite of
-    /// what shipped. See <c>docs/architecture/DOCK_SUBSYSTEM.md</c> — and #895, since those docs are
-    /// themselves still being corrected.</para>
-    /// </summary>
-    public enum WebViewLifecycleOperation
-    {
-        None,
-        PrepareForFloat,      // Signal View to dispose WebView before floating
-        RestoreAfterFloat,    // Signal View to recreate WebView after floating
-        PrepareForUnfloat,    // Signal View to dispose WebView before unfloating
-        RestoreAfterUnfloat   // Signal View to recreate WebView after unfloating
-    }
-
-    /// <summary>
-    /// Saved state for WebView recreation after float/unfloat operations
-    /// Related: docs/research/BUTTON_BASED_FLOAT_APPROACH.md Phase 4
-    /// </summary>
-    public class WebViewState
-    {
-        public string? HtmlContent { get; set; }
-        public int ScrollPosition { get; set; }
-        public List<TermPosition>? SearchPositions { get; set; }
-        public List<string>? SearchTerms { get; set; }
-        public Script BookScript { get; set; }
-        public string? CurrentAnchor { get; set; }
-        public int CurrentHitIndex { get; set; }
-        public int TotalHits { get; set; }
-    }
 }

--- a/src/CST.Avalonia/ViewModels/PdfDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/PdfDisplayViewModel.cs
@@ -27,8 +27,6 @@ namespace CST.Avalonia.ViewModels
         private bool _isWebViewAvailable = true;
         private string _pdfLocalPath = "";
         private string _pdfUrl = "";
-        private WebViewLifecycleOperation _webViewLifecycleOperation = WebViewLifecycleOperation.None;
-        private PdfWebViewState? _savedWebViewState = null;
 
         /// <summary>
         /// Event raised when the PDF URL is ready to be loaded in the WebView.
@@ -133,18 +131,6 @@ namespace CST.Avalonia.ViewModels
         {
             get => _pdfLocalPath;
             set => this.RaiseAndSetIfChanged(ref _pdfLocalPath, value);
-        }
-
-        public WebViewLifecycleOperation WebViewLifecycleOperation
-        {
-            get => _webViewLifecycleOperation;
-            set => this.RaiseAndSetIfChanged(ref _webViewLifecycleOperation, value);
-        }
-
-        public PdfWebViewState? SavedWebViewState
-        {
-            get => _savedWebViewState;
-            set => this.RaiseAndSetIfChanged(ref _savedWebViewState, value);
         }
 
         public string SourceTypeName => GetSourceTypeName(_sourceType);
@@ -259,12 +245,4 @@ namespace CST.Avalonia.ViewModels
         #endregion
     }
 
-    /// <summary>
-    /// Saved WebView state for PDF restoration after float/unfloat operations.
-    /// </summary>
-    public class PdfWebViewState
-    {
-        public string? Url { get; set; }
-        public int Page { get; set; }
-    }
 }

--- a/src/CST.Avalonia/ViewModels/PdfDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/PdfDisplayViewModel.cs
@@ -61,7 +61,18 @@ namespace CST.Avalonia.ViewModels
             }
             Title = $"{GetSourceTypeName(sourceType)} - Page {targetPage}";
             CanClose = true;
-            CanFloat = false;  // Float/unfloat not yet implemented for PDF windows
+            // A PDF tab floats into its own window like a book (#419). Everything the float depends on
+            // already handles this type: SplitToWindow disposes the live browser before the move,
+            // PrepareCrossWindowMove does the same for a cross-window drag, DisposeAndEvictRecycledView
+            // shuts the view down and drops the cache entry, and CloseDockable evicts on close. The fresh
+            // view at the destination reloads PdfUrl and builds a new browser, so no live WebView crosses
+            // a re-parent.
+            //
+            // CanDrag is left at its default true, as it always was: CanFloat=false never blocked dragging
+            // a PDF INTO an existing floating window - Dock's ValidateDocument gates on CanDrag/CanDrop and
+            // never consults CanFloat - so that re-parent has been reachable since #458 and goes through
+            // the same funnel. This flag adds a second way in, not a new hazard.
+            CanFloat = true;
             CanPin = false;
 
             // Initialize commands

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml.cs
@@ -42,7 +42,6 @@ public partial class BookDisplayView : UserControl
     // shared slot would silently hand one caller the other's answer.
     private TaskCompletionSource<(string? Text, int? Paragraph)>? _aiSelectionTcs;
     private ScrollViewer? _fallbackBrowser;
-    private IDisposable? _lifecycleSubscription; // Subscription to WebViewLifecycleOperation changes
     private int _lastScrollPosition = 0;
     private bool _isBrowserInitialized = false;
     private TaskCompletionSource<string?>? _paraAnchorTcs = null;
@@ -680,7 +679,6 @@ public partial class BookDisplayView : UserControl
             _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
             _viewModel.NavigateToHighlightRequested -= NavigateToHighlight;
             _viewModel.NavigateToChapterRequested -= NavigateToAnchor;
-            _lifecycleSubscription?.Dispose();
             _viewModel.BookDisplayControl = null;
         }
 
@@ -696,17 +694,6 @@ public partial class BookDisplayView : UserControl
             _viewModel.NavigateToHighlightRequested += NavigateToHighlight;
             _viewModel.NavigateToChapterRequested += NavigateToAnchor;
 
-            // Phase 4: Subscribe to WebViewLifecycleOperation changes for float/unfloat operations
-            // Related: docs/research/BUTTON_BASED_FLOAT_APPROACH.md
-            // IMPORTANT: Capture ViewModel in local variable so dispose has stable reference
-            var vm = _viewModel;
-            _lifecycleSubscription = System.Reactive.Linq.Observable
-                .FromEventPattern<System.ComponentModel.PropertyChangedEventHandler, System.ComponentModel.PropertyChangedEventArgs>(
-                    h => vm.PropertyChanged += h,
-                    h => vm.PropertyChanged -= h)
-                .Where(pattern => pattern.EventArgs.PropertyName == nameof(BookDisplayViewModel.WebViewLifecycleOperation))
-                .Subscribe(_ => OnWebViewLifecycleOperationChanged());
-
             // If the ViewModel already has HTML content, load it immediately
             // This handles the case where the view is recreated but the ViewModel persists
             if (!string.IsNullOrEmpty(_viewModel.HtmlContent))
@@ -715,51 +702,6 @@ public partial class BookDisplayView : UserControl
                 Dispatcher.UIThread.Post(() => LoadHtmlContent());
             }
         }
-    }
-
-    /// <summary>
-    /// Handle WebViewLifecycleOperation changes for float/unfloat operations
-    /// Phase 4: Manual WebView disposal and recreation to prevent CEF crash
-    /// Related: docs/research/BUTTON_BASED_FLOAT_APPROACH.md
-    /// </summary>
-    private void OnWebViewLifecycleOperationChanged()
-    {
-        if (_viewModel == null) return;
-
-        var operation = _viewModel.WebViewLifecycleOperation;
-        _logger.Information("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        _logger.Information("WebViewLifecycleOperation changed: {Operation}", operation);
-
-        switch (operation)
-        {
-            case WebViewLifecycleOperation.PrepareForFloat:
-            case WebViewLifecycleOperation.PrepareForUnfloat:
-                _logger.Warning("*** DISPOSING WebView before window operation ***");
-                DisposeWebView();
-                _logger.Information("WebView disposed, ready for window operation");
-                break;
-
-            case WebViewLifecycleOperation.RestoreAfterFloat:
-            case WebViewLifecycleOperation.RestoreAfterUnfloat:
-                _logger.Warning("*** RECREATING WebView after window operation ***");
-                TryCreateWebView();
-
-                // Reload HTML content if available
-                if (!string.IsNullOrEmpty(_viewModel.HtmlContent))
-                {
-                    _logger.Information("Reloading HTML content ({Length} chars) after WebView recreation",
-                        _viewModel.HtmlContent.Length);
-                    Dispatcher.UIThread.Post(() => LoadHtmlContent());
-                }
-                _logger.Information("WebView recreated and content reloaded");
-                break;
-
-            case WebViewLifecycleOperation.None:
-            default:
-                // No action needed
-                break;
-        }
-        _logger.Information("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     }
 
     private void OnIsVisibleChanged(object? sender, AvaloniaPropertyChangedEventArgs e)

--- a/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
@@ -18,7 +18,6 @@ public partial class PdfDisplayView : UserControl
     private readonly ILogger _logger;
     private PdfDisplayViewModel? _viewModel;
     private WebView? _webView;
-    private IDisposable? _lifecycleSubscription;
     private bool _hasPdfLoaded = false;
 
     public PdfDisplayView()
@@ -210,12 +209,6 @@ public partial class PdfDisplayView : UserControl
         // Subscribe to LoadPdfRequested event from ViewModel
         _viewModel.LoadPdfRequested += OnLoadPdfRequested;
 
-        // Subscribe to WebViewLifecycleOperation changes for float/unfloat
-        _lifecycleSubscription = _viewModel
-            .WhenAnyValue(vm => vm.WebViewLifecycleOperation)
-            .ObserveOn(new global::CST.Avalonia.AvaloniaUIThreadScheduler())
-            .Subscribe(OnWebViewLifecycleOperationChanged);
-
         // If PDF URL is already available (e.g., restored from state), load it
         // But only load once - don't reload on tab switches (preserves user's current page)
         if (!string.IsNullOrEmpty(_viewModel.PdfUrl) && !_hasPdfLoaded)
@@ -235,9 +228,6 @@ public partial class PdfDisplayView : UserControl
         {
             _viewModel.LoadPdfRequested -= OnLoadPdfRequested;
         }
-
-        _lifecycleSubscription?.Dispose();
-        _lifecycleSubscription = null;
 
         _logger.Information("PdfDisplayView unloaded (WebView kept alive)");
     }
@@ -279,62 +269,4 @@ public partial class PdfDisplayView : UserControl
         InjectShortcutRelay();
     }
 
-    private void OnWebViewLifecycleOperationChanged(WebViewLifecycleOperation operation)
-    {
-        switch (operation)
-        {
-            case WebViewLifecycleOperation.PrepareForFloat:
-            case WebViewLifecycleOperation.PrepareForUnfloat:
-                _logger.Information("PDF: Preparing for float/unfloat - saving state and disposing WebView");
-                SaveWebViewState();
-                DisposeWebView();
-                break;
-
-            case WebViewLifecycleOperation.RestoreAfterFloat:
-            case WebViewLifecycleOperation.RestoreAfterUnfloat:
-                _logger.Information("PDF: Restoring after float/unfloat - recreating WebView");
-                RecreateWebView();
-                RestoreWebViewState();
-                if (_viewModel != null)
-                {
-                    _viewModel.WebViewLifecycleOperation = WebViewLifecycleOperation.None;
-                }
-                break;
-        }
-    }
-
-    private void SaveWebViewState()
-    {
-        if (_viewModel != null && !string.IsNullOrEmpty(_viewModel.PdfUrl))
-        {
-            _viewModel.SavedWebViewState = new PdfWebViewState
-            {
-                Url = _viewModel.PdfUrl,
-                Page = _viewModel.TargetPage
-            };
-            _logger.Debug("PDF state saved: {Url}", _viewModel.PdfUrl);
-        }
-    }
-
-    private void RecreateWebView()
-    {
-        if (_webView == null)
-        {
-            TryCreateWebView();
-        }
-    }
-
-    private void RestoreWebViewState()
-    {
-        if (_viewModel?.SavedWebViewState != null && _webView != null)
-        {
-            var state = _viewModel.SavedWebViewState;
-            if (!string.IsNullOrEmpty(state.Url))
-            {
-                _logger.Information("Restoring PDF state: {Url}", state.Url);
-                LoadPdf(state.Url);
-            }
-            _viewModel.SavedWebViewState = null;
-        }
-    }
 }

--- a/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Reactive.Linq;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 using ReactiveUI;
 using WebViewControl;
 using CST.Avalonia.Input;
@@ -27,6 +29,46 @@ public partial class PdfDisplayView : UserControl
 
         // Try to create WebView
         TryCreateWebView();
+    }
+
+    /// <summary>
+    /// The window this view's browser belongs to, for the #458 invariant check below.
+    ///
+    /// <para>Adopted at the FIRST attach rather than at creation, because <c>TryCreateWebView</c> runs in the
+    /// constructor when there is no visual root yet — the same reason <c>BookDisplayView</c> uses <c>??=</c>
+    /// here. Cleared with the browser in <c>DisposeWebView</c>, so it always describes a live browser or
+    /// nothing, and a rebuilt browser adopts whichever window it is attached to next.</para>
+    /// </summary>
+    private Window? _browserBirthWindow;
+
+    /// <summary>
+    /// #458 invariant: a <b>live</b> browser must never re-attach to a window other than the one it was born
+    /// in — that is the crash, and on macOS it is a SIGSEGV with nothing in the log before it.
+    ///
+    /// <para>With dispose-before-move in place this cannot happen: every re-parent funnels through
+    /// <c>SplitToWindow</c> or <c>PrepareCrossWindowMove</c>, which call <c>DisposeAndEvictRecycledView</c>
+    /// first, so the view that arrives at the destination is a fresh one with no browser yet. If this Error
+    /// ever appears, a re-parent path is missing the guard — better a log line than a crash report. (#419)</para>
+    ///
+    /// <para><b>Deliberately only a log, unlike <c>BookDisplayView</c>, which also disposes and rebuilds
+    /// here.</b> That branch is a rescue, and writing one for PDFs would mean adding lifecycle handling this
+    /// view has never had, unverifiable without a GUI run, in the app's most fragile subsystem. The
+    /// diagnostic is the part that is free and cannot itself break anything.</para>
+    /// </summary>
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+
+        if (this.GetVisualRoot() is not Window newWindow) return;
+
+        if (_webView != null && _browserBirthWindow != null && !ReferenceEquals(_browserBirthWindow, newWindow))
+        {
+            _logger.Error("*** #458 VIOLATION: live PDF WebView re-attaching to a different window — {Book} {Source}, born in {OldHash}, now {NewHash}. A re-parent path is carrying a live browser (crash risk). ***",
+                _viewModel?.BookFilename ?? "null", _viewModel?.SourceType.ToString() ?? "null",
+                _browserBirthWindow.GetHashCode(), newWindow.GetHashCode());
+        }
+
+        _browserBirthWindow ??= newWindow;
     }
 
     private void TryCreateWebView()
@@ -132,6 +174,7 @@ public partial class PdfDisplayView : UserControl
                     focusReporter.BrowserGotFocus -= OnBrowserGotFocus;   // (fable review)
                 _webView.Dispose();
                 _webView = null;
+                _browserBirthWindow = null;  // no live browser, so no window to be born in (#419)
                 _hasPdfLoaded = false;  // Reset so PDF reloads after recreate
                 _logger.Information("PDF WebView disposed successfully");
             }
@@ -139,6 +182,7 @@ public partial class PdfDisplayView : UserControl
             {
                 _logger.Error(ex, "Error while disposing PDF WebView");
                 _webView = null;
+                _browserBirthWindow = null;
             }
         }
     }


### PR DESCRIPTION
Closes #419. Two commits, separable.

## 1. `2da966f` — the feature

**The gate was one line.** `PdfDisplayViewModel.CanFloat = false`. Every mechanism the float depends on already named this type — `SplitToWindow` and `PrepareCrossWindowMove` dispose the live browser before the move, `DisposeAndEvictRecycledView` shuts the view down and drops the cache entry, `CloseDockable` evicts on close — so the fresh view at the destination reloads `PdfUrl` and builds a new browser. No live WebView crosses a re-parent.

**The risk framing is inverted from the issue's**, and this is the part worth reading. `CanFloat = false` blocked only *new-window creation*. Dock's `ValidateDocument` gates a drop into an **existing** floating window on `CanDrag`/`CanDrop` and never consults `CanFloat`, and `PdfDisplayViewModel` never set `CanDrag`, so it has defaulted true throughout. **A PDF's browser could already cross windows before this PR**, and the funnel already had to handle it. This adds a second door, not a new hazard. `WelcomeViewModel` records the same asymmetry, which is why Welcome sets `CanDrag = false`.

`PdfDisplayView` also gains the **`#458` invariant check** `BookDisplayView` has and it never had — it had no attach handler at all, so a missed funnel would have failed as a blank pane with one warning, or a SIGSEGV with nothing in the log before it. Deliberately the Error log only, not `BookDisplayView`'s dispose-and-rebuild rescue: writing that means adding lifecycle handling this view has never had, in the most fragile subsystem, unverifiable headlessly. The log is the half that cannot itself break anything.

Three flag tests, **two mutants killed**. The second matters: `CanDrag = false` — the mistake of copying `WelcomeViewModel`'s guard — fails a test, because it would read as "floating is enabled" while the tab could not be picked up.

## 2. `48b5127` — delete the scaffold #39 orphaned

**229 lines, no behaviour change.** Nothing has entered these states since the float/unfloat buttons went in #39; the only assignment left was a reset to `None` inside the handler reacting to it. `BookDisplayViewModel.RestoreWebViewState` was defined and **never called**.

Kept for #419, and #419 turned out not to want it: `PdfWebViewState` captured `Url` and `TargetPage`, exactly what `PdfUrl` already carries and the fresh view already reloads.

**Why it survived is a process failure, not a technical one**, and is recorded in the commit. #896's body claimed *"Answered by the maintainer: … It stays"* with no quote anywhere; **[fsnow]** has since said *"That was a Claude instance's decision."* The attribution went into the code comment #896 commissioned — *"that is intentional. Do not delete them"* — then into a planning report, then back to him as his own prior decision. Four hops, no quote at any. #896 is corrected.

## Verified in the running app — [fsnow], macOS

All five of the risky paths, not just the happy one:

1. Drag a PDF tab out to its own window — **pass**
2. Drag a PDF **into an existing floating window** (`PrepareCrossWindowMove`, the path already live before this PR) — **pass**
3. Drag it back, and into a second floating window holding a book — **pass**
4. The #458 shape: book + PDF in one floating window, ⌘W the active tab so the sibling activates — **pass**
5. Close a floating window containing a PDF with the red button — **pass**
6. **Float a PDF mid-download**, on a slow connection so the window was floating throughout — the PDF appeared when the download landed. This is the interleaving where the view swap could have taken the `LoadPdfRequested` subscription with the old view. **pass**

No `#458 VIOLATION` line appeared.

**Known limitation, now observed rather than predicted:** a floated PDF reopens at the page it was opened at. **[fsnow]** *"I confirmed the jump back to the target page."* Chromium's PDF extension accepts `postMessage` only from its own origin and exposes four messages, none of them viewport or page; the WebView has no scroll event among its forty; `Address` never changes on scroll. Sources on #419. Same-window tab moves are unaffected — those do not rebuild.

## Verification

- `dotnet build src/CST.Avalonia` — 0 errors, 0 warnings
- `dotnet test src/CST.Avalonia.Tests` — **2853 passed, 0 failed, 18 skipped**, unchanged across the deletion since none of that code was reachable to test
- No `.axaml` markup touched, by design — Egret has an agent adding accessibility attributes to these same views
