### PR TITLE
Stop the suite going red for two reasons that were never the tests (#798, #960)

### DIFF
--- a/src/CST.Avalonia.Tests/Lemma/SqliteLemmaProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Lemma/SqliteLemmaProviderTests.cs
@@ -3,12 +3,14 @@ using System.IO;
 using System.Linq;
 using CST.Lemma;
 using Microsoft.Data.Sqlite;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Lemma;
 
 // Exercises SqliteLemmaProvider against a tiny hand-built fixture (rows mirror real DPD ground truth:
 // pajānāti=39702, paññā 1=39994, paññāya 1(ger)=40070, paññāya 2(fem)=40071, nappajānāti=35708).
+[Collection("Sqlite")]   // #960: ClearAllPools is process-wide
 public sealed class SqliteLemmaProviderTests : IDisposable
 {
     private readonly string _dbPath;

--- a/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
+++ b/src/CST.Avalonia.Tests/Lexicon/LexiconTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using CST.Conversion;
 using CST.Lexicon;
 using Microsoft.Data.Sqlite;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Lexicon
@@ -14,6 +15,7 @@ namespace CST.Avalonia.Tests.Lexicon
     /// homonyms surface together, HTML in a headword is stripped for the key but the published form is kept,
     /// and the exact/prefix/nearest search matches the flat-file dictionary's behaviour.
     /// </summary>
+    [Collection("Sqlite")]   // #960: ClearAllPools is process-wide
     public class LexiconTests : IDisposable
     {
         private readonly string _dir;

--- a/src/CST.Avalonia.Tests/Services/DictionaryRegistryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryRegistryTests.cs
@@ -10,6 +10,7 @@ using CST.Lemma;
 using CST.Lexicon;
 using CST.Tools;
 using Microsoft.Data.Sqlite;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services;
@@ -19,6 +20,7 @@ namespace CST.Avalonia.Tests.Services;
 /// the dpd-cst-subset asset, a downloaded lexicon (DPPN) is a source, and the flat-file languages are sources —
 /// all enumerated + routed through the one registry, with the RegistryDictionaryTool exposing them over /v1.
 /// </summary>
+[Collection("Sqlite")]   // #960: ClearAllPools is process-wide
 public sealed class DictionaryRegistryTests : IDisposable
 {
     private readonly string _dir;

--- a/src/CST.Avalonia.Tests/Services/DictionaryRetryTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DictionaryRetryTests.cs
@@ -8,6 +8,7 @@ using CST.Avalonia.Services;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services;
@@ -27,6 +28,7 @@ namespace CST.Avalonia.Tests.Services;
 /// enough to the shipped one that the updater could treat the fake as current indefinitely. A test suite must
 /// not be able to do that, which is why <see cref="DpdUpdateService"/> now takes a root.</para>
 /// </summary>
+[Collection("Sqlite")]   // #960: ClearAllPools is process-wide
 public sealed class DictionaryRetryTests : IDisposable
 {
     private readonly string _root;

--- a/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/DpdUpdateServiceTests.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using CST.Avalonia.Services;
 using Microsoft.Data.Sqlite;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services;
@@ -13,6 +14,7 @@ namespace CST.Avalonia.Tests.Services;
 // Unit tests for DpdUpdateService's testable core (#390/#468): CATALOG manifest parsing, the two-axis version
 // comparison, the per-asset version reads (a DPD lemma db vs a lexicon), and the verify→decompress→probe→atomic
 // install with preservation of a good existing asset.
+[Collection("Sqlite")]   // #960: ClearAllPools is process-wide
 public sealed class DpdUpdateServiceTests : IDisposable
 {
     private readonly string _dir;

--- a/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
+++ b/src/CST.Avalonia.Tests/Services/FirstRunDictionaryVisibilityTests.cs
@@ -11,6 +11,7 @@ using CST.Lemma;
 using CST.Tools;
 using Microsoft.Data.Sqlite;
 using Moq;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services;
@@ -31,6 +32,7 @@ namespace CST.Avalonia.Tests.Services;
 /// A clean first run has nothing to lock — see
 /// <c>DpdUpdateServiceTests.InstallFromGzip_into_an_empty_directory_reports_the_asset_live_not_staged</c>.</para>
 /// </summary>
+[Collection("Sqlite")]   // #960: ClearAllPools is process-wide
 public sealed class FirstRunDictionaryVisibilityTests : IDisposable
 {
     private readonly string _dir;

--- a/src/CST.Avalonia.Tests/Services/LemmaDeconstructTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LemmaDeconstructTests.cs
@@ -7,6 +7,7 @@ using CST.Avalonia.Services.LocalApi.Lemma;
 using CST.Conversion;
 using CST.Lemma;
 using Microsoft.Data.Sqlite;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services;
@@ -15,6 +16,7 @@ namespace CST.Avalonia.Tests.Services;
 // with a full-scope `forms` table (deconstructor populated for non-enclitic compounds too). Covers the four
 // shapes: pure sandhi (split, no headword), enclitic split, compound-stored-as-lemma (direct, no split), and
 // a plain word with neither.
+[Collection("Sqlite")]   // #960: ClearAllPools is process-wide
 public sealed class LemmaDeconstructTests : IDisposable
 {
     private readonly string _dbPath;

--- a/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
+++ b/src/CST.Avalonia.Tests/Services/LemmaSearchServiceTests.cs
@@ -9,6 +9,7 @@ using CST.Avalonia.Services;
 using CST.Conversion;
 using CST.Lemma;
 using Microsoft.Data.Sqlite;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services;
@@ -16,6 +17,7 @@ namespace CST.Avalonia.Tests.Services;
 // Orchestration tests for LemmaSearchService: form gathering, alternation building, result mapping.
 // Uses a real SqliteLemmaProvider over a tiny fixture + a fake ISearchService that "attests" a subset of
 // the alternation forms. outputScript=Ipe throughout so terms pass through without script conversion.
+[Collection("Sqlite")]   // #960: ClearAllPools is process-wide
 public sealed class LemmaSearchServiceTests : IDisposable
 {
     private readonly string _dbPath;

--- a/src/CST.Avalonia.Tests/Services/ReopenableLemmaProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/ReopenableLemmaProviderTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using CST.Avalonia.Services;
 using CST.Lemma;
 using Microsoft.Data.Sqlite;
+using CST.Avalonia.Tests.TestSupport;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services;
@@ -18,6 +19,7 @@ namespace CST.Avalonia.Tests.Services;
 /// the first-run bug would come straight back — silently, and only on a machine where the asset arrives
 /// after startup.</para>
 /// </summary>
+[Collection("Sqlite")]   // #960: ClearAllPools is process-wide
 public sealed class ReopenableLemmaProviderTests : IDisposable
 {
     private readonly string _dir;

--- a/src/CST.Avalonia.Tests/TestSupport/SqliteCollection.cs
+++ b/src/CST.Avalonia.Tests/TestSupport/SqliteCollection.cs
@@ -1,0 +1,33 @@
+using Xunit;
+
+namespace CST.Avalonia.Tests.TestSupport;
+
+/// <summary>
+/// Serialises every test class that touches SQLite. (#960)
+///
+/// <para><b>The hazard is <c>SqliteConnection.ClearAllPools()</c>, which is process-wide.</b> Nine classes
+/// call it in their cleanup to release file handles so a temp <c>.db</c> can be deleted. xunit runs
+/// collections in parallel, so one class's teardown was free to dispose a pooled <c>sqlite3</c> handle that
+/// another class's constructor was in the middle of using — surfacing as
+/// <c>ObjectDisposedException: Cannot access a disposed object. Object name: 'SQLitePCL.sqlite3'</c> thrown
+/// from a fixture builder, against a database file with a <c>Guid.NewGuid()</c> name that no other test could
+/// possibly know.</para>
+///
+/// <para>It failed roughly once in ten full-suite runs and never in isolation, which is the signature: the
+/// necessary condition is another SQLite class running concurrently, and running one class alone removes it.
+/// Putting them in one collection removes that condition rather than papering over the symptom.</para>
+///
+/// <para><b>Why this rather than <c>Pooling=False</c> everywhere.</b> That would also work — an unpooled
+/// handle is not in a pool for <c>ClearAllPools</c> to find — and <c>LexiconTests</c> already does it for one
+/// connection. But it would leave the sledgehammer in place for anything added later that forgets, whereas a
+/// collection is inherited by construction. It follows the precedent already in this project:
+/// <c>[Collection("LocalApiIntegration")]</c> serialises the endpoint tests for the same class of reason.</para>
+///
+/// <para>The cost is that these nine no longer run in parallel with <i>each other</i>; they still run in
+/// parallel with everything else. They are fixture-and-assert tests over tiny in-memory schemas, so the
+/// measured suite time did not move.</para>
+/// </summary>
+[CollectionDefinition("Sqlite")]
+public sealed class SqliteCollection
+{
+}

--- a/src/CST.Avalonia/Services/Ai/SseReader.cs
+++ b/src/CST.Avalonia/Services/Ai/SseReader.cs
@@ -60,15 +60,6 @@ internal static class SseReader
     {
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
 
-        // Linked so a real cancellation still propagates; the deadline is rescheduled after every successful
-        // read, which is what makes this an idle timeout rather than a total one.
-        //
-        // Benign race: the timer can fire in the window between a read returning and the reschedule below. The
-        // token is then permanently cancelled and the next read reports an idle timeout even though data had just
-        // arrived. It needs the stream to go quiet for the whole window and then deliver a line within
-        // microseconds of expiry; the cost is one spurious "stopped responding" that a retry clears.
-        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(ct);
-
         string? name = null;
         var data = new StringBuilder();
         var sawAnyData = false;
@@ -86,11 +77,29 @@ internal static class SseReader
             string? line;
             AiError? failure = null;
 
+            // ONE SOURCE PER READ, and this is load-bearing rather than tidy. A CancellationTokenSource that
+            // has fired is cancelled for good. Sharing one across reads meant a timer expiring in the gap
+            // between a read returning and the next re-arm poisoned every read that followed: the stream is
+            // alive and still delivering, and the reader reports "the model stopped responding".
+            //
+            // The comment that used to sit here called that race benign, on the grounds that it needs a line
+            // to arrive within microseconds of expiry. That measured the wrong interval. The window is not the
+            // arrival — it is however long this thread is descheduled between the read returning and the
+            // re-arm, which under a loaded machine is milliseconds. It is the cause of #798: the reader
+            // returned its first event and then a spurious network failure, roughly once in ten full-suite
+            // runs, and never when the test was run alone.
+            //
+            // A source per line costs an allocation and a timer against a loop that already allocates a
+            // string per line and awaits I/O on each one. Linked to ct throughout, so a real cancellation
+            // still propagates.
+            using var deadline = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
             try
             {
                 // Armed BEFORE the read, so the window in force always matches the pivot. Arming afterwards
                 // left one read carrying the previous line's verdict — harmless (always the more lenient of the
-                // two) but it made the timeout message name a window that had not applied.
+                // two) but it made the timeout message name a window that had not applied. With a source per
+                // read this is also the only arming that source ever gets.
                 //
                 // Two different shapes of window, deliberately. AFTER the first data line the idle window
                 // slides: a stream that keeps producing is allowed to run for as long as it likes, and only a


### PR DESCRIPTION
Closes #798, closes #960. **Both flakes were real defects, and one is in shipping code.**

## #798 — `SseReader` poisons itself

It shared **one** `CancellationTokenSource` across every read and rescheduled it with `CancelAfter`. A source that has fired is cancelled for good, so a timer expiring in the gap between a read returning and the next re-arm poisoned every read after it: the stream alive and still delivering, and the reader announcing *"The model stopped responding."*

The comment sitting on that source called the race benign, reasoning that it needs a line to arrive within microseconds of expiry. **That measures the wrong interval.** The window is not the arrival — it is how long the thread is descheduled between the read returning and the re-arm, which under a loaded machine is milliseconds.

**The failure shape is what identifies it.** The test returned `["one"]` and then a network failure. A first-event budget expiry would have returned **nothing**, because that budget is checked before the first read; only a source poisoned *after* a successful read yields exactly one event and then a spurious failure.

So this is user-visible: a reader watching a long answer arrive could see it cut off and be told the model had stopped. Now **one source per read** — it cannot carry a verdict from a previous read because it has no previous read. Costs an allocation and a timer per line, against a loop already allocating a string per line and awaiting I/O on each.

## #960 — `ClearAllPools()` is process-wide

Nine test classes call `SqliteConnection.ClearAllPools()` in cleanup to release file handles so a temp `.db` can be deleted, and xunit runs collections in parallel. One class's teardown was free to dispose a pooled `sqlite3` handle another class's **constructor** was in the middle of using — which is why it surfaced inside a fixture builder, against a database file named with a `Guid` no other test could know.

The nine now share a collection, so they cannot run concurrently with each other. That removes the necessary condition rather than papering over the symptom, and follows the precedent already here: `[Collection("LocalApiIntegration")]` serialises the endpoint tests for the same class of reason.

`Pooling=False` everywhere would also work — `LexiconTests` already does it for one connection — but it leaves the sledgehammer in place for whatever is added next, whereas a collection is inherited by construction.

**Measured cost of serialising them: none.** Full suite 3m11s and 3m05s, against ~3m07s before.

## No regression test for either, deliberately

#798's race needs the scheduler stalled at a chosen instant; #960's needs two collections interleaved at one. Both want an injected clock. #655 has since landed headless Avalonia infrastructure, which is adjacent but not the same mechanism. Saying so rather than shipping a test that passes for the wrong reason.

## Verification

- `dotnet build src/CST.Avalonia --no-incremental` — **0 errors, 0 warnings**
- `dotnet test src/CST.Avalonia.Tests` — **2857 passed, 0 failed, 18 skipped**, run twice
- `dotnet test src/CST.Avalonia.UiTests` — **13 passed** (#655's new project; both suites now, every time)
- Rebased onto current `main` after #987 and #992 landed

The test project's 10 warnings are pre-existing, in files not touched here.
