### PR TITLE
Name the UI for screen readers and scripts (#862)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ Guides for development workflows:
 - [Code Review 2026-07-01](development/CODE_REVIEW_2026-07-01.md) - Multi-agent whole-codebase review (80 findings, ranked; hand-off for the fixing session)
 - [Code Review 2026-08 Findings](development/CODE_REVIEW_2026-08_FINDINGS.md) - Fable review of the work since 2026-07-12, by area (81 findings: 4 HIGH now fixed, 26 MED and 51 LOW recorded here only)
 - [Cloud / Web Session Setup](development/CLOUD_SESSION_SETUP.md) - Provisioning a fresh remote container: XML corpus download, .NET SDK egress-policy block, CST_XML_DIR
+- [Accessibility Naming](development/ACCESSIBILITY_NAMING.md) - AutomationProperties.Name / AutomationId convention, what Avalonia's peers do with them, and what AppleScript can and cannot reach
 - [Proposed Claude Skills](development/PROPOSED_CLAUDE_SKILLS.md) - AI assistant skill definitions
 
 ### ✨ **features/** - Feature Planning & Specifications

--- a/docs/development/ACCESSIBILITY_NAMING.md
+++ b/docs/development/ACCESSIBILITY_NAMING.md
@@ -1,0 +1,127 @@
+# Accessibility naming: `AutomationProperties` in CST Reader
+
+How controls are labelled for screen readers and addressed by scripts. Introduced with #862.
+
+The convention below is **[suggestion]** — an agent's proposal, not a maintainer decision. The
+mechanics recorded as **[observed]** are measured facts about Avalonia 11.3.6, macOS and
+AppleScript, each with the measurement that produced it.
+
+---
+
+## 1. The two properties
+
+`AutomationProperties.Name` and `AutomationProperties.AutomationId` are different things and are
+used for different reasons.
+
+**`Name` — what a screen reader speaks.** It should be, or contain, the control's visible text.
+Set it where the control has no visible text of its own: an icon button, a glyph button, a bare
+`ToggleSwitch`, a picker whose only label is a `TextBlock` sitting beside it. Do not set it where
+the control already carries its own text — a `Button Content="Cancel"` is already named "Cancel",
+and a second, different name is a WCAG "label in name" failure waiting to happen.
+
+**`AutomationId` — a stable handle for scripts and tests.** Treat it as **public API**: once a
+script depends on one, renaming it breaks that script silently. Add ids freely; change them only
+deliberately.
+
+## 2. The `AutomationId` scheme
+
+Lowercase, dotted, `surface.group.control`, hyphens inside a segment:
+
+```
+settings.categories                 book.find.close          search.filter.vinaya
+settings.ai.tab.providers           book.zoom-out            dictionary.source
+settings.appearance.book-font       goto.type.pts-page       assistant.word-by-word
+```
+
+Surface prefixes in use: `settings`, `book`, `pdf`, `search`, `books` (the Open a Book tree),
+`dictionary`, `assistant`, `about`, `goto`, `main` (the app window's own chrome).
+
+**An id names the control, never where it currently sits.** Book, PDF, dictionary and assistant
+panes are all draggable into their own windows, so any id encoding "main window" becomes false the
+first time a reader floats the pane.
+
+**Do not put a static `AutomationId` on anything inside a `DataTemplate`** — every generated row
+would carry the same id. Put the id on the container (`settings.dictionary.sources`) and give the
+rows a bound `Name` instead.
+
+## 3. How to write it
+
+`AutomationProperties` lives in the default `avaloniaui` XML namespace, so it needs **no `xmlns`
+prefix and no namespace declaration** — write `AutomationProperties.Name="…"` directly.
+**[observed]** — parsed successfully in an `Avalonia.Headless` 11.3.6 harness on 2026-09-06.
+
+A generated container (`ListBoxItem`, `TreeViewItem`) has no text of its own, so name it with a
+style setter on the container, not inside the item template:
+
+```xml
+<ListBox.Styles>
+  <Style Selector="ListBoxItem" x:DataType="vm:SettingsCategoryViewModel">
+    <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
+  </Style>
+</ListBox.Styles>
+```
+
+A repeated control needs a name that distinguishes its row, so bind with a `StringFormat`:
+
+```xml
+<Button Content="&#x25B2;"
+        AutomationProperties.Name="{Binding DisplayName, StringFormat='Move {0} up'}"/>
+```
+
+## 4. What the framework already does, and what it will not do
+
+**[observed]**, all from `Avalonia.Controls` 11.3.6 (decompiled) and confirmed in a headless
+automation-peer walk on 2026-09-06:
+
+| Situation | Result |
+|---|---|
+| `AutomationProperties.Name` on `Button`, `CheckBox`, `ToggleButton`, `ComboBox`, `TextBox`, `Slider`, `TabItem`, `Expander`, `ListBox`, `TreeView` | Wins over every fallback — `ContentControlAutomationPeer.GetNameCore` calls `base.GetNameCore()` first |
+| `AutomationProperties.Name` on a **`TextBlock`** | **Ignored.** `TextBlockAutomationPeer.GetNameCore` returns `Owner.Text` unconditionally. Set only an `AutomationId` on a `TextBlock` |
+| `AutomationProperties.AutomationId` anywhere | Always reaches the peer, `TextBlock` included |
+| No `AutomationId`, but an `x:Name` | `x:Name` is used as the id (`GetAutomationIdCore` returns `AutomationProperties.GetAutomationId(Owner) ?? Owner.Name`). This is why template parts show up as `PART_ContentPresenter`, `ExpanderHeader` and so on — noise we did not put there, and a reason to set ids explicitly rather than rely on the fallback |
+| A container with no name (`ListBoxItem`, `TreeViewItem`) | Falls back to `Content?.ToString()` — **the view-model type name**. This is exactly what #862 reported as `row CST.Avalonia.ViewModels.SettingsCategoryViewModel` |
+| A `Button` whose `Content` is a layout element (`Grid`, `StackPanel`) | Same fallback, same type name — e.g. `Avalonia.Controls.StackPanel` for the assistant's model chip |
+| An `Expander` whose `Header` is a layout element | The **header `ToggleButton`** — the thing that is actually clicked — reports the header's type name. A `Name` on the `Expander` does **not** reach it; it has to be set through the template: `<Style Selector="Expander#X /template/ ToggleButton">`. `SearchPanel.axaml` does this for the text-type filters |
+| An `Expander` on its own | Reports `AutomationControlType.None`. Its name and id are still published; it is the header button that carries the role |
+
+## 5. What this buys, on macOS, and what it does not
+
+**[observed]** The macOS bridge does publish names, ids and roles. `Avalonia.Native` 11.3.6's
+`AvnAccessibilityElement` implements `accessibilityRole`, `accessibilityTitle` and
+`accessibilityIdentifier`, wired to the peer's control type, `GetName()` and `GetAutomationId()`
+respectively; the dylib imports `NSAccessibilityButtonRole`, `NSAccessibilityStaticTextRole`,
+`NSAccessibilityCheckBoxRole` and eighteen more from AppKit. (`otool -oV` and `nm -mu` on
+`libAvaloniaNative.dylib`, plus ILSpy on `Avalonia.Native.dll`, 2026-09-06.)
+
+**[observed]** #862's three failing AppleScript queries fail the same way against a fully native
+Cocoa app, so they were never evidence of an Avalonia gap:
+
+```
+$ osascript -e 'tell application "System Events" to tell process "Finder" \
+      to get every static text of entire contents of menu bar 1'
+execution error: Can't make every static text of entire contents of menu bar 1 …  (-1700)
+
+$ osascript -e 'tell application "System Events" to tell process "Finder" \
+      to get name of every menu bar item of menu bar 1'
+Apple, Finder, File, Edit, View, Go, Window, Help
+```
+
+`entire contents` is declared in System Events' own dictionary as a **property returning a list**
+(`<property name="entire contents" … <type type="specifier" list="yes"/>`), and AppleScript cannot
+apply an element specifier or a `whose` clause to a list. The forms that work are
+`<class>s of <container>` and `first <class> of <container> whose name is "…"` — both of which need
+elements to have **names**, which is what this convention supplies.
+
+**[observed]** `AXIdentifier` is readable per element —
+`value of attribute "AXIdentifier" of menu bar item 3 of menu bar 1` returned `_NS:1115` against
+Finder — but System Events cannot read it in bulk or filter on it: both
+`value of attribute "AXIdentifier" of every menu bar item …` and
+`… whose value of attribute "AXIdentifier" is "…"` fail with -1728. So from AppleScript,
+**`Name` is what makes a control findable**; `AutomationId` is a stable handle you verify once you
+have the element, and the property a real UI-automation driver (which talks to the AX API directly)
+would key on.
+
+**Not verified.** Nothing here was measured against a running CST Reader — the app was deliberately
+not launched. That the names and ids reach Avalonia's automation peers is measured; that macOS then
+surfaces them to AppleScript follows from the bridge implementation above but has not been observed
+end to end.

--- a/src/CST.Avalonia/Views/AboutWindow.axaml
+++ b/src/CST.Avalonia/Views/AboutWindow.axaml
@@ -133,7 +133,8 @@
                 Padding="20,12">
             <Grid ColumnDefinitions="Auto,*,Auto">
                 <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <Button Content="Copy version details" Click="OnCopyBuildSummary"/>
+                    <Button Content="Copy version details" Click="OnCopyBuildSummary"
+                            AutomationProperties.AutomationId="about.copy-version"/>
                     <TextBlock x:Name="CopyConfirm" Text="Copied ✓" Classes="Secondary"
                                VerticalAlignment="Center" IsVisible="False"/>
                 </StackPanel>
@@ -146,6 +147,7 @@
                      with 9px either side, which is what the Copy button does (145px, 9px either side).
                      Fluent sets no MinWidth of its own, so nothing puts the width back. -->
                 <Button Grid.Column="2" Content="Close" IsDefault="True" IsCancel="True"
+                        AutomationProperties.AutomationId="about.close"
                         Click="OnClose"/>
             </Grid>
         </Border>

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -59,7 +59,8 @@
                         <Button Content="Check again"
                                 Command="{Binding RefreshReadinessCommand}"
                                 HorizontalAlignment="Left"
-                                FontSize="11"/>
+                                FontSize="11"
+                                AutomationProperties.AutomationId="assistant.check-again"/>
                     </StackPanel>
                 </Border>
 
@@ -77,7 +78,9 @@
                          AcceptsReturn="False"
                          MaxHeight="90"
                          TextWrapping="Wrap"
-                         IsEnabled="{Binding CanAsk}">
+                         IsEnabled="{Binding CanAsk}"
+                         AutomationProperties.AutomationId="assistant.question"
+                         AutomationProperties.Name="Question">
                     <TextBox.KeyBindings>
                         <KeyBinding Gesture="Enter" Command="{Binding AskQuestionCommand}"/>
                     </TextBox.KeyBindings>
@@ -97,7 +100,9 @@
                         FontSize="11"
                         Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
                         BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                        BorderThickness="1">
+                        BorderThickness="1"
+                        AutomationProperties.AutomationId="assistant.model"
+                        AutomationProperties.Name="Model">
                     <StackPanel Orientation="Horizontal" Spacing="5">
                         <TextBlock Text="{Binding ModelPicker.CurrentLabel}" VerticalAlignment="Center"/>
                         <TextBlock Text="⌄" FontSize="10" VerticalAlignment="Center"
@@ -110,7 +115,9 @@
 
                                 <!-- Pinned above a scrolling list, and it takes focus: the list can grow. -->
                                 <TextBox Grid.Row="0" Text="{Binding ModelPicker.Search}"
-                                         Watermark="Search models" Margin="0,0,0,6"/>
+                                         Watermark="Search models" Margin="0,0,0,6"
+                                         AutomationProperties.AutomationId="assistant.model-search"
+                                         AutomationProperties.Name="Search models"/>
 
                                 <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
                                     <StackPanel>
@@ -252,7 +259,8 @@
                                         HorizontalAlignment="Left"
                                         Background="Transparent" BorderThickness="0"
                                         FontSize="11" Padding="4,4,4,0"
-                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                        AutomationProperties.AutomationId="assistant.manage-models"/>
                             </Grid>
                         </Flyout>
                     </Button.Flyout>
@@ -271,7 +279,9 @@
                         FontSize="11"
                         Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
                         BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                        BorderThickness="1">
+                        BorderThickness="1"
+                        AutomationProperties.AutomationId="assistant.effort"
+                        AutomationProperties.Name="Effort">
                     <StackPanel Orientation="Horizontal" Spacing="5">
                         <TextBlock Text="{Binding EffortPicker.CurrentLabel}" VerticalAlignment="Center"/>
                         <TextBlock Text="⌄" FontSize="10" VerticalAlignment="Center"
@@ -322,19 +332,25 @@
                     <!-- First, and disabled until something is typed: the other four are complete without a
                          question, and this one IS the question. -->
                     <Button Content="Ask" Command="{Binding AskQuestionCommand}"
-                            IsEnabled="{Binding CanAskQuestion}" Margin="0,0,10,4"/>
+                            IsEnabled="{Binding CanAskQuestion}" Margin="0,0,10,4"
+                            AutomationProperties.AutomationId="assistant.ask"/>
                     <Button Content="Explain" Command="{Binding ExplainCommand}"
-                            IsEnabled="{Binding CanAsk}" Margin="0,0,4,4"/>
+                            IsEnabled="{Binding CanAsk}" Margin="0,0,4,4"
+                            AutomationProperties.AutomationId="assistant.explain"/>
                     <Button Content="Translate" Command="{Binding TranslateCommand}"
-                            IsEnabled="{Binding CanAsk}" Margin="0,0,4,4"/>
+                            IsEnabled="{Binding CanAsk}" Margin="0,0,4,4"
+                            AutomationProperties.AutomationId="assistant.translate"/>
                     <Button Content="Grammar" Command="{Binding GrammarCommand}"
-                            IsEnabled="{Binding CanAsk}" Margin="0,0,4,4"/>
+                            IsEnabled="{Binding CanAsk}" Margin="0,0,4,4"
+                            AutomationProperties.AutomationId="assistant.grammar"/>
                     <Button Content="Word by word" Command="{Binding WordByWordCommand}"
-                            IsEnabled="{Binding CanAsk}" Margin="0,0,4,4"/>
+                            IsEnabled="{Binding CanAsk}" Margin="0,0,4,4"
+                            AutomationProperties.AutomationId="assistant.word-by-word"/>
                     <!-- Visible only while a turn runs: §10 requires a stop control, and a permanently dead
                          button is not one. -->
                     <Button Content="Stop" Command="{Binding StopCommand}"
-                            IsVisible="{Binding IsBusy}" Margin="0,0,4,4"/>
+                            IsVisible="{Binding IsBusy}" Margin="0,0,4,4"
+                            AutomationProperties.AutomationId="assistant.stop"/>
                 </WrapPanel>
 
                 <TextBlock Text="Answers are generated by a model you configure. They can be wrong — check them against the text."

--- a/src/CST.Avalonia/Views/AiModelsView.axaml
+++ b/src/CST.Avalonia/Views/AiModelsView.axaml
@@ -62,13 +62,16 @@
         <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,10"
               IsVisible="{Binding !HasNoConnections}">
             <TextBox Grid.Column="0" Text="{Binding Search}"
-                     Watermark="Search models"/>
+                     Watermark="Search models"
+                     AutomationProperties.AutomationId="settings.ai.model-search"
+                     AutomationProperties.Name="Search models"/>
             <!-- Built from published price, which is a fact the provider states rather than a preference of
                  ours. Off by default: on would be a claim about what the reader wants to spend. -->
             <CheckBox Grid.Column="1" IsChecked="{Binding FreeOnly}"
                       Content="Free models only"
                       Margin="10,0,0,0" VerticalAlignment="Center"
-                      ToolTip.Tip="Hides models the provider publishes a price for. Endpoints that publish no price at all — a local runner — are unaffected."/>
+                      ToolTip.Tip="Hides models the provider publishes a price for. Endpoints that publish no price at all — a local runner — are unaffected."
+                      AutomationProperties.AutomationId="settings.ai.free-models-only"/>
         </Grid>
 
         <Border Classes="SettingGroup" Padding="0"
@@ -86,7 +89,8 @@
                                 <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
                                     <Button Grid.Column="0" Classes="Link"
                                             Command="{Binding ToggleCommand}"
-                                            Padding="2,0" Margin="0,0,4,0">
+                                            Padding="2,0" Margin="0,0,4,0"
+                                            AutomationProperties.Name="{Binding DisplayName, StringFormat='Expand or collapse {0}'}">
                                         <TextBlock Text="{Binding IsExpanded, Converter={x:Static conv:ChevronConverter.Instance}}"
                                                    FontSize="10"/>
                                     </Button>
@@ -127,7 +131,8 @@
                                     <Button Grid.Column="4" Classes="Link"
                                             Content="Refresh"
                                             IsEnabled="{Binding CanFetch}"
-                                            Command="{Binding FetchCommand}"/>
+                                            Command="{Binding FetchCommand}"
+                                            AutomationProperties.Name="{Binding DisplayName, StringFormat='Refresh {0}'}"/>
                                 </Grid>
 
                                 <TextBlock Text="Asking the provider for its models…"
@@ -149,7 +154,8 @@
                                         IsVisible="{Binding ShowDoc}"
                                         Command="{Binding OpenDocCommand}"
                                         ToolTip.Tip="{Binding DocUrl}"
-                                        HorizontalAlignment="Left" Margin="26,0,0,0"/>
+                                        HorizontalAlignment="Left" Margin="26,0,0,0"
+                                        AutomationProperties.Name="{Binding DisplayName, StringFormat='See the models for {0}'}"/>
 
                             </StackPanel>
                         </Border>
@@ -191,7 +197,8 @@
                                      on at once, which is the entire point of a short list. -->
                                 <ToggleSwitch Grid.Column="2" IsChecked="{Binding Enabled}"
                                               OnContent="" OffContent=""
-                                              VerticalAlignment="Center"/>
+                                              VerticalAlignment="Center"
+                                              AutomationProperties.Name="{Binding DisplayName}"/>
                             </Grid>
                         </Border>
                     </DataTemplate>

--- a/src/CST.Avalonia/Views/AiProvidersView.axaml
+++ b/src/CST.Avalonia/Views/AiProvidersView.axaml
@@ -166,13 +166,15 @@
                                              straight duplicate of the sheet's own. -->
                                         <Button Content="{Binding EditLabel}" Classes="Link"
                                                 IsVisible="{Binding CanEdit}"
-                                                Command="{Binding EditCommand}"/>
+                                                Command="{Binding EditCommand}"
+                                                AutomationProperties.Name="{Binding DisplayName, StringFormat='Edit {0}'}"/>
                                         <!-- Two destructive actions, not one: stopping the billing and
                                              throwing away a hand-typed model list are different intentions.
                                              An environment-sourced row gets an EMPTY slot here rather than a
                                              disabled button — the app cannot delete a key it never stored,
                                              and a control there would lie about what it can do. -->
                                         <Button Content="Delete" Classes="Link"
+                                                AutomationProperties.Name="{Binding DisplayName, StringFormat='Delete {0}'}"
                                                 Command="{Binding DeleteCommand}"/>
                                     </StackPanel>
 
@@ -210,7 +212,8 @@
                  the lookup is unnecessary there rather than unavailable. -->
             <StackPanel IsVisible="{Binding ShowShellEnvironmentControl}" Margin="0,0,0,16">
                 <CheckBox IsChecked="{Binding ReadLoginShellEnvironment}"
-                          Content="Look for API keys in your login shell"/>
+                          Content="Look for API keys in your login shell"
+                          AutomationProperties.AutomationId="settings.ai.read-login-shell"/>
                 <TextBlock Text="{Binding ShellEnvironmentStatusText}"
                            IsVisible="{Binding ShellEnvironmentStatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                            Classes="SettingDescription" Margin="0,4,0,0"/>
@@ -261,7 +264,8 @@
 
                                         <Button Grid.Column="2" Content="Use it"
                                                 Command="{Binding UseCommand}"
-                                                VerticalAlignment="Center"/>
+                                                VerticalAlignment="Center"
+                                                AutomationProperties.Name="{Binding DisplayName, StringFormat='Use the key found for {0}'}"/>
                                     </Grid>
                                 </Border>
                             </DataTemplate>
@@ -278,7 +282,8 @@
                            Foreground="{DynamicResource SystemFillColorCautionBrush}"
                            Margin="0,0,0,6"/>
                 <Button Content="Try again" Command="{Binding RetryCatalogueCommand}"
-                        HorizontalAlignment="Left"/>
+                        HorizontalAlignment="Left"
+                        AutomationProperties.AutomationId="settings.ai.retry-catalogue"/>
             </StackPanel>
 
             <TextBlock Text="Looking for the provider list…"
@@ -290,7 +295,9 @@
             <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,8"
                   IsVisible="{Binding HasCatalogue}">
                 <TextBox Grid.Column="0" Text="{Binding PresetSearch}"
-                         Watermark="Search providers"/>
+                         Watermark="Search providers"
+                         AutomationProperties.AutomationId="settings.ai.provider-search"
+                         AutomationProperties.Name="Search providers"/>
                 <TextBlock Grid.Column="1" Text="{Binding CatalogueCount}" Classes="Secondary"
                            Margin="10,0,2,0" VerticalAlignment="Center"/>
             </Grid>
@@ -333,6 +340,7 @@
                                         </StackPanel>
 
                                         <Button Grid.Column="2" Content="+ Add"
+                                                AutomationProperties.Name="{Binding DisplayName, StringFormat='Add {0}'}"
                                                 Command="{Binding AddCommand}"
                                                 VerticalAlignment="Center"/>
                                     </Grid>
@@ -375,7 +383,9 @@
                             </StackPanel>
                             <Button Grid.Column="2" Content="+ Add"
                                     Command="{Binding AddCustomCommand}"
-                                    VerticalAlignment="Center"/>
+                                    VerticalAlignment="Center"
+                                    AutomationProperties.AutomationId="settings.ai.add-custom-endpoint"
+                                    AutomationProperties.Name="Add a custom endpoint"/>
                         </Grid>
                     </Border>
 
@@ -403,7 +413,9 @@
                             <TextBox Text="{Binding Id}"
                                      IsEnabled="{Binding IsIdEditable}"
                                      Watermark="myprovider"
-                                     Width="320" HorizontalAlignment="Left"/>
+                                     Width="320" HorizontalAlignment="Left"
+                                     AutomationProperties.AutomationId="settings.ai.editor.id"
+                                     AutomationProperties.Name="Id"/>
                             <!-- Immutable after creation because it is the account the credential is filed
                                  under. A URL-derived id would change with a port and the key would look
                                  rejected rather than lost. -->
@@ -413,14 +425,18 @@
                             <TextBlock Text="Display name" Classes="SettingLabel"/>
                             <TextBox Text="{Binding DisplayName}"
                                      Watermark="My provider"
-                                     Width="320" HorizontalAlignment="Left"/>
+                                     Width="320" HorizontalAlignment="Left"
+                                     AutomationProperties.AutomationId="settings.ai.editor.display-name"
+                                     AutomationProperties.Name="Display name"/>
                             <TextBlock Text="What this endpoint is called on screen. Rename it whenever you like."
                                        Classes="SettingDescription"/>
 
                             <TextBlock Text="Protocol" Classes="SettingLabel"/>
                             <ComboBox ItemsSource="{Binding Kinds}"
                                       SelectedItem="{Binding Kind}"
-                                      Width="320" HorizontalAlignment="Left">
+                                      Width="320" HorizontalAlignment="Left"
+                                      AutomationProperties.AutomationId="settings.ai.editor.protocol"
+                                      AutomationProperties.Name="Protocol">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate x:DataType="vm:AiKindChoice">
                                         <TextBlock Text="{Binding Display}"/>
@@ -433,7 +449,9 @@
                             <TextBlock Text="Endpoint address" Classes="SettingLabel"/>
                             <TextBox Text="{Binding BaseUrl}"
                                      Watermark="https://api.myprovider.com/v1"
-                                     Width="480" HorizontalAlignment="Left"/>
+                                     Width="480" HorizontalAlignment="Left"
+                                     AutomationProperties.AutomationId="settings.ai.editor.endpoint-address"
+                                     AutomationProperties.Name="Endpoint address"/>
                             <TextBlock Text="Required. For an OpenAI-compatible endpoint this is what selects the provider."
                                        Classes="SettingDescription"/>
 
@@ -466,7 +484,8 @@
                             </ItemsControl>
                             <Button Content="+ Add header" Classes="Link"
                                     Command="{Binding AddHeaderCommand}"
-                                    HorizontalAlignment="Left"/>
+                                    HorizontalAlignment="Left"
+                                    AutomationProperties.AutomationId="settings.ai.editor.add-header"/>
                             <TextBlock Text="For endpoints that authenticate with something other than a bearer key — a gateway token, or a provider's own key header. Mark such a value Secret: it then goes to the system keychain, and only the header's name is written to the settings file."
                                        Classes="SettingDescription" Margin="0,6,0,15"/>
                             <!-- Where there is nowhere to store a secret the checkbox is disabled, so the
@@ -508,11 +527,14 @@
                                          IsEnabled="{Binding CanStoreKeys}"
                                          Watermark="Paste a key"
                                          Width="320"
-                                         Loaded="OnApiKeyBoxLoaded"/>
+                                         Loaded="OnApiKeyBoxLoaded"
+                                         AutomationProperties.AutomationId="settings.ai.editor.api-key"
+                                         AutomationProperties.Name="API key"/>
                                 <Button Content="Remove stored key" Classes="Link"
                                         IsVisible="{Binding HasStoredKey}"
                                         Command="{Binding RemoveKeyCommand}"
-                                        VerticalAlignment="Center"/>
+                                        VerticalAlignment="Center"
+                                        AutomationProperties.AutomationId="settings.ai.editor.remove-key"/>
                             </StackPanel>
                             <TextBlock Text="{Binding KeyStatus}" Classes="SettingDescription" Margin="0,4,0,0"/>
                             <TextBlock Text="{Binding KeyUnavailable}"
@@ -545,7 +567,8 @@
                         </ItemsControl>
                         <Button Content="+ Add model" Classes="Link"
                                 Command="{Binding AddModelCommand}"
-                                HorizontalAlignment="Left"/>
+                                HorizontalAlignment="Left"
+                                AutomationProperties.AutomationId="settings.ai.editor.add-model"/>
                         <TextBlock Text="{Binding ModelsHint}"
                                    Classes="SettingDescription" Margin="0,6,0,0"/>
                         <TextBlock Text="The id goes on the wire, exactly as the provider spells it. The display name is yours, and is what the model picker shows."
@@ -592,8 +615,10 @@
                                  key box taking focus above: paste, Enter, done, no mouse. A single-line
                                  TextBox does not handle Enter itself, so it reaches the default button. -->
                             <Button Content="{Binding SaveText}" Command="{Binding SaveCommand}"
-                                    IsDefault="True"/>
-                            <Button Content="Cancel" Classes="Link" Command="{Binding CancelCommand}"/>
+                                    IsDefault="True"
+                                    AutomationProperties.AutomationId="settings.ai.editor.save"/>
+                            <Button Content="Cancel" Classes="Link" Command="{Binding CancelCommand}"
+                                    AutomationProperties.AutomationId="settings.ai.editor.cancel"/>
                         </StackPanel>
                     </StackPanel>
                 </DataTemplate>

--- a/src/CST.Avalonia/Views/BookDisplayView.axaml
+++ b/src/CST.Avalonia/Views/BookDisplayView.axaml
@@ -65,7 +65,9 @@
                           MinWidth="120"
                           Margin="5"
                           VerticalAlignment="Center"
-                          ToolTip.Tip="Script for displaying Pali text">
+                          ToolTip.Tip="Script for displaying Pali text"
+                          AutomationProperties.AutomationId="book.script"
+                          AutomationProperties.Name="Script">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding}"/>
@@ -85,7 +87,9 @@
                           Margin="5"
                           VerticalAlignment="Center"
                           IsVisible="{Binding HasChapters}"
-                          ToolTip.Tip="Navigate to chapter">
+                          ToolTip.Tip="Navigate to chapter"
+                          AutomationProperties.AutomationId="book.chapter"
+                          AutomationProperties.Name="Chapter">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding}"
@@ -100,10 +104,14 @@
                 <!-- Search Navigation (visible when search terms present) -->
                 <StackPanel Orientation="Horizontal" Margin="5" VerticalAlignment="Center"
                             IsVisible="{Binding HasSearchHighlights}">
