### PR TITLE
Replay the conversation to the model so follow-up questions work (#991)

### DIFF
--- a/docs/features/in-progress/AI_SURFACE_B.md
+++ b/docs/features/in-progress/AI_SURFACE_B.md
@@ -274,14 +274,25 @@ right semantic for a reader and it shapes B5's orchestrator.
 
 **A turn is part of a conversation** (#991, 2026-09-12). `ChatRequest.Messages` carries the turns before this
 one as `user`/`assistant` pairs, ahead of this turn's message. **[fsnow]** chose the layout *"Citation +
-question → answer"*: each earlier turn is replayed as the app's own citation line plus what was asked, then the
-raw answer; the passage, selection and lemma blocks are sent for the **current turn only**, so a ten-turn
-conversation about one paragraph sends that paragraph once. Reasoning is never replayed, a turn that produced no
-answer text is not replayed, and the token estimate covers the whole message list — the figure auto-compaction
-is driven by. A follow-up asked after the reader has moved on gets each earlier turn's citation but not its
-text. The stable-prefix requirement that prompt caching needs follows from the same layout: nothing that moves
-between turns may enter the system prompt or an already-sent message. Persistence, named sessions and
-compaction are planned separately in
+question → answer"*.
+
+**[suggestion]** How that is built: each earlier turn is replayed as the app's own citation line plus what was
+asked, then the raw answer; the passage, selection and lemma blocks are sent for the **current turn only**, so a
+ten-turn conversation about one paragraph sends that paragraph once. Reasoning is never replayed, a turn that
+produced no answer text is not replayed, and the token estimate covers the whole message list — the figure
+auto-compaction is driven by. A follow-up asked after the reader has moved on gets each earlier turn's citation
+but not its text.
+
+**[observed] The request has no prefix that is stable by construction, and nothing asks for caching**
+(2026-09-12). The replayed messages *are* byte-stable: they are the strings the earlier turns were built from,
+and nothing turn- or time-dependent enters them. **The system prompt is not.** `Resources/Ai/system.md` embeds
+`{{scope}}` and `{{outputLanguage}}`, and `PromptBuilder.Scope` renders the book name, the reference, a
+paragraphs-covered sentence and a selection-dependent sentence — so it holds only while the reader stays on the
+same reference with the same selection state and answer language, and changes as soon as any of those does.
+Neither adapter sets Anthropic's `cache_control`. A prefix that could be cached reliably therefore needs work
+beyond #991: the varying scope statement would have to move out of the system prompt into the per-turn
+message. Persistence,
+named sessions and compaction are planned separately in
 [ASSISTANT_SESSIONS.md](../planned/ASSISTANT_SESSIONS.md).
 
 All errors normalize into one `AiError` type: not-configured, no-network, 401, 429 + retry-after,

--- a/docs/features/in-progress/AI_SURFACE_B.md
+++ b/docs/features/in-progress/AI_SURFACE_B.md
@@ -277,11 +277,21 @@ one as `user`/`assistant` pairs, ahead of this turn's message. **[fsnow]** chose
 question → answer"*.
 
 **[suggestion]** How that is built: each earlier turn is replayed as the app's own citation line plus what was
-asked, then the raw answer; the passage, selection and lemma blocks are sent for the **current turn only**, so a
+asked, then the answer; the passage, selection and lemma blocks are sent for the **current turn only**, so a
 ten-turn conversation about one paragraph sends that paragraph once. Reasoning is never replayed, a turn that
 produced no answer text is not replayed, and the token estimate covers the whole message list — the figure
 auto-compaction is driven by. A follow-up asked after the reader has moved on gets each earlier turn's citation
 but not its text.
+
+**[fsnow] The replayed answer is the model's own marked text, not what the panel shows** — *"I want to fix this
+before we merge."* (2026-09-12, before #991 merged.) §9's `[[…]]` markers are stripped from the display by
+`PaliQuoteFilter`, so the answer on screen has none; `system.md` tells the model to wrap **every** Pāli span in
+them. Replaying the stripped text would hand the model, from turn 2 on, a transcript of its own answers ignoring
+the instruction it is being given — and a model shown its own apparent practice follows it. So the orchestrator
+emits both halves of each text delta (`AiTurnEvent.Text` for the screen, `AiTurnEvent.MarkedText` as written),
+`AiTurnViewModel` accumulates the marked half beside the displayed one, and the history replays the marked half.
+**Unbalanced markers go back as written**: the filter strips those from the display and counts them (#587), but
+what the model is shown of its own output should be what it produced, not a repaired version.
 
 **[observed] The request has no prefix that is stable by construction, and nothing asks for caching**
 (2026-09-12). The replayed messages *are* byte-stable: they are the strings the earlier turns were built from,

--- a/docs/features/in-progress/AI_SURFACE_B.md
+++ b/docs/features/in-progress/AI_SURFACE_B.md
@@ -272,6 +272,18 @@ public interface IChatProvider
 **Concurrency:** invoking a preset while a stream is running is **cancel-and-replace**, not queue. That is the
 right semantic for a reader and it shapes B5's orchestrator.
 
+**A turn is part of a conversation** (#991, 2026-09-12). `ChatRequest.Messages` carries the turns before this
+one as `user`/`assistant` pairs, ahead of this turn's message. **[fsnow]** chose the layout *"Citation +
+question → answer"*: each earlier turn is replayed as the app's own citation line plus what was asked, then the
+raw answer; the passage, selection and lemma blocks are sent for the **current turn only**, so a ten-turn
+conversation about one paragraph sends that paragraph once. Reasoning is never replayed, a turn that produced no
+answer text is not replayed, and the token estimate covers the whole message list — the figure auto-compaction
+is driven by. A follow-up asked after the reader has moved on gets each earlier turn's citation but not its
+text. The stable-prefix requirement that prompt caching needs follows from the same layout: nothing that moves
+between turns may enter the system prompt or an already-sent message. Persistence, named sessions and
+compaction are planned separately in
+[ASSISTANT_SESSIONS.md](../planned/ASSISTANT_SESSIONS.md).
+
 All errors normalize into one `AiError` type: not-configured, no-network, 401, 429 + retry-after,
 context-too-long, provider-shaped. **Provider error bodies are sanitized before logging** — some providers echo
 request material.
@@ -516,8 +528,6 @@ output quality, and it is far easier to critique as inspectable data than as a p
 
 ## 14. Open questions
 
-- **Follow-up turns** — one-shot per invocation, or a short conversation over the same bundle? (One-shot covers
-  the named use cases; conversation needs history management and re-budgeting.)
 - ~~**`ICorpusTools`** — delete as dead, or implement it?~~ *Deleted in #580: no implementation, no consumer,
   and one of its four members had no implementation at all.*
 - ~~**Which dictionaries feed glosses by default**~~ *Moot for v1: no glosses are injected (§4). Returns as a

--- a/docs/features/planned/ASSISTANT_SESSIONS.md
+++ b/docs/features/planned/ASSISTANT_SESSIONS.md
@@ -104,16 +104,23 @@ Mechanics:
 - `AiTurnRequest` gains `IReadOnlyList<AiExchange> History` (question-side text + answer text, both already
   rendered strings). The orchestrator prepends them to `Messages`. Failed turns with no answer text are not
   replayed; a turn with partial text is replayed as-is (it stands on screen, so it stands in the history).
-- `SentContext` (#665) must show the replayed messages, or "what did the model see" stops being true. Add a
-  `Messages` list to `SentContext`; the panel's expander renders them under the two prompt halves.
+- `SentContext` (#665) must show the replayed messages, or "what did the model see" stops being true. Shipped
+  in #991 as `SentContext.History` (plus `HasHistory`), rendered by the panel's Sent expander above the
+  message it sent.
 - The token estimate (`AiTokens.Estimate`) runs over the whole message list, and the "Estimated context"
   field says how much of it is history — the input to auto-compaction in P4.
 - Reasoning is **never** replayed. It was segregated from the answer for a reason (§8 of the design doc).
 - Retry re-asks with the history *as it is now*, not as it was. Simpler, and what a reader pressing "Try
   again" on a 504 wants.
 - **Prompt caching** (Anthropic `cache_control` on the stable prefix) is exactly what a replayed history
-  benefits from. Not in this plan; noted so nobody designs the message layout in a way that defeats it —
-  the system prompt and older history must stay byte-stable between turns, which the layout above does.
+  benefits from, and **[observed] the request has no prefix that is stable by construction, and nothing asks
+  for caching (2026-09-12)**. The layout above keeps the replayed messages byte-stable; the *system prompt* is
+  not, because `Resources/Ai/system.md` embeds `{{scope}}` and `{{outputLanguage}}` and `PromptBuilder.Scope`
+  renders the book name, the reference, a paragraphs-covered sentence and a selection-dependent sentence — it
+  holds only while the reader stays on the same reference with the same selection state and answer language.
+  Neither adapter sets `cache_control`. [suggestion] Whoever takes
+  caching up will have to move the scope statement out of the system prompt and into the per-turn message
+  first; that was not #991's work.
 
 ### 3.2 Persistence (P2)
 
@@ -211,7 +218,7 @@ UI phases are the maintainer's (standing pattern).
 | # | Issue | Work | UI-free | Depends on |
 |---|---|---|---|---|
 | **P0** | #850 | The **+** (new conversation) control; remove `ClearCommand`/`Clear()` | ✗ (one button) | — |
-| **P1** | #991 | Conversation: `History` on `AiTurnRequest`, replay in the orchestrator, `SentContext.Messages`, estimate over the whole request | ✅ | — |
+| **P1** | #991 | Conversation: `History` on `AiTurnRequest`, replay in the orchestrator, `SentContext.History`, estimate over the whole request | ✅ | — |
 | **P2** | #849 | `AiSession`/`AiTurnRecord` models, `IAiSessionStore` (load/save/list/delete, atomic writes, unreadable-file handling), reading-position capture at `StartTurn`, `ActiveAssistantSessionId` in `ApplicationState`, restore at launch | ✅ except the launch wiring | P1 |
 | **P3** | new | Session service: new / switch / rename / delete / auto-name; the list, rename and delete UI | service ✅, panel ✗ | P2 |
 | **P4** | new | Compaction: template, summariser, marker row, manual action, auto trigger from `ContextLength` | ✅ except the action | P1, P3 |
@@ -226,7 +233,7 @@ format, compaction boundary, prompt-cache stability) is shaped by.
 
 - **P1** — the fake-provider test that already asserts the assembled request (`AiChatOrchestrator` suite)
   gains cases for: history prepended in order; a failed turn without text omitted; reasoning never replayed;
-  `SentContext.Messages` matches what was sent; the estimate covers the list.
+  `SentContext.History` matches what was sent; the estimate covers the list.
 - **P2** — `IAiSessionStore` against a temp directory (the `ApplicationStateService` test seam pattern):
   round-trip of every field; a truncated file is moved aside and reported, not thrown; save is atomic (no
   `.tmp` promoted over good data); restore builds `Turns` identical to the live ones. A golden session file

--- a/docs/features/planned/ASSISTANT_SESSIONS.md
+++ b/docs/features/planned/ASSISTANT_SESSIONS.md
@@ -211,7 +211,7 @@ UI phases are the maintainer's (standing pattern).
 | # | Issue | Work | UI-free | Depends on |
 |---|---|---|---|---|
 | **P0** | #850 | The **+** (new conversation) control; remove `ClearCommand`/`Clear()` | ✗ (one button) | — |
-| **P1** | new | Conversation: `History` on `AiTurnRequest`, replay in the orchestrator, `SentContext.Messages`, estimate over the whole request | ✅ | — |
+| **P1** | #991 | Conversation: `History` on `AiTurnRequest`, replay in the orchestrator, `SentContext.Messages`, estimate over the whole request | ✅ | — |
 | **P2** | #849 | `AiSession`/`AiTurnRecord` models, `IAiSessionStore` (load/save/list/delete, atomic writes, unreadable-file handling), reading-position capture at `StartTurn`, `ActiveAssistantSessionId` in `ApplicationState`, restore at launch | ✅ except the launch wiring | P1 |
 | **P3** | new | Session service: new / switch / rename / delete / auto-name; the list, rename and delete UI | service ✅, panel ✗ | P2 |
 | **P4** | new | Compaction: template, summariser, marker row, manual action, auto trigger from `ContextLength` | ✅ except the action | P1, P3 |

--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -757,6 +757,49 @@ public class AiChatOrchestratorTests
     }
 
     /// <summary>
+    /// Both halves of every text delta reach the caller: the stripped text for the screen, and what the model
+    /// wrote for the history. (#991)
+    ///
+    /// <para>Split across deltas on purpose, including a delta that ends between the two brackets — the filter
+    /// holds that bracket back, so the visible half of one event is empty while its marked half is not, and an
+    /// event dropped for having nothing renderable would lose the span this exists to keep.</para>
+    /// </summary>
+    [Fact]
+    public async Task Each_text_delta_carries_both_the_stripped_and_the_marked_form()
+    {
+        var provider = new FakeProvider(new[]
+        {
+            ChatDelta.ForText("The term ["),
+            ChatDelta.ForText("[appam\u0101da]] matters."),
+        });
+
+        var events = await CollectAsync(Orchestrator(provider));
+
+        Assert.Equal("The term appam\u0101da matters.", TextOf(events));
+        Assert.Equal(
+            "The term [[appam\u0101da]] matters.",
+            string.Concat(events.Where(e => e.Kind == AiTurnEventKind.Text).Select(e => e.MarkedText)));
+    }
+
+    /// <summary>
+    /// A marker with no partner goes into the marked half as written. The filter strips it from the display and
+    /// counts it (#587); what the model is shown of its own output is what it produced.
+    /// </summary>
+    [Fact]
+    public async Task An_unbalanced_marker_survives_in_the_marked_form()
+    {
+        var provider = new FakeProvider(new[] { ChatDelta.ForText("The term [[appam\u0101da matters.") });
+
+        var events = await CollectAsync(Orchestrator(provider));
+
+        Assert.Equal("The term appam\u0101da matters.", TextOf(events));
+        Assert.Equal(
+            "The term [[appam\u0101da matters.",
+            string.Concat(events.Where(e => e.Kind == AiTurnEventKind.Text).Select(e => e.MarkedText)));
+        Assert.Equal(1, events[^1].Markers!.UnbalancedMarkers);
+    }
+
+    /// <summary>
     /// A turn that produced no answer is not replayed. The panel already leaves one out, but this is the last
     /// point before the wire: the Anthropic Messages API refuses an empty text block outright, so a caller's
     /// slip would be a rejected request rather than a slightly poorer one.

--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -707,4 +707,145 @@ public class AiChatOrchestratorTests
 
         Assert.Null(provider.LastRequest!.ReasoningEffort);
     }
+
+    // ---- The conversation (#991) ---------------------------------------------------------------------------
+
+    /// <summary>An earlier turn as the panel hands it over: the app's own citation line plus what was asked,
+    /// and the answer that came back. No passage, and no reasoning — there is nowhere to put either.</summary>
+    private static AiExchange Exchange(string asked, string answered) => new(asked, answered);
+
+    private static AiTurnRequest AskWith(params AiExchange[] history) =>
+        new(AiTask.Ask, "s0502m.mul.xml", new NavigationReference.Paragraph(21),
+            UserQuestion: "What does the third word mean?", History: history);
+
+    private const string FirstAsked = "\u00abExplain\u00bb \u2014 Dhammapadap\u0101\u1E37i \u2014 paragraph 21 (dhp)";
+    private const string FirstAnswer = "Heedfulness is the path to the deathless.";
+    private const string SecondAsked = FirstAsked + ": what is appam\u0101da?";
+    private const string SecondAnswer = "Vigilance, watchfulness.";
+
+    /// <summary>
+    /// The whole point of #991: the model is shown the turns before this one, in order, as user/assistant
+    /// pairs, and this turn's full context goes last.
+    /// </summary>
+    [Fact]
+    public async Task The_conversation_is_replayed_ahead_of_this_turns_message()
+    {
+        var provider = new FakeProvider();
+
+        await CollectAsync(
+            Orchestrator(provider),
+            AskWith(Exchange(FirstAsked, FirstAnswer), Exchange(SecondAsked, SecondAnswer)));
+
+        var sent = provider.LastRequest!;
+        Assert.Equal(
+            new[] { ChatRole.User, ChatRole.Assistant, ChatRole.User, ChatRole.Assistant, ChatRole.User },
+            sent.Messages.Select(m => m.Role));
+
+        Assert.Equal(FirstAsked, sent.Messages[0].Content);
+        Assert.Equal(FirstAnswer, sent.Messages[1].Content);
+        Assert.Equal(SecondAsked, sent.Messages[2].Content);
+        Assert.Equal(SecondAnswer, sent.Messages[3].Content);
+
+        // This turn's message is the FULL rendered prompt and it goes last, so the passage the model is being
+        // asked about is the last thing it reads.
+        Assert.Contains("Appam\u0101do amatapada\u1E43.", sent.Messages[^1].Content);
+
+        // And the passage is sent ONCE. Replaying each turn's own context would send the same paragraph once
+        // per turn, which is the layout this one was chosen over.
+        Assert.DoesNotContain(
+            sent.Messages.Take(4), m => m.Content.Contains("Appam\u0101do amatapada\u1E43."));
+    }
+
+    /// <summary>
+    /// A turn that produced no answer is not replayed. The panel already leaves one out, but this is the last
+    /// point before the wire: the Anthropic Messages API refuses an empty text block outright, so a caller's
+    /// slip would be a rejected request rather than a slightly poorer one.
+    /// </summary>
+    [Fact]
+    public async Task An_exchange_with_no_answer_text_is_not_replayed()
+    {
+        var provider = new FakeProvider();
+
+        await CollectAsync(
+            Orchestrator(provider),
+            AskWith(
+                Exchange(FirstAsked, FirstAnswer),
+                Exchange(SecondAsked, ""),
+                Exchange(SecondAsked, "   ")));
+
+        var sent = provider.LastRequest!;
+        Assert.Equal(3, sent.Messages.Count);
+        Assert.Equal(FirstAnswer, sent.Messages[1].Content);
+        Assert.DoesNotContain(sent.Messages, m => string.IsNullOrWhiteSpace(m.Content));
+    }
+
+    /// <summary>
+    /// What the reader is shown under "Context sent" is the request, history included. Once a conversation
+    /// exists, showing only the current message would be showing the last message of a longer request and
+    /// calling it the request. (#665, #991)
+    /// </summary>
+    [Fact]
+    public async Task The_sent_context_shows_the_replayed_conversation()
+    {
+        var provider = new FakeProvider();
+
+        var events = await CollectAsync(
+            Orchestrator(provider),
+            AskWith(Exchange(FirstAsked, FirstAnswer), Exchange(SecondAsked, SecondAnswer)));
+
+        var sent = events.First(e => e.Kind == AiTurnEventKind.Started).Context!.Sent!;
+        Assert.True(sent.HasHistory);
+
+        // Exactly what went on the wire, minus this turn's own message, which is UserContent.
+        Assert.Equal(
+            provider.LastRequest!.Messages.Take(4).Select(m => (m.Role, m.Content)),
+            sent.History!.Select(m => (m.Role, m.Content)));
+        Assert.Equal(sent.UserContent, provider.LastRequest!.Messages[^1].Content);
+    }
+
+    /// <summary>
+    /// The estimate covers the whole request and says how much of it the conversation accounts for — the figure
+    /// that decides when a conversation has to be compacted, and the one part of a request that grows without
+    /// the reader doing anything.
+    /// </summary>
+    [Fact]
+    public async Task The_estimate_covers_the_whole_request_and_names_the_historys_share()
+    {
+        var provider = new FakeProvider();
+
+        var events = await CollectAsync(
+            Orchestrator(provider),
+            AskWith(Exchange(FirstAsked, FirstAnswer), Exchange(SecondAsked, SecondAnswer)));
+
+        var sent = events.First(e => e.Kind == AiTurnEventKind.Started).Context!.Sent!;
+        var field = sent.Fields.First(f => f.Name == "Estimated context").Value;
+
+        var whole = AiTokens.Estimate(
+            new[] { sent.SystemPrompt, sent.UserContent }.Concat(sent.History!.Select(m => m.Content)));
+        var history = AiTokens.Estimate(sent.History!.Select(m => m.Content));
+
+        Assert.StartsWith($"~{whole:N0} tokens", field);
+        Assert.Contains($"~{history:N0} of them 2 earlier turns", field);
+
+        // The history is a real share of it, not a rounding artefact: the assertion above would hold trivially
+        // if the estimate had silently ignored the replayed messages and both figures were zero.
+        Assert.True(history > 0);
+        Assert.True(whole > history);
+    }
+
+    /// <summary>A first question is what it always was — one message, and nothing claimed about a
+    /// conversation that does not exist yet.</summary>
+    [Fact]
+    public async Task A_first_question_sends_one_message_and_reports_no_history()
+    {
+        var provider = new FakeProvider();
+
+        var events = await CollectAsync(Orchestrator(provider));
+
+        Assert.Single(provider.LastRequest!.Messages);
+
+        var sent = events.First(e => e.Kind == AiTurnEventKind.Started).Context!.Sent!;
+        Assert.False(sent.HasHistory);
+        Assert.DoesNotContain("earlier turn", sent.Fields.First(f => f.Name == "Estimated context").Value);
+    }
 }

--- a/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AnthropicMessagesProviderTests.cs
@@ -198,6 +198,47 @@ public class AnthropicMessagesProviderTests
         Assert.False(root.TryGetProperty("top_k", out _));
     }
 
+    /// <summary>
+    /// A conversation on the wire: the system prompt stays in its own top-level field and the turns go in the
+    /// messages array, alternating, in order. (#991)
+    ///
+    /// <para>Asserted on the serialized body rather than reasoned about, because "the adapter iterates the
+    /// list" is only half of what a longer list needs to be true — the API requires alternating roles and a
+    /// non-empty text block in each, and the system prompt must not be dealt into the array as a pseudo-turn
+    /// the way the OpenAI-compatible shape expects.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_replayed_conversation_is_serialized_as_alternating_turns()
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        var conversation = new ChatRequest(
+            "claude-opus-5", 1024, "You are a Pali reading assistant.",
+            new[]
+            {
+                new ChatMessage(ChatRole.User, "\u00abExplain\u00bb \u2014 Dhammapadap\u0101\u1E37i"),
+                new ChatMessage(ChatRole.Assistant, "Heedfulness is the path."),
+                new ChatMessage(ChatRole.User, "What does the third word mean?"),
+            });
+
+        await CollectAsync(Provider(handler), conversation);
+
+        using var body = JsonDocument.Parse(handler.LastRequestBody);
+        var root = body.RootElement;
+
+        // Top-level, not a message: Anthropic has no system role in the array.
+        Assert.Equal("You are a Pali reading assistant.", root.GetProperty("system").GetString());
+
+        var messages = root.GetProperty("messages").EnumerateArray().ToList();
+        Assert.Equal(3, messages.Count);
+        Assert.Equal(
+            new[] { "user", "assistant", "user" },
+            messages.Select(m => m.GetProperty("role").GetString()));
+        Assert.Equal(
+            conversation.Messages.Select(m => m.Content),
+            messages.Select(m => m.GetProperty("content").GetString()));
+        Assert.DoesNotContain(messages, m => string.IsNullOrEmpty(m.GetProperty("content").GetString()));
+    }
+
     [Fact]
     public async Task An_unset_cap_becomes_the_ceiling_every_current_model_accepts()
     {

--- a/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/OpenAiCompatibleProviderTests.cs
@@ -72,6 +72,41 @@ public class OpenAiCompatibleProviderTests
         Assert.False(body.RootElement.TryGetProperty("max_tokens", out _));
     }
 
