### PR TITLE
Carry the nullability the type pattern was carrying (#419 follow-up)

### DIFF
--- a/src/CST.Avalonia/Services/CstDockFactory.cs
+++ b/src/CST.Avalonia/Services/CstDockFactory.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -1200,8 +1201,14 @@ namespace CST.Avalonia.Services
         /// test could pin was a view model's CanFloat flag — and dropping a type from either pattern, or
         /// gutting its Shutdown, would have passed every test in the suite while re-introducing the crash.
         /// A membership test cannot prove the guards work; it can prove nobody quietly left a type out.</para>
+        ///
+        /// <para><c>NotNullWhen(true)</c> is load-bearing, not decoration. The guards this replaced were
+        /// type patterns, which narrow <c>dockable</c> to non-null for the rest of the method; a plain
+        /// <c>bool</c> method throws that away, and <c>PrepareCrossWindowMove</c>'s later
+        /// <c>dockable.Id</c> became a CS8602. Extracting a type test into a method has to carry the
+        /// nullability the pattern was carrying, or it silently costs the caller its flow analysis.</para>
         /// </summary>
-        internal static bool HostsLiveBrowser(IDockable? dockable) =>
+        internal static bool HostsLiveBrowser([NotNullWhen(true)] IDockable? dockable) =>
             dockable is BookDisplayViewModel or PdfDisplayViewModel or DictionaryViewModel;
 
         internal static bool IsToolDockable(IDockable? dockable) =>


### PR DESCRIPTION
Fixes a CS8602 I introduced in #988 and merged.

## What happened

Extracting the dispose-before-move guard into `HostsLiveBrowser` changed more than the shape. The old test was a **type pattern**:

```csharp
if (dockable is not (BookDisplayViewModel or PdfDisplayViewModel or DictionaryViewModel)) return;
```

which narrows `dockable` to non-null for the rest of the method. A plain `bool` call throws that away, so `PrepareCrossWindowMove`'s later `dockable.Id` became a dereference of a possibly-null reference.

`[NotNullWhen(true)]` restores exactly what the pattern gave. **No behaviour change** — it is a compile-time contract and the body is unchanged.

## Why I did not catch it

Every build I ran was incremental, and an incremental build does not re-report a warning from a file it did not rebuild. `dotnet build --no-incremental` shows it immediately. The zero-warning counts I reported while working on #984 and #988 were reading a cache.

## Verification

- `dotnet build src/CST.Avalonia --no-incremental` — **0 errors, 0 warnings**
- **Mutation tested**: removing the attribute brings the warning back at the same site; restoring it clears it
- `dotnet test src/CST.Avalonia.Tests` — **2857 passed, 0 failed, 18 skipped**