-                    <Button Command="{Binding FirstHitCommand}" ToolTip.Tip="First search result" Margin="2">
+                    <Button Command="{Binding FirstHitCommand}" ToolTip.Tip="First search result" Margin="2"
+                            AutomationProperties.AutomationId="book.hit.first"
+                            AutomationProperties.Name="First search result">
                         <Image Source="avares://CST.Avalonia/Assets/Images/ArrowFirst.png" Width="16" Height="16"/>
                     </Button>
-                    <Button Command="{Binding PreviousHitCommand}" ToolTip.Tip="Previous search result" Margin="2">
+                    <Button Command="{Binding PreviousHitCommand}" ToolTip.Tip="Previous search result" Margin="2"
+                            AutomationProperties.AutomationId="book.hit.previous"
+                            AutomationProperties.Name="Previous search result">
                         <Image Source="avares://CST.Avalonia/Assets/Images/ArrowPrevious.png" Width="16" Height="16"/>
                     </Button>
                     <!-- MinWidth is set in code-behind (UpdateHitCounterWidth) by MEASURING the widest
@@ -113,18 +121,24 @@
                          would shrink the WebView viewport and scroll the target hit out of view). We
                          measure rather than estimate px so a tuned window width can't tip into a wrap. (#196) -->
                     <TextBlock x:Name="HitCounterText" Text="{Binding HitStatusText}"