+    /// <summary>
+    /// A conversation on the wire: the system prompt leads the array, as this shape expects, and the turns
+    /// follow it in order with their own roles. (#991)
+    ///
+    /// <para>Asserted on the serialized body because the system-as-first-message step is the one place a longer
+    /// message list could go wrong here — the system prompt has to stay ahead of the conversation rather than
+    /// between the reader and their own last question.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_replayed_conversation_follows_the_system_message_in_order()
+    {
+        var handler = StubHttpMessageHandler.Sse(HappyStream);
+        var conversation = new ChatRequest(
+            "deepseek-chat", 1024, "You are a Pali reading assistant.",
+            new[]
+            {
+                new ChatMessage(ChatRole.User, "\u00abExplain\u00bb \u2014 Dhammapadap\u0101\u1E37i"),
+                new ChatMessage(ChatRole.Assistant, "Heedfulness is the path."),
+                new ChatMessage(ChatRole.User, "What does the third word mean?"),
+            });
+
+        await CollectAsync(Provider(handler), conversation);
+
+        using var body = JsonDocument.Parse(handler.LastRequestBody);
+        var messages = body.RootElement.GetProperty("messages").EnumerateArray().ToList();
+
+        Assert.Equal(
+            new[] { "system", "user", "assistant", "user" },
+            messages.Select(m => m.GetProperty("role").GetString()));
+        Assert.Equal("You are a Pali reading assistant.", messages[0].GetProperty("content").GetString());
+        Assert.Equal(
+            conversation.Messages.Select(m => m.Content),
+            messages.Skip(1).Select(m => m.GetProperty("content").GetString()));
+    }
+
     [Fact]
     public async Task Streams_text_deltas_in_order()
     {

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -1121,6 +1121,29 @@ public class AiAssistantViewModelTests
     }
 
     /// <summary>
