### PR TITLE
The window-change rescue in BookDisplayView is dead code (#419 follow-up)

### DIFF
--- a/docs/architecture/DOCK_SUBSYSTEM.md
+++ b/docs/architecture/DOCK_SUBSYSTEM.md
@@ -158,9 +158,15 @@ guard, which is better than a SIGSEGV.
   **reference equality**: a different non-null `_currentWindow` → dispose + recreate + reload; `null` →
   first attach or post-detach reattach, just track the window; same instance → ControlRecycling tab switch,
   no recreate.
-- `OnDetachedFromVisualTree` ([654](../../src/CST.Avalonia/Views/BookDisplayView.axaml.cs#L654)) — nulls
-  `_currentWindow`. Because detach nulls it, *which* path takes which branch is subtle and has been
-  iteratively patched; the funnel above is what actually guarantees safety, not this branching.
+- `OnDetachedFromVisualTree` — nulls `_currentWindow`, **unconditionally**. Avalonia detaches before it
+  attaches on every re-parent, so `_currentWindow` is **always null at attach**: of the three branches above,
+  the dispose + recreate + reload one **cannot execute**, and only "first attach / post-detach reattach" and
+  "same instance" are reachable.
+
+  This is not a subtlety to be careful around — it means the branching provides no protection at all, and
+  the funnel is not merely what *actually* guarantees safety but the only thing that does. Established by
+  reading `Visual.SetVisualParent` in Avalonia 11.3.6 during the #419 review. The dead branch is left in
+  place pending a decision on removing it; do not cite it as a safeguard.
 - **Drag-time airspace hide** (`SimpleTabbedWindow`, `DRAG_DETECTION_THRESHOLD = 150` ms): a timer watches
   `DockControl.IsDraggingDock` and, past the threshold, sets `IsVisible = false` on every WebView in every
   window, restoring shortly after the drag ends. This is a workaround for the native-WebView **airspace**

--- a/docs/architecture/DOCK_WEBVIEW_WORKAROUNDS.md
+++ b/docs/architecture/DOCK_WEBVIEW_WORKAROUNDS.md
@@ -23,11 +23,11 @@ candidate to *replace* (not re-add) in the overhaul.
 | What | Where | Works around / why |
 |---|---|---|
 | `TryCreateWebView()` / `DisposeWebView()` manual cycle | BookDisplayView ~160–215 | CEF native handle invalid after a window-context change; must dispose then recreate. |
-| Window-change detection by **reference equality** (3 branches) → dispose+recreate+reload only on real window change | BookDisplayView ~550–650 | Distinguish float/unfloat (recreate) from same-window tab switch (keep, instant). |
-| `OnDetachedFromVisualTree` nulls `_currentWindow` ("CRITICAL FIX") | BookDisplayView ~655–670 | Force window-change detection on a later ControlRecycling reattach; fixed float→unfloat→tab-switch→tab-back crash. |
+| Window-change detection by **reference equality** — the dispose+recreate branch is **DEAD** | BookDisplayView `OnAttachedToVisualTree` | Written to tell float/unfloat from a same-window tab switch. It cannot fire: the row below nulls `_currentWindow` unconditionally and Avalonia detaches before attaching, so the field is always null at attach. Left in place; **do not cite it as protection**. (#419 review) |
+| `OnDetachedFromVisualTree` nulls `_currentWindow` — was labelled "CRITICAL FIX" | BookDisplayView | The label is why the row above is dead. Whatever it fixed, it did not do so by *enabling* window-change detection — it disabled it permanently. |
 | Dispose-before-move funnel: `SplitToWindow` + the cross-dock `MoveDockable`/`SwapDockable`/`SplitToDock` overrides call `DisposeAndEvictRecycledView` before the move | CstDockFactory 2045, 1964, 1984, 1172 | No live browser ever crosses a re-parent; the framework builds a fresh one at the destination. Covers books, PDFs and the dictionary (#466). |
 | `LoadHtmlContent` writes HTML to a **temp file** + `LoadUrl(fileUrl)` instead of a data URI | BookDisplayView ~441–516 | CEF data-URI size limits — the largest books (~3.6 MB) exceed them. |
-| PDF tabs mirror the same dispose/recreate + lifecycle-op handling | PdfDisplayView ~31–177 | Same CEF reparent constraint for the PDFium WebView. |
+| PDF tabs float through the funnel and carry the same `#458` invariant log | PdfDisplayView | Same CEF re-parent constraint for the PDFium WebView. `PdfDisplayView` rebuilds nothing itself — the factory disposes and evicts, and the destination builds a fresh view. (#419) |
 
 ## B. ControlRecycling-specific
 

--- a/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/CstDockFactoryTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using CST.Avalonia.Services;
+using CST.Avalonia.ViewModels;
 using Dock.Model.Core;
 using Dock.Model.Mvvm.Controls;
 using Xunit;
@@ -304,6 +305,39 @@ public class CstDockFactoryTests
     public void Null_is_not_a_tool()
     {
         Assert.False(CstDockFactory.IsToolDockable(null));
+    }
+
+    // ---- HostsLiveBrowser: who must be disposed before a re-parent (#419) -----------------------------
+
+    /// <summary>
+    /// The three types that carry a live CEF browser. Dropping one from this set removes it from BOTH
+    /// dispose-before-move guards at once, and nothing else in the suite would notice: the guards need a
+    /// host window and cannot run headless (#655), and a view model's CanFloat flag stays true either way.
+    /// The failure that follows is the #458 SIGSEGV on macOS, with no log line before it.
+    ///
+    /// <para>This cannot prove the guards work. It proves nobody quietly left a type out of them.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(BookDisplayViewModel))]
+    [InlineData(typeof(PdfDisplayViewModel))]
+    [InlineData(typeof(DictionaryViewModel))]
+    public void Every_browser_hosting_type_must_be_disposed_before_a_reparent(System.Type type)
+    {
+        var dockable = (IDockable)System.Runtime.Serialization.FormatterServices
+            .GetUninitializedObject(type);
+
+        Assert.True(CstDockFactory.HostsLiveBrowser(dockable),
+            $"{type.Name} hosts a CEF browser but is not in HostsLiveBrowser, so neither SplitToWindow nor " +
+            "PrepareCrossWindowMove will dispose it before a re-parent.");
+    }
+
+    /// <summary>A dockable with no browser must NOT be disposed — that would rebuild views for nothing.</summary>
+    [Fact]
+    public void A_dockable_without_a_browser_is_left_alone()
+    {
+        Assert.False(CstDockFactory.HostsLiveBrowser(new CST.Avalonia.ViewModels.Dock.ReactiveTool()));
+        Assert.False(CstDockFactory.HostsLiveBrowser(new CST.Avalonia.ViewModels.Dock.ReactiveDocument()));
+        Assert.False(CstDockFactory.HostsLiveBrowser(null));
     }
 
 }

--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -1186,6 +1186,24 @@ namespace CST.Avalonia.Services
         /// <para>Extracted so it can be tested: the guards themselves end in <c>FloatDockable</c>, which
         /// needs a host window and cannot run headless.</para>
         /// </summary>
+        /// <summary>
+        /// Whether this dockable carries a live CEF browser, and therefore must be disposed before any
+        /// re-parent. (#419)
+        ///
+        /// <para>Three types do: books, source PDFs, and the Dictionary tool (#466). Carrying any of their
+        /// browsers across a re-parent is the #458 SIGSEGV, so this set is the input to
+        /// <see cref="SplitToWindow"/> and <see cref="PrepareCrossWindowMove"/> — the two guards that call
+        /// <c>DisposeAndEvictRecycledView</c> before the move.</para>
+        ///
+        /// <para><b>Extracted so membership can be tested.</b> The guards themselves need a host window and
+        /// a real ControlRecycling resource and cannot run headless (#655), so before this the only thing a
+        /// test could pin was a view model's CanFloat flag — and dropping a type from either pattern, or
+        /// gutting its Shutdown, would have passed every test in the suite while re-introducing the crash.
+        /// A membership test cannot prove the guards work; it can prove nobody quietly left a type out.</para>
+        /// </summary>
+        internal static bool HostsLiveBrowser(IDockable? dockable) =>
+            dockable is BookDisplayViewModel or PdfDisplayViewModel or DictionaryViewModel;
+
         internal static bool IsToolDockable(IDockable? dockable) =>
             dockable is ITool || dockable is IToolDock;
 
@@ -1997,7 +2015,7 @@ namespace CST.Avalonia.Services
         {
             // DictionaryViewModel is a CEF-hosting TOOL (#466) — same re-parent hazard as the book/PDF
             // documents, so it gets the same dispose-before-move.
-            if (dockable is BookDisplayViewModel or PdfDisplayViewModel or DictionaryViewModel)
+            if (HostsLiveBrowser(dockable))
             {
                 if (dockable is BookDisplayViewModel bookVm && bookVm.LastPositionToken is { } token)
                     bookVm.QueuePositionRestore(token);
@@ -2033,7 +2051,7 @@ namespace CST.Avalonia.Services
         private void PrepareCrossWindowMove(IDockable? dockable, IDock? targetDock)
         {
             // Books, PDFs, and the CEF-hosting Dictionary tool (#466) — everything that carries a live browser.
-            if (dockable is not (BookDisplayViewModel or PdfDisplayViewModel or DictionaryViewModel)) return;
+            if (!HostsLiveBrowser(dockable)) return;
             if (targetDock == null) return;
 
             var sourceRoot = GetRootOwner(dockable);

--- a/src/CST.Avalonia/ViewModels/PdfDisplayViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/PdfDisplayViewModel.cs
@@ -68,8 +68,8 @@ namespace CST.Avalonia.ViewModels
             //
             // CanDrag is left at its default true, as it always was: CanFloat=false never blocked dragging
             // a PDF INTO an existing floating window - Dock's ValidateDocument gates on CanDrag/CanDrop and
-            // never consults CanFloat - so that re-parent has been reachable since #458 and goes through
-            // the same funnel. This flag adds a second way in, not a new hazard.
+            // never consults CanFloat - so that re-parent was reachable BEFORE #458, which is what crashed;
+            // #458 is what made it safe. This flag adds a second way in, not a new hazard.
             CanFloat = true;
             CanPin = false;
 

--- a/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
+++ b/src/CST.Avalonia/Views/PdfDisplayView.axaml.cs
@@ -35,8 +35,13 @@ public partial class PdfDisplayView : UserControl
     ///
     /// <para>Adopted at the FIRST attach rather than at creation, because <c>TryCreateWebView</c> runs in the
     /// constructor when there is no visual root yet — the same reason <c>BookDisplayView</c> uses <c>??=</c>
-    /// here. Cleared with the browser in <c>DisposeWebView</c>, so it always describes a live browser or
-    /// nothing, and a rebuilt browser adopts whichever window it is attached to next.</para>
+    /// here. Cleared in <c>DisposeWebView</c>, which is the only place this view's browser goes away: nothing
+    /// here rebuilds one, so a disposed view stays disposed until the factory replaces it wholesale.</para>
+    ///
+    /// <para><c>_webView != null</c> is a proxy for "live", not a guarantee of it — WebViewControl
+    /// self-disposes when its root window's <c>PlatformImpl</c> goes null, and on a failed browser init — so
+    /// the check below can in principle report a violation for an already-dead browser. That direction is
+    /// harmless: a false alarm costs a log line, where a missed one costs a crash.</para>
     /// </summary>
     private Window? _browserBirthWindow;
 
@@ -49,10 +54,13 @@ public partial class PdfDisplayView : UserControl
     /// first, so the view that arrives at the destination is a fresh one with no browser yet. If this Error
     /// ever appears, a re-parent path is missing the guard — better a log line than a crash report. (#419)</para>
     ///
-    /// <para><b>Deliberately only a log, unlike <c>BookDisplayView</c>, which also disposes and rebuilds
-    /// here.</b> That branch is a rescue, and writing one for PDFs would mean adding lifecycle handling this
-    /// view has never had, unverifiable without a GUI run, in the app's most fragile subsystem. The
-    /// diagnostic is the part that is free and cannot itself break anything.</para>
+    /// <para><b>A log and nothing more, and that matches <c>BookDisplayView</c> — which appears to rescue
+    /// here but does not.</b> Its window-change branch tests <c>_currentWindow</c>, which
+    /// <c>OnDetachedFromVisualTree</c> nulls unconditionally; Avalonia detaches before it attaches on every
+    /// re-parent, so that field is always null at attach and the dispose-and-rebuild branch cannot execute.
+    /// An earlier version of this comment described declining to copy that rescue. There is no rescue to
+    /// copy: both views are protected solely by the <c>CstDockFactory</c> funnel, and the check in both is
+    /// diagnostic. (Established in review of #419; the dead branch itself is left alone.)</para>
     /// </summary>
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {


### PR DESCRIPTION
Follow-up to #984, from Fable's post-merge review. **No behaviour defect** — the PDF float is sound and every attack on the guard's correctness, the override-vs-event choice, deletion reachability and book-only assumptions failed to land. What this fixes is three comments and two docs that describe a mechanism which cannot run.

## The finding: `BookDisplayView`'s window-change rescue is dead code

The branch that disposes and rebuilds when a view re-attaches to a different window **cannot execute**. `_currentWindow` has three writes — inside that branch, inside the first-attach branch, and an **unconditional null in `OnDetachedFromVisualTree`**. Avalonia's `Visual.SetVisualParent` detaches before it attaches on every re-parent, so `_currentWindow` is always null at attach and only "first attach" and "same window" are reachable.

**This matters because my own rationale rested on it.** The comment I wrote for the new PDF check said it was *"deliberately only a log, unlike `BookDisplayView`, which also disposes and rebuilds here"*, framing the rescue as something I'd chosen not to copy. There was nothing to copy. Both views are protected **solely** by the `CstDockFactory` funnel, and the check in both is diagnostic.

**The dead branch is left in place.** Removing it is intent, not mechanics — the maintainer's call.

## Docs

`DOCK_WEBVIEW_WORKAROUNDS.md` listed that branch as a working workaround and credited the unconditional null with *"fixing"* a crash — when it's the reason the branch is dead. Both rows rewritten, with an explicit **"do not cite it as protection"**. `DOCK_SUBSYSTEM.md`'s *"which path takes which branch is subtle"* becomes what it actually is: the branching provides no protection at all, and the funnel isn't merely what *actually* guarantees safety — it's the only thing that does.

Rebased onto #985, which swept the same two files for button-era references without this finding.

## Two more of my own claims, corrected

- The `_browserBirthWindow` comment described *"a rebuilt browser adopts whichever window it is attached to next"*. Nothing in that view rebuilds a browser — `RecreateWebView` went out in the same commit that added the comment.
- `_webView != null` is a **proxy** for "live", not a guarantee: WebViewControl self-disposes when its root window's `PlatformImpl` goes null, and on a failed browser init. So the check can report a violation for an already-dead browser. Now stated, with why that direction is the safe one — a false alarm costs a log line, a missed one costs a crash.
- *"reachable since #458"* was backwards. The re-parent was reachable **before** #458 — that's what crashed. #458 made it safe.

## The fourth mutation

The PDF flag tests pinned `CanFloat`/`CanDrag`/`CanClose` and nothing else. **Dropping a type from either dispose-before-move guard leaves every test in the suite green while restoring the #458 SIGSEGV**, because the guards need a host window and can't run headless (#655).

The shared type filter is now `CstDockFactory.HostsLiveBrowser`, sitting next to `IsToolDockable` and extracted for the same stated reason, with a `Theory` pinning all three members and a companion asserting non-browser dockables are left alone.

**Mutant killed** — dropping `PdfDisplayViewModel` fails with:

```
PdfDisplayViewModel hosts a CEF browser but is not in HostsLiveBrowser, so neither
SplitToWindow nor PrepareCrossWindowMove will dispose it before a re-parent.
```

It cannot prove the guards work. It proves nobody quietly left a type out of them.

## Verification

- `dotnet build src/CST.Avalonia` — 0 errors, 0 warnings
- `dotnet test src/CST.Avalonia.Tests` — **2857 passed, 0 failed, 18 skipped**
- No `.axaml` markup touched, so no collision with Egret's accessibility work