-                               VerticalAlignment="Center" Margin="5,0" TextAlignment="Center"/>
-                    <Button Command="{Binding NextHitCommand}" ToolTip.Tip="Next search result" Margin="2">
+                               VerticalAlignment="Center" Margin="5,0" TextAlignment="Center"
+                               AutomationProperties.AutomationId="book.hit.counter"/>
+                    <Button Command="{Binding NextHitCommand}" ToolTip.Tip="Next search result" Margin="2"
+                            AutomationProperties.AutomationId="book.hit.next"
+                            AutomationProperties.Name="Next search result">
                         <Image Source="avares://CST.Avalonia/Assets/Images/ArrowNext.png" Width="16" Height="16"/>
                     </Button>
-                    <Button Command="{Binding LastHitCommand}" ToolTip.Tip="Last search result" Margin="2">
+                    <Button Command="{Binding LastHitCommand}" ToolTip.Tip="Last search result" Margin="2"
+                            AutomationProperties.AutomationId="book.hit.last"
+                            AutomationProperties.Name="Last search result">
                         <Image Source="avares://CST.Avalonia/Assets/Images/ArrowLast.png" Width="16" Height="16"/>
                     </Button>
                     <!-- #224: highlight on/off — lives with the hit-nav cluster, so it only appears when the
                          book was opened from search (CST4 hides Show Search Terms when totalHits == 0). -->
                     <ToggleButton IsChecked="{Binding ShowSearchTerms}"
                                   ToolTip.Tip="Highlight search terms"
-                                  Margin="6,2,2,2" VerticalAlignment="Center">
+                                  Margin="6,2,2,2" VerticalAlignment="Center"
+                                  AutomationProperties.AutomationId="book.highlight">
                         <TextBlock Text="Highlight"/>
                     </ToggleButton>
                 </StackPanel>
@@ -134,17 +148,20 @@
                             IsVisible="{Binding HasLinkedBooks}">
                     <Button Command="{Binding OpenMulaCommand}"
                             IsEnabled="{Binding HasMula}"
-                            ToolTip.Tip="Open root text" Margin="2">
+                            ToolTip.Tip="Open root text" Margin="2"
+                            AutomationProperties.AutomationId="book.open-mula">
                         <TextBlock Text="Mula"/>
                     </Button>
                     <Button Command="{Binding OpenAtthakathaCommand}"
                             IsEnabled="{Binding HasAtthakatha}"
-                            ToolTip.Tip="Open commentary" Margin="2">
+                            ToolTip.Tip="Open commentary" Margin="2"
+                            AutomationProperties.AutomationId="book.open-atthakatha">
                         <TextBlock Text="Aṭṭha"/>
                     </Button>
                     <Button Command="{Binding OpenTikaCommand}"
                             IsEnabled="{Binding HasTika}"