+    /// An earlier turn is replayed IDENTICALLY on every later turn. (#991)
+    ///
+    /// <para>The property a prompt-cache prefix would need from this half of the request, and the test that
+    /// fails the moment anyone appends a turn tag, a count or a timestamp to the replayed question line. (The
+    /// system prompt does not have this property today — <c>Resources/Ai/system.md</c> embeds a scope statement
+    /// that moves with the reader — so nothing is claimed here about the request as a whole.)</para>
+    /// </summary>
+    [Fact]
+    public async Task An_earlier_turn_is_replayed_byte_for_byte_on_every_later_turn()
+    {
+        var orchestrator = Answering(AiTurnEvent.ForText("An answer."));
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+
+        await vm.AskAsync(AiTask.Explain);
+        await vm.AskAsync(AiTask.Translate);
+        await vm.AskAsync(AiTask.Grammar);
+
+        // Value equality on the record, so both halves are compared — the question line and the answer.
+        Assert.Equal(orchestrator.Requests[1].History![0], orchestrator.Requests[2].History![0]);
+        Assert.Equal(2, orchestrator.Requests[2].History!.Count);
+    }
+
+    /// <summary>
     /// The question line, on its own. The layout is a decision about what the model is shown rather than an
     /// implementation detail: the preset says what was asked of the passage, and the citation says which
     /// passage — the answers alone say neither.
@@ -1146,6 +1169,8 @@ public class AiAssistantViewModelTests
 
         // A turn whose citation never arrived — the request failed before the Started event — still says what
         // was asked rather than opening with a dangling dash.
-        Assert.Equal("\u00abExplain\u00bb", AiAssistantViewModel.DescribeAsked(new AiTurnViewModel(AiTask.Explain, null)));
+        Assert.Equal(
+            "\u00abExplain\u00bb",
+            AiAssistantViewModel.DescribeAsked(new AiTurnViewModel(AiTask.Explain, null)));
     }
 }

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -976,6 +976,10 @@ public class AiAssistantViewModelTests
 
     // ---- The conversation the model is shown (#991) -----------------------------------------------
 
