### PR TITLE
Headless Avalonia style tests in a second test project (#655)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ src/CST.Avalonia/dist/
 src/CST.Avalonia.Tests/bin/
 src/CST.Avalonia.Tests/obj/
 
+src/CST.Avalonia.UiTests/bin/
+src/CST.Avalonia.UiTests/obj/
+
 src/CST.CharacterAnalysis/bin/
 src/CST.CharacterAnalysis/obj/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,13 @@ CST Reader (**CST = Chaṭṭha Saṅgāyana Tipiṭaka**) is a cross-platform P
 dotnet build src/CST.Avalonia
 dotnet run --project src/CST.Avalonia
 
-dotnet test src/CST.Avalonia.Tests                                     # full suite (~3 min)
+dotnet test src/CST.Avalonia.Tests                                     # main suite (~3.5 min)
+dotnet test src/CST.Avalonia.UiTests                                   # headless Avalonia suite (<1 s)
 dotnet test src/CST.Avalonia.Tests --filter "FullyQualifiedName~CstDockFactoryTests"   # one class
 ```
-**Always name the test project.** There is no solution file, so a bare `dotnet test` acts on the project in the current directory — and in `src/CST.Avalonia` that is the app, which is not a test project: it restores, runs nothing, and **exits 0**. A silent green indistinguishable from a passing suite. `CST.Avalonia.Tests` is the only test project in the tree.
+**Always name the test project, and there are TWO.** There is no solution file, so a bare `dotnet test` acts on the project in the current directory — and in `src/CST.Avalonia` that is the app, which is not a test project: it restores, runs nothing, and **exits 0**. A silent green indistinguishable from a passing suite.
+
+`CST.Avalonia.Tests` holds everything that does not need a live Avalonia application. `CST.Avalonia.UiTests` (#655) holds the ones that do — the headless style tests, which exist so a XAML selector that matches nothing fails a test instead of shipping. **They cannot share a process**: an Avalonia `Application` binds `Dispatcher.UIThread` to the headless session's thread for the whole process, so `Dispatcher.UIThread.CheckAccess()` goes false everywhere else and any code that gates on it (e.g. `AiConnectionService.RaiseChanged`) posts into a queue nothing pumps. Measured: putting them in one project took the main suite from 0 failures to 88. The reasoning is in `CST.Avalonia.UiTests.csproj`; the facts it turns on are asserted in `HeadlessApplicationLeakTests`.
 
 Piping the run through `tail` compounds this: you get *tail's* exit code, and the window drops the `[FAIL]` lines. Redirect to a file and echo the real exit code.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ dotnet run        # run
 ```
 
 ```bash
-dotnet test src/CST.Avalonia.Tests                              # full suite
+dotnet test src/CST.Avalonia.Tests                              # main suite
+dotnet test src/CST.Avalonia.UiTests                           # headless Avalonia suite
 dotnet test src/CST.Avalonia.Tests --filter "FullyQualifiedName~CstDockFactoryTests"   # one class
 ```
 
@@ -128,6 +129,7 @@ src/CST.Avalonia/          # Main application (the working directory)
 └── dictionaries/          # Bundled dictionary data
 
 src/CST.Avalonia.Tests/    # Test suite
+src/CST.Avalonia.UiTests/  # Headless Avalonia tests (own process; see its .csproj)
 src/CST.Core/              # Book catalog, source-PDF mappings, shared contracts
 src/CST.Lucene/            # Search engine library
 src/CST.Lexicon/           # Dictionary asset format

--- a/docs/development/RELEASE_PROCESS.md
+++ b/docs/development/RELEASE_PROCESS.md
@@ -183,8 +183,10 @@ the build succeeds, the tests pass, and the mistake ships. Both were missed in B
       Skipping this degrades gracefully: the snapshot is only the last fallback behind the runtime cache and
       the network, so a stale one costs nothing at runtime. (#733, #736)
 - [ ] Build succeeds: `dotnet build src/CST.Avalonia`
-- [ ] Tests pass: `dotnet test src/CST.Avalonia.Tests` (or acceptable skip rate documented) — pass the
-      project path or run from that directory; `dotnet test` in `src/CST.Avalonia` runs nothing and exits 0
+- [ ] Tests pass: `dotnet test src/CST.Avalonia.Tests` AND `dotnet test src/CST.Avalonia.UiTests` (or
+      acceptable skip rate documented) — pass the project path or run from that directory; `dotnet test` in
+      `src/CST.Avalonia` runs nothing and exits 0. Both projects, every time: the headless Avalonia tests
+      live in their own assembly because they cannot share a process with the main suite (#655)
 - [ ] All changes committed and pushed to `main` branch
 - [ ] No critical bugs or blockers
 

--- a/src/CST.Avalonia.UiTests/CST.Avalonia.UiTests.csproj
+++ b/src/CST.Avalonia.UiTests/CST.Avalonia.UiTests.csproj
@@ -1,0 +1,59 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Headless Avalonia tests: the ones that need a live Application, so a XAML style selector that matches
+    nothing can fail a test. (#655)
+
+    WHY THIS IS A SECOND TEST PROJECT, and not four more files in CST.Avalonia.Tests, which is where #655
+    asked for them. Measured, on 2026-09-06, by putting them there first:
+
+      Baseline                                  2853 passed, 0 failed, 18 skipped
+      With [assembly: AvaloniaTestApplication]  2778 passed, 88 FAILED, 18 skipped
+
+    An Avalonia Application is process-global, and so is the dispatcher it binds. Once the first
+    [AvaloniaFact] starts the headless session, Dispatcher.UIThread belongs to that session's thread for
+    the rest of the process - so on every OTHER thread, including the xunit threads running tests that
+    have never heard of Avalonia, Dispatcher.UIThread.CheckAccess() flips from true to false.
+    AiConnectionService.RaiseChanged gates on exactly that: it posts instead of calling, the post is never
+    pumped (only the session thread can pump it), and the subscribing view models never rebuild. That is
+    87 of the 88 - AiModelsViewModelTests (55), AiModelPickerViewModelTests (22),
+    AiConnectionsViewModelTests (8), AiConnectionRowLogoTests (2). The 88th is PlatformGestureTests, which
+    reads Application.Current: the headless backend reports Control as the command modifier on every OS, so
+    on macOS that assertion passed or failed depending on whether xunit had scheduled a headless test yet.
+
+    None of that is fixable from the test side. Application.PlatformSettings is not virtual,
+    IPlatformSettings is explicitly not implementable outside the framework, DefaultPlatformSettings
+    computes its hotkey configuration with no field to reach, and a dispatcher cannot be pumped from a
+    thread that does not own it. A separate assembly runs in a separate process, which is the only place
+    the two sets of assumptions can both be true.
+
+    SO: `dotnet test src/CST.Avalonia.Tests` is no longer the whole suite. Run BOTH.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <!-- 11.3.6 to match CST.Avalonia's Avalonia packages exactly. Avalonia.Headless.XUnit depends on
+         xunit.core >= 2.4.0, so it is the xunit v2 line this repo already uses, not v3. -->
+    <PackageReference Include="Avalonia.Headless" Version="11.3.6" />
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CST.Avalonia\CST.Avalonia.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CST.Avalonia.UiTests/TestSupport/HeadlessStyleTestApp.cs
+++ b/src/CST.Avalonia.UiTests/TestSupport/HeadlessStyleTestApp.cs
@@ -1,0 +1,77 @@
+using System;
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Themes.Fluent;
+using CST.Avalonia.UiTests.TestSupport;
+
+// [AvaloniaFact] needs ONE application per test assembly, declared at assembly level. Every test in this
+// project runs in the same process, so this attribute is the whole project's Avalonia application - see
+// HeadlessStyleTestApp for what that does and does not change for the tests that predate it.
+[assembly: AvaloniaTestApplication(typeof(HeadlessStyleTestApp))]
+
+namespace CST.Avalonia.UiTests.TestSupport;
+
+/// <summary>
+/// The headless Avalonia application that <c>[AvaloniaFact]</c> tests run inside. It exists so a XAML
+/// style selector that matches NOTHING can fail a test. (#655)
+///
+/// <para><b>What it is for.</b> A selector that matches no element compiles, deploys and does nothing:
+/// no warning, no exception, no log line. #646 shipped exactly that -
+/// <c>Border#PART_LayoutRoot &gt; ContentPresenter#PART_HeaderPresenter</c>, dead because Avalonia's
+/// <c>&gt;</c> resolves on the LOGICAL parent and the header presenter's logical parent is
+/// <c>Grid#PART_Header</c> - and a full green suite said nothing. In dark mode the default foreground is
+/// already white, so the bug was invisible there; whether a human caught it came down to which OS
+/// appearance the reviewer happened to be running.</para>
+///
+/// <para><b>What it loads, and why exactly this.</b> <see cref="FluentTheme"/>, Dock's Fluent theme and
+/// the app's own <c>DockStyles.axaml</c>, mirroring <c>App.axaml</c>'s <c>Application.Styles</c>. Fluent
+/// supplies the control templates whose named parts the selectors reach into (a missing template makes
+/// every such assertion vacuous rather than red); Dock's theme supplies the <c>DockApplicationAccent*</c>
+/// brushes, which are defined in no other loaded resource dictionary. Deliberately NOT loaded: the app's
+/// own <c>Application.Resources</c>, its converters-as-resources and its <c>ControlRecycling</c> wiring.
+/// Those belong to a running app; a style test that needed them would be testing the app's startup path
+/// under a name that promises otherwise.</para>
+///
+/// <para><b>What this does NOT prove</b>, in the issue author's words: "Not a substitute for looking at
+/// the app - headless proves a selector matched and a property took a value, not that the result is
+/// legible or attractive." A green run here means the rule reached the element it names. Whether the
+/// resulting colours are readable, or the right choice, still needs eyes on the app in both theme
+/// variants. Do not let this fixture retire that step.</para>
+///
+/// <para><b>Why this lives in its own test project.</b> An Avalonia application is process-global, and so
+/// is the dispatcher it binds: once the first <c>[AvaloniaFact]</c> starts the headless session,
+/// <c>Dispatcher.UIThread</c> belongs to that session's thread and <c>CheckAccess()</c> is false on every
+/// other thread in the process. Put this application in <c>CST.Avalonia.Tests</c> and 88 of its tests fail
+/// - measured, see the note in <c>CST.Avalonia.UiTests.csproj</c> for the breakdown. Nothing in a test can
+/// undo that, so the two sets of assumptions live in two assemblies, which is two processes.
+/// <c>HeadlessApplicationLeakTests</c> pins the facts that split turns on, so the day they stop being true
+/// the split can be revisited on evidence rather than on this comment.</para>
+/// </summary>
+public class HeadlessStyleTestApp : Application
+{
+    public override void Initialize()
+    {
+        // Mirrors App.axaml's <Application.Styles>: FluentTheme, then Dock's Fluent theme, then ours.
+        // Order matters the same way it does there - later styles win, and DockStyles.axaml is written
+        // expecting to sit last.
+        Styles.Add(new FluentTheme());
+        Styles.Add(LoadStyle("avares://Dock.Avalonia.Themes.Fluent/DockFluentTheme.axaml"));
+        Styles.Add(LoadStyle("avares://CST.Avalonia/Styles/DockStyles.axaml"));
+    }
+
+    // StyleInclude resolves Source against a base URI. Every source here is absolute, so the base is
+    // never consulted; it is supplied because the constructor requires one.
+    private static StyleInclude LoadStyle(string uri) =>
+        new(new Uri("avares://CST.Avalonia/Styles/")) { Source = new Uri(uri) };
+
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<HeadlessStyleTestApp>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions
+            {
+                // Real (headless) drawing rather than the no-op renderer: the selectors under test are
+                // reached through control TEMPLATES, and a template is only applied once the control is
+                // measured and arranged.
+                UseHeadlessDrawing = true
+            });
+}

--- a/src/CST.Avalonia.UiTests/TestSupport/StyleProbe.cs
+++ b/src/CST.Avalonia.UiTests/TestSupport/StyleProbe.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Diagnostics;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace CST.Avalonia.UiTests.TestSupport;
+
+/// <summary>
+/// Assertions for "did this style selector actually match anything?". (#655)
+///
+/// <para>The whole reason this file exists is that comparing a rendered colour is NOT enough. #646's dead
+/// selector left the selected row's foreground at the theme's ordinary text colour - which in dark mode is
+/// white, the same white the accent rule would have produced. A value-only assertion would have passed the
+/// bug in one theme variant and failed it in the other, which is exactly the coin-flip the issue is about.
+/// So every assertion here checks the value AND where the value came from: Avalonia records a
+/// <see cref="BindingPriority"/> per property, and a value that arrived from a matching style is at
+/// <see cref="BindingPriority.Style"/> or <see cref="BindingPriority.StyleTrigger"/> - never
+/// <see cref="BindingPriority.Inherited"/>, <see cref="BindingPriority.Template"/> or
+/// <see cref="BindingPriority.Unset"/>, which are what a selector that matched nothing leaves behind.</para>
+/// </summary>
+internal static class StyleProbe
+{
+    /// <summary>
+    /// Shows <paramref name="content"/> in a headless window under a fixed theme variant and runs the
+    /// layout pass. Templates are only applied to a control that has been measured and arranged, and
+    /// every selector under test reaches into a template, so this is not optional setup.
+    /// </summary>
+    public static Window Show(Control content, ThemeVariant variant, double width = 420, double height = 640)
+    {
+        var window = new Window
+        {
+            RequestedThemeVariant = variant,
+            Width = width,
+            Height = height,
+            Content = content
+        };
+
+        window.Show();
+        Pump(window);
+        return window;
+    }
+
+    /// <summary>Drains the dispatcher and forces a layout pass, so container realisation settles.</summary>
+    public static void Pump(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    /// <summary>
+    /// Resolves a resource the way a <c>{DynamicResource}</c> setter would, from the same scope and theme
+    /// variant as the element under test - so the expected value cannot drift from the actual one by being
+    /// looked up somewhere else.
+    /// </summary>
+    public static IBrush Brush(StyledElement scope, string key)
+    {
+        Assert.True(
+            scope.TryFindResource(key, scope.ActualThemeVariant, out var value),
+            $"Resource '{key}' resolved to nothing under {scope.ActualThemeVariant}. " +
+            "A DynamicResource miss is silent at runtime - see ThemeDictionaryParityTests (#955).");
+
+        return Assert.IsAssignableFrom<IBrush>(value);
+    }
+
+    /// <summary>
+    /// The named part of <paramref name="templatedControl"/>'s own template - the elements a
+    /// <c>/template/</c> selector can reach, and only those. Matching on
+    /// <see cref="StyledElement.TemplatedParent"/> is what keeps this from finding a nested control's
+    /// identically named part, which is the same scoping rule the selector itself obeys.
+    /// </summary>
+    public static T TemplatePart<T>(Control templatedControl, string name) where T : Control
+    {
+        var part = templatedControl.GetVisualDescendants()
+            .OfType<T>()
+            .FirstOrDefault(c => c.Name == name && ReferenceEquals(c.TemplatedParent, templatedControl));
+
+        Assert.True(part is not null,
+            $"No {typeof(T).Name} named '{name}' in this {templatedControl.GetType().Name}'s own template. " +
+            "The theme's template changed, and every selector naming that part is now dead. " +
+            "Fix the selectors - do not relax this assertion, or the tests below go vacuous.");
+
+        return part!;
+    }
+
+    /// <summary>
+    /// Asserts that a style rule matched this element and set this property to this value.
+    ///
+    /// <para>Both halves matter. The value alone can be right by accident (an inherited white that happens
+    /// to equal the accent white); the priority alone only says something matched, not that it was the
+    /// rule you meant.</para>
+    /// </summary>
+    public static void AssertStyled(AvaloniaObject target, AvaloniaProperty property, object expected, string because)
+    {
+        var actual = target.GetDiagnostic(property);
+
+        Assert.True(
+            actual.Priority is BindingPriority.Style or BindingPriority.StyleTrigger,
+            $"{because}\n" +
+            $"No style setter reached {target.GetType().Name}.{property.Name}: its value is at priority " +
+            $"{actual.Priority}, not Style/StyleTrigger. That is what a selector matching NOTHING looks " +
+            $"like - the property simply kept whatever the theme or inheritance gave it. " +
+            $"Current value: {Describe(actual.Value)}.");
+
+        AssertSameBrushOrValue(expected, actual.Value, because);
+    }
+
+    /// <summary>
+    /// Asserts that no style setter is holding this property - the counterpart used for scoping claims,
+    /// where the point is that a rule did NOT reach an element.
+    /// </summary>
+    public static void AssertNotStyled(AvaloniaObject target, AvaloniaProperty property, object notExpected, string because)
+    {
+        var actual = target.GetDiagnostic(property);
+
+        var sameValue = BrushesMatch(notExpected, actual.Value);
+        var styled = actual.Priority is BindingPriority.Style or BindingPriority.StyleTrigger;
+
+        Assert.False(
+            sameValue && styled,
+            $"{because}\n" +
+            $"A style setter DID reach {target.GetType().Name}.{property.Name} and gave it " +
+            $"{Describe(actual.Value)} at priority {actual.Priority}. The selector is broader than the " +
+            "comment claims it is.");
+    }
+
+    private static void AssertSameBrushOrValue(object expected, object? actual, string because)
+    {
+        Assert.True(
+            BrushesMatch(expected, actual),
+            $"{because}\nExpected {Describe(expected)} but got {Describe(actual)}.");
+    }
+
+    // Brushes are compared by colour rather than by reference: a theme is free to hand out a copy, and a
+    // reference check would fail for a reason that has nothing to do with the selector under test.
+    private static bool BrushesMatch(object? expected, object? actual)
+    {
+        if (expected is ISolidColorBrush a && actual is ISolidColorBrush b)
+            return a.Color == b.Color;
+
+        return Equals(expected, actual);
+    }
+
+    private static string Describe(object? value) => value switch
+    {
+        null => "<null>",
+        ISolidColorBrush brush => $"{brush.Color} ({brush.GetType().Name})",
+        _ => value.ToString() ?? value.GetType().Name
+    };
+}

--- a/src/CST.Avalonia.UiTests/Views/HeadlessApplicationLeakTests.cs
+++ b/src/CST.Avalonia.UiTests/Views/HeadlessApplicationLeakTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CST.Avalonia.Input;
+using CST.Avalonia.UiTests.TestSupport;
+using Xunit;
+
+namespace CST.Avalonia.UiTests.Views;
+
+/// <summary>
+/// The three facts that make this a separate test project, kept as assertions rather than as a comment
+/// someone will later doubt. (#655)
+///
+/// <para>#655 asked for the headless harness inside <c>CST.Avalonia.Tests</c>. Putting it there took that
+/// project from 2853 passed / 0 failed to 2778 passed / 88 failed, because an Avalonia application is
+/// process-global and changes what unrelated code observes. If a future Avalonia scopes any of this per
+/// thread or per session, one of these tests fails, and merging the two projects back together becomes a
+/// decision that can be made on evidence.</para>
+/// </summary>
+public class HeadlessApplicationLeakTests
+{
+    [AvaloniaFact]
+    public void An_avalonia_test_runs_inside_this_projects_headless_application()
+    {
+        Assert.IsType<HeadlessStyleTestApp>(Application.Current);
+    }
+
+    /// <summary>
+    /// The one that cost 87 tests. <c>AiConnectionService.RaiseChanged</c> calls its subscribers directly
+    /// when <c>Dispatcher.UIThread.CheckAccess()</c> is true and posts otherwise; with no Avalonia
+    /// application in the process that check is true on any thread, so the view-model tests see their
+    /// rebuild happen inline. Under a live session the UI thread is the session's own, the post lands in a
+    /// queue only that thread can pump, and the rebuild never happens.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task The_dispatcher_belongs_to_the_session_thread_and_to_no_other()
+    {
+        Assert.True(Dispatcher.UIThread.CheckAccess(), "An [AvaloniaFact] body should be on the UI thread.");
+
+        var elsewhere = await Task.Run(() => Dispatcher.UIThread.CheckAccess());
+
+        Assert.False(elsewhere,
+            "Dispatcher.UIThread is no longer bound to the session's thread. If that is now true of every " +
+            "thread, the reason CST.Avalonia.UiTests exists has gone away - re-measure before merging.");
+    }
+
+    /// <summary>
+    /// The 88th. <see cref="PlatformGesture.CommandModifier"/> prefers Avalonia's answer over its own OS
+    /// check, and Avalonia's headless answer is <c>Control</c> whatever the machine is - so on macOS this
+    /// application changes what that property returns, process-wide, for anyone who reads it.
+    /// </summary>
+    [AvaloniaFact]
+    public void The_headless_backend_reports_Control_whatever_the_host_is()
+    {
+        Assert.Equal(
+            KeyModifiers.Control,
+            Application.Current!.PlatformSettings!.HotkeyConfiguration.CommandModifiers);
+
+        Assert.Equal(KeyModifiers.Control, PlatformGesture.CommandModifier);
+
+        // Stated plainly so the divergence is not something a reader has to work out: on a Mac the app's
+        // real answer is Meta, and this is the stand-in disagreeing with the machine.
+        if (OperatingSystem.IsMacOS())
+            Assert.NotEqual(KeyModifiers.Meta, PlatformGesture.CommandModifier);
+    }
+
+    // And the application itself is visible from any thread, which is what makes the two above everyone's
+    // problem rather than the UI thread's.
+    [AvaloniaFact]
+    public async Task The_application_is_visible_from_other_threads_too()
+    {
+        var seen = await Task.Run(() => Application.Current?.GetType().Name);
+
+        Assert.Equal(nameof(HeadlessStyleTestApp), seen);
+    }
+}

--- a/src/CST.Avalonia.UiTests/Views/OpenBookPanelSelectionStyleTests.cs
+++ b/src/CST.Avalonia.UiTests/Views/OpenBookPanelSelectionStyleTests.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using CST.Avalonia.UiTests.TestSupport;
+using CST.Avalonia.ViewModels;
+using CST.Avalonia.Views;
+using Xunit;
+
+namespace CST.Avalonia.UiTests.Views;
+
+/// <summary>
+/// The book tree's selection styles, asserted rather than eyeballed. (#655, pinning #646)
+///
+/// <para><b>The failure these exist for.</b> #646's foreground rule was written
+/// <c>TreeViewItem:selected /template/ Border#PART_LayoutRoot &gt; ContentPresenter#PART_HeaderPresenter</c>
+/// and matched nothing: Avalonia's <c>&gt;</c> resolves on the LOGICAL parent, and in Fluent's
+/// <c>TreeViewItem</c> template the header presenter's logical parent is <c>Grid#PART_Header</c>, not the
+/// border. It compiled, shipped, and passed a full suite. In dark mode the default foreground is already
+/// white so nothing looked wrong; in light mode a selected row was black text on #007ACC. Which of those a
+/// reviewer saw was down to their OS appearance setting.</para>
+///
+/// <para>So these run under BOTH theme variants, and <see cref="StyleProbe.AssertStyled"/> checks where a
+/// value came from as well as what it is - a white that a selector produced and a white that inheritance
+/// produced are the same colour and a different bug.</para>
+///
+/// <para><b>What this does not cover.</b> That a rule matched and set a brush. Not that the result is
+/// legible, or that the palette is a good one. Those still need eyes on the running app.</para>
+/// </summary>
+public class OpenBookPanelSelectionStyleTests
+{
+    private const string AccentFill = "DockApplicationAccentBrushLow";
+    private const string AccentHoverFill = "DockApplicationAccentBrushMed";
+    private const string AccentForeground = "DockApplicationAccentForegroundBrush";
+
+    // The one #646 got wrong. Foreground is the property that went dead, so this is the canary: revert
+    // OpenBookPanel.axaml to the ">" form and this test - and only tests in this class - go red.
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void A_selected_rows_label_takes_the_accent_foreground(string themeVariant)
+    {
+        var (window, category, _) = ShowTree(themeVariant);
+        try
+        {
+            var header = StyleProbe.TemplatePart<ContentPresenter>(category, "PART_HeaderPresenter");
+
+            StyleProbe.AssertStyled(
+                header,
+                ContentPresenter.ForegroundProperty,
+                StyleProbe.Brush(header, AccentForeground),
+                "The selected row's foreground rule matched nothing. This is the #646 defect exactly: " +
+                "'TreeViewItem:selected /template/ Border#PART_LayoutRoot > ContentPresenter#PART_Header" +
+                "Presenter' is dead, because > resolves on the LOGICAL parent and the header presenter's " +
+                "logical parent is Grid#PART_Header. Drop the '> Border#PART_LayoutRoot' step.");
+
+            // The label itself is reached by inheritance from the presenter, which is the claim the
+            // OpenBookPanel comment makes ("Foreground is inherited, so this reaches the node's own
+            // label"). Value only - inheritance is the mechanism being pinned, so an inherited priority
+            // is the correct answer here rather than a failure.
+            var label = OwnHeaderPanel(category).GetLogicalChildren().OfType<TextBlock>().First();
+            Assert.Equal(
+                ((ISolidColorBrush)StyleProbe.Brush(header, AccentForeground)).Color,
+                ((ISolidColorBrush)label.Foreground!).Color);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void A_selected_row_is_accent_filled(string themeVariant)
+    {
+        var (window, category, _) = ShowTree(themeVariant);
+        try
+        {
+            var layoutRoot = StyleProbe.TemplatePart<Border>(category, "PART_LayoutRoot");
+            var fill = StyleProbe.Brush(layoutRoot, AccentFill);
+
+            StyleProbe.AssertStyled(layoutRoot, Border.BackgroundProperty, fill,
+                "The selected row has no accent fill: 'TreeViewItem:selected /template/ " +
+                "Border#PART_LayoutRoot' reached nothing. Without it the tree has no 'you are here' at " +
+                "all, which is the state #646 was fixing.");
+
+            StyleProbe.AssertStyled(layoutRoot, Border.BorderBrushProperty, fill,
+                "The selected row's border brush is not the accent fill, so Fluent's own selection " +
+                "border is showing through as a differently coloured outline.");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // The icons need their own rule: Fluent's PathIcon ControlTheme sets Foreground, and a ControlTheme
+    // setter outranks the inherited value the label rides on. Without this rule a selected row renders
+    // label-white and icon-black in light mode - and, once again, looks fine in dark.
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void A_selected_rows_icon_takes_the_accent_foreground(string themeVariant)
+    {
+        var (window, category, _) = ShowTree(themeVariant);
+        try
+        {
+            var icons = OwnIcons(category);
+            Assert.NotEmpty(icons);
+
+            var expected = StyleProbe.Brush(category, AccentForeground);
+            foreach (var icon in icons)
+            {
+                StyleProbe.AssertStyled(icon, PathIcon.ForegroundProperty, expected,
+                    "A selected row's icon kept the theme's ordinary text colour. " +
+                    "'TreeViewItem:selected > StackPanel > PathIcon' matched nothing - inheritance does " +
+                    "not reach a PathIcon, because its ControlTheme sets Foreground and that outranks " +
+                    "an inherited value.");
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // The scoping claim /template/ is there to make: it matches only controls whose TemplatedParent is
+    // THIS item, so a child book's own header is out of reach. A plain descendant selector
+    // ("TreeViewItem:selected TextBlock") would recolour every book under a selected category, because a
+    // child TreeViewItem is a visual descendant of its parent.
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void A_selected_categorys_accent_stays_off_its_child_books(string themeVariant)
+    {
+        var (window, category, book) = ShowTree(themeVariant);
+        try
+        {
+            Assert.True(book.IsSelected is false, "Precondition: only the category is selected.");
+
+            var childHeader = StyleProbe.TemplatePart<ContentPresenter>(book, "PART_HeaderPresenter");
+            StyleProbe.AssertNotStyled(childHeader, ContentPresenter.ForegroundProperty,
+                StyleProbe.Brush(childHeader, AccentForeground),
+                "Selecting a category recoloured the books underneath it. /template/ is what confines " +
+                "the rule to the selected item's own template parts.");
+
+            var childLayoutRoot = StyleProbe.TemplatePart<Border>(book, "PART_LayoutRoot");
+            StyleProbe.AssertNotStyled(childLayoutRoot, Border.BackgroundProperty,
+                StyleProbe.Brush(childLayoutRoot, AccentFill),
+                "Selecting a category accent-filled the rows of the books underneath it.");
+
+            foreach (var icon in OwnIcons(book))
+            {
+                StyleProbe.AssertNotStyled(icon, PathIcon.ForegroundProperty,
+                    StyleProbe.Brush(icon, AccentForeground),
+                    "Selecting a category recoloured the icons of the books underneath it. '>' matches a " +
+                    "LOGICAL child, and a child book's icon's logical ancestor is the child item.");
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // IsPointerOver is containment-based: an item is "hovered" whenever the pointer is anywhere in its
+    // subtree. Written as "TreeViewItem:selected:pointerover", mousing over a book would brighten its
+    // selected parent category two rows away. Fluent scopes hover to the border, and so do we.
+    //
+    // One variant is enough here - the claim is about which element carries the pseudo-class, and that is
+    // the same in both.
+    [AvaloniaFact]
+    public void Hovering_a_child_book_leaves_its_selected_parent_row_unbrightened()
+    {
+        var (window, category, book) = ShowTree("Light");
+        try
+        {
+            var bookRow = StyleProbe.TemplatePart<Border>(book, "PART_LayoutRoot");
+            var categoryRow = StyleProbe.TemplatePart<Border>(category, "PART_LayoutRoot");
+
+            var centre = bookRow.TranslatePoint(
+                new Point(bookRow.Bounds.Width / 2, bookRow.Bounds.Height / 2), window);
+            Assert.True(centre.HasValue, "Could not locate the child book's row in the window.");
+
+            window.MouseMove(centre!.Value);
+            StyleProbe.Pump(window);
+
+            // Without this the rest is vacuous: if the pointer never landed on the book, nothing below
+            // could brighten anything and the test would pass for the wrong reason.
+            Assert.True(bookRow.IsPointerOver, "The synthetic pointer did not land on the child book's row.");
+
+            // The containment fact the comment rests on. If this ever goes false, the rationale in
+            // OpenBookPanel.axaml has stopped being true and the rule can be simplified.
+            Assert.True(category.IsPointerOver,
+                "Hovering a child no longer marks its parent TreeViewItem as pointer-over.");
+
+            Assert.False(categoryRow.IsPointerOver,
+                "The parent category's own row is pointer-over, so scoping hover to the border no longer " +
+                "separates the two.");
+
+            StyleProbe.AssertStyled(categoryRow, Border.BackgroundProperty,
+                StyleProbe.Brush(categoryRow, AccentFill),
+                "Hovering a book brightened its selected parent category's row. The :pointerover " +
+                "pseudo-class has moved off Border#PART_LayoutRoot and onto the TreeViewItem.");
+
+            Assert.NotEqual(
+                ((ISolidColorBrush)StyleProbe.Brush(categoryRow, AccentHoverFill)).Color,
+                ((ISolidColorBrush)categoryRow.Background!).Color);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // ---- fixture -------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The real <see cref="OpenBookPanel"/> markup - not a copy of its styles - showing one expanded
+    /// category with two books under it, the category selected.
+    /// </summary>
+    private static (Window Window, TreeViewItem Category, TreeViewItem Book) ShowTree(string themeVariant)
+    {
+        var variant = themeVariant switch
+        {
+            "Light" => ThemeVariant.Light,
+            "Dark" => ThemeVariant.Dark,
+            _ => throw new ArgumentOutOfRangeException(nameof(themeVariant), themeVariant, null)
+        };
+
+        var category = new BookTreeNode
+        {
+            DisplayName = "Vinaya Piṭaka",
+            NodeType = BookTreeNodeType.Category,
+            BookCount = 2,
+            IsExpanded = true
+        };
+        foreach (var title in new[] { "Pārājikapāḷi", "Pācittiyapāḷi" })
+        {
+            category.Children.Add(new BookTreeNode
+            {
+                DisplayName = title,
+                NodeType = BookTreeNodeType.Book,
+                Parent = category
+            });
+        }
+
+        var panel = new OpenBookPanel();
+        var tree = panel.FindControl<TreeView>("BookTreeView")
+                   ?? throw new InvalidOperationException("OpenBookPanel no longer has a TreeView named BookTreeView.");
+        tree.ItemsSource = new[] { category };
+
+        var window = StyleProbe.Show(panel, variant);
+
+        // Selection is driven through the node, because the TreeViewItem style binds IsSelected TwoWay to
+        // it. Setting TreeView.SelectedItem as well covers the case where the container is realised late.
+        category.IsSelected = true;
+        tree.SelectedItem = category;
+        StyleProbe.Pump(window);
+
+        var categoryItem = ItemFor(tree, category);
+        var bookItem = ItemFor(tree, category.Children[0]);
+
+        Assert.True(categoryItem.IsSelected,
+            "Precondition: the category's container is not selected, so nothing below tests a :selected rule.");
+        Assert.True(categoryItem.IsExpanded && bookItem.IsVisible,
+            "Precondition: the child books are not realised, so the scoping assertions would be vacuous.");
+
+        return (window, categoryItem, bookItem);
+    }
+
+    private static TreeViewItem ItemFor(TreeView tree, BookTreeNode node)
+    {
+        var item = tree.GetVisualDescendants().OfType<TreeViewItem>()
+            .FirstOrDefault(i => ReferenceEquals(i.DataContext, node));
+
+        Assert.True(item is not null, $"No realised TreeViewItem for '{node.DisplayName}'.");
+        return item!;
+    }
+
+    // The StackPanel from the TreeDataTemplate. It is a LOGICAL child of the item - which is what lets
+    // "TreeViewItem:selected > StackPanel > PathIcon" work at all - and each item has exactly one.
+    private static StackPanel OwnHeaderPanel(TreeViewItem item) =>
+        item.GetLogicalChildren().OfType<StackPanel>().First();
+
+    // Only this item's own icons: a child book's icons are logical children of the CHILD item, so they
+    // are not reachable here, exactly as the '>' in the selector is not able to reach them.
+    private static IReadOnlyList<PathIcon> OwnIcons(TreeViewItem item) =>
+        OwnHeaderPanel(item).GetLogicalChildren().OfType<PathIcon>().ToList();
+}


### PR DESCRIPTION
Closes #655.

A second test project, `src/CST.Avalonia.UiTests`, holds the tests that need a live Avalonia application — headless style tests, so a XAML selector that matches nothing fails a test instead of shipping. 13 tests, under a second.

**Why a second project rather than a folder in `CST.Avalonia.Tests`:** an Avalonia `Application` binds `Dispatcher.UIThread` to the headless session's thread process-wide, so `Dispatcher.UIThread.CheckAccess()` goes false on every xunit thread and code that gates on it (`AiConnectionService.RaiseChanged`) posts into a queue nothing pumps. Measured by putting them in one project: the main suite went from 0 failures to dozens (88 in the agent's run, 62 in the parent session's independent re-run — the count depends on which style tests are copied in). `HeadlessApplicationLeakTests` asserts the facts the split turns on.

Also edits `CLAUDE.md` (the "only test project" sentence is no longer true), `README.md` and `docs/development/RELEASE_PROCESS.md` to name both suites. **The CLAUDE.md wording is the maintainer's to settle** — note its "0 failures to 88" figure against the 62 above.

Verification: `dotnet test src/CST.Avalonia.UiTests` → 13 passed, 0 failed; `dotnet test src/CST.Avalonia.Tests` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