-                            ToolTip.Tip="Open sub-commentary" Margin="2">
+                            ToolTip.Tip="Open sub-commentary" Margin="2"
+                            AutomationProperties.AutomationId="book.open-tika">
                         <TextBlock Text="Ṭīkā"/>
                     </Button>
                 </StackPanel>
@@ -153,13 +170,15 @@
                 <StackPanel Orientation="Horizontal" Margin="5" VerticalAlignment="Center">
                     <ToggleButton IsChecked="{Binding ShowFootnotes}"
                                   ToolTip.Tip="Show footnotes (variant readings)"
-                                  Margin="2" VerticalAlignment="Center">
+                                  Margin="2" VerticalAlignment="Center"
+                                  AutomationProperties.AutomationId="book.footnotes">
                         <TextBlock Text="Footnotes"/>
                     </ToggleButton>
                 </StackPanel>
 
                 <!-- View Source PDF buttons: one per source the book actually has (1957 / 2010 / PDF). -->
-                <ItemsControl ItemsSource="{Binding AvailableSources}" Margin="5" VerticalAlignment="Center">
+                <ItemsControl ItemsSource="{Binding AvailableSources}" Margin="5" VerticalAlignment="Center"
+                              AutomationProperties.AutomationId="book.sources">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
                             <StackPanel Orientation="Horizontal"/>
@@ -190,7 +209,9 @@
                 <StackPanel Orientation="Horizontal" Margin="5" VerticalAlignment="Center">
                     <Button x:Name="bookInfoButton"
                             Margin="2" Padding="9,2" MinWidth="0"
-                            ToolTip.Tip="Book information (source file, collection, type)">
+                            ToolTip.Tip="Book information (source file, collection, type)"
+                            AutomationProperties.AutomationId="book.info"
+                            AutomationProperties.Name="Book information">
                         <TextBlock Text="i" FontWeight="Bold"/>
                         <Button.Flyout>
                             <Flyout Placement="BottomEdgeAlignedLeft">
@@ -214,7 +235,9 @@
                                         <SelectableTextBlock Text="{Binding XmlFileName}" FontFamily="{DynamicResource ContentControlThemeFontFamily}"/>
                                         <Button x:Name="copyXmlFileNameButton"
                                                 Margin="10,0,0,0" Padding="6,1" MinWidth="0"
-                                                ToolTip.Tip="Copy the file name">
+                                                ToolTip.Tip="Copy the file name"
+                                                AutomationProperties.AutomationId="book.info.copy-file-name"
+                                                AutomationProperties.Name="Copy the file name">
                                             <TextBlock Text="Copy"/>
                                         </Button>
                                     </StackPanel>
@@ -253,7 +276,9 @@
                     <Button x:Name="zoomOutButton"
                             IsEnabled="{Binding CanZoomOut}"
                             Margin="2" Padding="8,2" MinWidth="0"
-                            ToolTip.Tip="Zoom out">
+                            ToolTip.Tip="Zoom out"
+                            AutomationProperties.AutomationId="book.zoom-out"
+                            AutomationProperties.Name="Zoom out">
                         <TextBlock Text="&#x2212;"/>
                     </Button>
                     <!-- Fixed width: the box holds "50%" through "300%", and letting it size to content
@@ -266,11 +291,15 @@
                              Margin="2"
                              VerticalContentAlignment="Center"
                              TextAlignment="Center"
-                             ToolTip.Tip="Book text zoom, stored per script — it applies to every open book in this script. Type a percentage, e.g. 115. Enter to apply, Escape to cancel."/>
+                             ToolTip.Tip="Book text zoom, stored per script — it applies to every open book in this script. Type a percentage, e.g. 115. Enter to apply, Escape to cancel."
+                             AutomationProperties.AutomationId="book.zoom"
+                             AutomationProperties.Name="Book text zoom"/>
                     <Button x:Name="zoomInButton"
                             IsEnabled="{Binding CanZoomIn}"
                             Margin="2" Padding="8,2" MinWidth="0"
-                            ToolTip.Tip="Zoom in">
+                            ToolTip.Tip="Zoom in"
+                            AutomationProperties.AutomationId="book.zoom-in"
+                            AutomationProperties.Name="Zoom in">
                         <TextBlock Text="+"/>
                     </Button>
                 </StackPanel>
@@ -289,13 +318,15 @@
             <!-- Page References (VRI, Myanmar, PTS, Thai, Other) -->
             <TextBlock Grid.Column="0" Text="{Binding PageReferencesText}" 
                        VerticalAlignment="Center" Margin="8,0"
-                       ToolTip.Tip="Page numbers: VRI=Vipassana Research Institute, Myanmar=Burmese edition, PTS=Pali Text Society, Thai=Thai edition, Other=Miscellaneous editions"/>
+                       ToolTip.Tip="Page numbers: VRI=Vipassana Research Institute, Myanmar=Burmese edition, PTS=Pali Text Society, Thai=Thai edition, Other=Miscellaneous editions"
+                       AutomationProperties.AutomationId="book.page-references"/>
             
             <!-- Book Info -->
             <TextBlock Grid.Column="1" Text="{Binding BookInfoText}" 
                        VerticalAlignment="Center" Margin="8,0"
                        converters:FontHelper.DynamicFontFamily="{Binding CurrentScriptFontFamily}"
-                       converters:FontHelper.DynamicFontSize="{Binding CurrentScriptFontSize}"/>
+                       converters:FontHelper.DynamicFontSize="{Binding CurrentScriptFontSize}"
+                       AutomationProperties.AutomationId="book.book-info"/>
             
             <!-- Loading Indicator -->
             <ProgressBar Grid.Column="2" IsIndeterminate="True" 
@@ -328,7 +359,9 @@
                 Padding="8,5"
                 Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
                 BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                BorderThickness="0,0,0,1">
+                BorderThickness="0,0,0,1"
+                AutomationProperties.AutomationId="book.find-bar"
+                AutomationProperties.Name="Find in page">
             <!-- Right-aligned so the controls sit near the scrollbar and the book's left margin stays
                  clean, but the Border itself stretches so the strip reads as chrome rather than a
                  floating island. -->
@@ -339,7 +372,9 @@
                                  Padding="6,2"
                                  VerticalContentAlignment="Center"
                                  Watermark="Find in page"
-                                 ToolTip.Tip="Find in this book. Enter for next, Shift+Enter for previous, Escape to close."/>
+                                 ToolTip.Tip="Find in this book. Enter for next, Shift+Enter for previous, Escape to close."
+                                 AutomationProperties.AutomationId="book.find.query"
+                                 AutomationProperties.Name="Find in page"/>
 
                         <!-- Fixed width so the bar does not resize as the count changes from "" to
                              "3 of 47" — a jittering overlay over settled text reads as a glitch. -->
@@ -348,21 +383,28 @@
                                    Margin="8,0,4,0"
                                    VerticalAlignment="Center"
                                    TextAlignment="Right"
-                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                   AutomationProperties.AutomationId="book.find.count"/>
 
                         <Button x:Name="findPrevButton"
                                 Margin="2,0,0,0" Padding="6,2" MinWidth="0"
-                                ToolTip.Tip="Previous match (Shift+Enter)">
+                                ToolTip.Tip="Previous match (Shift+Enter)"
+                                AutomationProperties.AutomationId="book.find.previous"
+                                AutomationProperties.Name="Previous match">
                             <TextBlock Text="&#x2227;"/>
                         </Button>
                         <Button x:Name="findNextButton"
                                 Margin="2,0,0,0" Padding="6,2" MinWidth="0"
-                                ToolTip.Tip="Next match (Enter)">
+                                ToolTip.Tip="Next match (Enter)"
+                                AutomationProperties.AutomationId="book.find.next"
+                                AutomationProperties.Name="Next match">
                             <TextBlock Text="&#x2228;"/>
                         </Button>
                         <Button x:Name="findCloseButton"
                                 Margin="6,0,0,0" Padding="6,2" MinWidth="0"
-                                ToolTip.Tip="Close (Escape)">
+                                ToolTip.Tip="Close (Escape)"
+                                AutomationProperties.AutomationId="book.find.close"
+                                AutomationProperties.Name="Close the find bar">
                             <TextBlock Text="&#x2715;"/>
                         </Button>
                     </StackPanel>
@@ -377,7 +419,9 @@
                            Focusable="True"
                            IsTabStop="True"
                            ZIndex="-1000"
-                           IsHitTestVisible="True"/>
+                           IsHitTestVisible="True"
+                                AutomationProperties.AutomationId="book.text"
+                                AutomationProperties.Name="Book text"/>
                 
                 <!-- Fallback Text Display -->
                 <ScrollViewer x:Name="fallbackBrowser"

--- a/src/CST.Avalonia/Views/DictionaryPanel.axaml
+++ b/src/CST.Avalonia/Views/DictionaryPanel.axaml
@@ -37,7 +37,9 @@
                      Text="{Binding SearchText}"
                      Watermark="Look up a word…"
                      HorizontalAlignment="Stretch"
-                     Margin="0,0,0,4"/>
+                     Margin="0,0,0,4"
+                     AutomationProperties.AutomationId="dictionary.search"
+                     AutomationProperties.Name="Look up a word"/>
             <!-- Hidden measurer: renders the longest DisplayName (plus room for the dropdown arrow) so the
                  Auto column stays fixed at that width regardless of which — possibly short — source is
                  selected. Opacity 0 + not hit-testable; shares the ComboBox's cell so it adds no height. -->
@@ -51,7 +53,9 @@
                       HorizontalAlignment="Stretch"
                       ItemsSource="{Binding Sources}"
                       SelectedItem="{Binding SelectedSource}"
-                      ToolTip.Tip="Dictionary source">
+                      ToolTip.Tip="Dictionary source"
+                      AutomationProperties.AutomationId="dictionary.source"
+                      AutomationProperties.Name="Dictionary source">
                 <ComboBox.ItemTemplate>
                     <DataTemplate x:DataType="dict:IDictionarySource">
                         <TextBlock Text="{Binding DisplayName}"/>
@@ -64,7 +68,9 @@
         <TextBlock Grid.Row="1" Classes="pane-label" Text="Words" Margin="8,4,8,2"/>
         <ListBox Grid.Row="2" Margin="8,0"
                  ItemsSource="{Binding Words}"
-                 SelectedItem="{Binding SelectedWord}">
+                 SelectedItem="{Binding SelectedWord}"
+                 AutomationProperties.AutomationId="dictionary.words"
+                 AutomationProperties.Name="Words">
             <ListBox.ItemTemplate>
                 <DataTemplate x:DataType="vm:DictionaryEntryViewModel">
                     <TextBlock Text="{Binding DisplayWord}"
@@ -73,9 +79,11 @@
                 </DataTemplate>
             </ListBox.ItemTemplate>
             <ListBox.Styles>