+    /// <summary>One text delta with both halves, as the orchestrator emits them for text carrying no
+    /// markers — the stripped form and the model's own form are the same string.</summary>
+    private static AiTurnEvent Said(string text) => AiTurnEvent.ForText(text, text);
+
     /// <summary>A stub that answers every turn the same way: citation, some text, done.</summary>
     private static StubOrchestrator Answering(params AiTurnEvent[] middle)
     {
@@ -993,7 +997,7 @@ public class AiAssistantViewModelTests
     [Fact]
     public async Task The_next_question_carries_the_conversation_so_far()
     {
-        var orchestrator = Answering(AiTurnEvent.ForText("Heedfulness is the path."));
+        var orchestrator = Answering(Said("Heedfulness is the path."));
         var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
 
         await vm.AskAsync(AiTask.Explain);
@@ -1017,7 +1021,7 @@ public class AiAssistantViewModelTests
     [Fact]
     public async Task A_replayed_turn_carries_the_question_that_was_asked()
     {
-        var orchestrator = Answering(AiTurnEvent.ForText("It means vigilance."));
+        var orchestrator = Answering(Said("It means vigilance."));
         var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
 
         vm.Question = "what is appamāda?";
@@ -1061,7 +1065,7 @@ public class AiAssistantViewModelTests
     {
         var orchestrator = new StubOrchestrator();
         orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
-        orchestrator.Events.Add(AiTurnEvent.ForText("Heedfulness is the pa"));
+        orchestrator.Events.Add(Said("Heedfulness is the pa"));
         orchestrator.Events.Add(AiTurnEvent.ForError(new AiError(AiErrorKind.Network, "dropped")));
 
         var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
@@ -1082,7 +1086,7 @@ public class AiAssistantViewModelTests
     {
         var orchestrator = Answering(
             AiTurnEvent.ForReasoning("Maybe it is a locative. Or maybe not — check the commentary."),
-            AiTurnEvent.ForText("It is an accusative of time."));
+            Said("It is an accusative of time."));
 
         var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
         await vm.AskAsync(AiTask.Grammar);
@@ -1106,7 +1110,7 @@ public class AiAssistantViewModelTests
     [Fact]
     public async Task Retry_re_asks_with_the_conversation_as_it_stands_now()
     {
-        var orchestrator = Answering(AiTurnEvent.ForText("An answer."));
+        var orchestrator = Answering(Said("An answer."));
         var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
 
         await vm.AskAsync(AiTask.Explain);
@@ -1131,7 +1135,7 @@ public class AiAssistantViewModelTests
     [Fact]
     public async Task An_earlier_turn_is_replayed_byte_for_byte_on_every_later_turn()
     {
-        var orchestrator = Answering(AiTurnEvent.ForText("An answer."));
+        var orchestrator = Answering(Said("An answer."));
         var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
 
         await vm.AskAsync(AiTask.Explain);
@@ -1141,6 +1145,75 @@ public class AiAssistantViewModelTests
         // Value equality on the record, so both halves are compared — the question line and the answer.
         Assert.Equal(orchestrator.Requests[1].History![0], orchestrator.Requests[2].History![0]);
         Assert.Equal(2, orchestrator.Requests[2].History!.Count);
+    }
+
+    /// <summary>
+    /// <b>The model is replayed its own marked text, not the text on screen.</b> (#991) The panel strips the
+    /// <c>[[…]]</c> Pāli markers, and the system prompt asks for them on every Pāli span — so replaying the
+    /// stripped answer would show the model a transcript of itself ignoring the instruction it is given, which
+    /// is the kind of thing a model imitates. <b>[fsnow]</b>: <i>"I want to fix this before we merge."</i>
+    /// </summary>
+    [Fact]
+    public async Task A_replayed_answer_keeps_the_markers_the_model_wrote()
+    {
+        var orchestrator = Answering(
+            AiTurnEvent.ForText("The term appamāda matters.", "The term [[appamāda]] matters."));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+        await vm.AskAsync(AiTask.Explain);
+        await vm.AskAsync(AiTask.Translate);
+
+        // On screen: stripped, exactly as before.
+        Assert.Equal("The term appamāda matters.", vm.Turns[0].Answer);
+        Assert.DoesNotContain("[[", vm.Turns[0].Answer);
+
+        // To the model: as written.
+        Assert.Equal(
+            "The term [[appamāda]] matters.",
+            Assert.Single(orchestrator.Requests[1].History!).Answer);
+    }
+
+    /// <summary>
+    /// A marker with no partner is replayed as written. The filter strips it from the display and counts it
+    /// (#587); what the model is shown of its own output should be what it produced, not a repair of it.
+    /// </summary>
+    [Fact]
+    public async Task An_unbalanced_marker_survives_replay()
+    {
+        var orchestrator = Answering(
+            AiTurnEvent.ForText("The term appamāda matters.", "The term [[appamāda matters."));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+        await vm.AskAsync(AiTask.Explain);
+        await vm.AskAsync(AiTask.Translate);
+
+        Assert.DoesNotContain("[[", vm.Turns[0].Answer);
+        Assert.Equal(
+            "The term [[appamāda matters.",
+            Assert.Single(orchestrator.Requests[1].History!).Answer);
+    }
+
+    /// <summary>
+    /// A delta the filter swallows whole — one that ends between the two brackets of a marker — puts nothing on
+    /// screen, so it must not be taken for progress or for an answer, and its marked half must still be kept.
+    /// </summary>
+    [Fact]
+    public async Task A_delta_with_nothing_renderable_yet_still_contributes_its_marked_text()
+    {
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.Add(AiTurnEvent.ForText("", "The term ["));
+        orchestrator.Events.Add(AiTurnEvent.ForText("The term appamāda.", "[appamāda]]."));
+        orchestrator.Events.Add(AiTurnEvent.ForCompleted(new PaliMarkerReport(1, 0)));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+        await vm.AskAsync(AiTask.Explain);
+        await vm.AskAsync(AiTask.Translate);
+
+        Assert.Equal("The term appamāda.", vm.Turns[0].Answer);
+        Assert.Equal(
+            "The term [[appamāda]].",
+            Assert.Single(orchestrator.Requests[1].History!).Answer);
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -32,10 +32,14 @@ public class AiAssistantViewModelTests
         internal int StopCalls { get; private set; }
         internal AiTurnRequest? LastRequest { get; private set; }
 
+        /// <summary>Every request, in order. A conversation is only visible across turns. (#991)</summary>
+        internal List<AiTurnRequest> Requests { get; } = new();
+
         public async IAsyncEnumerable<AiTurnEvent> RunAsync(
             AiTurnRequest request, [EnumeratorCancellation] CancellationToken ct = default)
         {
             LastRequest = request;
+            Requests.Add(request);
             foreach (var e in Events)
             {
                 ct.ThrowIfCancellationRequested();
@@ -968,5 +972,180 @@ public class AiAssistantViewModelTests
         Assert.Equal("The term **appamāda** matters.", vm.LastTurn!.Answer);
         Assert.Equal("The term appamāda matters.", AnswerMarkup.PlainText(vm.LastTurn!.Blocks));
         Assert.Equal("The term appamāda matters.", vm.LastTurn!.CopyText);
+    }
+
+    // ---- The conversation the model is shown (#991) -----------------------------------------------
+
+    /// <summary>A stub that answers every turn the same way: citation, some text, done.</summary>
+    private static StubOrchestrator Answering(params AiTurnEvent[] middle)
+    {
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.AddRange(middle);
+        orchestrator.Events.Add(AiTurnEvent.ForCompleted(new PaliMarkerReport(0, 0)));
+        return orchestrator;
+    }
+
+    /// <summary>
+    /// The panel sends what is on screen. Before #991 every request was one user message, so the model had
+    /// never seen the turn before it and a follow-up question was about nothing.
+    /// </summary>
+    [Fact]
+    public async Task The_next_question_carries_the_conversation_so_far()
+    {
+        var orchestrator = Answering(AiTurnEvent.ForText("Heedfulness is the path."));
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+
+        await vm.AskAsync(AiTask.Explain);
+        vm.Question = "what does the third word mean?";
+        await vm.AskAsync(AiTask.Ask);
+
+        // A first question has nothing to replay.
+        Assert.Empty(orchestrator.Requests[0].History ?? Array.Empty<AiExchange>());
+
+        var history = Assert.Single(orchestrator.Requests[1].History!);
+
+        // The question side is the app's own chrome — the preset that was pressed and the citation the panel
+        // drew from the bundle — never anything parsed out of what the model said.
+        Assert.Equal(
+            "\u00abExplain\u00bb \u2014 S\u012Blakkhandhavaggap\u0101\u1E37i \u2014 para 12", history.Question);
+        Assert.Equal("Heedfulness is the path.", history.Answer);
+    }
+
+    /// <summary>The reader's own words go in with the citation, so a follow-up about a follow-up still has the
+    /// thread of it.</summary>
+    [Fact]
+    public async Task A_replayed_turn_carries_the_question_that_was_asked()
+    {
+        var orchestrator = Answering(AiTurnEvent.ForText("It means vigilance."));
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+
+        vm.Question = "what is appamāda?";
+        await vm.AskAsync(AiTask.Ask);
+        await vm.AskAsync(AiTask.Translate);
+
+        var history = Assert.Single(orchestrator.Requests[1].History!);
+        Assert.Equal(
+            "\u00abQuestion\u00bb \u2014 S\u012Blakkhandhavaggap\u0101\u1E37i \u2014 para 12: "
+            + "what is appamāda?",
+            history.Question);
+    }
+
+    /// <summary>
+    /// A turn that failed before writing anything is not replayed: there is no answer to attribute to the
+    /// model, and a lone user message would tell it a question was asked and silently dropped.
+    /// </summary>
+    [Fact]
+    public async Task A_failed_turn_with_no_answer_is_not_replayed()
+    {
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.Add(AiTurnEvent.ForError(new AiError(AiErrorKind.Network, "dropped")));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+        await vm.AskAsync(AiTask.Explain);
+        await vm.AskAsync(AiTask.Translate);
+
+        Assert.True(vm.Turns[0].Failed);
+        Assert.False(vm.Turns[0].HasAnswer);
+        Assert.Empty(orchestrator.Requests[1].History ?? Array.Empty<AiExchange>());
+    }
+
+    /// <summary>
+    /// A turn that failed PART-WAY is replayed as it stands. It is on screen, the reader is reading it, and a
+    /// follow-up will be about what they read — so trimming it out of the history would answer a question
+    /// about something the reader cannot see.
+    /// </summary>
+    [Fact]
+    public async Task A_partial_answer_is_replayed_as_it_stands()
+    {
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.Add(AiTurnEvent.ForText("Heedfulness is the pa"));
+        orchestrator.Events.Add(AiTurnEvent.ForError(new AiError(AiErrorKind.Network, "dropped")));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+        await vm.AskAsync(AiTask.Explain);
+        await vm.AskAsync(AiTask.Translate);
+
+        Assert.True(vm.Turns[0].Failed);
+        Assert.Equal("Heedfulness is the pa", Assert.Single(orchestrator.Requests[1].History!).Answer);
+    }
+
+    /// <summary>
+    /// <b>Reasoning is never replayed.</b> It is kept out of the answer because it is the model thinking aloud
+    /// rather than what it told the reader, and that holds just as well on the way back in: replaying it would
+    /// feed half-formed guesses about a canonical text back as though they had been said.
+    /// </summary>
+    [Fact]
+    public async Task Reasoning_is_never_replayed()
+    {
+        var orchestrator = Answering(
+            AiTurnEvent.ForReasoning("Maybe it is a locative. Or maybe not — check the commentary."),
+            AiTurnEvent.ForText("It is an accusative of time."));
+
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+        await vm.AskAsync(AiTask.Grammar);
+        await vm.AskAsync(AiTask.Explain);
+
+        // The reasoning was genuinely there and genuinely kept — without this the test would pass on a turn
+        // that never produced any.
+        Assert.Contains("Maybe it is a locative", vm.Turns[0].Reasoning);
+
+        var history = Assert.Single(orchestrator.Requests[1].History!);
+        Assert.Equal("It is an accusative of time.", history.Answer);
+        Assert.DoesNotContain("locative", history.Question);
+        Assert.DoesNotContain("Maybe it is a locative", history.Answer);
+    }
+
+    /// <summary>
+    /// Retry re-asks with the history as it is NOW, not as it was — which is what a reader pressing "Try
+    /// again" after reading two more answers means by it, and what falls out of assembling the history from
+    /// the transcript rather than storing a copy per turn.
+    /// </summary>
+    [Fact]
+    public async Task Retry_re_asks_with_the_conversation_as_it_stands_now()
+    {
+        var orchestrator = Answering(AiTurnEvent.ForText("An answer."));
+        var vm = new AiAssistantViewModel(orchestrator, new StubReaderState(), null, null);
+
+        await vm.AskAsync(AiTask.Explain);
+        await vm.AskAsync(AiTask.Translate);
+
+        // Turn one was sent with no history at all; repeating it now sends both of the turns on screen.
+        await vm.RetryCommand.Execute(vm.Turns[0]).ToTask();
+
+        Assert.Equal(3, orchestrator.Requests.Count);
+        Assert.Equal(2, orchestrator.Requests[2].History!.Count);
+        Assert.Equal(AiTask.Explain, orchestrator.Requests[2].Task);
+    }
+
+    /// <summary>
+    /// The question line, on its own. The layout is a decision about what the model is shown rather than an
+    /// implementation detail: the preset says what was asked of the passage, and the citation says which
+    /// passage — the answers alone say neither.
+    /// </summary>
+    [Fact]
+    public void The_replayed_question_line_names_the_preset_and_the_passage()
+    {
+        var preset = new AiTurnViewModel(AiTask.Translate, null)
+        {
+            Citation = "Mahāvaggapāḷi — paragraph 1",
+        };
+        Assert.Equal(
+            "\u00abTranslate\u00bb \u2014 Mahāvaggapāḷi — paragraph 1",
+            AiAssistantViewModel.DescribeAsked(preset));
+
+        var asked = new AiTurnViewModel(AiTask.Ask, "  why the optative?  ")
+        {
+            Citation = "Mahāvaggapāḷi — paragraph 1",
+        };
+        Assert.Equal(
+            "\u00abQuestion\u00bb \u2014 Mahāvaggapāḷi — paragraph 1: why the optative?",
+            AiAssistantViewModel.DescribeAsked(asked));
+
+        // A turn whose citation never arrived — the request failed before the Started event — still says what
+        // was asked rather than opening with a dangling dash.
+        Assert.Equal("\u00abExplain\u00bb", AiAssistantViewModel.DescribeAsked(new AiTurnViewModel(AiTask.Explain, null)));
     }
 }

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -48,6 +48,20 @@ public interface IAiChatOrchestrator
 /// the caller gets a well-formed, successful, blank turn. So a turn that emitted no text is turned into a
 /// named error here, where it is still possible to say something useful about it.</para>
 ///
+/// <para><b>A turn is part of a conversation, not a request on its own.</b> The caller hands over the earlier
+/// turns (<see cref="AiTurnRequest.History"/>) and they are replayed as <c>user</c>/<c>assistant</c> pairs
+/// ahead of this turn's message, which is what makes a follow-up question mean anything — until #991 every turn
+/// was a single user message and the model had never seen the one before it. What is replayed is each turn's
+/// citation line, question and answer; the passage, selection and lemma blocks are sent for the CURRENT turn
+/// only, so a ten-turn conversation about one paragraph sends that paragraph once rather than ten times.
+/// Reasoning is never replayed.</para>
+///
+/// <para><b>The prefix has to stay byte-identical between turns.</b> Prompt caching (Anthropic's
+/// <c>cache_control</c>, and the automatic equivalents elsewhere) applies to a request prefix that has not
+/// changed, so nothing here may put the time, the turn count, or anything else that moves into the system
+/// prompt or into an already-sent message. It is also why the replayed strings are the ones the earlier turns
+/// were built from rather than anything re-rendered now.</para>
+///
 /// <para><b>What is never logged above Debug.</b> The prompt contains corpus text and the user's own question,
 /// and the answer contains both back again. Above Debug this logs only shapes and counts. (§10)</para>
 /// </summary>
@@ -256,14 +270,21 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
         // Content at Debug only — the prompt carries corpus text and the user's question. (§10)
         _logger.LogDebug("AI turn prompt for {Task}:\n{System}\n---\n{User}",
             request.Task, prompt.System, prompt.UserContent);
-        // Estimated over the RENDERED PROMPT — the strings that actually go on the wire — rather than over the
+        // The conversation so far, replayed ahead of this turn. Built before the estimate and before the
+        // Started event, because both of them have to account for it: a history the reader cannot see in the
+        // Sent block, or that the token figure does not count, is a request the app is misreporting. (#991)
+        var replayed = Replay(request.History);
+
+        // Estimated over the WHOLE REQUEST — the strings that actually go on the wire — rather than over the
         // bundle, which is a subset of them. The bundle figure omitted the system prompt, the preset's template
-        // and the reader's own question, all of which are sent. (#672)
-        var estimatedTokens = AiTokens.Estimate(prompt.System, prompt.UserContent);
+        // and the reader's own question, all of which are sent (#672); leaving the replayed conversation out
+        // would repeat that mistake on the one part of the request that grows by itself. (#991)
+        var estimatedTokens = EstimateRequest(prompt, replayed);
         _logger.LogInformation(
-            "AI turn: {Task} on {BookId} via {Provider}/{Model}, ~{Tokens} context tokens, {Notices} notice(s)",
+            "AI turn: {Task} on {BookId} via {Provider}/{Model}, ~{Tokens} context tokens, "
+            + "{History} replayed turn(s), {Notices} notice(s)",
             request.Task, request.BookId, provider.Provider.Id, provider.Model,
-            estimatedTokens, prompt.Notices.Count);
+            estimatedTokens, replayed.Count / 2, prompt.Notices.Count);
 
         // Read off the budget report rather than off the notice wording: the panel raises its partial-passage
         // badge from this, and a badge that depends on how a sentence is phrased stops working the first time
@@ -273,14 +294,19 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
 
         yield return AiTurnEvent.ForStarted(new AiTurnContext(
             bundle.Task, bundle.OutputLanguage, bundle.Citation, bundle.Book, prompt.Notices, passageTrimmed,
-            Describe(bundle, prompt, provider)));
+            Describe(bundle, prompt, provider, replayed)));
 
-        // ---- Stream.
+        // ---- Stream. The conversation, then this turn. This turn's message goes LAST and carries the full
+        // rendered prompt, so the passage the model is being asked about is the last thing it reads.
+        var messages = new List<ChatMessage>(replayed.Count + 1);
+        messages.AddRange(replayed);
+        messages.Add(new ChatMessage(ChatRole.User, prompt.UserContent));
+
         var chat = new ChatRequest(
             provider.Model,
             prompt.MaxOutputTokens,
             prompt.System,
-            new[] { new ChatMessage(ChatRole.User, prompt.UserContent) },
+            messages,
             effort);
 
         var markers = new PaliQuoteFilter();
@@ -424,11 +450,49 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
     /// </list>
     /// </summary>
     /// <summary>
-    /// What this turn sent, as named fields plus the two prompt halves. Assembled here because this is the
-    /// only place that holds the bundle, the rendered prompt and the resolved provider at once. (#665)
+    /// The conversation the caller handed over, as wire messages: each earlier turn's question side as a
+    /// <c>user</c> message and its answer as the <c>assistant</c> reply, oldest first. (#991)
+    ///
+    /// <para><b>An exchange missing either half is dropped here as well as by the caller.</b> The panel already
+    /// omits a failed turn that produced no answer text, but this is the last point before the wire and the
+    /// cost of trusting the caller is a rejected request rather than a degraded one: the Anthropic Messages API
+    /// refuses an empty text block outright, and an assistant turn with nothing in it means nothing to any
+    /// model even where it is accepted.</para>
+    ///
+    /// <para>Nothing is re-rendered and nothing is trimmed. These strings were already sent or already shown,
+    /// and rewriting one would change a prefix a provider may have cached.</para>
+    /// </summary>
+    private static IReadOnlyList<ChatMessage> Replay(IReadOnlyList<AiExchange>? history)
+    {
+        if (history is not { Count: > 0 }) return Array.Empty<ChatMessage>();
+
+        var messages = new List<ChatMessage>(history.Count * 2);
+        foreach (var exchange in history)
+        {
+            if (string.IsNullOrWhiteSpace(exchange.Question) || string.IsNullOrWhiteSpace(exchange.Answer))
+                continue;
+
+            messages.Add(new ChatMessage(ChatRole.User, exchange.Question));
+            messages.Add(new ChatMessage(ChatRole.Assistant, exchange.Answer));
+        }
+
+        return messages;
+    }
+
+    /// <summary>Every string this request puts on the wire, taken together — the system prompt, the replayed
+    /// conversation, and this turn's own message. (#672, #991)</summary>
+    private static int EstimateRequest(RenderedPrompt prompt, IReadOnlyList<ChatMessage> replayed) =>
+        AiTokens.Estimate(
+            new[] { prompt.System, prompt.UserContent }.Concat(replayed.Select(m => m.Content)));
+
+    /// <summary>
+    /// What this turn sent: named fields, the replayed conversation, and the two prompt halves. Assembled here
+    /// because this is the only place that holds the bundle, the rendered prompt and the resolved provider at
+    /// once. (#665)
     /// </summary>
     private static SentContext Describe(
-        AiContextBundle bundle, RenderedPrompt prompt, ChatProviderResolution provider)
+        AiContextBundle bundle, RenderedPrompt prompt, ChatProviderResolution provider,
+        IReadOnlyList<ChatMessage> replayed)
     {
         var fields = new List<SentField>
         {
@@ -439,10 +503,11 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
             new("Book", bundle.Book.Name),
             new("Book id", bundle.Book.BookId),
             new("Reference", bundle.Citation.NormalizedReference),
-            // Over the rendered prompt, which is what was sent. Reading this off the bundle omitted the system
+            // Over the whole request, which is what was sent. Reading this off the bundle omitted the system
             // prompt, the preset template and the reader's own question — a figure captioned as the context
-            // that measured a subset of it. (#672)
-            new("Estimated context", $"~{AiTokens.Estimate(prompt.System, prompt.UserContent):N0} tokens"),
+            // that measured a subset of it (#672) — and the replayed conversation is the part that grows without
+            // the reader doing anything, so its share is named rather than folded in. (#991)
+            new("Estimated context", DescribeEstimate(prompt, replayed)),
         };
 
         if (bundle.Budget.ParagraphsCovered is int covered)
@@ -459,7 +524,26 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
             fields.Add(new SentField($"Part: {part.Name}", detail));
         }
 
-        return new SentContext(fields, prompt.System, prompt.UserContent);
+        return new SentContext(fields, prompt.System, prompt.UserContent, replayed);
+    }
+
+    /// <summary>
+    /// The estimate as the Sent block states it: the whole request, and how much of it the conversation
+    /// accounts for. (#991)
+    ///
+    /// <para>The two figures answer different questions. The total is what this request costs; the history's
+    /// share is what it will cost to keep asking — the number a reader watching a long conversation approach a
+    /// context window needs, and cannot derive from the total.</para>
+    /// </summary>
+    private static string DescribeEstimate(RenderedPrompt prompt, IReadOnlyList<ChatMessage> replayed)
+    {
+        var total = EstimateRequest(prompt, replayed);
+        if (replayed.Count == 0) return $"~{total:N0} tokens";
+
+        var history = AiTokens.Estimate(replayed.Select(m => m.Content));
+        var turns = replayed.Count / 2;
+        return $"~{total:N0} tokens, ~{history:N0} of them "
+               + (turns == 1 ? "1 earlier turn" : $"{turns} earlier turns");
     }
 
     private static string PageRef(SnippetPageRef page)

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -53,8 +53,9 @@ public interface IAiChatOrchestrator
 /// ahead of this turn's message, which is what makes a follow-up question mean anything — until #991 every turn
 /// was a single user message and the model had never seen the one before it. What is replayed is each turn's
 /// citation line, question and answer; the passage, selection and lemma blocks are sent for the CURRENT turn
-/// only, so a ten-turn conversation about one paragraph sends that paragraph once rather than ten times.
-/// Reasoning is never replayed.</para>
+/// only, so a ten-turn conversation about one paragraph sends that paragraph once rather than ten times. The
+/// answer that goes back is the model's own marked text, not the stripped text on screen — see
+/// <see cref="AiTurnEvent.MarkedText"/>. Reasoning is never replayed.</para>
 ///
 /// <para><b>The replayed half is byte-stable; the system prompt is not.</b> [observed 2026-09-12] Nothing here
 /// puts the time, the turn count, or anything else that moves into a replayed message — what goes back is the
@@ -351,11 +352,16 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
                     case ChatDeltaKind.Text when delta.Text is { Length: > 0 } text:
                     {
                         var visible = markers.Feed(text);
-                        if (visible.Length > 0)
-                        {
-                            sawText = true;
-                            yield return AiTurnEvent.ForText(visible);
-                        }
+                        if (visible.Length > 0) sawText = true;
+
+                        // Yielded even when the filter held everything back, because the two halves are not
+                        // interchangeable: `visible` is what the panel renders, `text` is what the model wrote,
+                        // and the marked half has to reach the transcript whole so a later turn can replay it
+                        // (#991). A delta ending between the two brackets of a marker is the ordinary case, not
+                        // an edge one, so dropping the event when nothing is renderable yet would lose exactly
+                        // the spans this exists to preserve. `sawText` still follows the VISIBLE half: a turn
+                        // that produced only markers produced no answer.
+                        yield return AiTurnEvent.ForText(visible, text);
                         break;
                     }
 
@@ -381,6 +387,8 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
             }
         }
 