-                <Style Selector="ListBoxItem">
+                <Style Selector="ListBoxItem" x:DataType="vm:DictionaryEntryViewModel">
                     <Setter Property="Padding" Value="4,2"/>
                     <Setter Property="MinHeight" Value="0"/>
+                    <!-- #862 -->
+                    <Setter Property="AutomationProperties.Name" Value="{Binding DisplayWord}"/>
                 </Style>
             </ListBox.Styles>
         </ListBox>
@@ -94,11 +102,15 @@
                 <Button Grid.Column="1" Classes="nav"
                         Command="{Binding BackCommand}"
                         Content="◀"
-                        ToolTip.Tip="Back"/>
+                        ToolTip.Tip="Back"
+                        AutomationProperties.AutomationId="dictionary.back"
+                        AutomationProperties.Name="Back"/>
                 <Button Grid.Column="2" Classes="nav"
                         Command="{Binding ForwardCommand}"
                         Content="▶"
-                        ToolTip.Tip="Forward"/>
+                        ToolTip.Tip="Forward"
+                        AutomationProperties.AutomationId="dictionary.forward"
+                        AutomationProperties.Name="Forward"/>
             </Grid>
 
             <!-- Definition: rendered as an HTML document in a WebView (#466). The source's MeaningHtml is
@@ -108,7 +120,9 @@
                     BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     Background="{DynamicResource CardBackgroundFillColorDefaultBrush}">
-                <wv:WebView x:Name="MeaningWebView"/>
+                <wv:WebView x:Name="MeaningWebView"
+                            AutomationProperties.AutomationId="dictionary.meaning"
+                            AutomationProperties.Name="Meaning"/>
             </Border>
 
             <!-- Per-source attribution (from the source's recorded citation; hidden when blank). -->

--- a/src/CST.Avalonia/Views/GoToDialog.axaml
+++ b/src/CST.Avalonia/Views/GoToDialog.axaml
@@ -41,37 +41,43 @@
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=Paragraph}"
                          IsEnabled="{Binding IsParagraphAvailable}"
                          GroupName="NavType"
-                         Click="OnNavTypeClick"/>
+                         Click="OnNavTypeClick"
+                         AutomationProperties.AutomationId="goto.type.paragraph"/>
 
             <RadioButton Content="VRI Page"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=VriPage}"
                          IsEnabled="{Binding IsVriPageAvailable}"
                          GroupName="NavType"
-                         Click="OnNavTypeClick"/>
+                         Click="OnNavTypeClick"
+                         AutomationProperties.AutomationId="goto.type.vri-page"/>
 
             <RadioButton Content="Myanmar Page"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=MyanmarPage}"
                          IsEnabled="{Binding IsMyanmarPageAvailable}"
                          GroupName="NavType"
-                         Click="OnNavTypeClick"/>
+                         Click="OnNavTypeClick"
+                         AutomationProperties.AutomationId="goto.type.myanmar-page"/>
 
             <RadioButton Content="PTS Page"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=PtsPage}"
                          IsEnabled="{Binding IsPtsPageAvailable}"
                          GroupName="NavType"
-                         Click="OnNavTypeClick"/>
+                         Click="OnNavTypeClick"
+                         AutomationProperties.AutomationId="goto.type.pts-page"/>
 
             <RadioButton Content="Thai Page"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=ThaiPage}"
                          IsEnabled="{Binding IsThaiPageAvailable}"
                          GroupName="NavType"
-                         Click="OnNavTypeClick"/>
+                         Click="OnNavTypeClick"
+                         AutomationProperties.AutomationId="goto.type.thai-page"/>
 
             <RadioButton Content="Other Page"
                          IsChecked="{Binding SelectedType, Converter={x:Static converters:EnumEqualityConverter.Instance}, ConverterParameter=OtherPage}"
                          IsEnabled="{Binding IsOtherPageAvailable}"
                          GroupName="NavType"
-                         Click="OnNavTypeClick"/>
+                         Click="OnNavTypeClick"
+                         AutomationProperties.AutomationId="goto.type.other-page"/>
         </StackPanel>
 
         <!-- Right Column: Number input and buttons -->
@@ -84,7 +90,9 @@
                          Height="32"
                          FontSize="14"
                          HorizontalAlignment="Left"
-                         x:Name="NumberTextBox"/>
+                         x:Name="NumberTextBox"
+                         AutomationProperties.AutomationId="goto.number"
+                         AutomationProperties.Name="Number"/>
             </StackPanel>
 
             <!-- OK Button -->
@@ -94,7 +102,8 @@
                     Height="36"
                     HorizontalContentAlignment="Center"
                     IsDefault="True"
-                    x:Name="OkButton"/>
+                    x:Name="OkButton"
+                    AutomationProperties.AutomationId="goto.ok"/>
 
             <!-- Cancel Button -->
             <Button Content="Cancel"
@@ -102,7 +111,8 @@
                     Width="160"
                     Height="36"
                     HorizontalContentAlignment="Center"
-                    IsCancel="True"/>
+                    IsCancel="True"
+                    AutomationProperties.AutomationId="goto.cancel"/>
         </StackPanel>
 
     </Grid>

--- a/src/CST.Avalonia/Views/OpenBookPanel.axaml
+++ b/src/CST.Avalonia/Views/OpenBookPanel.axaml
@@ -42,12 +42,17 @@
                                   SelectedItem="{Binding SelectedNode}"
                                   AutoScrollToSelectedItem="False"
                                   Background="{DynamicResource SolidBackgroundFillColorBaseBrush}"
-                                  DoubleTapped="TreeView_DoubleTapped">
+                                  DoubleTapped="TreeView_DoubleTapped"
+                                  AutomationProperties.AutomationId="books.tree"
+                                  AutomationProperties.Name="Book tree">
                             <TreeView.Styles>
                                 <!-- Style for TreeViewItem -->
                                 <Style Selector="TreeViewItem" x:DataType="vm:BookTreeNode">
                                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
                                     <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}"/>
+                                    <!-- #862: a TreeViewItem has no text of its own, so without this every node
+                                         reports its accessible name as the view-model type name. -->
+                                    <Setter Property="AutomationProperties.Name" Value="{Binding DisplayName}"/>
                                     <Setter Property="Background" Value="Transparent"/>
                                 </Style>
                                 <!-- #646: the selected book is visible again. It used to be painted away —

--- a/src/CST.Avalonia/Views/PdfDisplayView.axaml
+++ b/src/CST.Avalonia/Views/PdfDisplayView.axaml
@@ -24,7 +24,8 @@
 
             <!-- Status Text -->
             <TextBlock Grid.Column="0" Text="{Binding StatusText}"
-                       VerticalAlignment="Center" Margin="8,0"/>
+                       VerticalAlignment="Center" Margin="8,0"
+                       AutomationProperties.AutomationId="pdf.status"/>
 
             <!-- Loading Indicator -->
             <ProgressBar Grid.Column="1" IsIndeterminate="True"
@@ -41,7 +42,9 @@
                            Focusable="True"
                            IsTabStop="True"
                            ZIndex="-1000"
-                           IsHitTestVisible="True"/>
+                           IsHitTestVisible="True"
+                                AutomationProperties.AutomationId="pdf.page"
+                                AutomationProperties.Name="Source PDF"/>
 
                 <!-- Fallback when WebView not available -->
                 <ScrollViewer x:Name="fallbackDisplay"

--- a/src/CST.Avalonia/Views/SearchPanel.axaml
+++ b/src/CST.Avalonia/Views/SearchPanel.axaml
@@ -49,6 +49,16 @@
       <Setter Property="FontSize" Value="12"/>
     </Style>
     
+    <!-- #862: the clickable part of an Expander is the ToggleButton in its template, and its
+         accessible name comes from its Content - the Expander's Header. Where that Header is a
+         layout element rather than text (here a Grid carrying the label, the filter summary and
+         the book count) the name is the panel's TYPE NAME, "Avalonia.Controls.Grid". A name on
+         the Expander itself does not reach the button, so it is set on the button through the
+         template. -->
+    <Style Selector="Expander#FilterExpander /template/ ToggleButton">
+      <Setter Property="AutomationProperties.Name" Value="Include text types"/>
+    </Style>
+
     <!-- Alternating row colors for better readability -->
     <Style Selector="ListBoxItem:nth-child(2n)">
       <Setter Property="Background" Value="{DynamicResource SubtleFillColorTransparentBrush}"/>
@@ -90,7 +100,9 @@
                    Text="{Binding SearchText}"
                    Watermark="Enter search terms..."
                    BorderThickness="0"
-                   Background="Transparent">
+                   Background="Transparent"
+                   AutomationProperties.AutomationId="search.terms"
+                   AutomationProperties.Name="Search terms">
             <TextBox.KeyBindings>
               <KeyBinding Gesture="Enter" Command="{Binding SearchCommand}"/>
               <KeyBinding Gesture="Escape" Command="{Binding ClearCommand}"/>
@@ -116,7 +128,9 @@
                       BorderThickness="0"
                       Padding="4"
                       CornerRadius="3"
-                      VerticalAlignment="Center">
+                      VerticalAlignment="Center"
+                      AutomationProperties.AutomationId="search.clear"
+                      AutomationProperties.Name="Clear the search">
                 <Button.IsVisible>
                   <MultiBinding Converter="{x:Static BoolConverters.And}">
                     <Binding Path="!IsSearching"/>
@@ -146,7 +160,9 @@
                   ItemsSource="{Binding SearchModes}"
                   SelectedItem="{Binding SelectedSearchMode}"
                   FontSize="12"
-                  Margin="0,4,0,8">
+                  Margin="0,4,0,8"
+                  AutomationProperties.AutomationId="search.mode"
+                  AutomationProperties.Name="Search mode">
           <ComboBox.ItemTemplate>
             <DataTemplate>
               <TextBlock Text="{Binding DisplayName}"/>
@@ -171,7 +187,9 @@
                    Value="{Binding ProximityDistance}"
                    TickFrequency="5"
                    TickPlacement="BottomRight"
-                   VerticalAlignment="Center"/>
+                   VerticalAlignment="Center"
+                    AutomationProperties.AutomationId="search.word-distance"
+                    AutomationProperties.Name="Word distance"/>
             <TextBlock Grid.Column="2"
                       Text="{Binding ProximityDistance}"
                       VerticalAlignment="Center"
@@ -209,7 +227,9 @@
         </Border>
 
         <!-- Book Type Filters -->
-        <Expander Name="FilterExpander" IsExpanded="{Binding IsTextTypesExpanded}" Margin="0,4,0,0">
+        <Expander Name="FilterExpander" IsExpanded="{Binding IsTextTypesExpanded}" Margin="0,4,0,0"
+                  AutomationProperties.AutomationId="search.text-types"
+                  AutomationProperties.Name="Include text types">
           <Expander.Header>
             <Grid ColumnDefinitions="Auto,*,Auto">
               <TextBlock Grid.Column="0" Text="Include Text Types" FontWeight="Medium" FontSize="12"/>
@@ -231,37 +251,46 @@
                       Content="Select All"
                       FontSize="12"
                       Padding="8,4"
-                      Margin="0,0,4,0"/>
+                      Margin="0,0,4,0"
+                      AutomationProperties.AutomationId="search.filters.select-all"/>
               <Button Command="{Binding SelectNoneFiltersCommand}"
                       Content="Select None"
                       FontSize="12"
-                      Padding="8,4"/>
+                      Padding="8,4"
+                      AutomationProperties.AutomationId="search.filters.select-none"/>
             </StackPanel>
             <!-- Pitaka Filters -->
             <TextBlock Text="Pitaka:" FontWeight="Medium" FontSize="12" Margin="0,0,0,4"/>
             <WrapPanel Margin="0,0,0,8">
               <CheckBox Classes="filter-checkbox" Content="Vinaya" 
-                       IsChecked="{Binding IncludeVinaya}"/>
+                       IsChecked="{Binding IncludeVinaya}"
+                        AutomationProperties.AutomationId="search.filter.vinaya"/>
               <CheckBox Classes="filter-checkbox" Content="Sutta" 
-                       IsChecked="{Binding IncludeSutta}"/>
+                       IsChecked="{Binding IncludeSutta}"
+                        AutomationProperties.AutomationId="search.filter.sutta"/>
               <CheckBox Classes="filter-checkbox" Content="Abhidhamma" 
-                       IsChecked="{Binding IncludeAbhidhamma}"/>
+                       IsChecked="{Binding IncludeAbhidhamma}"
+                        AutomationProperties.AutomationId="search.filter.abhidhamma"/>
             </WrapPanel>
             
             <!-- Commentary Level Filters -->
             <TextBlock Text="Commentary Level:" FontWeight="Medium" FontSize="12" Margin="0,4,0,4"/>
             <WrapPanel Margin="0,0,0,8">
               <CheckBox Classes="filter-checkbox" Content="Mūla" 
-                       IsChecked="{Binding IncludeMula}"/>
+                       IsChecked="{Binding IncludeMula}"
+                        AutomationProperties.AutomationId="search.filter.mula"/>
               <CheckBox Classes="filter-checkbox" Content="Aṭṭhakathā" 
-                       IsChecked="{Binding IncludeAttha}"/>
+                       IsChecked="{Binding IncludeAttha}"
+                        AutomationProperties.AutomationId="search.filter.atthakatha"/>
               <CheckBox Classes="filter-checkbox" Content="Ṭīkā" 
-                       IsChecked="{Binding IncludeTika}"/>
+                       IsChecked="{Binding IncludeTika}"
+                        AutomationProperties.AutomationId="search.filter.tika"/>
             </WrapPanel>
             
             <!-- Other Texts -->
             <CheckBox Classes="filter-checkbox" Content="Other Texts" 
-                     IsChecked="{Binding IncludeOther}"/>
+                     IsChecked="{Binding IncludeOther}"
+                      AutomationProperties.AutomationId="search.filter.other"/>
           </StackPanel>
         </Expander>
       </StackPanel>
@@ -281,7 +310,9 @@
                    ItemsSource="{Binding Terms}"
                    SelectionMode="Multiple"
                    Background="Transparent"
-                   BorderThickness="0">
+                   BorderThickness="0"
+                   AutomationProperties.AutomationId="search.matching-terms"
+                   AutomationProperties.Name="Matching terms">
             <ListBox.ItemTemplate>
               <DataTemplate x:DataType="vm:MatchingTermViewModel">
                 <Grid ColumnDefinitions="*,Auto" MinHeight="24" Margin="0,0,14,0">
@@ -312,9 +343,11 @@
             
             <!-- Compact item styling to match Books list -->
             <ListBox.Styles>
-              <Style Selector="ListBoxItem">
+              <Style Selector="ListBoxItem" x:DataType="vm:MatchingTermViewModel">
                 <Setter Property="Padding" Value="4"/>
                 <Setter Property="MinHeight" Value="0"/>
+                <!-- #862 -->
+                <Setter Property="AutomationProperties.Name" Value="{Binding DisplayTerm}"/>
               </Style>
             </ListBox.Styles>
           </ListBox>
@@ -338,7 +371,9 @@
                    Background="Transparent"
                    BorderThickness="0"
                    FontFamily="{Binding CurrentScriptFontFamily}"
-                   FontSize="{Binding CurrentScriptFontSize}">
+                   FontSize="{Binding CurrentScriptFontSize}"
+                   AutomationProperties.AutomationId="search.books"
+                   AutomationProperties.Name="Books">
             <ListBox.ItemTemplate>
               <DataTemplate x:DataType="vm:BookOccurrenceViewModel">
                 <Grid ColumnDefinitions="*,Auto" MinHeight="24" Margin="0,0,14,0">
@@ -369,9 +404,11 @@
             
             <!-- Double-click to open book -->
             <ListBox.Styles>
-              <Style Selector="ListBoxItem">
+              <Style Selector="ListBoxItem" x:DataType="vm:BookOccurrenceViewModel">
                 <Setter Property="Padding" Value="4"/>
                 <Setter Property="MinHeight" Value="0"/>
+                <!-- #862 -->
+                <Setter Property="AutomationProperties.Name" Value="{Binding DisplayName}"/>
               </Style>
             </ListBox.Styles>
           </ListBox>

--- a/src/CST.Avalonia/Views/SettingsWindow.axaml
+++ b/src/CST.Avalonia/Views/SettingsWindow.axaml
@@ -82,6 +82,8 @@
             <!-- Category List -->
             <Border Grid.Column="0" Background="{DynamicResource LayerFillColorDefaultBrush}" BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="0,0,1,0">
                 <ListBox ItemsSource="{Binding Categories}"
+                         AutomationProperties.AutomationId="settings.categories"
+                         AutomationProperties.Name="Settings categories"
                          SelectedItem="{Binding SelectedCategory}"
                          Background="Transparent"
                          BorderThickness="0">