+        // A bracket held back that never completed a marker: ordinary text after all. No marked half — it was
+        // already carried, markers and all, by the delta it arrived in.
         var tail = markers.Flush();
         if (tail.Length > 0)
         {
@@ -452,6 +460,11 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
     /// cost of trusting the caller is a rejected request rather than a degraded one: the Anthropic Messages API
     /// refuses an empty text block outright, and an assistant turn with nothing in it means nothing to any
     /// model even where it is accepted.</para>
+    ///
+    /// <para><b>The answers come back marked.</b> What the caller replays is the model's own text with its
+    /// <c>[[…]]</c> Pāli markers intact, not the stripped text on screen — the system prompt asks for those
+    /// markers on every Pāli span, so replaying the stripped form would show the model a transcript of itself
+    /// ignoring the instruction. Nothing here inspects or repairs them.</para>
     ///
     /// <para>Nothing is re-rendered and nothing is trimmed. These strings were already sent or already shown,
     /// and rewriting one would make the replayed half of the request differ from turn to turn for no reason —

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -56,11 +56,17 @@ public interface IAiChatOrchestrator
 /// only, so a ten-turn conversation about one paragraph sends that paragraph once rather than ten times.
 /// Reasoning is never replayed.</para>
 ///
-/// <para><b>The prefix has to stay byte-identical between turns.</b> Prompt caching (Anthropic's
-/// <c>cache_control</c>, and the automatic equivalents elsewhere) applies to a request prefix that has not
-/// changed, so nothing here may put the time, the turn count, or anything else that moves into the system
-/// prompt or into an already-sent message. It is also why the replayed strings are the ones the earlier turns
-/// were built from rather than anything re-rendered now.</para>
+/// <para><b>The replayed half is byte-stable; the system prompt is not.</b> [observed 2026-09-12] Nothing here
+/// puts the time, the turn count, or anything else that moves into a replayed message — what goes back is the
+/// strings the earlier turns were built from, never anything re-rendered now. The system prompt does move:
+/// <c>Resources/Ai/system.md</c> embeds <c>{{scope}}</c> and <c>{{outputLanguage}}</c>, and
+/// <c>PromptBuilder.Scope</c> renders the book name, the reference, how many paragraphs the window covers and a
+/// sentence that depends on whether anything is selected — so it holds only while the reader stays on the same
+/// reference with the same selection state and answer language, and changes as soon as any of those does.
+/// Neither adapter sets Anthropic's <c>cache_control</c>, and nothing else here asks for caching, so no
+/// behaviour depends on a stable prefix today. One that could be relied on would mean moving the scope
+/// statement out of the system prompt and into the per-turn message, which is not this layer's to decide.
+/// Keeping the replayed half stable is worth doing regardless, because it is the half that grows.</para>
 ///
 /// <para><b>What is never logged above Debug.</b> The prompt contains corpus text and the user's own question,
 /// and the answer contains both back again. Above Debug this logs only shapes and counts. (§10)</para>
@@ -438,18 +444,6 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
     }
 
     /// <summary>