@@ -99,6 +101,12 @@
                              not exist in any loaded theme until #955 defined it, so the setter set nothing. Re-pointed at the SAME fixed Dock accent the book/tool tabs and the
                              Highlight/Footnotes toggles use, so "selected" reads identically everywhere
                              whatever the OS accent colour is. (#270 established this convention.) -->
+                        <!-- #862: without this a row reports its accessible name as the container's
+                             Content.ToString() - the view-model type name - because a ListBoxItem has
+                             no visible text of its own. -->
+                        <Style Selector="ListBoxItem" x:DataType="vm:SettingsCategoryViewModel">
+                            <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
+                        </Style>
                         <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
                             <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
                         </Style>
@@ -141,10 +149,14 @@
                                         <DockPanel>
                                             <Button Content="Browse..." 
                                                    Command="{Binding BrowseCommand}"
+                                                   AutomationProperties.AutomationId="settings.general.browse-xml"
+                                                   AutomationProperties.Name="Browse for the XML books directory"
                                                    DockPanel.Dock="Right" 
                                                    Margin="5,0,0,0"
                                                    Width="80"/>
                                             <TextBox Text="{Binding XmlBooksDirectory}" 
+                                                     AutomationProperties.AutomationId="settings.general.xml-directory"
+                                                     AutomationProperties.Name="XML books directory"
                                                     IsReadOnly="True"/>
                                         </DockPanel>
                                         <TextBlock Text="Location of the Tipitaka XML book files" 
@@ -155,10 +167,14 @@
                                             <DockPanel>
                                                 <Button Content="Browse..." 
                                                        Command="{Binding BrowseIndexCommand}"
+                                                       AutomationProperties.AutomationId="settings.general.browse-index"
+                                                       AutomationProperties.Name="Browse for the index directory"
                                                        DockPanel.Dock="Right" 
                                                        Margin="5,0,0,0"
                                                        Width="80"/>
                                                 <TextBox Text="{Binding IndexDirectory}" 
+                                                         AutomationProperties.AutomationId="settings.general.index-directory"
+                                                         AutomationProperties.Name="Index directory"
                                                         Watermark="Default location will be used if empty"/>
                                             </DockPanel>
                                             <TextBlock Text="Location where search index files are stored" 
@@ -196,6 +212,8 @@
                                                  keeps it usable if the right-hand panel ever shrinks. -->
                                             <ListBox Grid.Column="0"
                                                     ItemsSource="{Binding ScriptFontSettings}"
+                                                    AutomationProperties.AutomationId="settings.appearance.scripts"
+                                                    AutomationProperties.Name="Pali scripts"
                                                     SelectedItem="{Binding SelectedScript}"
                                                     MinHeight="200"
                                                     VerticalAlignment="Stretch">
@@ -209,9 +227,11 @@
                                                      ~3 lines tall. Trimmed so all fourteen fit without
                                                      scrolling at the default dialog size. -->
                                                 <ListBox.Styles>
-                                                    <Style Selector="ListBoxItem">
+                                                    <Style Selector="ListBoxItem" x:DataType="vm:ScriptFontSettingViewModel">
                                                         <Setter Property="Padding" Value="10,4"/>
                                                         <Setter Property="MinHeight" Value="0"/>
+                                                        <!-- #862: as for the category list above. -->
+                                                        <Setter Property="AutomationProperties.Name" Value="{Binding ScriptName}"/>
                                                     </Style>
                                                 </ListBox.Styles>
                                             </ListBox>
@@ -249,6 +269,8 @@
                                                                      VerticalAlignment="Center" Margin="10,0,0,0"
                                                                      DockPanel.Dock="Right"/>
                                                         <ComboBox ItemsSource="{Binding SelectedScript.AvailableFonts}"
+                                                                  AutomationProperties.AutomationId="settings.appearance.ui-font"
+                                                                  AutomationProperties.Name="Pali UI font"
                                                                   SelectedItem="{Binding SelectedScript.SelectedFontFamily}"
                                                                   IsEnabled="{Binding !SelectedScript.IsLoadingFonts}"
                                                                   HorizontalAlignment="Stretch"/>
@@ -268,6 +290,8 @@
                                                               VerticalAlignment="Center" Margin="0,0,10,0"/>
                                                     <NumericUpDown Grid.Row="1" Grid.Column="1" 
                                                                   Value="{Binding SelectedScript.FontSize}"
+                                                                  AutomationProperties.AutomationId="settings.appearance.ui-font-size"
+                                                                  AutomationProperties.Name="Pali UI font size"
                                                                   Minimum="8" Maximum="32" Increment="1"
                                                                   Width="120" HorizontalAlignment="Left"
                                                                   Margin="0,0,0,10"/>
@@ -316,6 +340,8 @@
                                                               VerticalAlignment="Center" Margin="0,0,10,0"/>
                                                     <ComboBox Grid.Row="0" Grid.Column="1"
                                                               ItemsSource="{Binding SelectedScript.AvailableBookFonts}"
+                                                              AutomationProperties.AutomationId="settings.appearance.book-font"
+                                                              AutomationProperties.Name="Pali book font"
                                                               SelectedItem="{Binding SelectedScript.SelectedBookFontFamily}"
                                                               IsEnabled="{Binding !SelectedScript.IsLoadingFonts}"
                                                               HorizontalAlignment="Stretch"
@@ -344,6 +370,7 @@
                                         <TextBlock Text="Hardware acceleration for the reader view. If book pages occasionally go blank until you click or select text (seen with some GPUs and in virtual machines), turn this off to use software rendering."
                                                   Classes="SettingDescription" TextWrapping="Wrap"/>
                                         <CheckBox IsChecked="{Binding UseHardwareAcceleration}"
+                                                  AutomationProperties.AutomationId="settings.configuration.hardware-acceleration"
                                                  Content="Use hardware acceleration (requires restart)"
                                                  Margin="0,10,0,0"/>
                                     </StackPanel>
@@ -358,10 +385,13 @@
                                         <StackPanel Orientation="Horizontal" Margin="0,10,0,0" Spacing="10">
                                             <TextBlock Text="Books to remember:" VerticalAlignment="Center"/>
                                             <NumericUpDown Value="{Binding MaxRecentBooks}"
+                                                           AutomationProperties.AutomationId="settings.configuration.recent-books-count"
+                                                           AutomationProperties.Name="Books to remember"
                                                           Minimum="0" Maximum="50" Increment="1"
                                                           FormatString="0" Width="120"/>
                                             <Button Content="Clear List"
                                                    Command="{Binding ClearRecentBooksCommand}"
+                                                   AutomationProperties.AutomationId="settings.configuration.clear-recent-books"
                                                    VerticalAlignment="Center"
                                                    ToolTip.Tip="Empty the recent-books list now"/>
                                         </StackPanel>
@@ -383,6 +413,7 @@
 
                                         <Button Content="Open Settings Folder"
                                                Command="{Binding OpenSettingsFileCommand}"
+                                               AutomationProperties.AutomationId="settings.configuration.open-settings-folder"
                                                Margin="0,10,0,0"
                                                HorizontalAlignment="Left"/>
                                     </StackPanel>
@@ -400,6 +431,7 @@
                                                   Classes="SettingDescription"/>
                                         
                                         <CheckBox IsChecked="{Binding EnableAutomaticUpdates}" 
+                                                  AutomationProperties.AutomationId="settings.xml-updates.enabled"
                                                  Content="Enable automatic updates" 
                                                  Margin="0,10,0,15"/>
                                         
@@ -408,6 +440,8 @@
                                                       VerticalAlignment="Center" Margin="0,0,10,10"/>
                                             <TextBox Grid.Row="0" Grid.Column="1"
                                                     Text="{Binding XmlRepositoryOwner}"
+                                                    AutomationProperties.AutomationId="settings.xml-updates.repository-owner"
+                                                    AutomationProperties.Name="Repository owner"
                                                     Watermark="e.g., VipassanaTech"
                                                     Margin="0,0,0,10"/>
 
@@ -415,6 +449,8 @@
                                                       VerticalAlignment="Center" Margin="0,0,10,10"/>
                                             <TextBox Grid.Row="1" Grid.Column="1"
                                                     Text="{Binding XmlRepositoryName}"
+                                                    AutomationProperties.AutomationId="settings.xml-updates.repository-name"
+                                                    AutomationProperties.Name="Repository name"
                                                     Watermark="e.g., tipitaka-xml"
                                                     Margin="0,0,0,10"/>
 
@@ -422,6 +458,8 @@
                                                       VerticalAlignment="Center" Margin="0,0,10,10"/>
                                             <TextBox Grid.Row="2" Grid.Column="1"
                                                     Text="{Binding XmlRepositoryPath}"
+                                                    AutomationProperties.AutomationId="settings.xml-updates.repository-path"
+                                                    AutomationProperties.Name="Repository path"
                                                     Watermark="e.g., deva master (leave empty for root)"
                                                     Margin="0,0,0,10"/>
 
@@ -429,11 +467,14 @@
                                                       VerticalAlignment="Center" Margin="0,0,10,0"/>
                                             <TextBox Grid.Row="3" Grid.Column="1"
                                                     Text="{Binding XmlRepositoryBranch}"
+                                                    AutomationProperties.AutomationId="settings.xml-updates.repository-branch"
+                                                    AutomationProperties.Name="Repository branch"
                                                     Watermark="e.g., main"/>
                                         </Grid>
 
                                         <Button Content="Restore Defaults"
                                                Command="{Binding RestoreDefaultsCommand}"
+                                               AutomationProperties.AutomationId="settings.xml-updates.restore-defaults"
                                                Margin="0,15,0,0"
                                                HorizontalAlignment="Left"
                                                ToolTip.Tip="Reset the repository fields to their known-good defaults"/>
@@ -452,6 +493,7 @@
                                                   Classes="SettingDescription"/>
 
                                         <CheckBox IsChecked="{Binding EnableAutomaticUpdates}"
+                                                  AutomationProperties.AutomationId="settings.dictionary-updates.enabled"
                                                  Content="Enable automatic updates"
                                                  Margin="0,10,0,15"/>
 
@@ -460,6 +502,8 @@
                                                       VerticalAlignment="Center" Margin="0,0,10,10"/>
                                             <TextBox Grid.Row="0" Grid.Column="1"
                                                     Text="{Binding RepositoryOwner}"
+                                                    AutomationProperties.AutomationId="settings.dictionary-updates.repository-owner"
+                                                    AutomationProperties.Name="Repository owner"
                                                     Watermark="e.g., fsnow"
                                                     Margin="0,0,0,10"/>
 
@@ -467,11 +511,14 @@
                                                       VerticalAlignment="Center" Margin="0,0,10,0"/>
                                             <TextBox Grid.Row="1" Grid.Column="1"
                                                     Text="{Binding RepositoryName}"
+                                                    AutomationProperties.AutomationId="settings.dictionary-updates.repository-name"
+                                                    AutomationProperties.Name="Repository name"
                                                     Watermark="e.g., cst-dictionaries"/>
                                         </Grid>
 
                                         <Button Content="Restore Defaults"
                                                Command="{Binding RestoreDefaultsCommand}"
+                                               AutomationProperties.AutomationId="settings.dictionary-updates.restore-defaults"
                                                Margin="0,15,0,0"
                                                HorizontalAlignment="Left"
                                                ToolTip.Tip="Reset the repository fields to their known-good defaults"/>
@@ -490,9 +537,10 @@
                                         <TextBlock Text="Choose which dictionaries appear in the dictionary panel and their order. The first enabled source is the default. Uncheck a source to hide it; use the arrows to reorder."
                                                   Classes="SettingDescription"/>
 
-                                        <ItemsControl ItemsSource="{Binding Rows}" Margin="0,10,0,0">
+                                        <ItemsControl ItemsSource="{Binding Rows}" Margin="0,10,0,0"
+                                                      AutomationProperties.AutomationId="settings.dictionary.sources">
                                             <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
+                                                <DataTemplate x:DataType="vm:DictionarySourceRowViewModel">
                                                     <Grid ColumnDefinitions="Auto,*,Auto,Auto" Margin="0,3">
                                                         <CheckBox Grid.Column="0"
                                                                  IsChecked="{Binding Enabled}"
@@ -501,11 +549,13 @@
                                                                  VerticalAlignment="Center"/>
                                                         <Button Grid.Column="2" Content="&#x25B2;"
                                                                Command="{Binding MoveUpCommand}"
+                                                               AutomationProperties.Name="{Binding DisplayName, StringFormat='Move {0} up'}"
                                                                IsEnabled="{Binding CanMoveUp}"
                                                                Padding="8,2" Margin="0,0,4,0"
                                                                ToolTip.Tip="Move up"/>
                                                         <Button Grid.Column="3" Content="&#x25BC;"
                                                                Command="{Binding MoveDownCommand}"
+                                                               AutomationProperties.Name="{Binding DisplayName, StringFormat='Move {0} down'}"
                                                                IsEnabled="{Binding CanMoveDown}"
                                                                Padding="8,2"
                                                                ToolTip.Tip="Move down"/>
@@ -528,13 +578,15 @@
                              they belong to. The master switch stays on the first tab, adjacent to what it
                              gates, rather than becoming a left-nav row of its own. -->
                         <DataTemplate DataType="vm:AiSettingsViewModel">
-                            <TabControl SelectedIndex="{Binding SelectedTab}">
-                              <TabItem Header="General">
+                            <TabControl SelectedIndex="{Binding SelectedTab}"
+                                        AutomationProperties.AutomationId="settings.ai.tabs">
+                              <TabItem Header="General" AutomationProperties.AutomationId="settings.ai.tab.general">
                                 <StackPanel Margin="0,12,0,0">
                                 <Border Classes="SettingGroup">
                                     <StackPanel>
                                         <TextBlock Text="AI Features" Classes="SettingLabel"/>
                                         <CheckBox IsChecked="{Binding AiEnabled}"
+                                                  AutomationProperties.AutomationId="settings.ai.enabled"
                                                  Content="Enable AI Features"
                                                  Margin="0,10,0,0"/>
                                         <TextBlock Text="When off, all AI features are disabled."
@@ -552,6 +604,7 @@
                                         <TextBlock Text="AI Assistant" Classes="SettingLabel"/>
 
                                         <CheckBox IsChecked="{Binding ChatEnabled}"
+                                                  AutomationProperties.AutomationId="settings.ai.assistant-enabled"
                                                  IsEnabled="{Binding SubPermissionsEnabled}"
                                                  Content="Enable the assistant"
                                                  Margin="0,10,0,0"/>
@@ -562,6 +615,8 @@
                                              is genuinely one-per-app. -->
                                         <TextBlock Text="Answer language" Classes="SettingLabel" Margin="0,14,0,0"/>
                                         <AutoCompleteBox Text="{Binding AnswerLanguage}"
+                                                         AutomationProperties.AutomationId="settings.ai.answer-language"
+                                                         AutomationProperties.Name="Answer language"
                                                         ItemsSource="{Binding AnswerLanguageSuggestions}"
                                                         IsEnabled="{Binding AssistantFieldsEnabled}"
                                                         FilterMode="StartsWith"
@@ -578,13 +633,17 @@
 
                                         <!-- REST surface (/v1): for code agents. -->
                                         <CheckBox IsChecked="{Binding LocalApiEnabled}"
+                                                  AutomationProperties.AutomationId="settings.ai.local-api-enabled"
                                                  IsEnabled="{Binding SubPermissionsEnabled}"
                                                  Content="Run the local API server (Claude Code &amp; tool-calling agents)"
                                                  Margin="0,10,0,0"/>
 
-                                        <Expander Header="Sample agent prompt" Margin="24,4,0,0">
+                                        <Expander Header="Sample agent prompt" Margin="24,4,0,0"
+                                                  AutomationProperties.AutomationId="settings.ai.sample-prompt">
                                             <StackPanel>
                                                 <TextBox Text="{Binding LocalApiSamplePrompt, Mode=OneWay}"
+                                                         AutomationProperties.AutomationId="settings.ai.sample-prompt-text"
+                                                         AutomationProperties.Name="Sample agent prompt"
                                                         IsReadOnly="True"
                                                         AcceptsReturn="True"
                                                         TextWrapping="NoWrap"
@@ -594,6 +653,7 @@
                                                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                                                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                                                     <Button Content="Copy sample prompt"
+                                                            AutomationProperties.AutomationId="settings.ai.copy-sample-prompt"
                                                             Click="OnCopySamplePrompt"
                                                             IsEnabled="{Binding SubPermissionsEnabled}"
                                                             HorizontalAlignment="Left"/>
@@ -606,6 +666,7 @@
 
                                         <!-- MCP surface (/mcp): for chat clients, reached via the app's mcp-bridge relay. #280 -->
                                         <CheckBox IsChecked="{Binding McpEnabled}"
+                                                  AutomationProperties.AutomationId="settings.ai.mcp-enabled"
                                                  IsEnabled="{Binding SubPermissionsEnabled}"
                                                  Content="Enable MCP access (Claude Desktop &amp; other chat clients)"
                                                  Margin="0,10,0,0"/>
@@ -613,9 +674,12 @@
                                         <!-- Copy sits at the bottom of the expander, matching the prompt above: the button
                                              follows the thing it copies rather than preceding a collapsed panel. Clipboard is
                                              done in code-behind since the view model has no TopLevel. -->
-                                        <Expander Header="Sample MCP configuration" Margin="24,4,0,0">
+                                        <Expander Header="Sample MCP configuration" Margin="24,4,0,0"
+                                                  AutomationProperties.AutomationId="settings.ai.sample-mcp">
                                             <StackPanel>
                                                 <TextBox Text="{Binding McpClientConfigJson, Mode=OneWay}"
+                                                         AutomationProperties.AutomationId="settings.ai.sample-mcp-text"
+                                                         AutomationProperties.Name="Sample MCP configuration"
                                                         IsReadOnly="True"
                                                         AcceptsReturn="True"
                                                         TextWrapping="NoWrap"
@@ -625,6 +689,7 @@
                                                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                                                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                                                     <Button Content="Copy MCP configuration"
+                                                            AutomationProperties.AutomationId="settings.ai.copy-mcp-config"
                                                             Click="OnCopyMcpConfig"
                                                             IsEnabled="{Binding SubPermissionsEnabled}"
                                                             HorizontalAlignment="Left"/>
@@ -638,6 +703,7 @@
                                         <!-- Cross-cutting capability: navigate/highlight is offered over BOTH surfaces, so this
                                              is enabled whenever either one is on (RemoteControlEnabled). #440 -->
                                         <CheckBox IsChecked="{Binding AllowRemoteControl}"
+                                                  AutomationProperties.AutomationId="settings.ai.allow-remote-control"
                                                  IsEnabled="{Binding RemoteControlEnabled}"
                                                  Content="Allow agents to drive the reader (navigate and highlight)"
                                                  Margin="0,10,0,0"/>
@@ -648,12 +714,14 @@
                                 </StackPanel>
                               </TabItem>
 
-                              <TabItem Header="Providers" IsVisible="{Binding ShowConnectionTabs}">
+                              <TabItem Header="Providers" IsVisible="{Binding ShowConnectionTabs}"
+                                       AutomationProperties.AutomationId="settings.ai.tab.providers">
                                 <views:AiProvidersView DataContext="{Binding Connections}"
                                                        Margin="0,12,0,0"/>
                               </TabItem>
 
-                              <TabItem Header="Models" IsVisible="{Binding ShowConnectionTabs}">
+                              <TabItem Header="Models" IsVisible="{Binding ShowConnectionTabs}"
+                                       AutomationProperties.AutomationId="settings.ai.tab.models">
                                 <views:AiModelsView DataContext="{Binding Models}"
                                                     Margin="0,12,0,0"/>
                               </TabItem>
@@ -672,6 +740,8 @@
                                         <StackPanel Margin="0,10,0,15">
                                             <TextBlock Text="Log Level" Classes="SettingLabel"/>
                                             <ComboBox ItemsSource="{Binding LogLevels}" 
+                                                      AutomationProperties.AutomationId="settings.developer.log-level"
+                                                      AutomationProperties.Name="Log level"
                                                      SelectedItem="{Binding LogLevel}"
                                                      Width="200" HorizontalAlignment="Left"/>
                                             <TextBlock Text="Controls how much detail is written to log files" 
@@ -680,6 +750,7 @@
                                         
                                         <Button Content="Open Logs Folder" 
                                                Command="{Binding OpenLogsCommand}"
+                                               AutomationProperties.AutomationId="settings.developer.open-logs-folder"
                                                Width="150" HorizontalAlignment="Left"/>
                                         <TextBlock Text="Opens the folder containing application log files" 
                                                   Classes="SettingDescription"/>

--- a/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
+++ b/src/CST.Avalonia/Views/SimpleTabbedWindow.axaml
@@ -98,7 +98,9 @@
                 <ComboBox MinWidth="120"
                           Margin="0,0,20,0"
                           x:Name="InterfaceLangCombo"
-                          SelectedIndex="0">
+                          SelectedIndex="0"
+                          AutomationProperties.AutomationId="main.interface-language"
+                          AutomationProperties.Name="Interface language">
                     <ComboBoxItem Content="English"/>
                 </ComboBox>
                 
@@ -108,7 +110,9 @@
                           Margin="0,0,5,0"/>
                 <ComboBox MinWidth="120"
                           x:Name="PaliScriptCombo"
-                          ToolTip.Tip="Default script for the Open a Book tree and new book windows">
+                          ToolTip.Tip="Default script for the Open a Book tree and new book windows"
+                          AutomationProperties.AutomationId="main.pali-script"
+                          AutomationProperties.Name="Pali script">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding}"/>
@@ -121,6 +125,7 @@
         <!-- Main DockControl -->
         <dock:DockControl x:Name="DockControl"
                           Layout="{Binding Layout}"
-                          Factory="{Binding Factory}" />
+                          Factory="{Binding Factory}"
+                          AutomationProperties.AutomationId="main.dock" />
     </DockPanel>
 </Window>


### PR DESCRIPTION
Closes #862.

## The premise, corrected

The issue attributes three `-1700` failures to Avalonia. They aren't Avalonia's. They reproduce identically against **Finder**, a fully native Cocoa app:

```
$ osascript -e 'tell application "System Events" to tell process "Finder" \
      to get every static text of entire contents of menu bar 1'
execution error: Can't make every static text of entire contents … (-1700)

$ osascript -e 'tell application "System Events" to tell process "Finder" \
      to get name of every menu bar item of menu bar 1'
Apple, Finder, File, Edit, View, Go, Window, Help
```

`SystemEvents.sdef` declares `entire contents` as a **list-returning property** (`<type type="specifier" list="yes"/>`), and AppleScript cannot apply an element specifier or a `whose` clause to a list. I verified that declaration myself in `/System/Library/CoreServices/System Events.app/Contents/Resources/SystemEvents.sdef`.

The forms that *do* work — `<class>s of <container>`, `first <class> of <container> whose name is "…"` — need **names**. So the sweep is worth doing, but not for the reason the issue gives.

Names and ids do reach macOS: `Avalonia.Native` 11.3.6's `AvnAccessibilityElement` implements `accessibilityRole`, `accessibilityTitle` and `accessibilityIdentifier` from the peer's control type, `GetName()` and `GetAutomationId()`. The strongest evidence is in the issue itself — `row CST.Avalonia.ViewModels.SettingsCategoryViewModel` is `ContentControlAutomationPeer`'s `Content?.ToString()` fallback arriving as `AXTitle`. The channel worked; there was nothing to put in it.

One caveat for anyone writing a script: `AXIdentifier` is readable per element but System Events cannot read it in bulk or filter on it (`-1728`). **From AppleScript, `Name` is what makes a control findable**; `AutomationId` is the handle a real AX-API driver keys on.

## Measured at the Avalonia layer

- `AutomationProperties.Name/AutomationId` resolve **unprefixed** — no `xmlns` needed, so the diff stays small.
- `Name` wins over content fallbacks on Button, CheckBox, ComboBox, TextBox, Slider, TabItem, Expander.
- **`Name` on a `TextBlock` is a no-op** — `TextBlockAutomationPeer.GetNameCore` returns `Owner.Text` unconditionally. TextBlocks got ids only.
- `x:Name` already acts as an `AutomationId` fallback, which is why template parts leak `PART_ContentPresenter`.

## What was named

220 attributes — 136 ids, 84 names — across 12 view files, plus `docs/development/ACCESSIBILITY_NAMING.md`.

Ids are lowercase dotted `surface.group.control` (`settings.ai.tab.providers`, `book.find.close`), treated as public API, and **name the control rather than where it sits** — nothing encodes a window or parent, so floating a pane can't turn an id into a lie. No static ids inside DataTemplates, where they would collide by construction: the container takes the id, rows take a bound Name.

Three garbage-name fallbacks were fixed at source rather than worked around:

- **Containers** (`ListBoxItem`, `TreeViewItem`) fell back to the view-model type name — literally #862's `row CST.Avalonia.ViewModels.…`. Settings categories, the script list, the book tree, dictionary words and both search lists now name rows via a style setter.
- **Buttons whose Content is a layout element** — the assistant's model and effort chips read as `Avalonia.Controls.StackPanel`.
- **An Expander with a non-text Header** gives its ToggleButton the header's type name, and a Name on the Expander does not reach it. Fixed through the template.

## Verification

- `dotnet build src/CST.Avalonia` — 0 warnings, 0 errors.
- `dotnet test src/CST.Avalonia.Tests` — **2853 passed / 0 failed / 18 skipped**, exit 0. I re-ran both myself on the pushed branch rather than taking the report's word.
- `git diff -w` is byte-identical to `git diff`: no reindentation, no rewrapping. The 111 deletions are all `/>` moving to the end of an attribute list. No element changed parents — the dock structure and both WebView-bearing views are attribute-only.
- A headless probe loads the real view files, walks the automation peers, and asserts the values arrive: 75 ids and 37 names intact, none lost or overridden.

## Not verified

- **Nothing was measured against a running CST Reader.** That names reach Avalonia's peers is measured; that macOS surfaces them to AppleScript follows from the bridge implementation but has not been observed end to end. That check needs your machine — the app was deliberately not launched, since a second instance shares `~/Library/Application Support/CSTReader` and can clobber `app-state.json` under your running session.
- `AiProvidersView` and `SimpleTabbedWindow` fail the *runtime* XAML loader on `x:DataType`/`DockControl` resolution — a loader limitation, not a defect; both compile. Those two are verified by compilation and source audit, not a peer walk.
- Windows/UIA is untested: the peer layer is shared, the bridge is not.
- One style selector here (`Expander#FilterExpander /template/ ToggleButton`) is exactly the kind that fails silently. #655's harness is the thing that would pin it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)