-    /// What to tell the user when the model stopped at its output limit (#601). The three cases are genuinely
-    /// different situations, and the difference is invisible to the provider that detected the truncation:
-    ///
-    /// <list type="bullet">
-    /// <item>Text was written — <b>the dangerous one</b>. Without this message a half-finished translation
-    /// renders under a citation exactly like a finished one, and nothing on screen says otherwise.</item>
-    /// <item>Reasoning but no answer — #601's original case. The work was done and never written down; the fix
-    /// is a bigger budget or a lighter-reasoning model, not a retry.</item>
-    /// <item>Neither — the cap is small enough that nothing could be produced at all.</item>
-    /// </list>
-    /// </summary>
-    /// <summary>
     /// The conversation the caller handed over, as wire messages: each earlier turn's question side as a
     /// <c>user</c> message and its answer as the <c>assistant</c> reply, oldest first. (#991)
     ///
@@ -460,7 +454,8 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
     /// model even where it is accepted.</para>
     ///
     /// <para>Nothing is re-rendered and nothing is trimmed. These strings were already sent or already shown,
-    /// and rewriting one would change a prefix a provider may have cached.</para>
+    /// and rewriting one would make the replayed half of the request differ from turn to turn for no reason —
+    /// see the class remarks for what does and does not hold about a cacheable prefix.</para>
     /// </summary>
     private static IReadOnlyList<ChatMessage> Replay(IReadOnlyList<AiExchange>? history)
     {
@@ -574,6 +569,18 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
         }
     }
 
+    /// <summary>
+    /// What to tell the user when the model stopped at its output limit (#601). The three cases are genuinely
+    /// different situations, and the difference is invisible to the provider that detected the truncation:
+    ///
+    /// <list type="bullet">
+    /// <item>Text was written — <b>the dangerous one</b>. Without this message a half-finished translation
+    /// renders under a citation exactly like a finished one, and nothing on screen says otherwise.</item>
+    /// <item>Reasoning but no answer — #601's original case. The work was done and never written down; the fix
+    /// is a bigger budget or a lighter-reasoning model, not a retry.</item>
+    /// <item>Neither — the cap is small enough that nothing could be produced at all.</item>
+    /// </list>
+    /// </summary>
     private static string TruncationMessage(bool sawText, bool sawReasoning) =>
         sawText
             ? "This answer is incomplete: the model reached its output limit and stopped part-way through."

--- a/src/CST.Avalonia/Services/Ai/AiTurn.cs
+++ b/src/CST.Avalonia/Services/Ai/AiTurn.cs
@@ -4,6 +4,24 @@ using CST.Navigation;
 namespace CST.Avalonia.Services.Ai;
 
 /// <summary>
+/// One earlier turn, as the model is shown it again. (#991)
+///
+/// <para>Both halves are strings the app has ALREADY rendered — there is nothing here to re-render, and
+/// nothing to re-gather. <paramref name="Question"/> is the app's own citation line plus what was asked, never
+/// a re-send of that turn's passage: replaying each turn's full context would send the same paragraph once per
+/// turn. <paramref name="Answer"/> is the raw answer as it stands on screen.</para>
+///
+/// <para><b>What this deliberately does not carry.</b> No reasoning — it was segregated from the answer
+/// because it is the model thinking aloud rather than what it told the reader, and that holds just as well on
+/// the way back in. No notices, no usage, no timings: none of them was ever said to the model.</para>
+/// </summary>
+/// <param name="Question">The question side, already rendered: citation line, preset label, and the reader's
+/// own words where there were any.</param>
+/// <param name="Answer">The raw answer. A partial answer is replayed as it is — it stands on screen, so it
+/// stands in the history.</param>
+public sealed record AiExchange(string Question, string Answer);
+
+/// <summary>
 /// What the user asked for. The orchestrator's whole input — everything else it looks up.
 /// </summary>
 /// <param name="Reference">Where in the book. Null reads from the START of the book, so a caller that does not
@@ -12,13 +30,29 @@ namespace CST.Avalonia.Services.Ai;
 /// selected.</param>
 /// <param name="SelectionUnavailable">The reader could not read the selection — see
 /// <see cref="SelectionState.Unavailable"/>. Distinct from a null <paramref name="SelectionText"/>.</param>
+/// <param name="History">
+/// Earlier turns of the same conversation, oldest first, replayed to the model ahead of this one. (#991)
+///
+/// <para>Null or empty is a one-shot turn, which is what every turn was before this existed: the model saw
+/// one user message and nothing else, so "what did you mean by the third word?" could not work at all.</para>
+///
+/// <para><b>The caller owns which turns are in here</b>, because only the caller knows what is on screen. The
+/// panel sends what the reader can see, in the order they can see it, minus turns that produced no answer
+/// text; the orchestrator adds the current turn's context and sends the lot.</para>
+///
+/// <para><b>The passage is sent for the current turn only.</b> A follow-up asked after the reader has moved on
+/// gets each earlier turn's citation but not its text — enough for the model to know which passage an earlier
+/// answer was about, and not a re-send of the paragraph on every turn. Where that is not enough, the reader's
+/// recourse is to ask about the passage they are in.</para>
+/// </param>
 public sealed record AiTurnRequest(
     AiTask Task,
     string BookId,
     NavigationReference? Reference = null,
     string? SelectionText = null,
     string? UserQuestion = null,
-    bool SelectionUnavailable = false);
+    bool SelectionUnavailable = false,
+    IReadOnlyList<AiExchange>? History = null);
 
 /// <summary>What kind of thing a <see cref="AiTurnEvent"/> carries.</summary>
 public enum AiTurnEventKind
@@ -89,10 +123,26 @@ public sealed record AiTurnContext(
 /// </summary>
 /// <param name="Fields">Named values, in display order — provider, model, task, language, book, reference,
 /// pages, the estimated token count, and what each gathered part contributed.</param>
+/// <param name="History">
+/// The earlier turns replayed ahead of this one, in the order they were sent, or empty for a one-shot turn.
+/// (#991)
+///
+/// <para>Here because the conversation is part of what the model saw, and this type's whole claim is that it
+/// says what was sent. A panel that showed only <paramref name="UserContent"/> once history existed would be
+/// showing the last message of a longer request and calling it the request.</para>
+///
+/// <para>The request is <paramref name="SystemPrompt"/>, then these, then <paramref name="UserContent"/> as
+/// the final user message — so this list stops short of the current turn rather than repeating it.</para>
+/// </param>
 public sealed record SentContext(
     IReadOnlyList<SentField> Fields,
     string SystemPrompt,
-    string UserContent);
+    string UserContent,
+    IReadOnlyList<ChatMessage>? History = null)
+{
+    /// <summary>Whether anything was replayed. What the panel hides its history block on.</summary>
+    public bool HasHistory => History is { Count: > 0 };
+}
 
 /// <summary>One named value in <see cref="SentContext.Fields"/>.</summary>
 public sealed record SentField(string Name, string Value);

--- a/src/CST.Avalonia/Services/Ai/AiTurn.cs
+++ b/src/CST.Avalonia/Services/Ai/AiTurn.cs
@@ -17,8 +17,11 @@ namespace CST.Avalonia.Services.Ai;
 /// </summary>
 /// <param name="Question">The question side, already rendered: citation line, preset label, and the reader's
 /// own words where there were any.</param>
-/// <param name="Answer">The raw answer. A partial answer is replayed as it is — it stands on screen, so it
-/// stands in the history.</param>
+/// <param name="Answer">The answer <b>as the model wrote it</b>, Pāli markers and all — not the stripped text
+/// the panel displays. The system prompt tells the model to wrap every Pāli span in <c>[[…]]</c>; replaying the
+/// stripped version would show it a transcript of its own answers disobeying that instruction, which a model is
+/// expected to imitate. <b>[fsnow]</b>, deciding this before #991 merged: <i>"I want to fix this before we
+/// merge."</i> A partial answer is replayed as it is — it stands on screen, so it stands in the history.</param>
 public sealed record AiExchange(string Question, string Answer);
 
 /// <summary>
@@ -64,7 +67,15 @@ public enum AiTurnEventKind
     /// </summary>
     Started,
 
-    /// <summary>Answer text, marker-stripped and ready to render.</summary>
+    /// <summary>
+    /// Answer text. Two views of the same delta: <see cref="AiTurnEvent.Text"/> is marker-stripped and ready to
+    /// render, <see cref="AiTurnEvent.MarkedText"/> is what the model actually wrote.
+    ///
+    /// <para><b>Either can be empty.</b> A delta that ends between the two brackets of a marker renders nothing
+    /// yet — the filter holds the bracket back — and the flush at the end of a stream releases visible text
+    /// whose marked form was already carried by the delta it arrived in. A caller appends whichever halves are
+    /// present; it must not assume they arrive together.</para>
+    /// </summary>
     Text,
 
     /// <summary>Model reasoning, segregated. A caller may show it deliberately or drop it; never concatenate it
@@ -165,16 +176,31 @@ public sealed record PaliMarkerReport(int Quotes, int UnbalancedMarkers);
 public sealed record AiUsageReport(int? InputTokens, int? OutputTokens);
 
 /// <summary>One event in a turn. See <see cref="AiTurnEventKind"/> for which field each kind populates.</summary>
+/// <param name="MarkedText">
+/// On a <see cref="AiTurnEventKind.Text"/> event: the same delta as the model wrote it, <b>marker for marker</b>
+/// — including markers that never found a partner, which <see cref="PaliQuoteFilter"/> strips from
+/// <paramref name="Text"/> and counts. (#991)
+///
+/// <para>Kept because a later turn replays earlier answers to the model, and the text on screen is the wrong
+/// thing to replay: the system prompt tells the model to wrap every Pāli span in <c>[[…]]</c>, so a transcript
+/// of stripped answers is a transcript of itself disobeying that instruction. Unbalanced markers go back too —
+/// what the model is shown of its own output should be what it produced, not a repaired version of it.</para>
+/// </param>
 public sealed record AiTurnEvent(
     AiTurnEventKind Kind,
     string? Text = null,
     AiTurnContext? Context = null,
     AiUsageReport? Usage = null,
     AiError? Error = null,
-    PaliMarkerReport? Markers = null)
+    PaliMarkerReport? Markers = null,
+    string? MarkedText = null)
 {
     public static AiTurnEvent ForStarted(AiTurnContext context) => new(AiTurnEventKind.Started, Context: context);
-    public static AiTurnEvent ForText(string text) => new(AiTurnEventKind.Text, Text: text);
+
+    /// <param name="markedText">What the model wrote, markers intact. Null where there is nothing new to carry
+    /// — the end-of-stream flush releases text whose marked form went out with an earlier delta.</param>
+    public static AiTurnEvent ForText(string text, string? markedText = null) =>
+        new(AiTurnEventKind.Text, Text: text, MarkedText: markedText);
     public static AiTurnEvent ForReasoning(string text) => new(AiTurnEventKind.Reasoning, Text: text);
     public static AiTurnEvent ForUsage(AiUsageReport usage) => new(AiTurnEventKind.Usage, Usage: usage);
     public static AiTurnEvent ForError(AiError error) => new(AiTurnEventKind.Error, Error: error);

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -39,6 +39,13 @@ namespace CST.Avalonia.ViewModels;
 /// asking a second question destroyed the first answer — for a reader working through a passage, which is the
 /// only kind of reader this has, that is the ordinary case rather than an edge one.
 /// </para>
+///
+/// <para>
+/// <b>And it is the conversation.</b> What is on screen is what the model is shown of the turns before this
+/// one — see <see cref="HistoryFor"/> — so a follow-up question means what the reader means by it. The panel
+/// was a transcript to the reader and a series of unrelated requests to the model until #991, which is why
+/// "what did you mean by the third word?" used to answer about nothing.
+/// </para>
 /// </summary>
 public class AiAssistantViewModel : ReactiveTool
 {
@@ -384,7 +391,10 @@ public class AiAssistantViewModel : ReactiveTool
                 // Carried rather than collapsed into "no selection": a selection the reader could not read is
                 // a different state, and conflating them is what makes a dropped selection look to the user
                 // like the assistant ignored it. (#581)
-                state.SelectionUnavailable);
+                state.SelectionUnavailable,
+                // Read from the transcript AFTER StartTurn, so the turn just added is excluded by identity
+                // rather than by an index the next change to this method could invalidate. (#991)
+                HistoryFor(turn));
 
             await foreach (var e in _orchestrator.RunAsync(request, _turnCancellation!.Token))
                 Handle(turn, e);
@@ -684,6 +694,52 @@ public class AiAssistantViewModel : ReactiveTool
             + "mean, then ask again.",
         _ => "The reader could not say which passage you are on.",
     };
+
+    /// <summary>
+    /// The conversation as the model is shown it: every earlier turn on screen, oldest first. (#991)
+    ///
+    /// <para><b>Assembled from the transcript rather than kept as a second list.</b> What the reader can see is
+    /// what the model is told, with no third place for the two to drift apart — and it is why Retry re-asks with
+    /// the history as it stands now rather than as it stood when the turn it repeats was first sent.</para>
+    ///
+    /// <para><b>A turn with no answer text is left out.</b> A failed turn is a request the model never answered,
+    /// so there is no assistant reply to replay and a lone user message would tell it a question was asked and
+    /// silently dropped. A turn with PARTIAL text goes in as it stands: it is on screen, the reader is reading
+    /// it, and a follow-up will be about what they read.</para>
+    ///
+    /// <para>The turn being started is excluded — it is already in <see cref="Turns"/> by the time this runs,
+    /// and its own context is what the current message carries.</para>
+    /// </summary>
+    private IReadOnlyList<AiExchange> HistoryFor(AiTurnViewModel current) =>
+        Turns
+            .Where(t => !ReferenceEquals(t, current) && t.HasAnswer)
+            .Select(t => new AiExchange(DescribeAsked(t), t.Answer))
+            .ToList();
+
+    /// <summary>
+    /// The question side of an earlier turn, as the model is shown it again: which preset, which passage, and
+    /// the reader's own words where there were any. (#991)
+    ///
+    /// <para><b>Built from the app's own chrome, never re-gathered and never parsed out of anything the model
+    /// said.</b> The citation is the line the panel already drew from <see cref="CitationRef"/>, which is what
+    /// keeps a replayed conversation as trustworthy as the screen it came from; the preset label is there
+    /// because "Translate" and "Grammar" asked different things of the same passage and the answers alone do not
+    /// say which was asked.</para>
+    ///
+    /// <para><b>The passage itself is not here.</b> Replaying each turn's full context would send the same
+    /// paragraph once per turn; the citation tells the model which passage an earlier answer was about, which is
+    /// what a follow-up needs once the reader has moved on. A follow-up that needs the text of a passage the
+    /// reader has left will not get it — ask about the passage you are in.</para>
+    ///
+    /// <para>Nothing in here moves between turns: no clock, no turn number, no count. A replayed message that
+    /// changed from one request to the next would break the stable prefix a provider's prompt caching needs.</para>
+    /// </summary>
+    internal static string DescribeAsked(AiTurnViewModel turn)
+    {
+        var opening = $"\u00ab{turn.PresetLabel}\u00bb";
+        var head = string.IsNullOrWhiteSpace(turn.Citation) ? opening : $"{opening} \u2014 {turn.Citation}";
+        return turn.HasQuestion ? $"{head}: {turn.Question!.Trim()}" : head;
+    }
 
     /// <summary>
     /// The citation as ONE quiet line, built from the bundle rather than parsed out of the answer: the book's

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -470,16 +470,31 @@ public class AiAssistantViewModel : ReactiveTool
                 turn.Status = WaitingMessage(_elapsed.Elapsed, sawReasoning: false);
                 break;
 
-            case AiTurnEventKind.Text when e.Text is { Length: > 0 }:
+            case AiTurnEventKind.Text:
+            {
+                // Two views of one delta, and either half can be empty (see AiTurnEventKind.Text). The marked
+                // half is what the model wrote, markers and all — kept for replay to the model and bound to
+                // nothing; the visible half is what the reader sees.
+                var visible = e.Text is { Length: > 0 };
                 lock (_pendingGate)
                 {
-                    turn.AppendAnswer(e.Text);
-                    _pendingAnswer = true;
+                    if (e.MarkedText is { Length: > 0 } marked) turn.AppendMarkedAnswer(marked);
+                    if (visible)
+                    {
+                        turn.AppendAnswer(e.Text!);
+                        _pendingAnswer = true;
+                    }
                 }
+
+                // Only renderable text is progress: a delta the filter swallowed whole has put nothing on
+                // screen, so the waiting message still has something to say.
+                if (!visible) break;
+
                 // Text on screen IS the progress report; the counter has nothing left to say.
                 _sawText = true;
                 turn.Status = "";
                 break;
+            }
 
             case AiTurnEventKind.Reasoning when e.Text is { Length: > 0 }:
                 // Never concatenated into the answer — it is the model thinking aloud, not what it is telling
@@ -707,13 +722,19 @@ public class AiAssistantViewModel : ReactiveTool
     /// silently dropped. A turn with PARTIAL text goes in as it stands: it is on screen, the reader is reading
     /// it, and a follow-up will be about what they read.</para>
     ///
+    /// <para><b>What goes back is <see cref="AiTurnViewModel.MarkedAnswer"/>, never <c>Answer</c>.</b> The
+    /// screen shows the answer with its <c>[[…]]</c> Pāli markers stripped; the system prompt tells the model to
+    /// put those markers on every Pāli span. Replaying the stripped text would hand it a transcript of its own
+    /// answers ignoring that instruction, and a model shown its own apparent practice follows it. <b>[fsnow]</b>,
+    /// on fixing this before #991 merged: <i>"I want to fix this before we merge."</i></para>
+    ///
     /// <para>The turn being started is excluded — it is already in <see cref="Turns"/> by the time this runs,
     /// and its own context is what the current message carries.</para>
     /// </summary>
     private IReadOnlyList<AiExchange> HistoryFor(AiTurnViewModel current) =>
         Turns
             .Where(t => !ReferenceEquals(t, current) && t.HasAnswer)
-            .Select(t => new AiExchange(DescribeAsked(t), t.Answer))
+            .Select(t => new AiExchange(DescribeAsked(t), t.MarkedAnswer))
             .ToList();
 
     /// <summary>

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -731,8 +731,10 @@ public class AiAssistantViewModel : ReactiveTool
     /// what a follow-up needs once the reader has moved on. A follow-up that needs the text of a passage the
     /// reader has left will not get it — ask about the passage you are in.</para>
     ///
-    /// <para>Nothing in here moves between turns: no clock, no turn number, no count. A replayed message that
-    /// changed from one request to the next would break the stable prefix a provider's prompt caching needs.</para>
+    /// <para>Nothing in here moves between turns: no clock, no turn number, no count — so an earlier turn is
+    /// replayed identically for as long as it is on screen. That is the property a future prompt-cache prefix
+    /// would need from this half of the request; the system prompt does not have it today, for reasons recorded
+    /// on <see cref="AiChatOrchestrator"/>.</para>
     /// </summary>
     internal static string DescribeAsked(AiTurnViewModel turn)
     {

--- a/src/CST.Avalonia/ViewModels/AiTurnViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiTurnViewModel.cs
@@ -20,6 +20,7 @@ namespace CST.Avalonia.ViewModels;
 public sealed class AiTurnViewModel : ReactiveObject
 {
     private readonly StringBuilder _answer = new();
+    private readonly StringBuilder _markedAnswer = new();
     private readonly StringBuilder _reasoning = new();
 
     public AiTurnViewModel(AiTask task, string? question)
@@ -80,6 +81,22 @@ public sealed class AiTurnViewModel : ReactiveObject
         _answer.Append(text);
         HasAnswer = _answer.Length > 0;
     }
+
+    /// <summary>
+    /// The same answer as the model wrote it, <c>[[…]]</c> Pāli markers and all. (#991)
+    ///
+    /// <para><b>Not bound to anything, and not for the reader.</b> The markers exist so the app can convert
+    /// quoted Pāli into the reader's script; on screen they are stripped, which is what <see cref="Answer"/>
+    /// holds. This half exists because a later turn replays this one TO THE MODEL, and the system prompt tells
+    /// it to wrap every Pāli span in those markers — replaying the stripped form would show it a transcript of
+    /// its own answers disobeying that instruction, which is the kind of thing a model imitates.</para>
+    ///
+    /// <para>Unbalanced markers are kept as written. <see cref="PaliQuoteFilter"/> strips those from the
+    /// display, rightly; what the model is shown of its own output should still be what it produced.</para>
+    /// </summary>
+    internal string MarkedAnswer => _markedAnswer.ToString();
+
+    internal void AppendMarkedAnswer(string text) => _markedAnswer.Append(text);
 
     /// <summary>Re-parse and publish. Called once per flush, not once per delta.</summary>
     internal void PublishAnswer()

--- a/src/CST.Avalonia/Views/AiAssistantPanel.axaml
+++ b/src/CST.Avalonia/Views/AiAssistantPanel.axaml
@@ -483,6 +483,33 @@
                                                              FontSize="11"
                                                              Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
 
+                                        <!-- The conversation replayed ahead of this turn. Shown because it is
+                                             part of what the model saw: once history exists, "the message
+                                             sent" below is the last message of a longer request. Empty for a
+                                             first question, and the whole block goes with it. -->
+                                        <StackPanel Spacing="4" IsVisible="{Binding Sent.HasHistory}">
+                                            <TextBlock Text="Conversation replayed" FontSize="11" FontWeight="SemiBold"/>
+                                            <ItemsControl ItemsSource="{Binding Sent.History}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="ai:ChatMessage">
+                                                        <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,2">
+                                                            <SelectableTextBlock Grid.Column="0"
+                                                                                 Text="{Binding Role}"
+                                                                                 FontSize="11"
+                                                                                 FontWeight="SemiBold"
+                                                                                 MinWidth="70"
+                                                                                 Margin="0,0,8,0"/>
+                                                            <SelectableTextBlock Grid.Column="1"
+                                                                                 Text="{Binding Content}"
+                                                                                 FontSize="11"
+                                                                                 TextWrapping="Wrap"
+                                                                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+
                                         <TextBlock Text="Message sent" FontSize="11" FontWeight="SemiBold"/>
                                         <SelectableTextBlock Text="{Binding Sent.UserContent}"
                                                              TextWrapping="Wrap"


### PR DESCRIPTION
Closes #991. P1 of [ASSISTANT_SESSIONS.md](docs/features/planned/ASSISTANT_SESSIONS.md) — the walking skeleton: the first change that makes "what did you mean by the third word?" work.

**What changes.** Every Assistant turn was one-shot: the orchestrator sent a single user message. Now `AiTurnRequest` carries the earlier exchanges and the orchestrator replays them as `user`/`assistant` pairs ahead of the current turn's message, in the layout **[fsnow]** chose — *"Citation + question → answer"*: each earlier turn as the app's own citation line plus the question, then the answer; the passage bundle sent for the current turn only. Boilerplate is sent once per request, never per earlier turn.

- `AiTurnRequest.History`, `AiExchange`; `AiChatOrchestrator.Replay` (drops any exchange missing either half, so roles always alternate and no content block is empty); `SentContext.History` so #665's "what did the model see" stays true; the "Estimated context" field now reports the history's share.
- `AiAssistantViewModel.HistoryFor` / `DescribeAsked` — built from `PresetLabel`, the app-rendered citation and the reader's question; nothing from model output. Reasoning is never replayed. Retry re-asks with the history as it stands now.
- `AiAssistantPanel.axaml`: a "Conversation replayed" block inside the Sent expander (binding verified by a headless probe in review).
- `AI_SURFACE_B.md` §14's open question is answered and deleted; §5 records the decision, and records as a dated fact that the system prompt varies with scope and language today, so no request prefix is stable by construction (pre-existing; neither adapter sets `cache_control`).

**Review.** Fable adversarial review: mergeable with named fixes — all applied in `6079e14` (the prefix claim rewritten as fact, the `[fsnow]` clause separated from agent gloss, a byte-stability test, doc drift, an orphaned doc comment). It also found that replayed answers were marker-stripped (`PaliQuoteFilter`), so on later turns the model would see its own prior answers without `[[…]]`, contradicting `system.md`'s instruction — **[fsnow]**: *"I want to fix this before we merge."* Fixed in `8aabf8c`: each `Text` event now carries the marked form beside the visible one, the turn accumulates `MarkedAnswer`, and that is what is replayed; nothing on screen changes.

**Tests.** 2857 → 2877 passed, 0 failed, 18 skipped. New: orchestrator (order/roles, passage sent once, answerless exchange dropped, `SentContext.History` equals the wire minus the last message, estimate), view model (history and question carried, failed-answerless omitted, partial replayed, reasoning never replayed, retry, byte-for-byte replay across turns), and serialized-body tests on both adapters for a 3-message request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

